### PR TITLE
Setup Gulp, StandardJS and Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+language: node_js
+node_js:
+  - 6.0
 notifications:
   email: false
 sudo: false
+script:
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 GOV.UK Frontend ·
 [![Build Status](https://travis-ci.org/alphagov/govuk-frontend.svg?branch=master)](https://travis-ci.org/alphagov/govuk-frontend)
+[![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 =====================
 
 ## What is it?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-GOV.UK Frontend
+GOV.UK Frontend ·
+[![Build Status](https://travis-ci.org/alphagov/govuk-frontend.svg?branch=master)](https://travis-ci.org/alphagov/govuk-frontend)
 =====================
 
 ## What is it?

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,8 @@
+const gulp = require('gulp')
+
+// Default task --------------------------
+// Lists out available tasks.
+// ---------------------------------------
+gulp.task('default', () => {
+  // place code for your default task here
+})

--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   },
   "license": "MIT",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
-  "homepage": "https://github.com/alphagov/govuk-frontend#readme"
+  "homepage": "https://github.com/alphagov/govuk-frontend#readme",
+  "devDependencies": {
+    "gulp": "^3.9.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,11 @@
   "license": "MIT",
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
   "homepage": "https://github.com/alphagov/govuk-frontend#readme",
+  "scripts": {
+    "test": "standard"
+  },
   "devDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^3.9.1",
+    "standard": "^10.0.2"
   }
 }


### PR DESCRIPTION
Get Travis to run `npm test`.
Add a badge for Travis to the README for the build status.

Add Gulp
Add a default gulp task

Set `npm test` to check all js files using standardJS
Add a badge for StandardJS.



