### PR TITLE
Import-once mixin to ensure common imports are not duplicated

### DIFF
--- a/src/components/component-example/_component-example.scss
+++ b/src/components/component-example/_component-example.scss
@@ -1,0 +1,7 @@
+// dependencies go here, import-once at the end
+@import "import-once";
+
+// export styles with component name
+@include exports("component-example") {
+  // component styles go here
+}

--- a/src/globals/scss/_import-once.scss
+++ b/src/globals/scss/_import-once.scss
@@ -1,0 +1,14 @@
+$imported-modules: () !default;
+
+/// Module export mixin
+/// This mixin helps making sure a module is imported once and only once.
+/// @access public
+/// @param {String} $name - Name of exported module
+/// @param {Bool} $warn [true] - Warn when module has been already imported
+/// @require $imported-modules
+@mixin exports($name, $warn: true) {
+  @if (index($imported-modules, $name) == null) {
+    $imported-modules: append($imported-modules, $name) !global;
+    @content;
+  }
+}

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,0 +1,2 @@
+@import "import-once";
+@import "../../components/component-example/component-example";


### PR DESCRIPTION
An import-once mixin ensures that exported styles from globals that are imported into individual components are not duplicated in sass compilation.