### PR TITLE
Add link back component

### DIFF
--- a/src/components/link-back/README.md
+++ b/src/components/link-back/README.md
@@ -1,0 +1,3 @@
+# Link back component
+
+This is a back link.

--- a/src/components/link-back/_link-back.scss
+++ b/src/components/link-back/_link-back.scss
@@ -1,0 +1,48 @@
+@import "import-once";
+@import "../../globals/scss/helpers";
+@import "../../globals/scss/vars";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/typography";
+
+@include exports("link-back") {
+
+  .govuk-c-link-back {
+    display: inline-block;
+
+    position: relative;
+
+    @include core-16;
+
+    padding-left: 14px;
+
+    color: $govuk-black;
+    text-decoration: none;
+    border-bottom: 1px solid $govuk-black;
+
+    background: file-url("icon-arrow-left.png") no-repeat 0 4px;
+
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: $govuk-black;
+    }
+
+    // Back arrow - left pointing black arrow
+    &::before {
+      content: "";
+      display: block;
+      width: 0;
+      height: 0;
+
+      border-top: 5px solid transparent;
+      border-right: 6px solid $govuk-black;
+      border-bottom: 5px solid transparent;
+
+      position: absolute;
+      left: 0;
+      top: 50%;
+      margin-top: -6px;
+    }
+  }
+}

--- a/src/components/link-back/link-back.html
+++ b/src/components/link-back/link-back.html
@@ -1,0 +1,1 @@
+<a href="#" class="govuk-c-link-back">Back</a>

--- a/src/globals/scss/_colours.scss
+++ b/src/globals/scss/_colours.scss
@@ -1,201 +1,198 @@
 // https://raw.githubusercontent.com/alphagov/govuk_frontend_toolkit/master/stylesheets/colours/_palette.scss
-@import "import-once";
 
-@include exports("colors") {
 
-  // Brand colours
-  $govuk-blue: #005ea5;
-  $govuk-mainstream-brand: $govuk-blue;
+// Brand colours
+$govuk-blue: #005ea5;
+$govuk-mainstream-brand: $govuk-blue;
 
-  // Standard palette, colours
-  $govuk-purple: #2e358b;
-  $govuk-purple-50: #9799c4;
-  $govuk-purple-25: #d5d6e7;
-  $govuk-mauve: #6f72af;
-  $govuk-mauve-50: #b7b9d7;
-  $govuk-mauve-25: #e2e2ef;
-  $govuk-fuschia: #912b88;
-  $govuk-fuschia-50: #c994c3;
-  $govuk-fuschia-25: #e9d4e6;
-  $govuk-pink: #d53880;
-  $govuk-pink-50: #eb9bbe;
-  $govuk-pink-25: #f6d7e5;
-  $govuk-baby-pink: #f499be;
-  $govuk-baby-pink-50: #faccdf;
-  $govuk-baby-pink-25: #fdebf2;
-  $govuk-red: #b10e1e;
-  $govuk-red-50: #d9888c;
-  $govuk-red-25: #efcfd1;
-  $govuk-mellow-red: #df3034;
-  $govuk-mellow-red-50: #ef9998;
-  $govuk-mellow-red-25: #f9d6d6;
-  $govuk-orange: #f47738;
-  $govuk-orange-50: #fabb96;
-  $govuk-orange-25: #fde4d4;
-  $govuk-brown: #b58840;
-  $govuk-brown-50: #dac39c;
-  $govuk-brown-25: #f0e7d7;
-  $govuk-yellow: #ffbf47;
-  $govuk-yellow-50: #ffdf94;
-  $govuk-yellow-25: #fff2d3;
-  $govuk-grass-green: #85994b;
-  $govuk-grass-green-50: #c2cca3;
-  $govuk-grass-green-25: #e7ebda;
-  $govuk-green: #006435;
-  $govuk-green-50: #7fb299;
-  $govuk-green-25: #cce0d6;
-  $govuk-turquoise: #28a197;
-  $govuk-turquoise-50: #95d0cb;
-  $govuk-turquoise-25: #d5ecea;
-  $govuk-light-blue: #2b8cc4;
-  $govuk-light-blue-50: #96c6e2;
-  $govuk-light-blue-25: #d5e8f3;
+// Standard palette, colours
+$govuk-purple: #2e358b;
+$govuk-purple-50: #9799c4;
+$govuk-purple-25: #d5d6e7;
+$govuk-mauve: #6f72af;
+$govuk-mauve-50: #b7b9d7;
+$govuk-mauve-25: #e2e2ef;
+$govuk-fuschia: #912b88;
+$govuk-fuschia-50: #c994c3;
+$govuk-fuschia-25: #e9d4e6;
+$govuk-pink: #d53880;
+$govuk-pink-50: #eb9bbe;
+$govuk-pink-25: #f6d7e5;
+$govuk-baby-pink: #f499be;
+$govuk-baby-pink-50: #faccdf;
+$govuk-baby-pink-25: #fdebf2;
+$govuk-red: #b10e1e;
+$govuk-red-50: #d9888c;
+$govuk-red-25: #efcfd1;
+$govuk-mellow-red: #df3034;
+$govuk-mellow-red-50: #ef9998;
+$govuk-mellow-red-25: #f9d6d6;
+$govuk-orange: #f47738;
+$govuk-orange-50: #fabb96;
+$govuk-orange-25: #fde4d4;
+$govuk-brown: #b58840;
+$govuk-brown-50: #dac39c;
+$govuk-brown-25: #f0e7d7;
+$govuk-yellow: #ffbf47;
+$govuk-yellow-50: #ffdf94;
+$govuk-yellow-25: #fff2d3;
+$govuk-grass-green: #85994b;
+$govuk-grass-green-50: #c2cca3;
+$govuk-grass-green-25: #e7ebda;
+$govuk-green: #006435;
+$govuk-green-50: #7fb299;
+$govuk-green-25: #cce0d6;
+$govuk-turquoise: #28a197;
+$govuk-turquoise-50: #95d0cb;
+$govuk-turquoise-25: #d5ecea;
+$govuk-light-blue: #2b8cc4;
+$govuk-light-blue-50: #96c6e2;
+$govuk-light-blue-25: #d5e8f3;
 
-  // Standard palette, greys
-  $govuk-black: #0b0c0c;
-  $govuk-grey-1: #6f777b;
-  $govuk-grey-2: #bfc1c3;
-  $govuk-grey-3: #dee0e2;
-  $govuk-grey-4: #f8f8f8;
-  $govuk-white: #ffffff;
+// Standard palette, greys
+$govuk-black: #0b0c0c;
+$govuk-grey-1: #6f777b;
+$govuk-grey-2: #bfc1c3;
+$govuk-grey-3: #dee0e2;
+$govuk-grey-4: #f8f8f8;
+$govuk-white: #ffffff;
 
-  // Semantic colour names
-  $govuk-link-colour: $govuk-blue;
-  $govuk-link-active-colour: $govuk-light-blue;
-  $govuk-link-hover-colour: $govuk-light-blue;
-  $govuk-link-visited-colour: #4c2c92;
-  $govuk-button-colour: #00823b;
-  $govuk-focus-colour: $govuk-yellow;
-  $govuk-text-colour: $govuk-black;             // Standard text colour
-  $govuk-secondary-text-colour: $govuk-grey-1;  // Section headers, help text etc.
-  $govuk-border-colour: $govuk-grey-2;          // Borders, seperators, rules, keylines etc.
-  $govuk-panel-colour: $govuk-grey-3;           // Related links panel, page footer etc.
-  $govuk-canvas-colour: $govuk-grey-4;          // Page background
-  $govuk-highlight-colour: $govuk-grey-4;       // Table stripes etc.
-  $govuk-page-colour: $govuk-white;             // The page
-  $govuk-discovery-colour: $govuk-fuschia;      // Discovery badges and banners
-  $govuk-alpha-colour: $govuk-pink;             // Alpha badges and banners
-  $govuk-beta-colour: $govuk-orange;            // Beta badges and banners
-  $govuk-live-colour: $govuk-grass-green;       // Live badges and banners
-  $govuk-banner-text-colour: #000000;        // Text colour for Alpha & Beta banners
-  $govuk-error-colour: $govuk-red;              // Error text and border colour
-  $govuk-error-background: #fef7f7;       // Error background colour
+// Semantic colour names
+$govuk-link-colour: $govuk-blue;
+$govuk-link-active-colour: $govuk-light-blue;
+$govuk-link-hover-colour: $govuk-light-blue;
+$govuk-link-visited-colour: #4c2c92;
+$govuk-button-colour: #00823b;
+$govuk-focus-colour: $govuk-yellow;
+$govuk-text-colour: $govuk-black;             // Standard text colour
+$govuk-secondary-text-colour: $govuk-grey-1;  // Section headers, help text etc.
+$govuk-border-colour: $govuk-grey-2;          // Borders, seperators, rules, keylines etc.
+$govuk-panel-colour: $govuk-grey-3;           // Related links panel, page footer etc.
+$govuk-canvas-colour: $govuk-grey-4;          // Page background
+$govuk-highlight-colour: $govuk-grey-4;       // Table stripes etc.
+$govuk-page-colour: $govuk-white;             // The page
+$govuk-discovery-colour: $govuk-fuschia;      // Discovery badges and banners
+$govuk-alpha-colour: $govuk-pink;             // Alpha badges and banners
+$govuk-beta-colour: $govuk-orange;            // Beta badges and banners
+$govuk-live-colour: $govuk-grass-green;       // Live badges and banners
+$govuk-banner-text-colour: #000000;        // Text colour for Alpha & Beta banners
+$govuk-error-colour: $govuk-red;              // Error text and border colour
+$govuk-error-background: #fef7f7;       // Error background colour
 
-  // https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/styleguide/_colours.scss#L3
-  // GOV.UK template colours
+// https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/styleguide/_colours.scss#L3
+// GOV.UK template colours
 
-  $govuk-proposition-border: #2e3133;
-  // Based on GOV.UK brand blue but slightly lighter so it hits contrast on the
-  // black header bar when used as copy colour.
-  $govuk-proposition-active-nav: #1d8feb;
+$govuk-proposition-border: #2e3133;
+// Based on GOV.UK brand blue but slightly lighter so it hits contrast on the
+// black header bar when used as copy colour.
+$govuk-proposition-active-nav: #1d8feb;
 
-  $govuk-footer-background: $govuk-grey-3;
-  $govuk-footer-border-top: #a1acb2;
-  $govuk-footer-link: #454a4c;
-  $govuk-footer-link-hover: #171819;
-  $govuk-footer-text: $govuk-footer-link;
+$govuk-footer-background: $govuk-grey-3;
+$govuk-footer-border-top: #a1acb2;
+$govuk-footer-link: #454a4c;
+$govuk-footer-link-hover: #171819;
+$govuk-footer-text: $govuk-footer-link;
 
-  // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_organisation.scss
+// https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_organisation.scss
 
-  // We use `websafe` to mean strong enough contrast against white to
-  // be used for copy and meet the AAA (large text) and AA (smaller
-  // copy) WCAG guidelines.
+// We use `websafe` to mean strong enough contrast against white to
+// be used for copy and meet the AAA (large text) and AA (smaller
+// copy) WCAG guidelines.
 
-  $govuk-attorney-generals-office: #9f1888;
-  $govuk-attorney-generals-office-websafe: #a03a88;
-  $govuk-cabinet-office: #005abb;
-  $govuk-cabinet-office-websafe: #347da4;
-  $govuk-civil-service: #af292e;
-  $govuk-department-for-business-innovation-skills: #003479;
-  $govuk-department-for-business-innovation-skills-websafe: #347da4;
-  $govuk-department-for-communities-and-local-government: #00857e;
-  $govuk-department-for-communities-and-local-government-websafe: #37836e;
-  $govuk-department-for-culture-media-sport: #d40072;
-  $govuk-department-for-culture-media-sport-websafe: #a03155;
-  $govuk-department-for-education: #003a69;
-  $govuk-department-for-education-websafe: #347ca9;
-  $govuk-department-for-environment-food-rural-affairs: #00a33b;
-  $govuk-department-for-international-development: #002878;
-  $govuk-department-for-international-development-websafe: #405e9a;
-  $govuk-department-for-transport: #006c56;
-  $govuk-department-for-transport-websafe: #398373;
-  $govuk-department-for-work-pensions: #00beb7;
-  $govuk-department-for-work-pensions-websafe: #37807b;
-  $govuk-department-of-energy-climate-change: #009ddb;
-  $govuk-department-of-energy-climate-change-websafe: #2b7cac;
-  $govuk-department-of-health: #00ad93;
-  $govuk-department-of-health-websafe: #39836e;
-  $govuk-foreign-commonwealth-office: #003e74;
-  $govuk-foreign-commonwealth-office-websafe: #406e97;
-  $govuk-government-equalities-office: #9325b2;
-  $govuk-hm-government: #0076c0;
-  $govuk-hm-government-websafe: #347da4;
-  $govuk-hm-revenue-customs: #009390;
-  $govuk-hm-revenue-customs-websafe: #008770;
-  $govuk-hm-treasury: #af292e;
-  $govuk-hm-treasury-websafe: #832322;
-  $govuk-home-office: #9325b2;
-  $govuk-home-office-websafe: #9440b2;
-  $govuk-ministry-of-defence: #4d2942;
-  $govuk-ministry-of-defence-websafe: #5a5c92;
-  $govuk-ministry-of-justice: #231f20;
-  $govuk-ministry-of-justice-websafe: #5a5c92;
-  $govuk-northern-ireland-office: #002663;
-  $govuk-northern-ireland-office-websafe: #3e598c;
-  $govuk-office-of-the-advocate-general-for-scotland: #002663;
-  $govuk-office-of-the-advocate-general-for-scotland-websafe: $govuk-link-colour;
-  $govuk-office-of-the-leader-of-the-house-of-lords: #9c132e;
-  $govuk-office-of-the-leader-of-the-house-of-lords-websafe: #c2395d;
-  $govuk-scotland-office: #002663;
-  $govuk-scotland-office-websafe: #405c8a;
-  // Note: the "the" part here will get dropped
-  $govuk-the-office-of-the-leader-of-the-house-of-commons: #317023;
-  $govuk-the-office-of-the-leader-of-the-house-of-commons-websafe: #005f8f;
-  $govuk-uk-export-finance: #005747;
-  $govuk-uk-export-finance-websafe: $govuk-link-colour;
-  $govuk-uk-trade-investment: #c80651;
-  $govuk-uk-trade-investment-websafe: $govuk-link-colour;
-  $govuk-wales-office: #a33038;
-  $govuk-wales-office-websafe: #7a242a;
+$govuk-attorney-generals-office: #9f1888;
+$govuk-attorney-generals-office-websafe: #a03a88;
+$govuk-cabinet-office: #005abb;
+$govuk-cabinet-office-websafe: #347da4;
+$govuk-civil-service: #af292e;
+$govuk-department-for-business-innovation-skills: #003479;
+$govuk-department-for-business-innovation-skills-websafe: #347da4;
+$govuk-department-for-communities-and-local-government: #00857e;
+$govuk-department-for-communities-and-local-government-websafe: #37836e;
+$govuk-department-for-culture-media-sport: #d40072;
+$govuk-department-for-culture-media-sport-websafe: #a03155;
+$govuk-department-for-education: #003a69;
+$govuk-department-for-education-websafe: #347ca9;
+$govuk-department-for-environment-food-rural-affairs: #00a33b;
+$govuk-department-for-international-development: #002878;
+$govuk-department-for-international-development-websafe: #405e9a;
+$govuk-department-for-transport: #006c56;
+$govuk-department-for-transport-websafe: #398373;
+$govuk-department-for-work-pensions: #00beb7;
+$govuk-department-for-work-pensions-websafe: #37807b;
+$govuk-department-of-energy-climate-change: #009ddb;
+$govuk-department-of-energy-climate-change-websafe: #2b7cac;
+$govuk-department-of-health: #00ad93;
+$govuk-department-of-health-websafe: #39836e;
+$govuk-foreign-commonwealth-office: #003e74;
+$govuk-foreign-commonwealth-office-websafe: #406e97;
+$govuk-government-equalities-office: #9325b2;
+$govuk-hm-government: #0076c0;
+$govuk-hm-government-websafe: #347da4;
+$govuk-hm-revenue-customs: #009390;
+$govuk-hm-revenue-customs-websafe: #008770;
+$govuk-hm-treasury: #af292e;
+$govuk-hm-treasury-websafe: #832322;
+$govuk-home-office: #9325b2;
+$govuk-home-office-websafe: #9440b2;
+$govuk-ministry-of-defence: #4d2942;
+$govuk-ministry-of-defence-websafe: #5a5c92;
+$govuk-ministry-of-justice: #231f20;
+$govuk-ministry-of-justice-websafe: #5a5c92;
+$govuk-northern-ireland-office: #002663;
+$govuk-northern-ireland-office-websafe: #3e598c;
+$govuk-office-of-the-advocate-general-for-scotland: #002663;
+$govuk-office-of-the-advocate-general-for-scotland-websafe: $govuk-link-colour;
+$govuk-office-of-the-leader-of-the-house-of-lords: #9c132e;
+$govuk-office-of-the-leader-of-the-house-of-lords-websafe: #c2395d;
+$govuk-scotland-office: #002663;
+$govuk-scotland-office-websafe: #405c8a;
+// Note: the "the" part here will get dropped
+$govuk-the-office-of-the-leader-of-the-house-of-commons: #317023;
+$govuk-the-office-of-the-leader-of-the-house-of-commons-websafe: #005f8f;
+$govuk-uk-export-finance: #005747;
+$govuk-uk-export-finance-websafe: $govuk-link-colour;
+$govuk-uk-trade-investment: #c80651;
+$govuk-uk-trade-investment-websafe: $govuk-link-colour;
+$govuk-wales-office: #a33038;
+$govuk-wales-office-websafe: #7a242a;
 
-  // All organisation colours in a list
-  // (class_name, brand colour, WCAG acceptible text colour)
-  //
-  // example usage:
-  // @each $govuk-organisation in $govuk-all-organisation-brand-colours {
-  //    .#{nth($govuk-organisation, 1)} {
-  //      border-color: nth($govuk-organisation, 2);
-  //    }
-  // }
+// All organisation colours in a list
+// (class_name, brand colour, WCAG acceptible text colour)
+//
+// example usage:
+// @each $govuk-organisation in $govuk-all-organisation-brand-colours {
+//    .#{nth($govuk-organisation, 1)} {
+//      border-color: nth($govuk-organisation, 2);
+//    }
+// }
 
-  $govuk-all-organisation-brand-colours: (
-    "govuk-attorney-generals-office": $govuk-attorney-generals-office $govuk-attorney-generals-office-websafe,
-    "govuk-cabinet-office": $govuk-cabinet-office $govuk-cabinet-office-websafe,
-    "govuk-civil-service": $govuk-civil-service $govuk-civil-service,
-    "govuk-department-for-business-innovation-skills": $govuk-department-for-business-innovation-skills $govuk-department-for-business-innovation-skills-websafe,
-    "govuk-department-for-communities-and-local-government": $govuk-department-for-communities-and-local-government $govuk-department-for-communities-and-local-government-websafe,
-    "govuk-department-for-culture-media-sport": $govuk-department-for-culture-media-sport $govuk-department-for-culture-media-sport-websafe,
-    "govuk-department-for-education": $govuk-department-for-education $govuk-department-for-education-websafe,
-    "govuk-department-for-environment-food-rural-affairs": $govuk-department-for-environment-food-rural-affairs $govuk-department-for-environment-food-rural-affairs,
-    "govuk-department-for-international-development": $govuk-department-for-international-development $govuk-department-for-international-development-websafe,
-    "govuk-department-for-transport": $govuk-department-for-transport $govuk-department-for-transport-websafe,
-    "govuk-department-for-work-pensions": $govuk-department-for-work-pensions $govuk-department-for-work-pensions-websafe,
-    "govuk-department-of-energy-climate-change": $govuk-department-of-energy-climate-change $govuk-department-of-energy-climate-change-websafe,
-    "govuk-department-of-health": $govuk-department-of-health $govuk-department-of-health-websafe,
-    "govuk-foreign-commonwealth-office": $govuk-foreign-commonwealth-office $govuk-foreign-commonwealth-office-websafe,
-    "govuk-hm-government": $govuk-hm-government $govuk-hm-government-websafe,
-    "govuk-hm-revenue-customs": $govuk-hm-revenue-customs $govuk-hm-revenue-customs-websafe,
-    "govuk-hm-treasury": $govuk-hm-treasury $govuk-hm-treasury-websafe,
-    "govuk-home-office": $govuk-home-office $govuk-home-office-websafe,
-    "govuk-ministry-of-defence": $govuk-ministry-of-defence $govuk-ministry-of-defence-websafe,
-    "govuk-ministry-of-justice": $govuk-ministry-of-justice $govuk-ministry-of-justice-websafe,
-    "govuk-northern-ireland-office": $govuk-northern-ireland-office $govuk-northern-ireland-office-websafe,
-    "govuk-office-of-the-advocate-general-for-scotland": $govuk-office-of-the-advocate-general-for-scotland $govuk-office-of-the-advocate-general-for-scotland-websafe,
-    "govuk-office-of-the-leader-of-the-house-of-lords": $govuk-office-of-the-leader-of-the-house-of-lords $govuk-office-of-the-leader-of-the-house-of-lords-websafe,
-    "govuk-scotland-office": $govuk-scotland-office $govuk-scotland-office-websafe,
-    "govuk-the-office-of-the-leader-of-the-house-of-commons": $govuk-the-office-of-the-leader-of-the-house-of-commons $govuk-the-office-of-the-leader-of-the-house-of-commons-websafe,
-    "govuk-uk-export-finance": $govuk-uk-export-finance $govuk-uk-export-finance-websafe,
-    "govuk-uk-trade-investment": $govuk-uk-trade-investment $govuk-uk-trade-investment-websafe,
-    "govuk-wales-office": $govuk-wales-office $govuk-wales-office-websafe
-  );
-}
+$govuk-all-organisation-brand-colours: (
+  "govuk-attorney-generals-office": $govuk-attorney-generals-office $govuk-attorney-generals-office-websafe,
+  "govuk-cabinet-office": $govuk-cabinet-office $govuk-cabinet-office-websafe,
+  "govuk-civil-service": $govuk-civil-service $govuk-civil-service,
+  "govuk-department-for-business-innovation-skills": $govuk-department-for-business-innovation-skills $govuk-department-for-business-innovation-skills-websafe,
+  "govuk-department-for-communities-and-local-government": $govuk-department-for-communities-and-local-government $govuk-department-for-communities-and-local-government-websafe,
+  "govuk-department-for-culture-media-sport": $govuk-department-for-culture-media-sport $govuk-department-for-culture-media-sport-websafe,
+  "govuk-department-for-education": $govuk-department-for-education $govuk-department-for-education-websafe,
+  "govuk-department-for-environment-food-rural-affairs": $govuk-department-for-environment-food-rural-affairs $govuk-department-for-environment-food-rural-affairs,
+  "govuk-department-for-international-development": $govuk-department-for-international-development $govuk-department-for-international-development-websafe,
+  "govuk-department-for-transport": $govuk-department-for-transport $govuk-department-for-transport-websafe,
+  "govuk-department-for-work-pensions": $govuk-department-for-work-pensions $govuk-department-for-work-pensions-websafe,
+  "govuk-department-of-energy-climate-change": $govuk-department-of-energy-climate-change $govuk-department-of-energy-climate-change-websafe,
+  "govuk-department-of-health": $govuk-department-of-health $govuk-department-of-health-websafe,
+  "govuk-foreign-commonwealth-office": $govuk-foreign-commonwealth-office $govuk-foreign-commonwealth-office-websafe,
+  "govuk-hm-government": $govuk-hm-government $govuk-hm-government-websafe,
+  "govuk-hm-revenue-customs": $govuk-hm-revenue-customs $govuk-hm-revenue-customs-websafe,
+  "govuk-hm-treasury": $govuk-hm-treasury $govuk-hm-treasury-websafe,
+  "govuk-home-office": $govuk-home-office $govuk-home-office-websafe,
+  "govuk-ministry-of-defence": $govuk-ministry-of-defence $govuk-ministry-of-defence-websafe,
+  "govuk-ministry-of-justice": $govuk-ministry-of-justice $govuk-ministry-of-justice-websafe,
+  "govuk-northern-ireland-office": $govuk-northern-ireland-office $govuk-northern-ireland-office-websafe,
+  "govuk-office-of-the-advocate-general-for-scotland": $govuk-office-of-the-advocate-general-for-scotland $govuk-office-of-the-advocate-general-for-scotland-websafe,
+  "govuk-office-of-the-leader-of-the-house-of-lords": $govuk-office-of-the-leader-of-the-house-of-lords $govuk-office-of-the-leader-of-the-house-of-lords-websafe,
+  "govuk-scotland-office": $govuk-scotland-office $govuk-scotland-office-websafe,
+  "govuk-the-office-of-the-leader-of-the-house-of-commons": $govuk-the-office-of-the-leader-of-the-house-of-commons $govuk-the-office-of-the-leader-of-the-house-of-commons-websafe,
+  "govuk-uk-export-finance": $govuk-uk-export-finance $govuk-uk-export-finance-websafe,
+  "govuk-uk-trade-investment": $govuk-uk-trade-investment $govuk-uk-trade-investment-websafe,
+  "govuk-wales-office": $govuk-wales-office $govuk-wales-office-websafe
+);

--- a/src/globals/scss/_helpers.scss
+++ b/src/globals/scss/_helpers.scss
@@ -1,0 +1,8 @@
+@import "vars";
+
+// URL Helpers
+// A function which outputs a plain url which is prefixed with a defined
+// path variable.
+@function file-url($file) {
+  @return url($global-images + $file);
+}

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,0 +1,16 @@
+$base-font-size: 16px !default;
+
+@function rem($px) {
+  @return ($px / $base-font-size) * 1rem;
+}
+
+@mixin font-size($px) {
+  // sass-lint:disable no-duplicate-properties
+  font-size: $px;
+  font-size: rem($px);
+}
+
+@mixin core-16 {
+  @include font-size(16px);
+  line-height: (20 / 16);
+}

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -1,0 +1,1 @@
+$global-images: "./src/globals/images/";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,5 +1,4 @@
 @import "import-once";
 
-@import "colours";
 @import "../../components/component-example/component-example";
 @import "../../components/link-back/link-back";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -2,3 +2,4 @@
 
 @import "colours";
 @import "../../components/component-example/component-example";
+@import "../../components/link-back/link-back";


### PR DESCRIPTION
This PR adds a back link component, following our [css naming conventions](https://github.com/alphagov/govuk-frontend/blob/master/docs/coding-standards/css.md).

It adds global files for:

`_helpers.scss` 
- adds a file-url helper, this a simpler version of the file-url helper, from the govuk_frontend_toolkit, used for image paths. 

`_vars.scss` 
- adds a $global-images variable for use with the file-url helper

`_typography.scss`
- set 16px as the base font size
- add a function to convert pixels to rem
- use the rem function in the font-size mixin, to output a rem value from a pixel value with a fallback in pixels
- add a core-16 mixin - for now, create core- mixins for the font sizes we are using. This will
give us an idea which of the core typography styles are used by components.

The import-once wrapper is removed from`_colours.scss` , this file doesn't output any css - as it is only contains colour variables, so the wrapper isn't required.

Other things to note about this component:
- top and bottom spacing has been removed
- the inline-block mixin has been removed
- we still have a value which isn't a variable (14px) for left padding
- in future, when we start work on icons - we'd like to use a svg icon with png fallback for the left arrow
