### PR TITLE
Preview components HTML

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,8 @@ const gutil = require('gulp-util')
 const sasslint = require('gulp-sass-lint')
 const sass = require('gulp-sass')
 const runsequence = require('run-sequence')
+const gls = require('gulp-live-server')
+const inject = require('gulp-inject')
 
 // Styles build task ---------------------
 // Compiles CSS from Sass
@@ -35,6 +37,13 @@ gulp.task('scss:compile', () => {
 // ---------------------------------------
 gulp.task('watch', () => {
   gulp.watch([paths.src + '**/**/*.scss'], ['styles'])
+  const watcher = gulp.watch([paths.src + 'components/**/*.html'], ['combine:html'])
+  watcher.on('change', event => {
+    if (event.type === 'deleted') {
+      gulp.watch([paths.src + 'components/**/*.html'], ['combine:html'])
+    }
+    gulp.watch([paths.src + 'components/**/*.html'], ['combine:html'])
+  })
 })
 
 // Dev task --------------------------
@@ -42,7 +51,34 @@ gulp.task('watch', () => {
 // ---------------------------------------
 gulp.task('dev', cb => {
   runsequence('styles',
-              'watch', cb)
+              'watch',
+              'combine:html',
+              'serve', cb)
+})
+
+// Serve task --------------------------
+// Creates a server to preview components
+// ---------------------------------------
+gulp.task('serve', () => {
+  const server = gls.static(paths.dist, 8888)
+  server.start()
+  gulp.watch([paths.src + 'components/**/*.html'], ['combine:html'], file => {
+    server.notify.apply(server, [file])
+  })
+})
+
+// Combine html task --------------------------
+// Combines all html files in components into a single  file
+// ---------------------------------------
+gulp.task('combine:html', () => {
+  gulp.src(paths.dist + 'index.html')
+  .pipe(inject(gulp.src([paths.src + 'components/**/*.html']), {
+    starttag: '<!-- inject:html -->',
+    transform: function (filePath, file) {
+      return file.contents.toString('utf8')
+    }
+  }))
+  .pipe(gulp.dest(paths.dist))
 })
 
 // Default task --------------------------

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
+    "gulp-concat": "^2.6.1",
+    "gulp-inject": "^4.2.0",
+    "gulp-live-server": "0.0.30",
     "gulp-sass": "^3.1.0",
     "gulp-sass-lint": "^1.3.2",
     "run-sequence": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "gulp": "^3.9.1",
-    "gulp-concat": "^2.6.1",
     "gulp-inject": "^4.2.0",
     "gulp-live-server": "0.0.30",
     "gulp-sass": "^3.1.0",

--- a/src/components/component-example/component-example.html
+++ b/src/components/component-example/component-example.html
@@ -1,0 +1,5 @@
+Example component preview
+
+<div>
+  Example component html
+</div>


### PR DESCRIPTION
Utilising gulp-inject to grab html from all components and
injecting into a index.html preview file that is served with
gulp-live-server. Any change to component html will rebuild the
preview file. Added to `gulp dev` task.