### PR TITLE
Add a phase banner component

### DIFF
--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -1,0 +1,3 @@
+# Phase (Alpha and beta) banners
+
+You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.

--- a/src/components/phase-banner/_phase-banner.html
+++ b/src/components/phase-banner/_phase-banner.html
@@ -1,0 +1,17 @@
+<div class="govuk-c-phase-banner">
+  <p class="govuk-c-phase-banner__content">
+    <strong class="govuk-c-phase-banner__tag">ALPHA</strong>
+    <span class="govuk-c-phase-banner__text">
+      This is a new service – your <a href="#">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>
+
+<div class="govuk-c-phase-banner">
+  <p class="govuk-c-phase-banner__content">
+    <strong class="govuk-c-phase-banner__tag">BETA</strong>
+    <span class="govuk-c-phase-banner__text">
+      This is a new service – your <a href="#">feedback</a> will help us to improve it.
+    </span>
+  </p>
+</div>

--- a/src/components/phase-banner/_phase-banner.html
+++ b/src/components/phase-banner/_phase-banner.html
@@ -1,6 +1,6 @@
 <div class="govuk-c-phase-banner">
   <p class="govuk-c-phase-banner__content">
-    <strong class="govuk-c-phase-banner__tag">ALPHA</strong>
+    <strong class="govuk-c-phase-tag">ALPHA</strong>
     <span class="govuk-c-phase-banner__text">
       This is a new service – your <a href="#">feedback</a> will help us to improve it.
     </span>
@@ -9,7 +9,7 @@
 
 <div class="govuk-c-phase-banner">
   <p class="govuk-c-phase-banner__content">
-    <strong class="govuk-c-phase-banner__tag">BETA</strong>
+    <strong class="govuk-c-phase-tag">BETA</strong>
     <span class="govuk-c-phase-banner__text">
       This is a new service – your <a href="#">feedback</a> will help us to improve it.
     </span>

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -2,6 +2,7 @@
 @import "../../globals/scss/colours";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/typography";
+@import "../phase-tag/phase-tag";
 
 @include exports("phase-banner") {
   .govuk-c-phase-banner {
@@ -20,20 +21,6 @@
   .govuk-c-phase-banner__content {
     display: table;
     margin: 0;
-  }
-
-  .govuk-c-phase-banner__tag {
-    display: inline-block;
-    margin: 0 8px 0 0;
-    padding: 4px 5px 0;
-
-    @include bold-16;
-    letter-spacing: 1px;
-    text-transform: uppercase;
-    text-decoration: none;
-
-    color: $govuk-white;
-    background-color: $govuk-blue;
   }
 
   .govuk-c-phase-banner__text {

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -1,0 +1,45 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/font-face";
+@import "../../globals/scss/typography";
+
+@include exports("phase-banner") {
+  .govuk-c-phase-banner {
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+
+    padding-top: em(10px, 16px);
+    padding-bottom: em(8px, 16px);
+    // Apply styling to tablet and upwards
+    // @include mq($from:tablet) {
+    //  padding-bottom: em(10px, 16px);
+    // }
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+  .govuk-c-phase-banner__content {
+    display: table;
+    margin: 0;
+  }
+
+  .govuk-c-phase-banner__tag {
+    display: inline-block;
+    margin: 0 8px 0 0;
+    padding: 4px 5px 0;
+
+    @include bold-16;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    text-decoration: none;
+
+    color: $govuk-white;
+    background-color: $govuk-blue;
+  }
+
+  .govuk-c-phase-banner__text {
+    display: table-cell;
+    vertical-align: baseline;
+    color: $govuk-banner-text-colour;
+    @include core-16;
+  }
+}

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -1,0 +1,6 @@
+# Phase tag
+
+## Alpha and Beta phase tags
+
+Phase tags are mostly used inside phase banners as an indication of the state of a project. It’s possible to use them outside phase banners, for example as part of a service header.
+

--- a/src/components/phase-tag/_phase-tag.html
+++ b/src/components/phase-tag/_phase-tag.html
@@ -1,0 +1,3 @@
+<strong class="govuk-c-phase-tag">ALPHA</strong>
+
+<strong class="govuk-c-phase-tag">BETA</strong>

--- a/src/components/phase-tag/_phase-tag.scss
+++ b/src/components/phase-tag/_phase-tag.scss
@@ -1,0 +1,23 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/font-face";
+@import "../../globals/scss/typography";
+
+@include exports("phase-tag") {
+  .govuk-c-phase-tag {
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+
+    display: inline-block;
+    margin: 0 8px 0 0;
+    padding: 4px 5px 0;
+
+    @include bold-16;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    text-decoration: none;
+
+    color: $govuk-white;
+    background-color: $govuk-blue;
+  }
+}

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -29,6 +29,12 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
   font-weight: 700;
 }
 
+@mixin bold-16 {
+  @include font-size(16px);
+  line-height: (20 / 16);
+  font-weight: 700;
+}
+
 @mixin core-36 {
   @include font-size(36px);
   line-height: (40 / 36);

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -3,3 +3,4 @@
 @import "../../components/component-example/component-example";
 @import "../../components/link-back/link-back";
 @import "../../components/panel/panel";
+@import "../../components/phase-banner/phase-banner";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -4,3 +4,4 @@
 @import "../../components/link-back/link-back";
 @import "../../components/panel/panel";
 @import "../../components/phase-banner/phase-banner";
+@import "../../components/phase-tag/phase-tag";


### PR DESCRIPTION
Copy HTML from govuk_elements and styles from the govuk_frontend_toolkit.
Add a README.
Create a new bold-16 mixin
Import the styles for the phase banner and phase tag components.

Also split out the styles for the phase-tag and create a new component for the phase tag.

![phase-banner-tag](https://cloud.githubusercontent.com/assets/417754/26623062/602859a6-45e4-11e7-8af7-b41b26f933d2.png)
