### PR TITLE
Copy over remaining styles for the panel component

### DIFF
--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -11,6 +11,7 @@
     text-align: center;
 
     font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
   }
 
   .govuk-c-panel--confirmation {
@@ -31,6 +32,9 @@
 
   .govuk-c-panel__body {
     @include core-36;
+    // TODO: Fix margin values
+    margin-top: em(11.250px, 48px);
+    margin-bottom: em(37.895px, 48px);
   }
 
 }

--- a/src/components/panel/panel.html
+++ b/src/components/panel/panel.html
@@ -4,6 +4,7 @@
   </h2>
   <div class="govuk-c-panel__body">
     Your reference number is
+    <br>
     <strong>HDJ2123F</strong>
   </div>
 </div>


### PR DESCRIPTION
Copy margin values from govuk_elements (not pretty, but we can fix these later).

Set `-webkit-font-smoothing` for the panel component (for  govuk_elements, this
is set on the `<main>` element and inherited by all content inside it).

Add missing `<br>` element before the reference number.