### PR TITLE
Add a list component and an error summary component

### DIFF
--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -1,0 +1,29 @@
+# Error summary
+
+## Summarise errors at the top of the page
+
+You must:
+* show an error summary at the top of the page
+* include a heading to alert the user to the error
+* link to each of the problematic questions
+
+## Implementation advice
+
+When an error occurs:
+
+* show an error summary at the top of the page
+* move keyboard focus to the start of the summary
+
+> to move keyboard focus, put tabindex="-1" on the containing div and use obj.focus()
+
+* indicate to screenreaders that the summary represents a collection of information
+
+> add the ARIA role="group" to the containing div
+
+* use a heading at the top of the summary
+* associate the heading with the summary box
+
+> use the ARIA attribute aria-labelledby on the containing div, so that screen readers will automatically announce the
+> heading as soon as focus is moved to the div
+
+* link from the error list in the summary to the fields with errors

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -1,0 +1,80 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/font-face";
+@import "../../globals/scss/typography";
+@import "../../globals/scss/vars";
+
+@include exports("error-summary") {
+
+  .govuk-c-error-summary {
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+    border: $govuk-border-width-mobile solid $govuk-error-colour;
+
+    margin-top: 15px; // should these be 16px?
+    margin-bottom: 15px;
+
+    padding: 15px 10px;
+
+    @include mq($from: tablet) {
+      border: $govuk-border-width-tablet solid $govuk-error-colour;
+
+      margin-top: 30px; // should this be 32px?
+      margin-bottom: 30px;
+
+      padding: 20px 15px 15px;
+    }
+
+    // TODO: Fix IE < 8
+    @include ie-lte(6) {
+      zoom: 1;
+    }
+  }
+
+  .govuk-c-error-summary:focus {
+    outline: $govuk-outline-width-focus solid $govuk-focus-colour;
+  }
+
+  .govuk-c-error-summary__title {
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+
+    @include bold-24;
+    margin-top: 0;
+    margin-bottom: .5em;
+
+    @include mq($from: tablet) {
+      margin-bottom: 20px;
+    }
+  }
+
+  .govuk-c-error-summary__body {
+    @include core-19;
+
+    p {
+      margin-top: 6px;
+      margin-bottom: 10px;
+    }
+  }
+
+  // The list should use a list component
+  .govuk-c-list {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-left: 0;
+    list-style-type: none;
+
+    > li {
+      @include mq($from: tablet) {
+        margin-bottom: 5px;
+      }
+    }
+
+    a {
+      color: $govuk-error-colour;
+      font-weight: bold;
+      text-decoration: underline;
+    }
+  }
+
+}

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -3,6 +3,7 @@
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
+@import "../list/list";
 
 @include exports("error-summary") {
 
@@ -51,26 +52,24 @@
   .govuk-c-error-summary__body {
     @include core-19;
 
+    // TODO: consistent paragraph margins
     p {
       margin-top: 6px;
       margin-bottom: 10px;
     }
   }
 
-  // The list should use a list component
-  .govuk-c-list {
+  // Cross-component class - adjusts styling of list component
+  .govuk-c-error-summary__list {
     margin-top: 0;
     margin-bottom: 0;
-    padding-left: 0;
-    list-style-type: none;
+  }
 
-    > li {
-      @include mq($from: tablet) {
-        margin-bottom: 5px;
-      }
-    }
-
-    a {
+  .govuk-c-error-summary__list a {
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
       color: $govuk-error-colour;
       font-weight: bold;
       text-decoration: underline;

--- a/src/components/error-summary/error-summary.html
+++ b/src/components/error-summary/error-summary.html
@@ -9,7 +9,7 @@
       Optional description of the errors and how to correct them
     </p>
 
-    <ul class="govuk-c-list">
+    <ul class="govuk-c-list govuk-c-error-summary__list">
       <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
     </ul>
   </div>

--- a/src/components/error-summary/error-summary.html
+++ b/src/components/error-summary/error-summary.html
@@ -1,0 +1,17 @@
+<div class="govuk-c-error-summary" aria-labelledby="error-summary-title" role="group" tabindex="-1">
+
+  <h1 class="govuk-c-error-summary__title" id="error-summary-title">
+    Message to alert the user to a problem goes here
+  </h1>
+
+  <div class="govuk-c-error-summary__body">
+    <p>
+      Optional description of the errors and how to correct them
+    </p>
+
+    <ul class="govuk-c-list">
+      <li><a href="#example-personal-details">Descriptive link to the question with an error</a></li>
+    </ul>
+  </div>
+
+</div>

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -1,0 +1,4 @@
+# List
+
+* list items start with a lowercase letter and have no full stop at the end
+* see the style guide to check how to [punctuate numbered lists](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps)

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -17,7 +17,27 @@
   }
 
   .govuk-c-list > li {
-    margin-bottom: 5px;
+    @include mq($from: tablet) {
+      margin-bottom: 5px;
+    }
+  }
+
+  .govuk-c-list a {
+    &:link {
+      color: $govuk-link-colour;
+    }
+
+    &:visited {
+      color: $govuk-link-visited-colour;
+    }
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    a:active {
+      color: $govuk-link-active-colour;
+    }
   }
 
   .govuk-c-list--bullet {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,0 +1,36 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/font-face";
+@import "../../globals/scss/typography";
+@import "../../globals/scss/vars";
+
+@include exports("list") {
+  .govuk-c-list {
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+    @include core-19;
+
+    padding-left: 0;
+    margin-top: 5px;
+    margin-bottom: 20px;
+    list-style-type: none;
+  }
+
+  .govuk-c-list > li {
+    margin-bottom: 5px;
+  }
+
+  .govuk-c-list--bullet {
+    list-style-type: disc;
+    padding-left: 20px;
+  }
+
+  .govuk-c-list--number {
+    list-style-type: decimal;
+    padding-left: 20px;
+    // TODO: Fix IE < 8
+    @include ie-lte(7) {
+      padding-left: 28px;
+    }
+  }
+}

--- a/src/components/list/list.html
+++ b/src/components/list/list.html
@@ -1,0 +1,19 @@
+<ul class="govuk-c-list">
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+  <li><a href="#">Related link</a></li>
+</ul>
+
+<ul class="govuk-c-list govuk-c-list--bullet">
+  <li>here is a bulleted list</li>
+  <li>vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor</li>
+  <li>vestibulum id ligula porta felis euismod semper</li>
+  <li>integer posuere erat a ante venenatis dapibus posuere velit aliquet</li>
+</ul>
+
+<ol class="govuk-c-list govuk-c-list--number">
+  <li>This is a numbered list.</li>
+  <li>This is the second step in a numbered list.</li>
+  <li>The third step is to make sure each item is a full sentence ending with a full stop.</li>
+</ol>
+

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -33,7 +33,7 @@
   .govuk-c-panel__body {
     @include core-36;
     // TODO: Fix margin values
-    margin-top: em(11.250px, 48px);
+    margin-top: em(11.25px, 48px);
     margin-bottom: em(37.895px, 48px);
   }
 

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -25,6 +25,12 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
   font-weight: 700;
 }
 
+@mixin bold-18 {
+  @include font-size(18px);
+  line-height: (21.6 / 18);
+  font-weight: 700;
+}
+
 @mixin bold-16 {
   @include font-size(16px);
   line-height: (20 / 16);
@@ -32,14 +38,24 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
 }
 
 @mixin bold-24 {
-  @include font-size(24px);
-  line-height: (30 / 24);
-  font-weight: 700;
+  @include bold-18;
+  @include mq($from: tablet) {
+    @include font-size(24px);
+    line-height: (30 / 24);
+  }
 }
 
 @mixin core-36 {
   @include font-size(36px);
   line-height: (40 / 36);
+}
+
+@mixin core-19 {
+  @include core-16;
+  @include mq($from: tablet) {
+    @include font-size(19px);
+    line-height: (25 / 19);
+  }
 }
 
 @mixin core-16 {

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -1,1 +1,6 @@
 $global-images: "/images/";
+
+$govuk-border-width-mobile: 4px;
+$govuk-border-width-tablet: 5px;
+
+$govuk-outline-width-focus: 3px;

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -2,6 +2,7 @@
 
 @import "../../components/component-example/component-example";
 @import "../../components/link-back/link-back";
+@import "../../components/list/list";
 @import "../../components/panel/panel";
 @import "../../components/phase-banner/phase-banner";
 @import "../../components/phase-tag/phase-tag";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,10 +1,10 @@
 @import "import-once";
 
+@import "../../components/button/button";
 @import "../../components/component-example/component-example";
+@import "../../components/error-summary/error-summary";
 @import "../../components/link-back/link-back";
 @import "../../components/list/list";
 @import "../../components/panel/panel";
 @import "../../components/phase-banner/phase-banner";
 @import "../../components/phase-tag/phase-tag";
-@import "../../components/button/button";
-@import "../../components/error-summary/error-summary";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -6,3 +6,4 @@
 @import "../../components/phase-banner/phase-banner";
 @import "../../components/phase-tag/phase-tag";
 @import "../../components/button/button";
+@import "../../components/error-summary/error-summary";


### PR DESCRIPTION
Add an error summary component:
- create mixins for new typographic styles
- add vars for border and outline widths
- use a list component inside the error summary component
- create a cross-component list modifier class
- add guidance for implementing an error-summary box

Add a list component: 
- and examples of lists - default, bulleted and numbered
- add documentation for a list component

Re-order the list of imported partials - so these are ordered alphabetically.

Use px for margins for now - a later PR will amend these to use em.

**Screenshots:**

![gov uk frontend - error summary](https://cloud.githubusercontent.com/assets/417754/26675614/86ebee9e-46bc-11e7-9225-6845d435464e.png)

![gov uk frontend - lists](https://cloud.githubusercontent.com/assets/417754/26675623/8cd60880-46bc-11e7-95dc-5ed04801fda7.png)



