### PR TITLE
Add lang attribute to html element

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
   <title>GOV.UK Frontend</title>
   <!-- head:css -->


### PR DESCRIPTION
This was picked up as an error by the WAVE accessibility toolbar, using
lang=“en” fixes this.