### PR TITLE
Use gulp-tenon to test component HTML

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ const gls = require('gulp-live-server')
 const inject = require('gulp-inject')
 const concat = require('gulp-concat')
 const standard = require('gulp-standard')
+const gtenon = require('gulp-tenon-client')
 
 // Styles build task ---------------------
 // Compiles CSS from Sass
@@ -36,6 +37,7 @@ gulp.task('scss:compile', () => {
 
 // Scripts build tasks --------------------
 // Lints, compiles javascript partials
+// ---------------------------------------
 gulp.task('js:compile', () => {
   return gulp.src([paths.src + '/**/*.js'])
     .pipe(concat('govuk-frontend.js'))
@@ -63,7 +65,7 @@ gulp.task('watch', () => {
   gulp.watch([paths.src + 'components/**/*.html'], ['preview:components'])
 })
 
-// Dev task --------------------------
+// Dev task ------------------------------
 // Compiles assets and sets up watches.
 // ---------------------------------------
 gulp.task('dev', cb => {
@@ -74,7 +76,7 @@ gulp.task('dev', cb => {
               'watch', cb)
 })
 
-// Serve task --------------------------
+// Serve task ---------------------------
 // Creates a server to preview components
 // ---------------------------------------
 gulp.task('serve', () => {
@@ -82,7 +84,7 @@ gulp.task('serve', () => {
   server.start()
 })
 
-// Preview components --------------------------
+// Preview components --------------------
 // Combines all html files in components into a single  file
 // Inserts compiled component css into the head of the page
 // ---------------------------------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,6 +103,22 @@ gulp.task('preview:components', () => {
   gulp.start('copy:images')
 })
 
+// Check HTML using Tenon ----------------
+// ---------------------------------------
+gulp.task('html:tenon', function () {
+  gulp.src('src/components/**/*.html', {read: false})
+  .pipe(gtenon({
+    key: 'fc7b85e07ea9b862c6422e412e999f3b',
+    snippet: true, // include errorSnippet in the console output
+    filter: [
+      3,  // Ignore: language of page is not set
+      31, // Ignore: link uses an invalid hypertext reference
+      64, // Ignore: page has no title
+      97  // Ignore: page has no headings
+    ]
+  }))
+})
+
 // Copy images --------------------------
 // Copy images to dist for component preview
 // ---------------------------------------

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -103,6 +103,15 @@ gulp.task('preview:components', () => {
   gulp.start('copy:images')
 })
 
+// Tests ----------------
+// ---------------------------------------
+gulp.task('test', cb => {
+  runsequence('html:tenon',
+              'js:lint',
+              'scss:lint',
+              cb)
+})
+
 // Check HTML using Tenon ----------------
 // ---------------------------------------
 gulp.task('html:tenon', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -209,6 +209,12 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true
     },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+      "dev": true
+    },
     "body-parser": {
       "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
@@ -1327,6 +1333,68 @@
       "resolved": "https://registry.npmjs.org/gulp-standard/-/gulp-standard-10.0.0.tgz",
       "integrity": "sha1-s2uBSKib/Q9Tc4kMGxx/ybGGjeE=",
       "dev": true
+    },
+    "gulp-tenon-client": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/gulp-tenon-client/-/gulp-tenon-client-0.1.1.tgz",
+      "integrity": "sha1-V5VBFeFrEHij2Hytxo5H1hbRA54=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true
+        },
+        "clone": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+          "integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
+          "dev": true
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true
+        }
+      }
     },
     "gulp-util": {
       "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
@@ -2962,6 +3030,20 @@
       "version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true
+    },
+    "tenon-api-client": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/tenon-api-client/-/tenon-api-client-0.1.7.tgz",
+      "integrity": "sha1-VpjjS+vvq0KZtZxaYdy327A95QE=",
+      "dev": true,
+      "dependencies": {
+        "clone": {
+          "version": "0.1.19",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz",
+          "integrity": "sha1-YT+2hjmyaklKxTJT4Vsaa9iK2oU=",
+          "dev": true
+        }
+      }
     },
     "text-table": {
       "version": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-sass": "^3.1.0",
     "gulp-sass-lint": "^1.3.2",
     "gulp-standard": "^10.0.0",
+    "gulp-tenon-client": "^0.1.1",
     "run-sequence": "^1.2.2",
     "standard": "^10.0.2"
   },


### PR DESCRIPTION
Add gulp-tenon-client as devDependency
Add a task to check component HTML using Tenon

Create a gulp task - test, to run all three "test" tasks - checking HTML using Tenon, linting JS using Standard and checking SCSS using scss-lint.

**Screenshot:**

![screen shot 2017-06-02 at 12 35 33](https://cloud.githubusercontent.com/assets/417754/26724194/04871724-4790-11e7-8cd4-602bfdbf085d.png)

