### PR TITLE
Docs - add rules for components

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,5 +17,6 @@ To follow.
 
 ## Docs
 
-[Coding Standards](/docs/coding-standards/) - our guides for CSS and JavaScript.
-[Legacy IE](/docs/legacy-ie.md) - legacy IE support
+* [coding standards](/docs/coding-standards/) - our guides for CSS and JavaScript
+* [components](/docs/components.md) - rules for components
+* [legacy IE](/docs/legacy-ie.md) - legacy IE support

--- a/docs/coding-standards/css.md
+++ b/docs/coding-standards/css.md
@@ -70,8 +70,9 @@ The reason for double hyphens and underscores after the block name, is so that t
 
     .govuk-c-phase-banner
 
-BEM stands for `Block__Element--Modifier`, not `Block__Element__Element--Modifier`.
-Avoid multiple element level naming.
+**Why?**
+
+Styles can be applied without location dependence. This prevents module styles interfering with global or sidewide styles.
 
 ## Nesting
 
@@ -100,10 +101,40 @@ Good:
 }
 ```
 
+BEM stands for `Block__Element--Modifier`, not `Block__Element__Element--Modifier`.
+
+Avoid multiple element level naming.
+
 **Why?**
 
 This makes the code base more searchable and straightforward, making it easier to maintain.
 It also  discourages the (bad) habit of excessive nesting.
+
+## Single Responsibility Principle
+
+Each class has a single purpose, so you can be sure when making a change to a class - it will only affect the element that class is applied to.
+
+Also when deprecating classes, all of the CSS for this class can be removed without affecting another component that had reused this css.
+
+**Why?**
+
+To ensure that styles can safely be added or removed without fear of breaking other components.
+
+## Component modifiers
+
+Keep all of the variants of a component in the same place.
+
+`.govuk-c-error-summary` modifies the `.govuk-c-list` component.
+
+Component modifiers use an extra class, scoped to the component:
+
+`.govuk-c-error-summary__list`
+
+This class is part of the component, rather than a parent of a component.
+
+**Why?**
+This makes it easier to keep track of different contexts.
+
 
 ### Further reading:
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,13 @@
+# Components
+
+All components must use the `.govuk-` namespace and the `c` prefix.
+
+For example, `.govuk-c-button`.
+
+All components must follow the conventions described in our [CSS coding standards](coding-standards/css.md).
+
+## Every component should:
+* use classes for child elements, scoped to the parent component
+* be flexible, not set a width or external padding and margins
+* set internal margins in a single direction
+* not rely on any other selector outside of the component scss file to style its children


### PR DESCRIPTION
Add documentation for component modifers to the CSS coding standards.

Add a set of rules for components - we can check that the components we have built so far adhere to these guidelines. 

