### PR TITLE
Add an input component

### DIFF
--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -1,0 +1,9 @@
+# Input
+
+A single-line text field.
+
+Make field widths proportional to the input they take.
+
+Ensure that users can enter the information they need at smaller screen sizes.
+
+Snap form fields to 100% width at smaller screen sizes.

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,0 +1,22 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/typography";
+
+@include exports("input") {
+  .govuk-c-input {
+    box-sizing: border-box; // should this be global?
+
+    font-family: $govuk-font-stack;
+    -webkit-font-smoothing: antialiased;
+    @include core-19;
+  }
+
+  .govuk-c-input--text {
+    width: 100%;
+    padding: 5px 4px 4px;
+
+    // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
+    // as background-color and color need to always be set together, color should not be set either
+    border: $govuk-border-width-form-element solid $govuk-text-colour;
+  }
+}

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -11,6 +11,10 @@
     @include core-19;
   }
 
+  .govuk-c-input:focus {
+    outline: $govuk-outline-width-focus solid $govuk-focus-colour;
+  }
+
   .govuk-c-input--text {
     width: 100%;
     padding: 5px 4px 4px;

--- a/src/components/input/input.html
+++ b/src/components/input/input.html
@@ -1,0 +1,1 @@
+<input class="govuk-c-input govuk-c-input--text" type="text">

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -2,6 +2,7 @@ $global-images: "/images/";
 
 $govuk-border-width-mobile: 4px;
 $govuk-border-width-tablet: 5px;
+$govuk-border-width-form-element: 2px;
 
 $govuk-outline-width-focus: 3px;
 $govuk-site-width: 960px;

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -10,3 +10,4 @@
 @import "../../components/phase-tag/phase-tag";
 @import "../../components/cookie-banner/cookie-banner";
 @import "../../components/breadcrumb/breadcrumb";
+@import "../../components/input/input";


### PR DESCRIPTION
Copy styles from govuk-elements for input type="text".

Create a text input modifier.

The name here is up for grabs, I went for input as it is the shortest, but we might want to use `form-input`. If so, do we then want to prefix all other form components with `form-`?