### PR TITLE
Add a label component

### DIFF
--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -1,0 +1,8 @@
+# Label
+
+* all form fields should be given labels
+* don’t hide labels, unless the surrounding context makes them unnecessary
+* labels should be aligned above their fields
+* label text should be short, direct and in sentence case
+* avoid colons at the end of labels
+* labels should be associated with form fields using the `for` attribute

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -1,0 +1,24 @@
+@import "import-once";
+@import "../../globals/scss/colours";
+
+@include exports("label") {
+  .govuk-c-label {
+    display: block;
+
+    font-family: $govuk-font-stack;
+    @include font-smoothing;
+    @include core-19;
+    color: $govuk-text-colour;
+  }
+
+  .govuk-c-label--bold {
+    font-weight: 700;
+  }
+
+  // Hint text sits inside a label, to be read by AT
+  .govuk-c-label__hint {
+    display: block;
+    color: $govuk-secondary-text-colour;
+    font-weight: 400;
+  }
+}

--- a/src/components/label/label.html
+++ b/src/components/label/label.html
@@ -1,0 +1,15 @@
+<label class="govuk-c-label">
+  National Insurance number
+  <span class="govuk-c-label__hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.
+  </span>
+</label>
+
+<label class="govuk-c-label govuk-c-label--bold">
+  National Insurance number
+  <span class="govuk-c-label__hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.
+  </span>
+</label>

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -11,3 +11,4 @@
 @import "../../components/cookie-banner/cookie-banner";
 @import "../../components/breadcrumb/breadcrumb";
 @import "../../components/input/input";
+@import "../../components/label/label";


### PR DESCRIPTION

![gov uk frontend](https://cloud.githubusercontent.com/assets/417754/26785229/39c70aaa-49f9-11e7-90a0-6d2c7f118649.png)

Copy label styles from govuk_elements.

Make hint text a child element of the label component.

Add guidance.