### PR TITLE
Add gulp task listing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,7 @@
 
 const paths = require('./config/paths.json')
 const gulp = require('gulp')
-const gutil = require('gulp-util')
+const taskListing = require('gulp-task-listing')
 const sasslint = require('gulp-sass-lint')
 const sass = require('gulp-sass')
 const runsequence = require('run-sequence')
@@ -192,17 +192,4 @@ gulp.task('copy:images', () => {
 // Default task --------------------------
 // Lists out available tasks.
 // ---------------------------------------
-gulp.task('default', () => {
-  const cyan = gutil.colors.cyan
-  const green = gutil.colors.green
-
-  gutil.log(green('----------'))
-
-  gutil.log(('The following main ') + cyan('tasks') + (' are available:'))
-
-  gutil.log(cyan('dev'
-    ) + ': compiles assets then sets up watches.'
-  )
-
-  gutil.log(green('----------'))
-})
+gulp.task('default', taskListing)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,6 +1680,12 @@
       "integrity": "sha1-s2uBSKib/Q9Tc4kMGxx/ybGGjeE=",
       "dev": true
     },
+    "gulp-task-listing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-task-listing/-/gulp-task-listing-1.0.1.tgz",
+      "integrity": "sha1-jT2IqTOBcV2A1m0I2cVVh9iJ8ro=",
+      "dev": true
+    },
     "gulp-tenon-client": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/gulp-tenon-client/-/gulp-tenon-client-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp-sass": "^3.1.0",
     "gulp-sass-lint": "^1.3.2",
     "gulp-standard": "^10.0.0",
+    "gulp-task-listing": "^1.0.1",
     "gulp-tenon-client": "^0.1.1",
     "merge-stream": "^1.0.1",
     "oldie": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "author": "Government Digital Service developers (https://gds.blog.gov.uk/)",
   "homepage": "https://github.com/alphagov/govuk-frontend#readme",
   "scripts": {
-    "test": "standard"
+    "start": "gulp dev",
+    "test": "standard && gulp test"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",


### PR DESCRIPTION
Set the default task to list out all available tasks.

Running `gulp` lists out main tasks and subtasks.

![screen shot 2017-06-06 at 08 58 41](https://cloud.githubusercontent.com/assets/417754/26819352/68288a20-4a96-11e7-8e26-bffa69ccbd3b.png)
