### PR TITLE
Add labels to the form input component

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,6 +1,8 @@
 @import "import-once";
 @import "../../globals/scss/colours";
 @import "../../globals/scss/typography";
+@import "../label/label";
+@import "../error-message/error-message";
 
 @include exports("input") {
   .govuk-c-input {
@@ -24,6 +26,10 @@
 
   .govuk-c-input:focus {
     outline: $govuk-outline-width-focus solid $govuk-focus-colour;
+  }
+
+  .govuk-c-input--error {
+    border: $govuk-border-width-error solid $govuk-error-colour;
   }
 
 }

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,13 +9,7 @@
     font-family: $govuk-font-stack;
     -webkit-font-smoothing: antialiased;
     @include core-19;
-  }
 
-  .govuk-c-input:focus {
-    outline: $govuk-outline-width-focus solid $govuk-focus-colour;
-  }
-
-  .govuk-c-input--text {
     width: 100%;
     padding: 5px 4px 4px;
 
@@ -26,6 +20,10 @@
     // Disable inner shadow and remove rounded corners
     -webkit-appearance: none;
     border-radius: 0;
-
   }
+
+  .govuk-c-input:focus {
+    outline: $govuk-outline-width-focus solid $govuk-focus-colour;
+  }
+
 }

--- a/src/components/input/input.html
+++ b/src/components/input/input.html
@@ -6,7 +6,7 @@
 <label class="govuk-c-label" for="govuk-c-label-b">
   National Insurance number
   <span class="govuk-c-error-message">
-    Enter your National Insurance number
+    Error message goes here
   </span>
 </label>
 <input class="govuk-c-input govuk-c-input--error" id="govuk-c-input-b" type="text">
@@ -29,7 +29,7 @@
     For example, ‘QQ 12 34 56 C’.
   </span>
   <span class="govuk-c-error-message">
-    Enter your National Insurance number
+    Error message goes here
   </span>
 </label>
 <input class="govuk-c-input govuk-c-input--error" id="govuk-c-input-d" type="text">

--- a/src/components/input/input.html
+++ b/src/components/input/input.html
@@ -1,1 +1,36 @@
-<input class="govuk-c-input govuk-c-input--text" type="text">
+<label class="govuk-c-label" for="govuk-c-input-a">
+  National Insurance number
+</label>
+<input class="govuk-c-input" id="govuk-c-input-a" type="text">
+
+<label class="govuk-c-label" for="govuk-c-label-b">
+  National Insurance number
+  <span class="govuk-c-error-message">
+    Enter your National Insurance number
+  </span>
+</label>
+<input class="govuk-c-input govuk-c-input--error" id="govuk-c-input-b" type="text">
+
+<label class="govuk-c-label" for="govuk-c-input-c">
+  National Insurance number
+  <span class="govuk-c-label__hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    <br>
+    For example, ‘QQ 12 34 56 C’.
+  </span>
+</label>
+<input class="govuk-c-input" id="govuk-c-input-c" type="text">
+
+<label class="govuk-c-label" for="govuk-c-label-d">
+  National Insurance number
+  <span class="govuk-c-label__hint">
+    It's on your National Insurance card, benefit letter, payslip or P60.
+    <br>
+    For example, ‘QQ 12 34 56 C’.
+  </span>
+  <span class="govuk-c-error-message">
+    Enter your National Insurance number
+  </span>
+</label>
+<input class="govuk-c-input govuk-c-input--error" id="govuk-c-input-d" type="text">
+

--- a/src/components/textarea/textarea.html
+++ b/src/components/textarea/textarea.html
@@ -6,7 +6,7 @@
 <label class="govuk-c-label" for="govuk-c-textarea-b">
   Why can't you provide a National Insurance number?
   <span class="govuk-c-error-message">
-    National Insurance number is not in the correct format
+    Error message goes here
   </span>
 </label>
 <textarea class="govuk-c-textarea govuk-c-textarea--error" name="govuk-c-textarea-b" id="govuk-c-textarea-b" rows="5"></textarea>


### PR DESCRIPTION
Show how the label component is used with the form input component.
Show error states.

Make error messages generic - use 'Error message goes here'.

![gov uk frontend](https://cloud.githubusercontent.com/assets/417754/26827334/a91473be-4ab4-11e7-8baa-0a8239086da2.png)
