### PR TITLE
Add a file upload component

### DIFF
--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -1,0 +1,13 @@
+# File upload
+
+A control that lets the user select a file.
+
+We recommend using a native input using `type="file"`, rather than a custom implementation.
+
+This is so:
+* the control gains focus when tabbing through the page
+* the control functions using a keyboard
+* the control functions using assistive technology
+* the control functions when javascript is not available
+
+A custom implementation of this control would need to meet the criteria above.

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -1,0 +1,19 @@
+@import "../../globals/scss/import-once";
+@import "../../globals/scss/vars";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/font-face";
+@import "../../globals/scss/typography";
+
+@include exports("file-upload") {
+  .govuk-c-file-upload {
+    @include core-19;
+  }
+
+  .govuk-c-file-upload:focus {
+    outline: $govuk-outline-width-focus solid $govuk-focus-colour;
+  }
+
+  .govuk-c-file-upload--error {
+    border: $govuk-border-width-error solid $govuk-error-colour;
+  }
+}

--- a/src/components/file-upload/file-upload.html
+++ b/src/components/file-upload/file-upload.html
@@ -1,0 +1,12 @@
+<label class="govuk-c-label" for="file-upload-a">
+  Upload a file
+</label>
+<input class="govuk-c-file-upload" type="file" id="file-upload-a">
+
+<label class="govuk-c-label" for="file-upload-b">
+  Upload a file
+  <span class="govuk-c-error-message">
+    Error message goes here
+  </span>
+</label>
+<input class="govuk-c-file-upload govuk-c-file-upload--error" type="file" id="file-upload-b">

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -15,3 +15,5 @@
 @import "../../components/table/table";
 @import "../../components/checkbox/checkbox";
 @import "../../components/radio/radio";
+@import "../../components/file-upload/file-upload";
+


### PR DESCRIPTION
Show examples of a file upload component and a variant displaying an
error message.

This is a *draft* version of this component - it needs work - by increasing the font size, this overrides the user agent styles of the "choose a file" button.

![file-upload](https://user-images.githubusercontent.com/417754/27023746-cc33f504-4f4b-11e7-9da0-5268ad058c7e.png)
