### PR TITLE
Fix scss lint error for table component

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -25,6 +25,7 @@
     text-align: left;
     border-bottom: 1px solid $govuk-border-colour;
   }
+
   .govuk-c-table__cell--numeric {
     font-family: $govuk-font-stack-tabular;
   }


### PR DESCRIPTION
28:1  warning  Space expected between blocks  empty-line-between-blocks

Add empty line between blocks.