### PR TITLE
Add date component

### DIFF
--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -1,0 +1,3 @@
+# Date
+
+Component for entering Day/Month/Year dates.

--- a/src/components/date/_date.scss
+++ b/src/components/date/_date.scss
@@ -1,0 +1,29 @@
+@import "../../globals/scss/import-once";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/typography";
+@import "../label/label";
+@import "../input/input";
+@import "../error-message/error-message";
+
+@include exports("date") {
+  .govuk-c-date {
+    @include clearfix;
+  }
+
+  .govuk-c-date__item {
+    width: 50px;
+    margin-right: 20px;
+    margin-bottom: 0;
+    clear: none;
+    float: left;
+  }
+
+  .govuk-c-date__label {
+    display: block;
+    padding-bottom: 2px;
+  }
+
+  .govuk-c-date__item--year {
+    width: 70px;
+  }
+}

--- a/src/components/date/date.html
+++ b/src/components/date/date.html
@@ -1,0 +1,32 @@
+<div class="govuk-c-date">
+  <div class="govuk-c-date__item govuk-c-date__item--day">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
+    <input class="govuk-c-input govuk-c-date__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+  </div>
+  <div class="govuk-c-date__item govuk-c-date__item--month">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
+    <input class="govuk-c-input govuk-c-date__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+  </div>
+  <div class="govuk-c-date__item govuk-c-date__item--year">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
+    <input class="govuk-c-input govuk-c-date__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+  </div>
+</div>
+
+<legend>
+  <span class="govuk-c-error-message">Error message goes here</span>
+</legend>
+<div class="govuk-c-date">
+  <div class="govuk-c-date__item govuk-c-date__item--day">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
+    <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+  </div>
+  <div class="govuk-c-date__item govuk-c-date__item--month">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
+    <input class="govuk-c-input govuk-c-date__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+  </div>
+  <div class="govuk-c-date__item govuk-c-date__item--year">
+    <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
+    <input class="govuk-c-input govuk-c-date__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+  </div>
+</div>

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -23,6 +23,16 @@
     -webkit-appearance: none;
     border-radius: 0;
   }
+  
+  .govuk-c-input::-webkit-outer-spin-button,
+  .govuk-c-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  .govuk-c-input[type="number"] {
+    -moz-appearance: textfield;
+  }
 
   .govuk-c-input:focus {
     outline: $govuk-outline-width-focus solid $govuk-focus-colour;

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -18,3 +18,4 @@
 @import "../../components/file-upload/file-upload";
 @import "../../components/details/details";
 @import "../../components/select-box/select-box";
+@import "../../components/date/date";


### PR DESCRIPTION
This PR:
Adds date component markup
Adds date component styles
Amends input component styles to contain type="number"

**Screenshot**
<img width="237" alt="screen shot 2017-06-12 at 13 15 24" src="https://user-images.githubusercontent.com/3758555/27033487-7207a67c-4f71-11e7-9fac-6f88c31a697b.png">

Related: Amend usage docs separately for this and all other components
