### PR TITLE
Amends create:package to uncomment npm guide

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,6 +98,7 @@ gulp.task('scss:compile:ie', () => {
 // ---------------------------------------
 gulp.task('create:package', () => {
   let filterComponents = filter([paths.components + '**/*.scss'], {restore: true})
+  let readmeComponents = filter([paths.components + '**/*.md'], {restore: true})
   let components = gulp.src([paths.components + '**/*'])
     .pipe(changed(paths.packages))
     .pipe(replace('../../globals/scss', '@govuk-frontend/globals'))
@@ -108,9 +109,14 @@ gulp.task('create:package', () => {
       require('postcss-nested')
     ], {syntax: require('postcss-scss')}))
     .pipe(filterComponents.restore)
+    .pipe(readmeComponents)
+    .pipe(replace('<!--', ''))
+    .pipe(replace('-->', ''))
+    .pipe(readmeComponents.restore)
     .pipe(flatten({includeParents: -1}))
     .pipe(gulp.dest(paths.packages))
   let filterGlobals = filter([paths.globalScss + '**/*.scss'], {restore: true})
+  let readmeGlobals = filter([paths.globalScss + '**/*.md'], {restore: true})
   let globals = gulp.src([
     paths.globalScss + '**/*',
     '!' + paths.globalScss + 'govuk-frontend.scss',
@@ -124,6 +130,10 @@ gulp.task('create:package', () => {
       require('postcss-nested')
     ], {syntax: require('postcss-scss')}))
     .pipe(filterGlobals.restore)
+    .pipe(readmeGlobals)
+    .pipe(replace('<!--', ''))
+    .pipe(replace('-->', ''))
+    .pipe(readmeGlobals.restore)
     .pipe(flatten({includeParents: 1}))
     .pipe(rename({
       dirname: 'globals'

--- a/src/components/component-example/README.md
+++ b/src/components/component-example/README.md
@@ -1,3 +1,23 @@
-# Component example
+# Component name
 
 Description of component.
+
+## Guidance
+
+Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere)
+
+## Usage
+
+Code example(s)
+
+```
+// code goes here
+```
+
+<!--
+## Installation
+
+```
+npm i @govuk-frontend/name --save-dev
+```
+-->


### PR DESCRIPTION
This PR:
Amends the `gulp create:package` task to uncomment npm installation section of the README file when package is created for npm publishing.
Adds example README teh component-example/README.md


Note: When we have a task to create `dist/` files and folders we could reverse, so that npm section gets commented out in there