### PR TITLE
Fix: path to sass-mq and ensure it is a dependency of the global package

### DIFF
--- a/packages/globals/package.json
+++ b/packages/globals/package.json
@@ -1,4 +1,7 @@
 {
   "name": "@govuk-frontend/globals",
-  "version": "0.0.1-alpha"
+  "version": "0.0.1-alpha",
+  "dependencies": {
+    "sass-mq": "^3.3.2"
+  }
 }

--- a/src/globals/scss/_media-queries.scss
+++ b/src/globals/scss/_media-queries.scss
@@ -60,5 +60,5 @@ $mq-static-breakpoint: desktop;
 // to this list, ordered by width, e.g. (mobile, tablet, desktop).
 $mq-show-breakpoints: (mobile, tablet, desktop);
 
-@import "../../../node_modules/sass-mq/mq";
+@import "./node_modules/sass-mq/mq";
 


### PR DESCRIPTION
[sass-mq](https://github.com/sass-mq/sass-mq) is used by the `_media-queries.scss` partial, packaged as part of the global package.

Include it as a dependency in package.json and fix the path to `node_modules`.