### PR TITLE
Fix: Import path for example component and property order

### DIFF
--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -5,13 +5,15 @@
 
 @include exports("inset-text") {
   .govuk-c-inset-text {
+    margin-bottom: em(15, 19);
+    padding: em(15, 19);
+
+    clear: both;
+
     font-family: $govuk-font-stack;
     @include core-19;
     @include font-smoothing;
     @include govuk-u-border-left($govuk-border-width-wide, $govuk-border-colour);
-    clear: both;
-    padding: em(15, 19);
-    margin-bottom: em(15, 19);
 
     :first-child {
       margin-top: 0;

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,5 +1,4 @@
 @import "../../components/button/button";
-@import "../../components/component-example/component-example";
 @import "../../components/error-summary/error-summary";
 @import "../../components/link-back/link-back";
 @import "../../components/list/list";


### PR DESCRIPTION
Remove the example component from the list partials imported by govuk-frontend.scss

Fix the property order for the inset text component.