### PR TITLE
Fix: Add the govuk- prefix to core and bold typography mixins

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -18,7 +18,7 @@
   }
 
   .govuk-c-breadcrumb__list-item {
-    @include core-16;
+    @include govuk-core-16;
     margin-bottom: .4em;
     margin-left: .6em;
     padding-left: .9em;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -22,7 +22,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
     line-height: 1.25;
 
     text-decoration: none;
@@ -110,7 +110,7 @@
   }
 
   .govuk-c-button--start {
-    @include bold-24;
+    @include govuk-bold-24;
     // TODO: Fix padding values
     padding: em(8.842px, 24px) em(51.789px, 24px) em(5.053px, 24px) em(20.211px, 24px);
     background-image: file-url("icon-pointer.png");

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -18,7 +18,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
   }
 
   .govuk-c-checkbox:last-child,

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -21,7 +21,7 @@
 
   .govuk-c-cookie-banner__text {
     @include site-width-container;
-    @include core-16;
+    @include govuk-core-16;
     margin-top: 0;
     margin-bottom: 0;
   }

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -8,7 +8,7 @@
     clear: both;
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
   }
 
   .govuk-c-details__summary {

--- a/src/components/error-message/_error-message.scss
+++ b/src/components/error-message/_error-message.scss
@@ -17,7 +17,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include bold-19;
+    @include govuk-bold-19;
 
   }
 }

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -47,11 +47,11 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include bold-24;
+    @include govuk-bold-24;
   }
 
   .govuk-c-error-summary__body {
-    @include core-19;
+    @include govuk-core-19;
 
     // TODO: consistent paragraph margins
     p {

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -8,7 +8,7 @@
   .govuk-c-file-upload {
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
   }
 
   .govuk-c-file-upload:focus {

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -17,7 +17,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
 
     // Disable inner shadow and remove rounded corners
     -webkit-appearance: none;

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -6,7 +6,7 @@
 @include exports("inset-text") {
   .govuk-c-inset-text {
     font-family: $govuk-font-stack;
-    @include core-19;
+    @include govuk-core-19;
     @include font-smoothing;
     @include govuk-u-border-left($govuk-border-width-wide, $govuk-border-colour);
     clear: both;

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -7,7 +7,7 @@
     color: $govuk-text-colour;
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
   }
 
   .govuk-c-label--bold {

--- a/src/components/link-back/_link-back.scss
+++ b/src/components/link-back/_link-back.scss
@@ -20,7 +20,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-16;
+    @include govuk-core-16;
     line-height: 1.25;
 
     text-decoration: none;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -14,7 +14,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
   }
 
   .govuk-c-list > li {

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -11,7 +11,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
 
     text-align: center;
   }
@@ -30,7 +30,7 @@
     margin-top: em(60px, 48px);
     margin-bottom: em(30px, 48px);
 
-    @include bold-48;
+    @include govuk-bold-48;
   }
 
   .govuk-c-panel__body {
@@ -38,7 +38,7 @@
     margin-top: em(11.25px, 48px);
     margin-bottom: em(37.895px, 48px);
 
-    @include core-36;
+    @include govuk-core-36;
   }
 
 }

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -27,6 +27,6 @@
     display: table-cell;
     color: $govuk-banner-text-colour;
     vertical-align: baseline;
-    @include core-16;
+    @include govuk-core-16;
   }
 }

--- a/src/components/phase-tag/_phase-tag.scss
+++ b/src/components/phase-tag/_phase-tag.scss
@@ -14,7 +14,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include bold-16;
+    @include govuk-bold-16;
     letter-spacing: 1px;
     line-height: 1.25;
 

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -19,7 +19,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
     line-height: 1.25;
   }
 

--- a/src/components/select-box/_select-box.scss
+++ b/src/components/select-box/_select-box.scss
@@ -12,7 +12,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
     line-height: 1.25;
   }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -17,7 +17,7 @@
   .govuk-c-table__header {
     padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
-    @include core-19;
+    @include govuk-core-19;
 
     border-bottom: 1px solid $govuk-border-colour;
 
@@ -27,7 +27,7 @@
   }
 
   .govuk-c-table__cell {
-    @include core-19;
+    @include govuk-core-19;
     padding: em(12, 19) em(20, 19) em(9, 19) 0;
 
     border-bottom: 1px solid $govuk-border-colour;
@@ -51,6 +51,6 @@
 
   .govuk-c-table__caption {
     text-align: left;
-    @include bold-19;
+    @include govuk-bold-19;
   }
 }

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -18,7 +18,7 @@
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
-    @include core-19;
+    @include govuk-core-19;
     line-height: 1.25;
 
     -webkit-appearance: none;

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -17,62 +17,64 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
   -moz-osx-font-smoothing: grayscale;
 }
 
-@mixin font-size($px) {
+// Add the govuk- prefix to prevent inteference
+// with the govuk_frontend_toolkit's core-x and bold-x mixins
+@mixin govuk-font-size($px) {
   // sass-lint:disable no-duplicate-properties
   font-size: $px;
   font-size: rem($px);
 }
 
 
-@mixin bold-48 {
-  @include font-size(48px);
+@mixin govuk-bold-48 {
+  @include govuk-font-size(48px);
   font-weight: 700;
 
   line-height: (50 / 48);
 }
 
-@mixin bold-19 {
-  @include font-size(19px);
+@mixin govuk-bold-19 {
+  @include govuk-font-size(19px);
   font-weight: 700;
 
   line-height: (25 / 19);
 }
-@mixin bold-18 {
-  @include font-size(18px);
+@mixin govuk-bold-18 {
+  @include govuk-font-size(18px);
   font-weight: 700;
 
   line-height: (21.6 / 18);
 }
 
-@mixin bold-16 {
-  @include font-size(16px);
+@mixin govuk-bold-16 {
+  @include govuk-font-size(16px);
   font-weight: 700;
 
   line-height: (20 / 16);
 }
 
-@mixin bold-24 {
-  @include bold-18;
+@mixin govuk-bold-24 {
+  @include govuk-bold-18;
   @include mq($from: tablet) {
-    @include font-size(24px);
+    @include govuk-font-size(24px);
     line-height: (30 / 24);
   }
 }
 
-@mixin core-36 {
-  @include font-size(36px);
+@mixin govuk-core-36 {
+  @include govuk-font-size(36px);
   line-height: (40 / 36);
 }
 
-@mixin core-19 {
-  @include core-16;
+@mixin govuk-core-19 {
+  @include govuk-core-16;
   @include mq($from: tablet) {
-    @include font-size(19px);
+    @include govuk-font-size(19px);
     line-height: (25 / 19);
   }
 }
 
-@mixin core-16 {
-  @include font-size(16px);
+@mixin govuk-core-16 {
+  @include govuk-font-size(16px);
   line-height: (20 / 16);
 }


### PR DESCRIPTION
Add the `govuk-` prefix to prevent interference with the
govuk_frontend_toolkit's core-x and bold-x mixins.