### PR TITLE
Remove rem and pixel fallback, instead default to px

### DIFF
--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,9 +1,3 @@
-$govuk-base-font-size: 16px !default;
-
-@function rem($px) {
-  @return ($px / $govuk-base-font-size) * 1rem;
-}
-
 // New Transport Light font family
 $govuk-nta-light: "nta", Arial, sans-serif;
 $govuk-nta-light-tabular: "ntatabularnumbers", $govuk-nta-light;
@@ -20,34 +14,32 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
 // Add the govuk- prefix to prevent inteference
 // with the govuk_frontend_toolkit's core-x and bold-x mixins
 @mixin govuk-font-size($px) {
-  // sass-lint:disable no-duplicate-properties
-  font-size: $px;
-  font-size: rem($px);
+  font-size: $px + px;
 }
 
 
 @mixin govuk-bold-48 {
-  @include govuk-font-size(48px);
+  @include govuk-font-size(48);
   font-weight: 700;
 
   line-height: (50 / 48);
 }
 
 @mixin govuk-bold-19 {
-  @include govuk-font-size(19px);
+  @include govuk-font-size(19);
   font-weight: 700;
 
   line-height: (25 / 19);
 }
 @mixin govuk-bold-18 {
-  @include govuk-font-size(18px);
+  @include govuk-font-size(18);
   font-weight: 700;
 
   line-height: (21.6 / 18);
 }
 
 @mixin govuk-bold-16 {
-  @include govuk-font-size(16px);
+  @include govuk-font-size(16);
   font-weight: 700;
 
   line-height: (20 / 16);
@@ -56,25 +48,25 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
 @mixin govuk-bold-24 {
   @include govuk-bold-18;
   @include mq($from: tablet) {
-    @include govuk-font-size(24px);
+    @include govuk-font-size(24);
     line-height: (30 / 24);
   }
 }
 
 @mixin govuk-core-36 {
-  @include govuk-font-size(36px);
+  @include govuk-font-size(36);
   line-height: (40 / 36);
 }
 
 @mixin govuk-core-19 {
   @include govuk-core-16;
   @include mq($from: tablet) {
-    @include govuk-font-size(19px);
+    @include govuk-font-size(19);
     line-height: (25 / 19);
   }
 }
 
 @mixin govuk-core-16 {
-  @include govuk-font-size(16px);
+  @include govuk-font-size(16);
   line-height: (20 / 16);
 }


### PR DESCRIPTION
It makes me sad to remove this, but having tried out including the breadcrumb component in the govuk-elements application, the font sizes are too small.

In our new world of isolated components - we don't have any control over the :root or html element of the document.

The font-size on the html element - set by govuk_template to 62.5%, is affecting the font size of the breadcrumb component, this component, which previously used font-size 1rem = 16px, instead is rendered at 10px.

In a future where we are no longer using govuk_template, we can revisit this decision. However, if our components are to exist in codebases we don't have control over - where the font size on the root or html element could vary, we will have to use pixels to prevent unexpected differences in the font-sizes of components.
