### PR TITLE
Update component README files with npm install and usage instructions

### DIFF
--- a/packages/all/README.md
+++ b/packages/all/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 A [demo](linkgoeshere).
 
-## Usage
-
-Including the Sass
-
-```
-@import "@govuk-frontend/all";
-```
-
-
 <!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/all
+```
+## Usage
+
+Including the Sass
+
+```
+@import "@govuk-frontend/all/all";
 ```
 -->

--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -10,19 +10,18 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Breadcrumb [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/breadcrumb
 ```
 
+## Usage
+
+Including the Sass
+
+```
+@import "@govuk-frontend/breadcrumb/breadcrumb";
+```
+-->

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -10,19 +10,18 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Button [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/button
 ```
 
+## Usage
+
+Including the Sass
+
+```
+@import "@govuk-frontend/button/button";
+```
+-->

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Checkbox [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/checkbox
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/checkbox/checkbox";
+```
+-->

--- a/packages/cookie-banner/README.md
+++ b/packages/cookie-banner/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Cookie banner [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/cookie-banner
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/cookie-banner/cookie-banner";
+```
+-->

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Date [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/date
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/date/date";
+```
+-->

--- a/packages/details/README.md
+++ b/packages/details/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Details [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/details
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/details/details";
+```
+-->

--- a/packages/error-message/README.md
+++ b/packages/error-message/README.md
@@ -11,18 +11,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Error message [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/error-message
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/error-message/error-message";
+```
+-->

--- a/packages/error-summary/README.md
+++ b/packages/error-summary/README.md
@@ -10,22 +10,20 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Error summary [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/error-summary
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/error-summary/error-summary";
+```
+-->
 
 ## Implementation
 

--- a/packages/file-upload/README.md
+++ b/packages/file-upload/README.md
@@ -10,22 +10,20 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 File upload [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/file-upload
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/file-upload/file-upload";
+```
+-->
 
 ## Implementation
 

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Input [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/input
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/input/input";
+```
+-->

--- a/packages/inset-text/README.md
+++ b/packages/inset-text/README.md
@@ -10,18 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Inset text [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/inset-text
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/inset-text/inset-text";
+```
+-->

--- a/packages/label/README.md
+++ b/packages/label/README.md
@@ -10,22 +10,20 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Label [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/label
 ```
+## Usage
 
+Including the Sass
 
+```
+@import "@govuk-frontend/label/label";
+```
+-->
 
 # Implementation
 

--- a/packages/link-back/README.md
+++ b/packages/link-back/README.md
@@ -10,18 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 Link back [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/link-back
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/link-back/link-back";
+```
+-->

--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 List [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/list
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/list/list";
+```
+-->

--- a/packages/panel/README.md
+++ b/packages/panel/README.md
@@ -12,21 +12,19 @@ Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
 
 ## Demo
 
-* Panel [demo](linkgoeshere).
+Panel [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
-npm install --save @govuk-frontend/phase-banner
+npm install --save @govuk-frontend/panel
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/panel/panel";
+```
+-->

--- a/packages/phase-banner/README.md
+++ b/packages/phase-banner/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Phase banner [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/phase-banner
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/phase-banner/phase-banner";
+```
+-->

--- a/packages/phase-tag/README.md
+++ b/packages/phase-tag/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Phase tag [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/phase-tag
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/phase-tag/phase-tag";
+```
+-->

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Radio button [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/radio
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/radio/radio";
+```
+-->

--- a/packages/select-box/README.md
+++ b/packages/select-box/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Select box [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/select-box
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/select-box/select-box";
+```
+-->

--- a/packages/table/README.md
+++ b/packages/table/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Table [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/table
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/table/table";
+```
+-->

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -10,19 +10,17 @@ Guidance and documentation can be found on [GOV.UK Design system](linkgoeshere).
 
 Textarea [demo](linkgoeshere).
 
-## Usage
-
-Code example(s)
-
-```
-// code goes here
-```
-
-
-
+<!--
 ## Installation
 
 ```
 npm install --save @govuk-frontend/textarea
 ```
+## Usage
 
+Including the Sass
+
+```
+@import "@govuk-frontend/textarea/textarea";
+```
+-->


### PR DESCRIPTION
Move npm install instructions into commented block

Also move section ‘Including the Sass’ as this references the
govuk-frontend scope @govuk-frontend and will be different to the path
used when consuming the Sass via /dist.