### PR TITLE
Fix broken link in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -68,4 +68,4 @@ Scss source files.
 
 Component source files.
 
-[Component documentation](compoenents.md)
+[Component documentation](components.md)


### PR DESCRIPTION
Was `compoenents.md`, now `components.md`