### PR TITLE
Copy existing grid styles to a grid component

### DIFF
--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -1,6 +1,7 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/colours";
 @import "../../globals/scss/typography";
+@import "../site-width-container/site-width-container";
 
 @include exports("cookie-banner") {
   .govuk-c-cookie-banner {
@@ -20,7 +21,7 @@
   }
 
   .govuk-c-cookie-banner__text {
-    @include site-width-container;
+    @include govuk-site-width-container;
     @include govuk-core-16;
     margin-top: 0;
     margin-bottom: 0;

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -1,0 +1,27 @@
+# Grid
+
+Description of component.
+
+## Guidance
+
+Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
+
+## Demo
+
+Grid [demo](grid.html).
+
+## Usage
+
+Code example(s)
+
+```
+@@include('grid.html')
+```
+
+<!--
+## Installation
+
+```
+npm install --save @govuk-frontend/grid
+```
+-->

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -1,0 +1,36 @@
+@import "../../globals/scss/vars";
+@import "../../globals/scss/grid-layout";
+@import "../../globals/scss/import-once";
+@import "../site-width-container/site-width-container";
+
+@include exports("grid") {
+
+  .govuk-c-grid {
+    @include govuk-grid;
+  }
+
+  .govuk-c-grid__item {
+    @include govuk-grid-item;
+  }
+
+  .govuk-c-grid__item--full {
+    width: 100%;
+  }
+
+  .govuk-c-grid__item--one-half {
+    width: percentage( 1 / 2);
+  }
+
+  .govuk-c-grid__item--one-third {
+    width: percentage( 1 / 3);
+  }
+
+  .govuk-c-grid__item--two-thirds {
+    width: percentage( 2 / 3);
+  }
+
+  .govuk-c-grid__item--one-quarter {
+    width: percentage( 1 / 4);
+  }
+
+}

--- a/src/components/grid/grid.html
+++ b/src/components/grid/grid.html
@@ -1,0 +1,60 @@
+<div class="govuk-c-grid-wrapper">
+
+  <!-- Full width -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item govuk-c-grid__item--full">
+      Grid item
+    </div>
+  </div>
+
+  <!-- Halves -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
+      Grid item
+    </div>
+    <div class="govuk-c-grid__item  govuk-c-grid__item--one-half">
+      Grid item
+    </div>
+  </div>
+
+  <!-- Thirds -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item  govuk-c-grid__item--one-third">
+      Grid item
+    </div>
+    <div class="govuk-c-grid__item  govuk-c-grid__item--one-third">
+      Grid item
+    </div>
+  </div>
+
+  <!-- Two thirds / one third -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
+      Grid item
+    </div>
+    <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+      Grid item
+    </div>
+  </div>
+
+  <!-- One third / two thirds -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+      Grid item
+    </div>
+    <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
+      Grid item
+    </div>
+  </div>
+
+  <!-- Quarters -->
+  <div class="govuk-c-grid">
+    <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+      Grid item
+    </div>
+    <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+      Grid item
+    </div>
+  </div>
+
+</div>

--- a/src/components/grid/grid.html
+++ b/src/components/grid/grid.html
@@ -1,4 +1,4 @@
-<div class="govuk-c-grid-wrapper">
+<div class="govuk-c-site-width-container">
 
   <!-- Full width -->
   <div class="govuk-c-grid">

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -1,0 +1,27 @@
+# Site width container
+
+A container set to the width of the site (960px) and its margins.
+
+## Guidance
+
+Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
+
+## Demo
+
+Site width container [demo](site-width-container.html).
+
+## Usage
+
+Code example(s)
+
+```
+@@include('site-width-container.html')
+```
+
+<!--
+## Installation
+
+```
+npm install --save @govuk-frontend/site-width-container
+```
+-->

--- a/src/components/site-width-container/_site-width-container.scss
+++ b/src/components/site-width-container/_site-width-container.scss
@@ -1,0 +1,11 @@
+@import "../../globals/scss/vars";
+@import "../../globals/scss/grid-layout";
+@import "../../globals/scss/import-once";
+
+@include exports("site-width-container") {
+
+  .govuk-c-site-width-container {
+    @include govuk-site-width-container;
+  }
+
+}

--- a/src/components/site-width-container/site-width-container.html
+++ b/src/components/site-width-container/site-width-container.html
@@ -1,0 +1,3 @@
+<div class="govuk-c-site-width-container">
+  Site width container
+</div>

--- a/src/globals/scss/_grid-layout.scss
+++ b/src/globals/scss/_grid-layout.scss
@@ -1,0 +1,22 @@
+// Build your own grids using these grid mixins
+// usage:
+// .container {
+//   @include govuk-site-width-container;
+// }
+
+@mixin govuk-site-width-container {
+  max-width: $govuk-site-width;
+
+  @include ie-lte(8) {
+    width: $govuk-site-width;
+  }
+
+  margin: 0 $govuk-gutter-half;
+  @include mq($from: tablet) {
+    margin: 0 $govuk-gutter;
+  }
+
+  @include mq($and: "(min-width: #{($govuk-site-width + $govuk-gutter * 2)})") {
+    margin: 0 auto;
+  }
+}

--- a/src/globals/scss/_grid-layout.scss
+++ b/src/globals/scss/_grid-layout.scss
@@ -20,3 +20,15 @@
     margin: 0 auto;
   }
 }
+
+@mixin govuk-grid {
+  @include clearfix;
+  margin-right: - ($govuk-gutter / 2);
+  margin-left: - ($govuk-gutter / 2);
+}
+
+@mixin govuk-grid-item {
+  box-sizing: border-box;
+  padding: 0 $govuk-gutter-half;
+  float: left;
+}

--- a/src/globals/scss/_helpers.scss
+++ b/src/globals/scss/_helpers.scss
@@ -43,18 +43,3 @@ $is-ie: false !default;
     zoom: 1;
   }
 }
-
-// Mixin to wrap your entire site content block. It limits the sites width to be 960px wide and maintains consistent margins
-@mixin site-width-container {
-  max-width: $govuk-site-width;
-  @include ie-lte(8) {
-    width: $govuk-site-width;
-  }
-  margin: 0 $govuk-gutter-half;
-  @include mq($from: tablet) {
-    margin: 0 $govuk-gutter;
-  }
-  @include mq($and: "(min-width: #{($govuk-site-width + $govuk-gutter * 2)})") {
-    margin: 0 auto;
-  }
-}

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -19,3 +19,4 @@
 @import "../../components/select-box/select-box";
 @import "../../components/date/date";
 @import "../../components/inset-text/inset-text";
+@import "../../components/site-width-container/site-width-container";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -20,3 +20,4 @@
 @import "../../components/date/date";
 @import "../../components/inset-text/inset-text";
 @import "../../components/site-width-container/site-width-container";
+@import "../../components/grid/grid";


### PR DESCRIPTION
I haven't made any changes to these styles, other than to rename our existing grid placeholders and instead use mixins.

The grid component has the grid wrapper component as a dependency (as the grid wrapper must wrap a grid component). Alternatively, the grid-wrapper mixin can be used. 

Also update the cookie-banner component to use the grid-wrapper mixin. 