### PR TITLE
Add Prism.js and GOV.UK styles

### DIFF
--- a/src/component-list-template.html
+++ b/src/component-list-template.html
@@ -14,12 +14,14 @@
   }
   </style>
 </head>
-<body>
+<body class="govuk-c-site-width-container">
   <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
   <h1>Components</h1>
-  <!-- inject:componentlinks -->
-  <!-- links to components will be injected here -->
-  <!-- endinject -->
+  <ul class="govuk-c-list">
+    <!-- inject:componentlinks -->
+    <!-- links to components will be injected here -->
+    <!-- endinject -->
+  </ul>
   <script src="/js/govuk-frontend.js"></script>
 </body>
 </html>

--- a/src/component-view-template.html
+++ b/src/component-view-template.html
@@ -6,10 +6,12 @@
   <!--[if IE 8]>
   <link rel="stylesheet" href="/css/govuk-frontend-oldie.css">
   <![endif]-->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css">
 </head>
-<body>
+<body class="language-markup govuk-c-site-width-container">
   <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
   <%= contents %>
   <script src="/js/govuk-frontend.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This PR
Adds prism.js from cdn (quicker than npm)
Adds gov.uk list and site-width-container styles

Screenshot:

<img width="1254" alt="screen shot 2017-06-27 at 16 55 56" src="https://user-images.githubusercontent.com/3758555/27597507-74e8d9a2-5b5a-11e7-80b1-338967e38720.png">
<img width="693" alt="screen shot 2017-06-27 at 17 03 38" src="https://user-images.githubusercontent.com/3758555/27597549-96e3d34a-5b5a-11e7-9937-2331d462b695.png">
