### PR TITLE
Ensure Travis runs tests as first build stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ node_js:
 notifications:
   email: false
 sudo: false
-script:
-- npm test
 before_deploy:
 - test $TRAVIS_TEST_RESULT = 0
 jobs:
   include:
+    - stage: Run npm test
+      script:
+      - npm test
     - stage: Deploy to the review app
       script: echo "Deploying to govuk-frontend-review.herokuapp.com ..."
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ notifications:
 sudo: false
 script:
 - npm test
+before_deploy:
+- test $TRAVIS_TEST_RESULT = 0
 jobs:
   include:
     - stage: Deploy to the review app


### PR DESCRIPTION
Since we moved to using Travis' Build stages, `npm test` is no longer run
(see this job: https://travis-ci.org/alphagov/govuk-frontend/jobs/247591720, whereas it was working as expected here: https://travis-ci.org/alphagov/govuk-frontend/builds/247528763)
move this step to it's own build stage to ensure the tests have run and passed before any further stages occur.

Also add a check before deployment `test $TRAVIS_TEST_RESULT = 0`, to ensure the build has been successful.