### PR TITLE
Disallow search index indexing for Heroku apps

### DIFF
--- a/review.js
+++ b/review.js
@@ -20,6 +20,20 @@ if (herokuApp === 'DEMO') {
   app.use('/', express.static(path.join(__dirname, 'demo')))
 }
 
+// Disallow search index indexing
+app.use(function (req, res, next) {
+  // none - Equivalent to noindex, nofollow
+  // noindex - Do not show this page in search results and do not show a "Cached" link in search results.
+  // nofollow - Do not follow the links on this page
+  res.setHeader('X-Robots-Tag', 'none')
+  next()
+})
+
+app.get('/robots.txt', function (req, res) {
+  res.type('text/plain')
+  res.send('User-agent: *\nDisallow: /')
+})
+
 app.get('/', (req, res) => {
   res.render('index.html')
 })


### PR DESCRIPTION
Ensure that both Heroku apps aren’t indexed by Google.

Based on [govuk_prototype_kit](https://github.com/alphagov/govuk_prototype_kit/blob/master/server.js#L174).

Amended to set the X-Robots-Tag header to `none`, to set both `noindex` and `nofollow`.