### PR TITLE
Update docs for publishing components

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -18,6 +18,73 @@ We are using [lerna.js](https://lernajs.io/) to manage our packages and publish 
 
 Lerna is a tool that optimizes the workflow around managing multi-package repositories with git and npm.
 
+### Publishing components manually (while in Alpha)
+
+In a new branch:
+
+- Run the `build:packages` task to ensure any changes to `src/components/component-name` are copied to `packages/component-name`.
+
+```
+gulp build:packages
+```
+
+- Commit changes to the updated packages
+
+```
+git commit -m "chore(packages): copy changes to packages"
+```
+
+- Ensure each component has a package.json file listing its dependencies.
+
+```
+git commit -m "chore(componentname): add package.json"
+```
+
+- Run lerna bootstrap to install all package dependencies and link any cross-dependencies
+
+```
+lerna bootstrap
+```
+
+- Manually bump the version of each package
+
+```
+lerna publish --skip-git --skip-npm
+```
+
+- Update `dist` folder with the latest versions
+
+```
+gulp build:dist
+```
+
+- Update `demo` folder with latest files and versioned assets
+
+```
+gulp build:demo
+```
+
+Open a pull request for these changes. 
+[Here is an example](https://github.com/alphagov/govuk-frontend/pull/102).
+
+
+Once these changes have been merged into master.
+
+Update the master branch
+
+``
+git checkout master
+git pull --rebase origin/master
+```
+
+Publish these changes to git and to npm.
+
+```
+lerna publish -m "chore(release): update packages and publish"
+```
+
+### Publishing components using conventional-commits (when ready to publish pre-release components).
+
 We are using independent mode to version each package independently.
 
 To keep track of whether versions are major, minor or patch - we can use Lerna's conventional commits flag when publishing to decide on the next version number.
@@ -26,70 +93,13 @@ To test conventional-commits (but not publish to npm):
 
     lerna publish --conventional-commits --skip-npm
 
-This generates a changelog for each component split into:
+This will generate a changelog for each component split into:
 
+```
 fix:
 feature:
 BREAKING CHANGE:
-
-This enables changelogs to be automatically generated.
-
-## Publishing components workflow
-
-1. Make changes
-
-2. Commit those changes [use the following structure](#commit-structure).
-
-3. Run the build to ensure any changes to `src/components/component-name` are made to `packages/component-name`.
-
 ```
-gulp build:packages
-```
-
-4. Commit changes to the updated packages
-
-```
-git commit -m "chore(packages): copy changes to packages"
-```
-
-5. Run lerna bootstrap
-Install all package dependencies and link any cross-dependencies.
-
-```
-lerna:bootstrap
-```
-
-5. Publish (and automatically generate a CHANGELOG.md file for each component)
-
-```
-  lerna publish --conventional-commits -m "chore(release): update packages and publish"
-```
-
-This will bump the version number in each packages package.json file and update the CHANGELOG.md file.
-
-6. Update `dist` folder with the latest versions
-
-```
-gulp build:dist
-```
-
-7. Update `demo` folder with latest files and versioned assets
-
-```
-gulp build:demo
-```
-
-A brief [explanation](gulp-tasks.md) of used gulp tasks.
-
-## Useful Lerna commands
-
-To see which components have been changed since the last release:
-
-    lerna updated
-
-To list all packages:
-
-    lerna ls
 
 ## Commit structure
 


### PR DESCRIPTION
This documents how we currently publish components.

This will need to be revised to update the section on "Publishing components using conventional-commits" once we are ready to publish pre-release components.