### PR TITLE
Adding list with step icon variant

### DIFF
--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -3,18 +3,17 @@
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
+@import "../../globals/scss/utilities/shapes";
 
 @include exports("list") {
   .govuk-c-list {
+    @include font-smoothing;
+    @include govuk-core-19;
     margin-top: 5px;
     margin-bottom: 20px;
     padding-left: 0;
-
     list-style-type: none;
-
     font-family: $govuk-font-stack;
-    @include font-smoothing;
-    @include govuk-core-19;
   }
 
   .govuk-c-list > li {
@@ -48,12 +47,31 @@
   }
 
   .govuk-c-list--number {
-    padding-left: 20px;
     // TODO: Fix IE < 8
     @include ie-lte(7) {
       padding-left: 28px;
     }
-
+    padding-left: 20px;
     list-style-type: decimal;
+  }
+
+  .govuk-c-list--icon > li {
+    margin-bottom: 15px;
+  }
+
+  .govuk-c-list__icon {
+    @include govuk-bold-12;
+    min-width: 24px;
+    min-height: 24px;
+    margin-right: .75em;
+    font-family: $govuk-font-stack-tabular;
+    line-height: 24px;
+  }
+
+  .govuk-c-list__icon--large {
+    @include govuk-bold-19;
+    min-width: 38px;
+    min-height: 38px;
+    line-height: 38px;
   }
 }

--- a/src/components/list/list.html
+++ b/src/components/list/list.html
@@ -17,3 +17,38 @@
   <li>The third step is to make sure each item is a full sentence ending with a full stop.</li>
 </ol>
 
+<!-- normal steps icon size -->
+<ol class="govuk-c-list govuk-c-list--icon">
+  <li><span class="govuk-c-list__icon govuk-u-circle">1</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">2</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">3</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">4</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">5</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">6</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">7</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">8</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">9</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">10</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">11</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">12</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">13</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-u-circle">14</span>Step</li>
+</ol>
+
+<!-- large steps icon size -->
+<ol class="govuk-c-list govuk-c-list--icon">
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">1</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">2</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">3</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">4</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">5</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">6</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">7</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">8</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">9</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">10</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">11</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">12</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">13</span>Step</li>
+  <li><span class="govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle">14</span>Step</li>
+</ol>

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -44,6 +44,11 @@ $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
 
   line-height: (20 / 16);
 }
+@mixin govuk-bold-12 {
+  @include govuk-font-size(12);
+  font-weight: 700;
+  line-height: (12 / 12);
+}
 
 @mixin govuk-bold-24 {
   @include govuk-bold-18;

--- a/src/globals/scss/utilities/_shapes.scss
+++ b/src/globals/scss/utilities/_shapes.scss
@@ -1,0 +1,12 @@
+@import "../import-once";
+@import "../colours";
+
+@include exports("shapes") {
+  .govuk-u-circle {
+    display: inline-block;
+    border-radius: 50%;
+    color: $govuk-white;
+    background: $govuk-black;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
This PR:
Adds the step icon shape
Creates normal and large list icon variants
Reorders properties to conform to scss lint rules

**Screenshots**
![screen shot 2017-07-05 at 13 26 14](https://user-images.githubusercontent.com/3758555/27864279-d338b9a6-6185-11e7-8789-3bda7a2ae4ea.png)

![screen shot 2017-07-05 at 13 26 20](https://user-images.githubusercontent.com/3758555/27864272-d18f619a-6185-11e7-88f8-a3737290e9a9.png)
