### PR TITLE
Use a fork of gulp-tenon-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4114,9 +4114,7 @@
       }
     },
     "gulp-tenon-client": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/gulp-tenon-client/-/gulp-tenon-client-0.1.1.tgz",
-      "integrity": "sha1-V5VBFeFrEHij2Hytxo5H1hbRA54=",
+      "version": "git+https://git@github.com/alphagov/gulp-tenon-client.git#74c802b8ece80e179dab054abda0d69467431a51",
       "dev": true,
       "requires": {
         "chalk": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "gulp-sass-lint": "^1.3.2",
     "gulp-standard": "^10.0.0",
     "gulp-task-listing": "^1.0.1",
-    "gulp-tenon-client": "^0.1.1",
+    "gulp-tenon-client": "git+https://git@github.com/alphagov/gulp-tenon-client.git",
     "gulp-uglify": "^3.0.0",
     "gulp-wrap": "^0.13.0",
     "lerna": "^2.0.0-rc.5",


### PR DESCRIPTION
This version doesn’t output `gulp-tenon` to the console whenever ‘gulp’
is run.

I opened a [PR for the gulp-tenon-client to fix this](https://github.com/egauci/gulp-tenon-client/pull/3), but it hasn't been merged. 

Before:
![screen shot 2017-07-06 at 11 31 10](https://user-images.githubusercontent.com/417754/27907243-d2eb4716-623e-11e7-9681-8c53f06325a8.png)

After:
![screen shot 2017-07-06 at 11 31 24](https://user-images.githubusercontent.com/417754/27907246-d82dcb7c-623e-11e7-8f8f-2d80a468a420.png)
