### PR TITLE
Remove pattern and min max attributes from date component

### DIFF
--- a/src/components/date/date.html
+++ b/src/components/date/date.html
@@ -1,15 +1,15 @@
 <div class="govuk-c-date">
   <div class="govuk-c-date__item govuk-c-date__item--day">
     <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
-    <input class="govuk-c-input govuk-c-date__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+    <input class="govuk-c-input govuk-c-date__input" id="dob-day" name="dob-day" type="number">
   </div>
   <div class="govuk-c-date__item govuk-c-date__item--month">
     <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
-    <input class="govuk-c-input govuk-c-date__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+    <input class="govuk-c-input govuk-c-date__input" id="dob-month" name="dob-month" type="number">
   </div>
   <div class="govuk-c-date__item govuk-c-date__item--year">
     <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
-    <input class="govuk-c-input govuk-c-date__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+    <input class="govuk-c-input govuk-c-date__input" id="dob-year" name="dob-year" type="number">
   </div>
 </div>
 
@@ -19,14 +19,14 @@
 <div class="govuk-c-date">
   <div class="govuk-c-date__item govuk-c-date__item--day">
     <label class="govuk-c-label govuk-c-date__label" for="dob-day-1">Day</label>
-    <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day-1" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31">
+    <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day-1" name="dob-day" type="number">
   </div>
   <div class="govuk-c-date__item govuk-c-date__item--month">
     <label class="govuk-c-label govuk-c-date__label" for="dob-month-1">Month</label>
-    <input class="govuk-c-input govuk-c-date__input" id="dob-month-1" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+    <input class="govuk-c-input govuk-c-date__input" id="dob-month-1" name="dob-month" type="number">
   </div>
   <div class="govuk-c-date__item govuk-c-date__item--year">
     <label class="govuk-c-label govuk-c-date__label" for="dob-year-1">Year</label>
-    <input class="govuk-c-input govuk-c-date__input" id="dob-year-1" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+    <input class="govuk-c-input govuk-c-date__input" id="dob-year-1" name="dob-year" type="number">
   </div>
 </div>


### PR DESCRIPTION
Use input type=“number” to trigger a numeric keyboard.

The pattern attribute applies when the value of the type attribute is
text, search, tel, url, email, or password, otherwise it is ignored. 
So for input type="number" this will be ignored.

Also remove min and max, as these will not stop a user entering a
number manually outside of this range - this only works for the spinner
control buttons, which we aren’t displaying for this component.