### PR TITLE
Add 'selected' state for radios and checkboxes

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -91,14 +91,17 @@
     background: transparent;
   }
 
+  // Focused state
   .govuk-c-checkbox__input:focus + .govuk-c-checkbox__label:before {
     box-shadow: 0 0 0 3px $govuk-focus-colour;
   }
 
-  .govuk-c-checkbox__input:focus + .govuk-c-checkbox__label:after {
+  // Selected state
+  .govuk-c-checkbox__input:checked + .govuk-c-checkbox__label:after {
     opacity: 1;
   }
 
+  // Disabled state
   .govuk-c-checkbox__input:disabled + .govuk-c-checkbox__label {
     opacity: .5;
   }

--- a/src/components/checkbox/checkbox.html
+++ b/src/components/checkbox/checkbox.html
@@ -3,6 +3,10 @@
   <label class="govuk-c-checkbox__label" for="waste-type-1">Waste from animal carcasses</label>
 </div>
 <div class="govuk-c-checkbox">
-  <input class="govuk-c-checkbox__input" id="waste-type-2" name="waste-types" type="checkbox" disabled="disabled" value="waste-animal">
-  <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from animal carcasses</label>
+  <input class="govuk-c-checkbox__input" id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines">
+  <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from mines or quarries</label>
+</div>
+<div class="govuk-c-checkbox">
+  <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" disabled="disabled" value="waste-animal">
+  <label class="govuk-c-checkbox__label" for="waste-type-3">Waste from animal carcasses</label>
 </div>

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -94,14 +94,17 @@
     opacity: 0;
   }
 
+  // Focused state
   .govuk-c-radio__input:focus + .govuk-c-radio__label:before {
     box-shadow: 0 0 0 4px $govuk-focus-colour;
   }
 
-  .govuk-c-radio__input:focus + .govuk-c-radio__label:after {
+  // Selected state
+  .govuk-c-radio__input:checked + .govuk-c-radio__label:after {
     opacity: 1;
   }
 
+  // Disabled state
   .govuk-c-radio__input:disabled + .govuk-c-radio__label {
     opacity: .5;
   }

--- a/src/components/radio/radio.html
+++ b/src/components/radio/radio.html
@@ -1,12 +1,12 @@
 <div class="govuk-c-radio">
-  <input class="govuk-c-radio__input" id="radio-inline-1" type="radio" name="radio1" value="Yes">
-  <label class="govuk-c-radio__label" for="radio-inline-1">Yes</label>
+  <input class="govuk-c-radio__input" id="radio-1" type="radio" name="radio-group" value="Yes">
+  <label class="govuk-c-radio__label" for="radio-1">Yes</label>
 </div>
 <div class="govuk-c-radio">
-  <input class="govuk-c-radio__input" id="radio-inline-2" type="radio" name="radio2" value="No">
-  <label class="govuk-c-radio__label" for="radio-inline-2">No</label>
+  <input class="govuk-c-radio__input" id="radio-2" type="radio" name="radio-group" value="No">
+  <label class="govuk-c-radio__label" for="radio-2">No</label>
 </div>
 <div class="govuk-c-radio">
-  <input class="govuk-c-radio__input" id="radio-inline-3" type="radio" name="radio2" disabled="disabled" value="NA">
-  <label class="govuk-c-radio__label" for="radio-inline-3">Not applicable</label>
+  <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" disabled="disabled" value="NA">
+  <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
 </div>


### PR DESCRIPTION
Fixes #122.

Add the selected state for radio buttons and checkboxes and add comments for each state.

The bug can be seen here for [radio buttons](https://govuk-frontend-review.herokuapp.com/components/checkbox/checkbox.html) and [checkboxes](https://govuk-frontend-review.herokuapp.com/components/radio/radio.html).

Fixed here for [checkboxes](https://govuk-frontend-review-pr-124.herokuapp.com/components/checkbox/checkbox.html) and [radio buttons](https://govuk-frontend-review-pr-124.herokuapp.com/components/radio/radio.html).
