### PR TITLE
Keep border width the same for error messages

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,11 +9,11 @@
     box-sizing: border-box; // should this be global?
     width: 100%;
     padding: 5px 4px 4px;
-
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
+
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
@@ -38,6 +38,7 @@
   }
 
   .govuk-c-input--error {
+    padding: 3px 2px 2px;
     border: $govuk-border-width-error solid $govuk-error-colour;
   }
 

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -12,6 +12,7 @@
     display: block;
 
     width: 100%;
+    padding: 5px 4px 4px;
 
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
@@ -30,6 +31,7 @@
   }
 
   .govuk-c-textarea--error {
+    padding: 3px 2px 2px;
     border: $govuk-border-width-error solid $govuk-error-colour;
   }
 }


### PR DESCRIPTION
This avoids “jumping” form inputs and the difference in height between
inputs, when they sit next to each other (for example, for date of
birth).

@dashouse can you let me know if this fixes #119.

Examples are here:

Date of birth:
https://govuk-frontend-review-pr-127.herokuapp.com/components/date/date.html

Input:
https://govuk-frontend-review-pr-127.herokuapp.com/components/input/input.html

Textarea:
https://govuk-frontend-review-pr-127.herokuapp.com/components/textarea/textarea.html

