### PR TITLE
Fix #518: stray line on checkbox on IE11

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -85,6 +85,7 @@
     transform: rotate(-45deg);
     border: solid;
     border-width: 0 0 5px 5px;
+    border-top-color: transparent;
 
     opacity: 0;
 


### PR DESCRIPTION
IE sometimes miscalculates the border width of a rotated element resulting in a thin border as shown in #518. Setting a transparent border will fix the issue without affecting semantics or rendering on any other browser.