### PR TITLE
Upgrade node.js version for Heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "govuk-frontend",
   "description": "govuk-frontend",
   "version": "0.0.1",
+  "engines": {
+    "node": "6.11.1"
+  },
   "private": "true",
   "repository": "alphagov/govuk-frontend",
   "bugs": {


### PR DESCRIPTION
The Node.js team has announced that a high severity remote Denial of Service (DoS) Constant Hashtable Seeds vulnerability in Node.js versions 4.x through 8.x has been patched in the following versions: 

4.8.4
6.11.1
7.10.1
8.1.4

`heroku run node -v -a govuk-frontend` v 6.11.0.

Use the engines section of package.json to specify the version of Node.js to use on Heroku: 6.11.1