### PR TITLE
Add aria-disabled to buttons to support older versions of JAWS

### DIFF
--- a/src/components/button/button.html
+++ b/src/components/button/button.html
@@ -1,3 +1,3 @@
 <input class="govuk-c-button" type="submit" value="Save and continue">
 <a class="govuk-c-button govuk-c-button--start" href="#" role="button">Start now</a>
-<input class="govuk-c-button govuk-c-button--disabled" type="submit" value="Primary disabled button" disabled="disabled">
+<input class="govuk-c-button govuk-c-button--disabled" type="submit" value="Primary disabled button" disabled="disabled" aria-disabled="true">


### PR DESCRIPTION
JAWS 15 and below don't recognise the disabled attribute on buttons.

This adds the aria-disabled attribute to make disabled buttons
compatible with older screen readers.

See [govuk_elements #532](https://github.com/alphagov/govuk_elements/pull/532).