### PR TITLE
Use h2 for error summary heading

### DIFF
--- a/src/components/error-summary/error-summary.html
+++ b/src/components/error-summary/error-summary.html
@@ -1,8 +1,8 @@
 <div class="govuk-c-error-summary" aria-labelledby="error-summary-title" role="group" tabindex="-1">
 
-  <h1 class="govuk-c-error-summary__title" id="error-summary-title">
+  <h2 class="govuk-c-error-summary__title" id="error-summary-title">
     Message to alert the user to a problem goes here
-  </h1>
+  </h2>
 
   <div class="govuk-c-error-summary__body">
     <p>


### PR DESCRIPTION
To avoid having multiple h1s per page when an error occurs and the
summary box is shown, use h2 for the error summary heading.

See [govuk-elements #510](https://github.com/alphagov/govuk_elements/pull/510).