### PR TITLE
Fix stray line on checkbox in IE11

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -85,6 +85,9 @@
     transform: rotate(-45deg);
     border: solid;
     border-width: 0 0 5px 5px;
+    // Fix bug in IE11 caused by transform rotate (-45deg).
+    // See: alphagov/govuk_elements/issues/518
+    border-top-color: transparent;
 
     opacity: 0;
 


### PR DESCRIPTION
IE sometimes miscalculates the border width of a rotated element
resulting in a thin border as shown in #518.

Setting a transparent border fixes this.

Before:
<img width="310" alt="28029483-1f1a21fa-6598-11e7-8821-3d63dc822fe0" src="https://user-images.githubusercontent.com/417754/28223723-6c06db82-68c4-11e7-8ae8-2dae3c6a3ac9.png">

After:
<img width="310" alt="28029400-de1357a8-6597-11e7-87b9-dfbf8565c79e" src="https://user-images.githubusercontent.com/417754/28223710-634db81c-68c4-11e7-8127-e031fa77d798.png">

[See govuk-elements #520](https://github.com/alphagov/govuk_elements/pull/520).
