### PR TITLE
Set cursor:default for disabled radio buttons and checkboxes

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -102,6 +102,11 @@
   }
 
   // Disabled state
+  .govuk-c-checkbox__input:disabled,
+  .govuk-c-checkbox__input:disabled + .govuk-c-checkbox__label {
+    cursor: default;
+  }
+
   .govuk-c-checkbox__input:disabled + .govuk-c-checkbox__label {
     opacity: .5;
   }

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -105,6 +105,11 @@
   }
 
   // Disabled state
+  .govuk-c-radio__input:disabled,
+  .govuk-c-radio__input:disabled + .govuk-c-radio__label {
+    cursor: default;
+  }
+
   .govuk-c-radio__input:disabled + .govuk-c-radio__label {
     opacity: .5;
   }


### PR DESCRIPTION
[See govuk-elements #519](https://github.com/alphagov/govuk_elements/pull/519).