### PR TITLE
Prev/next pagination

### DIFF
--- a/src/component-list-template.html
+++ b/src/component-list-template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>GOV.UK Frontend</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/css/govuk-frontend.css">
   <!--[if IE 8]>
   <link rel="stylesheet" href="/css/govuk-frontend-oldie.css">

--- a/src/component-view-template.html
+++ b/src/component-view-template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <title>GOV.UK Frontend</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/css/govuk-frontend.css">
   <!--[if IE 8]>
   <link rel="stylesheet" href="/css/govuk-frontend-oldie.css">

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -1,0 +1,28 @@
+# Pagination
+
+Previous/next page links. Example [page](https://www.gov.uk/voting-in-the-uk/polling-stations)
+
+## Guidance
+
+Guidance and documentation can be found on [GOV.UK Design System](linkgoeshere).
+
+## Demo
+
+Component name [demo](pagination.html).
+
+## Usage
+
+Code example(s)
+
+```
+@@include('pagination.html')
+```
+
+
+<!--
+## Installation
+
+```
+npm install --save @govuk-frontend/component-name
+```
+-->

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -3,6 +3,7 @@
 @import "../../globals/scss/colours";
 @import "../../globals/scss/media-queries";
 @import "../../globals/scss/typography";
+@import "../../globals/scss/links";
 @import "../../globals/scss/import-once";
 
 @include exports("pagination") {

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -1,10 +1,9 @@
-@import "../../globals/scss/vars";
-@import "../../globals/scss/helpers";
-@import "../../globals/scss/colours";
+@import "../../globals/scss/import-once";
+@import "../../globals/scss/links";
 @import "../../globals/scss/media-queries";
 @import "../../globals/scss/typography";
-@import "../../globals/scss/links";
-@import "../../globals/scss/import-once";
+@import "../../globals/scss/utilities/clearfix";
+@import "../../globals/scss/vars";
 
 @include exports("pagination") {
 
@@ -19,7 +18,7 @@
   }
 
   .govuk-c-pagination__list {
-    @include clearfix;
+    @include govuk-u-clearfix;
     margin: 0;
     padding: 0;
   }

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -10,10 +10,10 @@
   .govuk-c-pagination {
     @include font-smoothing;
     display: block;
-    margin-top: $govuk-gutter;
-    margin-right: -$govuk-gutter-half;
-    margin-bottom: $govuk-gutter;
-    margin-left: -$govuk-gutter-half;
+    margin-top: $govuk-spacing-scale-5;
+    margin-right: -$govuk-spacing-scale-3;
+    margin-bottom: $govuk-spacing-scale-5;
+    margin-left: -$govuk-spacing-scale-3;
     font-family: $govuk-font-stack;
   }
 
@@ -51,7 +51,7 @@
 
   .govuk-c-pagination__link {
     display: block;
-    padding: $govuk-gutter-half;
+    padding: $govuk-spacing-scale-3;
     text-decoration: none;
 
     &:visited {

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -1,0 +1,90 @@
+@import "../../globals/scss/vars";
+@import "../../globals/scss/helpers";
+@import "../../globals/scss/colours";
+@import "../../globals/scss/media-queries";
+@import "../../globals/scss/typography";
+@import "../../globals/scss/import-once";
+
+@include exports("pagination") {
+
+  .govuk-c-pagination {
+    @include font-smoothing;
+    display: block;
+    margin-top: $govuk-gutter;
+    margin-right: -$govuk-gutter-half;
+    margin-bottom: $govuk-gutter;
+    margin-left: -$govuk-gutter-half;
+    font-family: $govuk-font-stack;
+  }
+
+  .govuk-c-pagination__list {
+    @include clearfix;
+    margin: 0;
+    padding: 0;
+  }
+
+  .govuk-c-pagination__item {
+    @include govuk-core-16;
+    width: 50%;
+    padding: 0;
+    list-style: none;
+    text-align: right;
+  }
+
+  .govuk-c-pagination__item--previous {
+    @include mq($until: tablet) {
+      width: 100%;
+      float: none;
+    }
+    float: left;
+    text-align: left;
+  }
+
+  .govuk-c-pagination__item--next {
+    @include mq($until: tablet) {
+      width: 100%;
+      float: none;
+    }
+    float: right;
+    text-align: right;
+  }
+
+  .govuk-c-pagination__link {
+    display: block;
+    padding: $govuk-gutter-half;
+    text-decoration: none;
+
+    &:visited {
+      color: $govuk-link-colour;
+    }
+
+    &:hover,
+    &:active {
+      background-color: $govuk-canvas-colour;
+    }
+  }
+
+  .govuk-c-pagination__link-title {
+    @include govuk-core-27;
+    display: block;
+    line-height: (33.75 / 27);
+  }
+
+  .govuk-c-pagination__link-icon {
+    display: inline-block;
+    width: .63em;
+    height: .482em;
+    margin-bottom: 1px;
+  }
+
+  .govuk-c-pagination__link-label {
+    display: inline-block;
+    margin-top: .1em;
+    text-decoration: underline;
+
+    &:empty {
+      display: none;
+    }
+  }
+
+}

--- a/src/components/pagination/pagination.html
+++ b/src/components/pagination/pagination.html
@@ -1,0 +1,26 @@
+<nav class="govuk-c-pagination" role="navigation" aria-label="Pagination">
+  <ul class="govuk-c-pagination__list">
+      <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+        <a class="govuk-c-pagination__link" href="#" rel="prev">
+          <span class="govuk-c-pagination__link-title">
+            <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+              <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+            </svg>
+            Previous
+          </span>
+          <span class="govuk-c-pagination__link-label">Overview</span>
+        </a>
+      </li>
+      <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+        <a class="govuk-c-pagination__link" href="#" rel="next">
+          <span class="govuk-c-pagination__link-title">
+            Next
+            <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+              <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+            </svg>
+          </span>
+            <span class="govuk-c-pagination__link-label">Voting by post</span>
+        </a>
+      </li>
+  </ul>
+</nav>

--- a/src/components/pagination/pagination.html
+++ b/src/components/pagination/pagination.html
@@ -1,26 +1,26 @@
 <nav class="govuk-c-pagination" role="navigation" aria-label="Pagination">
   <ul class="govuk-c-pagination__list">
-      <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-        <a class="govuk-c-pagination__link" href="#" rel="prev">
-          <span class="govuk-c-pagination__link-title">
-            <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-              <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-            </svg>
-            Previous
-          </span>
-          <span class="govuk-c-pagination__link-label">Overview</span>
-        </a>
-      </li>
-      <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-        <a class="govuk-c-pagination__link" href="#" rel="next">
-          <span class="govuk-c-pagination__link-title">
-            Next
-            <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-              <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-            </svg>
-          </span>
-            <span class="govuk-c-pagination__link-label">Voting by post</span>
-        </a>
-      </li>
+    <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+      <a class="govuk-c-pagination__link" href="#" rel="prev">
+        <span class="govuk-c-pagination__link-title">
+          <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          Previous
+        </span>
+        <span class="govuk-c-pagination__link-label">Overview</span>
+      </a>
+    </li>
+    <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+      <a class="govuk-c-pagination__link" href="#" rel="next">
+        <span class="govuk-c-pagination__link-title">
+          Next
+          <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        </span>
+          <span class="govuk-c-pagination__link-label">Voting by post</span>
+      </a>
+    </li>
   </ul>
 </nav>

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -36,7 +36,6 @@
 @mixin govuk-bold-16 {
   @include govuk-font-size(16);
   font-weight: 700;
-
   line-height: (20 / 16);
 }
 @mixin govuk-bold-12 {
@@ -56,6 +55,11 @@
 @mixin govuk-core-36 {
   @include govuk-font-size(36);
   line-height: (40 / 36);
+}
+
+@mixin govuk-core-27 {
+  @include govuk-font-size(27);
+  line-height: (30 / 27);
 }
 
 @mixin govuk-core-19 {

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -22,3 +22,4 @@
 @import "../../components/site-width-container/site-width-container";
 @import "../../components/table/table";
 @import "../../components/textarea/textarea";
+@import "../../components/pagination/pagination";


### PR DESCRIPTION
This PR:
Adds prev/next (big arrow) pagination from https://github.com/alphagov/static/pull/1051
Adds meta viewport to the view template
Adds used typography mixin

Screnshots:
![screen shot 2017-07-18 at 14 53 05](https://user-images.githubusercontent.com/3758555/28320721-33242538-6bc9-11e7-9022-c96674c87600.png)
![screen shot 2017-07-18 at 14 52 39](https://user-images.githubusercontent.com/3758555/28320717-32fb901e-6bc9-11e7-9ac1-ad1f70dad223.png)
![screen shot 2017-07-18 at 14 49 42](https://user-images.githubusercontent.com/3758555/28320718-32fc436a-6bc9-11e7-9f56-f8f27f8b20c7.png)
