### PR TITLE
Set a spacing scale and export spacing utility classes

### DIFF
--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -1,0 +1,44 @@
+@import "vars";
+
+// Spacing properties
+$spacing-properties: (
+  "padding": "p",
+  "margin": "m",
+) !default;
+
+// Spacing directions
+$spacing-directions: (
+  null: null,
+  "-top": "t",
+  "-right": "r",
+  "-bottom": "b",
+  "-left": "l"
+) !default;
+
+// Set spacing scale
+$spacing-scale: (
+  0: 0,
+  1: $spacing-scale-xs,
+  2: $spacing-scale-s,
+  3: $spacing-scale-m,
+  4: $spacing-scale-l,
+  5: $spacing-scale-xl,
+  6: $spacing-scale-xxl
+);
+
+@import "import-once";
+
+@include exports("spacing") {
+  // Create spacing utility classes
+  @each $spacing-property-key, $spacing-property-value in $spacing-properties {
+    @each $spacing-direction-key, $spacing-direction-value in $spacing-directions {
+      @each $spacing-scale-key, $spacing-scale-value in $spacing-scale {
+        .govuk-u-#{$spacing-property-value}#{$spacing-direction-value}-#{$spacing-scale-key} {
+          @each $direction in $spacing-direction-key {
+            #{$spacing-property-key}#{$direction}: $spacing-scale-value !important;
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -18,12 +18,12 @@ $spacing-directions: (
 // Set spacing scale
 $spacing-scale: (
   0: 0,
-  1: $spacing-scale-xs,
-  2: $spacing-scale-s,
-  3: $spacing-scale-m,
-  4: $spacing-scale-l,
-  5: $spacing-scale-xl,
-  6: $spacing-scale-xxl
+  1: $spacing-scale-1,
+  2: $spacing-scale-2,
+  3: $spacing-scale-3,
+  4: $spacing-scale-4,
+  5: $spacing-scale-5,
+  6: $spacing-scale-6
 );
 
 @import "import-once";

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -30,6 +30,14 @@ $govuk-gutter: 30px;
 $govuk-gutter-half: $govuk-gutter / 2;
 $gutter-one-third: $govuk-gutter / 3;
 
+// Spacing scale
+$spacing-scale-xs: 5px;
+$spacing-scale-s: 10px;
+$spacing-scale-m: 15px;
+$spacing-scale-l: 20px;
+$spacing-scale-xl: 30px;
+$spacing-scale-xxl: 60px;
+
 // Fonts
 // New Transport Light font family
 $govuk-nta-light: "nta", Arial, sans-serif;

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -31,12 +31,12 @@ $govuk-gutter-half: $govuk-gutter / 2;
 $gutter-one-third: $govuk-gutter / 3;
 
 // Spacing scale
-$spacing-scale-xs: 5px;
-$spacing-scale-s: 10px;
-$spacing-scale-m: 15px;
-$spacing-scale-l: 20px;
-$spacing-scale-xl: 30px;
-$spacing-scale-xxl: 60px;
+$spacing-scale-1: 5px;
+$spacing-scale-2: 10px;
+$spacing-scale-3: 15px;
+$spacing-scale-4: 20px;
+$spacing-scale-5: 30px;
+$spacing-scale-6: 60px;
 
 // Fonts
 // New Transport Light font family

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -26,6 +26,7 @@ $govuk-site-width: 960px;
 $govuk-full-width: 100%;
 
 // Spacing
+// TODO: remove these, instead use spacing scale
 $govuk-gutter: 30px;
 $govuk-gutter-half: $govuk-gutter / 2;
 $gutter-one-third: $govuk-gutter / 3;


### PR DESCRIPTION
- Add test values to a spacing scale
- Set spacing properties for margin and padding
- Set spacing directions - top, right, bottom, left
- Set a spacing scale, using spacing scale vars. Include 0 to reset
paddings and margins.

Export classes in the format: `.govuk-u-mb-2` where 2 is the spacing scale, from 0-6.

Note: we're testing this to see how these classes might work to provide spacing around components, and how these spacing vars can be combined with our typography styles. This is *very* likely to change. 

Todo: 

- [x] Ensure if spacing is imported by each component, that the classes are only output once in the compiled css.