### PR TITLE
Update components to use spacing scale

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,5 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-url";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/clearfix";
 @import "../../globals/scss/vars";
@@ -7,8 +8,8 @@
 
 @include exports("breadcrumb") {
   .govuk-c-breadcrumb {
-    padding-top: .75em;
-    padding-bottom: .75em;
+    padding-top: $spacing-scale-3;
+    padding-bottom: $spacing-scale-3;
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
@@ -20,9 +21,9 @@
 
   .govuk-c-breadcrumb__list-item {
     @include govuk-core-16;
-    margin-bottom: .4em;
-    margin-left: .6em;
-    padding-left: .9em;
+    margin-bottom: $spacing-scale-1;
+    margin-left: $spacing-scale-2;
+    padding-left: $spacing-scale-3;
     float: left;
     list-style: none;
     background-image: file-url("separator.png");

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -8,8 +8,8 @@
 
 @include exports("breadcrumb") {
   .govuk-c-breadcrumb {
-    padding-top: $spacing-scale-3;
-    padding-bottom: $spacing-scale-3;
+    padding-top: $govuk-spacing-scale-3;
+    padding-bottom: $govuk-spacing-scale-3;
 
     font-family: $govuk-font-stack;
     @include font-smoothing;
@@ -21,9 +21,9 @@
 
   .govuk-c-breadcrumb__list-item {
     @include govuk-core-16;
-    margin-bottom: $spacing-scale-1;
-    margin-left: $spacing-scale-2;
-    padding-left: $spacing-scale-3;
+    margin-bottom: $govuk-spacing-scale-1;
+    margin-left: $govuk-spacing-scale-2;
+    padding-left: $govuk-spacing-scale-3;
     float: left;
     list-style: none;
     background-image: file-url("separator.png");

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -11,7 +11,7 @@
     box-sizing: border-box;
     display: inline-block;
     position: relative;
-    padding: em($spacing-scale-2, 19px) em($spacing-scale-3, 19px) em($spacing-scale-1, 19px);
+    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
     border: 0;
     border-radius: 0; //used to be a mixin with vendor
 
@@ -113,7 +113,7 @@
   .govuk-c-button--start {
     @include govuk-bold-24;
     // TODO: Check padding values
-    padding: em($spacing-scale-2, 24px) em($spacing-scale-6, 24px) em($spacing-scale-1, 24px) em($spacing-scale-4, 24px);
+    padding: em($govuk-spacing-scale-2, 24px) em($govuk-spacing-scale-6, 24px) em($govuk-spacing-scale-1, 24px) em($govuk-spacing-scale-4, 24px);
     background-image: file-url("icon-pointer.png");
     background-repeat: no-repeat;
     background-position: 100% 50%;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,8 +1,8 @@
 @import "../../globals/scss/import-once";
-
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
 @import "../../globals/scss/media-queries";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 
@@ -11,7 +11,7 @@
     box-sizing: border-box;
     display: inline-block;
     position: relative;
-    padding: em(10px, 19px) em(15px, 19px) em(5px, 19px);
+    padding: em($spacing-scale-2, 19px) em($spacing-scale-3, 19px) em($spacing-scale-1, 19px);
     border: 0;
     border-radius: 0; //used to be a mixin with vendor
 
@@ -82,7 +82,7 @@
     }
 
     &:focus {
-      outline: 3px solid $govuk-focus-colour;
+      outline: $govuk-focus-width solid $govuk-focus-colour;
     }
   }
 
@@ -112,8 +112,8 @@
 
   .govuk-c-button--start {
     @include govuk-bold-24;
-    // TODO: Fix padding values
-    padding: em(8.842px, 24px) em(51.789px, 24px) em(5.053px, 24px) em(20.211px, 24px);
+    // TODO: Check padding values
+    padding: em($spacing-scale-2, 24px) em($spacing-scale-6, 24px) em($spacing-scale-1, 24px) em($spacing-scale-4, 24px);
     background-image: file-url("icon-pointer.png");
     background-repeat: no-repeat;
     background-position: 100% 50%;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -47,7 +47,7 @@
 
   .govuk-c-checkbox__label {
     display: block;
-    padding: 8px $spacing-scale-2 9px 12px;
+    padding: 8px $govuk-spacing-scale-2 9px 12px;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
@@ -76,7 +76,7 @@
     content: "";
 
     position: absolute;
-    top: $spacing-scale-2;
+    top: $govuk-spacing-scale-2;
     left: 8px;
 
     width: 17px;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -2,6 +2,7 @@
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
 @import "../../globals/scss/media-queries";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 
@@ -46,7 +47,7 @@
 
   .govuk-c-checkbox__label {
     display: block;
-    padding: 8px $gutter-one-third 9px 12px;
+    padding: 8px $spacing-scale-2 9px 12px;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
@@ -67,7 +68,7 @@
     width: 34px;
     height: 34px;
 
-    border: 2px solid;
+    border: $govuk-border-width-form-element solid;
     background: transparent;
   }
 
@@ -75,7 +76,7 @@
     content: "";
 
     position: absolute;
-    top: 10px;
+    top: $spacing-scale-2;
     left: 8px;
 
     width: 17px;
@@ -83,7 +84,7 @@
 
     transform: rotate(-45deg);
     border: solid;
-    border-width: 0 0 5px 5px;
+    border-width: 0 0 $govuk-border-width $govuk-border-width;
     // Fix bug in IE11 caused by transform rotate (-45deg).
     // See: alphagov/govuk_elements/issues/518
     border-top-color: transparent;
@@ -95,7 +96,7 @@
 
   // Focused state
   .govuk-c-checkbox__input:focus + .govuk-c-checkbox__label:before {
-    box-shadow: 0 0 0 3px $govuk-focus-colour;
+    box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 
   // Selected state

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../site-width-container/site-width-container";
@@ -7,8 +8,8 @@
   .govuk-c-cookie-banner {
     width: 100%;
 
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: $spacing-scale-2;
+    padding-bottom: $spacing-scale-2;
 
     background-color: $govuk-light-blue-25;
 

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -8,8 +8,8 @@
   .govuk-c-cookie-banner {
     width: 100%;
 
-    padding-top: $spacing-scale-2;
-    padding-bottom: $spacing-scale-2;
+    padding-top: $govuk-spacing-scale-2;
+    padding-bottom: $govuk-spacing-scale-2;
 
     background-color: $govuk-light-blue-25;
 

--- a/src/components/date/_date.scss
+++ b/src/components/date/_date.scss
@@ -14,7 +14,7 @@
 
   .govuk-c-date__item {
     width: 50px;
-    margin-right: $spacing-scale-4;
+    margin-right: $govuk-spacing-scale-4;
     margin-bottom: 0;
     float: left;
     clear: none;

--- a/src/components/date/_date.scss
+++ b/src/components/date/_date.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/clearfix";
 @import "../../globals/scss/vars";
@@ -13,7 +14,7 @@
 
   .govuk-c-date__item {
     width: 50px;
-    margin-right: 20px;
+    margin-right: $spacing-scale-4;
     margin-bottom: 0;
     float: left;
     clear: none;

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -17,7 +17,7 @@
     display: inline-block;
 
     position: relative;
-    margin-bottom: em($spacing-scale-1, 19);
+    margin-bottom: em($govuk-spacing-scale-1, 19);
 
     color: $govuk-blue;
     cursor: pointer;
@@ -43,8 +43,8 @@
   }
 
   .govuk-c-details__text {
-    margin-bottom: em($spacing-scale-3, 19);
-    padding: em($spacing-scale-3, 19);
+    margin-bottom: em($govuk-spacing-scale-3, 19);
+    padding: em($govuk-spacing-scale-3, 19);
     @include govuk-u-border-left($govuk-border-width, $govuk-border-colour);
   }
 

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";
 @import "../../globals/scss/vars";
@@ -16,7 +17,7 @@
     display: inline-block;
 
     position: relative;
-    margin-bottom: em(5, 19);
+    margin-bottom: em($spacing-scale-1, 19);
 
     color: $govuk-blue;
     cursor: pointer;
@@ -42,8 +43,8 @@
   }
 
   .govuk-c-details__text {
-    margin-bottom: em(15, 19);
-    padding: em(15, 19);
+    margin-bottom: em($spacing-scale-3, 19);
+    padding: em($spacing-scale-3, 19);
     @include govuk-u-border-left($govuk-border-width, $govuk-border-colour);
   }
 

--- a/src/components/error-message/_error-message.scss
+++ b/src/components/error-message/_error-message.scss
@@ -8,6 +8,7 @@
     display: block;
 
     margin: 0;
+    // TODO: use a var for padding
     padding: 2px 0;
 
     clear: both;

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -9,7 +9,7 @@
 
   .govuk-c-error-summary {
 
-    padding: $spacing-scale-3 $spacing-scale-2;
+    padding: $govuk-spacing-scale-3 $govuk-spacing-scale-2;
 
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
@@ -18,7 +18,7 @@
 
     @include mq($from: tablet) {
 
-      padding: $spacing-scale-4 $spacing-scale-3 $spacing-scale-3;
+      padding: $govuk-spacing-scale-4 $govuk-spacing-scale-3 $govuk-spacing-scale-3;
 
       border: $govuk-border-width-tablet solid $govuk-error-colour;
     }
@@ -35,10 +35,10 @@
 
   .govuk-c-error-summary__title {
     margin-top: 0;
-    margin-bottom: $spacing-scale-2;
+    margin-bottom: $govuk-spacing-scale-2;
 
     @include mq($from: tablet) {
-      margin-bottom: $spacing-scale-4;
+      margin-bottom: $govuk-spacing-scale-4;
     }
 
     font-family: $govuk-font-stack;

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -1,5 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../list/list";
@@ -7,10 +8,8 @@
 @include exports("error-summary") {
 
   .govuk-c-error-summary {
-    margin-top: 15px; // should these be 16px?
-    margin-bottom: 15px;
 
-    padding: 15px 10px;
+    padding: $spacing-scale-3 $spacing-scale-2;
 
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
@@ -18,10 +17,8 @@
     @include font-smoothing;
 
     @include mq($from: tablet) {
-      margin-top: 30px; // should this be 32px?
-      margin-bottom: 30px;
 
-      padding: 20px 15px 15px;
+      padding: $spacing-scale-4 $spacing-scale-3 $spacing-scale-3;
 
       border: $govuk-border-width-tablet solid $govuk-error-colour;
     }
@@ -38,10 +35,10 @@
 
   .govuk-c-error-summary__title {
     margin-top: 0;
-    margin-bottom: .5em;
+    margin-bottom: $spacing-scale-2;
 
     @include mq($from: tablet) {
-      margin-bottom: 20px;
+      margin-bottom: $spacing-scale-4;
     }
 
     font-family: $govuk-font-stack;

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../label/label";
@@ -8,7 +9,7 @@
   .govuk-c-input {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    padding: 5px 4px 4px;
+    padding: $spacing-scale-1;
 
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,7 +9,7 @@
   .govuk-c-input {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    padding: $spacing-scale-1;
+    padding: $govuk-spacing-scale-1;
 
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -1,12 +1,13 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";
 @import "../../globals/scss/vars";
 
 @include exports("inset-text") {
   .govuk-c-inset-text {
-    margin-bottom: em(15, 19);
-    padding: em(15, 19);
+    margin-bottom: em($spacing-scale-3, 19);
+    padding: em($spacing-scale-3, 19);
 
     clear: both;
 

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -6,8 +6,8 @@
 
 @include exports("inset-text") {
   .govuk-c-inset-text {
-    margin-bottom: em($spacing-scale-3, 19);
-    padding: em($spacing-scale-3, 19);
+    margin-bottom: em($govuk-spacing-scale-3, 19);
+    padding: em($govuk-spacing-scale-3, 19);
 
     clear: both;
 

--- a/src/globals/scss/_grid-layout.scss
+++ b/src/globals/scss/_grid-layout.scss
@@ -1,4 +1,5 @@
 @import "media-queries";
+@import "spacing";
 @import "utilities/clearfix";
 @import "vars";
 
@@ -17,18 +18,18 @@
 
   margin: 0 $govuk-gutter-half;
   @include mq($from: tablet) {
-    margin: 0 $govuk-gutter;
+    margin: 0 $spacing-scale-5;
   }
 
-  @include mq($and: "(min-width: #{($govuk-site-width + $govuk-gutter * 2)})") {
+  @include mq($and: "(min-width: #{($govuk-site-width + $spacing-scale-5 * 2)})") {
     margin: 0 auto;
   }
 }
 
 @mixin govuk-grid {
   @include govuk-u-clearfix;
-  margin-right: - ($govuk-gutter / 2);
-  margin-left: - ($govuk-gutter / 2);
+  margin-right: - ($spacing-scale-3);
+  margin-left: - ($spacing-scale-3);
 }
 
 @mixin govuk-grid-item {

--- a/src/globals/scss/_grid-layout.scss
+++ b/src/globals/scss/_grid-layout.scss
@@ -18,18 +18,18 @@
 
   margin: 0 $govuk-gutter-half;
   @include mq($from: tablet) {
-    margin: 0 $spacing-scale-5;
+    margin: 0 $govuk-spacing-scale-5;
   }
 
-  @include mq($and: "(min-width: #{($govuk-site-width + $spacing-scale-5 * 2)})") {
+  @include mq($and: "(min-width: #{($govuk-site-width + $govuk-spacing-scale-5 * 2)})") {
     margin: 0 auto;
   }
 }
 
 @mixin govuk-grid {
   @include govuk-u-clearfix;
-  margin-right: - ($spacing-scale-3);
-  margin-left: - ($spacing-scale-3);
+  margin-right: - ($govuk-spacing-scale-3);
+  margin-left: - ($govuk-spacing-scale-3);
 }
 
 @mixin govuk-grid-item {

--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -16,14 +16,14 @@ $spacing-directions: (
 ) !default;
 
 // Set spacing scale
-$spacing-scale: (
+$govuk-spacing-scale: (
   0: 0,
-  1: $spacing-scale-1,
-  2: $spacing-scale-2,
-  3: $spacing-scale-3,
-  4: $spacing-scale-4,
-  5: $spacing-scale-5,
-  6: $spacing-scale-6
+  1: $govuk-spacing-scale-1,
+  2: $govuk-spacing-scale-2,
+  3: $govuk-spacing-scale-3,
+  4: $govuk-spacing-scale-4,
+  5: $govuk-spacing-scale-5,
+  6: $govuk-spacing-scale-6
 );
 
 @import "import-once";
@@ -32,7 +32,7 @@ $spacing-scale: (
   // Create spacing utility classes
   @each $spacing-property-key, $spacing-property-value in $spacing-properties {
     @each $spacing-direction-key, $spacing-direction-value in $spacing-directions {
-      @each $spacing-scale-key, $spacing-scale-value in $spacing-scale {
+      @each $spacing-scale-key, $spacing-scale-value in $govuk-spacing-scale {
         .govuk-u-#{$spacing-property-value}#{$spacing-direction-value}-#{$spacing-scale-key} {
           @each $direction in $spacing-direction-key {
             #{$spacing-property-key}#{$direction}: $spacing-scale-value !important;

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -32,12 +32,12 @@ $govuk-gutter-half: $govuk-gutter / 2;
 $gutter-one-third: $govuk-gutter / 3;
 
 // Spacing scale
-$spacing-scale-1: 5px;
-$spacing-scale-2: 10px;
-$spacing-scale-3: 15px;
-$spacing-scale-4: 20px;
-$spacing-scale-5: 30px;
-$spacing-scale-6: 60px;
+$govuk-spacing-scale-1: 5px;
+$govuk-spacing-scale-2: 10px;
+$govuk-spacing-scale-3: 15px;
+$govuk-spacing-scale-4: 20px;
+$govuk-spacing-scale-5: 30px;
+$govuk-spacing-scale-6: 60px;
 
 // Fonts
 // New Transport Light font family


### PR DESCRIPTION
This PR:
- replaces px values with spacing-scale variables
- imports the spacing partial in each component that uses the spacing-scale variables

Things to decide:
In some cases em values have been swapped for pixel based values, where we have a values in em, would we like to keep this and use a px to em helper to convert between the two? this is currently inconsistent - see breadcrumb and button as examples. 

There are also a couple of places where we have 2px and 4px padding. I've added comments where hard coded px values still exist.