### PR TITLE
Fixes em() function output error

### DIFF
--- a/src/globals/scss/_helpers-px-to-em.scss
+++ b/src/globals/scss/_helpers-px-to-em.scss
@@ -1,4 +1,4 @@
 // Convert pixels to em
 @function em($px, $govuk-context-font-size) {
-  @return ($px / $govuk-context-font-size) * 1em;
+  @return #{$px / $govuk-context-font-size}em;
 }


### PR DESCRIPTION
Our pixel to em function was 
```
 @function em($px, $govuk-context-font-size) {
   @return ($px / $govuk-context-font-size) * 1em;
 }
```
When we switched to using spacing scale variables in the function, like 
`padding: em($spacing-scale-5, 19px)`

it resulted in an error
```
Error: 0.26316em*px isn't a valid CSS value.
on line 3 of src/globals/scss/_helpers-px-to-em.scss
@return ($px / $govuk-context-font-size) * 1em;
```
This PR amends the return statement to
`@return #{$px / $govuk-context-font-size}em;`
which fixes the above error, relying on interpolation.