### PR TITLE
Add typography styles from govuk_frontend_toolkit

### DIFF
--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,80 +1,355 @@
 @import "media-queries";
 @import "vars";
+@import "import-once";
+
+// $govuk-typography-scale-1: 14;
+// $govuk-typography-scale-2: 16;
+// $govuk-typography-scale-3: 19;
+// $govuk-typography-scale-4: 24;
+// $govuk-typography-scale-5: 27;
+// $govuk-typography-scale-6: 36;
+// $govuk-typography-scale-7: 48;
+// $govuk-typography-scale-8: 80;
 
 @mixin font-smoothing {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-// Add the govuk- prefix to prevent inteference
-// with the govuk_frontend_toolkit's core-x and bold-x mixins
-@mixin govuk-font-size($px) {
-  font-size: $px + px;
-}
+$is-print: false !default;
 
+@mixin _core-font-generator(
+  $font-size: 19px,
+  $font-size-640: 16px,
+  $font-size-print: 14pt,
+  $line-height: (25 / 19),
+  $line-height-640: (20 / 16),
+  $tabular-numbers: false,
+  $font-weight: 400
+  ) {
+  @if $tabular-numbers == true {
+    font-family: $govuk-font-stack-tabular;
+  } @else if $is-print {
+    font-family: $govuk-font-stack-print;
+  } @else {
+    font-family: $govuk-font-stack;
+    @if $govuk-font-stack == "$nta-light" {
+      @if $font-weight > 400 {
+        font-size-adjust: .525;
+      } @else {
+        font-size-adjust: .5;
+      }
+    }
+  }
+  font-weight: $font-weight;
+  text-transform: none;
 
-@mixin govuk-bold-48 {
-  @include govuk-font-size(48);
-  font-weight: 700;
+  @if $is-print {
+    font-size: $font-size-print;
+    line-height: $line-height;
 
-  line-height: (50 / 48);
-}
+  } @else {
+    font-size: $font-size-640;
+    line-height: $line-height-640;
 
-@mixin govuk-bold-19 {
-  @include govuk-font-size(19);
-  font-weight: 700;
-
-  line-height: (25 / 19);
-}
-@mixin govuk-bold-18 {
-  @include govuk-font-size(18);
-  font-weight: 700;
-
-  line-height: (21.6 / 18);
-}
-
-@mixin govuk-bold-16 {
-  @include govuk-font-size(16);
-  font-weight: 700;
-  line-height: (20 / 16);
-}
-@mixin govuk-bold-12 {
-  @include govuk-font-size(12);
-  font-weight: 700;
-  line-height: (12 / 12);
-}
-
-@mixin govuk-bold-24 {
-  @include govuk-bold-18;
-  @include mq($from: tablet) {
-    @include govuk-font-size(24);
-    line-height: (30 / 24);
+    @include mq($from: tablet) {
+      font-size: $font-size;
+      line-height: $line-height;
+    }
   }
 }
 
-@mixin govuk-core-36 {
-  @include govuk-font-size(36);
-  line-height: (40 / 36);
+@mixin govuk-core-80($line-height: (80 / 80), $line-height-640: (55 / 53), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 80px;
+  $font-size-640: 53px;
+  $font-size-print: 28pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
-@mixin govuk-core-27 {
-  @include govuk-font-size(27);
-  line-height: (30 / 27);
+@mixin govuk-core-48($line-height: (50 / 48), $line-height-640: (35 / 32), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 48px;
+  $font-size-640: 32px;
+  $font-size-print: 18pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
 }
 
-@mixin govuk-core-19 {
-  @include govuk-core-16;
+@mixin govuk-core-36($line-height: (40 / 36), $line-height-640: (25 / 24), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 36px;
+  $font-size-640: 24px;
+  $font-size-print: 18pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-core-27($line-height: (30 / 27), $line-height-640: (20 / 18), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 27px;
+  $font-size-640: 20px;
+  $font-size-print: 16pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-core-24($line-height: (30 / 24), $line-height-640: (24 / 20), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 24px;
+  $font-size-640: 18px;
+  $font-size-print: 16pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-core-19($line-height: (25 / 19), $line-height-640: (20 / 16), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 19px;
+  $font-size-640: 16px;
+  $font-size-print: 14pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-core-16($line-height: (20 / 16), $line-height-640: (16 / 14), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 16px;
+  $font-size-640: 14px;
+  $font-size-print: 12pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-core-14($line-height: (20 / 14), $line-height-640: (15 / 12), $tabular-numbers: false, $font-weight: 400) {
+  $font-size: 14px;
+  $font-size-640: 12px;
+  $font-size-print: 11pt;
+  @include _core-font-generator($font-size, $font-size-640, $font-size-print, $line-height, $line-height-640, $tabular-numbers, $font-weight);
+}
+
+@mixin govuk-bold-80($line-height: (80 / 80), $line-height-640: (55 / 53), $tabular-numbers: false) {
+  @include govuk-core-80($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-48($line-height: (50 / 48), $line-height-640: (35 / 32), $tabular-numbers: false) {
+  @include govuk-core-48($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-36($line-height: (40 / 36), $line-height-640: (25 / 24), $tabular-numbers: false) {
+  @include govuk-core-36($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-27($line-height: (30 / 27), $line-height-640: (20 / 18), $tabular-numbers: false) {
+  @include govuk-core-27($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-24($line-height: (30 / 24), $line-height-640: (24 / 20), $tabular-numbers: false) {
+  @include govuk-core-24($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-19($line-height: (25 / 19), $line-height-640: (20 / 16), $tabular-numbers: false) {
+  @include govuk-core-19($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-16($line-height: (20 / 16), $line-height-640: (16 / 14), $tabular-numbers: false) {
+  @include govuk-core-16($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin govuk-bold-14($line-height: (20 / 14), $line-height-640: (15 / 12), $tabular-numbers: false) {
+  @include govuk-core-14($line-height, $line-height-640, $tabular-numbers: $tabular-numbers, $font-weight: 700);
+}
+
+@mixin heading-80($tabular-numbers: false) {
+  @include govuk-core-80($tabular-numbers: $tabular-numbers);
+
+  display: block;
+
+  padding-top: 8px;
+  padding-bottom: 7px;
+
   @include mq($from: tablet) {
-    @include govuk-font-size(19);
-    line-height: (25 / 19);
+    padding-top: 6px;
+    padding-bottom: 14px;
   }
 }
 
-@mixin govuk-core-16 {
-  @include govuk-font-size(16);
-  line-height: (20 / 16);
+@mixin govuk-heading-48($tabular-numbers: false) {
+  @include govuk-core-48($tabular-numbers: $tabular-numbers);
+
+  display: block;
+
+  padding-top: 10px;
+  padding-bottom: 10px;
+
+  @include mq($from: tablet) {
+    padding-top: 7px;
+    padding-bottom: 13px;
+  }
+}
+
+@mixin govuk-heading-36($tabular-numbers: false) {
+  @include govuk-core-36($tabular-numbers: $tabular-numbers);
+
+  display: block;
+
+  padding-top: 8px;
+  padding-bottom: 7px;
+
+  @include mq($from: tablet) {
+    padding-top: 6px;
+    padding-bottom: 9px;
+  }
+}
+
+@mixin govuk-heading-27($tabular-numbers: false) {
+  @include govuk-core-27($tabular-numbers: $tabular-numbers);
+
+  display: block;
+
+  padding-top: 8px;
+  padding-bottom: 7px;
+
+  @include mq($from: tablet) {
+    padding-top: 4px;
+    padding-bottom: 6px;
+  }
+}
+
+@mixin govuk-heading-24($tabular-numbers: false) {
+  @include govuk-core-24($tabular-numbers: $tabular-numbers);
+
+  display: block;
+
+  padding-top: 9px;
+  padding-bottom: 6px;
+
+  @include mq($from: tablet) {
+    padding-top: 6px;
+    padding-bottom: 4px;
+  }
+}
+
+@mixin govuk-copy-19($tabular-numbers: false) {
+  @include govuk-core-19($tabular-numbers: $tabular-numbers);
+
+  padding-top: 2px;
+  padding-bottom: 8px;
+
+  @include mq($from: tablet) {
+    padding-top: 0;
+    padding-bottom: 5px;
+  }
+}
+
+@mixin govuk-copy-16($tabular-numbers: false) {
+  @include govuk-core-16($tabular-numbers: $tabular-numbers);
+
+  padding-top: 8px;
+  padding-bottom: 7px;
+
+  @include mq($from: tablet) {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+}
+
+@mixin govuk-copy-14($tabular-numbers: false) {
+  @include govuk-core-14($tabular-numbers: $tabular-numbers);
+
+  padding-top: 8px;
+  padding-bottom: 7px;
+
+  @include mq($from: tablet) {
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
 }
 
 @mixin govuk-bold {
   font-weight: 700;
+}
+
+@include exports("typography") {
+
+  .govuk-u-core-14 {
+    @include govuk-core-14;
+  }
+
+  .govuk-u-core-16 {
+    @include govuk-core-16;
+  }
+
+  .govuk-u-core-19 {
+    @include govuk-core-19;
+  }
+
+  .govuk-u-core-24 {
+    @include govuk-core-24;
+  }
+
+  .govuk-u-core-27 {
+    @include govuk-core-24;
+  }
+
+  .govuk-u-core-36 {
+    @include govuk-core-36;
+  }
+
+  .govuk-u-core-48 {
+    @include govuk-core-48;
+  }
+
+  .govuk-u-core-80 {
+    @include govuk-core-80;
+  }
+
+
+  .govuk-u-bold-14 {
+    @include govuk-bold-14;
+  }
+
+  .govuk-u-bold-16 {
+    @include govuk-bold-16;
+  }
+
+  .govuk-u-bold-19 {
+    @include govuk-bold-19;
+  }
+
+  .govuk-u-bold-24 {
+    @include govuk-bold-24;
+  }
+
+  .govuk-u-bold-27 {
+    @include govuk-bold-27;
+  }
+
+  .govuk-u-bold-36 {
+    @include govuk-bold-36;
+  }
+
+  .govuk-u-bold-48 {
+    @include govuk-bold-48;
+  }
+
+  .govuk-u-bold-80 {
+    @include govuk-bold-80;
+  }
+
+  .govuk-u-heading-24 {
+    @include govuk-heading-24;
+  }
+
+  .govuk-u-heading-27 {
+    @include govuk-heading-24;
+  }
+
+  .govuk-u-heading-36 {
+    @include govuk-heading-36;
+  }
+
+  .govuk-u-heading-48 {
+    @include govuk-heading-48;
+  }
+
+  .govuk-u-copy-14 {
+    @include govuk-copy-14;
+  }
+
+  .govuk-u-copy-16 {
+    @include govuk-copy-16;
+  }
+
+  .govuk-u-copy-19 {
+    @include govuk-copy-19;
+  }
+
 }

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -1,6 +1,7 @@
-@import "media-queries";
-@import "vars";
 @import "import-once";
+@import "media-queries";
+@import "spacing";
+@import "vars";
 
 // $govuk-typography-scale-1: 14;
 // $govuk-typography-scale-2: 16;
@@ -166,8 +167,8 @@ $is-print: false !default;
 
   display: block;
 
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: $govuk-spacing-scale-2;
+  padding-bottom: $govuk-spacing-scale-2;
 
   @include mq($from: tablet) {
     padding-top: 7px;
@@ -225,7 +226,7 @@ $is-print: false !default;
 
   @include mq($from: tablet) {
     padding-top: 0;
-    padding-bottom: 5px;
+    padding-bottom: $govuk-spacing-scale-1;
   }
 }
 
@@ -236,8 +237,8 @@ $is-print: false !default;
   padding-bottom: 7px;
 
   @include mq($from: tablet) {
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: $govuk-spacing-scale-1;
+    padding-bottom: $govuk-spacing-scale-1;
   }
 }
 
@@ -248,8 +249,8 @@ $is-print: false !default;
   padding-bottom: 7px;
 
   @include mq($from: tablet) {
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding-top: $govuk-spacing-scale-1;
+    padding-bottom: $govuk-spacing-scale-1;
   }
 }
 

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -47,3 +47,4 @@ $govuk-nta-light-tabular: "ntatabularnumbers", $govuk-nta-light;
 // Allow font stack to be overridden
 $govuk-font-stack: $govuk-nta-light !default;
 $govuk-font-stack-tabular: $govuk-nta-light-tabular !default;
+$govuk-font-stack-print: sans-serif !default;


### PR DESCRIPTION
Copy all typography mixins.

Prefix mixins with `govuk-`

Create utility classes using each of the mixins.

Note: We don't intend to keep all of these, or to use these classnames. 
For now, these exist to test how these typography mixins work with components and our spacing scale. 