### PR TITLE
Include the px to em helper in any component using em

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,6 +1,7 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/media-queries";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -1,5 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,5 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";


### PR DESCRIPTION
This was missing, which was why the compiled css didn’t have the correct
units.