### PR TITLE
Create a typography example page

### DIFF
--- a/src/examples/typography.html
+++ b/src/examples/typography.html
@@ -1,0 +1,107 @@
+<!-- This is missing from GOV.UK elements -->
+<!-- Services should not be using text this small -->
+<div class="govuk-u-core-14">
+  GOV.UK frontend toolkit 14px core text
+</div>
+<!-- In GOV.UK elements, this is .font-xsmall -->
+<div class="govuk-u-core-16">
+  GOV.UK frontend toolkit + GOV.UK elements 16px core text
+</div>
+<!-- In GOV.UK elements, this is .font-small -->
+<div class="govuk-u-core-19">
+  GOV.UK frontend toolkit + GOV.UK elements 19px core text
+</div>
+<!-- In GOV.UK elements, this is .lede -->
+<!-- In GOV.UK elements, this is .font-medium -->
+<div class="govuk-u-core-24">
+  GOV.UK frontend toolkit + GOV.UK elements 24px core text
+</div>
+<!-- This is missing from GOV.UK elements -->
+<div class="govuk-u-core-27">
+  GOV.UK frontend toolkit 27px core text
+</div>
+<!-- In GOV.UK elements, this is .font-large -->
+<div class="govuk-u-core-36">
+  GOV.UK frontend toolkit + GOV.UK elements 36px core text
+</div>
+<!-- In GOV.UK elements, this is .font-xlarge -->
+<div class="govuk-u-core-48">
+  GOV.UK frontend toolkit + GOV.UK elements 48px core text
+</div>
+<!-- In GOV.UK elements, this is .font-xxlarge -->
+<div class="govuk-u-core-80">
+  GOV.UK frontend toolkit + GOV.UK elements 80px core text
+</div>
+
+<!-- This is missing from GOV.UK elements -->
+<div class="govuk-u-bold-14">
+  GOV.UK frontend toolkit 14px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-xsmall -->
+<div class="govuk-u-bold-16">
+  GOV.UK frontend toolkit + GOV.UK elements 16px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-small -->
+<div class="govuk-u-bold-19">
+  GOV.UK frontend toolkit + GOV.UK elements 19px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-medium -->
+<div class="govuk-u-bold-24">
+  GOV.UK frontend toolkit + GOV.UK elements 24px bold heading
+</div>
+<!-- This is missing from GOV.UK elements -->
+<div class="govuk-u-bold-27">
+  GOV.UK frontend toolkit 27px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-large -->
+<div class="govuk-u-bold-36">
+  GOV.UK frontend toolkit + GOV.UK elements 36px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-xlarge -->
+<div class="govuk-u-bold-48">
+  GOV.UK frontend toolkit + GOV.UK elements 48px bold heading
+</div>
+<!-- In GOV.UK elements, this is .bold-xxlarge -->
+<div class="govuk-u-bold-80">
+  GOV.UK frontend toolkit + GOV.UK elements 80px bold heading
+</div>
+
+<div class="govuk-u-heading-24">
+  GOV.UK frontend toolkit 24px heading
+</div>
+<div class="govuk-u-heading-27">
+  GOV.UK frontend toolkit 27px heading
+</div>
+<div class="govuk-u-heading-36">
+  GOV.UK frontend toolkit 36px heading
+</div>
+<div class="govuk-u-heading-48">
+  GOV.UK frontend toolkit 48px heading
+</div>
+
+<div class="heading-xlarge">
+  GOV.UK elements heading-xlarge heading
+</div>
+<div class="heading-large">
+  GOV.UK elements heading-large heading
+</div>
+<div class="heading-medium">
+  GOV.UK elements heading-medium heading
+</div>
+<div class="heading-small">
+  GOV.UK elements heading-small heading
+</div>
+
+<div class="govuk-u-copy-14">
+  GOV.UK frontend toolkit 14px copy
+</div>
+<div class="govuk-u-copy-16">
+  GOV.UK frontend toolkit 16px copy
+</div>
+<div class="govuk-u-copy-19">
+  GOV.UK frontend toolkit 19px copy
+</div>
+
+<div class="body-text">
+  GOV.UK elements body text
+</div>

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -353,4 +353,79 @@ $is-print: false !default;
     @include govuk-copy-19;
   }
 
+  // Copy headings with extra margins from GOV.UK elements
+  .heading-xlarge {
+    @include govuk-bold-48;
+
+    margin-top: em(15, 32);
+    margin-bottom: em(30, 32);
+
+    @include mq($from: tablet) {
+      margin-top: em(30, 48);
+      margin-bottom: em(60, 48);
+    }
+
+    .heading-secondary {
+      @include govuk-heading-27;
+
+      display: block;
+      color: $govuk-secondary-text-colour;
+    }
+
+  }
+
+  .heading-large {
+    @include govuk-bold-36;
+
+    margin-top: em(25, 24);
+    margin-bottom: em(10, 24);
+
+    @include mq($from: tablet) {
+      margin-top: em(45, 36);
+      margin-bottom: em(20, 36);
+    }
+
+    .heading-secondary {
+      @include govuk-heading-24;
+
+      display: block;
+      color: $govuk-secondary-text-colour;
+    }
+
+  }
+
+  .heading-medium {
+    @include govuk-bold-24;
+
+    margin-top: em(25, 20);
+    margin-bottom: em(10, 20);
+
+    @include mq($from: tablet) {
+      margin-top: em(45, 24);
+      margin-bottom: em(20, 24);
+    }
+
+  }
+
+  .heading-small {
+    @include govuk-bold-19;
+
+    margin-top: em(10, 16);
+    margin-bottom: em(5, 16);
+
+    @include mq($from: tablet) {
+      margin-top: em(20, 19);
+    }
+  }
+
+  .body-text {
+    @include govuk-core-19;
+    margin-top: em(5, 16);
+    margin-bottom: em(20, 16);
+
+    @include mq($from: tablet) {
+      margin-top: em(5);
+      margin-bottom: em(20);
+    }
+  }
 }


### PR DESCRIPTION
Copy classes from GOV.UK elements for headings and body text.