### PR TITLE
Normalize form elements' heights

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "sass-mq": "^3.3.2"
   },
   "browserslist": [
-    "last 2 versions"
+    "last 2 versions",
+    "ie 8"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
   },
   "browserslist": [
     "last 2 versions",
-    "ie 8"
+    "ie 8",
+    "ie 9",
+    "iOS 9"
   ]
 }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -13,12 +13,12 @@
     display: inline-block;
     position: relative;
     width: 100%;
+    height: em(40px, 19px);
     margin-top: 0;
     padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
-    height: em(40px, 19px);
     border-width: 2px;
+    border-radius: 0;
     border-color: transparent  transparent darken($govuk-button-colour, 15%) transparent;
-    border-radius: 0; //used to be a mixin with vendor
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
     background-color: $govuk-button-colour;
@@ -26,7 +26,6 @@
     text-align: center;
     @include font-smoothing;
     @include govuk-core-19;
-    text-align: center;
     text-decoration: none;
     vertical-align: top;
     cursor: pointer;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -13,14 +13,15 @@
     display: inline-block;
     position: relative;
     width: 100%;
-    height: 100%;
-    padding: em(13px, 19px) em($govuk-spacing-scale-3, 19px) em(8px, 19px);
-    border: 0;
+    margin-top: 0;
+    padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
+    height: em(40px, 19px);
+    border-width: 2px;
+    border-color: transparent  transparent darken($govuk-button-colour, 15%) transparent;
     border-radius: 0; //used to be a mixin with vendor
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
     background-color: $govuk-button-colour;
-    box-shadow: 0 2px 0 darken($govuk-button-colour, 15%);
     font-family: $govuk-font-stack;
     text-align: center;
     @include font-smoothing;
@@ -33,7 +34,6 @@
 
     @include mq($from: tablet) {
       width: initial;
-      padding: em(9px, 19px) em($govuk-spacing-scale-3, 19px) em(4px, 19px);
     }
 
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -9,12 +9,11 @@
 
 @include exports("button") {
   .govuk-c-button {
-    width: 100%;
-    padding: em(12px, 19px) em($govuk-spacing-scale-3, 19px) em(10px, 19px);
-    text-align: center;
     box-sizing: border-box;
     display: inline-block;
     position: relative;
+    width: 100%;
+    padding: em(12px, 19px) em($govuk-spacing-scale-3, 19px) em(10px, 19px);
     border: 0;
     border-radius: 0; //used to be a mixin with vendor
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
@@ -22,6 +21,7 @@
     background-color: $govuk-button-colour;
     box-shadow: 0 2px 0 darken($govuk-button-colour, 15%);
     font-family: $govuk-font-stack;
+    text-align: center;
     @include font-smoothing;
     @include govuk-core-19;
     text-align: center;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -9,39 +9,32 @@
 
 @include exports("button") {
   .govuk-c-button {
+    width: 100%;
+    padding: em(12px, 19px) em($govuk-spacing-scale-3, 19px) em(10px, 19px);
+    text-align: center;
     box-sizing: border-box;
     display: inline-block;
     position: relative;
-    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
     border: 0;
     border-radius: 0; //used to be a mixin with vendor
-
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
-
     background-color: $govuk-button-colour;
     box-shadow: 0 2px 0 darken($govuk-button-colour, 15%);
-
     font-family: $govuk-font-stack;
     @include font-smoothing;
     @include govuk-core-19;
-    line-height: 1.25;
-
     text-align: center;
     text-decoration: none;
-
     vertical-align: top;
-
     cursor: pointer;
-
     -webkit-appearance: none;
 
-    // Apply styling up to devices smaller than tablets (exclude tablets)
-    @include mq($until: tablet) {
-      width: 100%;
-      padding: .7em .78947em .41em;
-      text-align: center;
+    @include mq($from: tablet) {
+      width: initial;
+      padding: em(9px, 19px) em($govuk-spacing-scale-3, 19px) em(4px, 19px);
     }
+
 
     // Set text colour depending on background colour
     @if lightness($govuk-button-colour) < 50% {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -13,7 +13,8 @@
     display: inline-block;
     position: relative;
     width: 100%;
-    padding: em(12px, 19px) em($govuk-spacing-scale-3, 19px) em(10px, 19px);
+    height: 100%;
+    padding: em(13px, 19px) em($govuk-spacing-scale-3, 19px) em(8px, 19px);
     border: 0;
     border-radius: 0; //used to be a mixin with vendor
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -13,7 +13,7 @@
     display: inline-block;
     position: relative;
     width: 100%;
-    height: em(40px, 19px);
+    min-height: em(40px, 19px);
     margin-top: 0;
     padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
     border-width: 2px;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -39,6 +39,7 @@
     // Apply styling up to devices smaller than tablets (exclude tablets)
     @include mq($until: tablet) {
       width: 100%;
+      padding: .7em .78947em .41em;
       text-align: center;
     }
 

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -11,8 +11,9 @@
     display: block;
     position: relative;
 
+
     margin-bottom: $gutter-one-third;
-    padding: 0 0 0 40px;
+    padding: 0 0 0 em(40px,19px);
 
     clear: left;
 
@@ -46,41 +47,35 @@
   }
 
   .govuk-c-checkbox__label {
+    border: 2px solid transparent;
     display: block;
-    padding: 12px $govuk-spacing-scale-2 8px 12px;
+    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
     touch-action: manipulation;
-    @include mq($from: tablet) {
-      padding-top: 10px;
-      padding-bottom: 7px;
-    }
   }
 
   .govuk-c-checkbox__input + .govuk-c-checkbox__label:before {
     content: "";
-
     position: absolute;
     top: 0;
     left: 0;
-
-    width: 36px;
-    height: 36px;
-
-    border: $govuk-border-width-form-element solid;
+    width: em(36px, 19px);
+    height: em(36px, 19px);
+    border: $govuk-border-width-form-element solid $govuk-text-colour;
     background: transparent;
+    // padding-bottom: 1px;
   }
 
   .govuk-c-checkbox__input + .govuk-c-checkbox__label:after {
     content: "";
 
     position: absolute;
-    top: 11px;
-    left: 9px;
-
-    width: 17px;
-    height: 7px;
+    top: em(12px, 19px);
+    left: em(10px, 19px);
+    width: em(18px, 19px);
+    height: em(7px, 19px);
 
     transform: rotate(-45deg);
     border: solid;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -13,7 +13,7 @@
 
 
     margin-bottom: $gutter-one-third;
-    padding: 0 0 0 em(40px,19px);
+    padding: 0 0 0 em(40px, 19px);
 
     clear: left;
 
@@ -47,9 +47,9 @@
   }
 
   .govuk-c-checkbox__label {
-    border: 2px solid transparent;
     display: block;
     padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
+    border: 2px solid transparent;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -49,7 +49,7 @@
   .govuk-c-checkbox__label {
     border: 2px solid transparent;
     display: block;
-    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
+    padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -12,7 +12,7 @@
     position: relative;
 
     margin-bottom: $gutter-one-third;
-    padding: 0 0 0 38px;
+    padding: 0 0 0 40px;
 
     clear: left;
 
@@ -33,8 +33,8 @@
     top: 0;
     left: 0;
 
-    width: 38px;
-    height: 38px;
+    width: 40px;
+    height: 40px;
 
     cursor: pointer;
 
@@ -47,13 +47,13 @@
 
   .govuk-c-checkbox__label {
     display: block;
-    padding: 8px $govuk-spacing-scale-2 9px 12px;
+    padding: 12px $govuk-spacing-scale-2 8px 12px;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
     touch-action: manipulation;
     @include mq($from: tablet) {
-      padding-top: 7px;
+      padding-top: 10px;
       padding-bottom: 7px;
     }
   }
@@ -65,8 +65,8 @@
     top: 0;
     left: 0;
 
-    width: 34px;
-    height: 34px;
+    width: 36px;
+    height: 36px;
 
     border: $govuk-border-width-form-element solid;
     background: transparent;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -76,8 +76,8 @@
     content: "";
 
     position: absolute;
-    top: $govuk-spacing-scale-2;
-    left: 8px;
+    top: 11px;
+    left: 9px;
 
     width: 17px;
     height: 7px;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -61,10 +61,11 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: em(36px, 19px);
-    height: em(36px, 19px);
+    width: em(40px, 19px);
+    height: em(40px, 19px);
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     background: transparent;
+    box-sizing: border-box;
     // padding-bottom: 1px;
   }
 
@@ -72,8 +73,8 @@
     content: "";
 
     position: absolute;
-    top: em(12px, 19px);
-    left: em(10px, 19px);
+    top: em(11px, 19px);
+    left: em(9px, 19px);
     width: em(18px, 19px);
     height: em(7px, 19px);
 

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -58,6 +58,7 @@
 
   .govuk-c-checkbox__input + .govuk-c-checkbox__label:before {
     content: "";
+    box-sizing: border-box;
     position: absolute;
     top: 0;
     left: 0;
@@ -65,7 +66,7 @@
     height: em(40px, 19px);
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     background: transparent;
-    box-sizing: border-box;
+
     // padding-bottom: 1px;
   }
 

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -56,7 +56,7 @@
     touch-action: manipulation;
   }
 
-  .govuk-c-checkbox__input + .govuk-c-checkbox__label:before {
+  .govuk-c-checkbox__input + .govuk-c-checkbox__label::before {
     content: "";
     box-sizing: border-box;
     position: absolute;
@@ -70,7 +70,7 @@
     // padding-bottom: 1px;
   }
 
-  .govuk-c-checkbox__input + .govuk-c-checkbox__label:after {
+  .govuk-c-checkbox__input + .govuk-c-checkbox__label::after {
     content: "";
 
     position: absolute;
@@ -92,12 +92,12 @@
   }
 
   // Focused state
-  .govuk-c-checkbox__input:focus + .govuk-c-checkbox__label:before {
+  .govuk-c-checkbox__input:focus + .govuk-c-checkbox__label::before {
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 
   // Selected state
-  .govuk-c-checkbox__input:checked + .govuk-c-checkbox__label:after {
+  .govuk-c-checkbox__input:checked + .govuk-c-checkbox__label::after {
     opacity: 1;
   }
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,11 +9,7 @@
   .govuk-c-input {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    padding: $govuk-spacing-scale-2 $govuk-spacing-scale-1 $govuk-spacing-scale-1 + 1;
-    @include mq($from: tablet) {
-      padding: $govuk-spacing-scale-1 + 3 $govuk-spacing-scale-1 $govuk-spacing-scale-1;
-    }
-
+    padding: em(10px, 19px) em($govuk-spacing-scale-3, 19px) em(9px, 19px);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;
@@ -25,6 +21,9 @@
 
     // Disable inner shadow and remove rounded corners
     -webkit-appearance: none;
+    @include mq($from: tablet) {
+      padding: em(7px, 19px) em($govuk-spacing-scale-3, 19px) em(4px, 19px);
+    }
   }
 
   .govuk-c-input::-webkit-outer-spin-button,

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -10,7 +10,7 @@
     box-sizing: border-box; // should this be global?
     width: 100%;
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-1 $govuk-spacing-scale-1 + 1;
-    @include mq($from:tablet) {
+    @include mq($from: tablet) {
       padding: $govuk-spacing-scale-1 + 3 $govuk-spacing-scale-1 $govuk-spacing-scale-1;
     }
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,7 +9,10 @@
   .govuk-c-input {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    padding: $govuk-spacing-scale-1;
+    padding: $govuk-spacing-scale-2 $govuk-spacing-scale-1 $govuk-spacing-scale-1 + 1;
+    @include mq($from:tablet) {
+      padding: $govuk-spacing-scale-1 + 3 $govuk-spacing-scale-1 $govuk-spacing-scale-1;
+    }
 
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,4 +1,5 @@
 @import "../../globals/scss/import-once";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
@@ -7,23 +8,22 @@
 
 @include exports("input") {
   .govuk-c-input {
-    box-sizing: border-box; // should this be global?
+    box-sizing: border-box;
     width: 100%;
-    height: 100%;
-    padding: em(9px, 19px) em(4px, 19px) em(8px, 19px);
+    margin-top: 0;
+    padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
+    height: em(40px, 19px);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
     font-family: $govuk-font-stack;
+
     @include font-smoothing;
     @include govuk-core-19;
 
     // Disable inner shadow and remove rounded corners
-    -webkit-appearance: none;
-    @include mq($from: tablet) {
-      padding: em(6px, 19px) em(4px, 19px) em(4px, 19px);
-    }
+    appearance: none;
   }
 
   .govuk-c-input::-webkit-outer-spin-button,

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,12 +9,12 @@
   .govuk-c-input {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    padding: em(10px, 19px) em($govuk-spacing-scale-3, 19px) em(9px, 19px);
+    height: 100%;
+    padding: em(9px, 19px) em(4px, 19px) em(8px, 19px);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
-
     font-family: $govuk-font-stack;
     @include font-smoothing;
     @include govuk-core-19;
@@ -22,7 +22,7 @@
     // Disable inner shadow and remove rounded corners
     -webkit-appearance: none;
     @include mq($from: tablet) {
-      padding: em(7px, 19px) em($govuk-spacing-scale-3, 19px) em(4px, 19px);
+      padding: em(6px, 19px) em(4px, 19px) em(4px, 19px);
     }
   }
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -10,9 +10,9 @@
   .govuk-c-input {
     box-sizing: border-box;
     width: 100%;
+    height: em(40px, 19px);
     margin-top: 0;
     padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
-    height: em(40px, 19px);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -13,7 +13,7 @@
     position: relative;
 
     margin-bottom: $govuk-spacing-scale-2;
-    padding: 0 0 0 38px;
+    padding: 0 0 0 40px;
 
     clear: left;
 
@@ -41,8 +41,8 @@
     top: 0;
     left: 0;
 
-    width: 38px;
-    height: 38px;
+    width: 40px;
+    height: 40px;
 
     cursor: pointer;
 
@@ -56,7 +56,7 @@
   .govuk-c-radio__label {
     display: block;
 
-    padding: 8px $govuk-spacing-scale-2 9px 12px;
+    padding: 12px $govuk-spacing-scale-2 8px 12px;
 
     cursor: pointer;
 
@@ -65,7 +65,7 @@
     touch-action: manipulation;
 
     @include mq($from: tablet) {
-      padding-top: 7px;
+      padding-top: 10px;
       padding-bottom: 7px;
     }
   }
@@ -77,8 +77,8 @@
     top: 0;
     left: 0;
 
-    width: 34px;
-    height: 34px;
+    width: 36px;
+    height: 36px;
 
     border: $govuk-border-width-form-element solid;
     border-radius: 50%;
@@ -89,8 +89,8 @@
     content: "";
 
     position: absolute;
-    top: 9px;
-    left: 9px;
+    top: 10px;
+    left: 10px;
 
     width: 0;
     height: 0;

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -20,7 +20,6 @@
     font-family: $govuk-font-stack;
     @include font-smoothing;
     @include govuk-core-19;
-    line-height: 1.25;
   }
 
   .govuk-c-radio:last-child,
@@ -41,8 +40,8 @@
     top: 0;
     left: 0;
 
-    width: 40px;
-    height: 40px;
+    width: em(40px, 19px);
+    height: em(40px, 19px);
 
     cursor: pointer;
 
@@ -55,19 +54,14 @@
 
   .govuk-c-radio__label {
     display: block;
-
-    padding: 12px $govuk-spacing-scale-2 8px 12px;
+    border: 2px solid transparent;
+    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
 
     cursor: pointer;
 
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
     touch-action: manipulation;
-
-    @include mq($from: tablet) {
-      padding-top: 10px;
-      padding-bottom: 7px;
-    }
   }
 
   .govuk-c-radio__input + .govuk-c-radio__label:before {
@@ -77,8 +71,8 @@
     top: 0;
     left: 0;
 
-    width: 36px;
-    height: 36px;
+    width: em(36px, 19px);
+    height: em(36px, 19px);
 
     border: $govuk-border-width-form-element solid;
     border-radius: 50%;
@@ -89,13 +83,13 @@
     content: "";
 
     position: absolute;
-    top: 10px;
-    left: 10px;
+    top: em(10px, 19px);
+    left: em(10px, 19px);
 
     width: 0;
     height: 0;
 
-    border: $govuk-spacing-scale-2 solid;
+    border: em(10px, 19px) solid;
     border-radius: 50%;
     opacity: 0;
   }

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -64,13 +64,13 @@
 
   .govuk-c-radio__input + .govuk-c-radio__label:before {
     content: "";
-
+    box-sizing: border-box;
     position: absolute;
     top: 0;
     left: 0;
 
-    width: em(36px, 19px);
-    height: em(36px, 19px);
+    width: em(40px, 19px);
+    height: em(40px, 19px);
 
     border: $govuk-border-width-form-element solid;
     border-radius: 50%;

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -55,7 +55,7 @@
   .govuk-c-radio__label {
     display: block;
     border: 2px solid transparent;
-    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
+    padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
 
     cursor: pointer;
 

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -1,6 +1,7 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
+@import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/media-queries";
 @import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
@@ -13,7 +14,7 @@
     position: relative;
 
     margin-bottom: $govuk-spacing-scale-2;
-    padding: 0 0 0 40px;
+    padding: 0 0 0 em(40px, 19px);
 
     clear: left;
 
@@ -45,7 +46,7 @@
 
     cursor: pointer;
 
-    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there. Double colons get ommited by IE8.
     @if ($is-ie == false) or ($ie-version == 9) {
       margin: 0;
       opacity: 0;
@@ -62,7 +63,7 @@
     touch-action: manipulation;
   }
 
-  .govuk-c-radio__input + .govuk-c-radio__label:before {
+  .govuk-c-radio__input + .govuk-c-radio__label::before {
     content: "";
     box-sizing: border-box;
     position: absolute;
@@ -77,7 +78,7 @@
     background: transparent;
   }
 
-  .govuk-c-radio__input + .govuk-c-radio__label:after {
+  .govuk-c-radio__input + .govuk-c-radio__label::after {
     content: "";
 
     position: absolute;
@@ -93,12 +94,12 @@
   }
 
   // Focused state
-  .govuk-c-radio__input:focus + .govuk-c-radio__label:before {
+  .govuk-c-radio__input:focus + .govuk-c-radio__label::before {
     box-shadow: 0 0 0 4px $govuk-focus-colour;
   }
 
   // Selected state
-  .govuk-c-radio__input:checked + .govuk-c-radio__label:after {
+  .govuk-c-radio__input:checked + .govuk-c-radio__label::after {
     opacity: 1;
   }
 

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -54,11 +54,9 @@
 
   .govuk-c-radio__label {
     display: block;
-    border: 2px solid transparent;
     padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
-
+    border: 2px solid transparent;
     cursor: pointer;
-
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
     touch-action: manipulation;

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -82,13 +82,13 @@
     content: "";
 
     position: absolute;
-    top: em(10px, 19px);
-    left: em(10px, 19px);
+    top: em($govuk-spacing-scale-2, 19px);
+    left: em($govuk-spacing-scale-2, 19px);
 
     width: 0;
     height: 0;
 
-    border: em(10px, 19px) solid;
+    border: em($govuk-spacing-scale-2, 19px) solid;
     border-radius: 50%;
     opacity: 0;
   }

--- a/src/components/select-box/_select-box.scss
+++ b/src/components/select-box/_select-box.scss
@@ -8,6 +8,7 @@
   .govuk-c-select-box {
     box-sizing: border-box; // should this be global?
     width: 100%;
+    height: 40px;
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
 

--- a/src/components/select-box/_select-box.scss
+++ b/src/components/select-box/_select-box.scss
@@ -8,7 +8,7 @@
   .govuk-c-select-box {
     box-sizing: border-box; // should this be global?
     width: 100%;
-    height: 40px;
+    height: em(40px, 19px);
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
 

--- a/src/examples/form-elements-alignment.html
+++ b/src/examples/form-elements-alignment.html
@@ -1,3 +1,29 @@
+<style>
+.govuk-u-w-full {
+width: 100%;
+}
+
+.govuk-u-w-half {
+width: 50%;
+float: left;
+}
+
+.govuk-u-w-third {
+width: 33.33333333%;
+float: left;
+}
+
+.govuk-u-w-quarter {
+width: 25%;
+float: left;
+}
+
+.govuk-u-w-two-thirds {
+width: 66.66666667%;
+float: left;
+}
+</style>
+
 <h1 class="govuk-u-heading-48">Form elements alignment</h1>
 <h2 class="govuk-u-heading-27">Input and button</h2>
 <form action="/" method="post">
@@ -79,7 +105,7 @@
   </div>
   <div class="govuk-u-w-half">
     <div class="govuk-c-radio">
-      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" disabled="disabled" value="NA">
+      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" checked="checked" value="NA">
       <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
     </div>
   </div>
@@ -90,13 +116,13 @@
   <fieldset class="govuk-c-fieldset">
   <div class="govuk-u-w-quarter">
     <div class="govuk-c-radio">
-      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" disabled="disabled" value="NA">
+      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" value="NA">
       <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
     </div>
   </div>
   <div class="govuk-u-w-quarter">
     <div class="govuk-c-radio">
-      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" disabled="disabled" value="NA">
+      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" value="NA">
       <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
     </div>
   </div>

--- a/src/examples/form-elements-alignment.html
+++ b/src/examples/form-elements-alignment.html
@@ -116,14 +116,14 @@ float: left;
   <fieldset class="govuk-c-fieldset">
   <div class="govuk-u-w-quarter">
     <div class="govuk-c-radio">
-      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" value="NA">
-      <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
+      <input class="govuk-c-radio__input" id="radio-1" type="radio" name="radio-group" value="NA">
+      <label class="govuk-c-radio__label" for="radio-1">Not applicable</label>
     </div>
   </div>
   <div class="govuk-u-w-quarter">
     <div class="govuk-c-radio">
-      <input class="govuk-c-radio__input" id="radio-3" type="radio" name="radio-group" value="NA">
-      <label class="govuk-c-radio__label" for="radio-3">Not applicable</label>
+      <input class="govuk-c-radio__input" id="radio-2" type="radio" name="radio-group" value="NA">
+      <label class="govuk-c-radio__label" for="radio-2">Not applicable</label>
     </div>
   </div>
   <div class="govuk-u-w-half">

--- a/src/examples/form-elements-alignment.html
+++ b/src/examples/form-elements-alignment.html
@@ -62,7 +62,7 @@ float: left;
   <fieldset class="govuk-c-fieldset">
   <div class="govuk-u-w-half">
     <label class="govuk-c-label" for="govuk-c-input-a">
-      National Insurance number
+      NIC
     </label>
     <input class="govuk-c-input" id="govuk-c-input-a" type="text">
   </div>
@@ -81,7 +81,7 @@ float: left;
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="govuk-c-input-a">
-    National Insurance number
+    NIC
   </label>
   <div class="govuk-u-w-half">
     <input class="govuk-c-input" id="govuk-c-input-a" type="text">
@@ -98,7 +98,7 @@ float: left;
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="govuk-c-input-a">
-    National Insurance number
+    NIC
   </label>
   <div class="govuk-u-w-half">
     <input class="govuk-c-input" id="govuk-c-input-a" type="text">

--- a/tasks/gulp/dist-prepare.js
+++ b/tasks/gulp/dist-prepare.js
@@ -60,7 +60,8 @@ gulp.task('dist:prepare', () => {
         require('oldie')({
           rgba: {filter: true},
           rem: {disable: true},
-          unmq: {disable: true}
+          unmq: {disable: true},
+          pseudo: {disable: true}
           // more rules go here
         })
       ])

--- a/tasks/gulp/preview-compile.js
+++ b/tasks/gulp/preview-compile.js
@@ -26,7 +26,8 @@ gulp.task('scss:compile', () => {
         require('oldie')({
           rgba: {filter: true},
           rem: {disable: true},
-          unmq: {disable: true}
+          unmq: {disable: true},
+          pseudo: {disable: true}
           // more rules go here
         })
       ])


### PR DESCRIPTION
This PR adjusts properties of the following elements to match their heights across the breakpoints:
- input
- button
- select-box
- radio
- checkbox

Test page: http://govuk-frontend-review-pr-160.herokuapp.com/examples/form-elements-alignment.html

Screenshots

Chrome
![screen shot 2017-07-26 at 15 32 13](https://user-images.githubusercontent.com/3758555/28626832-03f969c6-7218-11e7-8f72-bc323a75fccb.png)

Chrome mobile view
![screen shot 2017-07-26 at 15 31 25](https://user-images.githubusercontent.com/3758555/28626833-04651b3a-7218-11e7-8e30-0234ed089115.png)

IE10
![bs_win7_ie_10 0](https://user-images.githubusercontent.com/3758555/28666025-a65f46d6-72bd-11e7-8172-ece67aa20208.jpg)

IE 11
![bs_win7_ie_11 0](https://user-images.githubusercontent.com/3758555/28666027-a6601ef8-72bd-11e7-8141-a4f0e17a580d.jpg)

Safari
<img width="1093" alt="safari" src="https://user-images.githubusercontent.com/3758555/28666026-a6601804-72bd-11e7-9569-387fb559b468.png">


