### PR TITLE
Fixes for existing components

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -17,6 +17,9 @@
 
   .govuk-c-breadcrumb__list {
     @include govuk-u-clearfix;
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
   }
 
   .govuk-c-breadcrumb__list-item {
@@ -25,7 +28,6 @@
     margin-left: $govuk-spacing-scale-2;
     padding-left: $govuk-spacing-scale-3;
     float: left;
-    list-style: none;
     background-image: file-url("separator.png");
     background-repeat: no-repeat;
     background-position: 0% 50%;

--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -40,6 +40,11 @@
   }
 
   .govuk-c-breadcrumb__link {
-    color: $govuk-text-colour;
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: $govuk-text-colour;
+    }
   }
 }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -27,6 +27,7 @@
     @include govuk-core-19;
     line-height: 1.25;
 
+    text-align: center;
     text-decoration: none;
 
     vertical-align: top;

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -24,8 +24,6 @@
   .govuk-c-cookie-banner__text {
     @include govuk-site-width-container;
     @include govuk-core-16;
-    margin-top: 0;
-    margin-bottom: 0;
   }
 
   @include mq($media-type: print) {

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -18,6 +18,7 @@
     display: inline-block;
 
     position: relative;
+    // TODO: Make margins under components consistent
     margin-bottom: em($govuk-spacing-scale-1, 19px);
 
     color: $govuk-blue;

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -18,7 +18,7 @@
     display: inline-block;
 
     position: relative;
-    margin-bottom: em($govuk-spacing-scale-1, 19);
+    margin-bottom: em($govuk-spacing-scale-1, 19px);
 
     color: $govuk-blue;
     cursor: pointer;
@@ -44,13 +44,16 @@
   }
 
   .govuk-c-details__text {
-    margin-bottom: em($govuk-spacing-scale-3, 19);
-    padding: em($govuk-spacing-scale-3, 19);
+    // TODO: Make margins underneath components consistent
+    margin-bottom: em($govuk-spacing-scale-3, 19px);
+    padding: em($govuk-spacing-scale-3, 19px);
     @include govuk-u-border-left($govuk-border-width, $govuk-border-colour);
   }
 
   .govuk-c-details__text p {
+    // TODO: Make margins on paragraphs consistent
     margin-top: 0;
+    margin-bottom: em(20px, 19px);
   }
 
   .govuk-c-details__text p:last-child {

--- a/src/components/error-summary/error-summary.html
+++ b/src/components/error-summary/error-summary.html
@@ -1,4 +1,4 @@
-<div class="govuk-c-error-summary" aria-labelledby="error-summary-title" role="group" tabindex="-1">
+<div class="govuk-c-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
 
   <h2 class="govuk-c-error-summary__title" id="error-summary-title">
     Message to alert the user to a problem goes here

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -1,7 +1,7 @@
 # Fieldset
 
-The <fieldset> element is used to group several controls within a web form.
-The <legend> element represents a caption for the content of its parent <fieldset>.
+The fieldset element is used to group several controls within a web form.
+The legend element represents a caption for the content of its parent fieldset.
 
 ## Guidance
 

--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -44,7 +44,7 @@
   @each $govuk-width-proportions-key, $govuk-width-proportions-value in $govuk-width-proportions {
     .govuk-u-w-#{$govuk-width-proportions-key} {
       width: $govuk-width-proportions-value;
-      @if $govuk-width-proportions-key != 'full' {
+      @if $govuk-width-proportions-key != "full" {
         float: left;
      }
     }

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -7,8 +7,7 @@
 
 @include exports("inset-text") {
   .govuk-c-inset-text {
-    margin-bottom: em($govuk-spacing-scale-3, 19);
-    padding: em($govuk-spacing-scale-3, 19);
+    padding: em($govuk-spacing-scale-3, 19px);
 
     clear: both;
 

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -10,7 +10,7 @@
   .govuk-c-list {
     @include font-smoothing;
     @include govuk-core-19;
-    margin-top: $govuk-spacing-scale-1;
+    // TODO: Make margins under components consistent
     margin-bottom: $govuk-spacing-scale-4;
     padding-left: 0;
     list-style-type: none;

--- a/src/components/pagination/_pagination.scss
+++ b/src/components/pagination/_pagination.scss
@@ -10,8 +10,8 @@
   .govuk-c-pagination {
     @include font-smoothing;
     display: block;
-    margin-top: $govuk-spacing-scale-5;
     margin-right: -$govuk-spacing-scale-3;
+    // TODO: Make margins under components consistent
     margin-bottom: $govuk-spacing-scale-5;
     margin-left: -$govuk-spacing-scale-3;
     font-family: $govuk-font-stack;

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -8,7 +8,8 @@
 @include exports("panel") {
 
   .govuk-c-panel {
-    margin: $govuk-spacing-scale-3 0;
+    // TODO: Make margins under components consistent
+    margin-bottom: $govuk-spacing-scale-3;
     padding: $govuk-spacing-scale-5 $govuk-spacing-scale-3;
 
     font-family: $govuk-font-stack;

--- a/src/components/phase-tag/_phase-tag.scss
+++ b/src/components/phase-tag/_phase-tag.scss
@@ -6,7 +6,7 @@
 @include exports("phase-tag") {
   .govuk-c-phase-tag {
     display: inline-block;
-    margin: 0 $govuk-spacing-scale-2 0 0;
+    margin-right: $govuk-spacing-scale-2;
     padding: $govuk-spacing-scale-1 $govuk-spacing-scale-1 0;
 
     color: $govuk-white;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -15,7 +15,7 @@
   }
 
   .govuk-c-table__header {
-    padding: em($govuk-spacing-scale-2, 19) em($govuk-spacing-scale-4, 19) em($govuk-spacing-scale-2, 19) 0;
+    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-4, 19px) em($govuk-spacing-scale-2, 19px) 0;
     @include govuk-core-19;
     border-bottom: 1px solid $govuk-border-colour;
     font-weight: 700;
@@ -24,7 +24,7 @@
 
   .govuk-c-table__cell {
     @include govuk-core-19;
-    padding: em($govuk-spacing-scale-2, 19) em($govuk-spacing-scale-4, 19) em($govuk-spacing-scale-2, 19) 0;
+    padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-4, 19px) em($govuk-spacing-scale-2, 19px) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
   }


### PR DESCRIPTION
- Remove top margins on components
- Override user agent styles for lists
- Update unitless context values to use px, where the px to em function is used
- Add comments to components with bottom margins, we need to decide if these should be the same for all components, or if we should remove them entirely.