### PR TITLE
Ensure tests run in order

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,10 +74,11 @@ gulp.task('copy:icons', () => {
 // Runs js, scss and accessibility tests
 // --------------------------------------
 gulp.task('test', cb => {
-  runsequence('html:tenon',
-              'html:axe',
+  runsequence(
               'js:lint',
               'scss:lint',
+              'html:axe',
+              'html:tenon',
               cb)
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10223,13 +10223,40 @@
       "dev": true
     },
     "run-sequence": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-1.2.2.tgz",
-      "integrity": "sha1-UJWgvr6YczsBQL0I3YDsAw3azes=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/run-sequence/-/run-sequence-2.1.0.tgz",
+      "integrity": "sha1-FJ2gElFvIdz3nbbcmaKpVgNjGyE=",
       "dev": true,
       "requires": {
-        "chalk": "2.0.1",
+        "chalk": "1.1.3",
         "gulp-util": "3.0.8"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "rx-lite": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "merge-stream": "^1.0.1",
     "oldie": "^1.3.0",
     "postcss-normalize": "^3.0.0",
-    "run-sequence": "^1.2.2",
+    "run-sequence": "^2.1.0",
     "standard": "^10.0.2"
   },
   "dependencies": {

--- a/src/components/checkbox/checkbox.html
+++ b/src/components/checkbox/checkbox.html
@@ -7,6 +7,6 @@
   <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from mines or quarries</label>
 </div>
 <div class="govuk-c-checkbox">
-  <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" disabled="disabled" value="waste-animal">
-  <label class="govuk-c-checkbox__label" for="waste-type-3">Waste from animal carcasses</label>
+  <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" disabled="disabled" value="waste-farm">
+  <label class="govuk-c-checkbox__label" for="waste-type-3">Farm or agricultural waste</label>
 </div>

--- a/tasks/gulp/test.js
+++ b/tasks/gulp/test.js
@@ -6,7 +6,7 @@ const axe = require('gulp-axe-webdriver')
 // Check HTML using Tenon ----------------
 // ---------------------------------------
 gulp.task('html:tenon', function () {
-  gulp.src('src/components/**/*.html', {read: false})
+  return gulp.src('src/components/**/*.html', {read: false})
   .pipe(gtenon({
     config: 'config/tenon.json',
     snippet: true, // include errorSnippet in the console output


### PR DESCRIPTION
Update runsequence
Reorder tests to run scss and js tests first, then check html.
Add a return so the html tenon task runs to completion

Fix errors found by Tenon:
- update the label used for the disabled checkbox so it is unique.