### PR TITLE
Replace component url when published to npm

### DIFF
--- a/tasks/gulp/packages-update.js
+++ b/tasks/gulp/packages-update.js
@@ -17,6 +17,8 @@ gulp.task('packages:update', () => {
     .pipe(replace('../../globals/scss', '@govuk-frontend/globals'))
     .pipe(replace('../', '@govuk-frontend/'))
     .pipe(readmeComponents)
+    .pipe(replace('[demo](', '[demo](http://govuk-frontend.herokuapp.com/components/'))
+    .pipe(replace('.html)', '/index.html)'))
     .pipe(replace('<!--', ''))
     .pipe(replace('-->', ''))
     .pipe(replace(/---(.|\n)*---/g, ''))


### PR DESCRIPTION
This PR
will show the current heroku app url link to the component in the npm readme.

Currently the url is to, say /button.html
Now it will be to http://govuk-frontend.herokuapp.com/components/button/index.html