### PR TITLE
Replace path when importing from node_modules

### DIFF
--- a/tasks/gulp/packages-update.js
+++ b/tasks/gulp/packages-update.js
@@ -34,6 +34,7 @@ gulp.task('packages:update', () => {
     '!' + paths.tmp + 'globals/scss/govuk-frontend-oldie.scss'
   ])
     .pipe(replace('../../components', '@govuk-frontend'))
+    .pipe(replace('./node_modules/', ''))
     .pipe(flatten({
       newPath: 'globals',
       includeParents: -1


### PR DESCRIPTION
We are importing sass-mq from node modules with the path of ./node_modules/sass-mq/mq. This path doesnt resolve when a 3rd party installs our component. This commit removes the node_modules part of the path from the published package