### PR TITLE
Remove spacing classes from components

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-url";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/clearfix";
 @import "../../globals/scss/vars";

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -4,7 +4,6 @@
 @import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/helpers-url";
 @import "../../globals/scss/media-queries";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -2,7 +2,6 @@
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
 @import "../../globals/scss/media-queries";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -1,5 +1,4 @@
 @import "../../globals/scss/import-once";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../site-width-container/site-width-container";

--- a/src/components/date/_date.scss
+++ b/src/components/date/_date.scss
@@ -1,5 +1,4 @@
 @import "../../globals/scss/import-once";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/clearfix";
 @import "../../globals/scss/vars";

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-px-to-em";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";
 @import "../../globals/scss/vars";

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../list/list";

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-px-to-em";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../label/label";

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-px-to-em";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/borders";
 @import "../../globals/scss/vars";

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -1,5 +1,4 @@
 @import "../../globals/scss/import-once";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/legal-text/_legal-text.scss
+++ b/src/components/legal-text/_legal-text.scss
@@ -1,7 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/media-queries";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/shapes";
 @import "../../globals/scss/utilities/visually-hidden";

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -2,7 +2,6 @@
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-url";
 @import "../../globals/scss/links";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,7 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-ie";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/utilities/shapes";
 @import "../../globals/scss/vars";

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -1,7 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/font-face";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -1,7 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-px-to-em";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../phase-tag/phase-tag";

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -3,7 +3,6 @@
 @import "../../globals/scss/helpers-ie";
 @import "../../globals/scss/helpers-px-to-em";
 @import "../../globals/scss/media-queries";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/select-box/_select-box.scss
+++ b/src/components/select-box/_select-box.scss
@@ -1,5 +1,4 @@
 @import "../../globals/scss/import-once";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../label/label";

--- a/src/components/site-width-container/_site-width-container.scss
+++ b/src/components/site-width-container/_site-width-container.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/grid-layout";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/vars";
 
 @include exports("site-width-container") {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -1,7 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
 @import "../../globals/scss/helpers-px-to-em";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -1,6 +1,5 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/font-face";
-@import "../../globals/scss/spacing";
 @import "../../globals/scss/typography";
 @import "../../globals/scss/vars";
 @import "../label/label";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,3 +1,7 @@
+// Globals
+@import "../../globals/scss/spacing";
+
+// Components
 @import "../../components/breadcrumb/breadcrumb";
 @import "../../components/button/button";
 @import "../../components/checkbox/checkbox";


### PR DESCRIPTION
This is used to generate the concrete spacing classes and shouldn’t be
included with every component.

Instead import this at the top of the list of imported partials in
govuk-frontend.scss.

The spacing scale variables exist in _vars.scss so the global spacing partial doesn't need to be included with every component.