### PR TITLE
Update the example index page to link to component macros

### DIFF
--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -18,6 +18,23 @@ Code example(s)
 @@include('legal-text.html')
 ```
 
+## Nunjucks
+
+```
+{% from "legal-text/macro.njk" import govukLegalText %}
+
+{{ govukLegalText(
+  iconFallbackText='Warning',
+  legalText='You can be fined up to £5,000 if you don’t register.')
+}}
+```
+
+## Arguments
+
+| Name              | Type    | Default | Required  | Description
+|---                |---      |---      |---        |---
+| iconFallbackText  | string  |         | Yes       | The fallback text for the icon
+| legalText         | string  |         | Yes       | The text next to the icon
 
 <!--
 ## Installation

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -40,6 +40,6 @@ Code example(s)
 ## Installation
 
 ```
-npm install --save @govuk-frontend/component-name
+npm install --save @govuk-frontend/legal-text
 ```
 -->

--- a/src/components/legal-text/legal-text.njk
+++ b/src/components/legal-text/legal-text.njk
@@ -1,0 +1,6 @@
+{% from "legal-text/macro.njk" import govukLegalText %}
+
+{{ govukLegalText(
+  iconFallbackText='Warning',
+  legalText='You can be fined up to £5,000 if you don’t register.')
+}}

--- a/src/components/legal-text/macro.njk
+++ b/src/components/legal-text/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukLegalText(classes='govuk-c-legal-text', iconFallbackText, legalText) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/legal-text/template.njk
+++ b/src/components/legal-text/template.njk
@@ -1,0 +1,9 @@
+{% from "legal-text/macro.njk" import govukLegalText %}
+
+<div class="govuk-c-legal-text">
+  <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
+  <strong class="govuk-c-legal-text__text">
+    <span class="govuk-c-legal-text__assistive">{{ iconFallbackText }}</span>
+    {{ legalText }}
+  </strong>
+</div>

--- a/src/components/phase-banner/macro.njk
+++ b/src/components/phase-banner/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPhaseBanner(classes='', phaseBannerText, phaseTagText) %}
-    {% include './template.njk' %}
+  {% include './template.njk' %}
 {% endmacro %}

--- a/src/components/phase-banner/template.njk
+++ b/src/components/phase-banner/template.njk
@@ -2,7 +2,7 @@
 
 <div class="govuk-c-phase-banner {{ classes }}">
   <p class="govuk-c-phase-banner__content">
-  {{ govukPhaseTag(phaseTagText) }}
+    {{ govukPhaseTag(phaseTagText) }}
     <span class="govuk-c-phase-banner__text">
       {{ phaseBannerText | safe }}
     </span>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -1,0 +1,3 @@
+{% include "../components/phase-banner/phase-banner.njk" %}
+
+{% include "../components/legal-text/legal-text.njk" %}

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -1,5 +1,6 @@
 <h1 class="govuk-u-bold-48">Examples</h1>
 <ul class="govuk-c-list govuk-c-list--bullet">
+  <li><a href="component-macros.html">Component macros</a></li>
   <li><a href="form-elements.html">Form elements</a></li>
   <li><a href="form-elements-alignment.html">Form elements - alignment</a></li>
   <li><a href="typography.html">Typography</a></li>


### PR DESCRIPTION
Create an example page "Component macros", that includes each component's component-name.njk file. 

https://govuk-frontend-review-pr-174.herokuapp.com/examples/component-macros.html

Also add a macro for the legal text component.

