### PR TITLE
Add example showing text alignment with a button

### DIFF
--- a/src/examples/form-elements-alignment.html
+++ b/src/examples/form-elements-alignment.html
@@ -94,6 +94,7 @@ float: left;
   </div>
 </fieldset>
 </form>
+
 <h2 class="govuk-u-heading-27">Input and radio</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
@@ -111,6 +112,7 @@ float: left;
   </div>
 </fieldset>
 </form>
+
 <h2 class="govuk-u-heading-27">Radio, checkbox and button</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
@@ -129,6 +131,13 @@ float: left;
   <div class="govuk-u-w-half">
     <input class="govuk-c-button" type="submit" value="Save and continue">
   </div>
+</fieldset>
+
+<h2 class="govuk-u-heading-27">Align text with button</h2>
+<form action="/" method="post">
+  <fieldset class="govuk-c-fieldset">
+    <input class="govuk-c-button" type="submit" value="Sign in with your Austrian identity">
+    <span class="govuk-text-align-button">on the Austrian identity website</span>
 </fieldset>
 <br><br><br><br><br>
 </form>

--- a/src/globals/scss/_typography.scss
+++ b/src/globals/scss/_typography.scss
@@ -429,4 +429,13 @@ $is-print: false !default;
       margin-bottom: em($govuk-spacing-scale-4, 19);
     }
   }
+
+  .govuk-text-align-button {
+    @include govuk-core-19;
+    @include font-smoothing;
+    display: inline-block;
+    padding-top: em(8, 19);
+    padding-left: em($govuk-spacing-scale-1, 19px);
+  }
+
 }


### PR DESCRIPTION
![button-align](https://user-images.githubusercontent.com/417754/29372543-5eb0ee02-82a3-11e7-9cdc-5b8688912efb.png)

https://govuk-frontend-review-pr-176.herokuapp.com/examples/form-elements-alignment.html