### PR TITLE
Add breadcrumb macro

### DIFF
--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -18,6 +18,26 @@ Code example(s)
 @@include('breadcrumb.html')
 ```
 
+## Nunjucks
+
+```
+{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+
+{{ govukBreadcrumb(
+  [
+    { title: 'Home', url: '/' },
+    { title: 'Current page'}
+  ]
+) }}
+```
+
+## Arguments
+
+| Name        | Type   | Default | Required | Description
+|---          |---     |---      |---       |---
+| breadcrumbs | array  |         | Yes      | Breadcrumbs array with title and url keys
+| title       | string |         | Yes      | Title of the breadcrumb item
+| url         | string |         | Yes      | Url of the breadcrumb item
 
 <!--
 ## Installation

--- a/src/components/breadcrumb/breadcrumb.njk
+++ b/src/components/breadcrumb/breadcrumb.njk
@@ -1,0 +1,8 @@
+{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+
+{{ govukBreadcrumb(
+  [
+    { title: 'Home', url: '/' },
+    { title: 'Current page' }
+  ]
+) }}

--- a/src/components/breadcrumb/macro.njk
+++ b/src/components/breadcrumb/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukBreadcrumb(classes='', breadcrumbs) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/breadcrumb/template.njk
+++ b/src/components/breadcrumb/template.njk
@@ -1,0 +1,13 @@
+<div class="govuk-c-breadcrumb {{ classes }}">
+  <ol class="govuk-c-breadcrumb__list">
+    {% for breadcrumb in breadcrumbs %}
+      {% if breadcrumb.url %}
+      <li class="govuk-c-breadcrumb__list-item">
+        <a class="govuk-c-breadcrumb__link" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
+      </li>
+      {% else %}
+      <li class="govuk-c-breadcrumb__list-item" aria-current="page">{{ breadcrumb.title }}</li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -1,3 +1,5 @@
+{% include "../components/breadcrumb/breadcrumb.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Create a macro for the breadcrumb component.

Add Nunjucks usage example and table of arguments to the README.

Display the breadcrumb macro on the example page.
