### PR TITLE
Add button macro

### DIFF
--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -18,6 +18,32 @@ Code example(s)
 @@include('button.html')
 ```
 
+## Nunjucks
+
+{% from "button/macro.njk" import govukButton %}
+{{ govukButton(classes="", value="Save and continue", type="submit") }}
+
+{% from "button/macro.njk" import govukButtonLink %}
+{{ govukButtonLink(classes="govuk-c-button--start", url="#", text="Start now") }}
+
+## Arguments
+
+Button (Input)
+
+| Name       | Type    | Default | Required | Description
+|---         |---      |---      |---       |---
+| classes    | string  |         | No       | Optional additional classes
+| value      | string  |         | Yes      | Value of the button
+| type       | string  |         | No       | Type of the input, type="submit" is the default if the attribute is not specified
+| isDisabled | boolean |         | No       | Disables the button, using disabled="disabled" and aria-disabled="true"
+
+Button (Link)
+
+| Name       | Type   | Default | Required | Description
+|---         |---     |---      |---       |---
+| classes    | string |         | No       | Use govuk-c-button--start for a "Start now" button
+| url        | string |         | Yes      | Url that the hyperlink points to
+| text       | string |         | Yes      | Link text
 
 <!--
 ## Installation

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -20,30 +20,31 @@ Code example(s)
 
 ## Nunjucks
 
+```
 {% from "button/macro.njk" import govukButton %}
+
+Button
 {{ govukButton(classes="", value="Save and continue", type="submit") }}
 
-{% from "button/macro.njk" import govukButtonLink %}
-{{ govukButtonLink(classes="govuk-c-button--start", url="#", text="Start now") }}
+Disabled button
+{{ govukButton(classes="", value="Save and continue", type="submit", isDisabled="true") }}
+
+Start now button
+{{ govukButton(classes="", url="#", text="Start now", isStart="true") }}
+```
 
 ## Arguments
 
-Button (Input)
+Button
 
 | Name       | Type    | Default | Required | Description
 |---         |---      |---      |---       |---
 | classes    | string  |         | No       | Optional additional classes
-| value      | string  |         | Yes      | Value of the button
-| type       | string  |         | No       | Type of the input, type="submit" is the default if the attribute is not specified
-| isDisabled | boolean |         | No       | Disables the button, using disabled="disabled" and aria-disabled="true"
+| text       | string  |         | Yes      | Button or link text
+| isStart    | boolean |         | No       | Adds the class govuk-c-button--start for a "Start now" button
+| isDisabled | boolean |         | No       | Disables the button - adds the class govuk-c-button--disabled and sets disabled="disabled" and aria-disabled="true"
+| url        | string  |         | No       | Url that the hyperlink points to
 
-Button (Link)
-
-| Name       | Type   | Default | Required | Description
-|---         |---     |---      |---       |---
-| classes    | string |         | No       | Use govuk-c-button--start for a "Start now" button
-| url        | string |         | Yes      | Url that the hyperlink points to
-| text       | string |         | Yes      | Link text
 
 <!--
 ## Installation

--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,0 +1,8 @@
+{% from "button/macro.njk" import govukButton %}
+{% from "button/macro.njk" import govukButtonLink %}
+
+{{ govukButton(classes="", value="Save and continue", type="submit") }}
+
+{{ govukButton(classes="govuk-c-button--disabled", value="Save and continue", isDisabled="true") }}
+
+{{ govukButtonLink(classes="govuk-c-button--start", url="#", text="Start now") }}

--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,8 +1,7 @@
 {% from "button/macro.njk" import govukButton %}
-{% from "button/macro.njk" import govukButtonLink %}
 
-{{ govukButton(classes="", value="Save and continue", type="submit") }}
+{{ govukButton(classes="", text="Save and continue") }}
 
-{{ govukButton(classes="govuk-c-button--disabled", value="Save and continue", isDisabled="true") }}
+{{ govukButton(classes="", text="Save and continue", isDisabled="true") }}
 
-{{ govukButtonLink(classes="govuk-c-button--start", url="#", text="Start now") }}
+{{ govukButton(classes="", text="Start now", url="/", isStart="true") }}

--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,7 +1,3 @@
-{% macro govukButton(classes='', value, type) %}
+{% macro govukButton(classes='', text, url, isStart, isDisabled) %}
   {% include './template.njk' %}
-{% endmacro %}
-
-{% macro govukButtonLink(classes='', url, text) %}
-  {% include './template-button-link.njk' %}
 {% endmacro %}

--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,0 +1,7 @@
+{% macro govukButton(classes='', value, type) %}
+  {% include './template.njk' %}
+{% endmacro %}
+
+{% macro govukButtonLink(classes='', url, text) %}
+  {% include './template-button-link.njk' %}
+{% endmacro %}

--- a/src/components/button/template-button-link.njk
+++ b/src/components/button/template-button-link.njk
@@ -1,0 +1,1 @@
+<a class="govuk-c-button {{ classes }}" href="{{ url}}" role="button">{{ text }}</a>

--- a/src/components/button/template-button-link.njk
+++ b/src/components/button/template-button-link.njk
@@ -1,1 +1,0 @@
-<a class="govuk-c-button {{ classes }}" href="{{ url}}" role="button">{{ text }}</a>

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -1,1 +1,9 @@
-<input class="govuk-c-button {{ classes}}" {% if value %}value="{{ value }}"{% endif %} {% if type %}type="{{ type }}"{% endif %} {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
+{% if url %}
+<a class="govuk-c-button {% if isStart %}govuk-c-button--start{% endif %} {{ classes}}" href="{{ url | safe }}" role="button">
+  {% if text %}{{ text }}{% endif %}
+</a>
+{% else %}
+<input class="govuk-c-button {% if isDisabled %}govuk-c-button--disabled{% endif %} {{ classes}}"
+  {% if text %}value="{{ text }}"{% endif %}
+  {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
+{% endif %}

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -1,0 +1,1 @@
+<input class="govuk-c-button {{ classes}}" {% if value %}value="{{ value }}"{% endif %} {% if type %}type="{{ type }}"{% endif %} {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -1,5 +1,7 @@
 {% include "../components/breadcrumb/breadcrumb.njk" %}
 
+{% include "../components/button/button.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Create a macro for the button component.

Add Nunjucks usage example and table of arguments to the README.

Display the button macro on the example page.