### PR TITLE
Add a checkbox macro

### DIFF
--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -18,6 +18,51 @@ Code example(s)
 @@include('checkbox.html')
 ```
 
+## Nunjucks
+
+```
+{% from 'checkbox/macro.njk' import govukCheckbox %}
+
+{{ govukCheckbox(
+  classes="",
+  name="waste-types",
+  id="waste-type",
+  checkboxes=[
+   {
+      id: '1',
+      value: 'waste-animal',
+      label: 'Waste from animal carcasses'
+    },
+    {
+      id: '2',
+      value: 'waste-mines',
+      label: 'Waste from mines or quarries'
+    },
+    {
+      id: '3',
+      value: 'waste-farm',
+      label: 'Farm or agricultural waste',
+      checked: 'true'
+    },
+    {
+      id: '4',
+      value: 'waste-disabled',
+      label: 'Disabled checkbox option',
+      disabled: 'true'
+    }
+  ]
+) }}
+```
+
+## Arguments
+
+| Name        | Type    | Default | Required | Description
+|---          |---      |---      |---       |---
+| classes     | string  |         | No       | Optional additional classes
+| name        | string  |         | Yes      | Name of the group of checkboxes
+| id          | string  |         | Yes      | ID is prefixed to the ID of each checkbox
+| checkboxes  | array   |         | Yes      | Checkboxes array with id, value, label, checked and disabled keys
+
 
 <!--
 ## Installation

--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -1,0 +1,31 @@
+{% from 'checkbox/macro.njk' import govukCheckbox %}
+
+{{ govukCheckbox(
+  classes="",
+  name="waste-types",
+  id="waste-type",
+  checkboxes=[
+   {
+      id: '1',
+      value: 'waste-animal',
+      label: 'Waste from animal carcasses'
+    },
+    {
+      id: '2',
+      value: 'waste-mines',
+      label: 'Waste from mines or quarries'
+    },
+    {
+      id: '3',
+      value: 'waste-farm',
+      label: 'Farm or agricultural waste',
+      checked: 'true'
+    },
+    {
+      id: '4',
+      value: 'waste-disabled',
+      label: 'Disabled checkbox option',
+      disabled: 'true'
+    }
+  ]
+) }}

--- a/src/components/checkbox/macro.njk
+++ b/src/components/checkbox/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukCheckbox(classes='', name, id, checkboxes) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -1,0 +1,6 @@
+{% for checkbox in checkboxes %}
+  <div class="govuk-c-checkbox">
+    <input class="govuk-c-checkbox__input {{ classes }}" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"  {% if checkbox.checked %}checked{% endif %} {% if checkbox.disabled %}disabled{% endif %}>
+    <label class="govuk-c-checkbox__label" for="{{ id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
+  </div>
+{% endfor %}

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -2,6 +2,8 @@
 
 {% include "../components/button/button.njk" %}
 
+{% include "../components/checkbox/checkbox.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Show all checkbox macro variants, including standard checkboxes and
checked and disabled options.

Add an example of the macro to the README.

Include the checkbox nunjucks file in the page of example component
macros.

#### Screenshot:

![gov uk frontend - checboxes](https://user-images.githubusercontent.com/417754/29466957-a94bed38-8436-11e7-9ec7-c90625f9cea9.png)
