### PR TITLE
Add cookie banner macro

### DIFF
--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -18,6 +18,24 @@ Code example(s)
 @@include('cookie-banner.html')
 ```
 
+## Nunjucks
+
+```
+{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+{{ govukCookieBanner(
+  classes='',
+  cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
+  )
+}}
+```
+
+## Arguments
+
+| Name                | Type    | Default | Required  | Description
+|---                  |---      |---      |---        |---
+| classes             | string  |         | No        | Optional additional classes
+| cookieBannerText    | string  |         | Yes       | Cookie banner copy
+
 
 <!--
 ## Installation

--- a/src/components/cookie-banner/cookie-banner.njk
+++ b/src/components/cookie-banner/cookie-banner.njk
@@ -1,0 +1,6 @@
+{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+{{ govukCookieBanner(
+  classes='',
+  cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
+  )
+}}

--- a/src/components/cookie-banner/macro.njk
+++ b/src/components/cookie-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukCookieBanner(classes='', cookieBannerText) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/cookie-banner/template.njk
+++ b/src/components/cookie-banner/template.njk
@@ -1,0 +1,3 @@
+<div class="govuk-c-cookie-banner js-cookie-banner {{ classes }}">
+  <p class="govuk-c-cookie-banner__text">{{ cookieBannerText | safe }} </p>
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -4,6 +4,8 @@
 
 {% include "../components/checkbox/checkbox.njk" %}
 
+{% include "../components/cookie-banner/cookie-banner.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add nunjucks template file and macro for the cookie banner.

Add a table of arguments and usage example to the readme.

Display cookie banner on the example page of components.

### Screenshot:

![cookie-banner](https://user-images.githubusercontent.com/417754/29497481-5853c602-85e0-11e7-9174-64592a94e38f.png)
