### PR TITLE
Add details macro

### DIFF
--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -18,6 +18,29 @@ Code example(s)
 @@include('details.html')
 ```
 
+## Nunjucks
+
+{% from "details/macro.njk" import govukDetails %}
+
+{{ govukDetails(
+  classes='',
+  detailsSummaryText='Help with nationality',
+  detailsText='<p>
+    If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
+  </p>
+  <p>
+    We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  </p>'
+  )
+}}
+
+## Arguments
+
+| Name                | Type    | Default | Required  | Description
+|---                  |---      |---      |---        |---
+| classes             | string  |         | No        | Optional additional classes
+| detailsSummaryText  | string  |         | Yes       | Summary element text
+| detailsText         | string  |         | Yes       | Revealed details text
 
 <!--
 ## Installation

--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -1,0 +1,13 @@
+{% from "details/macro.njk" import govukDetails %}
+
+{{ govukDetails(
+  classes='',
+  detailsSummaryText='Help with nationality',
+  detailsText='<p>
+    If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
+  </p>
+  <p>
+    We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+  </p>'
+  )
+}}

--- a/src/components/details/macro.njk
+++ b/src/components/details/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukDetails(classes='', detailsSummaryText, detailsText) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -1,0 +1,10 @@
+<details class="govuk-c-details">
+  <summary class="govuk-c-details__summary">
+    <span class="govuk-c-details__summary-text">{{ detailsSummaryText}}</span>
+  </summary>
+  <div class="govuk-c-border govuk-c-border--left-narrow">
+    <div class="govuk-c-details__text">
+      {{ detailsText | safe }}
+    </div>
+  </div>
+</details>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -6,6 +6,8 @@
 
 {% include "../components/cookie-banner/cookie-banner.njk" %}
 
+{% include "../components/details/details.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add a macro for the details component. 

Show this component on the example page, that includes each component's nunjucks template file.

### Screenshot:

![details - gov uk frontend](https://user-images.githubusercontent.com/417754/29497711-dcbb23c8-85e4-11e7-8288-8ccc998e6686.png)
