### PR TITLE
Add error message macro

### DIFF
--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -1,6 +1,6 @@
 # Error message
 
-Component to show a red error message - used for form valiation.
+Component to show a red error message - used for form validation.
 Use inside a label or legend.
 
 ## Guidance
@@ -18,6 +18,26 @@ Code example(s)
 ```
 @@include('error-message.html')
 ```
+
+## Nujucks
+
+```
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+{{ govukErrorMessage(
+  classes='',
+  errorMessageText='Error message goes here'
+  )
+}}
+```
+
+## Usage
+
+
+| Name              | Type    | Default | Required  | Description
+|---                |---      |---      |---        |---
+| classes           | string  |         | No        | Optional additional classes
+| errorMessageText  | string  |         | Yes       | Error message
 
 <!--
 ## Installation

--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -1,0 +1,7 @@
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+{{ govukErrorMessage(
+  classes='',
+  errorMessageText='Error message goes here'
+  )
+}}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukErrorMessage(classes='', errorMessageText ) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,0 +1,5 @@
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+<span class="govuk-c-error-message {{ classes }}">
+  {{ errorMessageText }}
+</span>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -8,6 +8,8 @@
 
 {% include "../components/details/details.njk" %}
 
+{% include "../components/error-message/error-message.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add an error message macro.

Display this component on the page of example components.