### PR TITLE
Add fieldset macro

### DIFF
--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -19,6 +19,24 @@ Code example(s)
 @@include('fieldset.html')
 ```
 
+## Nunjucks
+
+```
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset(
+  classes='',
+  legendText='Legend text goes here'
+  )
+}}
+```
+
+## Arguments
+
+| Name        | Type    | Default | Required  | Description
+|---          |---      |---      |---        |---
+| classes     | string  |         | No        | Optional additional classes
+| legendText  | string  |         | No        | Legend text
 
 <!--
 ## Installation

--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -1,0 +1,7 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset(
+  classes='',
+  legendText='Legend text goes here'
+  )
+}}

--- a/src/components/fieldset/macro.njk
+++ b/src/components/fieldset/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukFieldset(classes='', legendText) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,0 +1,7 @@
+<fieldset class="govuk-c-fieldset {{ classes }}">
+{% if legendText %}
+  <legend class="govuk-c-fieldset__legend">
+    {{ legendText }}
+  </legend>
+{% endif %}
+</fieldset>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -10,6 +10,8 @@
 
 {% include "../components/error-message/error-message.njk" %}
 
+{% include "../components/fieldset/fieldset.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add fieldset macro, template file and component nujucks file.

Legend text is optional, if passed to the macro, it will be wrapped in a `legend` element.

Show usage example on the readme and add a table of arguments.

Display the fieldset component on the example page.

## Screenshot

![gov uk frontend - fieldset](https://user-images.githubusercontent.com/417754/29509066-cfb432a4-864e-11e7-8aec-80f0b13b6804.png)
