### PR TITLE
Add file upload macro

### DIFF
--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -29,13 +29,22 @@ Code example(s)
   )
 }}
 
+{{ govukFileUpload(
+  classes='',
+  id='file-upload',
+  fileUploadText='Upload a file',
+  errorMessageText='Error message goes here'
+  )
+}}
+
 ## Arguments
 
-| Name            | Type    | Default | Required  | Description
-|---              |---      |---      |---        |---
-| classes         | string  |         | No        | Optional additional classes
-| id              | string  |         | Yes       | The ID of the file upload input
-| fileUploadText  | string  |         | Yes       | Label text
+| Name              | Type    | Default | Required  | Description
+|---                |---      |---      |---        |---
+| classes           | string  |         | No        | Optional additional classes
+| id                | string  |         | Yes       | The ID of the file upload input
+| fileUploadText    | string  |         | Yes       | Label text
+| errorMessageText  | string  |         | No        | Error message text, also adds --error variant to input
 
 <!--
 ## Installation

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -18,6 +18,24 @@ Code example(s)
 @@include('file-upload.html')
 ```
 
+## Nunjucks
+
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload(
+  classes='',
+  id='file-upload',
+  fileUploadText='Upload a file'
+  )
+}}
+
+## Arguments
+
+| Name            | Type    | Default | Required  | Description
+|---              |---      |---      |---        |---
+| classes         | string  |         | No        | Optional additional classes
+| id              | string  |         | Yes       | The ID of the file upload input
+| fileUploadText  | string  |         | Yes       | Label text
 
 <!--
 ## Installation

--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -6,3 +6,11 @@
   fileUploadText='Upload a file'
   )
 }}
+
+{{ govukFileUpload(
+  classes='',
+  id='file-upload',
+  fileUploadText='Upload a file',
+  errorMessageText='Error message goes here'
+  )
+}}

--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -1,0 +1,8 @@
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
+{{ govukFileUpload(
+  classes='',
+  id='file-upload',
+  fileUploadText='Upload a file'
+  )
+}}

--- a/src/components/file-upload/macro.njk
+++ b/src/components/file-upload/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukFileUpload(classes='', id, fileUploadText) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/file-upload/macro.njk
+++ b/src/components/file-upload/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukFileUpload(classes='', id, fileUploadText) %}
+{% macro govukFileUpload(classes='', id, fileUploadText, errorMessageText) %}
   {% include './template.njk' %}
 {% endmacro %}

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,4 +1,11 @@
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
 <label class="govuk-c-label {{ classes }}" for="{{ id }}">
   {{ fileUploadText }}
+  {% if errorMessageText %}
+  <span class="govuk-c-error-message">
+    {{ govukErrorMessage(errorMessageText) }}
+  </span>
+  {% endif %}
 </label>
-<input class="govuk-c-file-upload" type="file" id="{{ id }}">
+<input class="govuk-c-file-upload {% if errorMessageText %}govuk-c-file-upload--error{% endif %}" type="file" id="{{ id }}">

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,0 +1,4 @@
+<label class="govuk-c-label {{ classes }}" for="{{ id }}">
+  {{ fileUploadText }}
+</label>
+<input class="govuk-c-file-upload" type="file" id="{{ id }}">

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -12,6 +12,8 @@
 
 {% include "../components/fieldset/fieldset.njk" %}
 
+{% include "../components/file-upload/file-upload.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add file upload macro.

Show the file upload component on the example page.

Add an option to display an error message using the error message macro.

Screenshot:

![gov uk frontend - file upload error](https://user-images.githubusercontent.com/417754/29511445-268561a4-8657-11e7-884a-e2eea7b80ccf.png)
