### PR TITLE
Add label and input macros

### DIFF
--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -25,8 +25,7 @@ Code example(s)
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
 {{ govukErrorMessage(
-  classes='',
-  errorMessageText='Error message goes here'
+  errorMessage='Error message goes here'
   )
 }}
 ```
@@ -34,10 +33,9 @@ Code example(s)
 ## Usage
 
 
-| Name              | Type    | Default | Required  | Description
-|---                |---      |---      |---        |---
-| classes           | string  |         | No        | Optional additional classes
-| errorMessageText  | string  |         | Yes       | Error message
+| Name          | Type    | Default | Required  | Description
+|---            |---      |---      |---        |---
+| errorMessage  | string  |         | Yes       | Error message
 
 <!--
 ## Installation

--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -1,7 +1,6 @@
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
 {{ govukErrorMessage(
-  classes='',
-  errorMessageText='Error message goes here'
+  errorMessage='Error message goes here'
   )
 }}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukErrorMessage(classes='', errorMessageText ) %}
+{% macro govukErrorMessage(errorMessage) %}
   {% include './template.njk' %}
 {% endmacro %}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,5 +1,5 @@
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
-<span class="govuk-c-error-message {{ classes }}">
-  {{ errorMessageText }}
+<span class="govuk-c-error-message">
+  {{ errorMessage }}
 </span>

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -18,6 +18,33 @@ Code example(s)
 @@include('input.html')
 ```
 
+## Nunjucks
+
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  errorMessage='Error message goes here',
+  id='input-id',
+  name='input-name',
+  value='initial value'
+  )
+}}
+
+## Arguments
+
+| Name          | Type    | Required  | Description
+|---            |---      |---        |---
+| classes       | string  | No        | Optional additional classes
+| labelText     | string  | Yes       | The label text
+| hintText      | string  | No        | Optional hint text
+| errorMessage  | string  | No        | Optional error message
+| id            | string  | Yes       | The id of the input
+| name          | string  | Yes       | The name of the input, which is submitted with the form data.
+| value         | string  | No        | Optional initial value of the input
 
 <!--
 ## Installation

--- a/src/components/input/input.njk
+++ b/src/components/input/input.njk
@@ -1,0 +1,32 @@
+{% from "input/macro.njk" import govukInput %}
+
+{{ govukInput(
+  classes='',
+  labelText='National Insurance number',
+  hintText='',
+  errorMessage='',
+  id='input-1',
+  name='test-name'
+  )
+}}
+
+{{ govukInput(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.',
+  errorMessage='',
+  id='input-2',
+  name='test-name-2'
+  )
+}}
+
+{{ govukInput(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  errorMessage='Error message goes here',
+  id='input-3',
+  name='test-name-3'
+  )
+}}

--- a/src/components/input/macro.njk
+++ b/src/components/input/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukInput(classes, labelText, hintText, errorMessage, id, name, value) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,0 +1,5 @@
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel(classes, labelText, hintText, errorMessage, id) }}
+
+<input class="govuk-c-input {% if errorMessage %}govuk-c-input--error{% endif %}" id="{{ id }}" name="{{ name }}" type="text" {% if value %}value="{{ value}}"{% endif %}>

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -18,6 +18,30 @@ Code example(s)
 @@include('label.html')
 ```
 
+## Nunjucks
+
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  errorMessage='Error message goes here',
+  id=''
+  )
+}}
+
+## Arguments
+
+| Name          | Type    | Required  | Description
+|---            |---      |---        |---
+| classes       | string  | No        | Optional additional classes
+| labelText     | string  | Yes       | The label text
+| hintText      | string  | No        | Optional hint text
+| errorMessage  | string  | No        | Optional error message
+| id            | string  | Yes       | The value of the for attribute, the id input the label is associated with
+
 <!--
 ## Installation
 
@@ -25,7 +49,6 @@ Code example(s)
 npm install --save @govuk-frontend/label
 ```
 -->
-
 
 # Implementation
 

--- a/src/components/label/label.njk
+++ b/src/components/label/label.njk
@@ -1,0 +1,29 @@
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  id=''
+  )
+}}
+
+{{ govukLabel(
+  classes='govuk-c-label--bold',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  id=''
+  )
+}}
+
+{{ govukLabel(
+  classes='',
+  labelText='National Insurance number',
+  hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.',
+  errorMessage='Error message goes here',
+  id=''
+  )
+}}

--- a/src/components/label/macro.njk
+++ b/src/components/label/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukLabel(classes, labelText, hintText, errorMessage, id) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -1,0 +1,13 @@
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
+<label class="govuk-c-label {% if classes %} {{ classes }} {% endif %}" for="{{ id }}">
+  {{ labelText }}
+
+  {% if hintText %}
+    <span class="govuk-c-label__hint">{{ hintText }}</span>
+  {% endif %}
+
+  {% if errorMessage %}
+    {{ govukErrorMessage(errorMessage) }}
+  {% endif %}
+</label>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -12,6 +12,11 @@
 
 {% include "../components/fieldset/fieldset.njk" %}
 
+{# Don't show label component as input component requires it #}
+{# include "../components/label/label.njk" #}
+
+{% include "../components/input/input.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Rename errorMessageText to errorMessage in the errorMessage component.

Add a label macro.

Add an input macro.

Show the variants of the input component on the example page.

Add Nunjucks implementation examples and a table of arguments for both macros.

#### Screenshot:

![gov uk frontend - label and input](https://user-images.githubusercontent.com/417754/29518839-eed0b512-8672-11e7-9b89-b5e15e2e0bd2.png)
