### PR TITLE
Add inset text macro

### DIFF
--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,5 +1,3 @@
-{% from "error-message/macro.njk" import govukErrorMessage %}
-
 <span class="govuk-c-error-message">
   {{ errorMessage }}
 </span>

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -18,6 +18,27 @@ Code example(s)
 @@include('inset-text.html')
 ```
 
+## Nunjucks
+
+```
+{% from "inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText(
+  content='<p>
+    It can take up to 8 weeks to register a lasting power of attorney if<br>
+    there are no mistakes in the application.
+  </p>'
+  )
+}}
+```
+
+## Arguments
+
+| Name      | Type    | Required  | Description
+|---        |---      |---        |---
+| classes   | string  | No        | Optional additional classes
+| content   | string  | Yes       | Inset text content
+
 <!--
 ## Installation
 

--- a/src/components/inset-text/inset-text.njk
+++ b/src/components/inset-text/inset-text.njk
@@ -1,0 +1,10 @@
+{% from "inset-text/macro.njk" import govukInsetText %}
+
+{{ govukInsetText(
+  classes='',
+  content='<p>
+    It can take up to 8 weeks to register a lasting power of attorney if<br>
+    there are no mistakes in the application.
+  </p>'
+  )
+}}

--- a/src/components/inset-text/macro.njk
+++ b/src/components/inset-text/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukInsetText(classes='', content) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/inset-text/template.njk
+++ b/src/components/inset-text/template.njk
@@ -1,0 +1,3 @@
+<div class="govuk-c-inset-text {{ classes }}">
+  {{ content | safe }}
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -17,6 +17,8 @@
 
 {% include "../components/input/input.njk" %}
 
+{% include "../components/inset-text/inset-text.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/legal-text/legal-text.njk" %}


### PR DESCRIPTION
Add a nunjucks component template file, template file and macro for the inset text component.
Display this component on the example page.

## Screenshot:

![gov uk frontend - inset text](https://user-images.githubusercontent.com/417754/29562933-59064d46-8733-11e7-93b3-e47659f802cf.png)

Include a fix for the error-message component - only import the macro from the template file with the same name as the component.