### PR TITLE
Make nunjucks files consistent

### DIFF
--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -24,9 +24,10 @@ Code example(s)
 {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
 {{ govukBreadcrumb(
+  classes='',
   [
     { title: 'Home', url: '/' },
-    { title: 'Current page'}
+    { title: 'Current page' }
   ]
 ) }}
 ```
@@ -35,6 +36,7 @@ Code example(s)
 
 | Name        | Type   | Default | Required | Description
 |---          |---     |---      |---       |---
+| classes     | string |         | No       | Optional additional classes
 | breadcrumbs | array  |         | Yes      | Breadcrumbs array with title and url keys
 | title       | string |         | Yes      | Title of the breadcrumb item
 | url         | string |         | Yes      | Url of the breadcrumb item

--- a/src/components/breadcrumb/breadcrumb.njk
+++ b/src/components/breadcrumb/breadcrumb.njk
@@ -1,6 +1,7 @@
 {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
 {{ govukBreadcrumb(
+  classes='',
   [
     { title: 'Home', url: '/' },
     { title: 'Current page' }

--- a/src/components/breadcrumb/macro.njk
+++ b/src/components/breadcrumb/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukBreadcrumb(classes='', breadcrumbs) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -23,14 +23,11 @@ Code example(s)
 ```
 {% from "button/macro.njk" import govukButton %}
 
-Button
-{{ govukButton(classes="", value="Save and continue", type="submit") }}
+{{ govukButton(classes='', text='Save and continue') }}
 
-Disabled button
-{{ govukButton(classes="", value="Save and continue", type="submit", isDisabled="true") }}
+{{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
 
-Start now button
-{{ govukButton(classes="", url="#", text="Start now", isStart="true") }}
+{{ govukButton(classes='', text='Start now', url='/', isStart='true') }}
 ```
 
 ## Arguments

--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,7 +1,7 @@
 {% from "button/macro.njk" import govukButton %}
 
-{{ govukButton(classes="", text="Save and continue") }}
+{{ govukButton(classes='', text='Save and continue') }}
 
-{{ govukButton(classes="", text="Save and continue", isDisabled="true") }}
+{{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
 
-{{ govukButton(classes="", text="Start now", url="/", isStart="true") }}
+{{ govukButton(classes='', text='Start now', url='/', isStart='true') }}

--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukButton(classes='', text, url, isStart, isDisabled) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -1,9 +1,9 @@
 {% if url %}
-<a class="govuk-c-button {% if isStart %}govuk-c-button--start{% endif %} {{ classes}}" href="{{ url | safe }}" role="button">
+<a class="govuk-c-button {% if isStart %} govuk-c-button--start {% endif %} {{ classes }}" href="{{ url | safe }}" role="button">
   {% if text %}{{ text }}{% endif %}
 </a>
 {% else %}
-<input class="govuk-c-button {% if isDisabled %}govuk-c-button--disabled{% endif %} {{ classes}}"
+<input class="govuk-c-button {% if isDisabled %} govuk-c-button--disabled {% endif %} {{ classes }}"
   {% if text %}value="{{ text }}"{% endif %}
   {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
 {% endif %}

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -24,9 +24,9 @@ Code example(s)
 {% from 'checkbox/macro.njk' import govukCheckbox %}
 
 {{ govukCheckbox(
-  classes="",
-  name="waste-types",
-  id="waste-type",
+  classes='',
+  name='waste-types',
+  id='waste-type',
   checkboxes=[
    {
       id: '1',

--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -1,9 +1,9 @@
 {% from 'checkbox/macro.njk' import govukCheckbox %}
 
 {{ govukCheckbox(
-  classes="",
-  name="waste-types",
-  id="waste-type",
+  classes='',
+  name='waste-types',
+  id='waste-type',
   checkboxes=[
    {
       id: '1',

--- a/src/components/checkbox/macro.njk
+++ b/src/components/checkbox/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukCheckbox(classes='', name, id, checkboxes) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -1,6 +1,6 @@
 {% for checkbox in checkboxes %}
-  <div class="govuk-c-checkbox">
-    <input class="govuk-c-checkbox__input {{ classes }}" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"  {% if checkbox.checked %}checked{% endif %} {% if checkbox.disabled %}disabled{% endif %}>
+  <div class="govuk-c-checkbox {{ classes }}">
+    <input class="govuk-c-checkbox__input" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"  {% if checkbox.checked %}checked{% endif %} {% if checkbox.disabled %}disabled{% endif %}>
     <label class="govuk-c-checkbox__label" for="{{ id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
   </div>
 {% endfor %}

--- a/src/components/cookie-banner/macro.njk
+++ b/src/components/cookie-banner/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukCookieBanner(classes='', cookieBannerText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/cookie-banner/template.njk
+++ b/src/components/cookie-banner/template.njk
@@ -1,3 +1,3 @@
 <div class="govuk-c-cookie-banner js-cookie-banner {{ classes }}">
-  <p class="govuk-c-cookie-banner__text">{{ cookieBannerText | safe }} </p>
+  <p class="govuk-c-cookie-banner__text">{{ cookieBannerText | safe }}</p>
 </div>

--- a/src/components/details/macro.njk
+++ b/src/components/details/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukDetails(classes='', detailsSummaryText, detailsText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -1,4 +1,4 @@
-<details class="govuk-c-details">
+<details class="govuk-c-details {{ classes }}">
   <summary class="govuk-c-details__summary">
     <span class="govuk-c-details__summary-text">{{ detailsSummaryText}}</span>
   </summary>

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -25,6 +25,7 @@ Code example(s)
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
 {{ govukErrorMessage(
+  classes='',
   errorMessage='Error message goes here'
   )
 }}
@@ -35,6 +36,7 @@ Code example(s)
 
 | Name          | Type    | Default | Required  | Description
 |---            |---      |---      |---        |---
+| classes       | string  |         | No        | Optional additional classes
 | errorMessage  | string  |         | Yes       | Error message
 
 <!--

--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -1,6 +1,7 @@
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
 {{ govukErrorMessage(
+  classes='',
   errorMessage='Error message goes here'
   )
 }}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukErrorMessage(errorMessage) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,3 +1,3 @@
-<span class="govuk-c-error-message">
+<span class="govuk-c-error-message {{ classes }}">
   {{ errorMessage }}
 </span>

--- a/src/components/fieldset/macro.njk
+++ b/src/components/fieldset/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukFieldset(classes='', legendText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/input/macro.njk
+++ b/src/components/input/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukInput(classes, labelText, hintText, errorMessage, id, name, value) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/label/macro.njk
+++ b/src/components/label/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukLabel(classes, labelText, hintText, errorMessage, id) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -24,6 +24,7 @@ Code example(s)
 {% from "legal-text/macro.njk" import govukLegalText %}
 
 {{ govukLegalText(
+  classes='',
   iconFallbackText='Warning',
   legalText='You can be fined up to £5,000 if you don’t register.')
 }}
@@ -33,6 +34,7 @@ Code example(s)
 
 | Name              | Type    | Default | Required  | Description
 |---                |---      |---      |---        |---
+| classes           | string  |         | No        | Optional additional classes
 | iconFallbackText  | string  |         | Yes       | The fallback text for the icon
 | legalText         | string  |         | Yes       | The text next to the icon
 

--- a/src/components/legal-text/legal-text.njk
+++ b/src/components/legal-text/legal-text.njk
@@ -1,6 +1,7 @@
 {% from "legal-text/macro.njk" import govukLegalText %}
 
 {{ govukLegalText(
+  classes='',
   iconFallbackText='Warning',
   legalText='You can be fined up to £5,000 if you don’t register.')
 }}

--- a/src/components/legal-text/macro.njk
+++ b/src/components/legal-text/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukLegalText(classes='govuk-c-legal-text', iconFallbackText, legalText) %}
-  {% include './template.njk' %}
+{% macro govukLegalText(classes='', iconFallbackText, legalText) %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/legal-text/template.njk
+++ b/src/components/legal-text/template.njk
@@ -1,6 +1,6 @@
 {% from "legal-text/macro.njk" import govukLegalText %}
 
-<div class="govuk-c-legal-text">
+<div class="govuk-c-legal-text {{ classes }}">
   <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
   <strong class="govuk-c-legal-text__text">
     <span class="govuk-c-legal-text__assistive">{{ iconFallbackText }}</span>

--- a/src/components/link/macro.njk
+++ b/src/components/link/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukLink(classes='', linkHref, linkText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/link/template.njk
+++ b/src/components/link/template.njk
@@ -1,3 +1,1 @@
-{% from "link/macro.njk" import govukLink %}
-
 <a href="{{ href }}" class="govuk-c-link {{ classes }}">{{ linkText | safe }}</a>

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -22,6 +22,7 @@ Code example(s)
 ```
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {{ govukPhaseBanner(
+  classes='',
   phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
   phaseTagText='BETA')
 }}
@@ -31,9 +32,9 @@ Code example(s)
 
 | Name              | Type    | Default | Required  | Description
 |---                |---      |---      |---        |---
+| classes           | string  |         | No        | Optional additional classes
 | phaseTagText      | string  |         | Yes       | Tag text
 | phaseBannerText   | string  |         | Yes       | Banner copy
-| classes           | string  |         | No        | Optional additional classes
 
 <!--
 ## Installation

--- a/src/components/phase-banner/macro.njk
+++ b/src/components/phase-banner/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPhaseBanner(classes='', phaseBannerText, phaseTagText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -22,15 +22,15 @@ Code example(s)
 ```
 {% from "phase-tag/macro.njk" import govukPhaseTag %}
 
-{{ govukPhaseTag(phaseTagText='Alpha') }}
+{{ govukPhaseTag(classes='', phaseTagText='Alpha') }}
 ```
 
 ## Arguments
 
 | Name              | Type    | Default | Required  | Description
 |---                |---      |---      |---        |---
-| phaseTagText      | string  |         | Yes       | Tag text
 | classes           | string  |         | No        | Optional additional classes
+| phaseTagText      | string  |         | Yes       | Tag text
 
 <!--
 ## Installation

--- a/src/components/phase-tag/macro.njk
+++ b/src/components/phase-tag/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPhaseTag(classes='',phaseTagText) %}
-  {% include './template.njk' %}
+  {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/phase-tag/phase-tag.njk
+++ b/src/components/phase-tag/phase-tag.njk
@@ -1,3 +1,3 @@
 {% from "phase-tag/macro.njk" import govukPhaseTag %}
 
-{{ govukPhaseTag(phaseTagText='Alpha') }}
+{{ govukPhaseTag(classes='', phaseTagText='Alpha') }}


### PR DESCRIPTION
These files should probably be linted, I've tried to fix any inconsistencies with the template files created so far.

Changes made:
- Use double quotes when referring to other files inside any .njk files
- Use single quotes within component macros
- Ensure all components use the classes argument to set optional additional classes 
- Add 'classes' as a row to the arguments table where it is missing
- Add spaces around nunjucks variables to make them easier to read
