### PR TITLE
Textarea macro

### DIFF
--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -18,6 +18,32 @@ Code example(s)
 @@include('textarea.html')
 ```
 
+## Nunjucks
+
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea(
+  classes='',
+  labelText='National Insurance number',
+  hintText='',
+  errorMessage='Error message goes here',
+  id='input-id',
+  name='input-name',
+  number='5'
+  )
+}}
+
+## Arguments
+
+| Name          | Type    | Default   | Required  | Description
+|---            |---      |---        |---        |---
+| classes       | string  |           | No        | Optional additional classes
+| labelText     | string  |           | Yes       | The label text
+| hintText      | string  |           | No        | Optional hint text
+| errorMessage  | string  |           | No        | Optional error message
+| id            | string  |           | Yes       | The id of the textarea
+| name          | string  |           | Yes       | The name of the textarea
+| rows          | string  | 5         | No        | Change default number of textarea rows
 
 <!--
 ## Installation

--- a/src/components/textarea/macro.njk
+++ b/src/components/textarea/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukTextarea(classes, labelText, hintText, errorMessage, id, name, value) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,0 +1,5 @@
+{% from "label/macro.njk" import govukLabel %}
+
+{{ govukLabel(classes, labelText, hintText, errorMessage, id) }}
+
+<textarea class="govuk-c-textarea {% if errorMessage %}govuk-c-input--error{% endif %} {{ classes }}" id="{{ id }}" name="{{ name }}" rows="{%if rows %} {{ rows }} {% else %} 5 {%endif %}"></textarea>

--- a/src/components/textarea/textarea.njk
+++ b/src/components/textarea/textarea.njk
@@ -1,0 +1,11 @@
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{{ govukTextarea(
+  classes='',
+  labelText='National Insurance number',
+  hintText='',
+  errorMessage='',
+  id='textarea',
+  name='name'
+  )
+}}

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -12,15 +12,17 @@
 
 {% include "../components/fieldset/fieldset.njk" %}
 
-{# Don't show label component as input component requires it #}
-{# include "../components/label/label.njk" #}
-
 {% include "../components/input/input.njk" %}
 
 {% include "../components/inset-text/inset-text.njk" %}
 
-{% include "../components/phase-banner/phase-banner.njk" %}
+{# Don't show label component as input component requires it #}
+{# include "../components/label/label.njk" #}
 
 {% include "../components/legal-text/legal-text.njk" %}
 
 {% include "../components/link/link.njk" %}
+
+{% include "../components/phase-banner/phase-banner.njk" %}
+
+{% include "../components/textarea/textarea.njk" %}


### PR DESCRIPTION
Create a macro for the textarea component.

Display this macro on the example page.

Add a table of arguments to the readme along with a usage example for Nunjucks.