### PR TITLE
Add a radio macro

### DIFF
--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -17,7 +17,50 @@ Code example(s)
 ```
 @@include('radio.html')
 ```
+## Nunjucks
 
+```
+{% from 'checkbox/macro.njk' import govukCheckbox %}
+
+{{ govukCheckbox(
+  classes='',
+  name='radio-group',
+  id='radio',
+  radios=[
+   {
+      id: '1',
+      value: 'Yes',
+      label: 'Waste from animal carcasses'
+    },
+    {
+      id: '2',
+      value: No',
+      label: 'Waste from mines or quarries'
+    },
+    {
+      id: '3',
+      value: 'No',
+      label: 'Farm or agricultural waste',
+      checked: 'true'
+    },
+    {
+      id: '4',
+      value: 'NA',
+      label: 'Not applicable',
+      disabled: 'true'
+    }
+  ]
+) }}
+```
+
+## Arguments
+
+| Name        | Type    | Default | Required | Description
+|---          |---      |---      |---       |---
+| classes     | string  |         | No       | Optional additional classes
+| name        | string  |         | Yes      | Name of the group of radio buttons
+| id          | string  |         | Yes      | ID is prefixed to the ID of each radio button
+| radios      | array   |         | Yes      | Radios array with id, value, label, checked and disabled keys
 
 <!--
 ## Installation

--- a/src/components/radio/macro.njk
+++ b/src/components/radio/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukRadio(classes='', name, id, radios) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/radio/radio.njk
+++ b/src/components/radio/radio.njk
@@ -1,0 +1,31 @@
+{% from 'radio/macro.njk' import govukRadio %}
+
+{{ govukRadio(
+  classes='',
+  name='radio-group',
+  id='radio',
+  radios=[
+   {
+      id: '1',
+      value: 'Yes',
+      label: 'Yes'
+    },
+    {
+      id: '2',
+      value: 'No',
+      label: 'No'
+    },
+    {
+      id: '3',
+      value: 'No',
+      label: 'No',
+      checked: 'true'
+    },
+    {
+      id: '4',
+      value: 'NA',
+      label: 'Not applicable',
+      disabled: 'true'
+    }
+  ]
+) }}

--- a/src/components/radio/template.njk
+++ b/src/components/radio/template.njk
@@ -1,0 +1,6 @@
+{% for radio in radios %}
+  <div class="govuk-c-radio">
+    <input class="govuk-c-radio__input {{ classes }}" id="{{ id }}-{{ radio.id }}" name="{{ name }}" type="radio" value="{{ radio.value }}" {% if radio.checked %}checked{% endif %} {% if radio.disabled %}disabled{% endif %}>
+    <label class="govuk-c-radio__label" for="{{ id }}-{{ radio.id }}">{{ radio.label }}</label>
+  </div>
+{% endfor %}

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -25,4 +25,6 @@
 
 {% include "../components/phase-banner/phase-banner.njk" %}
 
+{% include "../components/radio/radio.njk" %}
+
 {% include "../components/textarea/textarea.njk" %}


### PR DESCRIPTION
Add a template file, nunjucks macro and nunjucks file for the radio button component. 

Display the component on the example page of components.

#### Screenshot:

![gov uk frontend - radio buttons](https://user-images.githubusercontent.com/417754/29568193-7c35033e-8747-11e7-93e4-839745e193e2.png)


