### PR TITLE
Add a pagination macro

### DIFF
--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -18,6 +18,81 @@ Code example(s)
 @@include('pagination.html')
 ```
 
+## Nunjucks
+
+```
+{% from "pagination/macro.njk" import govukPagination %}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page',
+      label: '1 of 3'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page',
+      label: 'Tax disc'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page',
+      label: '1 of 3'
+    }
+  ],
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page',
+      label: '2 of 3'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page'
+    }
+  ],
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page'
+    }
+  ]
+  )
+}}
+```
+
+## Arguments
+
+| Name          | Type    | Default | Required | Description
+|---            |---      |---      |---       |---
+| classes       | string  |         | No       | Optional additional classes
+| name          | string  |         | Yes      | Name of the group of checkboxes
+| id            | string  |         | Yes      | ID is prefixed to the ID of each checkbox
+| previousPage  | array   |         | No       | previousPage array with url, title and label keys
+| nextPage      | array   |         | No       | nextPage array with url, title and label keys
 
 <!--
 ## Installation

--- a/src/components/pagination/macro.njk
+++ b/src/components/pagination/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPagination(classes='', previousPage, nextPage) %}
+  {% include './template.njk' %}
+{% endmacro %}

--- a/src/components/pagination/pagination.njk
+++ b/src/components/pagination/pagination.njk
@@ -1,0 +1,61 @@
+{% from "pagination/macro.njk" import govukPagination %}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page',
+      label: '1 of 3'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page',
+      label: 'Tax disc'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page',
+      label: '1 of 3'
+    }
+  ],
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page',
+      label: '2 of 3'
+    }
+  ]
+  )
+}}
+
+{{ govukPagination(
+  classes='',
+  previousPage=[
+   {
+      url: 'previous-page',
+      title: 'Previous page'
+    }
+  ],
+  nextPage=[
+   {
+      url: 'next-page',
+      title: 'Next page'
+    }
+  ]
+  )
+}}

--- a/src/components/pagination/template.njk
+++ b/src/components/pagination/template.njk
@@ -1,0 +1,39 @@
+<nav class="govuk-c-pagination {{ classes }}" role="navigation" aria-label="Pagination">
+  <ul class="govuk-c-pagination__list">
+    {% if previousPage %}
+    {% for page in previousPage %}
+    <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+      <a class="govuk-c-pagination__link" href="{{ page.url }}" rel="prev">
+        <span class="govuk-c-pagination__link-title">
+          <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          {{ page.title }}
+        </span>
+        {% if page.label %}
+          <span class="govuk-c-pagination__link-label">{{ page.label }}</span>
+        {% endif %}
+      </a>
+    </li>
+    {% endfor %}
+    {% endif %}
+
+    {% if nextPage %}
+    {% for page in nextPage %}
+    <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+      <a class="govuk-c-pagination__link" href="{{ page.url }}" rel="next">
+        <span class="govuk-c-pagination__link-title">
+          {{ page.title }}
+          <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        </span>
+        {% if page.label %}
+          <span class="govuk-c-pagination__link-label">{{ page.label }}</span>
+        {% endif %}
+      </a>
+    </li>
+    {% endfor %}
+    {% endif %}
+  </ul>
+</nav>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -28,3 +28,5 @@
 {% include "../components/radio/radio.njk" %}
 
 {% include "../components/textarea/textarea.njk" %}
+
+{% include "../components/pagination/pagination.njk" %}


### PR DESCRIPTION
Add a pagination template file, Nunjucks macro and component nunjucks file.

Display the variants for the pagination component on the example page.

Add a Nunjucks example and table of arguments to the README.

#### Screenshot:

![gov uk frontend - pagination](https://user-images.githubusercontent.com/417754/29569643-0dc4682c-874c-11e7-94cd-4a2cd5219364.png)
