### PR TITLE
Add a list macro

### DIFF
--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -18,6 +18,106 @@ Code example(s)
 @@include('list.html')
 ```
 
+## Nunjucks
+
+```
+{% from "list/macro.njk" import govukList %}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Related link',
+      url: '/'
+    },
+    {
+      text: 'Related link',
+      url: '/'
+    },
+    {
+      text: 'Related link',
+      url: '/'
+    }
+  ]
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'here is a bulleted list'
+    },
+    {
+      text: 'here is the second bulleted list item'
+    },
+    {
+      text: 'here is the third bulleted list item'
+    }
+  ],
+  isBullet='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'This is a numbered list.'
+    },
+    {
+      text: 'This is the second step in a numbered list.'
+    },
+    {
+      text: 'The third step is to make sure each item is a full sentence ending with a full stop.'
+    }
+  ],
+  isNumber='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Step 1'
+    },
+    {
+      text: 'Step 2'
+    },
+    {
+      text: 'Step 3'
+    }
+  ],
+  isStep='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Step 1 Large icon'
+    },
+    {
+      text: 'Step 2 Large icon'
+    },
+    {
+      text: 'Step 3 Large icon'
+    }
+  ],
+  isStepLarge='true'
+) }}
+```
+
+## Arguments
+
+| Name        | Type   | Default | Required | Description
+|---          |---     |---      |---       |---
+| classes     | string |         | No       | Optional additional classes
+| listItems   | array  |         | Yes      | List items array with url and text keys
+| url         | string |         | Yes      | List item url
+| text        | string |         | Yes      | List item text
+| isBullet    | string |         | No       | Optional - creates bulleted list
+| isNumber    | string |         | No       | Optional - creates numbered list
+| isStep      | string |         | No       | Optional - creates list of steps
+| isStepLarge | string |         | No       | Optional - creates list of steps with large icons
 
 <!--
 ## Installation

--- a/src/components/list/list.njk
+++ b/src/components/list/list.njk
@@ -1,0 +1,83 @@
+{% from "list/macro.njk" import govukList %}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Related link',
+      url: '/'
+    },
+    {
+      text: 'Related link',
+      url: '/'
+    },
+    {
+      text: 'Related link',
+      url: '/'
+    }
+  ]
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'here is a bulleted list'
+    },
+    {
+      text: 'here is the second bulleted list item'
+    },
+    {
+      text: 'here is the third bulleted list item'
+    }
+  ],
+  isBullet='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'This is a numbered list.'
+    },
+    {
+      text: 'This is the second step in a numbered list.'
+    },
+    {
+      text: 'The third step is to make sure each item is a full sentence ending with a full stop.'
+    }
+  ],
+  isNumber='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Step 1'
+    },
+    {
+      text: 'Step 2'
+    },
+    {
+      text: 'Step 3'
+    }
+  ],
+  isStep='true'
+) }}
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'Step 1 Large icon'
+    },
+    {
+      text: 'Step 2 Large icon'
+    },
+    {
+      text: 'Step 3 Large icon'
+    }
+  ],
+  isStepLarge='true'
+) }}

--- a/src/components/list/macro.njk
+++ b/src/components/list/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukList(classes='', listItems, isBullet, isNumber, isStep, isStepLarge) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/list/template.njk
+++ b/src/components/list/template.njk
@@ -1,0 +1,24 @@
+{% if isNumber or isStep or isStepLarge %}
+<ol class="govuk-c-list {% if isNumber %}govuk-c-list--number{% endif %} {% if isStep or isStepLarge %}govuk-c-list--icon{% endif %} {{ classes }}">
+{% else %}
+<ul class="govuk-c-list {% if isBullet %}govuk-c-list--bullet{% endif %} {{ classes }}">
+{% endif %}
+
+{% for item in listItems %}
+  <li>
+    {% if isStep or isStepLarge %}
+      <span class="govuk-c-list__icon govuk-u-circle {% if isStepLarge %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span>
+      {{ item.text }}
+    {% else %}
+      {% if item.url %}<a href="{{ item.url }} ">{% endif %}
+        {{ item.text }}
+      {% if item.url %}</a>{% endif %}
+    {% endif %}
+  </li>
+{% endfor %}
+
+{% if isNumber or isStep or isStepLarge %}
+</ol>
+{% else %}
+</ul>
+{% endif %}

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -23,6 +23,8 @@
 
 {% include "../components/link/link.njk" %}
 
+{% include "../components/list/list.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/textarea/textarea.njk" %}


### PR DESCRIPTION
Add a list macro, template file and nunjucks component file.

Display how to call the component using Nunjucks and a table of arguments for the README.

#### Screenshot:

![gov uk frontend - list items](https://user-images.githubusercontent.com/417754/29575041-37def028-875b-11e7-979b-a29cb9de49ce.png)
