### PR TITLE
Add panel macro

### DIFF
--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -22,6 +22,28 @@ Code example(s)
 @@include('panel.html')
 ```
 
+## Nunjucks
+
+```
+{% from "panel/macro.njk" import govukPanel %}
+
+{{ govukInput(
+  classes='',
+  title='Application complete',
+  content='Your reference number is',
+  reference='HDJ2123F'
+  )
+}}
+```
+
+## Arguments
+
+| Name          | Type    | Required  | Description
+|---            |---      |---        |---
+| classes       | string  | No        | Optional additional classes
+| title         | string  | Yes       | The panel title
+| content       | string  | No        | The panel content
+| reference     | string  | No        | Optional reference number
 
 <!--
 ## Installation

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -23,11 +23,6 @@
     background: $govuk-turquoise;
   }
 
-  .govuk-c-panel--information {
-    color: $govuk-white;
-    background: $govuk-blue;
-  }
-
   .govuk-c-panel__title {
     margin-top: em($govuk-spacing-scale-6, 48px);
     margin-bottom: em($govuk-spacing-scale-5, 48px);

--- a/src/components/panel/macro.njk
+++ b/src/components/panel/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPanel(classes, title, content, reference) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/panel/panel.njk
+++ b/src/components/panel/panel.njk
@@ -1,0 +1,9 @@
+{% from "panel/macro.njk" import govukPanel %}
+
+{{ govukPanel(
+  classes='',
+  title='Application complete',
+  content='Your reference number is',
+  reference='HDJ2123F'
+  )
+}}

--- a/src/components/panel/template.njk
+++ b/src/components/panel/template.njk
@@ -1,0 +1,12 @@
+<div class="govuk-c-panel govuk-c-panel--confirmation {{ classes }}">
+  <h2 class="govuk-c-panel__title">
+    {{ title }}
+  </h2>
+  <div class="govuk-c-panel__body">
+    {{ content }}
+    {% if reference %}
+    <br>
+    <strong>{{ reference }}</strong>
+    {%endif %}
+  </div>
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -25,6 +25,8 @@
 
 {% include "../components/list/list.njk" %}
 
+{% include "../components/panel/panel.njk" %}
+
 {% include "../components/phase-banner/phase-banner.njk" %}
 
 {% include "../components/radio/radio.njk" %}


### PR DESCRIPTION
Add panel nunjucks file, macro and template.

Display panel on the example page.

Make the confirmation page example the default, as we don't have an example of the information panel. We can add this variant later when we have a better idea of its usage.

#### Screenshot:
![gov uk frontend - panel](https://user-images.githubusercontent.com/417754/29616045-f519c2d8-8807-11e7-963f-666b195d10b6.png)


