### PR TITLE
Add error summary macro

### DIFF
--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -18,6 +18,39 @@ Code example(s)
 @@include('error-summary.html')
 ```
 
+## Nunjucks
+
+```
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+
+{{ govukErrorSummary(
+  classes='',
+  title='Message to alert the user to a problem goes here',
+  description='Optional description of the errors and how to correct them',
+  listClasses='',
+  listItems=[
+    {
+      text: 'Descriptive link to the question with an error',
+      url: '#example-error-1'
+    },
+    {
+      text: 'Descriptive link to the question with an error',
+      url: '#example-error-2'
+    }
+  ]
+) }}
+```
+
+## Arguments
+
+| Name        | Type   | Default | Required | Description
+|---          |---     |---      |---       |---
+| classes     | string |         | No       | Optional additional classes
+| title       | string |         | Yes      | Error summary title
+| description | string |         | No       | Optional error summary description
+| listItems   | array  |         | Yes      | List items array with url and text keys
+| url         | string |         | Yes      | List item url
+| text        | string |         | Yes      | List item text
 
 <!--
 ## Installation

--- a/src/components/error-summary/error-summary.njk
+++ b/src/components/error-summary/error-summary.njk
@@ -1,0 +1,18 @@
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+
+{{ govukErrorSummary(
+  classes='',
+  title='Message to alert the user to a problem goes here',
+  description='Optional description of the errors and how to correct them',
+  listClasses='',
+  listItems=[
+    {
+      text: 'Descriptive link to the question with an error',
+      url: '#example-error-1'
+    },
+    {
+      text: 'Descriptive link to the question with an error',
+      url: '#example-error-2'
+    }
+  ]
+) }}

--- a/src/components/error-summary/macro.njk
+++ b/src/components/error-summary/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukErrorSummary(classes='', title, description, listClasses, listItems) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/error-summary/template.njk
+++ b/src/components/error-summary/template.njk
@@ -1,0 +1,18 @@
+{% from "list/macro.njk" import govukList %}
+
+<div class="govuk-c-error-summary {{ classes }}" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+
+  <h2 class="govuk-c-error-summary__title" id="error-summary-title">
+    {{ title }}
+  </h2>
+
+  <div class="govuk-c-error-summary__body">
+    {% if description %}
+    <p>
+      {{ description }}
+    </p>
+    {% endif %}
+    {{ govukList(classes=listClasses + ' govuk-c-error-summary__list', listItems, '', '', '', '') }}
+  </div>
+
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -10,6 +10,8 @@
 
 {% include "../components/error-message/error-message.njk" %}
 
+{% include "../components/error-summary/error-summary.njk" %}
+
 {% include "../components/fieldset/fieldset.njk" %}
 
 {% include "../components/input/input.njk" %}


### PR DESCRIPTION
Add error summary nunjucks file, template and macro.

Add a table of arguments and how to use the nunjucks macro to the
readme.

#### Screenshot:

![gov uk frontend - error summary](https://user-images.githubusercontent.com/417754/29620102-e3a43f26-8814-11e7-8b72-74c912b2cf29.png)
