### PR TITLE
Add site-width-container and grid macros

### DIFF
--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -1,6 +1,6 @@
 # Grid
 
-Description of component.
+Grid row with grid items.
 
 ## Guidance
 
@@ -17,6 +17,80 @@ Code example(s)
 ```
 @@include('grid.html')
 ```
+
+## Nunjucks
+
+```
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'full' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-half' },
+    { width: 'one-half' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-third' },
+    { width: 'one-third' },
+    { width: 'one-third' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'two-thirds' },
+    { width: 'one-third' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-third' },
+    { width: 'two-thirds' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+
+{% call govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-quarter' },
+    { width: 'one-quarter' },
+    { width: 'one-quarter' },
+    { width: 'one-quarter' }]
+  )
+%}
+<!-- Insert macros to sit inside grid here -->
+{% endcall %}
+```
+
+## Arguments
+
+| Name          | Type    | Required  | Description
+|---            |---      |---        |---
+| classes       | string  | No        | Optional additional classes
+| gridItems     | array   | Yes       | Grid items array with width key
+| width         | string  | Yes       | Width of the grid item - full, one-half, one-third, two-thirds, one-quarter
 
 <!--
 ## Installation

--- a/src/components/grid/grid.njk
+++ b/src/components/grid/grid.njk
@@ -1,0 +1,57 @@
+{% from "grid/macro.njk" import govukGrid %}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'full' }
+  ]
+  )
+}}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-half' },
+    { width: 'one-half' }
+  ]
+  )
+}}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-third' },
+    { width: 'one-third' },
+    { width: 'one-third' }
+  ]
+  )
+}}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'two-thirds' },
+    { width: 'one-third' }
+  ]
+  )
+}}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-third' },
+    { width: 'two-thirds' }
+  ]
+  )
+}}
+
+{{ govukGrid(
+  classes='',
+  gridItems=[
+    { width: 'one-quarter' },
+    { width: 'one-quarter' },
+    { width: 'one-quarter' },
+    { width: 'one-quarter' }
+  ]
+  )
+}}

--- a/src/components/grid/macro.njk
+++ b/src/components/grid/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukGrid(classes, gridItems) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/grid/template.njk
+++ b/src/components/grid/template.njk
@@ -1,0 +1,9 @@
+{% from "grid/macro.njk" import govukGrid %}
+
+<div class="govuk-c-grid {{ classes }}">
+  {% for item in gridItems %}
+  <div class="govuk-c-grid__item govuk-c-grid__item--{{ item.width }}">
+    {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
+  </div>
+  {% endfor %}
+</div>

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -18,6 +18,34 @@ Code example(s)
 @@include('site-width-container.html')
 ```
 
+## Nunjucks
+
+```
+{% call govukSiteWidthContainer(classes='') %}
+  <!-- Insert content to sit inside govukSiteWidthContainer here -->
+{% endcall %}
+```
+
+Use call to nest of govukGrid items within govukSiteWidthContainer.
+
+```
+{% call govukSiteWidthContainer(classes='') %}
+  {% call govukGrid(
+    classes='',
+    gridItems=[ { width: 'two-thirds' } ]
+    )
+  %}
+  <!-- Insert macros to sit inside grid item here -->
+  {% endcall %}
+{% endcall %}
+```
+
+## Arguments
+
+| Name          | Type    | Required  | Description
+|---            |---      |---        |---
+| classes       | string  | No        | Optional additional classes
+
 <!--
 ## Installation
 

--- a/src/components/site-width-container/macro.njk
+++ b/src/components/site-width-container/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukSiteWidthContainer(classes='') %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/site-width-container/site-width-container.njk
+++ b/src/components/site-width-container/site-width-container.njk
@@ -1,0 +1,3 @@
+{% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
+
+{{ govukSiteWidthContainer(classes) }}

--- a/src/components/site-width-container/template.njk
+++ b/src/components/site-width-container/template.njk
@@ -1,0 +1,3 @@
+<div class="govuk-c-site-width-container {{ classes }}">
+  {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
+</div>

--- a/src/examples/component-macros.njk
+++ b/src/examples/component-macros.njk
@@ -14,6 +14,8 @@
 
 {% include "../components/fieldset/fieldset.njk" %}
 
+{% include "../components/grid/grid.njk" %}
+
 {% include "../components/input/input.njk" %}
 
 {% include "../components/inset-text/inset-text.njk" %}
@@ -38,3 +40,28 @@
 {% include "../components/pagination/pagination.njk" %}
 
 {% include "../components/select-box/select-box.njk" %}
+
+{# Example of calling site-width-container and nesting a grid row #}
+{% from "../components/site-width-container/macro.njk" import govukSiteWidthContainer %}
+{% from "../components/grid/macro.njk" import govukGrid %}
+
+{% call govukSiteWidthContainer() %}
+  {% call govukGrid(
+    classes='',
+    gridItems=[ { width: 'full' } ]
+    )
+  %}
+  Example full width grid column
+  <!-- Insert macros to sit inside grid item here -->
+  {% endcall %}
+
+  {% call govukGrid(
+    classes='',
+    gridItems=[ { width: 'two-thirds' } ]
+    )
+  %}
+  Example two-thirds width grid column
+  <!-- Insert macros to sit inside grid item here -->
+  {% endcall %}
+{% endcall %}
+


### PR DESCRIPTION
Show how grid items can be nested within site-width-container using call on the example page.

Add a template file, nunjucks file and component template file for both site-width-container and grid components.

Add Nunjucks examples and a table of arguments for both components to their READMEs.



