### PR TITLE
Use gulp-tenon npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "gulp-sass-lint": "^1.3.2",
     "gulp-standard": "^10.0.0",
     "gulp-task-listing": "^1.0.1",
-    "gulp-tenon-client": "git+https://git@github.com/alphagov/gulp-tenon-client.git",
+    "gulp-tenon-client": "^0.1.2",
     "gulp-uglify": "^3.0.0",
     "gulp-wrap": "^0.13.0",
     "lerna": "^2.0.0-rc.5",


### PR DESCRIPTION
Revert from a git repo to official npm package
New version released without console.log