### PR TITLE
Fix html include to readme

### DIFF
--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -10,7 +10,7 @@ Breadcrumb
 </p>
 
 <p class="govuk-u-copy-19">
-  <a href="http://www.linktodesignsystem.com">Find breadcrumb guidance on the GOV.UK Design System.</a>
+  <a href="http://www.linktodesignsystem.com/breadcrumb">Find breadcrumb guidance on the GOV.UK Design System.</a>
 </p>
 
 
@@ -46,15 +46,14 @@ Breadcrumb
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;breadcrumb/macro.njk&quot; import govukBreadcrumb %}
-
-{{ govukBreadcrumb(
-  classes=&#39;&#39;,
-  [
-    { title: &#39;Home&#39;, url: &#39;/&#39; },
-    { title: &#39;Current page&#39; }
-  ]
-) }}
+<pre><code>&lt;div class=&quot;govuk-c-breadcrumb&quot;&gt;
+  &lt;ol class=&quot;govuk-c-breadcrumb__list&quot;&gt;
+    &lt;li class=&quot;govuk-c-breadcrumb__list-item&quot;&gt;
+      &lt;a class=&quot;govuk-c-breadcrumb__link&quot; href=&quot;/&quot;&gt;Previous page&lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li class=&quot;govuk-c-breadcrumb__list-item&quot; aria-current=&quot;page&quot;&gt;Current page&lt;/li&gt;
+  &lt;/ol&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -49,13 +49,9 @@ Button
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;button/macro.njk&quot; import govukButton %}
-
-{{ govukButton(classes=&#39;&#39;, text=&#39;Save and continue&#39;) }}
-
-{{ govukButton(classes=&#39;&#39;, text=&#39;Save and continue&#39;, isDisabled=&#39;true&#39;) }}
-
-{{ govukButton(classes=&#39;&#39;, text=&#39;Start now&#39;, url=&#39;/&#39;, isStart=&#39;true&#39;) }}
+<pre><code>&lt;input class=&quot;govuk-c-button&quot; type=&quot;submit&quot; value=&quot;Save and continue&quot;&gt;
+&lt;a class=&quot;govuk-c-button govuk-c-button--start&quot; href=&quot;#&quot; role=&quot;button&quot;&gt;Start now&lt;/a&gt;
+&lt;input class=&quot;govuk-c-button govuk-c-button--disabled&quot; type=&quot;submit&quot; value=&quot;Primary disabled button&quot; disabled=&quot;disabled&quot; aria-disabled=&quot;true&quot;&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -72,37 +72,18 @@ Checkbox
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &#39;checkbox/macro.njk&#39; import govukCheckbox %}
-
-{{ govukCheckbox(
-  classes=&#39;&#39;,
-  name=&#39;waste-types&#39;,
-  id=&#39;waste-type&#39;,
-  checkboxes=[
-   {
-      id: &#39;1&#39;,
-      value: &#39;waste-animal&#39;,
-      label: &#39;Waste from animal carcasses&#39;
-    },
-    {
-      id: &#39;2&#39;,
-      value: &#39;waste-mines&#39;,
-      label: &#39;Waste from mines or quarries&#39;
-    },
-    {
-      id: &#39;3&#39;,
-      value: &#39;waste-farm&#39;,
-      label: &#39;Farm or agricultural waste&#39;,
-      checked: &#39;true&#39;
-    },
-    {
-      id: &#39;4&#39;,
-      value: &#39;waste-disabled&#39;,
-      label: &#39;Disabled checkbox option&#39;,
-      disabled: &#39;true&#39;
-    }
-  ]
-) }}
+<pre><code>&lt;div class=&quot;govuk-c-checkbox&quot;&gt;
+  &lt;input class=&quot;govuk-c-checkbox__input&quot; id=&quot;waste-type-1&quot; name=&quot;waste-types&quot; type=&quot;checkbox&quot; value=&quot;waste-animal&quot;&gt;
+  &lt;label class=&quot;govuk-c-checkbox__label&quot; for=&quot;waste-type-1&quot;&gt;Waste from animal carcasses&lt;/label&gt;
+&lt;/div&gt;
+&lt;div class=&quot;govuk-c-checkbox&quot;&gt;
+  &lt;input class=&quot;govuk-c-checkbox__input&quot; id=&quot;waste-type-2&quot; name=&quot;waste-types&quot; type=&quot;checkbox&quot; value=&quot;waste-mines&quot;&gt;
+  &lt;label class=&quot;govuk-c-checkbox__label&quot; for=&quot;waste-type-2&quot;&gt;Waste from mines or quarries&lt;/label&gt;
+&lt;/div&gt;
+&lt;div class=&quot;govuk-c-checkbox&quot;&gt;
+  &lt;input class=&quot;govuk-c-checkbox__input&quot; id=&quot;waste-type-3&quot; name=&quot;waste-types&quot; type=&quot;checkbox&quot; disabled=&quot;disabled&quot; value=&quot;waste-farm&quot;&gt;
+  &lt;label class=&quot;govuk-c-checkbox__label&quot; for=&quot;waste-type-3&quot;&gt;Farm or agricultural waste&lt;/label&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -45,12 +45,9 @@ Cookie banner
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;cookie-banner/macro.njk&quot; import govukCookieBanner %}
-{{ govukCookieBanner(
-  classes=&#39;&#39;,
-  cookieBannerText=&#39;GOV.UK uses cookies to make the site simpler. &lt;a href=&quot;https://www.gov.uk/help/cookies&quot;&gt;Find out more about cookies&lt;/a&gt;&#39;
-  )
-}}
+<pre><code>&lt;div class=&quot;govuk-c-cookie-banner js-cookie-banner&quot;&gt;
+  &lt;p class=&quot;govuk-c-cookie-banner__text&quot;&gt;GOV.UK uses cookies to make the site simpler. &lt;a href=&quot;https://www.gov.uk/help/cookies&quot;&gt;Find out more about cookies&lt;/a&gt;&lt;/p&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -32,7 +32,39 @@ Date
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code></code></pre>
+<pre><code>&lt;div class=&quot;govuk-c-date&quot;&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--day&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-day&quot;&gt;Day&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input&quot; id=&quot;dob-day&quot; name=&quot;dob-day&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--month&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-month&quot;&gt;Month&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input&quot; id=&quot;dob-month&quot; name=&quot;dob-month&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--year&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-year&quot;&gt;Year&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input&quot; id=&quot;dob-year&quot; name=&quot;dob-year&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;legend&gt;
+  &lt;span class=&quot;govuk-c-error-message&quot;&gt;Error message goes here&lt;/span&gt;
+&lt;/legend&gt;
+&lt;div class=&quot;govuk-c-date&quot;&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--day&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-day-1&quot;&gt;Day&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input govuk-c-input--error&quot; id=&quot;dob-day-1&quot; name=&quot;dob-day&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--month&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-month-1&quot;&gt;Month&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input&quot; id=&quot;dob-month-1&quot; name=&quot;dob-month&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+  &lt;div class=&quot;govuk-c-date__item govuk-c-date__item--year&quot;&gt;
+    &lt;label class=&quot;govuk-c-label govuk-c-date__label&quot; for=&quot;dob-year-1&quot;&gt;Year&lt;/label&gt;
+    &lt;input class=&quot;govuk-c-input govuk-c-date__input&quot; id=&quot;dob-year-1&quot; name=&quot;dob-year&quot; type=&quot;number&quot;&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+</code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>
 <pre><code>npm install --save @govuk-frontend/date</code></pre>

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -50,19 +50,21 @@ Details
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;details/macro.njk&quot; import govukDetails %}
-
-{{ govukDetails(
-  classes=&#39;&#39;,
-  detailsSummaryText=&#39;Help with nationality&#39;,
-  detailsText=&#39;&lt;p&gt;
-    If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-  &lt;/p&gt;
-  &lt;p&gt;
-    We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-  &lt;/p&gt;&#39;
-  )
-}}
+<pre><code>&lt;details class=&quot;govuk-c-details&quot;&gt;
+  &lt;summary class=&quot;govuk-c-details__summary&quot;&gt;
+    &lt;span class=&quot;govuk-c-details__summary-text&quot;&gt;Help with nationality&lt;/span&gt;
+  &lt;/summary&gt;
+  &lt;div class=&quot;govuk-c-border govuk-c-border--left-narrow&quot;&gt;
+    &lt;div class=&quot;govuk-c-details__text&quot;&gt;
+      &lt;p&gt;
+        If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
+      &lt;/p&gt;
+      &lt;p&gt;
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+      &lt;/p&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/details&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -44,13 +44,9 @@ Error message
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;error-message/macro.njk&quot; import govukErrorMessage %}
-
-{{ govukErrorMessage(
-  classes=&#39;&#39;,
-  errorMessage=&#39;Error message goes here&#39;
-  )
-}}
+<pre><code>&lt;span class=&quot;govuk-c-error-message&quot;&gt;
+  Error message goes here
+&lt;/span&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -59,24 +59,23 @@ Error summary
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;error-summary/macro.njk&quot; import govukErrorSummary %}
+<pre><code>&lt;div class=&quot;govuk-c-error-summary&quot; aria-labelledby=&quot;error-summary-title&quot; role=&quot;alert&quot; tabindex=&quot;-1&quot;&gt;
 
-{{ govukErrorSummary(
-  classes=&#39;&#39;,
-  title=&#39;Message to alert the user to a problem goes here&#39;,
-  description=&#39;Optional description of the errors and how to correct them&#39;,
-  listClasses=&#39;&#39;,
-  listItems=[
-    {
-      text: &#39;Descriptive link to the question with an error&#39;,
-      url: &#39;#example-error-1&#39;
-    },
-    {
-      text: &#39;Descriptive link to the question with an error&#39;,
-      url: &#39;#example-error-2&#39;
-    }
-  ]
-) }}
+  &lt;h2 class=&quot;govuk-c-error-summary__title&quot; id=&quot;error-summary-title&quot;&gt;
+    Message to alert the user to a problem goes here
+  &lt;/h2&gt;
+
+  &lt;div class=&quot;govuk-c-error-summary__body&quot;&gt;
+    &lt;p&gt;
+      Optional description of the errors and how to correct them
+    &lt;/p&gt;
+
+    &lt;ul class=&quot;govuk-c-list govuk-c-error-summary__list&quot;&gt;
+      &lt;li&gt;&lt;a href=&quot;#example-personal-details&quot;&gt;Descriptive link to the question with an error&lt;/a&gt;&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/div&gt;
+
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -44,13 +44,11 @@ Fieldset
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;fieldset/macro.njk&quot; import govukFieldset %}
-
-{{ govukFieldset(
-  classes=&#39;&#39;,
-  legendText=&#39;Legend text goes here&#39;
-  )
-}}
+<pre><code>&lt;fieldset class=&quot;govuk-c-fieldset&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    Legend text in here
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -41,7 +41,19 @@ File upload
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code></code></pre>
+<pre><code>&lt;label class=&quot;govuk-c-label&quot; for=&quot;file-upload-a&quot;&gt;
+  Upload a file
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-file-upload&quot; type=&quot;file&quot; id=&quot;file-upload-a&quot;&gt;
+
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;file-upload-b&quot;&gt;
+  Upload a file
+  &lt;span class=&quot;govuk-c-error-message&quot;&gt;
+    Error message goes here
+  &lt;/span&gt;
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-file-upload govuk-c-file-upload--error&quot; type=&quot;file&quot; id=&quot;file-upload-b&quot;&gt;
+</code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>
 <pre><code>npm install --save @govuk-frontend/file-upload</code></pre>

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -94,63 +94,66 @@ Grid
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;grid/macro.njk&quot; import govukGrid %}
+<pre><code>&lt;div class=&quot;govuk-c-site-width-container&quot;&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;full&#39; }
-  ]
-  )
-}}
+  &lt;!-- Full width --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--full&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;one-half&#39; },
-    { width: &#39;one-half&#39; }
-  ]
-  )
-}}
+  &lt;!-- Halves --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--one-half&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+    &lt;div class=&quot;govuk-c-grid__item  govuk-c-grid__item--one-half&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;one-third&#39; },
-    { width: &#39;one-third&#39; },
-    { width: &#39;one-third&#39; }
-  ]
-  )
-}}
+  &lt;!-- Thirds --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item  govuk-c-grid__item--one-third&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+    &lt;div class=&quot;govuk-c-grid__item  govuk-c-grid__item--one-third&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;two-thirds&#39; },
-    { width: &#39;one-third&#39; }
-  ]
-  )
-}}
+  &lt;!-- Two thirds / one third --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--two-thirds&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--one-third&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;one-third&#39; },
-    { width: &#39;two-thirds&#39; }
-  ]
-  )
-}}
+  &lt;!-- One third / two thirds --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--one-third&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--two-thirds&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
 
-{{ govukGrid(
-  classes=&#39;&#39;,
-  gridItems=[
-    { width: &#39;one-quarter&#39; },
-    { width: &#39;one-quarter&#39; },
-    { width: &#39;one-quarter&#39; },
-    { width: &#39;one-quarter&#39; }
-  ]
-  )
-}}
+  &lt;!-- Quarters --&gt;
+  &lt;div class=&quot;govuk-c-grid&quot;&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--one-quarter&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+    &lt;div class=&quot;govuk-c-grid__item govuk-c-grid__item--one-quarter&quot;&gt;
+      Grid item
+    &lt;/div&gt;
+  &lt;/div&gt;
+
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -73,38 +73,42 @@ Input
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;input/macro.njk&quot; import govukInput %}
+<pre><code>&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-input-a&quot;&gt;
+  National Insurance number
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-input&quot; id=&quot;govuk-c-input-a&quot; type=&quot;text&quot;&gt;
 
-{{ govukInput(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;&#39;,
-  errorMessage=&#39;&#39;,
-  id=&#39;input-1&#39;,
-  name=&#39;test-name&#39;
-  )
-}}
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-input-b&quot;&gt;
+  National Insurance number
+  &lt;span class=&quot;govuk-c-error-message&quot;&gt;
+    Error message goes here
+  &lt;/span&gt;
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-input govuk-c-input--error&quot; id=&quot;govuk-c-input-b&quot; type=&quot;text&quot;&gt;
 
-{{ govukInput(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.&#39;,
-  errorMessage=&#39;&#39;,
-  id=&#39;input-2&#39;,
-  name=&#39;test-name-2&#39;
-  )
-}}
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-input-c&quot;&gt;
+  National Insurance number
+  &lt;span class=&quot;govuk-c-label__hint&quot;&gt;
+    It&#39;s on your National Insurance card, benefit letter, payslip or P60.
+    &lt;br&gt;
+    For example, ‘QQ 12 34 56 C’.
+  &lt;/span&gt;
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-input&quot; id=&quot;govuk-c-input-c&quot; type=&quot;text&quot;&gt;
 
-{{ govukInput(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;It’s on your National Insurance card, benefit letter, payslip or P60.
-    For example, ‘QQ 12 34 56 C’.&#39;,
-  errorMessage=&#39;Error message goes here&#39;,
-  id=&#39;input-3&#39;,
-  name=&#39;test-name-3&#39;
-  )
-}}
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-input-d&quot;&gt;
+  National Insurance number
+  &lt;span class=&quot;govuk-c-label__hint&quot;&gt;
+    It&#39;s on your National Insurance card, benefit letter, payslip or P60.
+    &lt;br&gt;
+    For example, ‘QQ 12 34 56 C’.
+  &lt;/span&gt;
+  &lt;span class=&quot;govuk-c-error-message&quot;&gt;
+    Error message goes here
+  &lt;/span&gt;
+&lt;/label&gt;
+&lt;input class=&quot;govuk-c-input govuk-c-input--error&quot; id=&quot;govuk-c-input-d&quot; type=&quot;text&quot;&gt;
+
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -46,16 +46,12 @@ Inset text
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;inset-text/macro.njk&quot; import govukInsetText %}
-
-{{ govukInsetText(
-  classes=&#39;&#39;,
-  content=&#39;&lt;p&gt;
+<pre><code>&lt;div class=&quot;govuk-c-inset-text&quot;&gt;
+  &lt;p&gt;
     It can take up to 8 weeks to register a lasting power of attorney if&lt;br&gt;
     there are no mistakes in the application.
-  &lt;/p&gt;&#39;
-  )
-}}
+  &lt;/p&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -68,35 +68,21 @@ Label
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;label/macro.njk&quot; import govukLabel %}
+<pre><code>&lt;label class=&quot;govuk-c-label&quot;&gt;
+  National Insurance number
+  &lt;span class=&quot;govuk-c-label__hint&quot;&gt;
+    It&#39;s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.
+  &lt;/span&gt;
+&lt;/label&gt;
 
-{{ govukLabel(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;It’s on your National Insurance card, benefit letter, payslip or P60.
-    For example, ‘QQ 12 34 56 C’.&#39;,
-  id=&#39;&#39;
-  )
-}}
-
-{{ govukLabel(
-  classes=&#39;govuk-c-label--bold&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;It’s on your National Insurance card, benefit letter, payslip or P60.
-    For example, ‘QQ 12 34 56 C’.&#39;,
-  id=&#39;&#39;
-  )
-}}
-
-{{ govukLabel(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;It’s on your National Insurance card, benefit letter, payslip or P60.
-    For example, ‘QQ 12 34 56 C’.&#39;,
-  errorMessage=&#39;Error message goes here&#39;,
-  id=&#39;&#39;
-  )
-}}
+&lt;label class=&quot;govuk-c-label govuk-c-label--bold&quot;&gt;
+  National Insurance number
+  &lt;span class=&quot;govuk-c-label__hint&quot;&gt;
+    It&#39;s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.
+  &lt;/span&gt;
+&lt;/label&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -44,13 +44,13 @@ Legal text
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;legal-text/macro.njk&quot; import govukLegalText %}
-
-{{ govukLegalText(
-  classes=&#39;&#39;,
-  iconFallbackText=&#39;Warning&#39;,
-  legalText=&#39;You can be fined up to £5,000 if you don’t register.&#39;)
-}}
+<pre><code>&lt;div class=&quot;govuk-c-legal-text&quot;&gt;
+  &lt;span class=&quot;govuk-c-legal-text__icon govuk-u-circle&quot; aria-hidden=&quot;true&quot;&gt;!&lt;/span&gt;
+  &lt;strong class=&quot;govuk-c-legal-text__text&quot;&gt;
+    &lt;span class=&quot;govuk-c-legal-text__assistive&quot;&gt;Warning&lt;/span&gt;
+    You can be fined up to £5,000 if you don’t register.
+  &lt;/strong&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -78,31 +78,13 @@ Skiplink - skip to the main page content
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;link/macro.njk&quot; import govukLink %}
+<pre><code>&lt;a href=&quot;#&quot; class=&quot;govuk-c-link govuk-c-link--back&quot;&gt;Back&lt;/a&gt;
 
-{{ govukLink(
-  classes=&#39;govuk-c-link--back&#39;,
-  linkHref=&#39;&#39;,
-  linkText=&#39;Back&#39;)
-}}
+&lt;a href=&quot;#&quot; class=&quot;govuk-c-link govuk-c-link--muted&quot;&gt;Is there anything wrong with this page?&lt;/a&gt;
 
-{{ govukLink(
-  classes=&#39;govuk-c-link--muted&#39;,
-  linkHref=&#39;&#39;,
-  linkText=&#39;Is there anything wrong with this page?&#39;)
-}}
+&lt;a href=&quot;#&quot; class=&quot;govuk-c-link govuk-c-link--download&quot;&gt;Download&lt;/a&gt;
 
-{{ govukLink(
-  classes=&#39;govuk-c-link--download&#39;,
-  linkHref=&#39;&#39;,
-  tagText=&#39;Download&#39;)
-}}
-
-{{ govukLink(
-  classes=&#39;govuk-c-link--skip&#39;,
-  linkHref=&#39;&#39;,
-  linkText=&#39;Skip to main content&#39;)
-}}
+&lt;a href=&quot;#&quot; class=&quot;govuk-c-link govuk-c-link--skip&quot;&gt;Skip to main content&lt;/a&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -134,97 +134,60 @@ List
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;list/macro.njk&quot; import govukList %}
+<pre><code>&lt;ul class=&quot;govuk-c-list&quot;&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Related link&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Related link&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot;&gt;Related link&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
 
-{{ govukList(
-  classes=&#39;&#39;,
-  [
-    {
-      text: &#39;Related link&#39;,
-      url: &#39;/&#39;
-    },
-    {
-      text: &#39;Related link&#39;,
-      url: &#39;/&#39;
-    },
-    {
-      text: &#39;Related link&#39;,
-      url: &#39;/&#39;
-    }
-  ]
-) }}
+&lt;ul class=&quot;govuk-c-list govuk-c-list--bullet&quot;&gt;
+  &lt;li&gt;here is a bulleted list&lt;/li&gt;
+  &lt;li&gt;vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor&lt;/li&gt;
+  &lt;li&gt;vestibulum id ligula porta felis euismod semper&lt;/li&gt;
+  &lt;li&gt;integer posuere erat a ante venenatis dapibus posuere velit aliquet&lt;/li&gt;
+&lt;/ul&gt;
 
-{{ govukList(
-  classes=&#39;&#39;,
-  [
-    {
-      text: &#39;here is a bulleted list&#39;
-    },
-    {
-      text: &#39;here is the second bulleted list item&#39;
-    },
-    {
-      text: &#39;here is the third bulleted list item&#39;
-    }
-  ],
-  options = {
-    &#39;isBullet&#39;: &#39;true&#39;
-  }
-) }}
+&lt;ol class=&quot;govuk-c-list govuk-c-list--number&quot;&gt;
+  &lt;li&gt;This is a numbered list.&lt;/li&gt;
+  &lt;li&gt;This is the second step in a numbered list.&lt;/li&gt;
+  &lt;li&gt;The third step is to make sure each item is a full sentence ending with a full stop.&lt;/li&gt;
+&lt;/ol&gt;
 
-{{ govukList(
-  classes=&#39;&#39;,
-  [
-    {
-      text: &#39;This is a numbered list.&#39;
-    },
-    {
-      text: &#39;This is the second step in a numbered list.&#39;
-    },
-    {
-      text: &#39;The third step is to make sure each item is a full sentence ending with a full stop.&#39;
-    }
-  ],
-  options = {
-    &#39;isNumber&#39;: &#39;true&#39;
-  }
-) }}
+&lt;!-- normal steps icon size --&gt;
+&lt;ol class=&quot;govuk-c-list govuk-c-list--icon&quot;&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;1&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;2&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;3&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;4&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;5&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;6&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;7&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;8&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;9&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;10&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;11&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;12&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;13&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-u-circle&quot;&gt;14&lt;/span&gt;Step&lt;/li&gt;
+&lt;/ol&gt;
 
-{{ govukList(
-  classes=&#39;&#39;,
-  [
-    {
-      text: &#39;Step 1&#39;
-    },
-    {
-      text: &#39;Step 2&#39;
-    },
-    {
-      text: &#39;Step 3&#39;
-    }
-  ],
-  options = {
-    &#39;isStep&#39;: &#39;true&#39;
-  }
-) }}
-
-{{ govukList(
-  classes=&#39;&#39;,
-  [
-    {
-      text: &#39;Step 1 Large icon&#39;
-    },
-    {
-      text: &#39;Step 2 Large icon&#39;
-    },
-    {
-      text: &#39;Step 3 Large icon&#39;
-    }
-  ],
-  options = {
-    &#39;isStepLarge&#39;: &#39;true&#39;
-  }
-) }}
+&lt;!-- large steps icon size --&gt;
+&lt;ol class=&quot;govuk-c-list govuk-c-list--icon&quot;&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;1&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;2&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;3&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;4&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;5&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;6&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;7&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;8&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;9&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;10&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;11&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;12&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;13&lt;/span&gt;Step&lt;/li&gt;
+  &lt;li&gt;&lt;span class=&quot;govuk-c-list__icon govuk-c-list__icon--large govuk-u-circle&quot;&gt;14&lt;/span&gt;Step&lt;/li&gt;
+&lt;/ol&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -100,67 +100,33 @@ Pagination
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;pagination/macro.njk&quot; import govukPagination %}
-
-{{ govukPagination(
-  classes=&#39;&#39;,
-  previousPage=[
-   {
-      url: &#39;previous-page&#39;,
-      title: &#39;Previous page&#39;,
-      label: &#39;1 of 3&#39;
-    }
-  ]
-  )
-}}
-
-{{ govukPagination(
-  classes=&#39;&#39;,
-  nextPage=[
-   {
-      url: &#39;next-page&#39;,
-      title: &#39;Next page&#39;,
-      label: &#39;Tax disc&#39;
-    }
-  ]
-  )
-}}
-
-{{ govukPagination(
-  classes=&#39;&#39;,
-  previousPage=[
-   {
-      url: &#39;previous-page&#39;,
-      title: &#39;Previous page&#39;,
-      label: &#39;1 of 3&#39;
-    }
-  ],
-  nextPage=[
-   {
-      url: &#39;next-page&#39;,
-      title: &#39;Next page&#39;,
-      label: &#39;2 of 3&#39;
-    }
-  ]
-  )
-}}
-
-{{ govukPagination(
-  classes=&#39;&#39;,
-  previousPage=[
-   {
-      url: &#39;previous-page&#39;,
-      title: &#39;Previous page&#39;
-    }
-  ],
-  nextPage=[
-   {
-      url: &#39;next-page&#39;,
-      title: &#39;Next page&#39;
-    }
-  ]
-  )
-}}</code></pre>
+<pre><code>&lt;nav class=&quot;govuk-c-pagination&quot; role=&quot;navigation&quot; aria-label=&quot;Pagination&quot;&gt;
+  &lt;ul class=&quot;govuk-c-pagination__list&quot;&gt;
+    &lt;li class=&quot;govuk-c-pagination__item govuk-c-pagination__item--previous&quot;&gt;
+      &lt;a class=&quot;govuk-c-pagination__link&quot; href=&quot;#&quot; rel=&quot;prev&quot;&gt;
+        &lt;span class=&quot;govuk-c-pagination__link-title&quot;&gt;
+          &lt;svg class=&quot;govuk-c-pagination__link-icon&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; height=&quot;13&quot; width=&quot;17&quot; viewBox=&quot;0 0 17 13&quot;&gt;
+            &lt;path fill=&quot;currentColor&quot; d=&quot;m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z&quot;&gt;&lt;/path&gt;
+          &lt;/svg&gt;
+          Previous
+        &lt;/span&gt;
+        &lt;span class=&quot;govuk-c-pagination__link-label&quot;&gt;Overview&lt;/span&gt;
+      &lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li class=&quot;govuk-c-pagination__item govuk-c-pagination__item--next&quot;&gt;
+      &lt;a class=&quot;govuk-c-pagination__link&quot; href=&quot;#&quot; rel=&quot;next&quot;&gt;
+        &lt;span class=&quot;govuk-c-pagination__link-title&quot;&gt;
+          Next
+          &lt;svg class=&quot;govuk-c-pagination__link-icon&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; height=&quot;13&quot; width=&quot;17&quot; viewBox=&quot;0 0 17 13&quot;&gt;
+            &lt;path fill=&quot;currentColor&quot; d=&quot;m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z&quot;&gt;&lt;/path&gt;
+          &lt;/svg&gt;
+        &lt;/span&gt;
+          &lt;span class=&quot;govuk-c-pagination__link-label&quot;&gt;Voting by post&lt;/span&gt;
+      &lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/nav&gt;
+</code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>
 <pre><code>npm install --save @govuk-frontend/pagination</code></pre>

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -47,15 +47,20 @@ Panel
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;panel/macro.njk&quot; import govukPanel %}
+<pre><code>&lt;div class=&quot;govuk-c-panel govuk-c-panel--confirmation&quot;&gt;
+  &lt;h2 class=&quot;govuk-c-panel__title&quot;&gt;
+    Application complete
+  &lt;/h2&gt;
+  &lt;div class=&quot;govuk-c-panel__body&quot;&gt;
+    Your reference number is
+    &lt;br&gt;
+    &lt;strong&gt;HDJ2123F&lt;/strong&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
 
-{{ govukPanel(
-  classes=&#39;&#39;,
-  title=&#39;Application complete&#39;,
-  content=&#39;Your reference number is&#39;,
-  reference=&#39;HDJ2123F&#39;
-  )
-}}
+&lt;div class=&quot;govuk-c-panel govuk-c-panel--information&quot;&gt;
+  Panel content
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -42,11 +42,23 @@ Phase banner
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;phase-banner/macro.njk&quot; import govukPhaseBanner %}
-{{ govukPhaseBanner(
-  phaseBannerText=&#39;This is a new service – your &lt;a href=&quot;#&quot;&gt;feedback&lt;/a&gt; will help us to improve it.&#39;,
-  phaseTagText=&#39;BETA&#39;)
-}}
+<pre><code>&lt;div class=&quot;govuk-c-phase-banner&quot;&gt;
+  &lt;p class=&quot;govuk-c-phase-banner__content&quot;&gt;
+    &lt;strong class=&quot;govuk-c-phase-tag&quot;&gt;ALPHA&lt;/strong&gt;
+    &lt;span class=&quot;govuk-c-phase-banner__text&quot;&gt;
+      This is a new service – your &lt;a href=&quot;#&quot;&gt;feedback&lt;/a&gt; will help us to improve it.
+    &lt;/span&gt;
+  &lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;govuk-c-phase-banner&quot;&gt;
+  &lt;p class=&quot;govuk-c-phase-banner__content&quot;&gt;
+    &lt;strong class=&quot;govuk-c-phase-tag&quot;&gt;BETA&lt;/strong&gt;
+    &lt;span class=&quot;govuk-c-phase-banner__text&quot;&gt;
+      This is a new service – your &lt;a href=&quot;#&quot;&gt;feedback&lt;/a&gt; will help us to improve it.
+    &lt;/span&gt;
+  &lt;/p&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -39,9 +39,9 @@ Phase tag
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;phase-tag/macro.njk&quot; import govukPhaseTag %}
+<pre><code>&lt;strong class=&quot;govuk-c-phase-tag&quot;&gt;ALPHA&lt;/strong&gt;
 
-{{ govukPhaseTag(classes=&#39;&#39;, phaseTagText=&#39;Alpha&#39;) }}
+&lt;strong class=&quot;govuk-c-phase-tag&quot;&gt;BETA&lt;/strong&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -69,37 +69,18 @@ Radio
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &#39;radio/macro.njk&#39; import govukRadio %}
-
-{{ govukRadio(
-  classes=&#39;&#39;,
-  name=&#39;radio-group&#39;,
-  id=&#39;radio&#39;,
-  radios=[
-   {
-      id: &#39;1&#39;,
-      value: &#39;Yes&#39;,
-      label: &#39;Yes&#39;
-    },
-    {
-      id: &#39;2&#39;,
-      value: &#39;No&#39;,
-      label: &#39;No&#39;
-    },
-    {
-      id: &#39;3&#39;,
-      value: &#39;No&#39;,
-      label: &#39;No&#39;,
-      checked: &#39;true&#39;
-    },
-    {
-      id: &#39;4&#39;,
-      value: &#39;NA&#39;,
-      label: &#39;Not applicable&#39;,
-      disabled: &#39;true&#39;
-    }
-  ]
-) }}
+<pre><code>&lt;div class=&quot;govuk-c-radio&quot;&gt;
+  &lt;input class=&quot;govuk-c-radio__input&quot; id=&quot;radio-1&quot; type=&quot;radio&quot; name=&quot;radio-group&quot; value=&quot;Yes&quot;&gt;
+  &lt;label class=&quot;govuk-c-radio__label&quot; for=&quot;radio-1&quot;&gt;Yes&lt;/label&gt;
+&lt;/div&gt;
+&lt;div class=&quot;govuk-c-radio&quot;&gt;
+  &lt;input class=&quot;govuk-c-radio__input&quot; id=&quot;radio-2&quot; type=&quot;radio&quot; name=&quot;radio-group&quot; value=&quot;No&quot;&gt;
+  &lt;label class=&quot;govuk-c-radio__label&quot; for=&quot;radio-2&quot;&gt;No&lt;/label&gt;
+&lt;/div&gt;
+&lt;div class=&quot;govuk-c-radio&quot;&gt;
+  &lt;input class=&quot;govuk-c-radio__input&quot; id=&quot;radio-3&quot; type=&quot;radio&quot; name=&quot;radio-group&quot; disabled=&quot;disabled&quot; value=&quot;NA&quot;&gt;
+  &lt;label class=&quot;govuk-c-radio__label&quot; for=&quot;radio-3&quot;&gt;Not applicable&lt;/label&gt;
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/select-box/README.md
+++ b/src/components/select-box/README.md
@@ -85,51 +85,13 @@ Select box
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;select-box/macro.njk&quot; import govukSelectBox %}
-
-
-{{ govukSelectBox(
-  classes=&#39;&#39;,
-  id=&#39;select-box-1&#39;,
-  name=&#39;select-box-1&#39;,
-  options=[
-    {
-      value: &#39;1&#39;,
-      label: &#39;GOV.UK frontend option 1&#39;
-    },
-    {
-      value: &#39;2&#39;,
-      label: &#39;GOV.UK frontend option 2&#39;
-    },
-    {
-      value: &#39;3&#39;,
-      label: &#39;GOV.UK frontend option 3&#39;
-    }
-  ]
-)}}
-
-{{ govukSelectBox(
-  hasLabelWithText=&#39;Label for select box&#39;,
-  labelClasses=&#39;&#39;,
-  classes=&#39;&#39;,
-  id=&#39;select-box-2&#39;,
-  name=&#39;select-box-2&#39;,
-  options=[
-    {
-      value: &#39;a&#39;,
-      label: &#39;GOV.UK frontend option a&#39;
-    },
-    {
-      value: &#39;b&#39;,
-      label: &#39;GOV.UK frontend option b&#39;,
-      selected: &#39;true&#39;
-    },
-    {
-      value: &#39;c&#39;,
-      label: &#39;GOV.UK frontend option c&#39;
-    }
-  ]
-)}}
+<pre><code>
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;select-box&quot;&gt;This is the label text&lt;/label&gt;
+&lt;select class=&quot;govuk-c-select-box&quot; id=&quot;select-box&quot; name=&quot;select-box&quot;&gt;
+  &lt;option&gt;GOV.UK elements option 1&lt;/option&gt;
+  &lt;option&gt;GOV.UK elements option 2&lt;/option&gt;
+  &lt;option&gt;GOV.UK elements option 3&lt;/option&gt;
+&lt;/select&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -39,9 +39,9 @@ Site width container
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;site-width-container/macro.njk&quot; import govukSiteWidthContainer %}
-
-{{ govukSiteWidthContainer(classes) }}
+<pre><code>&lt;div class=&quot;govuk-c-site-width-container&quot;&gt;
+  Site width container
+&lt;/div&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -167,7 +167,60 @@ Table
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code></code></pre>
+<pre><code>&lt;table class=&quot;govuk-c-table&quot;&gt;
+  &lt;thead class=&quot;govuk-c-table__head&quot;&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;th class=&quot;govuk-c-table__header&quot; scope=&quot;col&quot;&gt;Month you apply&lt;/th&gt;
+      &lt;th class=&quot;govuk-c-table__header govuk-c-table__header--numeric&quot; scope=&quot;col&quot;&gt;Rate for vehicles&lt;/th&gt;
+      &lt;th class=&quot;govuk-c-table__header govuk-c-table__header--numeric&quot; scope=&quot;col&quot;&gt;Rate for bicycles&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody class=&quot;govuk-c-table__body&quot;&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;th class=&quot;govuk-c-table__header&quot; scope=&quot;row&quot;&gt;January&lt;/th&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£165.00&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£85.00&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;th class=&quot;govuk-c-table__header&quot; scope=&quot;row&quot;&gt;February&lt;/th&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£165.00&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£85.00&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;th class=&quot;govuk-c-table__header&quot; scope=&quot;row&quot;&gt;March&lt;/th&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£151.25&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£77.90&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;th class=&quot;govuk-c-table__header&quot; scope=&quot;row&quot;&gt;April&lt;/th&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£136.10&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell govuk-c-table__cell--numeric&quot;&gt;£70.10&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+&lt;/table&gt;
+
+&lt;table class=&quot;govuk-c-table&quot;&gt;
+  &lt;caption class=&quot;govuk-c-table__caption heading-small&quot;&gt;Dates and amounts&lt;/caption&gt;
+  &lt;tbody class=&quot;govuk-c-table__body&quot;&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;First 6 weeks&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;£109.80 per week&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;Next 33 weeks&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;£109.80 per week&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;Total estimated pay&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;£4,282.20&lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr class=&quot;govuk-c-table__row&quot;&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;Tell the mother’s employer&lt;/td&gt;
+      &lt;td class=&quot;govuk-c-table__cell&quot;&gt;28 days before they want to start maternity pay&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+&lt;/table&gt;
+</code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>
 <pre><code>npm install --save @govuk-frontend/table</code></pre>

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -53,17 +53,18 @@ Textarea
 </div>
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
-<pre><code>{% from &quot;textarea/macro.njk&quot; import govukTextarea %}
+<pre><code>&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-textarea-a&quot;&gt;
+  Why can&#39;t you provide a National Insurance number?
+&lt;/label&gt;
+&lt;textarea class=&quot;govuk-c-textarea&quot; name=&quot;govuk-c-textarea-a&quot; id=&quot;govuk-c-textarea-a&quot; rows=&quot;5&quot;&gt;&lt;/textarea&gt;
 
-{{ govukTextarea(
-  classes=&#39;&#39;,
-  labelText=&#39;National Insurance number&#39;,
-  hintText=&#39;&#39;,
-  errorMessage=&#39;&#39;,
-  id=&#39;textarea&#39;,
-  name=&#39;name&#39;
-  )
-}}
+&lt;label class=&quot;govuk-c-label&quot; for=&quot;govuk-c-textarea-b&quot;&gt;
+  Why can&#39;t you provide a National Insurance number?
+  &lt;span class=&quot;govuk-c-error-message&quot;&gt;
+    Error message goes here
+  &lt;/span&gt;
+&lt;/label&gt;
+&lt;textarea class=&quot;govuk-c-textarea govuk-c-textarea--error&quot; name=&quot;govuk-c-textarea-b&quot; id=&quot;govuk-c-textarea-b&quot; rows=&quot;5&quot;&gt;&lt;/textarea&gt;
 </code></pre>
 
 <h2 class="govuk-u-heading-24">Installation</h2>

--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -28,7 +28,7 @@ gulp.task('generate:readme', () => {
     vinylInfo.componentName = path.dirname(file.path).split(path.sep).pop()
     vinylInfo.componentPath = vinylInfo.componentName
     vinylInfo.componentNunjucksFile = fs.readFileSync(paths.components + vinylInfo.componentName + '/' + vinylInfo.componentName + '.njk', 'utf8')
-    vinylInfo.componentHtmlFile = vinylInfo.componentNunjucksFile
+    vinylInfo.componentHtmlFile = fs.readFileSync(paths.components + vinylInfo.componentName + '/' + vinylInfo.componentName + '.html', 'utf8')
   }))
   .pipe(data(getDataForFile))
   .pipe(nunjucksRender({


### PR DESCRIPTION
This PR:
fixes the wrong code example include in the html example section
updates all the readmes

This solution needs to be checked again if we still rely on html files being in the repo.