### PR TITLE
Add meta tag to fix character encoding

### DIFF
--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -2,6 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <meta charset="utf-8">
   <title>GOV.UK Frontend</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/public/css/govuk-frontend.css">


### PR DESCRIPTION
This fixes the component examples which have smart quotes which aren't displaying correctly.

#### Before:
![gov uk frontend - before - details](https://user-images.githubusercontent.com/417754/30113000-1fb644a4-930b-11e7-8d5c-b3c6956ae129.png)

#### After:
![gov uk frontend - details - after](https://user-images.githubusercontent.com/417754/30112983-117a8256-930b-11e7-961a-62fd3888a62d.png)

