### PR TITLE
Add middleware for icons

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ app.set('view engine', 'njk')
 
 // Set up middleware to serve static assets
 app.use('/public', express.static(path.join(__dirname, '/public')))
+app.use('/icons', express.static(path.join(__dirname, '/public/icons')))
 
 app.listen(port, () => {
   console.log('Listening on port ' + port + '   url: http://localhost:' + port)


### PR DESCRIPTION
This fixes the breadcrumb icon and the the start now arrow icon.

Before:
https://govuk-frontend-review.herokuapp.com/components/breadcrumb
https://govuk-frontend-review.herokuapp.com/components/button

