### PR TITLE
Use the table component to display component arguments

### DIFF
--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -14,10 +14,85 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-| Name        | Type   | Default | Required | Description
-|---          |---     |---      |---       |---
-| classes     | string |         | No       | Optional additional classes
-| breadcrumbs | array  |         | Yes      | Breadcrumbs array with title and url keys
-| title       | string |         | Yes      | Title of the breadcrumb item
-| url         | string |         | Yes      | Url of the breadcrumb item
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'breadcrumbs'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Breadcrumbs array with title and url keys'
+        }
+      ],
+      [
+        {
+          text: 'title'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Title of the breadcrumb item'
+        }
+      ],
+      [
+        {
+          text: 'url'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Url of the breadcrumb item'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -18,15 +18,99 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-
-<!-- TODO: Use the table macro here and pass it component argument data -->
-
-| Name       | Type    | Default | Required | Description
-|---         |---      |---      |---       |---
-| classes    | string  |         | No       | Optional additional classes
-| text       | string  |         | Yes      | Button or link text
-| isStart    | boolean |         | No       | Adds the class govuk-c-button--start for a "Start now" button
-| isDisabled | boolean |         | No       | Disables the button - adds the class govuk-c-button--disabled and sets disabled="disabled" and aria-disabled="true"
-| url        | string  |         | No       | Url that the hyperlink points to
-
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Button or link text'
+        }
+      ],
+      [
+        {
+          text: 'isStart'
+        },
+        {
+          text: 'boolean'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Adds the class govuk-c-button--start for a "Start now" button'
+        }
+      ],
+      [
+        {
+          text: 'isDisabled'
+        },
+        {
+          text: 'boolean'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Disables the button - adds the class govuk-c-button--disabled and sets disabled="disabled" and aria-disabled="true"'
+        }
+      ],
+       [
+        {
+          text: 'url'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Url that the hyperlink points to'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -18,14 +18,85 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-
-<!-- TODO: Use the table macro here and pass it component argument data -->
-
-| Name        | Type    | Default | Required | Description
-|---          |---      |---      |---       |---
-| classes     | string  |         | No       | Optional additional classes
-| name        | string  |         | Yes      | Name of the group of checkboxes
-| id          | string  |         | Yes      | ID is prefixed to the ID of each checkbox
-| checkboxes  | array   |         | Yes      | Checkboxes array with id, value, label, checked and disabled keys
-
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Name of the group of checkboxes'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'ID is prefixed to the ID of each checkbox'
+        }
+      ],
+      [
+        {
+          text: 'checkboxes'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Checkboxes array with id, value, label, checked and disabled keys'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -18,12 +18,57 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-
-<!-- TODO: Use the table macro here and pass it component argument data -->
-
-| Name                | Type    | Default | Required  | Description
-|---                  |---      |---      |---        |---
-| classes             | string  |         | No        | Optional additional classes
-| cookieBannerText    | string  |         | Yes       | Cookie banner copy
-
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'cookieBannerText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Cookie banner text'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -14,10 +14,70 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name                | Type    | Default | Required  | Description
-|---                  |---      |---      |---        |---
-| classes             | string  |         | No        | Optional additional classes
-| detailsSummaryText  | string  |         | Yes       | Summary element text
-| detailsText         | string  |         | Yes       | Revealed details text
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'detailsSummaryText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Summary element text'
+        }
+      ],
+      [
+        {
+          text: 'detailsText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Revealed details text'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -15,9 +15,56 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Default | Required  | Description
-|---            |---      |---      |---        |---
-| classes       | string  |         | No        | Optional additional classes
-| errorMessage  | string  |         | Yes       | Error message
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Error message text'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/error-summary/index.njk
+++ b/src/components/error-summary/index.njk
@@ -14,14 +14,126 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name        | Type   | Default | Required | Description
-|---          |---     |---      |---       |---
-| classes     | string |         | No       | Optional additional classes
-| title       | string |         | Yes      | Error summary title
-| description | string |         | No       | Optional error summary description
-| listItems   | array  |         | Yes      | List items array with url and text keys
-| url         | string |         | Yes      | List item url
-| text        | string |         | Yes      | List item text
-| listOptions | object |         | No       | List options
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'title'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Error summary title'
+        }
+      ],
+      [
+        {
+          text: 'description'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional error summary description'
+        }
+      ],
+      [
+        {
+          text: 'listItems'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List items array with url and text keys'
+        }
+      ],
+      [
+        {
+          text: 'url'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List item url'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List item text'
+        }
+      ],
+      [
+        {
+          text: 'listOptions'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'List options'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -15,9 +15,56 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name        | Type    | Default | Required  | Description
-|---          |---      |---      |---        |---
-| classes     | string  |         | No        | Optional additional classes
-| legendText  | string  |         | No        | Legend text
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'legendText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Legend text'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/grid/index.njk
+++ b/src/components/grid/index.njk
@@ -14,10 +14,70 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Required  | Description
-|---            |---      |---        |---
-| classes       | string  | No        | Optional additional classes
-| gridItems     | array   | Yes       | Grid items array with width key
-| width         | string  | Yes       | Width of the grid item - full, one-half, one-third, two-thirds, one-quarter
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'gridItems'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Grid items array with width key'
+        }
+      ],
+      [
+        {
+          text: 'width'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Width of the grid item - full, one-half, one-third, two-thirds, one-quarter'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -14,14 +14,126 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Required  | Description
-|---            |---      |---        |---
-| classes       | string  | No        | Optional additional classes
-| labelText     | string  | Yes       | The label text
-| hintText      | string  | No        | Optional hint text
-| errorMessage  | string  | No        | Optional error message
-| id            | string  | Yes       | The id of the input
-| name          | string  | Yes       | The name of the input, which is submitted with the form data.
-| value         | string  | No        | Optional initial value of the input
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'labelText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The label text'
+        }
+      ],
+      [
+        {
+          text: 'hintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional hint text'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional error message'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The id of the input'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The name of the input, which is submitted with the form data'
+        }
+      ],
+      [
+        {
+          text: 'value'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional initial value of the input'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/inset-text/index.njk
+++ b/src/components/inset-text/index.njk
@@ -14,9 +14,57 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name      | Type    | Required  | Description
-|---        |---      |---        |---
-| classes   | string  | No        | Optional additional classes
-| content   | string  | Yes       | Inset text content
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'content'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Inset text content'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -14,12 +14,99 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Required  | Description
-|---            |---      |---        |---
-| classes       | string  | No        | Optional additional classes
-| labelText     | string  | Yes       | The label text
-| hintText      | string  | No        | Optional hint text
-| errorMessage  | string  | No        | Optional error message
-| id            | string  | Yes       | The value of the for attribute, the id input the label is associated with
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'labelText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The label text'
+        }
+      ],
+      [
+        {
+          text: 'hintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional hint text'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional error message'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The value of the for attribute, the id input the label is associated with'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/legal-text/index.njk
+++ b/src/components/legal-text/index.njk
@@ -14,10 +14,71 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name              | Type    | Default | Required  | Description
-|---                |---      |---      |---        |---
-| classes           | string  |         | No        | Optional additional classes
-| iconFallbackText  | string  |         | Yes       | The fallback text for the icon
-| legalText         | string  |         | Yes       | The text next to the icon
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'iconFallbackText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The fallback text for the icon'
+        }
+      ],
+      [
+        {
+          text: 'legalText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The text next to the icon'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/list/index.njk
+++ b/src/components/list/index.njk
@@ -14,16 +14,155 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name                | Type   | Default | Required | Description
-|---                  |---     |---      |---       |---
-| classes             | string |         | No       | Optional additional classes
-| listItems           | array  |         | Yes      | List items array with url and text keys
-| url                 | string |         | Yes      | List item url
-| text                | string |         | Yes      | List item text
-| options             | object |         | No       | Options object
-| options.isBullet    |        |         | No       | Creates bulleted list
-| options.isNumber    |        |         | No       | Creates numbered list
-| options.isStep      |        |         | No       | Creates list of steps
-| options.isStepLarge |        |         | No       | Creates list of steps with large icons
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'listItems'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List items array with url and text keys'
+        }
+      ],
+      [
+        {
+          text: 'url'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List item url'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'List item text'
+        }
+      ],
+      [
+        {
+          text: 'options'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Options object'
+        }
+      ],
+      [
+        {
+          text: 'options.isBullet'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Creates bulleted list'
+        }
+      ],
+      [
+        {
+          text: 'options.isNumber'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Creates numbered list'
+        }
+      ],
+      [
+        {
+          text: 'options.isStep'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Creates list of steps'
+        }
+      ],
+      [
+        {
+          text: 'options.isStepLarge'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Creates list of steps with large icons'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/pagination/index.njk
+++ b/src/components/pagination/index.njk
@@ -15,12 +15,71 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Default | Required | Description
-|---            |---      |---      |---       |---
-| classes       | string  |         | No       | Optional additional classes
-| name          | string  |         | Yes      | Name of the group of checkboxes
-| id            | string  |         | Yes      | ID is prefixed to the ID of each checkbox
-| previousPage  | array   |         | No       | previousPage array with url, title and label keys
-| nextPage      | array   |         | No       | nextPage array with url, title and label keys
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'previousPage'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Previous page array with url, title and label keys'
+        }
+      ],
+      [
+        {
+          text: 'nextPage'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Next page array with url, title and label keys'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -14,11 +14,85 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name          | Type    | Required  | Description
-|---            |---      |---        |---
-| classes       | string  | No        | Optional additional classes
-| title         | string  | Yes       | The panel title
-| content       | string  | No        | The panel content
-| reference     | string  | No        | Optional reference number
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'title'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The panel title'
+        }
+      ],
+      [
+        {
+          text: 'content'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'The panel content'
+        }
+      ],
+      [
+        {
+          text: 'reference'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional reference number'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -14,10 +14,71 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name              | Type    | Default | Required  | Description
-|---                |---      |---      |---        |---
-| classes           | string  |         | No        | Optional additional classes
-| phaseTagText      | string  |         | Yes       | Tag text
-| phaseBannerText   | string  |         | Yes       | Banner copy
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'phaseTagText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Tag text'
+        }
+      ],
+      [
+        {
+          text: 'phaseBannerText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Banner copy'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/phase-tag/index.njk
+++ b/src/components/phase-tag/index.njk
@@ -14,9 +14,57 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name              | Type    | Default | Required  | Description
-|---                |---      |---      |---        |---
-| classes           | string  |         | No        | Optional additional classes
-| phaseTagText      | string  |         | Yes       | Tag text
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'phaseTagText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Tag text'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -14,11 +14,85 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name        | Type    | Default | Required | Description
-|---          |---      |---      |---       |---
-| classes     | string  |         | No       | Optional additional classes
-| name        | string  |         | Yes      | Name of the group of radio buttons
-| id          | string  |         | Yes      | ID is prefixed to the ID of each radio button
-| radios      | array   |         | Yes      | Radios array with id, value, label, checked and disabled keys
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Name of the group of radio buttons'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'ID is prefixed to the ID of each radio button'
+        }
+      ],
+      [
+        {
+          text: 'radios'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Radios array with id, value, label, checked and disabled keys'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/select-box/index.njk
+++ b/src/components/select-box/index.njk
@@ -14,13 +14,113 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name             | Type    | Default | Required | Description
-|---               |---      |---      |---       |---
-| classes          | string  |         | No       | Optional additional classes
-| id               | string  |         | Yes      | Id for each select box
-| name             | string  |         | Yes      | Name for each select box
-| options          | array   |         | Yes      | Options array with value, label, selected keys
-| hasLabelWithText | string  |         | No       | Optional to provide label text that will render the label element
-| labelClasses     | string  |         | No       | Optional to provide label with custom classes
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Id for each select box'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Name for each select box'
+        }
+      ],
+      [
+        {
+          text: 'options'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Options array with value, label, selected keys'
+        }
+      ],
+      [
+        {
+          text: 'hasLabelWithText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional to provide label text that will render the label element'
+        }
+      ],
+      [
+        {
+          text: 'labelClasses'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional to provide label with custom classes'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/site-width-container/index.njk
+++ b/src/components/site-width-container/index.njk
@@ -14,9 +14,42 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-
-| Name          | Type    | Required  | Description
-|---            |---      |---        |---
-| classes       | string  | No        | Optional additional classes
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -18,5 +18,70 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-  <!-- TODO: Use the table macro here and pass it component argument data -->
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'data'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Data array with text and type keys'
+        }
+      ],
+      [
+        {
+          text: 'options'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Options array with caption, captionSize and isFirstCellHeader keys'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -14,15 +14,140 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-
-| Name          | Type    | Default   | Required  | Description
-|---            |---      |---        |---        |---
-| classes       | string  |           | No        | Optional additional classes
-| labelText     | string  |           | Yes       | The label text
-| hintText      | string  |           | No        | Optional hint text
-| errorMessage  | string  |           | No        | Optional error message
-| id            | string  |           | Yes       | The id of the textarea
-| name          | string  |           | Yes       | The name of the textarea
-| rows          | string  | 5         | No        | Change default number of textarea rows
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'data'
+        },
+        {
+          text: 'array'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Data array with text and type keys'
+        }
+      ],
+      [
+        {
+          text: 'labelText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The label text'
+        }
+      ],
+      [
+        {
+          text: 'hintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional hint text'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional error message'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The id of the textarea'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'The name of the textarea'
+        }
+      ],
+      [
+        {
+          text: 'rows'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Change default number of textarea rows (default is 5 rows)'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -41,16 +41,12 @@
 
   <pre><code>{% block componentNunjucks %}{{ componentNunjucksFile }}{% endblock %}</code></pre>
 
-{% if isReadme %}
+
 <h2 class="govuk-u-heading-24">Component arguments</h2>
-
 <div>
-
 {% block componentArguments %}
 {% endblock %}
-
 </div>
-{% endif %}
 
 <h2 class="govuk-u-heading-24">Component HTML</h2>
 <pre><code>{% block componentHtml %}{{ componentHtmlFile }}{% endblock %}</code></pre>


### PR DESCRIPTION
Use the table component, to render tables of arguments for each of the components.

Delete the markdown previously used to display component arguments.