### PR TITLE
Display a breadcrumb on each component "detail" page

### DIFF
--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -8,6 +8,16 @@
   {% include "../components/"+ componentName +"/"+ componentName +".njk" ignore missing %}
 {% endset %}
 
+{% if not isReadme %}
+{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+{{ govukBreadcrumb(
+  classes='',
+  [
+    { title: 'GOV.UK Frontend', url: '/' },
+    { title: componentName | replace("-", " ") | capitalize }
+  ]
+)}}
+{% endif %}
 
 <h1 class="govuk-u-heading-36">
 {% block componentName %}


### PR DESCRIPTION
Add this at the top of the page, to provide a link back to the page of
components.

![gov uk frontend](https://user-images.githubusercontent.com/417754/30165655-ba91d434-93d8-11e7-881c-a9536b581a73.png)

Don’t show the breadcrumb on the README.