### PR TITLE
Update component introductions

### DIFF
--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -172,3 +172,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -181,3 +181,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -201,3 +201,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -7,7 +7,7 @@ Cookie banner
 
 <h2 class="govuk-u-heading-24">Introduction</h2>
 <p class="govuk-u-core-24">
-  Cookie banner description.
+  GOV.UK cookie message, with link to cookie help page.
 </p>
 
 

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -150,3 +150,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -5,7 +5,7 @@
 {# componentName #}
 
 {% block componentDescription %}
-  Cookie banner description.
+  GOV.UK cookie message, with link to cookie help page.
 {% endblock %}
 
 {# componentExample #}

--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -116,3 +116,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -176,3 +176,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -153,3 +153,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -215,3 +215,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -155,3 +155,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -125,3 +125,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -275,3 +275,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -245,3 +245,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -158,3 +158,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -221,3 +221,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -163,3 +163,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -7,19 +7,26 @@ Link
 
 <h2 class="govuk-u-heading-24">Introduction</h2>
 <p class="govuk-u-core-24">
-Link component, with the following modifiers:
 
-`--back`
-Back link - a black underlined link with a left pointing arrow. To sit at the top left of a page
+Link component, with four variants:
 
-`--muted`
-Muted link - used for is "anything wrong with this page?" links
+<ul class="govuk-c-list govuk-c-list--bullet ">
 
-`--download`
-Download Link - with download icon
+  <li>
+        back link - a black underlined link with a left pointing arrow
+  </li>
+  <li>
+        muted link - used for the “anything wrong with this page?” links
+  </li>
+  <li>
+        download link - with download icon
+  </li>
+  <li>
+        skip link - skip to the main page content
+  </li>
 
-`--skip`
-Skiplink - skip to the main page content
+</ul>
+
 </p>
 
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -181,3 +181,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -4,19 +4,30 @@
 
 {# componentName #}
 {% block componentDescription %}
-Link component, with the following modifiers:
+{% from "list/macro.njk" import govukList %}
 
-`--back`
-Back link - a black underlined link with a left pointing arrow. To sit at the top left of a page
+Link component, with four variants:
 
-`--muted`
-Muted link - used for is "anything wrong with this page?" links
-
-`--download`
-Download Link - with download icon
-
-`--skip`
-Skiplink - skip to the main page content
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'back link - a black underlined link with a left pointing arrow'
+    },
+    {
+      text: 'muted link - used for the “anything wrong with this page?” links'
+    },
+    {
+      text: 'download link - with download icon'
+    },
+    {
+      text: 'skip link - skip to the main page content'
+    }
+  ],
+  options = {
+    'isBullet': 'true'
+  }
+) }}
 {% endblock %}
 {# componentExample #}
 {# componentNunjucks #}

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -354,3 +354,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -297,3 +297,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -7,8 +7,7 @@ Pagination
 
 <h2 class="govuk-u-heading-24">Introduction</h2>
 <p class="govuk-u-core-24">
-  Previous/next page links.
-  <a href="https://www.gov.uk/voting-in-the-uk/polling-stations">View previous/next links on GOV.UK</a>
+  Navigational links that allow users navigate within a series of pages.
 </p>
 
 

--- a/src/components/pagination/index.njk
+++ b/src/components/pagination/index.njk
@@ -4,8 +4,7 @@
 
 {# componentName #}
 {% block componentDescription %}
-  Previous/next page links.
-  <a href="https://www.gov.uk/voting-in-the-uk/polling-stations">View previous/next links on GOV.UK</a>
+  Navigational links that allow users navigate within a series of pages.
 {% endblock %}
 {# componentExample #}
 {# componentNunjucks #}

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -173,3 +173,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -7,7 +7,7 @@ Phase banner
 
 <h2 class="govuk-u-heading-24">Introduction</h2>
 <p class="govuk-u-core-24">
-  You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
+  A banner that indicates content is in alpha or beta phase with a description.
 </p>
 
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -162,3 +162,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -4,7 +4,7 @@
 
 {# componentName #}
 {% block componentDescription %}
-  You have to use an alpha banner if your thing is in alpha, and a beta banner if it’s in beta.
+  A banner that indicates content is in alpha or beta phase with a description.
 {% endblock %}
 {# componentExample #}
 {# componentNunjucks #}

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -146,3 +146,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -202,3 +202,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/select-box/README.md
+++ b/src/components/select-box/README.md
@@ -233,3 +233,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -142,3 +142,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -316,3 +316,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -199,3 +199,5 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
+
+

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -25,7 +25,9 @@
 {% endblock %}
 </h1>
 
+{% if isReadme %}
 <h2 class="govuk-u-heading-24">Introduction</h2>
+{% endif %}
 <p class="govuk-u-core-24">
 {% block componentDescription %}
 {% endblock %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -158,4 +158,14 @@ nunjucks.configure('node_modules/@govuk-frontend`, {
 <h2 class="govuk-u-heading-24">License</h2>
 <p class="govuk-u-copy-19">MIT</p>
 {% endif %}
+
+{% if not isReadme %}
+<h2 class="govuk-u-heading-24">Installation and setup</h2>
+<p class="govuk-u-copy-19">
+  <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{ componentName}}">
+    View the {{ componentName }} README on GitHub
+  </a>
+</p>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
Update descriptions for the phase banner, pagination and cookie banner.

Hide the text "Introduction" from the component detail page, only show it on the README.

Generate updated readme files.