### PR TITLE
Add a component for entering dates

### DIFF
--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -7,7 +7,7 @@ Date
 
 <h2 class="govuk-u-heading-24">Introduction</h2>
 <p class="govuk-u-core-24">
-  Date description.
+  A component for entering dates, for example - date of birth.
 </p>
 
 
@@ -55,19 +55,244 @@ app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-fro
 <pre>
 <code>
   
+
+&lt;fieldset class=&quot;govuk-c-fieldset For example, 31 3 1980&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    What is your date of birth?
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
+
+
+
+&lt;fieldset class=&quot;govuk-c-fieldset For example, 31 3 1980&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    What is your date of birth?
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
+
+
+
+&lt;fieldset class=&quot;govuk-c-fieldset For example, 31 3 1980&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    What is your date of birth?
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
+
+
+
+&lt;fieldset class=&quot;govuk-c-fieldset For example, 31 3 1980&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    What is your date of birth?
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
+
+
+
+&lt;fieldset class=&quot;govuk-c-fieldset For example, 31 3 1980&quot;&gt;
+  &lt;legend class=&quot;govuk-c-fieldset__legend&quot;&gt;
+    What is your date of birth?
+  &lt;/legend&gt;
+&lt;/fieldset&gt;
+
 </code>
 </pre>
 
 
 <h2 class="govuk-u-heading-24">If you are using Nunjucks</h2>
 <p class="govuk-u-copy-19">To use a macro, follow the below code examples:</p>
-<pre><code></code></pre>
+<pre><code>{% from &quot;date/macro.njk&quot; import govukDate %}
+
+{{ govukDate(
+  fieldsetClasses=&#39;&#39;,
+  legendText=&#39;What is your date of birth?&#39;,
+  legendHintText=&#39;For example, 31 3 1980&#39;,
+  legendErrorMessage=&#39;&#39;,
+  id=&#39;dob&#39;,
+  name=&#39;dob&#39;,
+  dateItems=[
+    {
+      name: &#39;day&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;month&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;year&#39;,
+      error: &#39;&#39;
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses=&#39;&#39;,
+  legendText=&#39;What is your date of birth?&#39;,
+  legendHintText=&#39;For example, 31 3 1980&#39;,
+  legendErrorMessage=&#39;Error message goes here&#39;,
+  id=&#39;dob&#39;,
+  name=&#39;dob&#39;,
+  dateItems=[
+    {
+      name: &#39;day&#39;,
+      error: &#39;true&#39;
+    },
+    {
+      name: &#39;month&#39;,
+      error: &#39;true&#39;
+    },
+    {
+      name: &#39;year&#39;,
+      error: &#39;true&#39;
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses=&#39;&#39;,
+  legendText=&#39;What is your date of birth?&#39;,
+  legendHintText=&#39;For example, 31 3 1980&#39;,
+  legendErrorMessage=&#39;Error message goes here&#39;,
+  id=&#39;dob-day-error&#39;,
+  name=&#39;dob-day-error&#39;,
+  dateItems=[
+    {
+      name: &#39;day&#39;,
+      error: &#39;true&#39;
+    },
+    {
+      name: &#39;month&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;year&#39;,
+      error: &#39;&#39;
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses=&#39;&#39;,
+  legendText=&#39;What is your date of birth?&#39;,
+  legendHintText=&#39;For example, 31 3 1980&#39;,
+  legendErrorMessage=&#39;Error message goes here&#39;,
+  id=&#39;dob-month-error&#39;,
+  name=&#39;dob-month-error&#39;,
+  dateItems=[
+    {
+      name: &#39;day&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;month&#39;,
+      error: &#39;true&#39;
+    },
+    {
+      name: &#39;year&#39;,
+      error: &#39;&#39;
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses=&#39;&#39;,
+  legendText=&#39;What is your date of birth?&#39;,
+  legendHintText=&#39;For example, 31 3 1980&#39;,
+  legendErrorMessage=&#39;Error message goes here&#39;,
+  id=&#39;dob-year-error&#39;,
+  name=&#39;dob-year-error&#39;,
+  dateItems=[
+    {
+      name: &#39;day&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;month&#39;,
+      error: &#39;&#39;
+    },
+    {
+      name: &#39;year&#39;,
+      error: &#39;true&#39;
+    }
+  ]
+  )
+}}</code></pre>
 
 <p class="govuk-u-copy-19">Where the macros take the following arguments</p>
 
 <h2 class="govuk-u-heading-24">Component arguments</h2>
 <div>
-  <!-- TODO: Use the table macro here and pass it component argument data -->
+<table class="govuk-c-table ">
+  <thead class="govuk-c-table__head">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header "   scope="col">Name</th>
+      <th class="govuk-c-table__header "   scope="col">Type</th>
+      <th class="govuk-c-table__header "   scope="col">Required</th>
+      <th class="govuk-c-table__header "   scope="col">Description</th>
+  </tr>
+  </thead>
+  <tbody class="govuk-c-table__body">
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> fieldsetClasses</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >Optional additional classes</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> legendText</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >Legend text</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> legendHintText</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >Optional legend hint text</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> legendErrorMessage</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >Optional legend error message</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> id</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >Ids of date items</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> Names of date items</th>
+      <td class="govuk-c-table__cell "  >string</td>
+      <td class="govuk-c-table__cell "  >No</td>
+      <td class="govuk-c-table__cell "  >name of each date input</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> dateItems</th>
+      <td class="govuk-c-table__cell "  >object</td>
+      <td class="govuk-c-table__cell "  >Yes</td>
+      <td class="govuk-c-table__cell "  >dateItems object with name and error keys</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> dateItems.name</th>
+      <td class="govuk-c-table__cell "  ></td>
+      <td class="govuk-c-table__cell "  >Yes</td>
+      <td class="govuk-c-table__cell "  >Name of date item, for example - Day, Month or Year</td>
+    </tr>
+    <tr class="govuk-c-table__row">
+      <th class="govuk-c-table__header" scope="row"> dateItems.error</th>
+      <td class="govuk-c-table__cell "  ></td>
+      <td class="govuk-c-table__cell "  >Yes</td>
+      <td class="govuk-c-table__cell "  >Set error for date item</td>
+    </tr>
+  </tbody>
+</table>
+
 </div>
 
 <h3 class="govuk-u-bold-19">Setting up Nunjucks views and paths</h3>

--- a/src/components/date/date.njk
+++ b/src/components/date/date.njk
@@ -1,0 +1,121 @@
+{% from "date/macro.njk" import govukDate %}
+
+{{ govukDate(
+  fieldsetClasses='',
+  legendText='What is your date of birth?',
+  legendHintText='For example, 31 3 1980',
+  legendErrorMessage='',
+  id='dob',
+  name='dob',
+  dateItems=[
+    {
+      name: 'day',
+      error: ''
+    },
+    {
+      name: 'month',
+      error: ''
+    },
+    {
+      name: 'year',
+      error: ''
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses='',
+  legendText='What is your date of birth?',
+  legendHintText='For example, 31 3 1980',
+  legendErrorMessage='Error message goes here',
+  id='dob',
+  name='dob',
+  dateItems=[
+    {
+      name: 'day',
+      error: 'true'
+    },
+    {
+      name: 'month',
+      error: 'true'
+    },
+    {
+      name: 'year',
+      error: 'true'
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses='',
+  legendText='What is your date of birth?',
+  legendHintText='For example, 31 3 1980',
+  legendErrorMessage='Error message goes here',
+  id='dob-day-error',
+  name='dob-day-error',
+  dateItems=[
+    {
+      name: 'day',
+      error: 'true'
+    },
+    {
+      name: 'month',
+      error: ''
+    },
+    {
+      name: 'year',
+      error: ''
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses='',
+  legendText='What is your date of birth?',
+  legendHintText='For example, 31 3 1980',
+  legendErrorMessage='Error message goes here',
+  id='dob-month-error',
+  name='dob-month-error',
+  dateItems=[
+    {
+      name: 'day',
+      error: ''
+    },
+    {
+      name: 'month',
+      error: 'true'
+    },
+    {
+      name: 'year',
+      error: ''
+    }
+  ]
+  )
+}}
+
+{{ govukDate(
+  fieldsetClasses='',
+  legendText='What is your date of birth?',
+  legendHintText='For example, 31 3 1980',
+  legendErrorMessage='Error message goes here',
+  id='dob-year-error',
+  name='dob-year-error',
+  dateItems=[
+    {
+      name: 'day',
+      error: ''
+    },
+    {
+      name: 'month',
+      error: ''
+    },
+    {
+      name: 'year',
+      error: 'true'
+    }
+  ]
+  )
+}}

--- a/src/components/date/index.njk
+++ b/src/components/date/index.njk
@@ -3,20 +3,167 @@
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
-
 {% block componentDescription %}
-  Date description.
+  A component for entering dates, for example - date of birth.
 {% endblock %}
 
 {# componentExample #}
-
 {# componentNunjucks #}
-
 {# componentHtml #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-  <!-- TODO: Use the table macro here and pass it component argument data -->
+{% from "table/macro.njk" import govukTable %}
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'fieldsetClasses'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'legendText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Legend text'
+        }
+      ],
+      [
+        {
+          text: 'legendHintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional legend hint text'
+        }
+      ],
+      [
+        {
+          text: 'legendErrorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional legend error message'
+        }
+      ],
+      [
+        {
+          text: 'id'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Ids of date items'
+        }
+      ],
+      [
+        {
+          text: 'Names of date items'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'name of each date input'
+        }
+      ],
+      [
+        {
+          text: 'dateItems'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'dateItems object with name and error keys'
+        }
+      ],
+      [
+        {
+          text: 'dateItems.name'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Name of date item, for example - Day, Month or Year'
+        }
+      ],
+      [
+        {
+          text: 'dateItems.error'
+        },
+        {
+          text: ''
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Set error for date item'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/date/macro.njk
+++ b/src/components/date/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukDate(fieldsetClasses='', legendText, legendHintText, legendErrorMessage, id, name, dateItems) %}
+  {% include "./template.njk" %}
+{% endmacro %}

--- a/src/components/date/template.njk
+++ b/src/components/date/template.njk
@@ -1,0 +1,12 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{% call govukFieldset(fieldsetClasses='', legendText, legendHintText, legendErrorMessage) %}
+<div class="govuk-c-date {{ classes }}">
+  {% for item in dateItems %}
+  <div class="govuk-c-date__item govuk-c-date__item--{{ item.name }}">
+    <label class="govuk-c-label govuk-c-date__label" for="{{ id }}-{{ item.name }}">{{ (item.name) | capitalize }}</label>
+    <input class="govuk-c-input govuk-c-date__input {% if item.error %}govuk-c-input--error{% endif %}" id="{{ id }}-{{ item.name }}" name="{{ name }}-{{ item.name }}" type="number">
+  </div>
+  {% endfor %}
+</div>
+{% endcall %}

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -20,6 +20,23 @@
     padding: 0;
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;
+
+    color: $govuk-text-colour;
+    font-family: $govuk-font-stack;
     white-space: normal;    // 1
+    @include font-smoothing;
+    @include govuk-core-19;
   }
+
+  .govuk-c-fieldset__legend--bold {
+    font-weight: 700;
+  }
+
+  // Hint text sits inside a legend, to be read by AT
+  .govuk-c-fieldset__hint {
+    display: block;
+    color: $govuk-secondary-text-colour;
+    font-weight: 400;
+  }
+
 }

--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -2,6 +2,8 @@
 
 {{ govukFieldset(
   classes='',
-  legendText='Legend text goes here'
+  text='Legend text goes here',
+  hintText='Legend hint text goes here',
+  errorMessage='Error message goes here'
   )
 }}

--- a/src/components/fieldset/macro.njk
+++ b/src/components/fieldset/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukFieldset(classes='', legendText) %}
+{% macro govukFieldset(classes='', text, hintText, errorMessage) %}
   {% include "./template.njk" %}
 {% endmacro %}

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,7 +1,18 @@
+{% from "error-message/macro.njk" import govukErrorMessage %}
+
 <fieldset class="govuk-c-fieldset {{ classes }}">
-{% if legendText %}
+{% if text %}
   <legend class="govuk-c-fieldset__legend">
-    {{ legendText }}
+    {{ text }}
+
+    {% if hintText %}
+    <span class="govuk-c-fieldset__hint">{{ hintText }}</span>
+    {% endif %}
+
+    {% if errorMessage %}
+      {{ govukErrorMessage(errorMessage) }}
+    {% endif %}
   </legend>
 {% endif %}
+{{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
 </fieldset>

--- a/src/examples/index.njk
+++ b/src/examples/index.njk
@@ -10,6 +10,8 @@
 
   {% include "../components/cookie-banner/cookie-banner.njk" %}
 
+  {% include "../components/date/date.njk" %}
+
   {% include "../components/details/details.njk" %}
 
   {% include "../components/error-message/error-message.njk" %}


### PR DESCRIPTION
Update the fieldset component, so that it can display legend text, optional hint text and an error message.

Create a date macro for the date component.

Regenerate the README for the date component.

Use the table component to create a table of arguments for the date component, displayed in the README.