### PR TITLE
Fixes to ensure accessibility tests run

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "homepage": "https://github.com/alphagov/govuk-frontend#readme",
   "scripts": {
     "start": "gulp dev --destination 'public'",
-    "test": "standard && gulp test",
+    "test": "standard && gulp compile:components --destination 'public' && gulp test",
     "heroku": "gulp compile:components --destination 'public' && gulp copy-assets --destination 'public' && node app.js"
   },
   "devDependencies": {

--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -1,0 +1,1 @@
+<input type="file">

--- a/tasks/gulp/test.js
+++ b/tasks/gulp/test.js
@@ -6,7 +6,7 @@ const axe = require('gulp-axe-webdriver')
 // Check HTML using Tenon ----------------
 // ---------------------------------------
 gulp.task('html:tenon', function () {
-  return gulp.src('src/components/**/*.html', {read: false})
+  return gulp.src('public/components/**/*.html', {read: false})
   .pipe(gtenon({
     config: 'config/tenon.json',
     snippet: true, // include errorSnippet in the console output
@@ -25,7 +25,7 @@ gulp.task('html:axe', (done) => {
   let options = {
     browser: 'phantomjs',
     saveOutputIn: 'axeReport.json',
-    urls: ['src/components/**/*.html'],
+    urls: ['public/components/**/*.html'],
     // https://github.com/dequelabs/axe-core/blob/develop/doc/rule-descriptions.md
     a11yCheckOptions: {
       'rules': {


### PR DESCRIPTION
Amend npm test so that compile:components runs first to copy component html to /public/

Amend location of files for gulp-tenon and axe (to look for component html in public, not src).