### PR TITLE
Strip whitespace around component examples

### DIFF
--- a/src/components/breadcrumb/macro.njk
+++ b/src/components/breadcrumb/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukBreadcrumb(classes='', breadcrumbs) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukButton(classes='', text, url, isStart, isDisabled) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -3,7 +3,5 @@
   {% if text %}{{ text }}{% endif %}
 </a>
 {% else %}
-<input class="govuk-c-button {% if isDisabled %} govuk-c-button--disabled {% endif %} {{ classes }}"
-  {% if text %}value="{{ text }}"{% endif %}
-  {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
+<input class="govuk-c-button {% if isDisabled %} govuk-c-button--disabled {% endif %} {{ classes }}" {% if text %}value="{{ text }}"{% endif %} {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
 {% endif %}

--- a/src/components/checkbox/macro.njk
+++ b/src/components/checkbox/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukCheckbox(classes='', name, id, checkboxes) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/cookie-banner/macro.njk
+++ b/src/components/cookie-banner/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukCookieBanner(classes='', cookieBannerText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/date/macro.njk
+++ b/src/components/date/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukDate(fieldsetClasses='', legendText, legendHintText, legendErrorMessage, id, name, dateItems) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/details/macro.njk
+++ b/src/components/details/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukDetails(classes='', detailsSummaryText, detailsText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukErrorMessage(errorMessage) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-summary/macro.njk
+++ b/src/components/error-summary/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukErrorSummary(classes='', title, description, listClasses, listItems, listOptions) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/fieldset/macro.njk
+++ b/src/components/fieldset/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukFieldset(classes='', text, hintText, errorMessage) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/grid/macro.njk
+++ b/src/components/grid/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukGrid(classes, gridItems) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/input/macro.njk
+++ b/src/components/input/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukInput(classes, labelText, hintText, errorMessage, id, name, value) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/label/macro.njk
+++ b/src/components/label/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukLabel(classes, labelText, hintText, errorMessage, id) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -3,7 +3,7 @@
 <label class="govuk-c-label {% if classes %} {{ classes }} {% endif %}" for="{{ id }}">
   {{ labelText }}
 
-  {% if hintText %}
+  {%- if hintText %}
     <span class="govuk-c-label__hint">{{ hintText }}</span>
   {% endif %}
 

--- a/src/components/legal-text/macro.njk
+++ b/src/components/legal-text/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukLegalText(classes='', iconFallbackText, legalText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/link/macro.njk
+++ b/src/components/link/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukLink(classes='', linkHref, linkText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/list/macro.njk
+++ b/src/components/list/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukList(classes='', listItems, options) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/pagination/template.njk
+++ b/src/components/pagination/template.njk
@@ -18,7 +18,7 @@
     {% endfor %}
     {% endif %}
 
-    {% if nextPage %}
+    {%- if nextPage %}
     {% for page in nextPage %}
     <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
       <a class="govuk-c-pagination__link" href="{{ page.url }}" rel="next">

--- a/src/components/panel/macro.njk
+++ b/src/components/panel/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPanel(classes, title, content, reference) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/phase-banner/macro.njk
+++ b/src/components/phase-banner/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPhaseBanner(classes='', phaseBannerText, phaseTagText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/phase-tag/macro.njk
+++ b/src/components/phase-tag/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukPhaseTag(classes='',phaseTagText) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/radio/macro.njk
+++ b/src/components/radio/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukRadio(classes='', name, id, radios) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/select-box/macro.njk
+++ b/src/components/select-box/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukSelectBox(classes='', hasLabelWithText, labelClasses='', id, name, options) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/site-width-container/macro.njk
+++ b/src/components/site-width-container/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukSiteWidthContainer(classes='') %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/table/macro.njk
+++ b/src/components/table/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukTable(classes='', data, options) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/textarea/macro.njk
+++ b/src/components/textarea/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukTextarea(classes, labelText, hintText, errorMessage, id, name, value) %}
-  {% include "./template.njk" %}
+  {%- include "./template.njk" -%}
 {% endmacro %}

--- a/tasks/gulp/compile-components.js
+++ b/tasks/gulp/compile-components.js
@@ -20,7 +20,10 @@ gulp.task('compile:components', () => {
       '!' + paths.components + '**/template.njk',
       paths.components + '**/*.njk' // Only compile componentname.njk to html
     ])
-    .pipe(nunjucks.compile({ lstripBlocks: true, trimBlocks: true }))
+    .pipe(nunjucks.compile('', {
+      trimBlocks: true, // automatically remove trailing newlines from a block/tag
+      lstripBlocks: true // automatically remove leading whitespace from a block/tag
+    }))
     .pipe(rename({ extname: '.html' }))
     .pipe(gulp.dest(gulpif(isPackages, taskArguments.destination, taskArguments.destination + '/components/')))
 })

--- a/tasks/gulp/watch.js
+++ b/tasks/gulp/watch.js
@@ -8,5 +8,5 @@ const paths = require('../../config/paths.json')
 gulp.task('watch', () => {
   gulp.watch([paths.src + '**/**/*.scss'], ['styles'])
   gulp.watch([paths.src + '**/**/*.js'], ['scripts'])
-  gulp.watch([paths.src + '**/**/*.njk'], ['generate:readme'])
+  gulp.watch([paths.src + '**/**/*.njk'], ['generate:readme', 'compile:components'])
 })


### PR DESCRIPTION
Trim whitespace before and after components.

Amend the watch task to recompile components to html, if the component njk, macro or template files are changed. 

#### Screenshots:

Before:

![before - gov uk frontend](https://user-images.githubusercontent.com/417754/30370905-e012359a-9870-11e7-9c3a-b0ccf637a6b9.png)


After:
![after - gov uk frontend](https://user-images.githubusercontent.com/417754/30370891-d05d33c0-9870-11e7-9c53-8f109582b3e9.png)



