### PR TITLE
Show component variants

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,70 +55,54 @@ app.get('/examples*', function (req, res) {
 
 // Components
 app.get('/components*', function (req, res) {
-  let path = req.params[0]
-  // If it isn't the isolated preview, render the component "detail" page
-  if (path.indexOf('preview') === -1) {
-    path = path.replace(/\//g, '')
+  let path = req.params[0].slice(1).split('/') // split path into array items: [0 is base component], [1] will be the variant view
+
+  if (path.includes('preview')) {
+    // if this is a variant we need base component and variants for the template
+    if (path[1].includes('--')) {
+      res.locals.variantName = path[1]
+      res.locals.variantBase = path[0]
+      res.locals.componentPath = path.join('/')
+    } else {
+      // Show the isolated component preview
+      res.locals.componentPath = path[0]
+    }
+    res.render('component-preview')
+  } else {
+    // If it isn't the isolated preview, render the component "detail" page
     try {
+      let componentNjk = fs.readFileSync('src/components/' + path[0] + '/' + path[0] + '.njk', 'utf8')
+      // on npm run start we generate html files in public (which is git ignored) and use that to insert into the template
+      let componentHtml = fs.readFileSync('public/components/' + path[0] + '/' + path[0] + '.html', 'utf8')
+
+      // we want to show all variants' code and macros on the component details page
+      let allFiles = fs.readdirSync('src/components/' + path[0] + '/')
       let variantItems = []
-      let files = fs.readdirSync('src/components/' + path + '/')
-      files.forEach(file => {
+
+      allFiles.forEach(file => {
         if (file.indexOf('.njk') > -1 && file.indexOf('--') > -1) {
-          let njk = fs.readFileSync('src/components/' + path + '/' + file, 'utf8')
-          let name = file
-          let html = fs.readFileSync('public/components/' + path + '/' + path + '.html', 'utf8')
+          let fileName = file.split('.')[0]
+          let njk = fs.readFileSync('src/components/' + path[0] + '/' + fileName + '.njk', 'utf8')
+          let html = fs.readFileSync('public/components/' + path[0] + '/' + fileName + '.html', 'utf8')
           variantItems.push({
             njk: njk,
-            name: name,
+            name: fileName,
             html: html
           })
         }
       })
-      let componentNjk = fs.readFileSync('src/components/' + path + '/' + path + '.njk', 'utf8')
-      let componentHtml = fs.readFileSync('public/components/' + path + '/' + path + '.html', 'utf8')
 
-      res.locals.variantItems = variantItems
-      res.locals.componentPath = path
+      // make variables avaiable to nunjucks template
+      res.locals.componentPath = path[0]
       res.locals.componentNunjucksFile = componentNjk
       res.locals.componentHtmlFile = componentHtml
+      res.locals.variantItems = variantItems
+
+      // component details page in index.njk
+      res.render(path[0] + '/' + 'index')
     } catch (e) {
       console.log('Error:', e.stack)
     }
-
-    res.render(path, {
-      componentPath: res.locals.componentPath,
-      componentNunjucksFile: res.locals.componentNunjucksFile,
-      componentHtmlFile: res.locals.componentHtmlFile
-    },
-    function (err, html) {
-      if (err) {
-        res.render(path + '/' + 'index', function (err2, html) {
-          if (err2) {
-            res.status(404).send(err + '<br>' + err2)
-          } else {
-            res.end(html)
-          }
-        })
-      } else {
-        res.end(html)
-      }
-    })
-  } else {
-    // Show the isolated component preview
-    path = path.replace(/preview/g, '')
-    if (path.indexOf('--') > -1) {
-      let noLeadingSlash = path.split(/^\/(.+)/)[1]
-      let basePath = noLeadingSlash.substr(0, noLeadingSlash.lastIndexOf('/'))
-      let base = basePath.substr(0, basePath.lastIndexOf('/'))
-      let variant = basePath.split('/')[1]
-      res.locals.variantName = variant
-      res.locals.variantBase = base
-      path = path.replace(/preview/g, '')
-    } else {
-      path = path.replace(/\//g, '').replace(/preview/g, '')
-    }
-    res.locals.componentPath = path
-    res.render('component-preview')
   }
 })
 

--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -4,25 +4,29 @@
 
 A breadcrumb is a GOV.UK element that helps users to understand where they are within the site and move between levels.
 
-[Preview the breadcrumb component.](http://govuk-frontend-review.herokuapp.com/components/breadcrumb/preview)
-
 ## Guidance
 
 More information about when to use breadcrumb can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/breadcrumb "Link to read guidance on the use of breadcrumb on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-breadcrumb ">
-      <ol class="govuk-c-breadcrumb__list">
+### Component default
 
-          <li class="govuk-c-breadcrumb__list-item">
-            <a class="govuk-c-breadcrumb__link" href="/">Home</a>
-          </li>
+[Preview the breadcrumb component.](http://govuk-frontend-review.herokuapp.com/components/breadcrumb/preview)
 
-          <li class="govuk-c-breadcrumb__list-item" aria-current="page">Current page</li>
+#### Markup
 
-      </ol>
-    </div>
+#### Macro
+
+      {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+
+    {{ govukBreadcrumb(
+      classes='',
+      [
+        { title: 'Home', url: '/' },
+        { title: 'Current page' }
+      ]
+    ) }}
 
 ## Variants
 
@@ -52,23 +56,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
-
-    {{ govukBreadcrumb(
-      classes='',
-      [
-        { title: 'Home', url: '/' },
-        { title: 'Current page' }
-      ]
-    ) }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -10,6 +10,22 @@ A breadcrumb is a GOV.UK element that helps users to understand where they are w
 
 More information about when to use breadcrumb can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/breadcrumb "Link to read guidance on the use of breadcrumb on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-breadcrumb ">
+      <ol class="govuk-c-breadcrumb__list">
+
+          <li class="govuk-c-breadcrumb__list-item">
+            <a class="govuk-c-breadcrumb__link" href="/">Home</a>
+          </li>
+
+          <li class="govuk-c-breadcrumb__list-item" aria-current="page">Current page</li>
+
+      </ol>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the breadcrumb component you must be running npm version 5 or above.
@@ -36,20 +52,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-breadcrumb ">
-      <ol class="govuk-c-breadcrumb__list">
-          <li class="govuk-c-breadcrumb__list-item">
-            <a class="govuk-c-breadcrumb__link" href="/">Home</a>
-          </li>
-          <li class="govuk-c-breadcrumb__list-item" aria-current="page">Current page</li>
-      </ol>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 

--- a/src/components/breadcrumb/README.md
+++ b/src/components/breadcrumb/README.md
@@ -20,13 +20,13 @@ More information about when to use breadcrumb can be found on [GOV.UK Design Sys
 
       {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
-    {{ govukBreadcrumb(
+    {{- govukBreadcrumb(
       classes='',
       [
         { title: 'Home', url: '/' },
         { title: 'Current page' }
       ]
-    ) }}
+    ) -}}
 
 ## Variants
 
@@ -62,19 +62,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -4,8 +4,6 @@
 
 A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to **Start** an application or **Save and continue** their progress. A button should have a short text snippet that describes what it will do.
 
-[Preview the button component.](http://govuk-frontend-review.herokuapp.com/components/button/preview)
-
 ## Guidance
 
 More information about when to use button can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/button "Link to read guidance on the use of button on Gov.uk Design system website")
@@ -14,7 +12,17 @@ More information about when to use button can be found on [GOV.UK Design System]
 
 Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.
 
-    <input class="govuk-c-button  " value="Save and continue" >
+### Component default
+
+[Preview the button component.](http://govuk-frontend-review.herokuapp.com/components/button/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "button/macro.njk" import govukButton %}
+
+    {{ govukButton(classes='', text='Save and continue') }}
 
 ## Variants
 
@@ -73,17 +81,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "button/macro.njk" import govukButton %}
-
-    {{ govukButton(classes='', text='Save and continue') }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -22,11 +22,11 @@ Buttons are configured to perform an action and they can have a different look. 
 
 [Preview button--disabled variant.](/components/button/button--disabled/preview)
 
-Markup
+#### Markup
 
-    <input class="govuk-c-button  " value="Save and continue" >
+    <input class="govuk-c-button  govuk-c-button--disabled  " value="Save and continue" disabled="disabled" aria-disabled="true">
 
-Macro
+#### Macro
 
     {% from "button/macro.njk" import govukButton %}
 
@@ -36,11 +36,12 @@ Macro
 
 [Preview button--start variant.](/components/button/button--start/preview)
 
-Markup
+#### Markup
 
-    <input class="govuk-c-button  " value="Save and continue" >
+    <a class="govuk-c-button  govuk-c-button--start  " href="/" role="button">
+    Start now</a>
 
-Macro
+#### Macro
 
     {% from "button/macro.njk" import govukButton %}
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -20,8 +20,6 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--disabled
 
-<div><input class="govuk-c-button  govuk-c-button--disabled  " value="Save and continue" disabled="disabled" aria-disabled="true"></div>
-
 [Preview button--disabled variant.](/components/button/button--disabled/preview)
 
 Markup
@@ -35,8 +33,6 @@ Macro
     {{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
 
 ### Button--start
-
-<div>[Start now](/)</div>
 
 [Preview button--start variant.](/components/button/button--start/preview)
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -2,13 +2,53 @@
 
 ## Introduction
 
-A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to **Start** an application or **Save and continue** their progress. A button should have a short text snippet that describes what it will do:
+A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to **Start** an application or **Save and continue** their progress. A button should have a short text snippet that describes what it will do.
 
 [Preview the button component.](http://govuk-frontend-review.herokuapp.com/components/button/preview)
 
 ## Guidance
 
 More information about when to use button can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/button "Link to read guidance on the use of button on Gov.uk Design system website")
+
+## Quick start examples
+
+Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.
+
+    <input class="govuk-c-button  " value="Save and continue" >
+
+## Variants
+
+### Button--disabled
+
+<div><input class="govuk-c-button  govuk-c-button--disabled  " value="Save and continue" disabled="disabled" aria-disabled="true"></div>
+
+[Preview button--disabled variant.](/components/button/button--disabled/preview)
+
+Markup
+
+    <input class="govuk-c-button  " value="Save and continue" >
+
+Macro
+
+    {% from "button/macro.njk" import govukButton %}
+
+    {{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
+
+### Button--start
+
+<div>[Start now](/)</div>
+
+[Preview button--start variant.](/components/button/button--start/preview)
+
+Markup
+
+    <input class="govuk-c-button  " value="Save and continue" >
+
+Macro
+
+    {% from "button/macro.njk" import govukButton %}
+
+    {{ govukButton(classes='', text='Start now', url='/', isStart='true') }}
 
 ## Dependencies
 
@@ -36,30 +76,13 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user. You can use the following three variants:
-
-    <input class="govuk-c-button  "
-    value="Save and continue">
-
-    <input class="govuk-c-button  govuk-c-button--disabled  "
-    value="Save and continue"disabled="disabled" aria-disabled="true">
-
-    <a class="govuk-c-button  govuk-c-button--start  " href="/" role="button">
-    Start now</a>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "button/macro.njk" import govukButton %}
 
     {{ govukButton(classes='', text='Save and continue') }}
-
-    {{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
-
-    {{ govukButton(classes='', text='Start now', url='/', isStart='true') }}
 
 Where the macros take the following arguments
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -32,7 +32,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Markup
 
-    <input class="govuk-c-button  govuk-c-button--disabled  " value="Save and continue" disabled="disabled" aria-disabled="true">
+    <input class="govuk-c-button govuk-c-button--disabled" value="Save and continue" disabled="disabled" aria-disabled="true">
 
 #### Macro
 
@@ -46,8 +46,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Markup
 
-    <a class="govuk-c-button  govuk-c-button--start  " href="/" role="button">
-    Start now</a>
+    <a class="govuk-c-button govuk-c-button--start" href="/" role="button">Start now</a>
 
 #### Macro
 
@@ -87,19 +86,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/button/button--disabled.njk
+++ b/src/components/button/button--disabled.njk
@@ -1,0 +1,3 @@
+{% from "button/macro.njk" import govukButton %}
+
+{{ govukButton(classes='', text='Save and continue', isDisabled='true') }}

--- a/src/components/button/button--start.njk
+++ b/src/components/button/button--start.njk
@@ -1,0 +1,3 @@
+{% from "button/macro.njk" import govukButton %}
+
+{{ govukButton(classes='', text='Start now', url='/', isStart='true') }}

--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,7 +1,3 @@
 {% from "button/macro.njk" import govukButton %}
 
 {{ govukButton(classes='', text='Save and continue') }}
-
-{{ govukButton(classes='', text='Save and continue', isDisabled='true') }}
-
-{{ govukButton(classes='', text='Start now', url='/', isStart='true') }}

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -5,9 +5,9 @@
 {# componentName #}
 
 {% block componentDescription %}
-  A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to <b>Start</b> an application or <b>Save and continue</b> their progress.
+A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to <b>Start</b> an application or <b>Save and continue</b> their progress.
 
-  A button should have a short text snippet that describes what it will do.
+A button should have a short text snippet that describes what it will do.
 {% endblock %}
 
 {% block componentDependencies %}

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -7,7 +7,7 @@
 {% block componentDescription %}
   A button is an element that allows users to carry out an action on a GOV.UK page. Common use cases include allowing a user to <b>Start</b> an application or <b>Save and continue</b> their progress.
 
-  A button should have a short text snippet that describes what it will do:
+  A button should have a short text snippet that describes what it will do.
 {% endblock %}
 
 {% block componentDependencies %}
@@ -18,7 +18,7 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 {# componentNunjucks #}
 
 {% block componentHtmlUsageWriteup %}
-Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.  You can use the following three variants:
+Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.
 {% endblock %}
 {# componentHtml #}
 

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -4,65 +4,21 @@
 
 Breadcrumb navigation, showing page hierarchy.
 
-[Preview the checkbox component.](http://govuk-frontend-review.herokuapp.com/components/checkbox/preview)
-
 ## Guidance
 
 More information about when to use checkbox can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/checkbox "Link to read guidance on the use of checkbox on Gov.uk Design system website")
 
 ## Quick start examples
 
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal"   >
-        <label class="govuk-c-checkbox__label" for="waste-type-1">Waste from animal carcasses</label>
-      </div>
+### Component default
 
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines"   >
-        <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from mines or quarries</label>
-      </div>
+[Preview the checkbox component.](http://govuk-frontend-review.herokuapp.com/components/checkbox/preview)
 
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm"  checked >
-        <label class="govuk-c-checkbox__label" for="waste-type-3">Farm or agricultural waste</label>
-      </div>
+#### Markup
 
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-4" name="waste-types" type="checkbox" value="waste-disabled"   disabled>
-        <label class="govuk-c-checkbox__label" for="waste-type-4">Disabled checkbox option</label>
-      </div>
+#### Macro
 
-## Variants
-
-## Dependencies
-
-To consume the checkbox component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/checkbox
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from 'checkbox/macro.njk' import govukCheckbox %}
+      {% from 'checkbox/macro.njk' import govukCheckbox %}
 
     {{ govukCheckbox(
       classes='',
@@ -94,9 +50,35 @@ To use a macro, follow the below code example:
       ]
     ) }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the checkbox component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/checkbox
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -20,7 +20,7 @@ More information about when to use checkbox can be found on [GOV.UK Design Syste
 
       {% from 'checkbox/macro.njk' import govukCheckbox %}
 
-    {{ govukCheckbox(
+    {{- govukCheckbox(
       classes='',
       name='waste-types',
       id='waste-type',
@@ -48,7 +48,7 @@ More information about when to use checkbox can be found on [GOV.UK Design Syste
           disabled: 'true'
         }
       ]
-    ) }}
+    ) -}}
 
 ## Variants
 
@@ -82,19 +82,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/checkbox/README.md
+++ b/src/components/checkbox/README.md
@@ -10,6 +10,30 @@ Breadcrumb navigation, showing page hierarchy.
 
 More information about when to use checkbox can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/checkbox "Link to read guidance on the use of checkbox on Gov.uk Design system website")
 
+## Quick start examples
+
+      <div class="govuk-c-checkbox ">
+        <input class="govuk-c-checkbox__input" id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal"   >
+        <label class="govuk-c-checkbox__label" for="waste-type-1">Waste from animal carcasses</label>
+      </div>
+
+      <div class="govuk-c-checkbox ">
+        <input class="govuk-c-checkbox__input" id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines"   >
+        <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from mines or quarries</label>
+      </div>
+
+      <div class="govuk-c-checkbox ">
+        <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm"  checked >
+        <label class="govuk-c-checkbox__label" for="waste-type-3">Farm or agricultural waste</label>
+      </div>
+
+      <div class="govuk-c-checkbox ">
+        <input class="govuk-c-checkbox__input" id="waste-type-4" name="waste-types" type="checkbox" value="waste-disabled"   disabled>
+        <label class="govuk-c-checkbox__label" for="waste-type-4">Disabled checkbox option</label>
+      </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the checkbox component you must be running npm version 5 or above.
@@ -34,28 +58,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-1" name="waste-types" type="checkbox" value="waste-animal"   >
-        <label class="govuk-c-checkbox__label" for="waste-type-1">Waste from animal carcasses</label>
-      </div>
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-2" name="waste-types" type="checkbox" value="waste-mines"   >
-        <label class="govuk-c-checkbox__label" for="waste-type-2">Waste from mines or quarries</label>
-      </div>
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-3" name="waste-types" type="checkbox" value="waste-farm"  checked >
-        <label class="govuk-c-checkbox__label" for="waste-type-3">Farm or agricultural waste</label>
-      </div>
-      <div class="govuk-c-checkbox ">
-        <input class="govuk-c-checkbox__input" id="waste-type-4" name="waste-types" type="checkbox" value="waste-disabled"   disabled>
-        <label class="govuk-c-checkbox__label" for="waste-type-4">Disabled checkbox option</label>
-      </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from 'checkbox/macro.njk' import govukCheckbox %}
 

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -10,6 +10,14 @@ GOV.UK cookie message, with link to cookie help page.
 
 More information about when to use cookie-banner can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/cookie-banner "Link to read guidance on the use of cookie-banner on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-cookie-banner js-cookie-banner ">
+      <p class="govuk-c-cookie-banner__text">GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the cookie-banner component you must be running npm version 5 or above.
@@ -34,15 +42,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-      <div class="govuk-c-cookie-banner js-cookie-banner ">
-      <p class="govuk-c-cookie-banner__text">GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "cookie-banner/macro.njk" import govukCookieBanner %}
     {{ govukCookieBanner(

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -19,11 +19,12 @@ More information about when to use cookie-banner can be found on [GOV.UK Design 
 #### Macro
 
       {% from "cookie-banner/macro.njk" import govukCookieBanner %}
-    {{ govukCookieBanner(
+
+    {{- govukCookieBanner(
       classes='',
       cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -57,19 +58,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -4,17 +4,26 @@
 
 GOV.UK cookie message, with link to cookie help page.
 
-[Preview the cookie-banner component.](http://govuk-frontend-review.herokuapp.com/components/cookie-banner/preview)
-
 ## Guidance
 
 More information about when to use cookie-banner can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/cookie-banner "Link to read guidance on the use of cookie-banner on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-cookie-banner js-cookie-banner ">
-      <p class="govuk-c-cookie-banner__text">GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
-    </div>
+### Component default
+
+[Preview the cookie-banner component.](http://govuk-frontend-review.herokuapp.com/components/cookie-banner/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "cookie-banner/macro.njk" import govukCookieBanner %}
+    {{ govukCookieBanner(
+      classes='',
+      cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
+      )
+    }}
 
 ## Variants
 
@@ -42,20 +51,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "cookie-banner/macro.njk" import govukCookieBanner %}
-    {{ govukCookieBanner(
-      classes='',
-      cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -10,6 +10,176 @@ A component for entering dates, for example - date of birth.
 
 More information about when to use date can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/date "Link to read guidance on the use of date on Gov.uk Design system website")
 
+## Quick start examples
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        What is your date of birth?
+
+        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+
+      </legend>
+
+    <div class="govuk-c-date ">
+
+      <div class="govuk-c-date__item govuk-c-date__item--day">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-day" name="dob-day" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--month">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-month" name="dob-month" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--year">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-year" name="dob-year" type="number">
+      </div>
+
+    </div>
+
+    </fieldset>
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        What is your date of birth?
+
+        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+
+          <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+      </legend>
+
+    <div class="govuk-c-date ">
+
+      <div class="govuk-c-date__item govuk-c-date__item--day">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day" name="dob-day" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--month">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month" name="dob-month" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--year">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year" name="dob-year" type="number">
+      </div>
+
+    </div>
+
+    </fieldset>
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        What is your date of birth?
+
+        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+
+          <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+      </legend>
+
+    <div class="govuk-c-date ">
+
+      <div class="govuk-c-date__item govuk-c-date__item--day">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-day">Day</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--month">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-month">Month</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-month" name="dob-day-error-month" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--year">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-year">Year</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-year" name="dob-day-error-year" type="number">
+      </div>
+
+    </div>
+
+    </fieldset>
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        What is your date of birth?
+
+        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+
+          <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+      </legend>
+
+    <div class="govuk-c-date ">
+
+      <div class="govuk-c-date__item govuk-c-date__item--day">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-day">Day</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-day" name="dob-month-error-day" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--month">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-month">Month</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--year">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-year">Year</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-year" name="dob-month-error-year" type="number">
+      </div>
+
+    </div>
+
+    </fieldset>
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        What is your date of birth?
+
+        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+
+          <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+      </legend>
+
+    <div class="govuk-c-date ">
+
+      <div class="govuk-c-date__item govuk-c-date__item--day">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-day">Day</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-day" name="dob-year-error-day" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--month">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-month">Month</label>
+        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-month" name="dob-year-error-month" type="number">
+      </div>
+
+      <div class="govuk-c-date__item govuk-c-date__item--year">
+        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-year">Year</label>
+        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number">
+      </div>
+
+    </div>
+
+    </fieldset>
+
+## Variants
+
 ## Dependencies
 
 To consume the date component you must be running npm version 5 or above.
@@ -34,147 +204,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-      </legend>
-    <div class="govuk-c-date ">
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day" name="dob-day" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month" name="dob-month" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year" name="dob-year" type="number">
-      </div>
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-    <div class="govuk-c-date ">
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day" name="dob-day" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month" name="dob-month" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year" name="dob-year" type="number">
-      </div>
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-    <div class="govuk-c-date ">
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-month" name="dob-day-error-month" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-year" name="dob-day-error-year" type="number">
-      </div>
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-    <div class="govuk-c-date ">
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-day" name="dob-month-error-day" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-year" name="dob-month-error-year" type="number">
-      </div>
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-    <div class="govuk-c-date ">
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-day" name="dob-year-error-day" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-month" name="dob-year-error-month" type="number">
-      </div>
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number">
-      </div>
-    </div>
-
-    </fieldset>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "date/macro.njk" import govukDate %}
 

--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -20,7 +20,7 @@ More information about when to use date can be found on [GOV.UK Design System](h
 
       {% from "date/macro.njk" import govukDate %}
 
-    {{ govukDate(
+    {{- govukDate(
       fieldsetClasses='',
       legendText='What is your date of birth?',
       legendHintText='For example, 31 3 1980',
@@ -42,9 +42,9 @@ More information about when to use date can be found on [GOV.UK Design System](h
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukDate(
+    {{- govukDate(
       fieldsetClasses='',
       legendText='What is your date of birth?',
       legendHintText='For example, 31 3 1980',
@@ -66,9 +66,9 @@ More information about when to use date can be found on [GOV.UK Design System](h
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukDate(
+    {{- govukDate(
       fieldsetClasses='',
       legendText='What is your date of birth?',
       legendHintText='For example, 31 3 1980',
@@ -90,9 +90,9 @@ More information about when to use date can be found on [GOV.UK Design System](h
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukDate(
+    {{- govukDate(
       fieldsetClasses='',
       legendText='What is your date of birth?',
       legendHintText='For example, 31 3 1980',
@@ -114,9 +114,9 @@ More information about when to use date can be found on [GOV.UK Design System](h
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukDate(
+    {{- govukDate(
       fieldsetClasses='',
       legendText='What is your date of birth?',
       legendHintText='For example, 31 3 1980',
@@ -138,7 +138,7 @@ More information about when to use date can be found on [GOV.UK Design System](h
         }
       ]
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -172,19 +172,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/date/README.md
+++ b/src/components/date/README.md
@@ -4,211 +4,21 @@
 
 A component for entering dates, for example - date of birth.
 
-[Preview the date component.](http://govuk-frontend-review.herokuapp.com/components/date/preview)
-
 ## Guidance
 
 More information about when to use date can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/date "Link to read guidance on the use of date on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <fieldset class="govuk-c-fieldset ">
+### Component default
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+[Preview the date component.](http://govuk-frontend-review.herokuapp.com/components/date/preview)
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+#### Markup
 
-      </legend>
+#### Macro
 
-    <div class="govuk-c-date ">
-
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day" name="dob-day" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month" name="dob-month" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year" name="dob-year" type="number">
-      </div>
-
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-
-    <div class="govuk-c-date ">
-
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day" name="dob-day" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month" name="dob-month" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year" name="dob-year" type="number">
-      </div>
-
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-
-    <div class="govuk-c-date ">
-
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-month" name="dob-day-error-month" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-day-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-day-error-year" name="dob-day-error-year" type="number">
-      </div>
-
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-
-    <div class="govuk-c-date ">
-
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-day" name="dob-month-error-day" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-month-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-month-error-year" name="dob-month-error-year" type="number">
-      </div>
-
-    </div>
-
-    </fieldset>
-
-    <fieldset class="govuk-c-fieldset ">
-
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
-
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-
-    <div class="govuk-c-date ">
-
-      <div class="govuk-c-date__item govuk-c-date__item--day">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-day">Day</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-day" name="dob-year-error-day" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--month">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-month">Month</label>
-        <input class="govuk-c-input govuk-c-date__input " id="dob-year-error-month" name="dob-year-error-month" type="number">
-      </div>
-
-      <div class="govuk-c-date__item govuk-c-date__item--year">
-        <label class="govuk-c-label govuk-c-date__label" for="dob-year-error-year">Year</label>
-        <input class="govuk-c-input govuk-c-date__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number">
-      </div>
-
-    </div>
-
-    </fieldset>
-
-## Variants
-
-## Dependencies
-
-To consume the date component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/date
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "date/macro.njk" import govukDate %}
+      {% from "date/macro.njk" import govukDate %}
 
     {{ govukDate(
       fieldsetClasses='',
@@ -330,9 +140,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the date component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/date
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -10,6 +10,26 @@ Component for conditionally revealing content, using the details HTML element.
 
 More information about when to use details can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/details "Link to read guidance on the use of details on Gov.uk Design system website")
 
+## Quick start examples
+
+    <details class="govuk-c-details ">
+      <summary class="govuk-c-details__summary">
+        <span class="govuk-c-details__summary-text">Help with nationality</span>
+      </summary>
+      <div class="govuk-c-border govuk-c-border--left-narrow">
+        <div class="govuk-c-details__text">
+          <p>
+        If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
+      </p>
+      <p>
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+      </p>
+        </div>
+      </div>
+    </details>
+
+## Variants
+
 ## Dependencies
 
 To consume the details component you must be running npm version 5 or above.
@@ -34,27 +54,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <details class="govuk-c-details ">
-      <summary class="govuk-c-details__summary">
-        <span class="govuk-c-details__summary-text">Help with nationality</span>
-      </summary>
-      <div class="govuk-c-border govuk-c-border--left-narrow">
-        <div class="govuk-c-details__text">
-          <p>
-        If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-      </p>
-      <p>
-        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-      </p>
-        </div>
-      </div>
-    </details>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "details/macro.njk" import govukDetails %}
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -20,7 +20,7 @@ More information about when to use details can be found on [GOV.UK Design System
 
       {% from "details/macro.njk" import govukDetails %}
 
-    {{ govukDetails(
+    {{- govukDetails(
       classes='',
       detailsSummaryText='Help with nationality',
       detailsText='<p>
@@ -30,7 +30,7 @@ More information about when to use details can be found on [GOV.UK Design System
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
       </p>'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -64,19 +64,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -4,29 +4,33 @@
 
 Component for conditionally revealing content, using the details HTML element.
 
-[Preview the details component.](http://govuk-frontend-review.herokuapp.com/components/details/preview)
-
 ## Guidance
 
 More information about when to use details can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/details "Link to read guidance on the use of details on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <details class="govuk-c-details ">
-      <summary class="govuk-c-details__summary">
-        <span class="govuk-c-details__summary-text">Help with nationality</span>
-      </summary>
-      <div class="govuk-c-border govuk-c-border--left-narrow">
-        <div class="govuk-c-details__text">
-          <p>
+### Component default
+
+[Preview the details component.](http://govuk-frontend-review.herokuapp.com/components/details/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "details/macro.njk" import govukDetails %}
+
+    {{ govukDetails(
+      classes='',
+      detailsSummaryText='Help with nationality',
+      detailsText='<p>
         If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
       </p>
       <p>
         We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-      </p>
-        </div>
-      </div>
-    </details>
+      </p>'
+      )
+    }}
 
 ## Variants
 
@@ -54,27 +58,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "details/macro.njk" import govukDetails %}
-
-    {{ govukDetails(
-      classes='',
-      detailsSummaryText='Help with nationality',
-      detailsText='<p>
-        If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-      </p>
-      <p>
-        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-      </p>'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -20,11 +20,11 @@ More information about when to use error-message can be found on [GOV.UK Design 
 
       {% from "error-message/macro.njk" import govukErrorMessage %}
 
-    {{ govukErrorMessage(
+    {{- govukErrorMessage(
       classes='',
       errorMessage='Error message goes here'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -58,19 +58,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -10,6 +10,14 @@ Component to show a red error message - used for form validation. Use inside a l
 
 More information about when to use error-message can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-message "Link to read guidance on the use of error-message on Gov.uk Design system website")
 
+## Quick start examples
+
+    <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+## Variants
+
 ## Dependencies
 
 To consume the error-message component you must be running npm version 5 or above.
@@ -34,15 +42,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "error-message/macro.njk" import govukErrorMessage %}
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -4,17 +4,27 @@
 
 Component to show a red error message - used for form validation. Use inside a label or legend.
 
-[Preview the error-message component.](http://govuk-frontend-review.herokuapp.com/components/error-message/preview)
-
 ## Guidance
 
 More information about when to use error-message can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-message "Link to read guidance on the use of error-message on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
+### Component default
+
+[Preview the error-message component.](http://govuk-frontend-review.herokuapp.com/components/error-message/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "error-message/macro.njk" import govukErrorMessage %}
+
+    {{ govukErrorMessage(
+      classes='',
+      errorMessage='Error message goes here'
+      )
+    }}
 
 ## Variants
 
@@ -42,21 +52,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "error-message/macro.njk" import govukErrorMessage %}
-
-    {{ govukErrorMessage(
-      classes='',
-      errorMessage='Error message goes here'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -10,6 +10,46 @@ Component to show an error summary box - used at the top of the page, to summari
 
 More information about when to use error-summary can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-summary "Link to read guidance on the use of error-summary on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-error-summary " aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+
+      <h2 class="govuk-c-error-summary__title" id="error-summary-title">
+        Message to alert the user to a problem goes here
+      </h2>
+
+      <div class="govuk-c-error-summary__body">
+
+        <p>
+          Optional description of the errors and how to correct them
+        </p>
+
+    <ul class="govuk-c-list  govuk-c-error-summary__list">
+
+      <li>
+
+          <a href="#example-error-1 ">
+            Descriptive link to the question with an error
+          </a>
+
+      </li>
+
+      <li>
+
+          <a href="#example-error-2 ">
+            Descriptive link to the question with an error
+          </a>
+
+      </li>
+
+    </ul>
+
+      </div>
+
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the error-summary component you must be running npm version 5 or above.
@@ -34,36 +74,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-error-summary " aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-
-      <h2 class="govuk-c-error-summary__title" id="error-summary-title">
-        Message to alert the user to a problem goes here
-      </h2>
-
-      <div class="govuk-c-error-summary__body">
-        <p>
-          Optional description of the errors and how to correct them
-        </p>
-        <ul class="govuk-c-list  govuk-c-error-summary__list">
-
-      <li>
-    <a href="#example-error-1 ">        Descriptive link to the question with an error
-    </a>  </li>
-      <li>
-    <a href="#example-error-2 ">        Descriptive link to the question with an error
-    </a>  </li>
-
-    </ul>
-
-      </div>
-
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "error-summary/macro.njk" import govukErrorSummary %}
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -20,7 +20,7 @@ More information about when to use error-summary can be found on [GOV.UK Design 
 
       {% from "error-summary/macro.njk" import govukErrorSummary %}
 
-    {{ govukErrorSummary(
+    {{- govukErrorSummary(
       classes='',
       title='Message to alert the user to a problem goes here',
       description='Optional description of the errors and how to correct them',
@@ -35,7 +35,8 @@ More information about when to use error-summary can be found on [GOV.UK Design 
           url: '#example-error-2'
         }
       ]
-    ) }}
+    )
+    -}}
 
 ## Variants
 
@@ -69,19 +70,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -4,49 +4,38 @@
 
 Component to show an error summary box - used at the top of the page, to summarise validation errors.
 
-[Preview the error-summary component.](http://govuk-frontend-review.herokuapp.com/components/error-summary/preview)
-
 ## Guidance
 
 More information about when to use error-summary can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-summary "Link to read guidance on the use of error-summary on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-error-summary " aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+### Component default
 
-      <h2 class="govuk-c-error-summary__title" id="error-summary-title">
-        Message to alert the user to a problem goes here
-      </h2>
+[Preview the error-summary component.](http://govuk-frontend-review.herokuapp.com/components/error-summary/preview)
 
-      <div class="govuk-c-error-summary__body">
+#### Markup
 
-        <p>
-          Optional description of the errors and how to correct them
-        </p>
+#### Macro
 
-    <ul class="govuk-c-list  govuk-c-error-summary__list">
+      {% from "error-summary/macro.njk" import govukErrorSummary %}
 
-      <li>
-
-          <a href="#example-error-1 ">
-            Descriptive link to the question with an error
-          </a>
-
-      </li>
-
-      <li>
-
-          <a href="#example-error-2 ">
-            Descriptive link to the question with an error
-          </a>
-
-      </li>
-
-    </ul>
-
-      </div>
-
-    </div>
+    {{ govukErrorSummary(
+      classes='',
+      title='Message to alert the user to a problem goes here',
+      description='Optional description of the errors and how to correct them',
+      listClasses='',
+      listItems=[
+        {
+          text: 'Descriptive link to the question with an error',
+          url: '#example-error-1'
+        },
+        {
+          text: 'Descriptive link to the question with an error',
+          url: '#example-error-2'
+        }
+      ]
+    ) }}
 
 ## Variants
 
@@ -74,32 +63,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "error-summary/macro.njk" import govukErrorSummary %}
-
-    {{ govukErrorSummary(
-      classes='',
-      title='Message to alert the user to a problem goes here',
-      description='Optional description of the errors and how to correct them',
-      listClasses='',
-      listItems=[
-        {
-          text: 'Descriptive link to the question with an error',
-          url: '#example-error-1'
-        },
-        {
-          text: 'Descriptive link to the question with an error',
-          url: '#example-error-2'
-        }
-      ]
-    ) }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -20,13 +20,13 @@ More information about when to use fieldset can be found on [GOV.UK Design Syste
 
       {% from "fieldset/macro.njk" import govukFieldset %}
 
-    {{ govukFieldset(
+    {{- govukFieldset(
       classes='',
       text='Legend text goes here',
       hintText='Legend hint text goes here',
       errorMessage='Error message goes here'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -60,19 +60,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -4,28 +4,29 @@
 
 The fieldset element is used to group several controls within a web form. The legend element represents a caption for the content of its parent fieldset.
 
-[Preview the fieldset component.](http://govuk-frontend-review.herokuapp.com/components/fieldset/preview)
-
 ## Guidance
 
 More information about when to use fieldset can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/fieldset "Link to read guidance on the use of fieldset on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <fieldset class="govuk-c-fieldset ">
+### Component default
 
-      <legend class="govuk-c-fieldset__legend">
-        Legend text goes here
+[Preview the fieldset component.](http://govuk-frontend-review.herokuapp.com/components/fieldset/preview)
 
-        <span class="govuk-c-fieldset__hint">Legend hint text goes here</span>
+#### Markup
 
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
+#### Macro
 
-      </legend>
+      {% from "fieldset/macro.njk" import govukFieldset %}
 
-    </fieldset>
+    {{ govukFieldset(
+      classes='',
+      text='Legend text goes here',
+      hintText='Legend hint text goes here',
+      errorMessage='Error message goes here'
+      )
+    }}
 
 ## Variants
 
@@ -53,23 +54,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "fieldset/macro.njk" import govukFieldset %}
-
-    {{ govukFieldset(
-      classes='',
-      text='Legend text goes here',
-      hintText='Legend hint text goes here',
-      errorMessage='Error message goes here'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -10,6 +10,25 @@ The fieldset element is used to group several controls within a web form. The le
 
 More information about when to use fieldset can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/fieldset "Link to read guidance on the use of fieldset on Gov.uk Design system website")
 
+## Quick start examples
+
+    <fieldset class="govuk-c-fieldset ">
+
+      <legend class="govuk-c-fieldset__legend">
+        Legend text goes here
+
+        <span class="govuk-c-fieldset__hint">Legend hint text goes here</span>
+
+          <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+      </legend>
+
+    </fieldset>
+
+## Variants
+
 ## Dependencies
 
 To consume the fieldset component you must be running npm version 5 or above.
@@ -34,25 +53,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <fieldset class="govuk-c-fieldset ">
-      <legend class="govuk-c-fieldset__legend">
-        Legend text goes here
-
-        <span class="govuk-c-fieldset__hint">Legend hint text goes here</span>
-
-          <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-      </legend>
-
-    </fieldset>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "fieldset/macro.njk" import govukFieldset %}
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -12,7 +12,31 @@ More information about when to use file-upload can be found on [GOV.UK Design Sy
 
 ## Quick start examples
 
-      <input type="file">
+    <label class="govuk-c-label " for="file-upload-1">
+      Upload a file
+
+    </label>
+
+    <input class="govuk-c-file-upload " id="file-upload-1" name="file-upload-1" type="file">
+
+    <label class="govuk-c-label " for="file-upload-2">
+      Upload your photo
+        <span class="govuk-c-label__hint">Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.</span>
+
+    </label>
+
+    <input class="govuk-c-file-upload " id="file-upload-2" name="file-upload-2" type="file">
+
+    <label class="govuk-c-label " for="file-upload-3">
+      Upload a file
+
+        <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+    </label>
+
+    <input class="govuk-c-file-upload govuk-c-file-upload--error" id="file-upload-3" name="file-upload-3" type="file">
 
 ## Variants
 
@@ -43,8 +67,6 @@ To show the button image you need to configure your app to show these assets. Be
 ## If you are using Nunjucks
 
 To use a macro, follow the below code example:
-
-    <input type="file">
 
     {% from "file-upload/macro.njk" import govukFileUpload %}
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -10,6 +10,12 @@ The HTML `<input>` element with type="file" lets a user pick one or more files, 
 
 More information about when to use file-upload can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/file-upload "Link to read guidance on the use of file-upload on Gov.uk Design system website")
 
+## Quick start examples
+
+      <input type="file">
+
+## Variants
+
 ## Dependencies
 
 To consume the file-upload component you must be running npm version 5 or above.
@@ -34,33 +40,11 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <label class="govuk-c-label " for="file-upload-1">
-      Upload a file
-    </label>
-
-    <input class="govuk-c-file-upload " id="file-upload-1" name="file-upload-1" type="file">
-
-    <label class="govuk-c-label " for="file-upload-2">
-      Upload your photo
-      <span class="govuk-c-label__hint">
-        Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
-      </span>
-    </label>
-
-    <input class="govuk-c-file-upload " id="file-upload-2" name="file-upload-2" type="file">
-
-    <label class="govuk-c-label " for="file-upload-3">
-      Upload a file
-      <span class="govuk-c-error-message ">Error message goes here</span>
-    </label>
-
-    <input class="govuk-c-file-upload govuk-c-file-upload--error" id="file-upload-3" name="file-upload-3" type="file">
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
+
+    <input type="file">
 
     {% from "file-upload/macro.njk" import govukFileUpload %}
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -4,71 +4,21 @@
 
 The HTML `<input>` element with type="file" lets a user pick one or more files, to upload to a server.
 
-[Preview the file-upload component.](http://govuk-frontend-review.herokuapp.com/components/file-upload/preview)
-
 ## Guidance
 
 More information about when to use file-upload can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/file-upload "Link to read guidance on the use of file-upload on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <label class="govuk-c-label " for="file-upload-1">
-      Upload a file
+### Component default
 
-    </label>
+[Preview the file-upload component.](http://govuk-frontend-review.herokuapp.com/components/file-upload/preview)
 
-    <input class="govuk-c-file-upload " id="file-upload-1" name="file-upload-1" type="file">
+#### Markup
 
-    <label class="govuk-c-label " for="file-upload-2">
-      Upload your photo
-        <span class="govuk-c-label__hint">Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.</span>
+#### Macro
 
-    </label>
-
-    <input class="govuk-c-file-upload " id="file-upload-2" name="file-upload-2" type="file">
-
-    <label class="govuk-c-label " for="file-upload-3">
-      Upload a file
-
-        <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-    </label>
-
-    <input class="govuk-c-file-upload govuk-c-file-upload--error" id="file-upload-3" name="file-upload-3" type="file">
-
-## Variants
-
-## Dependencies
-
-To consume the file-upload component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/file-upload
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "file-upload/macro.njk" import govukFileUpload %}
+      {% from "file-upload/macro.njk" import govukFileUpload %}
 
     {{ govukFileUpload(
       classes='',
@@ -99,9 +49,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the file-upload component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/file-upload
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -20,34 +20,37 @@ More information about when to use file-upload can be found on [GOV.UK Design Sy
 
       {% from "file-upload/macro.njk" import govukFileUpload %}
 
-    {{ govukFileUpload(
-      classes='',
+    {{- govukFileUpload(
+      labelClasses='',
       labelText='Upload a file',
       errorMessage='',
+      classes='',
       id='file-upload-1',
       name='file-upload-1'
       )
-    }}
+    -}}
 
-    {{ govukFileUpload(
-      classes='',
+    {{- govukFileUpload(
+      labelClasses='',
       labelText='Upload your photo',
       hintText='Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.',
       errorMessage='',
+      classes='',
       id='file-upload-2',
       name='file-upload-2'
       )
-    }}
+    -}}
 
-    {{ govukFileUpload(
-      classes='',
+    {{- govukFileUpload(
+      labelClasses='',
       labelText='Upload a file',
       hintText='',
       errorMessage='Error message goes here',
+      classes='',
       id='file-upload-3',
       name='file-upload-3'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -81,19 +84,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -4,125 +4,21 @@
 
 Grid row with grid items.
 
-[Preview the grid component.](http://govuk-frontend-review.herokuapp.com/components/grid/preview)
-
 ## Guidance
 
 More information about when to use grid can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/grid "Link to read guidance on the use of grid on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-grid ">
+### Component default
 
-      <div class="govuk-c-grid__item govuk-c-grid__item--full">
+[Preview the grid component.](http://govuk-frontend-review.herokuapp.com/components/grid/preview)
 
-      </div>
+#### Markup
 
-    </div>
+#### Macro
 
-    <div class="govuk-c-grid ">
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
-
-      </div>
-
-    </div>
-
-    <div class="govuk-c-grid ">
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-
-    </div>
-
-    <div class="govuk-c-grid ">
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-
-    </div>
-
-    <div class="govuk-c-grid ">
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
-
-      </div>
-
-    </div>
-
-    <div class="govuk-c-grid ">
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-
-    </div>
-
-## Variants
-
-## Dependencies
-
-To consume the grid component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/grid
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "grid/macro.njk" import govukGrid %}
+      {% from "grid/macro.njk" import govukGrid %}
 
     {{ govukGrid(
       classes='',
@@ -180,9 +76,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the grid component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/grid
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -10,6 +10,90 @@ Grid row with grid items.
 
 More information about when to use grid can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/grid "Link to read guidance on the use of grid on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--full">
+
+      </div>
+
+    </div>
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
+
+      </div>
+
+    </div>
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+
+      </div>
+
+    </div>
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+
+      </div>
+
+    </div>
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
+
+      </div>
+
+    </div>
+
+    <div class="govuk-c-grid ">
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+
+      </div>
+
+      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
+
+      </div>
+
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the grid component you must be running npm version 5 or above.
@@ -34,71 +118,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--full">
-
-      </div>
-    </div>
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-half">
-
-      </div>
-    </div>
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-    </div>
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-    </div>
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-third">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--two-thirds">
-
-      </div>
-    </div>
-
-    <div class="govuk-c-grid ">
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-      <div class="govuk-c-grid__item govuk-c-grid__item--one-quarter">
-
-      </div>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "grid/macro.njk" import govukGrid %}
 

--- a/src/components/grid/README.md
+++ b/src/components/grid/README.md
@@ -20,24 +20,24 @@ More information about when to use grid can be found on [GOV.UK Design System](h
 
       {% from "grid/macro.njk" import govukGrid %}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'full' }
       ]
       )
-    }}
+    -}}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'one-half' },
         { width: 'one-half' }
       ]
       )
-    }}
+    -}}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'one-third' },
@@ -45,27 +45,27 @@ More information about when to use grid can be found on [GOV.UK Design System](h
         { width: 'one-third' }
       ]
       )
-    }}
+    -}}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'two-thirds' },
         { width: 'one-third' }
       ]
       )
-    }}
+    -}}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'one-third' },
         { width: 'two-thirds' }
       ]
       )
-    }}
+    -}}
 
-    {{ govukGrid(
+    {{- govukGrid(
       classes='',
       gridItems=[
         { width: 'one-quarter' },
@@ -74,7 +74,7 @@ More information about when to use grid can be found on [GOV.UK Design System](h
         { width: 'one-quarter' }
       ]
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -108,19 +108,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -4,73 +4,21 @@
 
 A single-line text field.
 
-[Preview the input component.](http://govuk-frontend-review.herokuapp.com/components/input/preview)
-
 ## Guidance
 
 More information about when to use input can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/input "Link to read guidance on the use of input on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <label class="govuk-c-label " for="input-1">
-      National Insurance number
+### Component default
 
-    </label>
+[Preview the input component.](http://govuk-frontend-review.herokuapp.com/components/input/preview)
 
-    <input class="govuk-c-input " id="input-1" name="test-name" type="text" >
+#### Markup
 
-    <label class="govuk-c-label " for="input-2">
-      National Insurance number
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.</span>
+#### Macro
 
-    </label>
-
-    <input class="govuk-c-input " id="input-2" name="test-name-2" type="text" >
-
-    <label class="govuk-c-label " for="input-3">
-      National Insurance number
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-        <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-    </label>
-
-    <input class="govuk-c-input govuk-c-input--error" id="input-3" name="test-name-3" type="text" >
-
-## Variants
-
-## Dependencies
-
-To consume the input component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/input
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "input/macro.njk" import govukInput %}
+      {% from "input/macro.njk" import govukInput %}
 
     {{ govukInput(
       classes='',
@@ -103,9 +51,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the input component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/input
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -10,6 +10,38 @@ A single-line text field.
 
 More information about when to use input can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/input "Link to read guidance on the use of input on Gov.uk Design system website")
 
+## Quick start examples
+
+    <label class="govuk-c-label " for="input-1">
+      National Insurance number
+
+    </label>
+
+    <input class="govuk-c-input " id="input-1" name="test-name" type="text" >
+
+    <label class="govuk-c-label " for="input-2">
+      National Insurance number
+        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.</span>
+
+    </label>
+
+    <input class="govuk-c-input " id="input-2" name="test-name-2" type="text" >
+
+    <label class="govuk-c-label " for="input-3">
+      National Insurance number
+        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
+        For example, ‘QQ 12 34 56 C’.</span>
+
+        <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+    </label>
+
+    <input class="govuk-c-input govuk-c-input--error" id="input-3" name="test-name-3" type="text" >
+
+## Variants
+
 ## Dependencies
 
 To consume the input component you must be running npm version 5 or above.
@@ -34,41 +66,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <label class="govuk-c-label " for="input-1">
-      National Insurance number
-
-    </label>
-
-    <input class="govuk-c-input " id="input-1" name="test-name" type="text" >
-
-    <label class="govuk-c-label " for="input-2">
-      National Insurance number
-
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.</span>
-
-    </label>
-
-    <input class="govuk-c-input " id="input-2" name="test-name-2" type="text" >
-
-    <label class="govuk-c-label " for="input-3">
-      National Insurance number
-
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-        <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-    </label>
-
-    <input class="govuk-c-input govuk-c-input--error" id="input-3" name="test-name-3" type="text" >
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "input/macro.njk" import govukInput %}
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -20,36 +20,39 @@ More information about when to use input can be found on [GOV.UK Design System](
 
       {% from "input/macro.njk" import govukInput %}
 
-    {{ govukInput(
-      classes='',
+    {{- govukInput(
+      labelClasses='',
       labelText='National Insurance number',
       hintText='',
       errorMessage='',
+      classes='',
       id='input-1',
       name='test-name'
       )
-    }}
+    -}}
 
-    {{ govukInput(
-      classes='',
+    {{- govukInput(
+      labelClasses='',
       labelText='National Insurance number',
       hintText='It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.',
       errorMessage='',
+      classes='',
       id='input-2',
       name='test-name-2'
       )
-    }}
+    -}}
 
-    {{ govukInput(
-      classes='',
+    {{- govukInput(
+      labelClasses='',
       labelText='National Insurance number',
       hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.',
       errorMessage='Error message goes here',
+      classes='',
       id='input-3',
       name='test-name-3'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -83,19 +86,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -4,20 +4,30 @@
 
 Use bordered inset text to draw attention to important content on the page.
 
-[Preview the inset-text component.](http://govuk-frontend-review.herokuapp.com/components/inset-text/preview)
-
 ## Guidance
 
 More information about when to use inset-text can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/inset-text "Link to read guidance on the use of inset-text on Gov.uk Design system website")
 
 ## Quick start examples
 
-      <div class="govuk-c-inset-text ">
-      <p>
+### Component default
+
+[Preview the inset-text component.](http://govuk-frontend-review.herokuapp.com/components/inset-text/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "inset-text/macro.njk" import govukInsetText %}
+
+    {{ govukInsetText(
+      classes='',
+      content='<p>
         It can take up to 8 weeks to register a lasting power of attorney if<br>
         there are no mistakes in the application.
-      </p>
-    </div>
+      </p>'
+      )
+    }}
 
 ## Variants
 
@@ -45,24 +55,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "inset-text/macro.njk" import govukInsetText %}
-
-    {{ govukInsetText(
-      classes='',
-      content='<p>
-        It can take up to 8 weeks to register a lasting power of attorney if<br>
-        there are no mistakes in the application.
-      </p>'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -10,6 +10,17 @@ Use bordered inset text to draw attention to important content on the page.
 
 More information about when to use inset-text can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/inset-text "Link to read guidance on the use of inset-text on Gov.uk Design system website")
 
+## Quick start examples
+
+      <div class="govuk-c-inset-text ">
+      <p>
+        It can take up to 8 weeks to register a lasting power of attorney if<br>
+        there are no mistakes in the application.
+      </p>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the inset-text component you must be running npm version 5 or above.
@@ -34,18 +45,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-inset-text ">
-      <p>
-        It can take up to 8 weeks to register a lasting power of attorney if<br>
-        there are no mistakes in the application.
-      </p>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "inset-text/macro.njk" import govukInsetText %}
 

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -20,14 +20,14 @@ More information about when to use inset-text can be found on [GOV.UK Design Sys
 
       {% from "inset-text/macro.njk" import govukInsetText %}
 
-    {{ govukInsetText(
+    {{- govukInsetText(
       classes='',
       content='<p>
         It can take up to 8 weeks to register a lasting power of attorney if<br>
         there are no mistakes in the application.
       </p>'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -61,19 +61,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -4,70 +4,21 @@
 
 Use labels for all form fields.
 
-[Preview the label component.](http://govuk-frontend-review.herokuapp.com/components/label/preview)
-
 ## Guidance
 
 More information about when to use label can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/label "Link to read guidance on the use of label on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <label class="govuk-c-label " for="">
-      National Insurance number
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
+### Component default
 
-    </label>
+[Preview the label component.](http://govuk-frontend-review.herokuapp.com/components/label/preview)
 
-    <label class="govuk-c-label  govuk-c-label--bold " for="">
-      National Insurance number
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
+#### Markup
 
-    </label>
+#### Macro
 
-    <label class="govuk-c-label " for="">
-      National Insurance number
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-        <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-    </label>
-
-## Variants
-
-## Dependencies
-
-To consume the label component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/label
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "label/macro.njk" import govukLabel %}
+      {% from "label/macro.njk" import govukLabel %}
 
     {{ govukLabel(
       classes='',
@@ -97,9 +48,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the label component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/label
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -20,25 +20,25 @@ More information about when to use label can be found on [GOV.UK Design System](
 
       {% from "label/macro.njk" import govukLabel %}
 
-    {{ govukLabel(
+    {{- govukLabel(
       classes='',
       labelText='National Insurance number',
       hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.',
       id=''
       )
-    }}
+    -}}
 
-    {{ govukLabel(
+    {{- govukLabel(
       classes='govuk-c-label--bold',
       labelText='National Insurance number',
       hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.',
       id=''
       )
-    }}
+    -}}
 
-    {{ govukLabel(
+    {{- govukLabel(
       classes='',
       labelText='National Insurance number',
       hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
@@ -46,7 +46,7 @@ More information about when to use label can be found on [GOV.UK Design System](
       errorMessage='Error message goes here',
       id=''
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -80,19 +80,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -10,6 +10,35 @@ Use labels for all form fields.
 
 More information about when to use label can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/label "Link to read guidance on the use of label on Gov.uk Design system website")
 
+## Quick start examples
+
+    <label class="govuk-c-label " for="">
+      National Insurance number
+        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
+        For example, ‘QQ 12 34 56 C’.</span>
+
+    </label>
+
+    <label class="govuk-c-label  govuk-c-label--bold " for="">
+      National Insurance number
+        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
+        For example, ‘QQ 12 34 56 C’.</span>
+
+    </label>
+
+    <label class="govuk-c-label " for="">
+      National Insurance number
+        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
+        For example, ‘QQ 12 34 56 C’.</span>
+
+        <span class="govuk-c-error-message ">
+      Error message goes here
+    </span>
+
+    </label>
+
+## Variants
+
 ## Dependencies
 
 To consume the label component you must be running npm version 5 or above.
@@ -34,39 +63,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <label class="govuk-c-label " for="">
-      National Insurance number
-
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-    </label>
-
-    <label class="govuk-c-label  govuk-c-label--bold " for="">
-      National Insurance number
-
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-    </label>
-
-    <label class="govuk-c-label " for="">
-      National Insurance number
-
-        <span class="govuk-c-label__hint">It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.</span>
-
-        <span class="govuk-c-error-message ">
-      Error message goes here
-    </span>
-
-    </label>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "label/macro.njk" import govukLabel %}
 

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -10,6 +10,18 @@ Use bold text with an exclamation icon if there are legal consequences - for exa
 
 More information about when to use legal-text can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/legal-text "Link to read guidance on the use of legal-text on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-legal-text ">
+      <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
+      <strong class="govuk-c-legal-text__text">
+        <span class="govuk-c-legal-text__assistive">Warning</span>
+        You can be fined up to £5,000 if you don’t register.
+      </strong>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the legal-text component you must be running npm version 5 or above.
@@ -34,19 +46,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-legal-text ">
-      <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
-      <strong class="govuk-c-legal-text__text">
-        <span class="govuk-c-legal-text__assistive">Warning</span>
-        You can be fined up to £5,000 if you don’t register.
-      </strong>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "legal-text/macro.njk" import govukLegalText %}
 

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -20,11 +20,12 @@ More information about when to use legal-text can be found on [GOV.UK Design Sys
 
       {% from "legal-text/macro.njk" import govukLegalText %}
 
-    {{ govukLegalText(
+    {{- govukLegalText(
       classes='',
       iconFallbackText='Warning',
-      legalText='You can be fined up to £5,000 if you don’t register.')
-    }}
+      legalText='You can be fined up to £5,000 if you don’t register.'
+      )
+    -}}
 
 ## Variants
 
@@ -58,19 +59,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/legal-text/README.md
+++ b/src/components/legal-text/README.md
@@ -4,21 +4,27 @@
 
 Use bold text with an exclamation icon if there are legal consequences - for example, a fine or prison sentence.
 
-[Preview the legal-text component.](http://govuk-frontend-review.herokuapp.com/components/legal-text/preview)
-
 ## Guidance
 
 More information about when to use legal-text can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/legal-text "Link to read guidance on the use of legal-text on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-legal-text ">
-      <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
-      <strong class="govuk-c-legal-text__text">
-        <span class="govuk-c-legal-text__assistive">Warning</span>
-        You can be fined up to £5,000 if you don’t register.
-      </strong>
-    </div>
+### Component default
+
+[Preview the legal-text component.](http://govuk-frontend-review.herokuapp.com/components/legal-text/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "legal-text/macro.njk" import govukLegalText %}
+
+    {{ govukLegalText(
+      classes='',
+      iconFallbackText='Warning',
+      legalText='You can be fined up to £5,000 if you don’t register.')
+    }}
 
 ## Variants
 
@@ -46,21 +52,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "legal-text/macro.njk" import govukLegalText %}
-
-    {{ govukLegalText(
-      classes='',
-      iconFallbackText='Warning',
-      legalText='You can be fined up to £5,000 if you don’t register.')
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -9,21 +9,45 @@ Link component, with four variants:
 *   download link - with download icon
 *   skip link - skip to the main page content
 
-[Preview the link component.](http://govuk-frontend-review.herokuapp.com/components/link/preview)
-
 ## Guidance
 
 More information about when to use link can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/link "Link to read guidance on the use of link on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <a href="" class="govuk-c-link govuk-c-link--back">Back</a>
+### Component default
 
-    <a href="" class="govuk-c-link govuk-c-link--muted">Is there anything wrong with this page?</a>
+[Preview the link component.](http://govuk-frontend-review.herokuapp.com/components/link/preview)
 
-    <a href="" class="govuk-c-link govuk-c-link--download"></a>
+#### Markup
 
-    <a href="" class="govuk-c-link govuk-c-link--skip">Skip to main content</a>
+#### Macro
+
+      {% from "link/macro.njk" import govukLink %}
+
+    {{ govukLink(
+      classes='govuk-c-link--back',
+      linkHref='',
+      linkText='Back')
+    }}
+
+    {{ govukLink(
+      classes='govuk-c-link--muted',
+      linkHref='',
+      linkText='Is there anything wrong with this page?')
+    }}
+
+    {{ govukLink(
+      classes='govuk-c-link--download',
+      linkHref='',
+      tagText='Download')
+    }}
+
+    {{ govukLink(
+      classes='govuk-c-link--skip',
+      linkHref='',
+      linkText='Skip to main content')
+    }}
 
 ## Variants
 
@@ -51,39 +75,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "link/macro.njk" import govukLink %}
-
-    {{ govukLink(
-      classes='govuk-c-link--back',
-      linkHref='',
-      linkText='Back')
-    }}
-
-    {{ govukLink(
-      classes='govuk-c-link--muted',
-      linkHref='',
-      linkText='Is there anything wrong with this page?')
-    }}
-
-    {{ govukLink(
-      classes='govuk-c-link--download',
-      linkHref='',
-      tagText='Download')
-    }}
-
-    {{ govukLink(
-      classes='govuk-c-link--skip',
-      linkHref='',
-      linkText='Skip to main content')
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>| Name | Type | Default | Required | Description |--- |--- |--- |--- |--- | linkHref | string | | Yes | The value of the link href attribute | linkText | string | | Yes | The link text | classes | string | | Yes | The modifier required for the link type | --back | --muted | --download | --skip</div>
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -15,6 +15,18 @@ Link component, with four variants:
 
 More information about when to use link can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/link "Link to read guidance on the use of link on Gov.uk Design system website")
 
+## Quick start examples
+
+    <a href="" class="govuk-c-link govuk-c-link--back">Back</a>
+
+    <a href="" class="govuk-c-link govuk-c-link--muted">Is there anything wrong with this page?</a>
+
+    <a href="" class="govuk-c-link govuk-c-link--download"></a>
+
+    <a href="" class="govuk-c-link govuk-c-link--skip">Skip to main content</a>
+
+## Variants
+
 ## Dependencies
 
 To consume the link component you must be running npm version 5 or above.
@@ -39,19 +51,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <a href="" class="govuk-c-link govuk-c-link--back">Back</a>
-
-    <a href="" class="govuk-c-link govuk-c-link--muted">Is there anything wrong with this page?</a>
-
-    <a href="" class="govuk-c-link govuk-c-link--download"></a>
-
-    <a href="" class="govuk-c-link govuk-c-link--skip">Skip to main content</a>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "link/macro.njk" import govukLink %}
 

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -25,29 +25,29 @@ More information about when to use link can be found on [GOV.UK Design System](h
 
       {% from "link/macro.njk" import govukLink %}
 
-    {{ govukLink(
+    {{- govukLink(
       classes='govuk-c-link--back',
       linkHref='',
       linkText='Back')
-    }}
+    -}}
 
-    {{ govukLink(
+    {{- govukLink(
       classes='govuk-c-link--muted',
       linkHref='',
       linkText='Is there anything wrong with this page?')
-    }}
+    -}}
 
-    {{ govukLink(
+    {{- govukLink(
       classes='govuk-c-link--download',
       linkHref='',
-      tagText='Download')
-    }}
+      linkText='Download')
+    -}}
 
-    {{ govukLink(
+    {{- govukLink(
       classes='govuk-c-link--skip',
       linkHref='',
       linkText='Skip to main content')
-    }}
+    -}}
 
 ## Variants
 

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -10,6 +10,132 @@ Breadcrumb navigation, showing page hierarchy.
 
 More information about when to use list can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/list "Link to read guidance on the use of list on Gov.uk Design system website")
 
+## Quick start examples
+
+    <ul class="govuk-c-list ">
+
+      <li>
+
+          <a href="/ ">
+            Related link
+          </a>
+
+      </li>
+
+      <li>
+
+          <a href="/ ">
+            Related link
+          </a>
+
+      </li>
+
+      <li>
+
+          <a href="/ ">
+            Related link
+          </a>
+
+      </li>
+
+    </ul>
+
+    <ul class="govuk-c-list govuk-c-list--bullet ">
+
+      <li>
+
+            here is a bulleted list
+
+      </li>
+
+      <li>
+
+            here is the second bulleted list item
+
+      </li>
+
+      <li>
+
+            here is the third bulleted list item
+
+      </li>
+
+    </ul>
+
+    <ol class="govuk-c-list govuk-c-list--number ">
+
+      <li>
+
+            This is a numbered list.
+
+      </li>
+
+      <li>
+
+            This is the second step in a numbered list.
+
+      </li>
+
+      <li>
+
+            The third step is to make sure each item is a full sentence ending with a full stop.
+
+      </li>
+
+    </ol>
+
+    <ol class="govuk-c-list govuk-c-list--icon ">
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle ">1</span>
+          Step 1
+
+      </li>
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle ">2</span>
+          Step 2
+
+      </li>
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle ">3</span>
+          Step 3
+
+      </li>
+
+    </ol>
+
+    <ol class="govuk-c-list govuk-c-list--icon ">
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">1</span>
+          Step 1 Large icon
+
+      </li>
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">2</span>
+          Step 2 Large icon
+
+      </li>
+
+      <li>
+
+          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">3</span>
+          Step 3 Large icon
+
+      </li>
+
+    </ol>
+
+## Variants
+
 ## Dependencies
 
 To consume the list component you must be running npm version 5 or above.
@@ -34,87 +160,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <ul class="govuk-c-list ">
-
-      <li>
-    <a href="/ ">        Related link
-    </a>  </li>
-      <li>
-    <a href="/ ">        Related link
-    </a>  </li>
-      <li>
-    <a href="/ ">        Related link
-    </a>  </li>
-
-    </ul>
-
-    <ul class="govuk-c-list govuk-c-list--bullet ">
-
-      <li>
-            here is a bulleted list
-      </li>
-      <li>
-            here is the second bulleted list item
-      </li>
-      <li>
-            here is the third bulleted list item
-      </li>
-
-    </ul>
-
-    <ol class="govuk-c-list govuk-c-list--number ">
-
-      <li>
-            This is a numbered list.
-      </li>
-      <li>
-            This is the second step in a numbered list.
-      </li>
-      <li>
-            The third step is to make sure each item is a full sentence ending with a full stop.
-      </li>
-
-    </ol>
-
-    <ol class="govuk-c-list govuk-c-list--icon ">
-
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle ">1</span>
-          Step 1
-      </li>
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle ">2</span>
-          Step 2
-      </li>
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle ">3</span>
-          Step 3
-      </li>
-
-    </ol>
-
-    <ol class="govuk-c-list govuk-c-list--icon ">
-
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">1</span>
-          Step 1 Large icon
-      </li>
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">2</span>
-          Step 2 Large icon
-      </li>
-      <li>
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">3</span>
-          Step 3 Large icon
-      </li>
-
-    </ol>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "list/macro.njk" import govukList %}
 

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -4,167 +4,21 @@
 
 Breadcrumb navigation, showing page hierarchy.
 
-[Preview the list component.](http://govuk-frontend-review.herokuapp.com/components/list/preview)
-
 ## Guidance
 
 More information about when to use list can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/list "Link to read guidance on the use of list on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <ul class="govuk-c-list ">
+### Component default
 
-      <li>
+[Preview the list component.](http://govuk-frontend-review.herokuapp.com/components/list/preview)
 
-          <a href="/ ">
-            Related link
-          </a>
+#### Markup
 
-      </li>
+#### Macro
 
-      <li>
-
-          <a href="/ ">
-            Related link
-          </a>
-
-      </li>
-
-      <li>
-
-          <a href="/ ">
-            Related link
-          </a>
-
-      </li>
-
-    </ul>
-
-    <ul class="govuk-c-list govuk-c-list--bullet ">
-
-      <li>
-
-            here is a bulleted list
-
-      </li>
-
-      <li>
-
-            here is the second bulleted list item
-
-      </li>
-
-      <li>
-
-            here is the third bulleted list item
-
-      </li>
-
-    </ul>
-
-    <ol class="govuk-c-list govuk-c-list--number ">
-
-      <li>
-
-            This is a numbered list.
-
-      </li>
-
-      <li>
-
-            This is the second step in a numbered list.
-
-      </li>
-
-      <li>
-
-            The third step is to make sure each item is a full sentence ending with a full stop.
-
-      </li>
-
-    </ol>
-
-    <ol class="govuk-c-list govuk-c-list--icon ">
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle ">1</span>
-          Step 1
-
-      </li>
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle ">2</span>
-          Step 2
-
-      </li>
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle ">3</span>
-          Step 3
-
-      </li>
-
-    </ol>
-
-    <ol class="govuk-c-list govuk-c-list--icon ">
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">1</span>
-          Step 1 Large icon
-
-      </li>
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">2</span>
-          Step 2 Large icon
-
-      </li>
-
-      <li>
-
-          <span class="govuk-c-list__icon govuk-u-circle govuk-c-list__icon--large">3</span>
-          Step 3 Large icon
-
-      </li>
-
-    </ol>
-
-## Variants
-
-## Dependencies
-
-To consume the list component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/list
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "list/macro.njk" import govukList %}
+      {% from "list/macro.njk" import govukList %}
 
     {{ govukList(
       classes='',
@@ -256,9 +110,35 @@ To use a macro, follow the below code example:
       }
     ) }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the list component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/list
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/list/README.md
+++ b/src/components/list/README.md
@@ -18,9 +18,9 @@ More information about when to use list can be found on [GOV.UK Design System](h
 
 #### Macro
 
-      {% from "list/macro.njk" import govukList %}
+      {% from "list/macro.njk" import govukList -%}
 
-    {{ govukList(
+    {{- govukList(
       classes='',
       [
         {
@@ -36,9 +36,10 @@ More information about when to use list can be found on [GOV.UK Design System](h
           url: '/'
         }
       ]
-    ) }}
+    )
+    -}}
 
-    {{ govukList(
+    {{- govukList(
       classes='',
       [
         {
@@ -54,9 +55,10 @@ More information about when to use list can be found on [GOV.UK Design System](h
       options = {
         'isBullet': 'true'
       }
-    ) }}
+    )
+    -}}
 
-    {{ govukList(
+    {{- govukList(
       classes='',
       [
         {
@@ -72,9 +74,10 @@ More information about when to use list can be found on [GOV.UK Design System](h
       options = {
         'isNumber': 'true'
       }
-    ) }}
+    )
+    -}}
 
-    {{ govukList(
+    {{- govukList(
       classes='',
       [
         {
@@ -90,9 +93,10 @@ More information about when to use list can be found on [GOV.UK Design System](h
       options = {
         'isStep': 'true'
       }
-    ) }}
+    )
+    -}}
 
-    {{ govukList(
+    {{- govukList(
       classes='',
       [
         {
@@ -108,7 +112,8 @@ More information about when to use list can be found on [GOV.UK Design System](h
       options = {
         'isStepLarge': 'true'
       }
-    ) }}
+    )
+    -}}
 
 ## Variants
 
@@ -142,19 +147,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -4,149 +4,21 @@
 
 Navigational links that allow users navigate within a series of pages.
 
-[Preview the pagination component.](http://govuk-frontend-review.herokuapp.com/components/pagination/preview)
-
 ## Guidance
 
 More information about when to use pagination can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/pagination "Link to read guidance on the use of pagination on Gov.uk Design system website")
 
 ## Quick start examples
 
-      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
+### Component default
 
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
+[Preview the pagination component.](http://govuk-frontend-review.herokuapp.com/components/pagination/preview)
 
-              <span class="govuk-c-pagination__link-label">1 of 3</span>
+#### Markup
 
-          </a>
-        </li>
+#### Macro
 
-      </ul>
-    </nav>
-
-      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-
-              <span class="govuk-c-pagination__link-label">Tax disc</span>
-
-          </a>
-        </li>
-
-      </ul>
-    </nav>
-
-      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
-
-              <span class="govuk-c-pagination__link-label">1 of 3</span>
-
-          </a>
-        </li>
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-
-              <span class="govuk-c-pagination__link-label">2 of 3</span>
-
-          </a>
-        </li>
-
-      </ul>
-    </nav>
-
-      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
-
-          </a>
-        </li>
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-
-          </a>
-        </li>
-
-      </ul>
-    </nav>
-
-## Variants
-
-## Dependencies
-
-To consume the pagination component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/pagination
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "pagination/macro.njk" import govukPagination %}
+      {% from "pagination/macro.njk" import govukPagination %}
 
     {{ govukPagination(
       classes='',
@@ -208,9 +80,35 @@ To use a macro, follow the below code example:
       )
     }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the pagination component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/pagination
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -10,6 +10,114 @@ Navigational links that allow users navigate within a series of pages.
 
 More information about when to use pagination can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/pagination "Link to read guidance on the use of pagination on Gov.uk Design system website")
 
+## Quick start examples
+
+      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
+      <ul class="govuk-c-pagination__list">
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
+            <span class="govuk-c-pagination__link-title">
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+              </svg>
+              Previous page
+            </span>
+
+              <span class="govuk-c-pagination__link-label">1 of 3</span>
+
+          </a>
+        </li>
+
+      </ul>
+    </nav>
+
+      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
+      <ul class="govuk-c-pagination__list">
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+          <a class="govuk-c-pagination__link" href="next-page" rel="next">
+            <span class="govuk-c-pagination__link-title">
+              Next page
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+              </svg>
+            </span>
+
+              <span class="govuk-c-pagination__link-label">Tax disc</span>
+
+          </a>
+        </li>
+
+      </ul>
+    </nav>
+
+      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
+      <ul class="govuk-c-pagination__list">
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
+            <span class="govuk-c-pagination__link-title">
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+              </svg>
+              Previous page
+            </span>
+
+              <span class="govuk-c-pagination__link-label">1 of 3</span>
+
+          </a>
+        </li>
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+          <a class="govuk-c-pagination__link" href="next-page" rel="next">
+            <span class="govuk-c-pagination__link-title">
+              Next page
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+              </svg>
+            </span>
+
+              <span class="govuk-c-pagination__link-label">2 of 3</span>
+
+          </a>
+        </li>
+
+      </ul>
+    </nav>
+
+      <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
+      <ul class="govuk-c-pagination__list">
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
+          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
+            <span class="govuk-c-pagination__link-title">
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+              </svg>
+              Previous page
+            </span>
+
+          </a>
+        </li>
+
+        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
+          <a class="govuk-c-pagination__link" href="next-page" rel="next">
+            <span class="govuk-c-pagination__link-title">
+              Next page
+              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+              </svg>
+            </span>
+
+          </a>
+        </li>
+
+      </ul>
+    </nav>
+
+## Variants
+
 ## Dependencies
 
 To consume the pagination component you must be running npm version 5 or above.
@@ -34,99 +142,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
-              <span class="govuk-c-pagination__link-label">1 of 3</span>
-          </a>
-        </li>
-
-      </ul>
-    </nav>
-
-    <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-              <span class="govuk-c-pagination__link-label">Tax disc</span>
-          </a>
-        </li>
-      </ul>
-    </nav>
-
-    <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
-              <span class="govuk-c-pagination__link-label">1 of 3</span>
-          </a>
-        </li>
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-              <span class="govuk-c-pagination__link-label">2 of 3</span>
-          </a>
-        </li>
-      </ul>
-    </nav>
-
-    <nav class="govuk-c-pagination " role="navigation" aria-label="Pagination">
-      <ul class="govuk-c-pagination__list">
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--previous">
-          <a class="govuk-c-pagination__link" href="previous-page" rel="prev">
-            <span class="govuk-c-pagination__link-title">
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              Previous page
-            </span>
-          </a>
-        </li>
-
-        <li class="govuk-c-pagination__item govuk-c-pagination__item--next">
-          <a class="govuk-c-pagination__link" href="next-page" rel="next">
-            <span class="govuk-c-pagination__link-title">
-              Next page
-              <svg class="govuk-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
-                <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-              </svg>
-            </span>
-          </a>
-        </li>
-      </ul>
-    </nav>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "pagination/macro.njk" import govukPagination %}
 

--- a/src/components/pagination/README.md
+++ b/src/components/pagination/README.md
@@ -18,9 +18,9 @@ More information about when to use pagination can be found on [GOV.UK Design Sys
 
 #### Macro
 
-      {% from "pagination/macro.njk" import govukPagination %}
+      {% from "pagination/macro.njk" import govukPagination -%}
 
-    {{ govukPagination(
+    {{- govukPagination(
       classes='',
       previousPage=[
        {
@@ -30,9 +30,9 @@ More information about when to use pagination can be found on [GOV.UK Design Sys
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukPagination(
+    {{- govukPagination(
       classes='',
       nextPage=[
        {
@@ -42,9 +42,9 @@ More information about when to use pagination can be found on [GOV.UK Design Sys
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukPagination(
+    {{- govukPagination(
       classes='',
       previousPage=[
        {
@@ -61,9 +61,9 @@ More information about when to use pagination can be found on [GOV.UK Design Sys
         }
       ]
       )
-    }}
+    -}}
 
-    {{ govukPagination(
+    {{- govukPagination(
       classes='',
       previousPage=[
        {
@@ -78,7 +78,7 @@ More information about when to use pagination can be found on [GOV.UK Design Sys
         }
       ]
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -112,19 +112,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -4,26 +4,29 @@
 
 The confirmation panel has a turquoise background and white text. Used for transaction end pages, and Bank Holidays.
 
-[Preview the panel component.](http://govuk-frontend-review.herokuapp.com/components/panel/preview)
-
 ## Guidance
 
 More information about when to use panel can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/panel "Link to read guidance on the use of panel on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-panel govuk-c-panel--confirmation ">
-      <h2 class="govuk-c-panel__title">
-        Application complete
-      </h2>
-      <div class="govuk-c-panel__body">
-        Your reference number is
+### Component default
 
-        <br>
-        <strong>HDJ2123F</strong>
+[Preview the panel component.](http://govuk-frontend-review.herokuapp.com/components/panel/preview)
 
-      </div>
-    </div>
+#### Markup
+
+#### Macro
+
+      {% from "panel/macro.njk" import govukPanel %}
+
+    {{ govukPanel(
+      classes='',
+      title='Application complete',
+      content='Your reference number is',
+      reference='HDJ2123F'
+      )
+    }}
 
 ## Variants
 
@@ -51,23 +54,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "panel/macro.njk" import govukPanel %}
-
-    {{ govukPanel(
-      classes='',
-      title='Application complete',
-      content='Your reference number is',
-      reference='HDJ2123F'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -20,13 +20,13 @@ More information about when to use panel can be found on [GOV.UK Design System](
 
       {% from "panel/macro.njk" import govukPanel %}
 
-    {{ govukPanel(
+    {{- govukPanel(
       classes='',
       title='Application complete',
       content='Your reference number is',
       reference='HDJ2123F'
       )
-    }}
+    -}}
 
 ## Variants
 
@@ -60,19 +60,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -10,6 +10,23 @@ The confirmation panel has a turquoise background and white text. Used for trans
 
 More information about when to use panel can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/panel "Link to read guidance on the use of panel on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-panel govuk-c-panel--confirmation ">
+      <h2 class="govuk-c-panel__title">
+        Application complete
+      </h2>
+      <div class="govuk-c-panel__body">
+        Your reference number is
+
+        <br>
+        <strong>HDJ2123F</strong>
+
+      </div>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the panel component you must be running npm version 5 or above.
@@ -34,22 +51,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-panel govuk-c-panel--confirmation ">
-      <h2 class="govuk-c-panel__title">
-        Application complete
-      </h2>
-      <div class="govuk-c-panel__body">
-        Your reference number is
-        <br>
-        <strong>HDJ2123F</strong>
-      </div>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "panel/macro.njk" import govukPanel %}
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -10,6 +10,20 @@ A banner that indicates content is in alpha or beta phase with a description.
 
 More information about when to use phase-banner can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/phase-banner "Link to read guidance on the use of phase-banner on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-phase-banner ">
+      <p class="govuk-c-phase-banner__content">
+        <strong class="govuk-c-phase-tag "> BETA</strong>
+
+        <span class="govuk-c-phase-banner__text">
+          This is a new service – your <a href="#">feedback</a> will help us to improve it.
+        </span>
+      </p>
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the phase-banner component you must be running npm version 5 or above.
@@ -34,21 +48,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-phase-banner ">
-      <p class="govuk-c-phase-banner__content">
-        <strong class="govuk-c-phase-tag "> BETA</strong>
-
-        <span class="govuk-c-phase-banner__text">
-          This is a new service – your <a href="#">feedback</a> will help us to improve it.
-        </span>
-      </p>
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "phase-banner/macro.njk" import govukPhaseBanner %}
     {{ govukPhaseBanner(

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -4,23 +4,25 @@
 
 A banner that indicates content is in alpha or beta phase with a description.
 
-[Preview the phase-banner component.](http://govuk-frontend-review.herokuapp.com/components/phase-banner/preview)
-
 ## Guidance
 
 More information about when to use phase-banner can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/phase-banner "Link to read guidance on the use of phase-banner on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-phase-banner ">
-      <p class="govuk-c-phase-banner__content">
-        <strong class="govuk-c-phase-tag "> BETA</strong>
+### Component default
 
-        <span class="govuk-c-phase-banner__text">
-          This is a new service – your <a href="#">feedback</a> will help us to improve it.
-        </span>
-      </p>
-    </div>
+[Preview the phase-banner component.](http://govuk-frontend-review.herokuapp.com/components/phase-banner/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "phase-banner/macro.njk" import govukPhaseBanner %}
+    {{ govukPhaseBanner(
+      phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
+      phaseTagText='BETA')
+    }}
 
 ## Variants
 
@@ -48,19 +50,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "phase-banner/macro.njk" import govukPhaseBanner %}
-    {{ govukPhaseBanner(
-      phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
-      phaseTagText='BETA')
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -19,10 +19,10 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
 #### Macro
 
       {% from "phase-banner/macro.njk" import govukPhaseBanner %}
-    {{ govukPhaseBanner(
+    {{- govukPhaseBanner(
       phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
       phaseTagText='BETA')
-    }}
+    -}}
 
 ## Variants
 
@@ -56,19 +56,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -4,15 +4,23 @@
 
 Phase tags are mostly used inside phase banners as an indication of the state of a project. It’s possible to use them outside phase banners, for example as part of a service header.
 
-[Preview the phase-tag component.](http://govuk-frontend-review.herokuapp.com/components/phase-tag/preview)
-
 ## Guidance
 
 More information about when to use phase-tag can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/phase-tag "Link to read guidance on the use of phase-tag on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <strong class="govuk-c-phase-tag "> Alpha</strong>
+### Component default
+
+[Preview the phase-tag component.](http://govuk-frontend-review.herokuapp.com/components/phase-tag/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "phase-tag/macro.njk" import govukPhaseTag %}
+
+    {{ govukPhaseTag(classes='', phaseTagText='Alpha') }}
 
 ## Variants
 
@@ -40,17 +48,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "phase-tag/macro.njk" import govukPhaseTag %}
-
-    {{ govukPhaseTag(classes='', phaseTagText='Alpha') }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -18,9 +18,9 @@ More information about when to use phase-tag can be found on [GOV.UK Design Syst
 
 #### Macro
 
-      {% from "phase-tag/macro.njk" import govukPhaseTag %}
+      {%- from "phase-tag/macro.njk" import govukPhaseTag -%}
 
-    {{ govukPhaseTag(classes='', phaseTagText='Alpha') }}
+    {{- govukPhaseTag(classes='', phaseTagText='Alpha') -}}
 
 ## Variants
 
@@ -54,19 +54,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/phase-tag/README.md
+++ b/src/components/phase-tag/README.md
@@ -10,6 +10,12 @@ Phase tags are mostly used inside phase banners as an indication of the state of
 
 More information about when to use phase-tag can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/phase-tag "Link to read guidance on the use of phase-tag on Gov.uk Design system website")
 
+## Quick start examples
+
+    <strong class="govuk-c-phase-tag "> Alpha</strong>
+
+## Variants
+
 ## Dependencies
 
 To consume the phase-tag component you must be running npm version 5 or above.
@@ -34,13 +40,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <strong class="govuk-c-phase-tag "> Alpha</strong>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "phase-tag/macro.njk" import govukPhaseTag %}
 

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -4,67 +4,21 @@
 
 A radio button is a GOV.UK element that allows users to answer a question by selecting an option. If you have a question with more than one option you should stack radio buttons.
 
-[Preview the radio component.](http://govuk-frontend-review.herokuapp.com/components/radio/preview)
-
 ## Guidance
 
 More information about when to use radio can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/radio "Link to read guidance on the use of radio on Gov.uk Design system website")
 
 ## Quick start examples
 
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-1" name="radio-group" type="radio" value="Yes"  >
-        <label class="govuk-c-radio__label" for="radio-1">Yes</label>
-      </div>
+### Component default
 
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-2" name="radio-group" type="radio" value="No"  >
-        <label class="govuk-c-radio__label" for="radio-2">No</label>
-      </div>
+[Preview the radio component.](http://govuk-frontend-review.herokuapp.com/components/radio/preview)
 
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-3" name="radio-group" type="radio" value="No" checked >
-        <label class="govuk-c-radio__label" for="radio-3">No</label>
-      </div>
+#### Markup
 
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-4" name="radio-group" type="radio" value="NA"  disabled>
-        <label class="govuk-c-radio__label" for="radio-4">Not applicable</label>
-      </div>
+#### Macro
 
-## Variants
-
-## Dependencies
-
-To consume the radio component you must be running npm version 5 or above.
-
-Please note, this component depends on @govuk-frontend/globals, which will automatically be installed with the package.
-
-## Installation
-
-    npm install --save @govuk-frontend/radio
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from 'radio/macro.njk' import govukRadio %}
+      {% from 'radio/macro.njk' import govukRadio %}
 
     {{ govukRadio(
       classes='',
@@ -96,9 +50,37 @@ To use a macro, follow the below code example:
       ]
     ) }}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the radio component you must be running npm version 5 or above.
+
+Please note, this component depends on @govuk-frontend/globals, which will automatically be installed with the package.
+
+## Installation
+
+    npm install --save @govuk-frontend/radio
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -20,7 +20,7 @@ More information about when to use radio can be found on [GOV.UK Design System](
 
       {% from 'radio/macro.njk' import govukRadio %}
 
-    {{ govukRadio(
+    {{- govukRadio(
       classes='',
       name='radio-group',
       id='radio',
@@ -48,7 +48,7 @@ More information about when to use radio can be found on [GOV.UK Design System](
           disabled: 'true'
         }
       ]
-    ) }}
+    ) -}}
 
 ## Variants
 
@@ -84,19 +84,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/radio/README.md
+++ b/src/components/radio/README.md
@@ -10,6 +10,30 @@ A radio button is a GOV.UK element that allows users to answer a question by sel
 
 More information about when to use radio can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/radio "Link to read guidance on the use of radio on Gov.uk Design system website")
 
+## Quick start examples
+
+      <div class="govuk-c-radio">
+        <input class="govuk-c-radio__input " id="radio-1" name="radio-group" type="radio" value="Yes"  >
+        <label class="govuk-c-radio__label" for="radio-1">Yes</label>
+      </div>
+
+      <div class="govuk-c-radio">
+        <input class="govuk-c-radio__input " id="radio-2" name="radio-group" type="radio" value="No"  >
+        <label class="govuk-c-radio__label" for="radio-2">No</label>
+      </div>
+
+      <div class="govuk-c-radio">
+        <input class="govuk-c-radio__input " id="radio-3" name="radio-group" type="radio" value="No" checked >
+        <label class="govuk-c-radio__label" for="radio-3">No</label>
+      </div>
+
+      <div class="govuk-c-radio">
+        <input class="govuk-c-radio__input " id="radio-4" name="radio-group" type="radio" value="NA"  disabled>
+        <label class="govuk-c-radio__label" for="radio-4">Not applicable</label>
+      </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the radio component you must be running npm version 5 or above.
@@ -36,28 +60,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-1" name="radio-group" type="radio" value="Yes"  >
-        <label class="govuk-c-radio__label" for="radio-1">Yes</label>
-      </div>
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-2" name="radio-group" type="radio" value="No"  >
-        <label class="govuk-c-radio__label" for="radio-2">No</label>
-      </div>
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-3" name="radio-group" type="radio" value="No" checked >
-        <label class="govuk-c-radio__label" for="radio-3">No</label>
-      </div>
-      <div class="govuk-c-radio">
-        <input class="govuk-c-radio__input " id="radio-4" name="radio-group" type="radio" value="NA"  disabled>
-        <label class="govuk-c-radio__label" for="radio-4">Not applicable</label>
-      </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from 'radio/macro.njk' import govukRadio %}
 

--- a/src/components/select-box/README.md
+++ b/src/components/select-box/README.md
@@ -4,70 +4,21 @@
 
 The HTML `<select>` element represents a control that provides a menu of options.
 
-[Preview the select-box component.](http://govuk-frontend-review.herokuapp.com/components/select-box/preview)
-
 ## Guidance
 
 More information about when to use select-box can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/select-box "Link to read guidance on the use of select-box on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <select class="govuk-c-select-box " id="select-box-1" name="select-box-1">
+### Component default
 
-      <option value="1">GOV.UK frontend option 1</option>
+[Preview the select-box component.](http://govuk-frontend-review.herokuapp.com/components/select-box/preview)
 
-      <option value="2">GOV.UK frontend option 2</option>
+#### Markup
 
-      <option value="3">GOV.UK frontend option 3</option>
+#### Macro
 
-    </select>
-
-    <label class="govuk-c-label " for="select-box-2">
-      Label for select box
-
-    </label>
-
-    <select class="govuk-c-select-box " id="select-box-2" name="select-box-2">
-
-      <option value="a">GOV.UK frontend option a</option>
-
-      <option value="b"selected>GOV.UK frontend option b</option>
-
-      <option value="c">GOV.UK frontend option c</option>
-
-    </select>
-
-## Variants
-
-## Dependencies
-
-To consume the select-box component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/select-box
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "select-box/macro.njk" import govukSelectBox %}
+      {% from "select-box/macro.njk" import govukSelectBox %}
 
     {{ govukSelectBox(
       classes='',
@@ -112,9 +63,35 @@ To use a macro, follow the below code example:
       ]
     )}}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the select-box component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/select-box
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/select-box/README.md
+++ b/src/components/select-box/README.md
@@ -20,7 +20,7 @@ More information about when to use select-box can be found on [GOV.UK Design Sys
 
       {% from "select-box/macro.njk" import govukSelectBox %}
 
-    {{ govukSelectBox(
+    {{- govukSelectBox(
       classes='',
       id='select-box-1',
       name='select-box-1',
@@ -38,9 +38,10 @@ More information about when to use select-box can be found on [GOV.UK Design Sys
           label: 'GOV.UK frontend option 3'
         }
       ]
-    )}}
+    )
+    -}}
 
-    {{ govukSelectBox(
+    {{- govukSelectBox(
       hasLabelWithText='Label for select box',
       labelClasses='',
       classes='',
@@ -61,7 +62,8 @@ More information about when to use select-box can be found on [GOV.UK Design Sys
           label: 'GOV.UK frontend option c'
         }
       ]
-    )}}
+    )
+    -}}
 
 ## Variants
 
@@ -95,19 +97,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/select-box/README.md
+++ b/src/components/select-box/README.md
@@ -10,6 +10,35 @@ The HTML `<select>` element represents a control that provides a menu of options
 
 More information about when to use select-box can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/select-box "Link to read guidance on the use of select-box on Gov.uk Design system website")
 
+## Quick start examples
+
+    <select class="govuk-c-select-box " id="select-box-1" name="select-box-1">
+
+      <option value="1">GOV.UK frontend option 1</option>
+
+      <option value="2">GOV.UK frontend option 2</option>
+
+      <option value="3">GOV.UK frontend option 3</option>
+
+    </select>
+
+    <label class="govuk-c-label " for="select-box-2">
+      Label for select box
+
+    </label>
+
+    <select class="govuk-c-select-box " id="select-box-2" name="select-box-2">
+
+      <option value="a">GOV.UK frontend option a</option>
+
+      <option value="b"selected>GOV.UK frontend option b</option>
+
+      <option value="c">GOV.UK frontend option c</option>
+
+    </select>
+
+## Variants
+
 ## Dependencies
 
 To consume the select-box component you must be running npm version 5 or above.
@@ -34,28 +63,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <select class="govuk-c-select-box " id="select-box-1" name="select-box-1">
-      <option value="1">GOV.UK frontend option 1</option>
-      <option value="2">GOV.UK frontend option 2</option>
-      <option value="3">GOV.UK frontend option 3</option>
-    </select>
-
-    <label class="govuk-c-label " for="select-box-2">
-      Label for select box
-
-    </label>
-
-    <select class="govuk-c-select-box " id="select-box-2" name="select-box-2">
-      <option value="a">GOV.UK frontend option a</option>
-      <option value="b"selected>GOV.UK frontend option b</option>
-      <option value="c">GOV.UK frontend option c</option>
-    </select>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "select-box/macro.njk" import govukSelectBox %}
 

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -10,6 +10,14 @@ A container set to the width of the site (960px) and its margins.
 
 More information about when to use site-width-container can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/site-width-container "Link to read guidance on the use of site-width-container on Gov.uk Design system website")
 
+## Quick start examples
+
+    <div class="govuk-c-site-width-container ">
+
+    </div>
+
+## Variants
+
 ## Dependencies
 
 To consume the site-width-container component you must be running npm version 5 or above.
@@ -34,15 +42,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <div class="govuk-c-site-width-container ">
-
-    </div>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
 

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -4,17 +4,23 @@
 
 A container set to the width of the site (960px) and its margins.
 
-[Preview the site-width-container component.](http://govuk-frontend-review.herokuapp.com/components/site-width-container/preview)
-
 ## Guidance
 
 More information about when to use site-width-container can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/site-width-container "Link to read guidance on the use of site-width-container on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <div class="govuk-c-site-width-container ">
+### Component default
 
-    </div>
+[Preview the site-width-container component.](http://govuk-frontend-review.herokuapp.com/components/site-width-container/preview)
+
+#### Markup
+
+#### Macro
+
+      {% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
+
+    {{ govukSiteWidthContainer(classes) }}
 
 ## Variants
 
@@ -42,17 +48,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
-
-    {{ govukSiteWidthContainer(classes) }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/site-width-container/README.md
+++ b/src/components/site-width-container/README.md
@@ -18,7 +18,7 @@ More information about when to use site-width-container can be found on [GOV.UK 
 
 #### Macro
 
-      {% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
+      {% from "site-width-container/macro.njk" import govukSiteWidthContainer -%}
 
     {{ govukSiteWidthContainer(classes) }}
 
@@ -54,19 +54,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -10,6 +10,98 @@ Table description.
 
 More information about when to use table can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/table "Link to read guidance on the use of table on Gov.uk Design system website")
 
+## Quick start examples
+
+    <table class="govuk-c-table ">
+
+      <caption class="govuk-c-table__caption  small ">Months and rates</caption>
+
+      <tbody class="govuk-c-table__body">
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> January</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
+
+        </tr>
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> February</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
+
+        </tr>
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> March</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
+
+        </tr>
+
+      </tbody>
+    </table>
+
+    <table class="govuk-c-table ">
+
+      <thead class="govuk-c-table__head">
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header "   scope="col">Month you apply</th>
+
+          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for bicycles</th>
+
+          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for vehicles</th>
+
+      </tr>
+      </thead>
+
+      <tbody class="govuk-c-table__body">
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> January</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
+
+        </tr>
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> February</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
+
+        </tr>
+
+        <tr class="govuk-c-table__row">
+
+          <th class="govuk-c-table__header" scope="row"> March</th>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
+
+          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
+
+        </tr>
+
+      </tbody>
+    </table>
+
+## Variants
+
 ## Dependencies
 
 To consume the table component you must be running npm version 5 or above.
@@ -34,59 +126,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <table class="govuk-c-table ">
-      <caption class="govuk-c-table__caption  small ">Months and rates</caption>
-      <tbody class="govuk-c-table__body">
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> January</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
-        </tr>
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> February</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
-        </tr>
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> March</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
-        </tr>
-      </tbody>
-    </table>
-
-    <table class="govuk-c-table ">
-      <thead class="govuk-c-table__head">
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header "   scope="col">Month you apply</th>
-          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for bicycles</th>
-          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for vehicles</th>
-      </tr>
-      </thead>
-      <tbody class="govuk-c-table__body">
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> January</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
-        </tr>
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> February</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
-        </tr>
-        <tr class="govuk-c-table__row">
-          <th class="govuk-c-table__header" scope="row"> March</th>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
-        </tr>
-      </tbody>
-    </table>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from 'table/macro.njk' import govukTable %}
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -169,19 +169,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -4,133 +4,21 @@
 
 Table description.
 
-[Preview the table component.](http://govuk-frontend-review.herokuapp.com/components/table/preview)
-
 ## Guidance
 
 More information about when to use table can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/table "Link to read guidance on the use of table on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <table class="govuk-c-table ">
+### Component default
 
-      <caption class="govuk-c-table__caption  small ">Months and rates</caption>
+[Preview the table component.](http://govuk-frontend-review.herokuapp.com/components/table/preview)
 
-      <tbody class="govuk-c-table__body">
+#### Markup
 
-        <tr class="govuk-c-table__row">
+#### Macro
 
-          <th class="govuk-c-table__header" scope="row"> January</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
-
-        </tr>
-
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header" scope="row"> February</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
-
-        </tr>
-
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header" scope="row"> March</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
-
-        </tr>
-
-      </tbody>
-    </table>
-
-    <table class="govuk-c-table ">
-
-      <thead class="govuk-c-table__head">
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header "   scope="col">Month you apply</th>
-
-          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for bicycles</th>
-
-          <th class="govuk-c-table__header  govuk-c-table__header--numeric "   scope="col">Rate for vehicles</th>
-
-      </tr>
-      </thead>
-
-      <tbody class="govuk-c-table__body">
-
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header" scope="row"> January</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£85</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£95</td>
-
-        </tr>
-
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header" scope="row"> February</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£75</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£55</td>
-
-        </tr>
-
-        <tr class="govuk-c-table__row">
-
-          <th class="govuk-c-table__header" scope="row"> March</th>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£165</td>
-
-          <td class="govuk-c-table__cell  govuk-c-table__cell--numeric "  >£125</td>
-
-        </tr>
-
-      </tbody>
-    </table>
-
-## Variants
-
-## Dependencies
-
-To consume the table component you must be running npm version 5 or above.
-
-## Installation
-
-    npm install --save @govuk-frontend/table
-
-## Requirements
-
-### Build tool configuration
-
-When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
-
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
-
-### Static asset path configuration
-
-To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
-
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from 'table/macro.njk' import govukTable %}
+      {% from 'table/macro.njk' import govukTable %}
 
     {# table with a caption #}
     {{ govukTable(
@@ -249,9 +137,35 @@ To use a macro, follow the below code example:
       }
     )}}
 
-Where the macros take the following arguments
+## Variants
+
+## Dependencies
+
+To consume the table component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/table
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -30,6 +30,17 @@ More information about when to use textarea can be found on [GOV.UK Design Syste
       )
     }}
 
+    {{ govukTextarea(
+      classes='',
+      labelText='National Insurance number',
+      hintText='',
+      errorMessage='',
+      id='textarea-2',
+      name='name-2',
+      rows='10'
+      )
+    }}
+
 ## Variants
 
 ## Dependencies
@@ -62,19 +73,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <div>
 
-<table class="govuk-c-table ">
+<table class="govuk-c-table">
 
 <thead class="govuk-c-table__head">
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header " scope="col">Name</th>
+<th class="govuk-c-table__header" scope="col">Name</th>
 
-<th class="govuk-c-table__header " scope="col">Type</th>
+<th class="govuk-c-table__header" scope="col">Type</th>
 
-<th class="govuk-c-table__header " scope="col">Required</th>
+<th class="govuk-c-table__header" scope="col">Required</th>
 
-<th class="govuk-c-table__header " scope="col">Description</th>
+<th class="govuk-c-table__header" scope="col">Description</th>
 
 </tr>
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -10,6 +10,17 @@ A multi-line text field.
 
 More information about when to use textarea can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/textarea "Link to read guidance on the use of textarea on Gov.uk Design system website")
 
+## Quick start examples
+
+    <label class="govuk-c-label " for="textarea">
+      National Insurance number
+
+    </label>
+
+    <textarea class="govuk-c-textarea  " id="textarea" name="name" rows=" 5 "></textarea>
+
+## Variants
+
 ## Dependencies
 
 To consume the textarea component you must be running npm version 5 or above.
@@ -34,18 +45,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## Quick start examples
-
-    <label class="govuk-c-label " for="textarea">
-      National Insurance number
-
-    </label>
-
-    <textarea class="govuk-c-textarea  " id="textarea" name="name" rows=" 5 "></textarea>
-
 ## If you are using Nunjucks
 
-To use a macro, follow the below code examples:
+To use a macro, follow the below code example:
 
     {% from "textarea/macro.njk" import govukTextarea %}
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -4,20 +4,31 @@
 
 A multi-line text field.
 
-[Preview the textarea component.](http://govuk-frontend-review.herokuapp.com/components/textarea/preview)
-
 ## Guidance
 
 More information about when to use textarea can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/textarea "Link to read guidance on the use of textarea on Gov.uk Design system website")
 
 ## Quick start examples
 
-    <label class="govuk-c-label " for="textarea">
-      National Insurance number
+### Component default
 
-    </label>
+[Preview the textarea component.](http://govuk-frontend-review.herokuapp.com/components/textarea/preview)
 
-    <textarea class="govuk-c-textarea  " id="textarea" name="name" rows=" 5 "></textarea>
+#### Markup
+
+#### Macro
+
+      {% from "textarea/macro.njk" import govukTextarea %}
+
+    {{ govukTextarea(
+      classes='',
+      labelText='National Insurance number',
+      hintText='',
+      errorMessage='',
+      id='textarea',
+      name='name'
+      )
+    }}
 
 ## Variants
 
@@ -45,25 +56,9 @@ To show the button image you need to configure your app to show these assets. Be
 
     app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
-## If you are using Nunjucks
-
-To use a macro, follow the below code example:
-
-    {% from "textarea/macro.njk" import govukTextarea %}
-
-    {{ govukTextarea(
-      classes='',
-      labelText='National Insurance number',
-      hintText='',
-      errorMessage='',
-      id='textarea',
-      name='name'
-      )
-    }}
-
-Where the macros take the following arguments
-
 ## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
 
 <div>
 

--- a/src/views/component-preview.njk
+++ b/src/views/component-preview.njk
@@ -1,6 +1,7 @@
 {% extends "layout.njk" %}
 
 {% block content %}
-  {% set componentName = componentPath %}
-  {% include "../components/"+componentName+"/"+componentName+".njk" %}
+{% set componentName = variantName | default(componentPath) %}
+{% set componentBase = variantBase | default(componentPath) %}
+{% include "../components/"+componentBase+"/"+ componentName +".njk" %}
 {% endblock %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -53,6 +53,45 @@
   More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website">GOV.UK Design System</a>
 </p>
 
+<h2 class="govuk-u-heading-24">Quick start examples</h2>
+<p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
+
+{% if not isReadme %}
+<pre><code>{%- block componentHtmlUsage %}{{- componentHtmlFile -}}{% endblock -%}</code></pre>
+{% else %}
+<pre><code>
+  {{- htmlMarkup | escape -}}
+</code></pre>
+
+{% endif %}
+
+{% if variantItems %}
+<h2 class="govuk-u-heading-24">Variants</h2>
+
+{% for variant in variantItems %}
+{% set variantName = variant.name | replace('.njk', '') %}
+{% set variantPreviewPath = "/components/" + componentPath + '/' + variantName +"/preview" %}
+
+<h3 class="govuk-u-bold-19">{{ variantName | capitalize }}</h2>
+
+<div>
+{% include "../components/"+ componentName +"/"+ variant.name ignore missing %}
+</div>
+
+<p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variantName }} variant.</a></p>
+
+<p class="govuk-u-copy-19">Markup</p>
+<pre><code>
+{{- variant.html | escape -}}
+</code></pre>
+
+<p class="govuk-u-copy-19">Macro</p>
+<pre><code>
+{{- variant.njk | escape -}}
+</code></pre>
+{% endfor %}
+{% endif %}
+
 {% if isReadme %}
 <h2 class="govuk-u-heading-24">Dependencies</h2>
 
@@ -83,21 +122,8 @@ app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-fro
 </pre>
 {% endif %}
 
-<h2 class="govuk-u-heading-24">Quick start examples</h2>
-<p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
-{% if not isReadme %}
-<pre><code>{% block componentHtmlUsage %}{{ componentHtmlFile }}{% endblock %}</code></pre>
-{% else %}
-<pre>
-<code>
-  {{ htmlMarkup | escape }}
-</code>
-</pre>
-
-{% endif %}
-
 <h2 class="govuk-u-heading-24">If you are using Nunjucks</h2>
-<p class="govuk-u-copy-19">To use a macro, follow the below code examples:</p>
+<p class="govuk-u-copy-19">To use a macro, follow the below code example:</p>
 <pre><code>{% block componentNunjucks %}{{ componentNunjucksFile }}{% endblock %}</code></pre>
 
 <p class="govuk-u-copy-19">Where the macros take the following arguments</p>

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -33,37 +33,40 @@
 {% endblock %}
 </p>
 
+<h2 class="govuk-u-heading-24">Guidance</h2>
+<p class="govuk-u-copy-19">
+  More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website">GOV.UK Design System</a>
+</p>
+
+
+{% if isReadme %}
+<h2 class="govuk-u-heading-24">Quick start examples</h2>
+<p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
+{% endif %}
+
+<h3 class="govuk-u-bold-19">Component default</h2>
 {% if not isReadme %}
 <div>
 {% block componentExample %}
 {% include "../components/"+ componentName +"/"+ componentName +".njk" ignore missing %}
 {% endblock %}
 </div>
-{% endif %}
-
+{% endif %}  
 <p class="govuk-u-copy-19">
 {% set componentPreviewPath = "/components/" + componentPath + "/preview" %}
 <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ componentPreviewPath }}">Preview the {{ componentName}} component.
 </a>
 </p>
 
-<h2 class="govuk-u-heading-24">Guidance</h2>
-
-<p class="govuk-u-copy-19">
-  More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website">GOV.UK Design System</a>
-</p>
-
-<h2 class="govuk-u-heading-24">Quick start examples</h2>
-<p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
-
-{% if not isReadme %}
-<pre><code>{%- block componentHtmlUsage %}{{- componentHtmlFile -}}{% endblock -%}</code></pre>
-{% else %}
+<h4 class="govuk-u-copy-19">Markup</h4>
 <pre><code>
-  {{- htmlMarkup | escape -}}
+  {{- componentHtmlFile -}}
+</code></pre>
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>
+  {{ componentNunjucksFile }}
 </code></pre>
 
-{% endif %}
 
 {% if variantItems %}
 <h2 class="govuk-u-heading-24">Variants</h2>
@@ -122,13 +125,8 @@ app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-fro
 </pre>
 {% endif %}
 
-<h2 class="govuk-u-heading-24">If you are using Nunjucks</h2>
-<p class="govuk-u-copy-19">To use a macro, follow the below code example:</p>
-<pre><code>{% block componentNunjucks %}{{ componentNunjucksFile }}{% endblock %}</code></pre>
-
-<p class="govuk-u-copy-19">Where the macros take the following arguments</p>
-
 <h2 class="govuk-u-heading-24">Component arguments</h2>
+<p class="govuk-u-copy-19">If you are using Nunjucks,then macros take the following arguments</p>
 <div>
 {% from "table/macro.njk" import govukTable %}
 {% block componentArguments %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -73,10 +73,11 @@
 {% set variantPreviewPath = "/components/" + componentPath + '/' + variantName +"/preview" %}
 
 <h3 class="govuk-u-bold-19">{{ variantName | capitalize }}</h2>
-
+{% if not isReadme %}
 <div>
 {% include "../components/"+ componentName +"/"+ variant.name ignore missing %}
 </div>
+{% endif %}
 
 <p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variantName }} variant.</a></p>
 

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -69,17 +69,16 @@
 <h2 class="govuk-u-heading-24">Variants</h2>
 
 {% for variant in variantItems %}
-{% set variantName = variant.name | replace('.njk', '') %}
-{% set variantPreviewPath = "/components/" + componentPath + '/' + variantName +"/preview" %}
+{% set variantPreviewPath = "/components/" + componentPath + '/' + variant.name +"/preview" %}
 
-<h3 class="govuk-u-bold-19">{{ variantName | capitalize }}</h2>
+<h3 class="govuk-u-bold-19">{{ variant.name | capitalize }}</h2>
 {% if not isReadme %}
 <div>
-{% include "../components/"+ componentName +"/"+ variant.name ignore missing %}
+{% include "../components/"+ componentName +"/"+ variant.name + '.njk' ignore missing %}
 </div>
 {% endif %}
 
-<p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variantName }} variant.</a></p>
+<p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variant.name }} variant.</a></p>
 
 <h4 class="govuk-u-copy-19">Markup</h4>
 <pre><code>

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -47,11 +47,11 @@
 <h3 class="govuk-u-bold-19">Component default</h2>
 {% if not isReadme %}
 <div>
-{% block componentExample %}
+{%- block componentExample -%}
 {% include "../components/"+ componentName +"/"+ componentName +".njk" ignore missing %}
-{% endblock %}
+{%- endblock -%}
 </div>
-{% endif %}  
+{% endif %}
 <p class="govuk-u-copy-19">
 {% set componentPreviewPath = "/components/" + componentPath + "/preview" %}
 <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ componentPreviewPath }}">Preview the {{ componentName}} component.
@@ -60,11 +60,11 @@
 
 <h4 class="govuk-u-copy-19">Markup</h4>
 <pre><code>
-  {{- componentHtmlFile -}}
+{{- componentHtmlFile -}}
 </code></pre>
 <h4 class="govuk-u-copy-19">Macro</h4>
 <pre><code>
-  {{ componentNunjucksFile }}
+{{- componentNunjucksFile -}}
 </code></pre>
 
 

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -81,12 +81,12 @@
 
 <p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variantName }} variant.</a></p>
 
-<p class="govuk-u-copy-19">Markup</p>
+<h4 class="govuk-u-copy-19">Markup</h4>
 <pre><code>
 {{- variant.html | escape -}}
 </code></pre>
 
-<p class="govuk-u-copy-19">Macro</p>
+<h4 class="govuk-u-copy-19">Macro</h4>
 <pre><code>
 {{- variant.njk | escape -}}
 </code></pre>

--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -10,11 +10,12 @@ const fs = require('fs')
 const toMarkdown = require('gulp-to-markdown')
 const gulpNunjucks = require('gulp-nunjucks')
 const nunjucks = require('nunjucks')
-const vinylInfo = {}
+const objectData = {}
 
+// data variable to be passed to the nunjucks template
 function getDataForFile (file) {
   let finalData = {}
-  finalData = Object.assign(finalData, vinylInfo)
+  finalData = Object.assign(finalData, objectData)
   return finalData
 }
 
@@ -26,25 +27,26 @@ environment.addGlobal('isReadme', 'true')
 gulp.task('generate:readme', () => {
   return gulp.src(['!' + configPath.components + '_component-example/index.njk', configPath.components + '**/index.njk'])
   .pipe(vinylPaths(paths => {
-    vinylInfo.componentName = paths.split(path.sep).slice(-2, -1)[0]
-    vinylInfo.componentPath = vinylInfo.componentName
-    vinylInfo.componentNunjucksFile = fs.readFileSync(configPath.components + vinylInfo.componentName + '/' + vinylInfo.componentName + '.njk', 'utf8')
+    objectData.componentName = paths.split(path.sep).slice(-2, -1)[0]
+    objectData.componentPath = objectData.componentName
+    objectData.componentNunjucksFile = fs.readFileSync(configPath.components + objectData.componentName + '/' + objectData.componentName + '.njk', 'utf8')
 
+    // we want to show all variants' code and macros on the component details page
+    let allFiles = fs.readdirSync('src/components/' + objectData.componentName + '/')
     let variantItems = []
-    let files = fs.readdirSync(configPath.components + vinylInfo.componentName + '/')
-    files.forEach(file => {
+    allFiles.forEach(file => {
       if (file.indexOf('.njk') > -1 && file.indexOf('--') > -1) {
-        let njk = fs.readFileSync('src/components/' + vinylInfo.componentName + '/' + file, 'utf8')
-        let name = file
-        let html = fs.readFileSync('public/components/' + vinylInfo.componentName + '/' + vinylInfo.componentName + '.html', 'utf8')
+        let fileName = file.split('.')[0]
+        let njk = fs.readFileSync('src/components/' + objectData.componentName + '/' + fileName + '.njk', 'utf8')
+        let html = fs.readFileSync('public/components/' + objectData.componentName + '/' + fileName + '.html', 'utf8')
         variantItems.push({
           njk: njk,
-          name: name,
+          name: fileName,
           html: html
         })
       }
     })
-    vinylInfo.variantItems = variantItems
+    objectData.variantItems = variantItems
     return Promise.resolve()
   }))
   .pipe(data(getDataForFile))
@@ -56,9 +58,9 @@ gulp.task('generate:readme', () => {
   .pipe(toMarkdown({
     gfm: true // github flavoured markdown https://github.com/domchristie/to-markdown#gfm-boolean
   }))
-  .pipe(rename(function (path) {
+  .pipe(rename(path => {
     path.basename = 'README'
     path.extname = '.md'
   }))
-  .pipe(gulp.dest(configPath.src + 'components/'))
+  .pipe(gulp.dest(configPath.components))
 })

--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -29,6 +29,22 @@ gulp.task('generate:readme', () => {
     vinylInfo.componentName = paths.split(path.sep).slice(-2, -1)[0]
     vinylInfo.componentPath = vinylInfo.componentName
     vinylInfo.componentNunjucksFile = fs.readFileSync(configPath.components + vinylInfo.componentName + '/' + vinylInfo.componentName + '.njk', 'utf8')
+
+    let variantItems = []
+    let files = fs.readdirSync(configPath.components + vinylInfo.componentName + '/')
+    files.forEach(file => {
+      if (file.indexOf('.njk') > -1 && file.indexOf('--') > -1) {
+        let njk = fs.readFileSync('src/components/' + vinylInfo.componentName + '/' + file, 'utf8')
+        let name = file
+        let html = fs.readFileSync('public/components/' + vinylInfo.componentName + '/' + vinylInfo.componentName + '.html', 'utf8')
+        variantItems.push({
+          njk: njk,
+          name: name,
+          html: html
+        })
+      }
+    })
+    vinylInfo.variantItems = variantItems
     return Promise.resolve()
   }))
   .pipe(data(getDataForFile))


### PR DESCRIPTION
To aid the usefulness of our accessibility tests we're splitting variants out of the main file into separate files. 
This PR:
* updates app.js to store variants and make them available to the nunjucks template
* updates the component preview and view templates to include the variants section
* updates the gulp generate:readme task to show the same content
* splits button as an example 

@gemmaleigh have a look at the new content structure if it makes sense