### PR TITLE
Remove whitespace and fix component indentation

### DIFF
--- a/src/components/breadcrumb/breadcrumb.njk
+++ b/src/components/breadcrumb/breadcrumb.njk
@@ -1,9 +1,9 @@
 {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
-{{ govukBreadcrumb(
+{{- govukBreadcrumb(
   classes='',
   [
     { title: 'Home', url: '/' },
     { title: 'Current page' }
   ]
-) }}
+) -}}

--- a/src/components/breadcrumb/template.njk
+++ b/src/components/breadcrumb/template.njk
@@ -1,13 +1,14 @@
-<div class="govuk-c-breadcrumb {{ classes }}">
+<div class="govuk-c-breadcrumb
+{%- if classes %} {{ classes }}{% endif %}">
   <ol class="govuk-c-breadcrumb__list">
-    {% for breadcrumb in breadcrumbs %}
-      {% if breadcrumb.url %}
-      <li class="govuk-c-breadcrumb__list-item">
-        <a class="govuk-c-breadcrumb__link" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
-      </li>
-      {% else %}
-      <li class="govuk-c-breadcrumb__list-item" aria-current="page">{{ breadcrumb.title }}</li>
-      {% endif %}
-    {% endfor %}
+  {% for breadcrumb in breadcrumbs %}
+    {% if breadcrumb.url %}
+    <li class="govuk-c-breadcrumb__list-item">
+      <a class="govuk-c-breadcrumb__link" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
+    </li>
+    {% else %}
+    <li class="govuk-c-breadcrumb__list-item" aria-current="page">{{ breadcrumb.title }}</li>
+    {% endif %}
+  {% endfor %}
   </ol>
 </div>

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -1,7 +1,13 @@
 {% if url %}
-<a class="govuk-c-button {% if isStart %} govuk-c-button--start {% endif %} {{ classes }}" href="{{ url | safe }}" role="button">
-  {% if text %}{{ text }}{% endif %}
+<a class="govuk-c-button
+{%- if isStart %} govuk-c-button--start{% endif %}
+{%- if classes %} {{ classes }}{% endif %}" href="{{ url | safe }}" role="button">
+  {%- if text %}{{ text }}{% endif %}
 </a>
 {% else %}
-<input class="govuk-c-button {% if isDisabled %} govuk-c-button--disabled {% endif %} {{ classes }}" {% if text %}value="{{ text }}"{% endif %} {% if isDisabled %}disabled="disabled" aria-disabled="true"{% endif %}>
+<input class="govuk-c-button
+{%- if isDisabled %} govuk-c-button--disabled{% endif %}
+{%- if classes %} {{ classes }}{% endif %}"
+{%- if text %} value="{{ text }}"{% endif %}
+{%- if isDisabled %} disabled="disabled" aria-disabled="true"{% endif %}>
 {% endif %}

--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -1,6 +1,6 @@
 {% from 'checkbox/macro.njk' import govukCheckbox %}
 
-{{ govukCheckbox(
+{{- govukCheckbox(
   classes='',
   name='waste-types',
   id='waste-type',
@@ -28,4 +28,4 @@
       disabled: 'true'
     }
   ]
-) }}
+) -}}

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -1,6 +1,9 @@
 {% for checkbox in checkboxes %}
-  <div class="govuk-c-checkbox {{ classes }}">
-    <input class="govuk-c-checkbox__input" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"  {% if checkbox.checked %}checked{% endif %} {% if checkbox.disabled %}disabled{% endif %}>
-    <label class="govuk-c-checkbox__label" for="{{ id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
-  </div>
+<div class="govuk-c-checkbox
+{%- if classes %} {{ classes }}{% endif %}">
+  <input class="govuk-c-checkbox__input" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"
+  {%- if checkbox.checked %} checked{% endif %}
+  {%- if checkbox.disabled %} disabled{% endif %}>
+  <label class="govuk-c-checkbox__label" for="{{ id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
+</div>
 {% endfor %}

--- a/src/components/cookie-banner/cookie-banner.njk
+++ b/src/components/cookie-banner/cookie-banner.njk
@@ -1,6 +1,7 @@
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
-{{ govukCookieBanner(
+
+{{- govukCookieBanner(
   classes='',
   cookieBannerText='GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
   )
-}}
+-}}

--- a/src/components/cookie-banner/template.njk
+++ b/src/components/cookie-banner/template.njk
@@ -1,3 +1,4 @@
-<div class="govuk-c-cookie-banner js-cookie-banner {{ classes }}">
+<div class="govuk-c-cookie-banner js-cookie-banner
+{%- if classes %} {{ classes }}{% endif %}">
   <p class="govuk-c-cookie-banner__text">{{ cookieBannerText | safe }}</p>
 </div>

--- a/src/components/date/date.njk
+++ b/src/components/date/date.njk
@@ -1,6 +1,6 @@
 {% from "date/macro.njk" import govukDate %}
 
-{{ govukDate(
+{{- govukDate(
   fieldsetClasses='',
   legendText='What is your date of birth?',
   legendHintText='For example, 31 3 1980',
@@ -22,9 +22,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukDate(
+{{- govukDate(
   fieldsetClasses='',
   legendText='What is your date of birth?',
   legendHintText='For example, 31 3 1980',
@@ -46,9 +46,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukDate(
+{{- govukDate(
   fieldsetClasses='',
   legendText='What is your date of birth?',
   legendHintText='For example, 31 3 1980',
@@ -70,9 +70,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukDate(
+{{- govukDate(
   fieldsetClasses='',
   legendText='What is your date of birth?',
   legendHintText='For example, 31 3 1980',
@@ -94,9 +94,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukDate(
+{{- govukDate(
   fieldsetClasses='',
   legendText='What is your date of birth?',
   legendHintText='For example, 31 3 1980',
@@ -118,4 +118,4 @@
     }
   ]
   )
-}}
+-}}

--- a/src/components/date/template.njk
+++ b/src/components/date/template.njk
@@ -1,12 +1,14 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 
 {% call govukFieldset(fieldsetClasses='', legendText, legendHintText, legendErrorMessage) %}
-<div class="govuk-c-date {{ classes }}">
-  {% for item in dateItems %}
-  <div class="govuk-c-date__item govuk-c-date__item--{{ item.name }}">
-    <label class="govuk-c-label govuk-c-date__label" for="{{ id }}-{{ item.name }}">{{ (item.name) | capitalize }}</label>
-    <input class="govuk-c-input govuk-c-date__input {% if item.error %}govuk-c-input--error{% endif %}" id="{{ id }}-{{ item.name }}" name="{{ name }}-{{ item.name }}" type="number">
+  <div class="govuk-c-date
+    {%- if classes %} {{ classes }}{% endif %}">
+    {% for item in dateItems %}
+    <div class="govuk-c-date__item govuk-c-date__item--{{ item.name }}">
+      <label class="govuk-c-label govuk-c-date__label" for="{{ id }}-{{ item.name }}">{{ (item.name) | capitalize }}</label>
+      <input class="govuk-c-input govuk-c-date__input
+      {%- if item.error %}govuk-c-input--error{% endif %}" id="{{ id }}-{{ item.name }}" name="{{ name }}-{{ item.name }}" type="number">
+    </div>
+    {% endfor %}
   </div>
-  {% endfor %}
-</div>
 {% endcall %}

--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -1,6 +1,6 @@
 {% from "details/macro.njk" import govukDetails %}
 
-{{ govukDetails(
+{{- govukDetails(
   classes='',
   detailsSummaryText='Help with nationality',
   detailsText='<p>
@@ -10,4 +10,4 @@
     We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
   </p>'
   )
-}}
+-}}

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -1,4 +1,5 @@
-<details class="govuk-c-details {{ classes }}">
+<details class="govuk-c-details
+  {%- if classes %} {{ classes }}{% endif %}">
   <summary class="govuk-c-details__summary">
     <span class="govuk-c-details__summary-text">{{ detailsSummaryText}}</span>
   </summary>

--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -1,7 +1,7 @@
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
-{{ govukErrorMessage(
+{{- govukErrorMessage(
   classes='',
   errorMessage='Error message goes here'
   )
-}}
+-}}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,3 +1,2 @@
-<span class="govuk-c-error-message {{ classes }}">
-  {{ errorMessage }}
-</span>
+<span class="govuk-c-error-message
+  {%- if classes %} {{ classes }}{% endif %}">{{ errorMessage }}</span>

--- a/src/components/error-summary/error-summary.njk
+++ b/src/components/error-summary/error-summary.njk
@@ -1,6 +1,6 @@
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 
-{{ govukErrorSummary(
+{{- govukErrorSummary(
   classes='',
   title='Message to alert the user to a problem goes here',
   description='Optional description of the errors and how to correct them',
@@ -15,4 +15,5 @@
       url: '#example-error-2'
     }
   ]
-) }}
+)
+-}}

--- a/src/components/error-summary/template.njk
+++ b/src/components/error-summary/template.njk
@@ -1,11 +1,10 @@
-{% from "list/macro.njk" import govukList %}
+{% from "list/macro.njk" import govukList -%}
 
-<div class="govuk-c-error-summary {{ classes }}" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
-
+<div class="govuk-c-error-summary
+  {%- if classes %} {{ classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
   <h2 class="govuk-c-error-summary__title" id="error-summary-title">
     {{ title }}
   </h2>
-
   <div class="govuk-c-error-summary__body">
     {% if description %}
     <p>
@@ -14,5 +13,4 @@
     {% endif %}
     {{ govukList(classes=listClasses + ' govuk-c-error-summary__list', listItems, listOptions) }}
   </div>
-
 </div>

--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -1,9 +1,9 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 
-{{ govukFieldset(
+{{- govukFieldset(
   classes='',
   text='Legend text goes here',
   hintText='Legend hint text goes here',
   errorMessage='Error message goes here'
   )
-}}
+-}}

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,18 +1,17 @@
-{% from "error-message/macro.njk" import govukErrorMessage %}
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 
-<fieldset class="govuk-c-fieldset {{ classes }}">
-{% if text %}
+<fieldset class="govuk-c-fieldset
+  {%- if classes %} {{ classes }}{% endif %}">
+  {% if text %}
   <legend class="govuk-c-fieldset__legend">
     {{ text }}
-
     {% if hintText %}
     <span class="govuk-c-fieldset__hint">{{ hintText }}</span>
     {% endif %}
-
     {% if errorMessage %}
-      {{ govukErrorMessage(errorMessage) }}
+    {{ govukErrorMessage(errorMessage) -}}
     {% endif %}
   </legend>
-{% endif %}
+{%- endif -%}
 {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
 </fieldset>

--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -1,15 +1,15 @@
 {% from "file-upload/macro.njk" import govukFileUpload %}
 
-{{ govukFileUpload(
+{{- govukFileUpload(
   classes='',
   labelText='Upload a file',
   errorMessage='',
   id='file-upload-1',
   name='file-upload-1'
   )
-}}
+-}}
 
-{{ govukFileUpload(
+{{- govukFileUpload(
   classes='',
   labelText='Upload your photo',
   hintText='Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.',
@@ -17,9 +17,9 @@
   id='file-upload-2',
   name='file-upload-2'
   )
-}}
+-}}
 
-{{ govukFileUpload(
+{{- govukFileUpload(
   classes='',
   labelText='Upload a file',
   hintText='',
@@ -27,4 +27,4 @@
   id='file-upload-3',
   name='file-upload-3'
   )
-}}
+-}}

--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -1,29 +1,32 @@
 {% from "file-upload/macro.njk" import govukFileUpload %}
 
 {{- govukFileUpload(
-  classes='',
+  labelClasses='',
   labelText='Upload a file',
   errorMessage='',
+  classes='',
   id='file-upload-1',
   name='file-upload-1'
   )
 -}}
 
 {{- govukFileUpload(
-  classes='',
+  labelClasses='',
   labelText='Upload your photo',
   hintText='Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.',
   errorMessage='',
+  classes='',
   id='file-upload-2',
   name='file-upload-2'
   )
 -}}
 
 {{- govukFileUpload(
-  classes='',
+  labelClasses='',
   labelText='Upload a file',
   hintText='',
   errorMessage='Error message goes here',
+  classes='',
   id='file-upload-3',
   name='file-upload-3'
   )

--- a/src/components/file-upload/macro.njk
+++ b/src/components/file-upload/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukFileUpload(classes, labelText, hintText, errorMessage, id, name, value) %}
+{% macro govukFileUpload(labelClasses, labelText, hintText, errorMessage, classes, id, name, value) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,6 +1,7 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel(classes, labelText, hintText, errorMessage, id) -}}
+{{- govukLabel(labelClasses, labelText, hintText, errorMessage, id) -}}
 
 <input class="govuk-c-file-upload
+{%- if classes %} {{ classes }}{% endif %}
 {%- if errorMessage %} govuk-c-file-upload--error{% endif %}" id="{{ id }}" name="{{ name }}" type="file">

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,5 +1,6 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{ govukLabel(classes, labelText, hintText, errorMessage, id) }}
+{{- govukLabel(classes, labelText, hintText, errorMessage, id) -}}
 
-<input class="govuk-c-file-upload {% if errorMessage %}govuk-c-file-upload--error{% endif %}" id="{{ id }}" name="{{ name }}" type="file">
+<input class="govuk-c-file-upload
+{%- if errorMessage %} govuk-c-file-upload--error{% endif %}" id="{{ id }}" name="{{ name }}" type="file">

--- a/src/components/grid/grid.njk
+++ b/src/components/grid/grid.njk
@@ -1,23 +1,23 @@
 {% from "grid/macro.njk" import govukGrid %}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'full' }
   ]
   )
-}}
+-}}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'one-half' },
     { width: 'one-half' }
   ]
   )
-}}
+-}}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'one-third' },
@@ -25,27 +25,27 @@
     { width: 'one-third' }
   ]
   )
-}}
+-}}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'two-thirds' },
     { width: 'one-third' }
   ]
   )
-}}
+-}}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'one-third' },
     { width: 'two-thirds' }
   ]
   )
-}}
+-}}
 
-{{ govukGrid(
+{{- govukGrid(
   classes='',
   gridItems=[
     { width: 'one-quarter' },
@@ -54,4 +54,4 @@
     { width: 'one-quarter' }
   ]
   )
-}}
+-}}

--- a/src/components/grid/template.njk
+++ b/src/components/grid/template.njk
@@ -1,9 +1,10 @@
 {% from "grid/macro.njk" import govukGrid %}
 
-<div class="govuk-c-grid {{ classes }}">
+<div class="govuk-c-grid
+  {%- if classes %} {{ classes }}{% endif %}">
   {% for item in gridItems %}
   <div class="govuk-c-grid__item govuk-c-grid__item--{{ item.width }}">
-    {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
+    {{- caller() if caller -}} {# if statement allows usage of `call` to be optional #}
   </div>
   {% endfor %}
 </div>

--- a/src/components/input/input.njk
+++ b/src/components/input/input.njk
@@ -1,32 +1,35 @@
 {% from "input/macro.njk" import govukInput %}
 
-{{ govukInput(
-  classes='',
+{{- govukInput(
+  labelClasses='',
   labelText='National Insurance number',
   hintText='',
   errorMessage='',
+  classes='',
   id='input-1',
   name='test-name'
   )
-}}
+-}}
 
-{{ govukInput(
-  classes='',
+{{- govukInput(
+  labelClasses='',
   labelText='National Insurance number',
   hintText='It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.',
   errorMessage='',
+  classes='',
   id='input-2',
   name='test-name-2'
   )
-}}
+-}}
 
-{{ govukInput(
-  classes='',
+{{- govukInput(
+  labelClasses='',
   labelText='National Insurance number',
   hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
     For example, ‘QQ 12 34 56 C’.',
   errorMessage='Error message goes here',
+  classes='',
   id='input-3',
   name='test-name-3'
   )
-}}
+-}}

--- a/src/components/input/macro.njk
+++ b/src/components/input/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukInput(classes, labelText, hintText, errorMessage, id, name, value) %}
+{% macro govukInput(labelClasses, labelText, hintText, errorMessage, classes, id, name, value) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,5 +1,8 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{ govukLabel(classes, labelText, hintText, errorMessage, id) }}
+{{- govukLabel(labelClasses, labelText, hintText, errorMessage, id) -}}
 
-<input class="govuk-c-input {% if errorMessage %}govuk-c-input--error{% endif %}" id="{{ id }}" name="{{ name }}" type="text" {% if value %}value="{{ value}}"{% endif %}>
+<input class="govuk-c-input
+{%- if classes %} {{ classes }}{% endif %}
+{%- if errorMessage %} govuk-c-input--error{% endif %}" id="{{ id }}" name="{{ name }}" type="text"
+{%- if value %} value="{{ value}}"{% endif %}>

--- a/src/components/inset-text/inset-text.njk
+++ b/src/components/inset-text/inset-text.njk
@@ -1,10 +1,10 @@
 {% from "inset-text/macro.njk" import govukInsetText %}
 
-{{ govukInsetText(
+{{- govukInsetText(
   classes='',
   content='<p>
     It can take up to 8 weeks to register a lasting power of attorney if<br>
     there are no mistakes in the application.
   </p>'
   )
-}}
+-}}

--- a/src/components/inset-text/macro.njk
+++ b/src/components/inset-text/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukInsetText(classes='', content) %}
-  {% include './template.njk' %}
+  {%- include './template.njk' -%}
 {% endmacro %}

--- a/src/components/inset-text/template.njk
+++ b/src/components/inset-text/template.njk
@@ -1,3 +1,4 @@
-<div class="govuk-c-inset-text {{ classes }}">
+<div class="govuk-c-inset-text
+  {%- if classes %} {{ classes }}{% endif %}">
   {{ content | safe }}
 </div>

--- a/src/components/label/label.njk
+++ b/src/components/label/label.njk
@@ -1,24 +1,24 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{ govukLabel(
+{{- govukLabel(
   classes='',
   labelText='National Insurance number',
   hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
     For example, ‘QQ 12 34 56 C’.',
   id=''
   )
-}}
+-}}
 
-{{ govukLabel(
+{{- govukLabel(
   classes='govuk-c-label--bold',
   labelText='National Insurance number',
   hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
     For example, ‘QQ 12 34 56 C’.',
   id=''
   )
-}}
+-}}
 
-{{ govukLabel(
+{{- govukLabel(
   classes='',
   labelText='National Insurance number',
   hintText='It’s on your National Insurance card, benefit letter, payslip or P60.
@@ -26,4 +26,4 @@
   errorMessage='Error message goes here',
   id=''
   )
-}}
+-}}

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -1,13 +1,14 @@
-{% from "error-message/macro.njk" import govukErrorMessage %}
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 
-<label class="govuk-c-label {% if classes %} {{ classes }} {% endif %}" for="{{ id }}">
+<label class="govuk-c-label
+  {%- if classes %} {{ classes }}{% endif %}" for="{{ id }}">
   {{ labelText }}
-
-  {%- if hintText %}
-    <span class="govuk-c-label__hint">{{ hintText }}</span>
+  {% if hintText %}
+  <span class="govuk-c-label__hint">
+    {{ hintText }}
+  </span>
   {% endif %}
-
   {% if errorMessage %}
-    {{ govukErrorMessage(errorMessage) }}
+  {{ govukErrorMessage(errorMessage) -}}
   {% endif %}
 </label>

--- a/src/components/legal-text/legal-text.njk
+++ b/src/components/legal-text/legal-text.njk
@@ -1,7 +1,8 @@
 {% from "legal-text/macro.njk" import govukLegalText %}
 
-{{ govukLegalText(
+{{- govukLegalText(
   classes='',
   iconFallbackText='Warning',
-  legalText='You can be fined up to £5,000 if you don’t register.')
-}}
+  legalText='You can be fined up to £5,000 if you don’t register.'
+  )
+-}}

--- a/src/components/legal-text/template.njk
+++ b/src/components/legal-text/template.njk
@@ -1,6 +1,7 @@
-{% from "legal-text/macro.njk" import govukLegalText %}
+{% from "legal-text/macro.njk" import govukLegalText -%}
 
-<div class="govuk-c-legal-text {{ classes }}">
+<div class="govuk-c-legal-text
+  {%- if classes %} {{ classes }}{% endif %}">
   <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
   <strong class="govuk-c-legal-text__text">
     <span class="govuk-c-legal-text__assistive">{{ iconFallbackText }}</span>

--- a/src/components/link/link.njk
+++ b/src/components/link/link.njk
@@ -1,25 +1,25 @@
 {% from "link/macro.njk" import govukLink %}
 
-{{ govukLink(
+{{- govukLink(
   classes='govuk-c-link--back',
   linkHref='',
   linkText='Back')
-}}
+-}}
 
-{{ govukLink(
+{{- govukLink(
   classes='govuk-c-link--muted',
   linkHref='',
   linkText='Is there anything wrong with this page?')
-}}
+-}}
 
-{{ govukLink(
+{{- govukLink(
   classes='govuk-c-link--download',
   linkHref='',
-  tagText='Download')
-}}
+  linkText='Download')
+-}}
 
-{{ govukLink(
+{{- govukLink(
   classes='govuk-c-link--skip',
   linkHref='',
   linkText='Skip to main content')
-}}
+-}}

--- a/src/components/link/template.njk
+++ b/src/components/link/template.njk
@@ -1,1 +1,2 @@
-<a href="{{ href }}" class="govuk-c-link {{ classes }}">{{ linkText | safe }}</a>
+<a href="{{ href }}" class="govuk-c-link
+  {%- if classes %} {{ classes }}{% endif %}">{{ linkText | safe }}</a>

--- a/src/components/list/list.njk
+++ b/src/components/list/list.njk
@@ -1,6 +1,6 @@
-{% from "list/macro.njk" import govukList %}
+{% from "list/macro.njk" import govukList -%}
 
-{{ govukList(
+{{- govukList(
   classes='',
   [
     {
@@ -16,9 +16,10 @@
       url: '/'
     }
   ]
-) }}
+)
+-}}
 
-{{ govukList(
+{{- govukList(
   classes='',
   [
     {
@@ -34,9 +35,10 @@
   options = {
     'isBullet': 'true'
   }
-) }}
+)
+-}}
 
-{{ govukList(
+{{- govukList(
   classes='',
   [
     {
@@ -52,9 +54,10 @@
   options = {
     'isNumber': 'true'
   }
-) }}
+)
+-}}
 
-{{ govukList(
+{{- govukList(
   classes='',
   [
     {
@@ -70,9 +73,10 @@
   options = {
     'isStep': 'true'
   }
-) }}
+)
+-}}
 
-{{ govukList(
+{{- govukList(
   classes='',
   [
     {
@@ -88,4 +92,5 @@
   options = {
     'isStepLarge': 'true'
   }
-) }}
+)
+-}}

--- a/src/components/list/template.njk
+++ b/src/components/list/template.njk
@@ -1,27 +1,35 @@
 {% if options.isBullet %}
-<ul class="govuk-c-list govuk-c-list--bullet {{ classes }}">
+<ul class="govuk-c-list govuk-c-list--bullet
+  {%- if classes %} {{ classes }}{% endif %}">
 {% elseif options.isNumber %}
-<ol class="govuk-c-list govuk-c-list--number {{ classes }}">
+<ol class="govuk-c-list govuk-c-list--number
+  {%- if classes %} {{ classes }}{% endif %}">
 {% elseif options.isStep %}
-<ol class="govuk-c-list govuk-c-list--icon {{ classes }}">
+<ol class="govuk-c-list govuk-c-list--icon
+  {%- if classes %} {{ classes }}{% endif %}">
 {% elseif options.isStepLarge %}
-<ol class="govuk-c-list govuk-c-list--icon {{ classes }}">
+<ol class="govuk-c-list govuk-c-list--icon
+  {%- if classes %} {{ classes }}{% endif %}">
 {% else %}
-<ul class="govuk-c-list {{ classes }}">
+<ul class="govuk-c-list
+  {%- if classes %} {{ classes }}{% endif %}">
 {% endif %}
 
-{% for item in listItems %}
+{%- for item in listItems %}
   <li>
     {% if (options.isStep) or (options.isStepLarge) %}
-      <span class="govuk-c-list__icon govuk-u-circle {% if (options.isStepLarge) %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span>
-      {{ item.text }}
+    <span class="govuk-c-list__icon govuk-u-circle {% if (options.isStepLarge) %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span> {{ item.text }}
     {% else %}
-      {% if item.url %}<a href="{{ item.url }} ">{% endif %}
-        {{ item.text }}
-      {% if item.url %}</a>{% endif %}
+    {% if item.url %}
+    <a href="{{ item.url }}">
+    {% endif %}
+    {{ item.text }}
+    {% if item.url %}
+    </a>
+    {% endif %}
     {% endif %}
   </li>
-{% endfor %}
+{% endfor -%}
 
 {% if (options.isNumber) or (options.isStep) or (options.isStepLarge) %}
 </ol>

--- a/src/components/pagination/pagination.njk
+++ b/src/components/pagination/pagination.njk
@@ -1,6 +1,6 @@
-{% from "pagination/macro.njk" import govukPagination %}
+{% from "pagination/macro.njk" import govukPagination -%}
 
-{{ govukPagination(
+{{- govukPagination(
   classes='',
   previousPage=[
    {
@@ -10,9 +10,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukPagination(
+{{- govukPagination(
   classes='',
   nextPage=[
    {
@@ -22,9 +22,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukPagination(
+{{- govukPagination(
   classes='',
   previousPage=[
    {
@@ -41,9 +41,9 @@
     }
   ]
   )
-}}
+-}}
 
-{{ govukPagination(
+{{- govukPagination(
   classes='',
   previousPage=[
    {
@@ -58,4 +58,4 @@
     }
   ]
   )
-}}
+-}}

--- a/src/components/pagination/template.njk
+++ b/src/components/pagination/template.njk
@@ -1,4 +1,5 @@
-<nav class="govuk-c-pagination {{ classes }}" role="navigation" aria-label="Pagination">
+<nav class="govuk-c-pagination
+  {%- if classes %} {{ classes }}{% endif %}" role="navigation" aria-label="Pagination">
   <ul class="govuk-c-pagination__list">
     {% if previousPage %}
     {% for page in previousPage %}
@@ -11,7 +12,7 @@
           {{ page.title }}
         </span>
         {% if page.label %}
-          <span class="govuk-c-pagination__link-label">{{ page.label }}</span>
+        <span class="govuk-c-pagination__link-label">{{ page.label }}</span>
         {% endif %}
       </a>
     </li>

--- a/src/components/panel/panel.njk
+++ b/src/components/panel/panel.njk
@@ -1,9 +1,9 @@
 {% from "panel/macro.njk" import govukPanel %}
 
-{{ govukPanel(
+{{- govukPanel(
   classes='',
   title='Application complete',
   content='Your reference number is',
   reference='HDJ2123F'
   )
-}}
+-}}

--- a/src/components/panel/template.njk
+++ b/src/components/panel/template.njk
@@ -1,4 +1,5 @@
-<div class="govuk-c-panel govuk-c-panel--confirmation {{ classes }}">
+<div class="govuk-c-panel govuk-c-panel--confirmation
+  {%- if classes %} {{ classes }}{% endif %}">
   <h2 class="govuk-c-panel__title">
     {{ title }}
   </h2>

--- a/src/components/phase-banner/phase-banner.njk
+++ b/src/components/phase-banner/phase-banner.njk
@@ -1,5 +1,5 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{{ govukPhaseBanner(
+{{- govukPhaseBanner(
   phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
   phaseTagText='BETA')
-}}
+-}}

--- a/src/components/phase-banner/template.njk
+++ b/src/components/phase-banner/template.njk
@@ -1,6 +1,7 @@
-{% from "phase-tag/macro.njk" import govukPhaseTag %}
+{% from "phase-tag/macro.njk" import govukPhaseTag -%}
 
-<div class="govuk-c-phase-banner {{ classes }}">
+<div class="govuk-c-phase-banner
+  {%- if classes %} {{ classes }}{% endif %}">
   <p class="govuk-c-phase-banner__content">
     {{ govukPhaseTag(phaseTagText) }}
     <span class="govuk-c-phase-banner__text">

--- a/src/components/phase-tag/phase-tag.njk
+++ b/src/components/phase-tag/phase-tag.njk
@@ -1,3 +1,3 @@
-{% from "phase-tag/macro.njk" import govukPhaseTag %}
+{%- from "phase-tag/macro.njk" import govukPhaseTag -%}
 
-{{ govukPhaseTag(classes='', phaseTagText='Alpha') }}
+{{- govukPhaseTag(classes='', phaseTagText='Alpha') -}}

--- a/src/components/phase-tag/template.njk
+++ b/src/components/phase-tag/template.njk
@@ -1,1 +1,2 @@
-<strong class="govuk-c-phase-tag {{ classes }}"> {{ phaseTagText }}</strong>
+<strong class="govuk-c-phase-tag
+  {%- if classes %} {{ classes }}{% endif %}">{{ phaseTagText }}</strong>

--- a/src/components/radio/radio.njk
+++ b/src/components/radio/radio.njk
@@ -1,6 +1,6 @@
 {% from 'radio/macro.njk' import govukRadio %}
 
-{{ govukRadio(
+{{- govukRadio(
   classes='',
   name='radio-group',
   id='radio',
@@ -28,4 +28,4 @@
       disabled: 'true'
     }
   ]
-) }}
+) -}}

--- a/src/components/radio/template.njk
+++ b/src/components/radio/template.njk
@@ -1,6 +1,9 @@
 {% for radio in radios %}
-  <div class="govuk-c-radio">
-    <input class="govuk-c-radio__input {{ classes }}" id="{{ id }}-{{ radio.id }}" name="{{ name }}" type="radio" value="{{ radio.value }}" {% if radio.checked %}checked{% endif %} {% if radio.disabled %}disabled{% endif %}>
-    <label class="govuk-c-radio__label" for="{{ id }}-{{ radio.id }}">{{ radio.label }}</label>
-  </div>
+<div class="govuk-c-radio
+{%- if classes %} {{ classes }}{% endif %}">
+  <input class="govuk-c-radio__input" id="{{ id }}-{{ radio.id }}" name="{{ name }}" type="radio" value="{{ radio.value }}"
+  {%- if radio.checked %} checked{% endif %}
+  {%- if radio.disabled %} disabled{% endif %}>
+  <label class="govuk-c-radio__label" for="{{ id }}-{{ radio.id }}">{{ radio.label }}</label>
+</div>
 {% endfor %}

--- a/src/components/select-box/select-box.njk
+++ b/src/components/select-box/select-box.njk
@@ -1,7 +1,6 @@
 {% from "select-box/macro.njk" import govukSelectBox %}
 
-
-{{ govukSelectBox(
+{{- govukSelectBox(
   classes='',
   id='select-box-1',
   name='select-box-1',
@@ -19,9 +18,10 @@
       label: 'GOV.UK frontend option 3'
     }
   ]
-)}}
+)
+-}}
 
-{{ govukSelectBox(
+{{- govukSelectBox(
   hasLabelWithText='Label for select box',
   labelClasses='',
   classes='',
@@ -42,4 +42,6 @@
       label: 'GOV.UK frontend option c'
     }
   ]
-)}}
+)
+-}}
+

--- a/src/components/select-box/template.njk
+++ b/src/components/select-box/template.njk
@@ -4,8 +4,10 @@
 {% set forAttribute = id %}
 {{ govukLabel(labelClasses, hasLabelWithText, '', '', forAttribute) }}
 {% endif %}
-<select class="govuk-c-select-box {{ classes }}" id="{{ id }}" name="{{ name }}">
+<select class="govuk-c-select-box
+  {%- if classes %} {{ classes }}{% endif %}" id="{{ id }}" name="{{ name }}">
   {% for option in options %}
-  <option value="{{ option.value }}"{% if option.selected %}selected{% endif %}>{{ option.label }}</option>
+  <option value="{{ option.value }}"
+  {%- if option.selected %} selected{% endif %}>{{ option.label }}</option>
   {% endfor %}
 </select>

--- a/src/components/site-width-container/macro.njk
+++ b/src/components/site-width-container/macro.njk
@@ -1,3 +1,3 @@
 {% macro govukSiteWidthContainer(classes='') %}
   {%- include "./template.njk" -%}
-{% endmacro %}
+{% endmacro -%}

--- a/src/components/site-width-container/site-width-container.njk
+++ b/src/components/site-width-container/site-width-container.njk
@@ -1,3 +1,3 @@
-{% from "site-width-container/macro.njk" import govukSiteWidthContainer %}
+{% from "site-width-container/macro.njk" import govukSiteWidthContainer -%}
 
 {{ govukSiteWidthContainer(classes) }}

--- a/src/components/site-width-container/template.njk
+++ b/src/components/site-width-container/template.njk
@@ -1,3 +1,4 @@
-<div class="govuk-c-site-width-container {{ classes }}">
+<div class="govuk-c-site-width-container
+{% if classes %}{{ classes }}{% endif -%}">
   {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
 </div>

--- a/src/components/site-width-container/template.njk
+++ b/src/components/site-width-container/template.njk
@@ -1,4 +1,4 @@
 <div class="govuk-c-site-width-container
-{% if classes %}{{ classes }}{% endif -%}">
+  {% if classes %}{{ classes }}{% endif %}">
   {{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
 </div>

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -1,14 +1,19 @@
-<table class="govuk-c-table {{ classes }}">
+<table class="govuk-c-table
+  {%- if classes %} {{ classes }}{% endif %}">
   {% if options.caption %}
-  <caption class="govuk-c-table__caption {% if options.captionSize %} {{ options.captionSize }} {% endif %}">{{ options.caption }}</caption>
+  <caption class="govuk-c-table__caption
+  {%- if options.captionSize %} {{ options.captionSize }}{% endif %}">{{ options.caption }}</caption>
   {% endif %}
   {% if data.head %}
   <thead class="govuk-c-table__head">
     <tr class="govuk-c-table__row">
     {% for item in data.head %}
-      <th class="govuk-c-table__header {% if item.type %} govuk-c-table__header--{{ item.type }} {% endif %}" {% if item.colspan %} colspan="{{ item.colspan }}" {% endif %} {% if item.rowspan %} rowspan="{{ item.rowspan }}" {% endif %} scope="col">{{ item.text }}</th>
+      <th class="govuk-c-table__header
+      {%- if item.type %} govuk-c-table__header--{{ item.type }}{% endif %}"
+      {%- if item.colspan %} colspan="{{ item.colspan }}"{% endif %}
+      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %} scope="col">{{ item.text }}</th>
     {% endfor %}
-  </tr>
+    </tr>
   </thead>
   {% endif %}
   <tbody class="govuk-c-table__body">
@@ -16,11 +21,16 @@
     <tr class="govuk-c-table__row">
     {% for cell in row %}
       {% if loop.first and options.isFirstCellHeader %}
-      <th class="govuk-c-table__header" scope="row"> {{ cell.text }}</th>
+      <th class="govuk-c-table__header" scope="row">{{ cell.text }}</th>
       {% elseif loop.first %}
-      <td class="govuk-c-table__cell {% if cell.type %} govuk-c-table__cell--{{cell.type}} {% endif %}" {% if cell.colspan %} colspan="{{ cell.colspan }}" {% endif %} {% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %} scope="row">{{ cell.text }}</td>
+      <td class="govuk-c-table__cell
+      {%- if cell.type %} govuk-c-table__cell--{{ cell.type }}{% endif %}"
+      {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
+      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %} scope="row">{{ cell.text }}</td>
       {% else %}
-      <td class="govuk-c-table__cell {% if cell.type %} govuk-c-table__cell--{{cell.type}} {% endif %}" {% if cell.colspan %} colspan="{{ cell.colspan }}" {% endif %} {% if cell.rowspan %} rowspan="{{ cell.rowspan }}" {% endif %}>{{ cell.text }}</td>
+      <td class="govuk-c-table__cell {% if cell.type %}govuk-c-table__cell--{{ cell.type }}{% endif %}"
+      {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
+      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.text }}</td>
       {% endif %}
     {% endfor %}
     </tr>

--- a/src/components/textarea/macro.njk
+++ b/src/components/textarea/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukTextarea(classes, labelText, hintText, errorMessage, id, name, value) %}
+{% macro govukTextarea(classes, labelText, hintText, errorMessage, id, name, value, rows) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,5 +1,7 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{ govukLabel(classes, labelText, hintText, errorMessage, id) }}
+{{- govukLabel(classes, labelText, hintText, errorMessage, id) -}}
 
-<textarea class="govuk-c-textarea {% if errorMessage %}govuk-c-input--error{% endif %} {{ classes }}" id="{{ id }}" name="{{ name }}" rows="{%if rows %} {{ rows }} {% else %} 5 {%endif %}"></textarea>
+<textarea class="govuk-c-textarea
+{%- if errorMessage %}govuk-c-input--error{% endif %}
+{%- if classes %} {{ classes }}{% endif -%}" id="{{ id }}" name="{{ name }}" rows="{%if rows %} {{- rows -}} {% else %}5{%endif %}"></textarea>

--- a/src/components/textarea/textarea.njk
+++ b/src/components/textarea/textarea.njk
@@ -9,3 +9,14 @@
   name='name'
   )
 }}
+
+{{ govukTextarea(
+  classes='',
+  labelText='National Insurance number',
+  hintText='',
+  errorMessage='',
+  id='textarea-2',
+  name='name-2',
+  rows='10'
+  )
+}}


### PR DESCRIPTION
This PR removes the whitespace after each class attribute and ensures the indentation of the HTML output when the component template file is compiled is correct.
