### PR TITLE
Link variants

### DIFF
--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -37,14 +37,71 @@ Link component, with four variants:
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-<!-- TODO: Use the table macro here and pass it component argument data -->
-| Name      | Type    | Default | Required  | Description
-|---        |---      |---      |---        |---
-| linkHref  | string  |         | Yes       | The value of the link href attribute
-| linkText  | string  |         | Yes       | The link text
-| classes   | string  |         | Yes       | The modifier required for the link type
-                                            | --back
-                                            | --muted
-                                            | --download
-                                            | --skip
+
+{{ govukTable(
+  classes='',
+  options = {
+    'isFirstCellHeader': 'true'
+  },
+  data = {
+    'head' : [
+      {
+        text: 'Name'
+      },
+      {
+        text: 'Type'
+      },
+      {
+        text: 'Required'
+      },
+      {
+        text: 'Description'
+      }
+    ],
+    'rows' : [
+      [
+        {
+          text: 'linkHref'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'Yes'
+        },
+        {
+          text: 'The value of the link href attribute'
+        }
+      ],
+      [
+        {
+          text: 'linkText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'Yes'
+        },
+        {
+          text: 'The link text'
+        }
+      ],
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'No'
+        },
+        {
+          text: 'The available modifiers for the link type: --back, --muted, --download and --skip'
+        }
+      ]
+    ]
+  }
+)}}
 {% endblock %}

--- a/src/components/link/link--back.njk
+++ b/src/components/link/link--back.njk
@@ -1,7 +1,7 @@
 {% from "link/macro.njk" import govukLink %}
 
 {{- govukLink(
-  classes='govuk-c-link',
+  classes='govuk-c-link--back',
   linkHref='',
-  linkText='Default link')
+  linkText='Back')
 -}}

--- a/src/components/link/link--download.njk
+++ b/src/components/link/link--download.njk
@@ -1,7 +1,7 @@
 {% from "link/macro.njk" import govukLink %}
 
 {{- govukLink(
-  classes='govuk-c-link',
+  classes='govuk-c-link--download',
   linkHref='',
-  linkText='Default link')
+  linkText='Download')
 -}}

--- a/src/components/link/link--muted.njk
+++ b/src/components/link/link--muted.njk
@@ -1,0 +1,7 @@
+{% from "link/macro.njk" import govukLink %}
+
+{{- govukLink(
+  classes='govuk-c-link--muted',
+  linkHref='',
+  linkText='Is there anything wrong with this page?')
+-}}

--- a/src/components/link/link--skip.njk
+++ b/src/components/link/link--skip.njk
@@ -1,7 +1,7 @@
 {% from "link/macro.njk" import govukLink %}
 
 {{- govukLink(
-  classes='govuk-c-link',
+  classes='govuk-c-link--skip',
   linkHref='',
-  linkText='Default link')
+  linkText='Skip to main content')
 -}}


### PR DESCRIPTION
This PR:
* splits link variable into separate files
* replaces markdown table syntax with govuk-c-table component, to be consistent with other components