### PR TITLE
Add whitespace between classes to show input error state styling

### DIFF
--- a/src/components/date/template.njk
+++ b/src/components/date/template.njk
@@ -6,8 +6,7 @@
     {% for item in dateItems %}
     <div class="govuk-c-date__item govuk-c-date__item--{{ item.name }}">
       <label class="govuk-c-label govuk-c-date__label" for="{{ id }}-{{ item.name }}">{{ (item.name) | capitalize }}</label>
-      <input class="govuk-c-input govuk-c-date__input
-      {%- if item.error %}govuk-c-input--error{% endif %}" id="{{ id }}-{{ item.name }}" name="{{ name }}-{{ item.name }}" type="number">
+      <input class="govuk-c-input govuk-c-date__input {%- if item.error %} govuk-c-input--error{% endif %}" id="{{ id }}-{{ item.name }}" name="{{ name }}-{{ item.name }}" type="number">
     </div>
     {% endfor %}
   </div>


### PR DESCRIPTION
We've been too agressive removing whitespace from output that we've removed space between element class and error class. 

This PR adds the space back in so that the error state is correctly shown

Screenshots
Before
![screen shot 2017-09-19 at 13 46 14](https://user-images.githubusercontent.com/3758555/30593442-74bd73c8-9d42-11e7-8aa6-146ce8d87432.png)


After
![screen shot 2017-09-19 at 13 47 55](https://user-images.githubusercontent.com/3758555/30593449-7c203e20-9d42-11e7-891f-ebd3cbdaf876.png)

