### PR TITLE
Compile components before generating README files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -68,8 +68,8 @@ gulp.task('copy-assets', cb => {
 // --------------------------------------
 gulp.task('dev', cb => {
   runsequence(
-              'generate:readme',
               'compile:components',
+              'generate:readme',
               'copy-assets',
               'serve',
               cb)


### PR DESCRIPTION
The task to generate the readme files requires that the nunjucks
templates have first been compiled to html.