### PR TITLE
Split fieldset component variants

### DIFF
--- a/src/components/fieldset/fieldset--with-legend-hint-and-error.njk
+++ b/src/components/fieldset/fieldset--with-legend-hint-and-error.njk
@@ -1,0 +1,8 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset(
+  classes='',
+  text='Legend text goes here',
+  hintText='Legend hint text goes here',
+  errorMessage='Error message goes here'
+) }}

--- a/src/components/fieldset/fieldset--with-legend-hint-and-error.njk
+++ b/src/components/fieldset/fieldset--with-legend-hint-and-error.njk
@@ -2,7 +2,7 @@
 
 {{ govukFieldset(
   classes='',
-  text='Legend text goes here',
-  hintText='Legend hint text goes here',
-  errorMessage='Error message goes here'
+  legendText='Legend text goes here',
+  legendHintText='Legend hint text goes here',
+  legendErrorMessage='Error message goes here'
 ) }}

--- a/src/components/fieldset/fieldset--with-legend.njk
+++ b/src/components/fieldset/fieldset--with-legend.njk
@@ -2,7 +2,7 @@
 
 {{ govukFieldset(
   classes='',
-  text='Legend text goes here',
-  hintText='',
-  errorMessage=''
+  legendText='Legend text goes here',
+  legendHintText='',
+  legendErrorMessage=''
 ) }}

--- a/src/components/fieldset/fieldset--with-legend.njk
+++ b/src/components/fieldset/fieldset--with-legend.njk
@@ -1,0 +1,8 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset(
+  classes='',
+  text='Legend text goes here',
+  hintText='',
+  errorMessage=''
+) }}

--- a/src/components/fieldset/fieldset-with-legend-and-hint.njk
+++ b/src/components/fieldset/fieldset-with-legend-and-hint.njk
@@ -1,0 +1,8 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
+
+{{ govukFieldset(
+  classes='',
+  text='Legend text goes here',
+  hintText='Legend hint text goes here',
+  errorMessage=''
+) }}

--- a/src/components/fieldset/fieldset-with-legend-and-hint.njk
+++ b/src/components/fieldset/fieldset-with-legend-and-hint.njk
@@ -2,7 +2,7 @@
 
 {{ govukFieldset(
   classes='',
-  text='Legend text goes here',
-  hintText='Legend hint text goes here',
-  errorMessage=''
+  legendText='Legend text goes here',
+  legendHintText='Legend hint text goes here',
+  legendErrorMessage=''
 ) }}

--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -2,7 +2,7 @@
 
 {{ govukFieldset(
   classes='',
-  legendText='Legend text goes here',
-  legendHintText='Legend hint text goes here',
-  legendErrorMessage='Error message goes here'
+  legendText='',
+  legendHintText='',
+  legendErrorMessage=''
 ) }}

--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -1,9 +1,8 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 
-{{- govukFieldset(
+{{ govukFieldset(
   classes='',
-  text='Legend text goes here',
-  hintText='Legend hint text goes here',
-  errorMessage='Error message goes here'
-  )
--}}
+  legendText='Legend text goes here',
+  legendHintText='Legend hint text goes here',
+  legendErrorMessage='Error message goes here'
+) }}

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -64,6 +64,34 @@
         {
           text: 'Legend text'
         }
+      ],
+      [
+        {
+          text: 'legendHintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Legend hint text'
+        }
+      ],
+      [
+        {
+          text: 'legendErrorMessage'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Legend error message'
+        }
       ]
     ]
   }

--- a/src/components/fieldset/macro.njk
+++ b/src/components/fieldset/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukFieldset(classes='', text, hintText, errorMessage) %}
+{% macro govukFieldset(classes='', legendText, legendHintText, legendErrorMessage) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -2,14 +2,14 @@
 
 <fieldset class="govuk-c-fieldset
   {%- if classes %} {{ classes }}{% endif %}">
-  {% if text %}
+  {% if legendText %}
   <legend class="govuk-c-fieldset__legend">
-    {{ text }}
-    {% if hintText %}
-    <span class="govuk-c-fieldset__hint">{{ hintText }}</span>
+    {{ legendText }}
+    {% if legendHintText %}
+    <span class="govuk-c-fieldset__hint">{{ legendHintText }}</span>
     {% endif %}
-    {% if errorMessage %}
-    {{ govukErrorMessage(errorMessage) -}}
+    {% if legendErrorMessage %}
+    {{ govukErrorMessage(legendErrorMessage) -}}
     {% endif %}
   </legend>
 {%- endif -%}


### PR DESCRIPTION
Split the fieldset component into its variants - with legend, legend and hint and legend hint and error text.

Prefix the attributes which apply to the legend element with `legend`.
