### PR TITLE
Use YAML definition for component view, variants and isolated preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "gulp-tenon-client": "^0.1.2",
     "gulp-to-markdown": "^1.0.0",
     "gulp-uglify": "^3.0.0",
+    "js-yaml": "^3.10.0",
     "lerna": "^2.0.0-rc.5",
     "merge-stream": "^1.0.1",
     "nodemon": "^1.12.0",

--- a/src/components/breadcrumb/breadcrumb.njk
+++ b/src/components/breadcrumb/breadcrumb.njk
@@ -1,9 +1,14 @@
 {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
-{{- govukBreadcrumb(
-  classes='',
-  [
-    { title: 'Home', url: '/' },
-    { title: 'Current page' }
-  ]
-) -}}
+{{ govukBreadcrumb(classes='',
+[
+  {
+    "title": "Section 1",
+    "url": "/section"
+  },
+  {
+    "title": "Sub-section",
+    "url": "/section/sub-section"
+  }
+]
+) }}

--- a/src/components/breadcrumb/breadcrumb.yaml
+++ b/src/components/breadcrumb/breadcrumb.yaml
@@ -5,7 +5,7 @@ variants:
         url: '/section'
       - title: 'Sub-section'
         url: '/section/sub-section'
-  - name: Single section
+  - name: single-section
     data:
       - title: 'Section 1'
         url: '/section'

--- a/src/components/breadcrumb/breadcrumb.yaml
+++ b/src/components/breadcrumb/breadcrumb.yaml
@@ -1,0 +1,34 @@
+variants:
+  - name: default
+    data:
+      - title: 'Section 1'
+        url: '/section'
+      - title: 'Sub-section'
+        url: '/section/sub-section'
+  - name: Single section
+    data:
+      - title: 'Section 1'
+        url: '/section'
+  - name: many-breadcrumbs
+    data:
+      - title: 'Home'
+        url: '/'
+      - title: 'Section 3'
+        url: '/section'
+      - title: 'Sub-section 1'
+        url: '/section/sub-section'
+      - title: 'Sub Sub-section 1'
+        url: '/section/sub-section/sub-sub-section'
+  - name: no-home-section
+    data:
+      - title: 'Service Manual'
+        url: '/service-manual'
+      - title: 'Agile Delivery'
+        url: '/service-manual/agile-delivery'
+  - name: last-breadcrumb-is-current-page
+    data:
+      - title: 'Home'
+        url: '/'
+      - title: 'Passports, travel and living abroad'
+        url: '/browse/abroad'
+      - title: 'Travel abroad'

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -23,12 +23,13 @@ A breadcrumb is a GOV.UK element that helps users to understand where they are w
 
 {% if not isReadme %}
 {{ govukBreadcrumb(classes='', item.data) }}
-{% endif %}
+
 
 <p class="govuk-u-copy-19">
 <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
 </a>
 </p>
+{% endif %}
 <h4 class="govuk-u-copy-19">Markup</h4>
 
 {% set componentHtml %}

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -1,18 +1,54 @@
 {% extends "component.njk" %}
+{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
-{# componentName #}
 {% block componentDescription %}
 A breadcrumb is a GOV.UK element that helps users to understand where they are within the site and move between levels.
+{% endblock %}
+
+{% block defaultAndVariants %}
+{% for item in componentData.variants %}
+{% if item.name == 'default' %}
+  {% set itemName = 'Component default' %}
+  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+  {% set previewText = 'Preview the ' + componentName + ' component' %}
+{% else %}
+  {% set itemName = componentName + '--' + item.name %}
+  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
+  {% set previewText = 'Preview the ' + itemName + ' variant' %}
+{% endif %}
+
+<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
+
+{% if not isReadme %}
+{{ govukBreadcrumb(classes='', item.data) }}
+{% endif %}
+
+<p class="govuk-u-copy-19">
+<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
+</a>
+</p>
+<h4 class="govuk-u-copy-19">Markup</h4>
+
+{% set componentHtml %}
+{{ govukBreadcrumb(classes='',item.data) }}
+{% endset %}
+<pre><code>
+  {{- componentHtml | e -}}
+</code></pre>
+
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>{% raw %}{{ govukBreadcrumb(classes='',{% endraw %}
+{{ item.data | dump(2) }}
+{% raw %}) }}{% endraw %}
+</code></pre>
+{% endfor %}
 {% endblock %}
 
 {% block componentDependencies %}
 Please note, this component depends on @govuk-frontend/globals and @govuk-frontend/icons, which will automatically be installed with the package.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/views/component-preview.njk
+++ b/src/views/component-preview.njk
@@ -1,7 +1,5 @@
 {% extends "layout.njk" %}
 
 {% block content %}
-{% set componentName = variantName | default(componentPath) %}
-{% set componentBase = variantBase | default(componentPath) %}
-{% include "../components/"+componentBase+"/"+ componentName +".njk" %}
+{{ componentView | safe }}
 {% endblock %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -44,56 +44,8 @@
 <p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
 {% endif %}
 
-<h3 class="govuk-u-bold-19">Component default</h2>
-{% if not isReadme %}
-<div>
-{%- block componentExample -%}
-{% include "../components/"+ componentName +"/"+ componentName +".njk" ignore missing %}
-{%- endblock -%}
-</div>
-{% endif %}
-<p class="govuk-u-copy-19">
-{% set componentPreviewPath = "/components/" + componentPath + "/preview" %}
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ componentPreviewPath }}">Preview the {{ componentName}} component.
-</a>
-</p>
-
-<h4 class="govuk-u-copy-19">Markup</h4>
-<pre><code>
-{{- componentHtmlFile -}}
-</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{{- componentNunjucksFile -}}
-</code></pre>
-
-
-{% if variantItems %}
-<h2 class="govuk-u-heading-24">Variants</h2>
-
-{% for variant in variantItems %}
-{% set variantPreviewPath = "/components/" + componentPath + '/' + variant.name +"/preview" %}
-
-<h3 class="govuk-u-bold-19">{{ variant.name | capitalize }}</h2>
-{% if not isReadme %}
-<div>
-{% include "../components/"+ componentName +"/"+ variant.name + '.njk' ignore missing %}
-</div>
-{% endif %}
-
-<p class="govuk-u-copy-19"><a href="{{variantPreviewPath}}">Preview {{ variant.name }} variant.</a></p>
-
-<h4 class="govuk-u-copy-19">Markup</h4>
-<pre><code>
-{{- variant.html | escape -}}
-</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{{- variant.njk | escape -}}
-</code></pre>
-{% endfor %}
-{% endif %}
+{% block defaultAndVariants %}
+{% endblock %}
 
 {% if isReadme %}
 <h2 class="govuk-u-heading-24">Dependencies</h2>

--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -11,6 +11,7 @@ const toMarkdown = require('gulp-to-markdown')
 const gulpNunjucks = require('gulp-nunjucks')
 const nunjucks = require('nunjucks')
 const objectData = {}
+const yaml = require('js-yaml')
 
 // data variable to be passed to the nunjucks template
 function getDataForFile (file) {
@@ -32,21 +33,8 @@ gulp.task('generate:readme', () => {
     objectData.componentNunjucksFile = fs.readFileSync(configPath.components + objectData.componentName + '/' + objectData.componentName + '.njk', 'utf8')
 
     // we want to show all variants' code and macros on the component details page
-    let allFiles = fs.readdirSync('src/components/' + objectData.componentName + '/')
-    let variantItems = []
-    allFiles.forEach(file => {
-      if (file.indexOf('.njk') > -1 && file.indexOf('--') > -1) {
-        let fileName = file.split('.')[0]
-        let njk = fs.readFileSync('src/components/' + objectData.componentName + '/' + fileName + '.njk', 'utf8')
-        let html = fs.readFileSync('public/components/' + objectData.componentName + '/' + fileName + '.html', 'utf8')
-        variantItems.push({
-          njk: njk,
-          name: fileName,
-          html: html
-        })
-      }
-    })
-    objectData.variantItems = variantItems
+    let componentData = yaml.safeLoad(fs.readFileSync(`src/components/${objectData.componentName}/${objectData.componentName}.yaml`, 'utf8'), {json: true})
+    objectData.componentData = componentData
     return Promise.resolve()
   }))
   .pipe(data(getDataForFile))


### PR DESCRIPTION
Currently we have a a separate file for any variant of a component. There we repeat macro call and just tweak the parameters. we want to avoid too much repetition.
This PR
* makes changes to the app.js, so that we can read a YAML file, turn it into a javascript object and expose that to a nunjucks template
* changes the way component view nunjucks file iterates over the object and renders a dynamically created string, consisting of  a macro import statement and a macro definition.
* renders the dynamically created macro definition in an isolated preview
* makes the changes to the breadcrumb component as the first example