### PR TITLE
Phase-banner component default and variants from YAML file

### DIFF
--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -1,4 +1,5 @@
 {% extends "component.njk" %}
+{% from "phase-banner/macro.njk" import govukPhaseBanner %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -6,9 +7,46 @@
 {% block componentDescription %}
   A banner that indicates content is in alpha or beta phase with a description.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+
+{% block defaultAndVariants %}
+{% for item in componentData.variants %}
+{% if item.name == 'default' %}
+  {% set itemName = 'Component default' %}
+  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+  {% set previewText = 'Preview the ' + componentName + ' component' %}
+{% else %}
+  {% set itemName = componentName + '--' + item.name %}
+  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
+  {% set previewText = 'Preview the ' + itemName + ' variant' %}
+{% endif %}
+
+<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
+
+{% if not isReadme %}
+{{ govukPhaseBanner(classes='', item.data) }}
+
+
+<p class="govuk-u-copy-19">
+<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
+</a>
+</p>
+{% endif %}
+<h4 class="govuk-u-copy-19">Markup</h4>
+
+{% set componentHtml %}
+{{ govukPhaseBanner(classes='',item.data) }}
+{% endset %}
+<pre><code>
+  {{- componentHtml | e -}}
+</code></pre>
+
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>{% raw %}{{ govukPhaseBanner(classes='',{% endraw %}
+{{ item.data | dump(2) }}
+{% raw %}) }}{% endraw %}
+</code></pre>
+{% endfor %}
+{% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/phase-banner/macro.njk
+++ b/src/components/phase-banner/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukPhaseBanner(classes='', phaseBannerText, phaseTagText) %}
+{% macro govukPhaseBanner(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/phase-banner/phase-banner.njk
+++ b/src/components/phase-banner/phase-banner.njk
@@ -1,5 +1,7 @@
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{{- govukPhaseBanner(
-  phaseBannerText='This is a new service – your <a href="#">feedback</a> will help us to improve it.',
-  phaseTagText='BETA')
--}}
+{{ govukPhaseBanner(classes='',
+  {
+    "tag": "alpha",
+    "message": "This part of GOV.UK Frontend is being built"
+  }
+) }}

--- a/src/components/phase-banner/phase-banner.yaml
+++ b/src/components/phase-banner/phase-banner.yaml
@@ -1,0 +1,9 @@
+variants:
+  - name: default
+    data:
+      tag: alpha
+      message: This part of GOV.UK Frontend is being built
+  - name: with-html
+    data:
+      tag: beta
+      message: 'This is a new service – your <a href="#">feedback</a> will help us to improve it.'

--- a/src/components/phase-banner/template.njk
+++ b/src/components/phase-banner/template.njk
@@ -3,9 +3,9 @@
 <div class="govuk-c-phase-banner
   {%- if classes %} {{ classes }}{% endif %}">
   <p class="govuk-c-phase-banner__content">
-    {{ govukPhaseTag(phaseTagText) }}
+    {{ govukPhaseTag(params.tag) }}
     <span class="govuk-c-phase-banner__text">
-      {{ phaseBannerText | safe }}
+      {{ params.message | safe }}
     </span>
   </p>
 </div>


### PR DESCRIPTION
This PR:

* adds a YAML file where default option and variants are defined
* updates macro, template and documentation to read and display those variants
