### PR TITLE
Read component YAML inside a try/catch block

### DIFF
--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -30,11 +30,13 @@ gulp.task('generate:readme', () => {
   .pipe(vinylPaths(paths => {
     objectData.componentName = paths.split(path.sep).slice(-2, -1)[0]
     objectData.componentPath = objectData.componentName
-    objectData.componentNunjucksFile = fs.readFileSync(configPath.components + objectData.componentName + '/' + objectData.componentName + '.njk', 'utf8')
-
     // we want to show all variants' code and macros on the component details page
-    let componentData = yaml.safeLoad(fs.readFileSync(`src/components/${objectData.componentName}/${objectData.componentName}.yaml`, 'utf8'), {json: true})
-    objectData.componentData = componentData
+    try {
+      let componentData = yaml.safeLoad(fs.readFileSync(`src/components/${objectData.componentName}/${objectData.componentName}.yaml`, 'utf8'), {json: true})
+      objectData.componentData = componentData
+    } catch (e) {
+      console.log('you are missing', paths)
+    }
     return Promise.resolve()
   }))
   .pipe(data(getDataForFile))

--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -35,7 +35,7 @@ gulp.task('generate:readme', () => {
       let componentData = yaml.safeLoad(fs.readFileSync(`src/components/${objectData.componentName}/${objectData.componentName}.yaml`, 'utf8'), {json: true})
       objectData.componentData = componentData
     } catch (e) {
-      console.log('you are missing', paths)
+      console.log('ENOENT: no such file or directory: ', paths)
     }
     return Promise.resolve()
   }))


### PR DESCRIPTION
If a yaml file is missing the gulp task fails to continue
This PR
* moves the reading of the file inside a try{}catch{} block so that if a file is missing, the task fill continue, but output a warning about the missing file(s)