### PR TITLE
Link component default and variants from YAML file

### DIFF
--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -1,37 +1,40 @@
 {% extends "component.njk" %}
+{% from "link/macro.njk" import govukLink %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
 {% block componentDescription %}
-{% from "list/macro.njk" import govukList %}
-
 Link component, with four variants:
-
-{{ govukList(
-  classes='',
-  [
-    {
-      text: 'back link - a black underlined link with a left pointing arrow'
-    },
-    {
-      text: 'muted link - used for the “anything wrong with this page?” links'
-    },
-    {
-      text: 'download link - with download icon'
-    },
-    {
-      text: 'skip link - skip to the main page content'
-    }
-  ],
-  options = {
-    'isBullet': 'true'
-  }
-) }}
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+
+{% block defaultAndVariants %}
+{% for item in componentData.variants %}
+{% if item.name == 'default' %}
+{% set itemName = 'Component default' %}
+{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+{% set previewText = 'Preview the ' + componentName + ' component' %}
+{% else %}
+{% set itemName = componentName + '--' + item.name %}
+{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
+{% set previewText = 'Preview the ' + itemName + ' variant' %}
+{% endif %}
+<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
+{% if not isReadme %}
+{{ govukLink(item.data) }}
+{% endif %}
+<p class="govuk-u-copy-19">
+  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}</a>
+</p>
+<h4 class="govuk-u-copy-19">Markup</h4>
+{% set componentHtml %}
+{{- govukLink(item.data) -}}
+{% endset %}
+<pre><code>{{- componentHtml | e -}}</code></pre>
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>{% raw %}{{ govukLink({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
+{% endfor %}
+{% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
@@ -61,7 +64,7 @@ Link component, with four variants:
     'rows' : [
       [
         {
-          text: 'linkHref'
+          text: 'href'
         },
         {
           text: 'string'
@@ -75,7 +78,7 @@ Link component, with four variants:
       ],
       [
         {
-          text: 'linkText'
+          text: 'content'
         },
         {
           text: 'string'

--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -1,4 +1,5 @@
 {% extends "component.njk" %}
+{% from "list/macro.njk" import govukList %}
 {% from "link/macro.njk" import govukLink %}
 
 {# Commented out blocks below inherit from views/component.njk #}
@@ -6,6 +7,27 @@
 {# componentName #}
 {% block componentDescription %}
 Link component, with four variants:
+
+{{ govukList(
+  classes='',
+  [
+    {
+      text: 'back link - a black underlined link with a left pointing arrow'
+    },
+    {
+      text: 'muted link - used for the “anything wrong with this page?” links'
+    },
+    {
+      text: 'download link - with download icon'
+    },
+    {
+      text: 'skip link - skip to the main page content'
+    }
+  ],
+  options = {
+    'isBullet': 'true'
+  }
+) }}
 {% endblock %}
 
 {% block defaultAndVariants %}

--- a/src/components/link/link--back.njk
+++ b/src/components/link/link--back.njk
@@ -1,7 +1,0 @@
-{% from "link/macro.njk" import govukLink %}
-
-{{- govukLink(
-  classes='govuk-c-link--back',
-  linkHref='',
-  linkText='Back')
--}}

--- a/src/components/link/link--download.njk
+++ b/src/components/link/link--download.njk
@@ -1,7 +1,0 @@
-{% from "link/macro.njk" import govukLink %}
-
-{{- govukLink(
-  classes='govuk-c-link--download',
-  linkHref='',
-  linkText='Download')
--}}

--- a/src/components/link/link--muted.njk
+++ b/src/components/link/link--muted.njk
@@ -1,7 +1,0 @@
-{% from "link/macro.njk" import govukLink %}
-
-{{- govukLink(
-  classes='govuk-c-link--muted',
-  linkHref='',
-  linkText='Is there anything wrong with this page?')
--}}

--- a/src/components/link/link--skip.njk
+++ b/src/components/link/link--skip.njk
@@ -1,7 +1,0 @@
-{% from "link/macro.njk" import govukLink %}
-
-{{- govukLink(
-  classes='govuk-c-link--skip',
-  linkHref='',
-  linkText='Skip to main content')
--}}

--- a/src/components/link/link.njk
+++ b/src/components/link/link.njk
@@ -1,7 +1,3 @@
 {% from "link/macro.njk" import govukLink %}
 
-{{- govukLink(
-  classes='govuk-c-link',
-  linkHref='',
-  linkText='Default link')
--}}
+{{ govukLink({classes: 'govuk-c-link', href: '', content: 'Default link'}) }}

--- a/src/components/link/link.yaml
+++ b/src/components/link/link.yaml
@@ -1,0 +1,20 @@
+variants:
+- name: default
+  data:
+    content: Default link
+- name: back
+  data:
+    content: Back
+    classes: govuk-c-link--back
+- name: download
+  data:
+    content: Download
+    classes: govuk-c-link--download
+- name: muted
+  data:
+    content: Is there anything wrong with this page?
+    classes: govuk-c-link--muted
+- name: skip
+  data:
+    content: Skip to main content
+    classes: govuk-c-link--skip

--- a/src/components/link/macro.njk
+++ b/src/components/link/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukLink(classes='', linkHref, linkText) %}
+{% macro govukLink(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/link/template.njk
+++ b/src/components/link/template.njk
@@ -1,2 +1,2 @@
-<a href="{{ href }}" class="govuk-c-link
-  {%- if classes %} {{ classes }}{% endif %}">{{ linkText | safe }}</a>
+<a href="{%- if params.href %}{{ params.href }}{% else %}#{% endif -%}" class="govuk-c-link
+  {%- if params.classes %} {{ params.classes }}{% endif -%}">{{ params.content | safe }}</a>


### PR DESCRIPTION
This PR:
- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants
- removes separate variant files