### PR TITLE
Checkbox component default and variants from YAML file

### DIFF
--- a/src/components/checkbox/checkbox.njk
+++ b/src/components/checkbox/checkbox.njk
@@ -1,31 +1,14 @@
 {% from 'checkbox/macro.njk' import govukCheckbox %}
 
-{{- govukCheckbox(
-  classes='',
-  name='waste-types',
-  id='waste-type',
-  checkboxes=[
+{{- govukCheckbox({
+  classes: '',
+  inputName: 'waste-types',
+  id: 'waste-type',
+  checkboxes: [
    {
       id: '1',
       value: 'waste-animal',
       label: 'Waste from animal carcasses'
-    },
-    {
-      id: '2',
-      value: 'waste-mines',
-      label: 'Waste from mines or quarries'
-    },
-    {
-      id: '3',
-      value: 'waste-farm',
-      label: 'Farm or agricultural waste',
-      checked: 'true'
-    },
-    {
-      id: '4',
-      value: 'waste-disabled',
-      label: 'Disabled checkbox option',
-      disabled: 'true'
     }
   ]
-) -}}
+}) -}}

--- a/src/components/checkbox/checkbox.yaml
+++ b/src/components/checkbox/checkbox.yaml
@@ -1,0 +1,25 @@
+variants:
+- name: default
+  data:
+    id: 'waste-types'
+    inputName: 'waste-types'
+    classes:
+    checkboxes:
+      -
+        id: 1
+        value: 'waste-animal'
+        label: 'Waste from animal carcasses'
+      -
+        id: 2
+        value: 'waste-mines'
+        label: 'Waste from mines or quarries'
+      -
+        id: 3
+        value: 'waste-farm'
+        label: 'Farm or agricultural waste'
+        checked: true
+      -
+        id: 4
+        value: 'waste-disabled'
+        label: 'Disabled checkbox option'
+        disabled: true

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -1,30 +1,54 @@
 {% extends "component.njk" %}
+{% from "checkbox/macro.njk" import govukCheckbox %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
 
 {% block componentDescription %}
-  Breadcrumb navigation, showing page hierarchy.
+  Checkbox description goes here
 {% endblock %}
 
-{# componentExample #}
-
-{# componentNunjucks #}
-
-{# componentHtml #}
+{% block defaultAndVariants %}
+{% for item in componentData.variants %}
+{% if item.name == 'default' %}
+{% set itemName = 'Component default' %}
+{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+{% set previewText = 'Preview the ' + componentName + ' component' %}
+{% else %}
+{% set itemName = componentName + '--' + item.name %}
+{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
+{% set previewText = 'Preview the ' + itemName + ' variant' %}
+{% endif %}
+<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
+{% if not isReadme %}
+{{ govukCheckbox(item.data) }}
+{% endif %}
+<p class="govuk-u-copy-19">
+<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
+</a>
+</p>
+<h4 class="govuk-u-copy-19">Markup</h4>
+{% set componentHtml %}
+{{- govukCheckbox(item.data) -}}
+{% endset %}
+<pre><code>{{- componentHtml | e -}}</code></pre>
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>{% raw %}{{ govukCheckbox({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
+{% endfor %}
+{% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
 {% from "table/macro.njk" import govukTable %}
-{{ govukTable(
-  classes='',
-  options = {
+{{ govukTable({
+  classes: '',
+  options: {
     'isFirstCellHeader': 'true'
   },
-  data = {
+  data: {
     'head' : [
       {
         text: 'Name'
@@ -56,7 +80,7 @@
       ],
       [
         {
-          text: 'name'
+          text: 'inputName'
         },
         {
           text: 'string'
@@ -98,5 +122,5 @@
       ]
     ]
   }
-)}}
+})}}
 {% endblock %}

--- a/src/components/checkbox/macro.njk
+++ b/src/components/checkbox/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukCheckbox(classes='', name, id, checkboxes) %}
+{% macro govukCheckbox(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -1,9 +1,9 @@
-{% for checkbox in checkboxes %}
+{% for checkbox in params.checkboxes %}
 <div class="govuk-c-checkbox
-{%- if classes %} {{ classes }}{% endif %}">
-  <input class="govuk-c-checkbox__input" id="{{ id }}-{{ checkbox.id }}" name="{{ name }}" type="checkbox" value="{{ checkbox.value }}"
+{%- if params.classes %} {{ params.classes }}{% endif %}">
+  <input class="govuk-c-checkbox__input" id="{{ params.id }}-{{ checkbox.id }}" name="{{ params.inputName }}" type="checkbox" value="{{ checkbox.value }}"
   {%- if checkbox.checked %} checked{% endif %}
   {%- if checkbox.disabled %} disabled{% endif %}>
-  <label class="govuk-c-checkbox__label" for="{{ id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
+  <label class="govuk-c-checkbox__label" for="{{ params.id }}-{{ checkbox.id }}">{{ checkbox.label }}</label>
 </div>
 {% endfor %}


### PR DESCRIPTION
This PR:
* adds a YAML file where default option and variants are defined
* updates macro, template and documentation to read and display those variants
* uses updated macro for the arguments table

Not sure about naming input's `name` attribute `inputName`, but `name` is already used in YAML file for variation names.

Note: prefixing the boolean attributes (e.g. checked, disabled) is already subject to discussion