### PR TITLE
Replace breadcrumb macro with new syntax in component view template

### DIFF
--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -10,13 +10,13 @@
 
 {% if not isReadme %}
 {% from "breadcrumb/macro.njk" import govukBreadcrumb %}
-{{ govukBreadcrumb(
-  classes='',
-  [
+
+{{ govukBreadcrumb({
+  "items": [
     { title: 'GOV.UK Frontend', url: '/' },
     { title: componentName | replace("-", " ") | capitalize }
   ]
-)}}
+}) }}
 {% endif %}
 
 <h1 class="govuk-u-heading-36">


### PR DESCRIPTION
When viewing each component we have a breadcrumb at the top of the page that enables you to go back to the list of all components.
Since we updated the way breadcrumb macro parameters are defined, breadcrumb wasn't showing.
This PR fixes that and breadcrumbs are functional again.

<img width="334" alt="screen shot 2017-10-06 at 21 14 24" src="https://user-images.githubusercontent.com/3758555/31296768-64c00cdc-aadb-11e7-9b03-a659f6fb7fed.png">
