### PR TITLE
Update label parameter definition when used in input

### DIFF
--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,6 +1,6 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel(params.labelClasses, params.labelText, params.hintText, params.errorMessage, params.id) -}}
+{{- govukLabel(params) -}}
 
 <input class="govuk-c-input
 {%- if params.classes %} {{ params.classes }}{% endif %}


### PR DESCRIPTION
When we updated the label and input parameter definition, the label stopped showing when used in the input macro.
This PR removes unneeded specific parameter item declarations with the params object. Keys  are picked up by the label macro automacitally