### PR TITLE
Use macro for default and variants

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.get('/components*', function (req, res, next) {
   let path = req.params[0].slice(1).split('/') // split path into array items: [0 is base component], [1] will be the variant view
   let componentData = yaml.safeLoad(fs.readFileSync(`src/components/${path[0]}/${path[0]}.yaml`, 'utf8'), {json: true})
   res.locals.componentData = componentData  // make it available to the nunjucks template to loop over and display code
-
+  res.locals.importStatement = env.renderString(`{% from '${path[0]}/macro.njk' import govuk${capitaliseComponentName(path[0])} %}`)
   if (path.includes('preview')) {
     // Show the isolated component preview
     let componentNameCapitalized = capitaliseComponentName(path[0])

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-
 {% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
@@ -9,8 +8,7 @@ A breadcrumb is a GOV.UK element that helps users to understand where they are w
 {% endblock %}
 
 {% block defaultAndVariants %}
-{# {% from "breadcrumb/macro.njk" import govukBreadcrumb %} #}
-{{ showDefaultAndVariants(importStatement, componentName, componentData) }}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {% block componentDependencies %}

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -7,19 +6,16 @@
 A breadcrumb is a GOV.UK element that helps users to understand where they are within the site and move between levels.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
-
 {% block componentDependencies %}
 Please note, this component depends on @govuk-frontend/globals and @govuk-frontend/icons, which will automatically be installed with the package.
 {% endblock %}
+
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/breadcrumb/index.njk
+++ b/src/components/breadcrumb/index.njk
@@ -1,5 +1,6 @@
 {% extends "component.njk" %}
-{% from "breadcrumb/macro.njk" import govukBreadcrumb %}
+
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -8,44 +9,8 @@ A breadcrumb is a GOV.UK element that helps users to understand where they are w
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-
-{% if not isReadme %}
-{{ govukBreadcrumb(item.data) }}
-
-
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-{% endif %}
-<h4 class="govuk-u-copy-19">Markup</h4>
-
-{% set componentHtml %}
-{{ govukBreadcrumb(item.data) }}
-{% endset %}
-<pre><code>
-  {{- componentHtml | e -}}
-</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{% raw %}{{ govukBreadcrumb({% endraw %}
-  {{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
-{% endfor %}
+{# {% from "breadcrumb/macro.njk" import govukBreadcrumb %} #}
+{{ showDefaultAndVariants(importStatement, componentName, componentData) }}
 {% endblock %}
 
 {% block componentDependencies %}

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "button/macro.njk" import govukButton %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -23,32 +23,7 @@ Buttons are configured to perform an action and they can have a different look. 
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukButton(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukButton(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukButton({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -14,23 +13,17 @@ A button should have a short text snippet that describes what it will do.
 {% block componentDependencies %}
 Please note, this component depends on @govuk-frontend/globals and @govuk-frontend/icons, which will automatically be installed with the package.
 {% endblock %}
-{# componentExample #}
-
-{# componentNunjucks #}
 
 {% block componentHtmlUsageWriteup %}
 Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,15 +8,12 @@
   Checkbox description goes here
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "checkbox/macro.njk" import govukCheckbox %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -10,32 +10,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukCheckbox(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukCheckbox(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukCheckbox({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -10,32 +10,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukCookieBanner(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukCookieBanner(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukCookieBanner({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,15 +8,12 @@
   GOV.UK cookie message, with link to cookie help page.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/file-upload/index.njk
+++ b/src/components/file-upload/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -10,32 +10,7 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukFileUpload(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukFileUpload(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukFileUpload({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -1,22 +1,19 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
+
 {% block componentDescription %}
   A single-line text field.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "input/macro.njk" import govukInput %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,43 +9,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-
-{% if not isReadme %}
-{{ govukInput(item.data) }}
-
-
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-{% endif %}
-<h4 class="govuk-u-copy-19">Markup</h4>
-
-{% set componentHtml %}
-{{ govukInput(classes='',item.data) }}
-{% endset %}
-<pre><code>
-  {{- componentHtml | e -}}
-</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukInput({% endraw %}
-{{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,44 +9,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-
-{% if not isReadme %}
-{{ govukLabel(item.data) }}
-
-
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-{% endif %}
-<h4 class="govuk-u-copy-19">Markup</h4>
-
-{% set componentHtml %}
-{{ govukLabel(item.data) }}
-{% endset %}
-<pre><code>
-  {{- componentHtml | e -}}
-</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{% raw %}{{ govukLabel({% endraw %}
-  {{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -1,22 +1,19 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
+
 {% block componentDescription %}
   Use labels for all form fields.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -1,6 +1,6 @@
 {% extends "component.njk" %}
 {% from "list/macro.njk" import govukList %}
-{% from "link/macro.njk" import govukLink %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -31,31 +31,7 @@ Link component, with four variants:
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukLink(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukLink(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukLink({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -1,10 +1,10 @@
 {% extends "component.njk" %}
 {% from "list/macro.njk" import govukList %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
+
 {% block componentDescription %}
 Link component, with four variants:
 
@@ -30,15 +30,12 @@ Link component, with four variants:
 ) }}
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/list/index.njk
+++ b/src/components/list/index.njk
@@ -1,22 +1,19 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
+
 {% block componentDescription %}
   A list of items, list variants are bulleted or numbered.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/list/index.njk
+++ b/src/components/list/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "list/macro.njk" import govukList %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,31 +9,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-{% set itemName = 'Component default' %}
-{% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-{% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-{% set itemName = componentName + '--' + item.name %}
-{% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-{% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-{% if not isReadme %}
-{{ govukList(item.data) }}
-{% endif %}
-<p class="govuk-u-copy-19">
-  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-{% set componentHtml %}
-{{- govukList(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukList({% endraw %}{{ item.data | dump }}{% raw %})}}{% endraw %}</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -1,22 +1,19 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
 {# componentName #}
+
 {% block componentDescription %}
   A banner that indicates content is in alpha or beta phase with a description.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   classes: '',
   options: {

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,43 +9,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-
-{% if not isReadme %}
-{{ govukPhaseBanner(classes='', item.data) }}
-
-
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-{% endif %}
-<h4 class="govuk-u-copy-19">Markup</h4>
-
-{% set componentHtml %}
-{{ govukPhaseBanner(classes='',item.data) }}
-{% endset %}
-<pre><code>
-  {{- componentHtml | e -}}
-</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>{% raw %}{{ govukPhaseBanner(classes='',{% endraw %}
-{{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -9,15 +8,12 @@
   Table description.
 {% endblock %}
 
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
-{% endblock %}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-
 {{ govukTable(
 {
   "data": {

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -1,5 +1,5 @@
 {% extends "component.njk" %}
-{% from 'table/macro.njk' import govukTable %}
+{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -10,41 +10,7 @@
 {% endblock %}
 
 {% block defaultAndVariants %}
-{% for item in componentData.variants %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
-{% endif %}
-
-<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
-
-{% if not isReadme %}
-{{ govukTable(item.data)}}
-{% endif %}
-
-<p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
-</p>
-<h4 class="govuk-u-copy-19">Markup</h4>
-
-{% set componentHtml %}
-{{- govukTable(item.data) -}}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
-
-<h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{% raw %}{{ govukTable({% endraw %}
-{{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
-{% endfor %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -44,7 +44,9 @@
 <p class="govuk-u-copy-19">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
 {% endif %}
 
+{% from "./macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 {% block defaultAndVariants %}
+{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {% if isReadme %}

--- a/src/views/macros/loadComponentTemplate.njk
+++ b/src/views/macros/loadComponentTemplate.njk
@@ -1,0 +1,3 @@
+{% macro loadComponentTemplate(componentName, params) %}
+  {%- include "../../components/" + componentName + "/template.njk" -%}
+{% endmacro %}

--- a/src/views/macros/showDefaultAndVariants.njk
+++ b/src/views/macros/showDefaultAndVariants.njk
@@ -1,11 +1,11 @@
-{% macro showDefaultAndVariants(importStatement, componentName, componentData) %}
+{% from "./loadComponentTemplate.njk" import loadComponentTemplate %}
 
-{{ importStatement | safe }}
+{% macro showDefaultAndVariants(componentName, componentData) %}
 
 {% for item in componentData.variants %}
 {% if item.name == 'default' %}
   {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+  {% set previewLink = "/components/" + componentName + "/preview" %}
   {% set previewText = 'Preview the ' + componentName + ' component' %}
 {% else %}
   {% set itemName = componentName + '--' + item.name %}
@@ -16,26 +16,24 @@
 <h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
 
 {% if not isReadme %}
-{# {{ govukBreadcrumb(item.data) }} #}
-
+{{ loadComponentTemplate(componentName, item.data) }}
+{% endif %}
 
 <p class="govuk-u-copy-19">
-<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
-</a>
+  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}</a>
 </p>
-{% endif %}
-<h4 class="govuk-u-copy-19">Markup</h4>
 
+<h4 class="govuk-u-copy-19">Markup</h4>
 {% set componentHtml %}
-{# {{ govukBreadcrumb(item.data) }} #}
+{{ loadComponentTemplate(componentName, item.data) }}
 {% endset %}
 <pre><code>
-  {# {{- componentHtml | e -}} #}
+  {{- componentHtml | e -}}
 </code></pre>
 
 <h4 class="govuk-u-copy-19">Macro</h4>
 <pre><code>
-{% raw %}{{ govukBreadcrumb({% endraw %}
+{% raw %}{{ loadComponentTemplate(componentName, {% endraw %}
   {{ item.data | dump(2) }}
 {% raw %}) }}{% endraw %}
 </code></pre>

--- a/src/views/macros/showDefaultAndVariants.njk
+++ b/src/views/macros/showDefaultAndVariants.njk
@@ -1,0 +1,43 @@
+{% macro showDefaultAndVariants(importStatement, componentName, componentData) %}
+
+{{ importStatement | safe }}
+
+{% for item in componentData.variants %}
+{% if item.name == 'default' %}
+  {% set itemName = 'Component default' %}
+  {% set previewLink = "/components/" + componentName + '/' + "/preview" %}
+  {% set previewText = 'Preview the ' + componentName + ' component' %}
+{% else %}
+  {% set itemName = componentName + '--' + item.name %}
+  {% set previewLink = "/components/" + componentName + '/' + componentName + '--' + item.name  + "/preview" %}
+  {% set previewText = 'Preview the ' + itemName + ' variant' %}
+{% endif %}
+
+<h3 class="govuk-u-bold-19">{{ itemName  | capitalize }}</h3>
+
+{% if not isReadme %}
+{# {{ govukBreadcrumb(item.data) }} #}
+
+
+<p class="govuk-u-copy-19">
+<a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}
+</a>
+</p>
+{% endif %}
+<h4 class="govuk-u-copy-19">Markup</h4>
+
+{% set componentHtml %}
+{# {{ govukBreadcrumb(item.data) }} #}
+{% endset %}
+<pre><code>
+  {# {{- componentHtml | e -}} #}
+</code></pre>
+
+<h4 class="govuk-u-copy-19">Macro</h4>
+<pre><code>
+{% raw %}{{ govukBreadcrumb({% endraw %}
+  {{ item.data | dump(2) }}
+{% raw %}) }}{% endraw %}
+</code></pre>
+{% endfor %}
+{% endmacro %}


### PR DESCRIPTION
This PR avoids redundancy by:
* Adding a macro for generating default and variants
* Replacing the current 'default and variants' block with a macro call