### PR TITLE
Fix autogenerated macro examples

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,8 @@ const capitaliseComponentName = string => {
   }
   return string.join('')
 }
+// make the function above available as a filter for all templates
+env.addFilter('capitaliseComponentName', capitaliseComponentName)
 
 // Set view engine
 app.set('view engine', 'njk')

--- a/src/views/macros/showDefaultAndVariants.njk
+++ b/src/views/macros/showDefaultAndVariants.njk
@@ -27,15 +27,11 @@
 {% set componentHtml %}
 {{ loadComponentTemplate(componentName, item.data) }}
 {% endset %}
-<pre><code>
-  {{- componentHtml | e -}}
-</code></pre>
+<pre><code>{{- componentHtml | e -}}</code></pre>
 
 <h4 class="govuk-u-copy-19">Macro</h4>
-<pre><code>
-{% raw %}{{ loadComponentTemplate(componentName, {% endraw %}
-  {{ item.data | dump(2) }}
-{% raw %}) }}{% endraw %}
-</code></pre>
+<pre><code>{% raw %}{{ {% endraw %}govuk{{ componentName | capitaliseComponentName }}(
+  {{- item.data | dump(2) -}}
+){% raw %} }}{% endraw %}</code></pre>
 {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
This PR:
- makes the `capitaliseComponentName()` function available to all Nunjucks templates and macros
- uses this function in `showDefaultAndVariants.njk` for autogenerating the macro examples