### PR TITLE
Grid component from Yaml and usage documentation

### DIFF
--- a/src/components/grid/_grid.scss
+++ b/src/components/grid/_grid.scss
@@ -33,6 +33,13 @@
     width: percentage( 1 / 4);
   }
 
+  // visibly show grid layout
+  .preview-grid .govuk-c-grid__item {
+    background-color: $govuk-light-blue-25;
+    border: 1px dashed $govuk-purple;
+    padding-bottom: $govuk-spacing-scale-3;
+    padding-top: $govuk-spacing-scale-3;
+  }
   // for testing purposes
   $govuk-width-proportions: (
     full: 100%,

--- a/src/components/grid/grid.njk
+++ b/src/components/grid/grid.njk
@@ -1,57 +1,46 @@
 {% from "grid/macro.njk" import govukGrid %}
 
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'full' }
+{{ govukGrid({
+  "classes": "preview-grid",
+  "items": [
+    {
+      "width": "full",
+      "gridStart": true
+    },
+    {
+      "width": "one-half"
+    },
+    {
+      "width": "one-half"
+    },
+    {
+      "width": "one-third"
+    },
+    {
+      "width": "one-third"
+    },
+    {
+      "width": "one-third"
+    },
+    {
+      "width": "two-thirds"
+    },
+    {
+      "width": "one-third"
+    },
+    {
+      "width": "one-quarter"
+    },
+    {
+      "width": "one-quarter"
+    },
+    {
+      "width": "one-quarter"
+    },
+    {
+      "width": "one-quarter",
+      "gridEnd": true
+    }
   ]
-  )
--}}
-
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'one-half' },
-    { width: 'one-half' }
-  ]
-  )
--}}
-
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'one-third' },
-    { width: 'one-third' },
-    { width: 'one-third' }
-  ]
-  )
--}}
-
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'two-thirds' },
-    { width: 'one-third' }
-  ]
-  )
--}}
-
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'one-third' },
-    { width: 'two-thirds' }
-  ]
-  )
--}}
-
-{{- govukGrid(
-  classes='',
-  gridItems=[
-    { width: 'one-quarter' },
-    { width: 'one-quarter' },
-    { width: 'one-quarter' },
-    { width: 'one-quarter' }
-  ]
-  )
--}}
+})
+}}

--- a/src/components/grid/grid.yaml
+++ b/src/components/grid/grid.yaml
@@ -1,0 +1,31 @@
+variants:
+  - name: default
+    data:
+      classes: preview-grid
+      items:
+        -
+          width: 'full'
+          gridStart: true
+        -
+          width: 'one-half'
+        -
+          width: 'one-half'
+        -
+          width: 'one-third'
+        -
+          width: 'one-third'
+        -
+          width: 'one-third'
+        -
+          width: 'two-thirds'
+        -
+          width: 'one-third'
+        -
+          width: 'one-quarter'
+        -
+          width: 'one-quarter'
+        -
+          width: 'one-quarter'
+        -
+          width: 'one-quarter'
+          gridEnd: true

--- a/src/components/grid/index.njk
+++ b/src/components/grid/index.njk
@@ -1,4 +1,7 @@
 {% extends "component.njk" %}
+{% from "list/macro.njk" import govukList %}
+{% from "button/macro.njk" import govukButton %}
+{% from "grid/macro.njk" import govukGrid %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -6,9 +9,64 @@
 {% block componentDescription %}
   Grid row with grid items.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+
+{% block additionalExampleWriteup %}
+<p class="govuk-u-copy-19">The above example is a macro to render a pure grid. In reality however you'd want to add content and other components inside the grid.</p>
+
+<p class="govuk-u-copy-19">The way to do that is shown in the below example:</p>
+<ul class="govuk-c-list govuk-c-list--bullet">
+  <li>you call the grid macro</li>
+  <li>specify the item width and whether is opens or closes the grid wrapper</li>
+  <li>add content inside the call</li>
+  <li>close the grid macro call</li>
+</ul>
+<pre><code>
+  {% raw %}
+  {% call govukGrid({
+    "items": [
+      {
+          "width": "one-half",
+          "gridStart": true
+      }
+    ]
+  })%}
+  {{ govukButton({classes: '', text:'Save and continue', url: '', isStart: '', isDisabled: ''}) }}
+  {% endcall %}
+  {% call govukGrid({
+    "items": [
+      {
+      "width": "one-half",
+      "gridEnd": true
+      }
+    ]
+  })%}
+  <p>This is a magical button</p>
+  {% endcall %}
+{% endraw %}
+</code></pre>
+<p class="govuk-u-copy-19">above results in</p>
+{% call govukGrid({
+  "items": [
+    {
+        "width": "one-half",
+        "gridStart": true
+    }
+  ]
+})%}
+{{ govukButton({classes: '', text:'Save and continue', url: '', isStart: '', isDisabled: ''}) }}
+{% endcall %}
+{% call govukGrid({
+  "items": [
+    {
+    "width": "one-half",
+    "gridEnd": true
+    }
+  ]
+})%}
+<p>This is a magical button</p>
+{% endcall %}
+
+{% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/grid/macro.njk
+++ b/src/components/grid/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukGrid(classes, gridItems) %}
+{% macro govukGrid(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/grid/template.njk
+++ b/src/components/grid/template.njk
@@ -1,10 +1,13 @@
 {% from "grid/macro.njk" import govukGrid %}
-
-<div class="govuk-c-grid
-  {%- if classes %} {{ classes }}{% endif %}">
-  {% for item in gridItems %}
+  {% for item in params.items %}
+  {% if item.gridStart %}
+  <div class="govuk-c-grid
+    {%- if params.classes %} {{ params.classes }}{% endif %}">
+  {% endif %}
   <div class="govuk-c-grid__item govuk-c-grid__item--{{ item.width }}">
-    {{- caller() if caller -}} {# if statement allows usage of `call` to be optional #}
+    {{- caller() if caller -}}
   </div>
-  {% endfor %}
-</div>
+  {% if item.gridEnd %}
+  </div>
+  {% endif %}
+{% endfor %}

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -49,6 +49,10 @@
 {{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
+{% block additionalExampleWriteup %}
+{# block for extra context sorrounding example #}
+{% endblock %}
+
 {% if isReadme %}
 <h2 class="govuk-u-heading-24">Dependencies</h2>
 

--- a/src/views/examples/all-components/index.njk
+++ b/src/views/examples/all-components/index.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-  {% include "../components/breadcrumb/breadcrumb.njk" %}
+  {# {% include "../components/breadcrumb/breadcrumb.njk" %}
 
   {% include "../components/button/button.njk" %}
 
@@ -24,12 +24,12 @@
 
   {% include "../components/input/input.njk" %}
 
-  {% include "../components/inset-text/inset-text.njk" %}
+  {% include "../components/inset-text/inset-text.njk" %} #}
 
   {# Don't show label component as input component requires it #}
   {# include "../components/label/label.njk" #}
 
-  {% include "../components/legal-text/legal-text.njk" %}
+  {# {% include "../components/legal-text/legal-text.njk" %}
 
   {% include "../components/link/link.njk" %}
 
@@ -45,30 +45,32 @@
 
   {% include "../components/pagination/pagination.njk" %}
 
-  {% include "../components/select-box/select-box.njk" %}
+  {% include "../components/select-box/select-box.njk" %} #}
 
   {# Example of calling site-width-container and nesting a grid row #}
-  {% from "../components/site-width-container/macro.njk" import govukSiteWidthContainer %}
-  {% from "../components/grid/macro.njk" import govukGrid %}
+  {# {% from "../components/site-width-container/macro.njk" import govukSiteWidthContainer %} #}
+  {% from "button/macro.njk" import govukButton %}
+  {% from "grid/macro.njk" import govukGrid %}
 
-  {% call govukSiteWidthContainer() %}
-    {% call govukGrid(
-      classes='',
-      gridItems=[ { width: 'full' } ]
-      )
-    %}
-    Example full width grid column
-    <!-- Insert macros to sit inside grid item here -->
+    {% call govukGrid({
+      "items": [
+        {
+            "width": "one-half",
+            "gridStart": true
+        }
+      ]
+    })%}
+    {{ govukButton({classes: '', text:'Save and continue', url: '', isStart: '', isDisabled: ''}) }}
     {% endcall %}
-
-    {% call govukGrid(
-      classes='',
-      gridItems=[ { width: 'two-thirds' } ]
-      )
-    %}
-    Example two-thirds width grid column
-    <!-- Insert macros to sit inside grid item here -->
+    {% call govukGrid({
+      "items": [
+        {
+        "width": "one-half",
+        "gridEnd": true
+        }
+      ]
+    })%}
+    <p>This is a magical button</p>
     {% endcall %}
-  {% endcall %}
 
 {% endblock %}


### PR DESCRIPTION
Grid component is the first component where any other content and component might live inside it. There needs to be a way to open the grid wrapper, specify grid item width, insert content and other component macros, and finally close the grid wrapper
In this PR I'm
* adding yaml file for data
* updating macro and template to accept parameters from yaml
* add extra documentation block to show real world usage of the grid component

To effectively open and close the grid wrapper, I'm using gridStart and gridEnd keys on relevant items.
There are also some styles to show the grid structure, which could be also be used for debug
