### PR TITLE
Panel component default and variants from YAML file

### DIFF
--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -6,9 +6,7 @@
 {% block componentDescription %}
   The confirmation panel has a turquoise background and white text. Used for transaction end pages, and Bank Holidays.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/panel/macro.njk
+++ b/src/components/panel/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukPanel(classes, title, content, reference) %}
+{% macro govukPanel(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/panel/panel.njk
+++ b/src/components/panel/panel.njk
@@ -1,9 +1,9 @@
 {% from "panel/macro.njk" import govukPanel %}
 
-{{- govukPanel(
-  classes='',
-  title='Application complete',
-  content='Your reference number is',
-  reference='HDJ2123F'
-  )
--}}
+{{ govukPanel(
+  {
+    "classes": "",
+    "title": "Application complete",
+    "content": "Thank you for your application"
+  })
+}}

--- a/src/components/panel/panel.yaml
+++ b/src/components/panel/panel.yaml
@@ -1,0 +1,11 @@
+variants:
+ - name: default
+   data:
+     title: Application complete
+     content: Your refence number
+     reference: HDJ2123F
+ - name: no-reference-number
+   data:
+     classes: extra-dummy-class
+     title: Application complete
+     content: Thank you for your application

--- a/src/components/panel/template.njk
+++ b/src/components/panel/template.njk
@@ -1,13 +1,13 @@
 <div class="govuk-c-panel govuk-c-panel--confirmation
-  {%- if classes %} {{ classes }}{% endif %}">
+  {%- if params.classes %} {{ params.classes }}{% endif %}">
   <h2 class="govuk-c-panel__title">
-    {{ title }}
+    {{ params.title }}
   </h2>
   <div class="govuk-c-panel__body">
-    {{ content }}
-    {% if reference %}
+    {{ params.content }}
+    {% if params.reference %}
     <br>
-    <strong>{{ reference }}</strong>
+    <strong>{{ params.reference }}</strong>
     {%endif %}
   </div>
 </div>


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

[Trello ticket](https://trello.com/c/svqoRrSp/195-1-show-default-example-and-variants-of-the-panel-component)