### PR TITLE
Update error-summary component with variants and new API conventions

### DIFF
--- a/src/components/error-summary/error-summary.njk
+++ b/src/components/error-summary/error-summary.njk
@@ -1,19 +1,17 @@
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 
-{{- govukErrorSummary(
-  classes='',
-  title='Message to alert the user to a problem goes here',
-  description='Optional description of the errors and how to correct them',
-  listClasses='',
-  listItems=[
+{{ govukErrorSummary({
+  "titleText": "Message to alert the user to a problem goes here",
+  "descriptionText": "Optional description of the errors and how to correct them",
+  "classes": "optional-extra-class",
+  "errorList": [
     {
-      text: 'Descriptive link to the question with an error',
-      url: '#example-error-1'
+      "text": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
     },
     {
-      text: 'Descriptive link to the question with an error',
-      url: '#example-error-2'
+      "text": "Descriptive link to the question with an error",
+      "href": "#example-error-1"
     }
   ]
-)
--}}
+}) }}

--- a/src/components/error-summary/error-summary.yaml
+++ b/src/components/error-summary/error-summary.yaml
@@ -1,0 +1,13 @@
+variants:
+  - name: default
+    data:
+      titleText: Message to alert the user to a problem goes here
+      descriptionText: Optional description of the errors and how to correct them
+      classes: optional-extra-class
+      errorList:
+        -
+          text: Descriptive link to the question with an error
+          href: '#example-error-1'
+        -
+          html: Descriptive link to the question with an error
+          href: '#example-error-1'

--- a/src/components/error-summary/index.njk
+++ b/src/components/error-summary/index.njk
@@ -14,7 +14,6 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
 {{ govukTable({
   'firstCellIsHeader': 'true',
   'head' : [
@@ -37,7 +36,7 @@
         text: 'classes'
       },
       {
-        text: 'String'
+        text: 'string'
       },
       {
         text: 'No'
@@ -51,7 +50,7 @@
         text: 'titleText'
       },
       {
-        text: 'String'
+        text: 'string'
       },
       {
         text: 'No'
@@ -65,7 +64,7 @@
         text: 'titleHtml'
       },
       {
-        text: 'String'
+        text: 'string'
       },
       {
         text: 'No'
@@ -79,7 +78,7 @@
         text: 'descriptionText'
       },
       {
-        text: 'String'
+        text: 'string'
       },
       {
         text: 'No'
@@ -93,7 +92,7 @@
         text: 'descriptionHtml'
       },
       {
-        text: 'String'
+        text: 'string'
       },
       {
         text: 'No'
@@ -107,7 +106,7 @@
         text: 'errorList'
       },
       {
-        text: 'Object'
+        text: 'object'
       },
       {
         text: 'Yes'

--- a/src/components/error-summary/macro.njk
+++ b/src/components/error-summary/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukErrorSummary(classes='', title, description, listClasses, listItems, listOptions) %}
+{% macro govukErrorSummary(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-summary/template.njk
+++ b/src/components/error-summary/template.njk
@@ -1,16 +1,20 @@
 {% from "list/macro.njk" import govukList -%}
 
 <div class="govuk-c-error-summary
-  {%- if classes %} {{ classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+  {%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <h2 class="govuk-c-error-summary__title" id="error-summary-title">
-    {{ title }}
+    {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h2>
   <div class="govuk-c-error-summary__body">
-    {% if description %}
+    {% if params.descriptionHtml or params.descriptionText %}
     <p>
-      {{ description }}
+      {{ params.descriptionHtml | safe if params.descriptionHtml else params.descriptionText }}
     </p>
     {% endif %}
-    {{ govukList(classes=listClasses + ' govuk-c-error-summary__list', listItems, listOptions) }}
+    {{ govukList({
+      classes: 'govuk-c-error-summary__list',
+      items: params.errorList
+    }) }}
   </div>
 </div>


### PR DESCRIPTION
- template.njk file is updated to be able to read the YAML file
structure
- update macro.njk file to accept new paramaters from YAML
- update table of arguments in index.njk
- update example in error-summary.njk
- rename listofErrors to errors
- remove classes key from listofErrors
- replace content in errorList with either text or html keys and amend
template accordingly
- update title to accept either titleText or titleHtml and amend
template accordingly
- update description to accept either descriptionText or descriptionHtml
and amend template accordingly
- add functionality to specify html attributes that get
appended to the element

This component uses the list component and accepts the `text`,`html`and `href` arguments for it. The rest we do not want to expose as we're not allowing changes to the error-summary look.

[Trello ticket](https://trello.com/c/LoF1Zp4D/189-3-show-default-example-and-variants-of-the-error-summary-component)