### PR TITLE
Legal text component default and variants from YAML file

### DIFF
--- a/src/components/legal-text/index.njk
+++ b/src/components/legal-text/index.njk
@@ -6,9 +6,7 @@
 {% block componentDescription %}
   Use bold text with an exclamation icon if there are legal consequences - for example, a fine or prison sentence.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/legal-text/legal-text.njk
+++ b/src/components/legal-text/legal-text.njk
@@ -1,8 +1,9 @@
 {% from "legal-text/macro.njk" import govukLegalText %}
 
 {{- govukLegalText(
-  classes='',
-  iconFallbackText='Warning',
-  legalText='You can be fined up to £5,000 if you don’t register.'
-  )
+  {
+    "classes": "",
+    "legalText": "You can be fined up to £5,000 if you don’t register.",
+    "iconFallbackText": "Warning"
+  })
 -}}

--- a/src/components/legal-text/legal-text.yaml
+++ b/src/components/legal-text/legal-text.yaml
@@ -1,0 +1,6 @@
+variants:
+  - name: default
+    data:
+      classes:
+      legalText: You can be fined up to £5,000 if you don’t register.
+      iconFallbackText: Warning

--- a/src/components/legal-text/macro.njk
+++ b/src/components/legal-text/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukLegalText(classes='', iconFallbackText, legalText) %}
+{% macro govukLegalText(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/legal-text/template.njk
+++ b/src/components/legal-text/template.njk
@@ -1,10 +1,10 @@
 {% from "legal-text/macro.njk" import govukLegalText -%}
 
 <div class="govuk-c-legal-text
-  {%- if classes %} {{ classes }}{% endif %}">
+  {%- if params.classes %} {{ params.classes }}{% endif %}">
   <span class="govuk-c-legal-text__icon govuk-u-circle" aria-hidden="true">!</span>
   <strong class="govuk-c-legal-text__text">
-    <span class="govuk-c-legal-text__assistive">{{ iconFallbackText }}</span>
-    {{ legalText }}
+    <span class="govuk-c-legal-text__assistive">{{ params.iconFallbackText }}</span>
+    {{ params.legalText }}
   </strong>
 </div>


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

[Trello ticket](https://trello.com/c/B9p0l7kI/193-2-show-default-example-and-variants-of-the-legal-text-component)