### PR TITLE
Move variants for details component to YAML file

### DIFF
--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -1,13 +1,13 @@
 {% from "details/macro.njk" import govukDetails %}
 
-{{- govukDetails(
-  classes='',
-  detailsSummaryText='Help with nationality',
-  detailsText='<p>
+{{- govukDetails({
+  "classes": "",
+  "summary": "Help with nationality",
+  "text": "<p>
     If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
   </p>
   <p>
     We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-  </p>'
-  )
+  </p>"
+  })
 -}}

--- a/src/components/details/details.yaml
+++ b/src/components/details/details.yaml
@@ -1,0 +1,11 @@
+variants:
+  - name: default
+    data:
+      summary: Help with nationality
+      text:
+        <p>If you’re not sure about your nationality, try to find out from an
+        official document like a passport or national ID card.</p>
+        <p>We need to know your nationality so we can work out which elections
+        you’re entitled to vote in. If you can’t provide your nationality,
+        you’ll have to send copies of identity documents through the post.</p>
+

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -6,9 +6,8 @@
 {% block componentDescription %}
   Component for conditionally revealing content, using the details HTML element.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
@@ -52,7 +51,7 @@
       ],
       [
         {
-          text: 'detailsSummaryText'
+          text: 'summary'
         },
         {
           text: 'string'
@@ -66,7 +65,7 @@
       ],
       [
         {
-          text: 'detailsText'
+          text: 'text'
         },
         {
           text: 'string'

--- a/src/components/details/macro.njk
+++ b/src/components/details/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukDetails(classes='', detailsSummaryText, detailsText) %}
+{% macro govukDetails(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -1,11 +1,11 @@
 <details class="govuk-c-details
-  {%- if classes %} {{ classes }}{% endif %}">
+  {%- if classes %} {{ params.classes }}{% endif %}">
   <summary class="govuk-c-details__summary">
-    <span class="govuk-c-details__summary-text">{{ detailsSummaryText}}</span>
+    <span class="govuk-c-details__summary-text">{{ params.summary }}</span>
   </summary>
   <div class="govuk-c-border govuk-c-border--left-narrow">
     <div class="govuk-c-details__text">
-      {{ detailsText | safe }}
+      {{ params.text | safe }}
     </div>
   </div>
 </details>


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

https://trello.com/c/uOvTuVc1/187-2-show-default-example-and-variants-of-the-details-component