### PR TITLE
Move variants for inset-text component to YAML file

### DIFF
--- a/src/components/inset-text/index.njk
+++ b/src/components/inset-text/index.njk
@@ -6,9 +6,7 @@
 {% block componentDescription %}
   Use bordered inset text to draw attention to important content on the page.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/inset-text/inset-text.njk
+++ b/src/components/inset-text/inset-text.njk
@@ -1,10 +1,10 @@
 {% from "inset-text/macro.njk" import govukInsetText %}
 
-{{- govukInsetText(
-  classes='',
-  content='<p>
+{{- govukInsetText({
+  "classes": "",
+  "content": "<p>
     It can take up to 8 weeks to register a lasting power of attorney if<br>
     there are no mistakes in the application.
-  </p>'
-  )
+  </p>"
+  })
 -}}

--- a/src/components/inset-text/inset-text.yaml
+++ b/src/components/inset-text/inset-text.yaml
@@ -1,0 +1,6 @@
+variants:
+  - name: default
+    data:
+      content:
+        It can take up to 8 weeks to register a lasting power of attorney if
+        there are no mistakes in the application.

--- a/src/components/inset-text/macro.njk
+++ b/src/components/inset-text/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukInsetText(classes='', content) %}
+{% macro govukInsetText(params) %}
   {%- include './template.njk' -%}
 {% endmacro %}

--- a/src/components/inset-text/template.njk
+++ b/src/components/inset-text/template.njk
@@ -1,4 +1,4 @@
 <div class="govuk-c-inset-text
-  {%- if classes %} {{ classes }}{% endif %}">
-  {{ content | safe }}
+  {%- if classes %} {{ params.classes }}{% endif %}">
+  {{ params.content | safe }}
 </div>


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

https://trello.com/c/DD2oUb8e/192-2-show-default-example-and-variants-of-the-inset-text-component