### PR TITLE
Update to list component "type" parameter

### DIFF
--- a/src/components/list/index.njk
+++ b/src/components/list/index.njk
@@ -93,58 +93,16 @@
       ],
       [
         {
-          text: 'isBullet'
+          text: 'type'
         },
         {
-          text: 'boolean'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Creates bulleted list'
-        }
-      ],
-      [
-        {
-          text: 'isNumber'
-        },
-        {
-          text: 'boolean'
+          text: 'String'
         },
         {
           text: 'No'
         },
         {
-          text: 'Creates numbered list'
-        }
-      ],
-      [
-        {
-          text: 'isStep'
-        },
-        {
-          text: 'boolean'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Creates list of steps with normal icons'
-        }
-      ],
-      [
-        {
-          text: 'isStepLarge'
-        },
-        {
-          text: 'boolean'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Creates list of steps with large icons'
+          text: 'Type of modifier for the list: options: "bullet", "number", "step" and "step--large"'
         }
       ]
     ]

--- a/src/components/list/list.yaml
+++ b/src/components/list/list.yaml
@@ -14,7 +14,7 @@ variants:
 - name: bulleted-list
   data:
     classes: govuk-c-list--bullet
-    isBullet: true
+    type: bullet
     items:
       -
         content: 'here is a bulleted list'
@@ -27,7 +27,7 @@ variants:
 - name: numbered-list
   data:
     classes: govuk-c-list--number
-    isNumber: true
+    type: number
     items:
       -
         content: 'This is a numbered list.'
@@ -39,7 +39,7 @@ variants:
   data:
     content: Steps icon list
     classes: govuk-c-list--icon
-    isStep: true
+    type: step
     items:
       -
         content: 'Step'
@@ -72,7 +72,7 @@ variants:
 - name: steps-large-icon-list
   data:
     classes: govuk-c-list--icon
-    isStepLarge: true
+    type: step--large
     items:
       -
         content: 'Step'

--- a/src/components/list/template.njk
+++ b/src/components/list/template.njk
@@ -1,13 +1,14 @@
-{% if params.isBullet %}
+{% set type = params.type | lower %}
+{% if type == 'bullet' %}
 <ul class="govuk-c-list govuk-c-list--bullet
   {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif params.isNumber %}
+{% elseif type == 'number' %}
 <ol class="govuk-c-list govuk-c-list--number
   {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif params.isStep %}
+{% elseif type == 'step' %}
 <ol class="govuk-c-list govuk-c-list--icon
   {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif params.isStepLarge %}
+{% elseif type == 'step--large' %}
 <ol class="govuk-c-list govuk-c-list--icon
   {%- if params.classes %} {{ params.classes }}{% endif %}">
 {% else %}
@@ -17,8 +18,8 @@
 
 {%- for item in params.items %}
   <li>
-    {% if (params.isStep) or (params.isStepLarge) %}
-    <span class="govuk-c-list__icon govuk-u-circle {% if (params.isStepLarge) %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span> {{ item.content }}
+    {% if type == 'step' or type == 'step--large' %}
+    <span class="govuk-c-list__icon govuk-u-circle {% if type == 'step--large' %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span> {{ item.content }}
     {% else %}
     {% if item.href %}
     <a href="{{ item.href }}">
@@ -31,7 +32,7 @@
   </li>
 {% endfor -%}
 
-{% if (params.isNumber) or (params.isStep) or (params.isStepLarge) %}
+{% if type == 'number' or type == 'step' or type == 'step--large' %}
 </ol>
 {% else %}
 </ul>


### PR DESCRIPTION
Previously we had different boolean keys to identify different types of list:
isNumber, isBullet,  isStep and isStepLarge

This made it difficult to pass that parameter to the component from a parent component, like error-summary, as in #284 

This PR updates this to be a "type" key and we run a filter on the variable that converts it to lowercase (just in case)