### PR TITLE
Error message component default and variants from YAML file

### DIFF
--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -1,7 +1,8 @@
 {% from "error-message/macro.njk" import govukErrorMessage %}
 
 {{- govukErrorMessage(
-  classes='',
-  errorMessage='Error message goes here'
-  )
+  {
+    "classes": "" ,
+    "errorMessage": "Error message about full name goes here"
+  })
 -}}

--- a/src/components/error-message/error-message.yaml
+++ b/src/components/error-message/error-message.yaml
@@ -1,0 +1,5 @@
+variants:
+ - name: default
+   data:
+    classes: ''
+    errorMessage: Error message about full name goes here

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -7,9 +7,7 @@
   Component to show a red error message - used for form validation.
   Use inside a label or legend.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukErrorMessage(errorMessage) %}
+{% macro govukErrorMessage(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,2 +1,2 @@
 <span class="govuk-c-error-message
-  {%- if classes %} {{ classes }}{% endif %}">{{ errorMessage }}</span>
+  {%- if params.classes %} {{ params.classes }}{% endif %}">{{ params.errorMessage }}</span>


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

[Trello ticket](https://trello.com/c/R7RYqHd9/188-2-show-default-example-and-variants-of-the-error-message-component)