### PR TITLE
Update site-width-container use in the app

### DIFF
--- a/src/views/layout.njk
+++ b/src/views/layout.njk
@@ -12,7 +12,7 @@
   {% block styles %}
   {% endblock %}
 </head>
-<body class="{% block bodyClasses %}{% endblock %} govuk-c-site-width-container">
+<body class="{% block bodyClasses %}{% endblock %} govuk-o-site-width-container">
   <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 {% endif %}
   {% block content %}


### PR DESCRIPTION
In #290 we changed the prefix to be `govuk-o` for layout elements (grid and side-width-container)
This PR updated the template to use the same class name. Without it the layout in the app is broken.
