### PR TITLE
Move variants for textarea component to YAML file

### DIFF
--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -6,20 +6,19 @@
 {% block componentDescription %}
   A multi-line text field.
 {% endblock %}
-{# componentExample #}
-{# componentNunjucks #}
-{# componentHtml #}
+
+{# defaultAndVariants #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{{ govukTable(
-  classes='',
-  options = {
+{{ govukTable({
+  classes: '',
+  options: {
     'isFirstCellHeader': 'true'
   },
-  data = {
+  data: {
     'head' : [
       {
         text: 'Name'
@@ -51,21 +50,7 @@
       ],
       [
         {
-          text: 'data'
-        },
-        {
-          text: 'array'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'Data array with text and type keys'
-        }
-      ],
-      [
-        {
-          text: 'labelText'
+          text: 'label.labelText'
         },
         {
           text: 'string'
@@ -79,7 +64,7 @@
       ],
       [
         {
-          text: 'hintText'
+          text: 'label.hintText'
         },
         {
           text: 'string'
@@ -93,7 +78,7 @@
       ],
       [
         {
-          text: 'errorMessage'
+          text: 'label.errorMessage.errorMessage'
         },
         {
           text: 'string'
@@ -103,6 +88,20 @@
         },
         {
           text: 'Optional error message'
+        }
+      ],
+      [
+        {
+          text: 'label.errorMessage.classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Additional classes for error message'
         }
       ],
       [
@@ -149,5 +148,6 @@
       ]
     ]
   }
-)}}
+})
+}}
 {% endblock %}

--- a/src/components/textarea/macro.njk
+++ b/src/components/textarea/macro.njk
@@ -1,3 +1,3 @@
-{% macro govukTextarea(classes, labelText, hintText, errorMessage, id, name, value, rows) %}
+{% macro govukTextarea(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,7 +1,13 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel(classes, labelText, hintText, errorMessage, id) -}}
+{{- govukLabel({
+  "labelText": params.label.labelText,
+  "hintText": params.label.hintText,
+  "errorMessage": params.label.errorMessage,
+  "classes": params.label.classes,
+  "id": params.id
+}) -}}
 
 <textarea class="govuk-c-textarea
-{%- if errorMessage %}govuk-c-input--error{% endif %}
-{%- if classes %} {{ classes }}{% endif -%}" id="{{ id }}" name="{{ name }}" rows="{%if rows %} {{- rows -}} {% else %}5{%endif %}"></textarea>
+{%- if params.label.errorMessage %} govuk-c-textarea--error{% endif %}
+{%- if params.classes %} {{ params.classes }}{% endif -%}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"></textarea>

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -10,4 +10,4 @@
 
 <textarea class="govuk-c-textarea
 {%- if params.label.errorMessage %} govuk-c-textarea--error{% endif %}
-{%- if params.classes %} {{ params.classes }}{% endif -%}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"></textarea>
+{%- if params.classes %} {{ params.classes }}{% endif -%}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}">{{ params.value }}</textarea>

--- a/src/components/textarea/textarea.njk
+++ b/src/components/textarea/textarea.njk
@@ -1,22 +1,11 @@
 {% from "textarea/macro.njk" import govukTextarea %}
 
-{{ govukTextarea(
-  classes='',
-  labelText='National Insurance number',
-  hintText='',
-  errorMessage='',
-  id='textarea',
-  name='name'
-  )
-}}
-
-{{ govukTextarea(
-  classes='',
-  labelText='National Insurance number',
-  hintText='',
-  errorMessage='',
-  id='textarea-2',
-  name='name-2',
-  rows='10'
-  )
+{{ govukTextarea({
+  "id": "more-detail",
+  "name": "more-detail",
+  "label": {
+    "labelText": "Can you provide more detail?",
+    "hintText": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+  }
+})
 }}

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -1,0 +1,26 @@
+variants:
+  - name: default
+    data:
+      name: more-detail
+      id: more-detail
+      label:
+        labelText: Can you provide more detail?
+        hintText: Don't include personal or financial information, eg your
+                  National Insurance number or credit card details.
+
+  - name: error-state
+    data:
+      name: no-ni-reason
+      id: no-ni-reason
+      label:
+        labelText: Why can't you provide a National Insurance number?
+        errorMessage:
+          errorMessage: You must provide an explanation
+
+  - name: specifying-rows
+    data:
+      id: full-address
+      name: address
+      label:
+        labelText: Full address
+      rows: 8

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -17,6 +17,17 @@ variants:
         errorMessage:
           errorMessage: You must provide an explanation
 
+  - name: with-value
+    data:
+      id: full-address
+      name: address
+      value: |
+        221B Baker Street
+        London
+        NW1 6XE
+      label:
+        labelText: Full address
+
   - name: specifying-rows
     data:
       id: full-address


### PR DESCRIPTION
This PR:

- adds a YAML file where default option and variants are defined
- updates macro, template and documentation to read and display those variants

https://trello.com/c/z2wOWUFc/200-2-show-default-example-and-variants-of-the-textarea-component