### PR TITLE
Update error message component to follow convention

### DIFF
--- a/src/components/error-message/error-message.njk
+++ b/src/components/error-message/error-message.njk
@@ -2,7 +2,6 @@
 
 {{- govukErrorMessage(
   {
-    "classes": "" ,
-    "errorMessage": "Error message about full name goes here"
+    "text": "Error message about full name goes here"
   })
 -}}

--- a/src/components/error-message/error-message.yaml
+++ b/src/components/error-message/error-message.yaml
@@ -1,5 +1,4 @@
 variants:
- - name: default
-   data:
-    classes: ''
-    errorMessage: Error message about full name goes here
+- name: default
+  data:
+    text: Error message about full name goes here

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -14,12 +14,12 @@
 
 {% block componentArguments %}
 {% from "table/macro.njk" import govukTable %}
-{{ govukTable(
-  classes='',
-  options = {
+{{ govukTable({
+  classes: '',
+  options: {
     'isFirstCellHeader': 'true'
   },
-  data = {
+  data: {
     'head' : [
       {
         text: 'Name'
@@ -51,19 +51,47 @@
       ],
       [
         {
-          text: 'errorMessage'
+          text: 'text'
         },
         {
           text: 'string'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'Error message text'
+          text: 'Text to use within the error message'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use within the error message. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the error message span tag'
         }
       ]
     ]
   }
-)}}
+})}}
 {% endblock %}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,3 +1,7 @@
 {% macro govukErrorMessage(params) %}
+  {% if params|string === params %}
+    {% set params = { text: params } %}
+  {% endif %}
+
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-message/template.njk
+++ b/src/components/error-message/template.njk
@@ -1,2 +1,3 @@
-<span class="govuk-c-error-message
-  {%- if params.classes %} {{ params.classes }}{% endif %}">{{ params.errorMessage }}</span>
+<span class="govuk-c-error-message{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+   {{ params.html | safe if params.html else params.text }}
+</span>


### PR DESCRIPTION
- Allow error message content to be passed as either `text` or `html` rather than `errorMessage`. If HTML is provided, use with the safe filter, otherwise use text.
- Allow for extra attributes to be specified on the error message `<span>` through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (error-message.yaml) to use the new arguments
- Update the example nunjucks template (error-message.njk) to use the new arguments
- Allow for `text` to be passed as a single argument by itself without having to pass the entire object.