### PR TITLE
Update cookie banner component to follow convention

### DIFF
--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -20,7 +20,7 @@
     display: none;
   }
 
-  .govuk-c-cookie-banner__text {
+  .govuk-c-cookie-banner__message {
     @include govuk-site-width-container;
     @include govuk-core-16;
   }

--- a/src/components/cookie-banner/cookie-banner.njk
+++ b/src/components/cookie-banner/cookie-banner.njk
@@ -1,8 +1,5 @@
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
 
-{{- govukCookieBanner(
-  {
-    classes: '',
-    content: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
-  }
-) -}}
+{{ govukCookieBanner({
+  "html": "GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a>"
+}) }}

--- a/src/components/cookie-banner/cookie-banner.njk
+++ b/src/components/cookie-banner/cookie-banner.njk
@@ -1,5 +1,5 @@
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
 
 {{ govukCookieBanner({
-  "html": "GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a>"
+  'html': 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
 }) }}

--- a/src/components/cookie-banner/cookie-banner.yaml
+++ b/src/components/cookie-banner/cookie-banner.yaml
@@ -1,4 +1,4 @@
 variants:
 - name: default
   data:
-    html: "GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a>"
+    html: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'

--- a/src/components/cookie-banner/cookie-banner.yaml
+++ b/src/components/cookie-banner/cookie-banner.yaml
@@ -1,4 +1,4 @@
 variants:
 - name: default
   data:
-    content: GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
+    html: "GOV.UK uses cookies to make the site simpler. <a href='https://www.gov.uk/help/cookies'>Find out more about cookies</a>"

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -51,16 +51,44 @@
       ],
       [
         {
-          text: 'content'
+          text: 'text'
         },
         {
           text: 'string'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'Cookie banner text'
+          text: 'Text to use for the cookie-banner message'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use for the cookie-banner message. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the cookie-banner container.'
         }
       ]
     ]

--- a/src/components/cookie-banner/macro.njk
+++ b/src/components/cookie-banner/macro.njk
@@ -1,3 +1,6 @@
 {% macro govukCookieBanner(params) %}
+  {% if params|string === params %}
+    {% set params = { text: params } %}
+  {% endif %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/cookie-banner/template.njk
+++ b/src/components/cookie-banner/template.njk
@@ -1,3 +1,3 @@
 <div class="govuk-c-cookie-banner js-cookie-banner{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <p class="govuk-c-cookie-banner__text">{{ params.html | safe if params.html else params.text }}</p>
+  <p class="govuk-c-cookie-banner__message">{{ params.html | safe if params.html else params.text }}</p>
 </div>

--- a/src/components/cookie-banner/template.njk
+++ b/src/components/cookie-banner/template.njk
@@ -1,4 +1,3 @@
-<div class="govuk-c-cookie-banner js-cookie-banner
-{%- if params.classes %} {{ params.classes }}{% endif %}">
-  <p class="govuk-c-cookie-banner__text">{{ params.content | safe }}</p>
+<div class="govuk-c-cookie-banner js-cookie-banner{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  <p class="govuk-c-cookie-banner__text">{{ params.html | safe if params.html else params.text }}</p>
 </div>


### PR DESCRIPTION
- replace content parameter so that either text or html parameters, so
that both can be used
- update template to accept text (as default) or html parameters, where
html is marked as safe
- add functionality to specify html attributes that get appended to the
element
- update YAML file to reflect new parameters
- update table of arguments to reflect changes
- update example in cookie-banner.njk file
- change message container css class:
`.govuk-c-cookie-banner__text` is too specific, so its been updated to
`.govuk-c-cookie-banner__message`