### PR TITLE
Update label component to follow convention

### DIFF
--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -51,7 +51,35 @@
       ],
       [
         {
-          text: 'labelText'
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Text to use within the label'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use within the label. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'for'
         },
         {
           text: 'string'
@@ -60,7 +88,7 @@
           text: 'Yes'
         },
         {
-          text: 'The label text'
+          text: 'The value of the for attribute, the id of the input the label is associated with'
         }
       ],
       [
@@ -74,12 +102,12 @@
           text: 'No'
         },
         {
-          text: 'Optional hint text'
+          text: 'Optional text to use as a hint'
         }
       ],
       [
         {
-          text: 'errorMessage'
+          text: 'hintHtml'
         },
         {
           text: 'string'
@@ -88,21 +116,35 @@
           text: 'No'
         },
         {
-          text: 'Optional error message'
+          text: 'Optional HTML to use as a hint. If this is provided, the hintText argument will be ignored.'
         }
       ],
       [
         {
-          text: 'id'
+          text: 'errorMessage'
         },
         {
-          text: 'string'
+          text: 'object'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'The value of the for attribute, the id input the label is associated with'
+          text: 'Optional error message. See errorMessage component.'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the error message span tag.'
         }
       ]
     ]

--- a/src/components/label/label.njk
+++ b/src/components/label/label.njk
@@ -1,8 +1,7 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{ govukLabel(
-  {
-  "labelText": "National Insurance number,",
+{{ govukLabel({
+  "text": "National Insurance number",
   "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
 }
 ) }}

--- a/src/components/label/label.yaml
+++ b/src/components/label/label.yaml
@@ -1,20 +1,19 @@
 variants:
   - name: default
     data:
-      labelText: National Insurance number,
+      text: National Insurance number
       hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.'
-      # id: when combined with an input/form element
-  - name: with-bold-label
+  - name: with bold text
     data:
       classes: govuk-c-label--bold
-      labelText: National Insurance number,
+      text: National Insurance number
       hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.'
-
-  - name: with-error-message
+  - name: with error message
     data:
-      labelText: National Insurance number,
+      text: National Insurance number
       hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.'
-      errorMessage: Error message goes here
+      errorMessage:
+        text: Error message goes here

--- a/src/components/label/macro.njk
+++ b/src/components/label/macro.njk
@@ -1,3 +1,6 @@
 {% macro govukLabel(params) %}
+  {% if params|string === params %}
+    {% set params = { text: params } %}
+  {% endif %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -1,11 +1,12 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 
-<label class="govuk-c-label
-  {%- if params.classes %} {{ params.classes }}{% endif %}" for="{{ params.id }}">
-  {{ params.labelText }}
-  {% if params.hintText %}
+<label class="govuk-c-label{%- if params.classes %} {{ params.classes }}{% endif %}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+  {%- if params.for %} for="{{ params.for }}"{% endif %}>
+  {{ params.html | safe if params.html else params.text }}
+  {% if params.hintText or params.hintHtml %}
   <span class="govuk-c-label__hint">
-    {{ params.hintText }}
+    {{ params.hintHtml | safe if params.hintHtml else params.hintText }}
   </span>
   {% endif %}
   {% if params.errorMessage %}


### PR DESCRIPTION
- Allow label content to be passed as either `text` or `html` rather than `labelText`.
- Allow for extra attributes to be specified on the `<label>` through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (label.yaml) to use the new arguments
- Update the example nunjucks template (label.njk) to use the new arguments
- Allow for `text` to be passed as a single argument by itself without having to pass the entire object.

[Trello ticket](https://trello.com/c/bw1RwNDs)