### PR TITLE
Update button component to follow convention

### DIFF
--- a/src/components/button/button.njk
+++ b/src/components/button/button.njk
@@ -1,3 +1,3 @@
 {% from "button/macro.njk" import govukButton %}
 
-{{ govukButton({classes: '', text:'Save and continue', url: '', isStart: '', isDisabled: ''}) }}
+{{ govukButton({ text:'Save and continue', href: '/' }) }}

--- a/src/components/button/button.yaml
+++ b/src/components/button/button.yaml
@@ -6,9 +6,42 @@ variants:
 - name: disabled
   data:
     text: Disabled button
-    isDisabled: true
+    disabled: true
+- name: link
+  data:
+    text: Link button
+    href: '/'
+- name: disabled-link
+  data:
+    text: Disabled link button
+    href: '/'
+    disabled: true
 - name: start
   data:
+    text: Start now button
+    classes: 'govuk-c-button--start'
+- name: start-link
+  data:
+    text: Start now link button
+    href: /
+    classes: 'govuk-c-button--start'
+- name: button-with-html
+  data:
+    name: start-now
+    html: Start <em>now</em>
+- name: explicit-button
+  data:
+    name: start-now
     text: Start now
-    url: /
-    isStart: true
+    element: button
+- name: button-with-value
+  data:
+    name: start-now
+    value: start
+    text: Start now
+    element: button
+- name: non-submit-button
+  data:
+    name: add-another
+    text: Add another
+    type: button

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -47,6 +47,118 @@ Buttons are configured to perform an action and they can have a different look. 
     'rows' : [
       [
         {
+          text: 'element'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Text for the button'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'HTML for the button or link. If this is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.'
+        }
+      ],
+      [
+        {
+          text: 'name'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Name for the `input` or `button`. This has no effect on `a` elements.'
+        }
+      ],
+      [
+        {
+          text: 'type'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Type of `input` or `button` – `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.'
+        }
+      ],
+      [
+        {
+          text: 'value'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Value for the `button` tag. This has no effect on `a` or `input` elements.'
+        }
+      ],
+      [
+        {
+          text: 'disabled'
+        },
+        {
+          text: 'boolean'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.'
+        }
+      ],
+       [
+        {
+          text: 'href'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.'
+        }
+      ],
+      [
+        {
           text: 'classes'
         },
         {
@@ -61,58 +173,16 @@ Buttons are configured to perform an action and they can have a different look. 
       ],
       [
         {
-          text: 'text'
+          text: 'attributes'
         },
         {
-          text: 'string'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'Button or link text'
-        }
-      ],
-      [
-        {
-          text: 'isStart'
-        },
-        {
-          text: 'boolean'
+          text: 'object'
         },
         {
           text: 'No'
         },
         {
-          text: 'Adds the class govuk-c-button--start for a "Start now" button'
-        }
-      ],
-      [
-        {
-          text: 'isDisabled'
-        },
-        {
-          text: 'boolean'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Disables the button - adds the class govuk-c-button--disabled and sets disabled="disabled" and aria-disabled="true"'
-        }
-      ],
-       [
-        {
-          text: 'url'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Url that the hyperlink points to'
+          text: 'Any extra HTML attributes (for example data attributes) to add to the error message span tag'
         }
       ]
     ]

--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,3 +1,7 @@
 {% macro govukButton(params) %}
+  {%- if params|string === params %}
+    {% set params = { text: params } %}
+  {% endif %}
+
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -1,13 +1,37 @@
-{% if params.url %}
-<a class="govuk-c-button
-{%- if params.isStart %} govuk-c-button--start{% endif %}
-{%- if params.classes %} {{ params.classes }}{% endif %}" href="{{ params.url | safe }}" role="button">
-  {%- if params.text %}{{ params.text }}{% endif %}
-</a>
+{# Determine type of element to use, if not explicitly set -#}
+
+{% if params.element %}
+  {% set element = params.element %}
 {% else %}
-<input class="govuk-c-button
-{%- if params.isDisabled %} govuk-c-button--disabled{% endif %}
-{%- if params.classes %} {{ params.classes }}{% endif %}"
-{%- if params.text %} value="{{ params.text }}"{% endif %}
-{%- if params.isDisabled %} disabled="disabled" aria-disabled="true"{% endif %}>
+  {% if params.href %}
+    {% set element = 'a' %}
+  {% elseif params.html %}
+    {% set element = 'button' %}
+  {% else %}
+    {% set element = 'input' %}
+  {% endif %}
 {% endif %}
+
+{#- Define common attributes that we can use across all element types #}
+
+{%- set commonAttributes %} class="govuk-c-button{% if params.classes %} {{ params.classes }}{% endif %}{% if params.disabled %} govuk-c-button--disabled{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}{% endset %}
+
+{#- Define common attributes we can use for both button and input types #}
+
+{%- set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% endset %}
+
+{#- Actually create a button... or a link! #}
+
+{%- if element == 'a' %}
+<a href="{{ params.href if params.href else '#' }}" role="button" {{- commonAttributes | safe }}>
+  {{ params.html | safe if params.html else params.text }}
+</a>
+
+{%- elseif element == 'button' %}
+<button {%- if params.value %} value="{{ params.value }}"{% endif %} {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
+  {{ params.html | safe if params.html else params.text }}
+</button>
+
+{%- elseif element == 'input' %}
+<input value="{{ params.text }}" {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
+{%- endif %}


### PR DESCRIPTION
- Fix a bug where buttons were actually text inputs in disguise (!) because the `type` attribute was not being set.
- Allow users to pass either html or text for both `a` and `button` type buttons.
- Allow users to choose the element they want to use for the button (input, button or a), but choose a sensible default based on usage of html or href.
- Allow users to set the name of the button or input.
- Allow users to set the type of the button or input (defaults to `submit`).
- Rename `isDisabled` argument to `disabled`.
- Rename `url` argument to `href`.
- Allow for additional attributes to be added to the button through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (button.yaml) to use the new arguments
- Update the example nunjucks template (button.njk) to use the new arguments
- Allow for text argument to be passed by itself

https://trello.com/c/R69h2v0n/260-update-button-component-api