### PR TITLE
Update details component to follow convention

### DIFF
--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -1,13 +1,7 @@
 {% from "details/macro.njk" import govukDetails %}
 
 {{- govukDetails({
-  "classes": "",
   "summary": "Help with nationality",
-  "text": "<p>
-    If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card.
-  </p>
-  <p>
-    We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-  </p>"
+  "text": "If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."
   })
 -}}

--- a/src/components/details/details.yaml
+++ b/src/components/details/details.yaml
@@ -1,11 +1,21 @@
 variants:
-  - name: default
-    data:
-      summary: Help with nationality
-      text:
-        <p>If you’re not sure about your nationality, try to find out from an
-        official document like a passport or national ID card.</p>
-        <p>We need to know your nationality so we can work out which elections
-        you’re entitled to vote in. If you can’t provide your nationality,
-        you’ll have to send copies of identity documents through the post.</p>
-
+  
+- name: default
+  data:
+    summaryText: Help with nationality
+    text:
+      We need to know your nationality so we can work out which elections
+      you’re entitled to vote in. If you can’t provide your nationality,
+      you’ll have to send copies of identity documents through the post.
+- name: with-html
+  data:
+    summaryText: Where to find your National Insurance Number
+    html: |
+      Your National Insurance number can be found on
+      <ul>
+        <li>your National Insurance card</li>
+        <li>your payslip</li>
+        <li>P60</li>
+        <li>benefits information</li>
+        <li>tax return</li>
+      </ul>

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -14,12 +14,11 @@
 
 {% block componentArguments %}
 {% from "table/macro.njk" import govukTable %}
-{{ govukTable(
-  classes='',
-  options = {
+{{ govukTable({
+  options: {
     'isFirstCellHeader': 'true'
   },
-  data = {
+  data: {
     'head' : [
       {
         text: 'Name'
@@ -37,6 +36,62 @@
     'rows' : [
       [
         {
+          text: 'summaryText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Text to use within the summary element (the visible part of the details element)'
+        }
+      ],
+      [
+        {
+          text: 'summaryHtml'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'HTML to use within the summary element (the visible part of the details element). If this is provided, the summaryText argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Text to use within the disclosed part of the details element.'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'HTML to use within the disclosed part of the details element. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
           text: 'classes'
         },
         {
@@ -51,33 +106,19 @@
       ],
       [
         {
-          text: 'summary'
+          text: 'attributes'
         },
         {
-          text: 'string'
+          text: 'object'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'Summary element text'
-        }
-      ],
-      [
-        {
-          text: 'text'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'Revealed details text'
+          text: 'Any extra HTML attributes (for example data attributes) to add to the details element'
         }
       ]
     ]
   }
-)}}
+})}}
 {% endblock %}

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -1,11 +1,12 @@
-<details class="govuk-c-details
-  {%- if classes %} {{ params.classes }}{% endif %}">
+<details class="govuk-c-details {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <summary class="govuk-c-details__summary">
-    <span class="govuk-c-details__summary-text">{{ params.summary }}</span>
+    <span class="govuk-c-details__summary-text">
+      {{ params.summaryHtml | safe if params.summaryHtml else params.summaryText }}
+    </span>
   </summary>
   <div class="govuk-c-border govuk-c-border--left-narrow">
     <div class="govuk-c-details__text">
-      {{ params.text | safe }}
+      {{ params.html | safe if params.html else params.text }}
     </div>
   </div>
 </details>


### PR DESCRIPTION
- Allow users to pass either html or text for both the disclosed content and the summary element.
- Allow for additional attributes to be added to the button through the attributes argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (details.yaml) to use the new arguments
- Update the example nunjucks template (details.njk) to use the new arguments

https://trello.com/c/yTAakDSH/253-update-details-component-api