### PR TITLE
Update link component to follow convention

### DIFF
--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -8,9 +8,8 @@
 {% block componentDescription %}
 Link component, with four variants:
 
-{{ govukList(
-  classes='',
-  [
+{{ govukList({
+  items: [
     {
       text: 'back link - a black underlined link with a left pointing arrow'
     },
@@ -24,10 +23,8 @@ Link component, with four variants:
       text: 'skip link - skip to the main page content'
     }
   ],
-  options = {
-    'isBullet': 'true'
-  }
-) }}
+  type: 'bullet'
+}) }}
 {% endblock %}
 
 {# defaultAndVariants #}
@@ -59,6 +56,48 @@ Link component, with four variants:
     'rows' : [
       [
         {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'No'
+        },
+        {
+          text: 'The available classes for the link: govuk-c-link--back, govuk-c-link--download, govuk-c-link--muted and govuk-c-link--skip'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'No'
+        },
+        {
+          text: 'Text to use within the link'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text:'No'
+        },
+        {
+          text: 'HTML to use within the link. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
           text: 'href'
         },
         {
@@ -73,30 +112,16 @@ Link component, with four variants:
       ],
       [
         {
-          text: 'content'
+          text: 'attributes'
         },
         {
-          text: 'string'
+          text: 'object'
         },
         {
-          text:'Yes'
+          text: 'No'
         },
         {
-          text: 'The link text'
-        }
-      ],
-      [
-        {
-          text: 'classes'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text:'No'
-        },
-        {
-          text: 'The available modifiers for the link type: --back, --muted, --download and --skip'
+          text: 'Any extra HTML attributes (for example data attributes) to add to the anchor tag.'
         }
       ]
     ]

--- a/src/components/link/link.njk
+++ b/src/components/link/link.njk
@@ -1,3 +1,3 @@
 {% from "link/macro.njk" import govukLink %}
 
-{{ govukLink({classes: 'govuk-c-link', href: '', content: 'Default link'}) }}
+{{ govukLink({href: '#', text: 'Default link'}) }}

--- a/src/components/link/link.yaml
+++ b/src/components/link/link.yaml
@@ -1,20 +1,20 @@
 variants:
 - name: default
   data:
-    content: Default link
+    text: Default link
 - name: back
   data:
-    content: Back
+    text: Back
     classes: govuk-c-link--back
 - name: download
   data:
-    content: Download
+    text: Download
     classes: govuk-c-link--download
 - name: muted
   data:
-    content: Is there anything wrong with this page?
+    text: Is there anything wrong with this page?
     classes: govuk-c-link--muted
 - name: skip
   data:
-    content: Skip to main content
+    text: Skip to main content
     classes: govuk-c-link--skip

--- a/src/components/link/template.njk
+++ b/src/components/link/template.njk
@@ -1,2 +1,2 @@
-<a href="{%- if params.href %}{{ params.href }}{% else %}#{% endif -%}" class="govuk-c-link
-  {%- if params.classes %} {{ params.classes }}{% endif -%}">{{ params.content | safe }}</a>
+<a href="{%- if params.href %}{{ params.href }}{% else %}#{% endif -%}" class="govuk-c-link{%- if params.classes %} {{ params.classes }}{% endif -%}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.html | safe if params.html else params.text }}</a>


### PR DESCRIPTION
- Allow link content to be passed as either `text` or `html` rather than `content`.
- Allow for extra attributes to be specified on the `<a>` tag through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (link.yaml) to use the new arguments
- Update the example nunjucks template (link.njk) to use the new arguments

[Trello ticket](https://trello.com/c/XQBbTTwy)