### PR TITLE
Remove single argument definition check from components

### DIFF
--- a/src/components/button/macro.njk
+++ b/src/components/button/macro.njk
@@ -1,7 +1,3 @@
 {% macro govukButton(params) %}
-  {%- if params|string === params %}
-    {% set params = { text: params } %}
-  {% endif %}
-
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/cookie-banner/macro.njk
+++ b/src/components/cookie-banner/macro.njk
@@ -1,6 +1,3 @@
 {% macro govukCookieBanner(params) %}
-  {% if params|string === params %}
-    {% set params = { text: params } %}
-  {% endif %}
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/error-message/macro.njk
+++ b/src/components/error-message/macro.njk
@@ -1,7 +1,3 @@
 {% macro govukErrorMessage(params) %}
-  {% if params|string === params %}
-    {% set params = { text: params } %}
-  {% endif %}
-
   {%- include "./template.njk" -%}
 {% endmacro %}

--- a/src/components/label/macro.njk
+++ b/src/components/label/macro.njk
@@ -1,6 +1,3 @@
 {% macro govukLabel(params) %}
-  {% if params|string === params %}
-    {% set params = { text: params } %}
-  {% endif %}
   {%- include "./template.njk" -%}
 {% endmacro %}


### PR DESCRIPTION
Initially we wanted to provide an option to specify just the string for some components and we would figure out the right way to pass data.

It is becoming very hacky to check for that option when components are nested.
We're removing for now but might revisit in the future.