### PR TITLE
Update file upload component to follow convention

### DIFF
--- a/src/components/file-upload/file-upload.njk
+++ b/src/components/file-upload/file-upload.njk
@@ -1,11 +1,9 @@
 {% from "file-upload/macro.njk" import govukFileUpload %}
 
 {{- govukFileUpload({
-  labelClasses: '',
-  labelText: 'Upload a file',
-  errorMessage: '',
-  classes: '',
   id: 'file-upload-1',
-  name: 'file-upload-1'
-  })
--}}
+  name: 'file-upload-1',
+  label: {
+    text: 'Upload a file'
+  }
+}) -}}

--- a/src/components/file-upload/file-upload.yaml
+++ b/src/components/file-upload/file-upload.yaml
@@ -1,18 +1,32 @@
 variants:
 - name: default
   data:
-    labelText: Upload a file
     id: file-upload-1
     name: file-upload-1
+    label:
+      text: Upload a file
 - name: with-hint-text
   data:
-    labelText: Upload your photo
-    hintText: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
     id: file-upload-2
     name: file-upload-2
+    label:
+      text: Upload your photo
+      hintText: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
 - name: with-error-message
   data:
-    labelText: Upload a file
-    errorMessage: Error message goes here
     id: file-upload-3
     name: file-upload-3
+    label:
+      text: Upload a file
+      hintText: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+    errorMessage:
+      text: Error message goes here
+- name: with-value-and-attributes
+  data:
+    id: file-upload-4
+    name: file-upload-4
+    value: C:\fakepath\myphoto.jpg
+    label:
+      text: Upload a photo
+    attributes:
+      accept: .jpg, .jpeg, .png

--- a/src/components/file-upload/index.njk
+++ b/src/components/file-upload/index.njk
@@ -41,62 +41,6 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
     'rows' : [
       [
         {
-          text: 'classes'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional additional classes'
-        }
-      ],
-      [
-        {
-          text: 'labelText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'The label text'
-        }
-      ],
-      [
-        {
-          text: 'hintText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional hint text'
-        }
-      ],
-      [
-        {
-          text: 'errorMessage'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional error message'
-        }
-      ],
-      [
-        {
           text: 'id'
         },
         {
@@ -135,6 +79,62 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
         },
         {
           text: 'Optional initial value of the input'
+        }
+      ],
+      [
+        {
+          text: 'label'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Arguments for the label component'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Arguments for the error message component'
+        }
+      ],
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example accept or data attributes) to add to the input tag'
         }
       ]
     ]

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,15 +1,16 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel(
-  {
-    labelClasses: params.labelClasses,
-    labelText: params.labelText,
-    hintText: params.hintText,
-    errorMessage: params.errorMessage,
-    id: params.id
-  }
-) -}}
+{#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
 
-<input class="govuk-c-file-upload
-{%- if params.classes %} {{ params.classes }}{% endif %}
-{%- if params.errorMessage %} govuk-c-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file">
+{{- govukLabel({
+  html: params.label.html,
+  text: params.label.text,
+  hintText: params.label.hintText,
+  hintHtml: params.label.hintHtml,
+  classes: params.label.classes,
+  attributes: params.label.attributes,
+  errorMessage: params.errorMessage,
+  for: params.id
+}) -}}
+
+<input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-c-file-upload {{- ' govuk-c-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>


### PR DESCRIPTION
- Allow users to pass all possible attributes to the label component
- Automatically set the for parameter on the label to match the id of the input
- Allow user to specify the value attribute for the input
- Allow for additional attributes to be added to the input through the attributes argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (file-upload.yaml) to use the new arguments
- Update the example nunjucks template (file-upload.njk) to use the new arguments

https://trello.com/c/hw5PPLrc/262-update-file-upload-component-api