### PR TITLE
Debug file when compiling dist / packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp-changed": "^3.1.0",
     "gulp-concat": "^2.6.1",
     "gulp-data": "^1.2.1",
+    "gulp-debug": "^3.1.0",
     "gulp-eol": "^0.1.2",
     "gulp-filter": "^5.0.0",
     "gulp-flatten": "^0.3.1",

--- a/tasks/gulp/compile-components.js
+++ b/tasks/gulp/compile-components.js
@@ -2,6 +2,7 @@
 
 const configPaths = require('../../config/paths.json')
 const gulp = require('gulp')
+const debug = require('gulp-debug')
 const nunjucks = require('gulp-nunjucks')
 const rename = require('gulp-rename')
 const taskArguments = require('./task-arguments')
@@ -20,6 +21,7 @@ gulp.task('compile:components', () => {
       '!' + configPaths.components + '**/template.njk',
       configPaths.components + '**/*.njk' // Only compile componentname.njk to html
     ])
+    .pipe(debug())
     .pipe(nunjucks.compile('', {
       trimBlocks: true, // automatically remove trailing newlines from a block/tag
       lstripBlocks: true // automatically remove leading whitespace from a block/tag


### PR DESCRIPTION
When the compile:components task fails due to a syntax error, it can be difficult to understand which component caused it.

This adds the gulp-debug package and uses it to outputs the file being processed, which can help to work out which file you should be looking in.

### Before
```
[10:49:34] Starting 'compile:components'...

events.js:160
      throw er; // Unhandled 'error' event
      ^
Template render error: (unknown path) [Line 8, Column 3]
  unexpected token: }
```

### After
```
[10:53:46] Starting 'compile:components'...
[10:53:46] gulp-debug: src/components/breadcrumb/breadcrumb.njk
[10:53:46] gulp-debug: src/components/button/button.njk
[10:53:46] gulp-debug: src/components/checkbox/checkbox.njk
[10:53:46] gulp-debug: src/components/cookie-banner/cookie-banner.njk
[10:53:46] gulp-debug: src/components/date/date.njk
[10:53:46] gulp-debug: src/components/details/details.njk
[10:53:46] gulp-debug: src/components/error-message/error-message.njk
[10:53:46] gulp-debug: src/components/error-summary/error-summary.njk
[10:53:46] gulp-debug: src/components/fieldset/fieldset.njk
[10:53:46] gulp-debug: src/components/input/input.njk
[10:53:46] gulp-debug: src/components/file-upload/file-upload.njk

events.js:160
      throw er; // Unhandled 'error' event
      ^
Template render error: (unknown path) [Line 8, Column 3]
  unexpected token: }
```