### PR TITLE
Update fieldset component to follow conventions

### DIFF
--- a/src/components/fieldset/fieldset.njk
+++ b/src/components/fieldset/fieldset.njk
@@ -1,7 +1,9 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 
-{{- govukFieldset({
-  classes: '',
-  legendText: 'Legend text goes here'
-  })
--}}
+{{ govukFieldset({
+  "legendText": "Legend text goes here",
+  "legendHintText": "Legend hint text goes here",
+  "errorMessage": {
+    "text": "Error message goes here"
+  }
+}) }}

--- a/src/components/fieldset/fieldset.yaml
+++ b/src/components/fieldset/fieldset.yaml
@@ -1,16 +1,17 @@
 variants:
 - name: default
   data:
-    classes: ''
-    legendText: 'Legend text goes here'
-- name: with-hint-text
-  data:
-    classes: ''
-    legendText: 'Legend text goes here'
-    hintText: 'Legend hint text goes here'
+    legendText: Legend text goes here
+    legendHintText: Legend hint text goes here
 - name: with-error-message
   data:
-    classes: ''
-    legendText: 'Legend text goes here'
-    hintText: 'Legend hint text goes here'
-    errorMessage: 'Error message goes here'
+    legendText: Legend text goes here
+    legendHintText: Legend hint text goes here
+    errorMessage:
+      text: 'Error message goes here'
+- name: with-html-instead-of-text
+  data:
+    legendHtml: Legend text <i>goes</i> here
+    legendHintHtml: Legend hint text <i>goes</i> here
+    errorMessage:
+      html: Error message <i>goes</i>  here

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -65,7 +65,7 @@
       ],
       [
         {
-          text: 'hintText'
+          text: 'legendHtml'
         },
         {
           text: 'string'
@@ -74,7 +74,35 @@
           text: 'No'
         },
         {
-          text: 'Hint text'
+          text: 'Legend text'
+        }
+      ],
+      [
+        {
+          text: 'legendHintText'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use within the legend element. If this is used, the legendText argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'legendHintHtml'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use within the legend hint element. If this is used, the hintText argument will be ignored.'
         }
       ],
       [
@@ -82,13 +110,27 @@
           text: 'errorMessage'
         },
         {
-          text: 'string'
+          text: 'object'
         },
         {
           text: 'No'
         },
         {
-          text: 'Error message'
+          text: 'Provide text or html key with values. See errorMessage component for more details.'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the fieldset container.'
         }
       ]
     ]

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,12 +1,12 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 
 <fieldset class="govuk-c-fieldset
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-  {% if params.legendText %}
+  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% if params.legendHtml or params.legendText %}
   <legend class="govuk-c-fieldset__legend">
-    {{ params.legendText }}
-    {% if params.hintText %}
-    <span class="govuk-c-fieldset__hint">{{ params.hintText }}</span>
+    {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+    {% if params.legendHintText or params.legendHintHtml %}
+    <span class="govuk-c-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
     {% endif %}
     {% if params.errorMessage %}
     {{ govukErrorMessage(params.errorMessage) -}}


### PR DESCRIPTION
- provide text and html variations for the legend and hint parameters,
so developers can use either and in the template we default to text and
mark html as safe
- update YAML file to reflect new parameters
- update table of arguments to reflect changes
- update example in fieldset.njk file
- add functionality to accept an object of additional html attributes

Trello ticket: https://trello.com/c/9iL8IIzc/278-update-fieldset-component-api