### PR TITLE
Update list component to follow convention

### DIFF
--- a/src/components/list/index.njk
+++ b/src/components/list/index.njk
@@ -37,16 +37,16 @@
     'rows' : [
       [
         {
-          text: 'classes'
+          text: 'type'
         },
         {
-          text: 'string'
+          text: 'String'
         },
         {
           text: 'No'
         },
         {
-          text: 'Optional additional classes'
+          text: 'Type of list to create: "bullet", "number", "step" or "step-large", or omit for an unordered list without bullets.'
         }
       ],
       [
@@ -60,7 +60,7 @@
           text: 'Yes'
         },
         {
-          text: 'List items array with href and content keys'
+          text: 'Items for the list. An array of objects with text or html and optional href attributes'
         }
       ],
       [
@@ -71,38 +71,66 @@
           text: 'string'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'List item url'
+          text: 'Link target for the list item'
         }
       ],
       [
         {
-          text: 'content'
+          text: 'text'
         },
         {
           text: 'string'
         },
         {
-          text: 'Yes'
+          text: 'No'
         },
         {
-          text: 'List item content'
+          text: 'Text content for the list item'
         }
       ],
       [
         {
-          text: 'type'
+          text: 'html'
         },
         {
-          text: 'String'
+          text: 'string'
         },
         {
           text: 'No'
         },
         {
-          text: 'Type of modifier for the list: options: "bullet", "number", "step" and "step--large"'
+          text: 'HTML content for the list item. If this is specified, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'classes'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional additional classes for the list tag'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the list tag'
         }
       ]
     ]

--- a/src/components/list/list.njk
+++ b/src/components/list/list.njk
@@ -1,3 +1,18 @@
 {% from "list/macro.njk" import govukList -%}
 
-{{ govukList({classes: 'govuk-c-list', href: '/', content: 'Related link'}) }}
+{{- govukList({
+  items: [
+    {
+      text: 'Related link',
+      href: '#'
+    },
+    {
+      text: 'Related link',
+      href: '#'
+    },
+    {
+      text: 'Not a link'
+    }
+  ]
+})
+-}}

--- a/src/components/list/list.yaml
+++ b/src/components/list/list.yaml
@@ -2,103 +2,59 @@ variants:
 - name: default
   data:
     items:
-      -
-        content: Related link
-        href: /
-      -
-        content: Related link
-        href: /
-      -
-        content: Related link
-        href: /
+      - text: Related link
+        href: #
+      - text: Related link
+        href: #
+      - html: <strong>Not</strong> a link
 - name: bulleted-list
   data:
-    classes: govuk-c-list--bullet
     type: bullet
     items:
-      -
-        content: 'here is a bulleted list'
-      -
-        content: 'vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor'
-      -
-        content: 'vestibulum id ligula porta felis euismod semper'
-      -
-        content: 'integer posuere erat a ante venenatis dapibus posuere velit aliquet'
+      - text: 'here is a bulleted list'
+      - text: 'vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor'
+      - text: 'vestibulum id ligula porta felis euismod semper'
+      - text: 'integer posuere erat a ante venenatis dapibus posuere velit aliquet'
 - name: numbered-list
   data:
-    classes: govuk-c-list--number
     type: number
     items:
-      -
-        content: 'This is a numbered list.'
-      -
-        content: 'This is the second step in a numbered list.'
-      -
-        content: 'The third step is to make sure each item is a full sentence ending with a full stop.'
+      - text: 'This is a numbered list.'
+      - text: 'This is the second step in a numbered list.'
+      - text: 'The third step is to make sure each item is a full sentence ending with a full stop.'
 - name: steps-icon-list
   data:
-    content: Steps icon list
-    classes: govuk-c-list--icon
     type: step
     items:
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
+      - text: 'Step 1'
+      - text: 'Step 2'
+      - text: 'Step 3'
+      - text: 'Step 4'
+      - text: 'Step 5'
+      - text: 'Step 6'
+      - text: 'Step 7'
+      - text: 'Step 8'
+      - text: 'Step 9'
+      - text: 'Step 10'
+      - text: 'Step 11'
+      - text: 'Step 12'
+      - text: 'Step 13'
+      - text: 'Step 14'
 - name: steps-large-icon-list
   data:
-    classes: govuk-c-list--icon
-    type: step--large
+    type: step-large
     items:
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
-      -
-        content: 'Step'
+      - text: 'Step 1'
+      - text: 'Step 2'
+      - text: 'Step 3'
+      - text: 'Step 4'
+      - text: 'Step 5'
+      - text: 'Step 6'
+      - text: 'Step 7'
+      - text: 'Step 8'
+      - text: 'Step 9'
+      - text: 'Step 10'
+      - text: 'Step 11'
+      - text: 'Step 12'
+      - text: 'Step 13'
+      - text: 'Step 14'

--- a/src/components/list/template.njk
+++ b/src/components/list/template.njk
@@ -1,39 +1,31 @@
-{% set type = params.type | lower %}
-{% if type == 'bullet' %}
-<ul class="govuk-c-list govuk-c-list--bullet
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif type == 'number' %}
-<ol class="govuk-c-list govuk-c-list--number
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif type == 'step' %}
-<ol class="govuk-c-list govuk-c-list--icon
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% elseif type == 'step--large' %}
-<ol class="govuk-c-list govuk-c-list--icon
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% else %}
-<ul class="govuk-c-list
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
-{% endif %}
+{# Default to unordered list unless we redefine it later #}
+{%- set element = 'ul' %}
 
-{%- for item in params.items %}
+{#- Setup classes and element type depending on type argument. #}
+{%- set type = params.type | lower %}
+{%- if type == 'bullet' %}
+  {% set listClass = 'govuk-c-list--bullet' %}
+{% elseif type == 'number' %}
+  {% set element = 'ol' %}
+  {% set listClass = 'govuk-c-list--number' %}
+{% elseif type == 'step' or type == 'step-large' %}
+  {% set element = 'ol' %}
+  {% set listClass = 'govuk-c-list--icon' %}
+{% endif -%}
+
+<{{ element }} class="govuk-c-list {%- if listClass %} {{ listClass }}{% endif %} {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+{% for item in params.items %}
   <li>
-    {% if type == 'step' or type == 'step--large' %}
-    <span class="govuk-c-list__icon govuk-u-circle {% if type == 'step--large' %}govuk-c-list__icon--large{% endif %}">{{ loop.index }}</span> {{ item.content }}
-    {% else %}
-    {% if item.href %}
-    <a href="{{ item.href }}">
-    {% endif %}
-    {{ item.content }}
-    {% if item.href %}
-    </a>
-    {% endif %}
-    {% endif %}
+  {% if type == 'step' or type == 'step-large' %}
+    <span class="govuk-c-list__icon {%- if type == 'step-large' %} govuk-c-list__icon--large{% endif %} govuk-u-circle">
+      {{- loop.index -}}
+    </span>
+  {% endif %}
+  {% if item.href %}
+    <a href="{{ item.href }}">{{ item.html | safe if item.html else item.text }}</a>
+  {% else %}
+    {{ item.html | safe if item.html else item.text }}
+  {% endif %}
   </li>
 {% endfor -%}
-
-{% if type == 'number' or type == 'step' or type == 'step--large' %}
-</ol>
-{% else %}
-</ul>
-{% endif %}
+</{{ element }}>


### PR DESCRIPTION
Unlike the other components we are continuing to provide a way to opt in to different modifiers without using `classes`, because of the extra spans that are required for the step variant.

- Allow users to specify either html or text for each list item
- Allow users to pass extra attributes to the list tag
- Refactor template to set element type and classes up front, rather than multiple if conditions throughout.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (list.yaml) to use the new arguments
- Update the example nunjucks template (list.njk) to use the new arguments

https://trello.com/c/jCMGx2l1/259-update-list-component-api