### PR TITLE
Update textarea component to follow convention

### DIFF
--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -50,62 +50,6 @@
       ],
       [
         {
-          text: 'label.labelText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'The label text'
-        }
-      ],
-      [
-        {
-          text: 'label.hintText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional hint text'
-        }
-      ],
-      [
-        {
-          text: 'label.errorMessage.errorMessage'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional error message'
-        }
-      ],
-      [
-        {
-          text: 'label.errorMessage.classes'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Additional classes for error message'
-        }
-      ],
-      [
-        {
           text: 'id'
         },
         {
@@ -129,7 +73,7 @@
           text: 'Yes'
         },
         {
-          text: 'The name of the textarea'
+          text: 'The name of the textarea, which is submitted with the form data'
         }
       ],
       [
@@ -143,7 +87,63 @@
           text: 'No'
         },
         {
-          text: 'Change default number of textarea rows (default is 5 rows)'
+          text: 'Optional number of textarea rows (default is 5 rows)'
+        }
+      ],
+      [
+        {
+          text: 'value'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional initial value of the textarea'
+        }
+      ],
+      [
+        {
+          text: 'label'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'Yes'
+        },
+        {
+          text: 'Arguments for the label component'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Arguments for the error message component'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the textarea tag'
         }
       ]
     ]

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,13 +1,16 @@
 {% from "label/macro.njk" import govukLabel %}
 
+{#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
+
 {{- govukLabel({
-  "labelText": params.label.labelText,
-  "hintText": params.label.hintText,
-  "errorMessage": params.label.errorMessage,
-  "classes": params.label.classes,
-  "id": params.id
+  html: params.label.html,
+  text: params.label.text,
+  hintText: params.label.hintText,
+  hintHtml: params.label.hintHtml,
+  classes: params.label.classes,
+  attributes: params.label.attributes,
+  errorMessage: params.errorMessage,
+  for: params.id
 }) -}}
 
-<textarea class="govuk-c-textarea
-{%- if params.label.errorMessage %} govuk-c-textarea--error{% endif %}
-{%- if params.classes %} {{ params.classes }}{% endif -%}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}">{{ params.value }}</textarea>
+<textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-c-textarea {{- ' govuk-c-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>

--- a/src/components/textarea/textarea.njk
+++ b/src/components/textarea/textarea.njk
@@ -1,11 +1,11 @@
 {% from "textarea/macro.njk" import govukTextarea %}
 
 {{ govukTextarea({
-  "id": "more-detail",
-  "name": "more-detail",
-  "label": {
-    "labelText": "Can you provide more detail?",
-    "hintText": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+  id: "more-detail",
+  name: "more-detail",
+  label: {
+    text: "Can you provide more detail?",
+    hintText: "Don't include personal or financial information, eg your National Insurance number or credit card details."
   }
 })
 }}

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -4,20 +4,20 @@ variants:
       name: more-detail
       id: more-detail
       label:
-        labelText: Can you provide more detail?
+        text: Can you provide more detail?
         hintText: Don't include personal or financial information, eg your
                   National Insurance number or credit card details.
 
-  - name: error-state
+  - name: with error message
     data:
       name: no-ni-reason
       id: no-ni-reason
       label:
-        labelText: Why can't you provide a National Insurance number?
-        errorMessage:
-          errorMessage: You must provide an explanation
+        text: Why can't you provide a National Insurance number?
+      errorMessage:
+        text: You must provide an explanation
 
-  - name: with-value
+  - name: with default value
     data:
       id: full-address
       name: address
@@ -26,12 +26,12 @@ variants:
         London
         NW1 6XE
       label:
-        labelText: Full address
+        text: Full address
 
-  - name: specifying-rows
+  - name: with custom rows
     data:
       id: full-address
       name: address
       label:
-        labelText: Full address
+        text: Full address
       rows: 8


### PR DESCRIPTION
- Allow textarea content to be passed as `value`.
- Allow for extra attributes to be specified on the `<textarea>` through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (textarea.yaml) to use the new arguments
- Update the example nunjucks template (textarea.njk) to use the new arguments

[Trello ticket](https://trello.com/c/LfdfXD1U)