### PR TITLE
Update radio component to follow conventions

### DIFF
--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -23,7 +23,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
     'isFirstCellHeader': 'true'
   },
   data: {
-    'head': [
+    'head' : [
       {
         text: 'Name'
       },
@@ -37,7 +37,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
         text: 'Description'
       }
     ],
-    'rows': [
+    'rows' : [
       [
         {
           text: 'classes'
@@ -54,7 +54,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
       ],
       [
         {
-          text: 'inputName'
+          text: 'idPrefix'
         },
         {
           text: 'string'
@@ -63,12 +63,12 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
           text: 'Yes'
         },
         {
-          text: 'Name of the group of radio buttons'
+          text: 'String to prefix id for each radio item if no id is specified on each item.'
         }
       ],
       [
         {
-          text: 'id'
+          text: 'name'
         },
         {
           text: 'string'
@@ -77,12 +77,12 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
           text: 'Yes'
         },
         {
-          text: 'ID is prefixed to the ID of each radio button'
+          text: 'Name attribute for each radio item.'
         }
       ],
       [
         {
-          text: 'radios'
+          text: 'items'
         },
         {
           text: 'array'
@@ -91,7 +91,91 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
           text: 'Yes'
         },
         {
-          text: 'Radios array with id, value, label, checked and disabled keys'
+          text: 'Array of radio items.'
+        }
+      ],
+      [
+        {
+          text: 'text'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Text to use within the radio label.'
+        }
+      ],
+      [
+        {
+          text: 'html'
+        },
+        {
+          text: 'string'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'HTML to use within the radio label. If this is provided, the text argument will be ignored.'
+        }
+      ],
+      [
+        {
+          text: 'label'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Provide additional attributes to the radio label.'
+        }
+      ],
+      [
+        {
+          text: 'checked'
+        },
+        {
+          text: 'boolean'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'If true, radio will be checked.'
+        }
+      ],
+      [
+        {
+          text: 'disabled'
+        },
+        {
+          text: 'boolean'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'If true, radio will be disabled.'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the radio container.'
         }
       ]
     ]

--- a/src/components/radio/radio.njk
+++ b/src/components/radio/radio.njk
@@ -1,19 +1,27 @@
 {% from 'radio/macro.njk' import govukRadio %}
 
-{{- govukRadio({
-  classes: '',
-  inputName: 'radio-group',
-  id: 'radio',
-  checkboxes: [
-   {
-      id: '1',
-      value: 'Yes',
-      label: 'Yes'
+{{ govukRadio({
+  "idPrefix": "radio",
+  "name": "radio-group",
+  "items": [
+    {
+      "value": "waste-animal",
+      "text": "Waste from animal carcasses"
     },
     {
-       id: '2',
-       value: 'No',
-       label: 'No'
-     }
+      "id": "custom-id",
+      "value": "waste-mines",
+      "text": "Waste from mines or quarries"
+    },
+    {
+      "value": "waste-farm",
+      "text": "Farm or agricultural waste",
+      "checked": true
+    },
+    {
+      "value": "waste-disabled",
+      "text": "Disabled radio option",
+      "disabled": true
+    }
   ]
-}) -}}
+}) }}

--- a/src/components/radio/radio.yaml
+++ b/src/components/radio/radio.yaml
@@ -1,25 +1,21 @@
 variants:
-- name: default
-  data:
-    id: 'radio'
-    inputName: 'radio-group'
-    classes:
-    radios:
-      -
-        id: 1
-        value: 'Yes'
-        label: 'Yes'
-      -
-        id: 2
-        value: 'No'
-        label: 'No'
-      -
-        id: 3
-        value: 'No'
-        label: 'No'
-        checked: true
-      -
-        id: 4
-        value: 'NA'
-        label: 'Not applicable'
-        disabled: true
+  - name: default
+    data:
+      idPrefix: 'radio'
+      name: 'radio-group'
+      items:
+        -
+          value: 'waste-animal'
+          text: 'Waste from animal carcasses'
+        -
+          id: 'custom-id'
+          value: 'waste-mines'
+          text: 'Waste from mines or quarries'
+        -
+          value: 'waste-farm'
+          text: 'Farm or agricultural waste'
+          checked: true
+        -
+          value: 'waste-disabled'
+          text: 'Disabled radio option'
+          disabled: true

--- a/src/components/radio/template.njk
+++ b/src/components/radio/template.njk
@@ -1,9 +1,16 @@
-{% for radio in params.radios %}
+{% from "label/macro.njk" import govukLabel %}
+{% for item in params.items %}
 <div class="govuk-c-radio
-{%- if params.classes %} {{ params.classes }}{% endif %}">
-  <input class="govuk-c-radio__input" id="{{ params.id }}-{{ radio.id }}" name="{{ params.inputName }}" type="radio" value="{{ radio.value }}"
-  {%- if radio.checked %} checked{% endif %}
-  {%- if radio.disabled %} disabled{% endif %}>
-  <label class="govuk-c-radio__label" for="{{ params.id }}-{{ radio.id }}">{{ radio.label }}</label>
+{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  <input class="govuk-c-radio__input" id="{% if item.id %}{{ item.id }}{% else %}{{params.idPrefix}}-{{loop.index}}{% endif %}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+  {{-" checked" if item.checked }}
+  {{-" disabled" if item.disabled }}>
+  {{- govukLabel({
+    html: item.html,
+    text: item.text,
+    classes: 'govuk-c-radio__label',
+    attributes: item.label.attributes,
+    for: item.id if item.id else params.idPrefix+'-'+loop.index
+  }) -}}
 </div>
 {% endfor %}


### PR DESCRIPTION
- replace InputName parameter with name
- add idPrefix parameter which will be used if no specific id is set for
each item. if no id on items is then append loop index to idPrefix for
each item
- replace label parameter for each item with text or html parameters,
where either can be used, text is default and gets superseded by html
- for label use label component with additional govuk-c-radio__label
class (because of specific styling)
- rename radio array to items
- update template to reflect above changes
- add functionality to specify html attributes that get appended to the
element
- update YAML file to reflect new parameters
- update table of arguments to reflect changes
- update example in radio.njk file