### PR TITLE
Update input component to follow convention

### DIFF
--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -51,48 +51,6 @@
       ],
       [
         {
-          text: 'labelText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'Yes'
-        },
-        {
-          text: 'The label text'
-        }
-      ],
-      [
-        {
-          text: 'hintText'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional hint text'
-        }
-      ],
-      [
-        {
-          text: 'errorMessage'
-        },
-        {
-          text: 'string'
-        },
-        {
-          text: 'No'
-        },
-        {
-          text: 'Optional error message'
-        }
-      ],
-      [
-        {
           text: 'id'
         },
         {
@@ -117,6 +75,48 @@
         },
         {
           text: 'The name of the input, which is submitted with the form data'
+        }
+      ],
+      [
+        {
+          text: 'label'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Arguments for the label component. See label component.'
+        }
+      ],
+      [
+        {
+          text: 'errorMessage'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Optional error message'
+        }
+      ],
+      [
+        {
+          text: 'attributes'
+        },
+        {
+          text: 'object'
+        },
+        {
+          text: 'No'
+        },
+        {
+          text: 'Any extra HTML attributes (for example data attributes) to add to the input component.'
         }
       ],
       [

--- a/src/components/input/input.njk
+++ b/src/components/input/input.njk
@@ -1,9 +1,9 @@
 {% from "input/macro.njk" import govukInput %}
 
-{{ govukInput(
-{
-  "labelText": "National Insurance number",
-  "id": "input-1",
-  "name": "test-name"
-}
-) }}
+{{ govukInput({
+  label: {
+    "text": "National Insurance Number"
+  },
+  id: "input-1",
+  name: "test-name"
+}) }}

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -1,24 +1,23 @@
 variants:
   - name: default
     data:
-      labelText: National Insurance number
+      label:
+        text: National Insurance number
       id: input-1
       name: test-name
-
   - name: with-hint-text
     data:
-      labelText: National Insurance number
-      hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-      id: input-2,
+      label:
+        text: National insurance number
+        hintText: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-2
       name: test-name-2
-
   - name: with-error-message
     data:
-      labelClasses: dummy-extra-class
-      labelText: National Insurance number
-      hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.'
-      errorMessage: Error message goes here
-      classes: '' # extra classes if needed
+      label:
+        text: National Insurance number
+        hintHtml: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-3
       name: test-name-3
+      errorMessage:
+        text: Error message goes here

--- a/src/components/input/macro.njk
+++ b/src/components/input/macro.njk
@@ -1,6 +1,3 @@
 {% macro govukInput(params) %}
   {%- include "./template.njk" -%}
 {% endmacro %}
-{# {% macro govukInput(labelClasses, labelText, hintText, errorMessage, classes, id, name, value) %}
-  {%- include "./template.njk" -%}
-{% endmacro %} #}

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,16 +1,16 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel(
-  {
-    labelClasses: params.labelClasses,
-    labelText: params.labelText,
-    hintText: params.hintText,
-    errorMessage: params.errorMessage,
-    id: params.id
-  }
-) -}}
+{{- govukLabel({
+  html: params.label.html,
+  text: params.label.text,
+  hintText: params.label.hintText,
+  hintHtml: params.label.hintHtml,
+  classes: params.label.classes,
+  attributes: params.label.attributes,
+  errorMessage: params.errorMessage,
+  for: params.id
+}) -}}
 
-<input class="govuk-c-input
-{%- if params.classes %} {{ params.classes }}{% endif %}
-{%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
-{%- if params.value %} value="{{ params.value}}"{% endif %}>
+<input class="govuk-c-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
+{%- if params.value %} value="{{ params.value}}"{% endif %}
+{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>


### PR DESCRIPTION
- Allow for extra attributes to be specified on the `<input>` through the `attributes` argument.
- Update readme definition (index.njk) to document these changes to the arguments list.
- Update the component definition (input.yaml) to use the new arguments
- Update the example nunjucks template (input.njk) to use the new arguments

[Trello ticket](https://trello.com/c/shMtL1kU)