### PR TITLE
Catch 404 and 500 http errors

### DIFF
--- a/src/views/http-error.njk
+++ b/src/views/http-error.njk
@@ -1,0 +1,6 @@
+{% extends "layout-debug.njk" %}
+
+{% block content %}
+  <h1 class="govuk-u-heading-36">{{ error }}</h1>
+  <p class="govuk-u-copy-19">{{ message }}</p>
+{% endblock %}


### PR DESCRIPTION
This PR:
* Catches most common errors (404 and 500)
* Adds a default http error template
* Prevents server from crashing from uncaught errors
* Prompts the user with a proper error message