### PR TITLE
Fix table of arguments for two components

### DIFF
--- a/src/components/inset-text/index.njk
+++ b/src/components/inset-text/index.njk
@@ -12,8 +12,7 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
-{{ govukTable(
+{{ govukTable({
   'firstCellIsHeader': true,
   'head' : [
     {
@@ -59,5 +58,5 @@
       }
     ]
   ]
-)}}
+} )}}
 {% endblock %}

--- a/src/components/legal-text/index.njk
+++ b/src/components/legal-text/index.njk
@@ -12,8 +12,7 @@
 {# {% set componentGuidanceLink = 'new link here' %} #}
 
 {% block componentArguments %}
-{% from "table/macro.njk" import govukTable %}
-{{ govukTable(
+{{ govukTable({
   'firstCellIsHeader': true,
   'head' : [
     {
@@ -73,5 +72,5 @@
       }
     ]
   ]
-)}}
+})}}
 {% endblock %}


### PR DESCRIPTION
This PR:
* fixes the table of arguments for the following components: `inset-text` and `legal-text`

Mention: this also stop `generate-readme.js` gulp script from crashing.

This was found by @igloosi while doing pair programming, so we need another developer for review.