### PR TITLE
Exclude .yaml files from being copied to /packages and /dist

### DIFF
--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -32,7 +32,8 @@ gulp.task('copy-files', () => {
     '!' + configPaths.src + 'examples',
     '!' + configPaths.src + 'examples/**',
     '!' + configPaths.src + 'globals/scss/govuk-frontend-oldie.scss',
-    '!' + configPaths.src + 'components/**/index.njk'
+    '!' + configPaths.src + 'components/**/index.njk',
+    '!' + configPaths.src + 'components/**/*.{yml,yaml}'
   ])
   .pipe(scssFiles)
   .pipe(replace('//start:devonly', '/*start:devonly'))


### PR DESCRIPTION
They're configuration files, so there is no need for them to be in `/packages` or `/dist` folders.