### PR TITLE
Fix em fucntion to accept px or not

### DIFF
--- a/src/globals/scss/_helpers-px-to-em.scss
+++ b/src/globals/scss/_helpers-px-to-em.scss
@@ -1,4 +1,10 @@
 // Convert pixels to em
-@function em($px, $govuk-context-font-size) {
-  @return #{$px / $govuk-context-font-size}em;
+@function em($value, $govuk-context-font-size) {
+  @if (unitless($value)) {
+    $value: $value * 1px;
+  }
+  @if (unitless($govuk-context-font-size)) {
+    $govuk-context-font-size: $govuk-context-font-size * 1px;
+  }
+  @return $value / $govuk-context-font-size * 1em;
 }


### PR DESCRIPTION
At the moment `em()` helper function falls down if px units are present in the argument value for either of the two arguments it accepts.

This PR fixes this issue, so the `em()` function now accepts arguments with px units and without.

See test here: https://codepen.io/anon/pen/NwqRZd