### PR TITLE
Fix sass import paths

### DIFF
--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -1,6 +1,6 @@
 @import "../../globals/scss/import-once";
 @import "../../globals/scss/vars";
-@import "utilities/clearfix";
+@import "../../globals/scss/utilities/clearfix";
 
 @include exports("fieldset") {
   .govuk-c-fieldset {

--- a/src/globals/scss/layout/_grid-layout.scss
+++ b/src/globals/scss/layout/_grid-layout.scss
@@ -1,7 +1,7 @@
-@import "media-queries";
-@import "spacing";
-@import "utilities/clearfix";
-@import "vars";
+@import "../media-queries";
+@import "../spacing";
+@import "../utilities/clearfix";
+@import "../vars";
 
 // Build your own grids using these grid mixins
 // usage:

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -49,7 +49,7 @@ gulp.task('copy-files', () => {
   .pipe(icons.restore)
   .pipe(globals)  // replace import in scss files and bring globals/ up one level
   .pipe(gulpif(isPackages, replace('../../components', '@govuk-frontend')))
-  .pipe(gulpif(isPackages, replace('../../globals', '@govuk-frontend')))
+  .pipe(gulpif(isPackages, replace('../../globals/scss', '@govuk-frontend/globals')))
   .pipe(gulpif(isPackages, replace('./node_modules/', '')))
   .pipe(flatten({
     subPath: [2, 3],


### PR DESCRIPTION
Some of the paths that are incorrect need to updated and the copy task path replacing is missing part of the path.
This PR updates the path in sass files and modifies the copy task to correctly replace the path when packages are created