### PR TITLE
Fix grid issues

### DIFF
--- a/src/globals/scss/layout/_grid-layout.scss
+++ b/src/globals/scss/layout/_grid-layout.scss
@@ -34,6 +34,6 @@
 
 @mixin govuk-grid-item {
   box-sizing: border-box;
-  padding: 0 $govuk-spacing-scale-5;
+  padding: 0 $govuk-spacing-scale-3;
   float: left;
 }

--- a/src/globals/scss/layout/_grid.scss
+++ b/src/globals/scss/layout/_grid.scss
@@ -18,18 +18,26 @@
   }
 
   .govuk-o-grid__item--one-half {
-    width: percentage(1 / 2);
+    @include mq($from: tablet) {
+      width: percentage(1 / 2);
+    }
   }
 
   .govuk-o-grid__item--one-third {
-    width: percentage(1 / 3);
+    @include mq($from: tablet) {
+      width: percentage(1 / 3);
+    }
   }
 
   .govuk-o-grid__item--two-thirds {
-    width: percentage(2 / 3);
+    @include mq($from: tablet) {
+      width: percentage(2 / 3);
+    }
   }
 
   .govuk-o-grid__item--one-quarter {
-    width: percentage(1 / 4);
+    @include mq($from: tablet) {
+      width: percentage(1 / 4);
+    }
   }
 }

--- a/src/views/examples/grid/index.njk
+++ b/src/views/examples/grid/index.njk
@@ -1,0 +1,76 @@
+{% extends "layout.njk" %}
+
+{% block content %}
+
+  <main id="content" role="main" class="govuk-o-site-width-container">
+    <h1 class="heading-large">Example: Grid layout</h1>
+    <div class="govuk-o-grid">
+      <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+        <h2 class="heading-medium">Two thirds</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h2 class="heading-medium">One third</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h2 class="heading-medium">One third</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h2 class="heading-medium">One third</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-third">
+        <h2 class="heading-medium">One third</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+        <h2 class="heading-medium">One half</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-half">
+        <h2 class="heading-medium">One half</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
+        <h2 class="heading-medium">One quarter</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
+        <h2 class="heading-medium">One quarter</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
+        <h2 class="heading-medium">One quarter</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-o-grid__item govuk-o-grid__item--one-quarter">
+        <h2 class="heading-medium">One quarter</h2>
+        <p>
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+    </div>
+  </main>
+{% endblock %}


### PR DESCRIPTION
There were discussions about making the grid more versatile and changing how it breaks on different viewports, so we held off making changes. 
This PR:
* reinstates current behaviour, where the grid columns become full width on mobile
* fixes incorrect padding between items
* creates an example grid layout page
