### PR TITLE
Update generate:readme task behaviour

### DIFF
--- a/tasks/gulp/generate-readme.js
+++ b/tasks/gulp/generate-readme.js
@@ -12,6 +12,9 @@ const nunjucks = require('nunjucks')
 const objectData = {}
 const yaml = require('js-yaml')
 const helperFunctions = require('../../lib/helper-functions.js')
+const taskArguments = require('./task-arguments')
+const gulpif = require('gulp-if')
+const isPackages = (taskArguments.destination === 'packages') || false
 
 // data variable to be passed to the nunjucks template
 function getDataForFile (file) {
@@ -53,5 +56,5 @@ gulp.task('generate:readme', () => {
     path.basename = 'README'
     path.extname = '.md'
   }))
-  .pipe(gulp.dest(configPath.components))
+  .pipe(gulp.dest(gulpif(isPackages, taskArguments.destination, taskArguments.destination + '/components/')))
 })


### PR DESCRIPTION
Currently the task defaults to amending files in `src/` which is not always convenient if latest changes to readme files don't exist there.

With this change, the `generate:readme` task checks for --destination flag and places the modified file to the correct directory.
