### PR TITLE
Amend image path variable definition

### DIFF
--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -4,7 +4,7 @@
 @import "vars/colours";
 
 // Image paths
-$global-images: "/icons/";
+$global-images: "/icons/" !default;
 
 // Media query breakpoints
 // in ../_media-queries.scss


### PR DESCRIPTION
To create css image paths we use the  `file-url` helper Sass function. We mistakenly forgot to allow it to be overwritten in host app where Frontend is consumed.

This PR Fixes that.