### PR TITLE
Fix radio checked state rendering on smaller screens

### DIFF
--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -90,6 +90,7 @@
     border: em($govuk-spacing-scale-2, 19px) solid;
     border-radius: 50%;
     opacity: 0;
+    background: currentColor;
   }
 
   // Focused state


### PR DESCRIPTION
When on smaller viewports such as on a mobile device, there seems to be a rounding error
which results in you being able to see a small white dot on the checked radio input.

By setting the background colour to the `currentColor` we ensure if a round error happens
the background will look the same as the border, removing any possible rendering issue.

Before

<img width="274" alt="screen shot 2017-11-09 at 14 04 45" src="https://user-images.githubusercontent.com/2445413/32609621-28904bcc-c558-11e7-962e-81fe5fea23b1.png">

After

<img width="277" alt="screen shot 2017-11-09 at 14 08 33" src="https://user-images.githubusercontent.com/2445413/32609627-2baef24a-c558-11e7-8549-d394aa0a5bfb.png">

