### PR TITLE
Fix example usage of the details macro

### DIFF
--- a/src/components/details/details.njk
+++ b/src/components/details/details.njk
@@ -1,7 +1,7 @@
 {% from "details/macro.njk" import govukDetails %}
 
 {{- govukDetails({
-  "summary": "Help with nationality",
+  "summaryText": "Help with nationality",
   "text": "If you’re not sure about your nationality, try to find out from an official document like a passport or national ID card."
   })
 -}}


### PR DESCRIPTION
The macro has been updated to accept either summaryText or summaryHtml, but the change to the example was missed.

Fixes #345