### PR TITLE
Update spacing scale and variables

### DIFF
--- a/src/globals/scss/_spacing.scss
+++ b/src/globals/scss/_spacing.scss
@@ -17,13 +17,15 @@ $spacing-directions: (
 
 // Set spacing scale
 $govuk-spacing-scale: (
-  0: 0,
+  0: $govuk-spacing-scale-0,
   1: $govuk-spacing-scale-1,
   2: $govuk-spacing-scale-2,
   3: $govuk-spacing-scale-3,
   4: $govuk-spacing-scale-4,
   5: $govuk-spacing-scale-5,
-  6: $govuk-spacing-scale-6
+  6: $govuk-spacing-scale-6,
+  7: $govuk-spacing-scale-7,
+  8: $govuk-spacing-scale-8
 );
 
 @import "import-once";

--- a/src/globals/scss/_vars.scss
+++ b/src/globals/scss/_vars.scss
@@ -32,12 +32,15 @@ $govuk-gutter-half: $govuk-gutter / 2;
 $gutter-one-third: $govuk-gutter / 3;
 
 // Spacing scale
+$govuk-spacing-scale-0: 0;
 $govuk-spacing-scale-1: 5px;
 $govuk-spacing-scale-2: 10px;
 $govuk-spacing-scale-3: 15px;
 $govuk-spacing-scale-4: 20px;
 $govuk-spacing-scale-5: 30px;
-$govuk-spacing-scale-6: 60px;
+$govuk-spacing-scale-6: 40px;
+$govuk-spacing-scale-7: 50px;
+$govuk-spacing-scale-8: 60px;
 
 // Fonts
 // New Transport Light font family


### PR DESCRIPTION
This expands the spacing scale to cover all expected units at both mobile and desktop breakpoints.

I have also added an explicit `$govuk-spacing-scale-0` so that a utility class for applying 0 margin or padding is output.

There is no impact on components as the only breaking change was to `$govuk-spacing-scale-6`, the rest either remain the same or are additional units.

The only visible change will be on `heading-xl` (which used $govuk-spacing-scale-6`) within typography, which will be addressed in a full typography update