### PR TITLE
Add .editorconfig file to the repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Added a very basic .editorconfig file to the repo. This standard is now being adopted in various teams across GDS and is listed in the [GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages.html#code-styleguides). Used a wildcard at the moment but we can be more specific if needed:
````
[*.{scss,js,erb,json}]
...
````