### PR TITLE
Default component spacing

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -2,9 +2,8 @@
 
 @include exports("breadcrumb") {
   .govuk-c-breadcrumb {
-    padding-top: $govuk-spacing-scale-3;
-    padding-bottom: $govuk-spacing-scale-3;
-
+    margin-top: $govuk-spacing-scale-3;
+    margin-bottom: $govuk-spacing-scale-2;
     font-family: $govuk-font-stack;
   }
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -8,6 +8,10 @@
     width: 100%;
     min-height: em(40px, 19px);
     margin-top: 0;
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     padding: 0 em($govuk-spacing-scale-3, 19px) 0;
     border-width: $govuk-border-width-form-element;
     border-radius: 0;

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -3,6 +3,10 @@
 @include exports("details") {
   .govuk-c-details {
     display: block;
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     clear: both;
     font-family: $govuk-font-stack;
     @include govuk-font-regular-19;

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -2,7 +2,10 @@
 
 @include exports("fieldset") {
   .govuk-c-fieldset {
-    margin: 0;
+    margin: 0 0 $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     padding: 0;
     border: 0;
     @include govuk-h-clearfix;

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -2,6 +2,10 @@
 
 @include exports("file-upload") {
   .govuk-c-file-upload {
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     font-family: $govuk-font-stack;
     @include govuk-font-regular-19;
   }

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -8,6 +8,10 @@
     width: 100%;
     height: em(40px, 19px);
     margin-top: 0;
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -12,14 +12,14 @@
 
   .govuk-c-link--back {
     display: inline-block;
-
     position: relative;
-
+    margin-top: $govuk-spacing-scale-3;
+    margin-bottom: $govuk-spacing-scale-3;
     padding-left: 14px;
-
     border-bottom: 1px solid $govuk-black;
     color: $govuk-black;
     background: file-url("icon-arrow-left.png") no-repeat 0 4px;
+    background-repeat: no-repeat;
     text-decoration: none;
 
     &:link,

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -19,7 +19,6 @@
     border-bottom: 1px solid $govuk-black;
     color: $govuk-black;
     background: file-url("icon-arrow-left.png") no-repeat 0 4px;
-    background-repeat: no-repeat;
     text-decoration: none;
 
     &:link,

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -3,8 +3,11 @@
 @include exports("list") {
   .govuk-c-list {
     @include govuk-font-regular-19;
-    // TODO: Make margins under components consistent
-    margin-bottom: $govuk-spacing-scale-4;
+    margin-top: $govuk-spacing-scale-0;
+    margin-bottom: $govuk-spacing-scale-3;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-4;
+    }
     padding-left: 0;
     list-style-type: none;
     font-family: $govuk-font-stack;

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -3,14 +3,9 @@
 
 @include exports("phase-banner") {
   .govuk-c-phase-banner {
-    padding-top: em($govuk-spacing-scale-2, 16px);
-    padding-bottom: em($govuk-spacing-scale-2, 16px); //use to be 8
-    // Apply styling to tablet and upwards
-    // @include mq($from:tablet) {
-    //  padding-bottom: em(10px, 16px);
-    // }
+    padding-top: $govuk-spacing-scale-2;
+    padding-bottom: $govuk-spacing-scale-2;
     border-bottom: 1px solid $govuk-border-colour;
-
     font-family: $govuk-font-stack;
   }
 

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -6,7 +6,10 @@
     display: block;
     margin-right: -$govuk-spacing-scale-3;
     // TODO: Make margins under components consistent
-    margin-bottom: $govuk-spacing-scale-5;
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     margin-left: -$govuk-spacing-scale-3;
     font-family: $govuk-font-stack;
   }

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -6,6 +6,10 @@
     box-sizing: border-box; // should this be global?
     width: 100%;
     height: em(40px, 19px);
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -3,6 +3,10 @@
 @include exports("table") {
   .govuk-c-table {
     width: 100%;
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     border-spacing: 0;
     border-collapse: collapse;
     font-family: $govuk-font-stack;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -6,9 +6,11 @@
   .govuk-c-textarea {
     box-sizing: border-box; // should this be global?
     display: block;
-
     width: 100%;
-
+    margin-bottom: $govuk-spacing-scale-4;
+    @include mq($from: tablet) {
+      margin-bottom: $govuk-spacing-scale-5;
+    }
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
 


### PR DESCRIPTION
First pass of adding default margins to the components that require them.

The first commit is for components that belong between the `header` and the `main` content areas such as breadcrumb, back link and phase banner which all require a similar approach using both margin top **and** bottom.

The second commit is for the majority of components that will exist inside the `main` content area where a responsive margin-bottom only has been applied. Radio, Checkbox and Date Input components have been excluded as they will be affected by the update to fieldset

Regarding the change to `_breadcrumb.scss` that may look a little weird - The margin bottom is smaller than the margin-top because it is combined with the margin-bottom of `.govuk-c-breadcrumb__list-item` (required spacing for wrapping)