### PR TITLE
Ensure breakpoints CSS only gets included once

### DIFF
--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -20,13 +20,11 @@
 @import "tools/legacy-ie";
 @import "tools/px-to-em";
 
-// Vendor libraries
-@import "./node_modules/sass-mq/mq"; // We use sass-mq module for media queries
-
 // Helpers
 @import "helpers/device-pixels";
 @import "helpers/clearfix";
 @import "helpers/visually-hidden";
+@import "helpers/media-queries";
 
 // Core
 @import "core/links";

--- a/src/globals/scss/helpers/_media-queries.scss
+++ b/src/globals/scss/helpers/_media-queries.scss
@@ -1,0 +1,16 @@
+// We use sass-mq module for media queries
+
+// This is a horrible, horrible hack to prevent the 'dev mode' CSS to display
+// the current breakpoint from being included multiple times. 
+// 
+// We can't use the `exports` mixin for this because import directives cannot be
+// used within control directives 😠
+$sass-mq-already-included: false !default;
+
+@if $sass-mq-already-included {
+  $mq-show-breakpoints: ();
+}
+
+@import "./node_modules/sass-mq/mq";
+
+$sass-mq-already-included: true;


### PR DESCRIPTION
Whilst this only appears in 'dev mode', currently this CSS is being included 38 times.

Unfortunately, we can't just wrap the import with the `exports` mixin because import directives cannot be used within control directives 😠

This is therefore a horrible, horrible hack which overrides the particular sass-mq setting if we record that we have previously imported it.