### PR TITLE
‘Fix’ package publishing

### DIFF
--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,5 +1,5 @@
 // Settings
-@import "common";
+@import "../../globals/scss/common";
 
 // Components
 @import "../../components/breadcrumb/breadcrumb";


### PR DESCRIPTION
The transformations in our build pipeline rely on the import path for things inside globals referencing “../../globals/scss/“ so that the version in @govuk-frontend/all/all ends up referencing @govuk-frontend/globals/common. So for now, despite the `common` file being in the same directory, we need to be more explicit.

This has been tested by compiling the packages locally and symlinking the packages folder into the node_modules folder of our ‘Frontend version’ of the prototype kit.

At some point we should revisit whether it makes sense to have such major differences between our `src` directory and our `packages` directory.