### PR TITLE
Fix radio checked state rendering on smaller screens

### DIFF
--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -90,6 +90,7 @@
     border: em($govuk-spacing-scale-2, 19px) solid;
     border-radius: 50%;
     opacity: 0;
+    background: currentColor;
   }
 
   // Focused state


### PR DESCRIPTION
When on smaller viewports such as on a mobile device, there seems to be a rounding error
which results in you being able to see a small white dot on the checked radio input.

By setting the background colour to the `currentColor` we ensure if a round error happens
the background will look the same as the border, removing any possible rendering issue.

This is Nick's work from #339, hoping that re-opening the PR from a non-forked branch will get the tests passing.