### PR TITLE
Fix text colour boo boo

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -2,6 +2,7 @@
 
 @include exports("breadcrumb") {
   .govuk-c-breadcrumb {
+    @include govuk-text-colour;
     margin-top: $govuk-spacing-scale-3;
     margin-bottom: $govuk-spacing-scale-2;
     font-family: $govuk-font-stack;

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -2,6 +2,7 @@
 
 @include exports("cookie-banner") {
   .govuk-c-cookie-banner {
+    @include govuk-text-colour;
     width: 100%;
 
     padding-top: $govuk-spacing-scale-2;

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -4,7 +4,7 @@
 @include exports("error-summary") {
 
   .govuk-c-error-summary {
-
+    @include govuk-text-colour;
     padding: $govuk-spacing-scale-3;
 
     border: $govuk-border-width-mobile solid $govuk-error-colour;

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -8,6 +8,7 @@
     }
     font-family: $govuk-font-stack;
     @include govuk-font-regular-19;
+    @include govuk-text-colour;
   }
 
   .govuk-c-file-upload:focus {

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -2,6 +2,7 @@
 
 @include exports("inset-text") {
   .govuk-c-inset-text {
+    @include govuk-text-colour;
     padding: em($govuk-spacing-scale-3, 19px);
 
     clear: both;

--- a/src/components/legal-text/_legal-text.scss
+++ b/src/components/legal-text/_legal-text.scss
@@ -3,6 +3,7 @@
 @include exports("legal-text") {
 
   .govuk-c-legal-text {
+    @include govuk-text-colour;
     position: relative;
     padding: $govuk-spacing-scale-1 0;
 

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -3,6 +3,7 @@
 @include exports("list") {
   .govuk-c-list {
     @include govuk-font-regular-19;
+    @include govuk-text-colour;
     margin-top: $govuk-spacing-scale-0;
     margin-bottom: $govuk-spacing-scale-3;
     @include mq($from: tablet) {

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -3,6 +3,7 @@
 
 @include exports("phase-banner") {
   .govuk-c-phase-banner {
+    @include govuk-text-colour;
     padding-top: $govuk-spacing-scale-2;
     padding-bottom: $govuk-spacing-scale-2;
     border-bottom: 1px solid $govuk-border-colour;

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -2,6 +2,7 @@
 
 @include exports("table") {
   .govuk-c-table {
+    @include govuk-text-colour;
     width: 100%;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -1,8 +1,7 @@
 @include exports("typography") {
 
-  // Headings
-
   .govuk-heading-xl {
+    @include govuk-text-colour;
     @include govuk-font-bold-48;
 
     display: block;
@@ -16,6 +15,7 @@
   }
 
   .govuk-heading-l {
+    @include govuk-text-colour;
     @include govuk-font-bold-36;
 
     display: block;
@@ -29,6 +29,7 @@
   }
 
   .govuk-heading-m {
+    @include govuk-text-colour;
     @include govuk-font-bold-24;
 
     display: block;
@@ -42,6 +43,7 @@
   }
 
   .govuk-heading-s {
+    @include govuk-text-colour;
     @include govuk-font-bold-19;
 
     margin-top: 0;
@@ -55,6 +57,7 @@
   // Captions to be used inside headings
 
   .govuk-caption-xl {
+    @include govuk-text-colour;
     @include govuk-font-regular-27;
 
     display: block;
@@ -63,6 +66,7 @@
   }
 
   .govuk-caption-l {
+    @include govuk-text-colour;
     @include govuk-font-regular-24;
 
     display: block;
@@ -75,6 +79,7 @@
   }
 
   .govuk-caption-m {
+    @include govuk-text-colour;
     @include govuk-font-regular-19;
 
     display: block;
@@ -84,6 +89,7 @@
   // Body (paragraphs)
 
   .govuk-body-l {
+    @include govuk-text-colour;
     @include govuk-font-regular-24;
 
     margin-top: 0;
@@ -95,6 +101,7 @@
   }
 
   .govuk-body-m {
+    @include govuk-text-colour;
     @include govuk-font-regular-19;
 
     margin-top: 0;
@@ -106,6 +113,7 @@
   }
 
   .govuk-body-s {
+    @include govuk-text-colour;
     @include govuk-font-regular-16;
 
     margin-top: 0;
@@ -117,6 +125,7 @@
   }
 
   .govuk-body-xs {
+    @include govuk-text-colour;
     @include govuk-font-regular-14;
 
     margin-top: 0;

--- a/src/globals/scss/helpers/_typography.scss
+++ b/src/globals/scss/helpers/_typography.scss
@@ -1,14 +1,18 @@
 @mixin govuk-typography-common($font-family: $govuk-font-stack) {
-  color: $govuk-text-colour;
-
   font-family: $font-family;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
   @include mq($media-type: print) {
-    color: $govuk-print-text-colour;
-
     font-family: $govuk-font-stack-print;
+  }
+}
+
+@mixin govuk-text-colour {
+  color: $govuk-text-colour;
+
+  @include mq($media-type: print) {
+    color: $govuk-print-text-colour;
   }
 }
 

--- a/src/views/layout-debug.njk
+++ b/src/views/layout-debug.njk
@@ -42,6 +42,15 @@ you can also apply .govuk-c-debug-grid class to a specific container
 .govuk-c-debug-grid--full-page.is-visible {
   display: block;
 }
+
+/*
+Make it clear when we're not applying the text colour to a component - our
+text colour is too visually similar to #000 so making the body red makes it
+obvious
+ */
+body {
+  color: red;
+}
 </style>
 {% endblock %}
 {% endif %}


### PR DESCRIPTION
My relatively last minute change to add text colour to the typography helpers broke a number of the components – like the panel – as the text colour ended up being more specific and overriding the component text colours.

This moves text colour into a separate mixin which is included in every component and typographic element.

It also adds styling to the *app* when using the debug layout to set the default text colour on the body to red. This makes it a lot more obvious when we are not setting text colour than if we fall back to #000.