### PR TITLE
Fix typography example page

### DIFF
--- a/src/views/examples/typography/index.njk
+++ b/src/views/examples/typography/index.njk
@@ -13,44 +13,63 @@
     <!-- Headings -->
 
     <section>
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings</h2>
-
+      <div>
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings</h2>
+      </div>
+      <div>
       <h1 class="govuk-heading-xl">govuk-heading-xl</h1>
-      <h2 class="govuk-heading-l">govuk-heading-l</h2>
-      <h3 class="govuk-heading-m">govuk-heading-m</h3>
-      <h4 class="govuk-heading-s">govuk-heading-s</h4>
+      </div>
+      <div>
+        <h2 class="govuk-heading-l">govuk-heading-l</h2>
+      </div>
+      <div>
+        <h3 class="govuk-heading-m">govuk-heading-m</h3>
+      </div>
+      <div>
+        <h4 class="govuk-heading-s">govuk-heading-s</h4>
+      </div>
     </section>
 
     <!-- Headings with captions -->
 
     <section class="govuk-!-mt-7">
       <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings with captions</h2>
-
-      <h1 class="govuk-heading-xl">
-        <span class="govuk-caption-xl">govuk-caption-xl</span>
-        govuk-heading-xl
-      </h1>
-
-      <h2 class="govuk-heading-l">
-        <span class="govuk-caption-l">govuk-caption-l</span>
-        govuk-heading-l
-      </h2>
-
-      <h3 class="govuk-heading-m">
-        <span class="govuk-caption-m">govuk-caption-m</span>
-        govuk-heading-m
-      </h3>
+      <div>
+        <h1 class="govuk-heading-xl">
+          <span class="govuk-caption-xl">govuk-caption-xl</span>
+          govuk-heading-xl
+        </h1>
+      </div>
+      <div>
+        <h2 class="govuk-heading-l">
+          <span class="govuk-caption-l">govuk-caption-l</span>
+          govuk-heading-l
+        </h2>
+      </div>
+      <div>
+        <h3 class="govuk-heading-m">
+          <span class="govuk-caption-m">govuk-caption-m</span>
+          govuk-heading-m
+        </h3>
+      </div>
     </section>
 
     <!-- Body text -->
 
     <section class="govuk-!-mt-7">
       <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Body text</h2>
-
-      <p class="govuk-body-l">govuk-body-l</p>
-      <p class="govuk-body-m">govuk-body / govuk-body-m</p>
-      <p class="govuk-body-s">govuk-body-s</p>
-      <p class="govuk-body-xs">govuk-body-xs</p>
+      <div>
+        <p class="govuk-body-l">govuk-body-l</p>
+      </div>
+      <div>
+        <p class="govuk-body-m">govuk-body / govuk-body-m</p>
+      </div>
+      <div>
+        <p class="govuk-body-s">govuk-body-s</p>
+      </div>
+      <div>
+        <p class="govuk-body-xs">govuk-body-xs</p>
+      </div>
     </section>
 
     <!-- Overrides -->


### PR DESCRIPTION
The `div`'s around the heading and body examples were removed in the previous merge. These were there to exclude these examples from the contextual adjustments and show the default margin of the heading and body classes in isolation.