### PR TITLE
Fix visual regression of input and text area components

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -12,7 +12,7 @@
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-5;
     }
-    padding: 0 em($govuk-spacing-scale-3, 19px) 0 em($govuk-spacing-scale-1, 19px);
+    padding: $govuk-spacing-scale-1;
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -11,6 +11,7 @@
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-5;
     }
+    padding: $govuk-spacing-scale-1;
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
 


### PR DESCRIPTION
This is is a very simple padding change to the `input` and `textarea` component to give them equal padding.