### PR TITLE
Update left: -9999em to use clip: rect(0 0 0 0); as visually-hidden

### DIFF
--- a/src/components/skip-link/_skip-link.scss
+++ b/src/components/skip-link/_skip-link.scss
@@ -3,14 +3,11 @@
 @include exports("skip-link") {
   .govuk-c-skip-link {
     position: absolute;
-    left: -9999em;
     padding: $govuk-spacing-scale-1 $govuk-spacing-scale-3;
+    clip: rect(0 0 0 0);
     font-family: $govuk-font-stack;
     @include govuk-font-regular-16;
     line-height: 1.5;
-    @include mq($from: tablet) {
-      padding: $govuk-spacing-scale-1 $govuk-spacing-scale-5;
-    }
   }
 
   // Default link colour doesn't have enough contrast against $govuk-focus-colour


### PR DESCRIPTION
There was a thread about this on cross gov slack this morning. Noticed that this is handled differently on `govuk-h-visually-hidden` to `govuk-c-skip-link` so have swapped this out.