### PR TITLE
Details component - Visual regression and design tweaks

### DIFF
--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -43,9 +43,8 @@
   }
 
   .govuk-c-details__text {
-    // TODO: Make margins underneath components consistent
-    margin-bottom: em($govuk-spacing-scale-3, 19px);
-    padding: em($govuk-spacing-scale-3, 19px);
+    margin-left: 3px;
+    padding: $govuk-spacing-scale-3;
     border-left: $govuk-border-width solid $govuk-border-colour;
     color: $govuk-black;
   }

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -47,6 +47,7 @@
     margin-bottom: em($govuk-spacing-scale-3, 19px);
     padding: em($govuk-spacing-scale-3, 19px);
     border-left: $govuk-border-width solid $govuk-border-colour;
+    color: $govuk-black;
   }
 
   .govuk-c-details__text p {


### PR DESCRIPTION
e6cacf0 - Give the text a specific font colour as it's currently unspecified and appearing as red in the frontend review app.

9c759b3 - Design tweaks - Visually align the summary and details text. Align the border to the centre of the pointer when open.

**Before** 
![screen shot 2017-12-05 at 13 31 58](https://user-images.githubusercontent.com/23356842/33609796-59757b18-d9c1-11e7-8a8c-20754cb4033c.png)

**After**
![screen shot 2017-12-05 at 13 31 28](https://user-images.githubusercontent.com/23356842/33609801-60b8162e-d9c1-11e7-8da2-ce3241f29267.png)

