### PR TITLE
Add new point to spacing scale. Create new responsive spacing scale.

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -9,10 +9,7 @@
     position: relative;
     width: 100%;
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
     padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element) $govuk-spacing-scale-2;
     border-width: $govuk-border-width-form-element;
     border-style: solid;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -11,7 +11,7 @@
     margin-top: 0;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element) $govuk-spacing-scale-2;
     border-width: $govuk-border-width-form-element;
@@ -109,9 +109,10 @@
     @include govuk-font-bold-24;
     min-height: auto;
     padding-top: $govuk-spacing-scale-2 - $govuk-border-width-form-element;
-    padding-right: $govuk-spacing-scale-6;
+    padding-right: $govuk-spacing-scale-7;
     padding-bottom: $govuk-spacing-scale-2 - $govuk-border-width-form-element;
     padding-left: $govuk-spacing-scale-3;
+
     background-image: file-url("icon-pointer.png");
 
     @include govuk-h-device-pixel-ratio {

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -7,7 +7,7 @@
     display: block;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     clear: both;
   }

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -5,10 +5,8 @@
     @include govuk-font-regular-19;
 
     display: block;
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
     clear: both;
   }
 
@@ -52,7 +50,7 @@
   .govuk-c-details__text p {
     // TODO: Make margins on paragraphs consistent
     margin-top: 0;
-    margin-bottom: em(20px, 19px);
+    margin-bottom: em($govuk-spacing-scale-4, 19px);
   }
 
   .govuk-c-details__text p:last-child {

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -6,11 +6,10 @@
   .govuk-c-error-summary {
     @include govuk-text-colour;
 
-    padding: $govuk-spacing-scale-3;
+    @include govuk-responsive-padding($govuk-spacing-responsive-4);
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
     @include mq($from: tablet) {
-      padding: $govuk-spacing-scale-4;
       border: $govuk-border-width-tablet solid $govuk-error-colour;
     }
 
@@ -28,11 +27,7 @@
     @include govuk-font-bold-24;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   .govuk-c-error-summary__body {
@@ -40,11 +35,7 @@
 
     p {
       margin-top: 0;
-      margin-bottom: $govuk-spacing-scale-3;
-
-      @include mq($from: tablet) {
-        margin-bottom: $govuk-spacing-scale-4;
-      }
+      @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
     }
   }
 

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -4,7 +4,7 @@
   .govuk-c-fieldset {
     margin: 0 0 $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     padding: 0;
     border: 0;

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -5,10 +5,7 @@
     @include govuk-font-regular-19;
     @include govuk-text-colour;
 
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
   .govuk-c-file-upload:focus {

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -7,7 +7,7 @@
 
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
   }
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -12,7 +12,7 @@
     margin-top: 0;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     padding: $govuk-spacing-scale-1;
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -10,10 +10,8 @@
     width: 100%;
     height: em(40px, 19px);
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
     padding: $govuk-spacing-scale-1;
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -65,7 +65,7 @@
     @include govuk-font-bold;
     display: block;
     min-height: 40px;
-    padding: 0 0 0 40px;
+    padding: 0 0 0 $govuk-spacing-scale-7;
     background: file-url("icon-file-download.png") no-repeat scroll 0 0;
   }
 

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -4,12 +4,8 @@
   .govuk-c-list {
     @include govuk-font-regular-19;
     @include govuk-text-colour;
-
-    margin-top: $govuk-spacing-scale-0;
-    margin-bottom: $govuk-spacing-scale-3;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    margin-top: 0;
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
     padding-left: 0;
     list-style-type: none;
   }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -47,7 +47,7 @@
   .govuk-c-list--number {
     // TODO: Fix IE < 8
     @include ie-lte(7) {
-      padding-left: $govuk-spacing-scale-5; //used to be 28
+      padding-left: $govuk-spacing-scale-6; //used to be 28
     }
     padding-left: $govuk-spacing-scale-4;
     list-style-type: decimal;

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -6,11 +6,11 @@
     @include govuk-font-regular-19;
 
     @include mq($until: tablet) {
-      padding: $govuk-spacing-scale-5;
+      padding: $govuk-spacing-scale-6;
     }
 
     margin-bottom: $govuk-spacing-scale-3;
-    padding: $govuk-spacing-scale-6;
+    padding: $govuk-spacing-scale-7;
 
     text-align: center;
   }
@@ -22,7 +22,7 @@
 
   .govuk-c-panel__title {
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-5;
+    margin-bottom: $govuk-spacing-scale-6;
 
     @include govuk-font-bold-48;
   }

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -5,12 +5,8 @@
   .govuk-c-previous-next {
     display: block;
     margin-right: -$govuk-spacing-scale-3;
-    // TODO: Make margins under components consistent
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
     margin-left: -$govuk-spacing-scale-3;
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
   .govuk-c-previous-next__list {

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -8,7 +8,7 @@
     // TODO: Make margins under components consistent
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     margin-left: -$govuk-spacing-scale-3;
   }

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -9,7 +9,7 @@
     position: relative;
 
     margin-bottom: $govuk-spacing-scale-2;
-    padding: 0 0 0 em(40px, 19px);
+    padding: 0 0 0 em($govuk-spacing-scale-7, 19px);
 
     clear: left;
   }
@@ -32,8 +32,8 @@
     top: 0;
     left: 0;
 
-    width: em(40px, 19px);
-    height: em(40px, 19px);
+    width: em($govuk-spacing-scale-7, 19px);
+    height: em($govuk-spacing-scale-7, 19px);
 
     cursor: pointer;
 
@@ -61,8 +61,8 @@
     top: 0;
     left: 0;
 
-    width: em(40px, 19px);
-    height: em(40px, 19px);
+    width: em($govuk-spacing-scale-7, 19px);
+    height: em($govuk-spacing-scale-7, 19px);
 
     border: $govuk-border-width-form-element solid;
     border-radius: 50%;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -10,7 +10,7 @@
     height: em(40px, 19px);
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -8,10 +8,8 @@
     box-sizing: border-box; // should this be global?
     width: 100%;
     height: em(40px, 19px);
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -4,10 +4,8 @@
   .govuk-c-table {
     @include govuk-text-colour;
     width: 100%;
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
     border-spacing: 0;
     border-collapse: collapse;
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -6,7 +6,7 @@
     width: 100%;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     border-spacing: 0;
     border-collapse: collapse;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -11,7 +11,7 @@
     width: 100%;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
     padding: $govuk-spacing-scale-1;
     border: $govuk-border-width-form-element solid $govuk-text-colour;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -9,11 +9,9 @@
     box-sizing: border-box; // should this be global?
     display: block;
     width: 100%;
-    margin-bottom: $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
     padding: $govuk-spacing-scale-1;
+
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
 

--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -28,6 +28,7 @@
 @import "helpers/device-pixels";
 @import "helpers/media-queries";
 @import "helpers/typography";
+@import "helpers/spacing";
 @import "helpers/visually-hidden";
 
 // Core

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -7,11 +7,7 @@
     display: block;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-6;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-8;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
   }
 
   .govuk-heading-l {
@@ -21,11 +17,8 @@
     display: block;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-4;
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
   }
 
   .govuk-heading-m {
@@ -35,11 +28,7 @@
     display: block;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   .govuk-heading-s {
@@ -47,11 +36,7 @@
     @include govuk-font-bold-19;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   // Captions to be used inside headings
@@ -93,11 +78,7 @@
     @include govuk-font-regular-24;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-4;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
   .govuk-body-m {
@@ -105,11 +86,7 @@
     @include govuk-font-regular-19;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   .govuk-body-s {
@@ -117,11 +94,7 @@
     @include govuk-font-regular-16;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   .govuk-body-xs {
@@ -129,11 +102,7 @@
     @include govuk-font-regular-14;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
   // Usage aliases
@@ -149,21 +118,6 @@
     @extend .govuk-body-m;
   }
 
-  // Contextual adjustments
-
-  // Add a negative top margin to headings that appear directly after other
-  // headings
-
-  .govuk-heading-l + .govuk-heading-m {
-    margin-top: -$govuk-spacing-scale-1;
-  }
-
-  .govuk-heading-m + .govuk-heading-s {
-    margin-top: -$govuk-spacing-scale-2;
-  }
-
-  // Add top padding to headings that appear directly after paragraphs
-
   .govuk-body-l  + .govuk-heading-l {
     padding-top: $govuk-spacing-scale-1;
 
@@ -174,11 +128,7 @@
 
   .govuk-body-m  + .govuk-heading-l,
   .govuk-body-s  + .govuk-heading-l {
-    padding-top: $govuk-spacing-scale-3;
-
-    @include mq($from: tablet) {
-      padding-top: $govuk-spacing-scale-4;
-    }
+    @include govuk-responsive-padding($govuk-spacing-responsive-4, "top");
   }
 
   .govuk-body-m + .govuk-heading-m,

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -7,10 +7,10 @@
     display: block;
 
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-5;
+    margin-bottom: $govuk-spacing-scale-6;
 
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-7;
+      margin-bottom: $govuk-spacing-scale-8;
     }
   }
 
@@ -24,7 +24,7 @@
     margin-bottom: $govuk-spacing-scale-4;
 
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
   }
 
@@ -96,7 +96,7 @@
     margin-bottom: $govuk-spacing-scale-4;
 
     @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-5;
+      margin-bottom: $govuk-spacing-scale-6;
     }
   }
 

--- a/src/globals/scss/helpers/_spacing.scss
+++ b/src/globals/scss/helpers/_spacing.scss
@@ -1,0 +1,42 @@
+// Create responsive spacing, with media query for each breakpoint as set
+// in settings/spacing,
+
+// Create responsive margins
+// Arguments:
+// $value = top \ right \ bottom \ left \ all
+@mixin govuk-responsive-margin($scale-map, $value: "all", $important: false) {
+  @include govuk-responsive-spacing($scale-map, "margin", $value, $important);
+}
+
+// // Create responsive padding
+// // Arguments:
+// // $value = top \ right \ bottom \ left \ all
+@mixin govuk-responsive-padding($scale-map, $value: "all", $important: false) {
+  @include govuk-responsive-spacing($scale-map, "padding", $value, $important);
+}
+
+//  Base mixin, also used by 'generate-spacing-overrides' mixin
+@mixin govuk-responsive-spacing($scale-map, $property, $value: "all", $important: false) {
+
+  // Loop through each breakpoint
+  @each $breakpoint, $breakpoint-value in $scale-map {
+
+    // The 'null' breakpoint is for mobile.
+    @if $breakpoint == null {
+
+      @if $value == all {
+        #{$property}: $breakpoint-value iff($important, !important);
+      } @else {
+        #{$property}-#{$value}: $breakpoint-value iff($important, !important);
+      }
+    } @else {
+      @include mq($from: $breakpoint) {
+        @if $value == all {
+          #{$property}: $breakpoint-value iff($important, !important);
+        } @else {
+          #{$property}-#{$value}: $breakpoint-value iff($important, !important);
+        }
+      }
+    }
+  }
+}

--- a/src/globals/scss/objects/_grid.scss
+++ b/src/globals/scss/objects/_grid.scss
@@ -1,5 +1,5 @@
 // Gutters
-$govuk-gutter: $govuk-spacing-scale-5;
+$govuk-gutter: $govuk-spacing-scale-6;
 $govuk-gutter-half: $govuk-gutter / 2;
 
 @mixin govuk-grid {

--- a/src/globals/scss/overrides/_spacing.scss
+++ b/src/globals/scss/overrides/_spacing.scss
@@ -8,31 +8,37 @@ $spacing-directions: (
 
 // Generate spacing override classes for the given property (e.g. margin)
 // for each point in the spacing scale.
+
+// These override classes are responsive - the 'r' before the scale point
+// indicates that. We might want to add non-responsive ones later.
 //
 // Example output:
 //
-// .govuk-\!-m-0 {
+// .govuk-\!-m-r0 {
 //   margin: 0;
 // }
-// 
+//
 // [..]
-// 
-// .govuk-\!-mt-1 {
+//
+// .govuk-\!-mt-r1 {
 //   margin-top: [whatever spacing point 1 is...]
 // }
 
 @mixin generate-spacing-overrides($property, $property-shorthand) {
   // For each point in the spacing scale (defined in settings), create an
   // override that affects all directions...
-  @each $scale-point, $scale-value in $govuk-spacing-scale {
-    .govuk-\!-#{$property-shorthand}-#{$scale-point} {
-      #{$property}: $scale-value !important;
+  @each $scale-point, $scale-map in $govuk-spacing-responsive-scale {
+
+    .govuk-\!-#{$property-shorthand}-r#{$scale-point} {
+
+      @include govuk-responsive-spacing($scale-map, $property, "all", true);
     }
 
     // ... and then an override for each individual direction
     @each $direction-name, $direction-shorthand in $spacing-directions {
-      .govuk-\!-#{$property-shorthand}#{$direction-shorthand}-#{$scale-point} {
-        #{$property}-#{$direction-name}: $scale-value !important;
+
+      .govuk-\!-#{$property-shorthand}#{$direction-shorthand}-r#{$scale-point} {
+        @include govuk-responsive-spacing($scale-map, $property, $direction-name, true);
       }
     }
   }

--- a/src/globals/scss/settings/_spacing.scss
+++ b/src/globals/scss/settings/_spacing.scss
@@ -4,10 +4,11 @@ $govuk-spacing-scale-1: 5px;
 $govuk-spacing-scale-2: 10px;
 $govuk-spacing-scale-3: 15px;
 $govuk-spacing-scale-4: 20px;
-$govuk-spacing-scale-5: 30px;
-$govuk-spacing-scale-6: 40px;
-$govuk-spacing-scale-7: 50px;
-$govuk-spacing-scale-8: 60px;
+$govuk-spacing-scale-5: 25px;
+$govuk-spacing-scale-6: 30px;
+$govuk-spacing-scale-7: 40px;
+$govuk-spacing-scale-8: 50px;
+$govuk-spacing-scale-9: 60px;
 
 // Create a list of all spacing points we can iterate over elsewhere
 $govuk-spacing-scale: (
@@ -19,5 +20,6 @@ $govuk-spacing-scale: (
   5: $govuk-spacing-scale-5,
   6: $govuk-spacing-scale-6,
   7: $govuk-spacing-scale-7,
-  8: $govuk-spacing-scale-8
+  8: $govuk-spacing-scale-8,
+  9: $govuk-spacing-scale-9
 );

--- a/src/globals/scss/settings/_spacing.scss
+++ b/src/globals/scss/settings/_spacing.scss
@@ -1,5 +1,4 @@
-// Spacing scale
-$govuk-spacing-scale-0: 0;
+// Single points on spacing scale
 $govuk-spacing-scale-1: 5px;
 $govuk-spacing-scale-2: 10px;
 $govuk-spacing-scale-3: 15px;
@@ -10,16 +9,80 @@ $govuk-spacing-scale-7: 40px;
 $govuk-spacing-scale-8: 50px;
 $govuk-spacing-scale-9: 60px;
 
+// Responsive spacing maps
+//
+// These definitions are used to generate responsive spacing that adapts
+// according to the breakpoints (see 'helpers/spacing'). These maps should be
+// used wherever possible to standardise responsive spacing.
+
+// You can define different behaviour on tablet and desktop. The 'null'
+// breakpoint is for mobile.
+
+// To use the responsive spacing maps, combine them with
+// 'govuk-responsive-margin' or 'govuk-responsive-padding' mixins
+// (see 'helpers/spacing').
+
+
+$govuk-spacing-responsive-0: (
+  null: 0,
+  tablet: 0
+);
+
+$govuk-spacing-responsive-1: (
+  null: 5px,
+  tablet: 5px
+);
+
+$govuk-spacing-responsive-2: (
+  null: 10px,
+  tablet: 10px
+);
+
+$govuk-spacing-responsive-3: (
+  null: 15px,
+  tablet: 15px
+);
+
+$govuk-spacing-responsive-4: (
+  null: 15px,
+  tablet: 20px
+);
+
+$govuk-spacing-responsive-5: (
+  null: 15px,
+  tablet: 25px
+);
+
+$govuk-spacing-responsive-6: (
+  null: 20px,
+  tablet: 30px
+);
+
+$govuk-spacing-responsive-7: (
+  null: 25px,
+  tablet: 40px
+);
+
+$govuk-spacing-responsive-8: (
+  null: 30px,
+  tablet: 50px
+);
+
+$govuk-spacing-responsive-9: (
+  null: 40px,
+  tablet: 60px
+);
+
 // Create a list of all spacing points we can iterate over elsewhere
-$govuk-spacing-scale: (
-  0: $govuk-spacing-scale-0,
-  1: $govuk-spacing-scale-1,
-  2: $govuk-spacing-scale-2,
-  3: $govuk-spacing-scale-3,
-  4: $govuk-spacing-scale-4,
-  5: $govuk-spacing-scale-5,
-  6: $govuk-spacing-scale-6,
-  7: $govuk-spacing-scale-7,
-  8: $govuk-spacing-scale-8,
-  9: $govuk-spacing-scale-9
+$govuk-spacing-responsive-scale: (
+  0: $govuk-spacing-responsive-0,
+  1: $govuk-spacing-responsive-1,
+  2: $govuk-spacing-responsive-2,
+  3: $govuk-spacing-responsive-3,
+  4: $govuk-spacing-responsive-4,
+  5: $govuk-spacing-responsive-5,
+  6: $govuk-spacing-responsive-6,
+  7: $govuk-spacing-responsive-7,
+  8: $govuk-spacing-responsive-8,
+  9: $govuk-spacing-responsive-9
 );


### PR DESCRIPTION
This PR:
- adds a new point 25px to spacing scale which was missing to make it consistent and updates globals and components accordingly to maintain previously set spacing
- sets spacing scale points in maps to allow us to map relationships between spacing points across different breakpoints
- updates `generate-spacing-overrides` mixin to use the maps and to produce spacing across viewpoints, essentially making the spacing overrides responsive
- creates `govuk-spacing-unit` function that allows a single point to be retrieved from a spacing map
- creates ` govuk-spacing-responsive` mixin to produce responsive spacing when given a spacing map - this will standardise spacing for components and global styles

I've worked with @dashouse to visually verify the accuracy of the new spacing styles on global and components. Also, we decided to comment out the negative margin styles for contextual headings in core/typography as they appear not to be needed after all. These might go back in later or get removed altogether.
