### PR TITLE
Remove font face and weight declarations

### DIFF
--- a/src/components/breadcrumb/_breadcrumb.scss
+++ b/src/components/breadcrumb/_breadcrumb.scss
@@ -2,21 +2,22 @@
 
 @include exports("breadcrumb") {
   .govuk-c-breadcrumb {
+    @include govuk-font-regular-16;
     @include govuk-text-colour;
+
     margin-top: $govuk-spacing-scale-3;
     margin-bottom: $govuk-spacing-scale-2;
-    font-family: $govuk-font-stack;
   }
 
   .govuk-c-breadcrumb__list {
     @include govuk-h-clearfix;
+
     margin: 0;
     padding: 0;
     list-style-type: none;
   }
 
   .govuk-c-breadcrumb__list-item {
-    @include govuk-font-regular-16;
     margin-bottom: $govuk-spacing-scale-1;
     margin-left: $govuk-spacing-scale-2;
     padding-left: $govuk-spacing-scale-3;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -2,6 +2,8 @@
 
 @include exports("button") {
   .govuk-c-button {
+    @include govuk-font-regular-19;
+
     box-sizing: border-box;
     display: inline-block;
     position: relative;
@@ -19,9 +21,7 @@
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
     background-color: $govuk-button-colour;
-    font-family: $govuk-font-stack;
     text-align: center;
-    @include govuk-font-regular-19;
     text-decoration: none;
     vertical-align: top;
     cursor: pointer;

--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -2,17 +2,15 @@
 
 @include exports("checkbox") {
   .govuk-c-checkbox {
+    @include govuk-font-regular-19;
+
     display: block;
     position: relative;
-
 
     margin-bottom: $govuk-spacing-scale-2;
     padding: 0 0 0 em(40px, 19px);
 
     clear: left;
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
   }
 
   .govuk-c-checkbox:last-child,

--- a/src/components/cookie-banner/_cookie-banner.scss
+++ b/src/components/cookie-banner/_cookie-banner.scss
@@ -2,15 +2,15 @@
 
 @include exports("cookie-banner") {
   .govuk-c-cookie-banner {
+    @include govuk-font-regular-16;
     @include govuk-text-colour;
+
     width: 100%;
 
     padding-top: $govuk-spacing-scale-2;
     padding-bottom: $govuk-spacing-scale-2;
 
     background-color: $govuk-light-blue-25;
-
-    font-family: $govuk-font-stack;
   }
 
   .js-enabled .govuk-c-cookie-banner {
@@ -19,7 +19,6 @@
 
   .govuk-c-cookie-banner__message {
     @include govuk-site-width-container;
-    @include govuk-font-regular-16;
   }
 
   @include mq($media-type: print) {

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -2,14 +2,14 @@
 
 @include exports("details") {
   .govuk-c-details {
+    @include govuk-font-regular-19;
+
     display: block;
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-5;
     }
     clear: both;
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
   }
 
   .govuk-c-details__summary {

--- a/src/components/error-message/_error-message.scss
+++ b/src/components/error-message/_error-message.scss
@@ -2,6 +2,8 @@
 
 @include exports("error-message") {
   .govuk-c-error-message {
+    @include govuk-font-bold-19;
+
     display: block;
 
     margin: 0;
@@ -11,8 +13,5 @@
     clear: both;
 
     color: $govuk-error-colour;
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-bold-19;
   }
 }

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -5,16 +5,12 @@
 
   .govuk-c-error-summary {
     @include govuk-text-colour;
-    padding: $govuk-spacing-scale-3;
 
+    padding: $govuk-spacing-scale-3;
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
-    font-family: $govuk-font-stack;
-
     @include mq($from: tablet) {
-
       padding: $govuk-spacing-scale-4;
-
       border: $govuk-border-width-tablet solid $govuk-error-colour;
     }
 
@@ -29,15 +25,14 @@
   }
 
   .govuk-c-error-summary__title {
+    @include govuk-font-bold-24;
+
     margin-top: 0;
     margin-bottom: $govuk-spacing-scale-3;
 
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-4;
     }
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-bold-24;
   }
 
   .govuk-c-error-summary__body {
@@ -64,8 +59,9 @@
     &:visited,
     &:hover,
     &:active {
+      @include govuk-typography-weight-bold;
+
       color: $govuk-error-colour;
-      font-weight: bold;
       text-decoration: underline;
     }
   }

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -12,6 +12,8 @@
   }
 
   .govuk-c-fieldset__legend {
+    @include govuk-font-regular-19;
+
     // Fix legend text wrapping in Edge and IE
     // 1. IE9-11 & Edge 12-13
     // 2. IE8-11
@@ -23,20 +25,19 @@
     overflow: hidden;
 
     color: $govuk-text-colour;
-    font-family: $govuk-font-stack;
     white-space: normal;    // 1
-    @include govuk-font-regular-19;
   }
 
   .govuk-c-fieldset__legend--bold {
-    font-weight: 700;
+    @include govuk-typography-weight-bold;
   }
 
   // Hint text sits inside a legend, to be read by AT
   .govuk-c-fieldset__hint {
+    @include govuk-typography-weight-regular;
+
     display: block;
     color: $govuk-secondary-text-colour;
-    font-weight: 400;
   }
 
 }

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -2,13 +2,13 @@
 
 @include exports("file-upload") {
   .govuk-c-file-upload {
+    @include govuk-font-regular-19;
+    @include govuk-text-colour;
+
     margin-bottom: $govuk-spacing-scale-4;
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-5;
     }
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
-    @include govuk-text-colour;
   }
 
   .govuk-c-file-upload:focus {

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -4,6 +4,8 @@
 
 @include exports("input") {
   .govuk-c-input {
+    @include govuk-font-regular-19;
+
     box-sizing: border-box;
     width: 100%;
     height: em(40px, 19px);
@@ -17,8 +19,6 @@
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
 
     // Disable inner shadow and remove rounded corners
     appearance: none;

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -2,20 +2,21 @@
 
 @include exports("label") {
   .govuk-c-label {
-    display: block;
-    color: $govuk-text-colour;
-    font-family: $govuk-font-stack;
     @include govuk-font-regular-19;
+    @include govuk-text-colour;
+
+    display: block;
   }
 
   .govuk-c-label--bold {
-    font-weight: 700;
+    @include govuk-typography-weight-bold;
   }
 
   // Hint text sits inside a label, to be read by AT
   .govuk-c-label__hint {
+    @include govuk-typography-weight-regular;
+
     display: block;
     color: $govuk-secondary-text-colour;
-    font-weight: 400;
   }
 }

--- a/src/components/legal-text/_legal-text.scss
+++ b/src/components/legal-text/_legal-text.scss
@@ -3,12 +3,11 @@
 @include exports("legal-text") {
 
   .govuk-c-legal-text {
+    @include govuk-font-regular-19;
     @include govuk-text-colour;
+
     position: relative;
     padding: $govuk-spacing-scale-1 0;
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
   }
 
   .govuk-c-legal-text__assistive {
@@ -16,6 +15,8 @@
   }
 
   .govuk-c-legal-text__icon {
+    @include govuk-font-bold;
+
     display: inline-block;
 
     position: absolute;
@@ -28,7 +29,6 @@
     padding-top: 3px;
 
     font-size: 1.6em;
-    @include govuk-font-bold;
     line-height: 35px;
   }
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -3,8 +3,8 @@
 @include exports("link") {
 
   .govuk-c-link {
-    font-family: $govuk-font-stack;
     @include govuk-font-regular-16;
+
     line-height: 1.25;
 
     text-decoration: underline;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -4,6 +4,7 @@
   .govuk-c-list {
     @include govuk-font-regular-19;
     @include govuk-text-colour;
+
     margin-top: $govuk-spacing-scale-0;
     margin-bottom: $govuk-spacing-scale-3;
     @include mq($from: tablet) {
@@ -11,7 +12,6 @@
     }
     padding-left: 0;
     list-style-type: none;
-    font-family: $govuk-font-stack;
   }
 
   .govuk-c-list > li {

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -3,15 +3,14 @@
 @include exports("panel") {
 
   .govuk-c-panel {
+    @include govuk-font-regular-19;
+
     @include mq($until: tablet) {
       padding: $govuk-spacing-scale-5;
     }
 
     margin-bottom: $govuk-spacing-scale-3;
     padding: $govuk-spacing-scale-6;
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
 
     text-align: center;
   }

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -3,11 +3,13 @@
 
 @include exports("phase-banner") {
   .govuk-c-phase-banner {
+    @include govuk-font-regular-16;
     @include govuk-text-colour;
+
     padding-top: $govuk-spacing-scale-2;
     padding-bottom: $govuk-spacing-scale-2;
+
     border-bottom: 1px solid $govuk-border-colour;
-    font-family: $govuk-font-stack;
   }
 
   .govuk-c-phase-banner__content {
@@ -20,7 +22,6 @@
   }
 
   .govuk-c-phase-banner__text {
-    @include govuk-font-regular-16;
     display: table-cell;
     vertical-align: baseline;
   }

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -11,7 +11,6 @@
       margin-bottom: $govuk-spacing-scale-5;
     }
     margin-left: -$govuk-spacing-scale-3;
-    font-family: $govuk-font-stack;
   }
 
   .govuk-c-previous-next__list {
@@ -22,6 +21,7 @@
 
   .govuk-c-previous-next__item {
     @include govuk-font-regular-16;
+
     width: 50%;
     padding: 0;
     list-style: none;

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -2,6 +2,8 @@
 
 @include exports("radio") {
   .govuk-c-radio {
+    @include govuk-font-regular-19;
+
     display: block;
 
     position: relative;
@@ -10,9 +12,6 @@
     padding: 0 0 0 em(40px, 19px);
 
     clear: left;
-
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
   }
 
   .govuk-c-radio:last-child,

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -3,6 +3,8 @@
 
 @include exports("select") {
   .govuk-c-select {
+    @include govuk-font-regular-19;
+
     box-sizing: border-box; // should this be global?
     width: 100%;
     height: em(40px, 19px);
@@ -13,8 +15,6 @@
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
 
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
     line-height: 1.25;
   }
 

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -10,19 +10,19 @@
     }
     border-spacing: 0;
     border-collapse: collapse;
-    font-family: $govuk-font-stack;
   }
 
   .govuk-c-table__header {
+    @include govuk-font-bold-19;
+
     padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-4, 19px) em($govuk-spacing-scale-2, 19px) 0;
-    @include govuk-font-regular-19;
     border-bottom: 1px solid $govuk-border-colour;
-    font-weight: 700;
     text-align: left;
   }
 
   .govuk-c-table__cell {
     @include govuk-font-regular-19;
+
     padding: em($govuk-spacing-scale-2, 19px) em($govuk-spacing-scale-4, 19px) em($govuk-spacing-scale-2, 19px) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -4,6 +4,8 @@
 
 @include exports("textarea") {
   .govuk-c-textarea {
+    @include govuk-font-regular-19;
+
     box-sizing: border-box; // should this be global?
     display: block;
     width: 100%;
@@ -15,12 +17,9 @@
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     border-radius: 0;
 
-    font-family: $govuk-font-stack;
-    @include govuk-font-regular-19;
     line-height: 1.25;
 
     -webkit-appearance: none;
-
   }
 
   .govuk-c-textarea:focus {


### PR DESCRIPTION
The font-face is being set twice in a lot of the components - once by the typography mixin and once in the component itself. This removes the duplication by removing all font-face declarations.

It also replaces font-weight declarations with the appropriate mixin, so that e.g if in the future we choose to re-introduce font-size-adjust we can ensure that it’s applied correctly according to the font-weight.

Finally, it moves all typography mixin includes to the top of their respective rulesets.