### PR TITLE
Add Back-link component

### DIFF
--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -1,0 +1,171 @@
+# Back link
+
+## Introduction
+
+Link back component, to go back a page.
+
+## Guidance
+
+More information about when to use back-link can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/back-link "Link to read guidance on the use of back-link on Gov.uk Design system website")
+
+## Quick start examples
+
+### Component default
+
+[Preview the back-link component](http://govuk-frontend-review.herokuapp.com/components/back-link/preview)
+
+#### Markup
+
+    <a href="#" class="govuk-c-back-link">Back</a>
+
+#### Macro
+
+    {{ govukBackLink({
+      "text": "Back"
+    }) }}
+
+## Dependencies
+
+To consume the back-link component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/back-link
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+      .pipe(sass({
+          includePaths: 'node_modules/'
+      }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+
+## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
+
+<div>
+
+<table class="govuk-c-table">
+
+<thead class="govuk-c-table__head">
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="col">Name</th>
+
+<th class="govuk-c-table__header" scope="col">Type</th>
+
+<th class="govuk-c-table__header" scope="col">Required</th>
+
+<th class="govuk-c-table__header" scope="col">Description</th>
+
+</tr>
+
+</thead>
+
+<tbody class="govuk-c-table__body">
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">classes</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Optional additional classes for the back-link component.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">text</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Text to use within the back link component.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">html</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">HTML to use within the back link. If this is provided, the text argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">href</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">Yes</td>
+
+<td class="govuk-c-table__cell ">The value of the link href attribute</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">attributes</th>
+
+<td class="govuk-c-table__cell ">object</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor tag.</td>
+
+</tr>
+
+</tbody>
+
+</table>
+
+</div>
+
+### Setting up Nunjucks views and paths
+
+Below is an example setup using express configure views:
+
+    nunjucks.configure('node_modules/@govuk-frontend`, {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
+
+## Getting updates
+
+To check whether you have the latest version of the button run:
+
+    npm outdated @govuk-frontend/back-link
+
+To update the latest version run:
+
+    npm update @govuk-frontend/back-link
+
+## Contribution
+
+Guidelines can be found at [on our Github repository.](https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md "link to contributing guidelines on our github repository")
+
+## Acknowledgements/credits
+
+## License
+
+MIT

--- a/src/components/back-link/_back-link.scss
+++ b/src/components/back-link/_back-link.scss
@@ -1,0 +1,43 @@
+@import "../../globals/scss/common";
+
+@include exports("back-link") {
+
+  .govuk-c-back-link {
+    display: inline-block;
+    position: relative;
+    margin-top: $govuk-spacing-scale-3;
+    margin-bottom: $govuk-spacing-scale-3;
+    padding-left: 14px;
+    border-bottom: 1px solid $govuk-black;
+    color: $govuk-black;
+    @include govuk-font-regular-16;
+    line-height: 1.25;
+    text-decoration: none;
+
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: $govuk-black;
+    }
+
+    // Back arrow - left pointing black arrow
+    &:before {
+      content: "";
+      display: block;
+
+      position: absolute;
+      top: 50%;
+      left: 0;
+
+      width: 0;
+      height: 0;
+
+      margin-top: -6px;
+
+      border-top: $govuk-spacing-scale-1 solid transparent;
+      border-right: 6px solid $govuk-black;
+      border-bottom: $govuk-spacing-scale-1 solid transparent;
+    }
+  }
+}

--- a/src/components/back-link/back-link.njk
+++ b/src/components/back-link/back-link.njk
@@ -1,0 +1,3 @@
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{{ govukBackLink({href: '#', text: 'Back'}) }}

--- a/src/components/back-link/back-link.yaml
+++ b/src/components/back-link/back-link.yaml
@@ -1,0 +1,4 @@
+variants:
+- name: default
+  data:
+    text: Back

--- a/src/components/back-link/index.njk
+++ b/src/components/back-link/index.njk
@@ -1,0 +1,106 @@
+{% extends "component.njk" %}
+
+{# Commented out blocks below inherit from views/component.njk #}
+
+{# componentName #}
+
+{% block componentDescription %}
+Link back component, to go back a page.
+{% endblock %}
+
+{# defaultAndVariants #}
+
+{# override link to design system here if it's different to base url + componentName #}
+{# {% set componentGuidanceLink = 'new link here' %} #}
+
+{% block componentArguments %}
+{{ govukTable({
+  'firstCellIsHeader': true,
+  'head' : [
+    {
+      text: 'Name'
+    },
+    {
+      text: 'Type'
+    },
+    {
+      text: 'Required'
+    },
+    {
+      text: 'Description'
+    }
+  ],
+  'rows' : [
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'No'
+      },
+      {
+        text: 'Optional additional classes for the back-link component.'
+      }
+    ],
+    [
+      {
+        text: 'text'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'No'
+      },
+      {
+        text: 'Text to use within the back link component.'
+      }
+    ],
+    [
+      {
+        text: 'html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'No'
+      },
+      {
+        text: 'HTML to use within the back link. If this is provided, the text argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'href'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'Yes'
+      },
+      {
+        text: 'The value of the link href attribute'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the anchor tag.'
+      }
+    ]
+  ]
+})}}
+{% endblock %}

--- a/src/components/back-link/macro.njk
+++ b/src/components/back-link/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukBackLink(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/back-link/template.njk
+++ b/src/components/back-link/template.njk
@@ -1,0 +1,2 @@
+<a href="{%- if params.href %}{{ params.href }}{% else %}#{% endif -%}" class="govuk-c-back-link{%- if params.classes %} {{ params.classes }}{% endif -%}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ (params.html | safe if params.html else params.text) }}</a>

--- a/src/components/link/README.md
+++ b/src/components/link/README.md
@@ -2,12 +2,10 @@
 
 ## Introduction
 
-Link component, with four variants:
+Link component, with 2 variants:
 
-*   back link - a black underlined link with a left pointing arrow
 *   muted link - used for the “anything wrong with this page?” links
 *   download link - with download icon
-*   skip link - skip to the main page content
 
 ## Guidance
 
@@ -17,39 +15,47 @@ More information about when to use link can be found on [GOV.UK Design System](h
 
 ### Component default
 
-[Preview the link component.](http://govuk-frontend-review.herokuapp.com/components/link/preview)
+[Preview the link component](http://govuk-frontend-review.herokuapp.com/components/link/preview)
 
 #### Markup
 
+    <a href="#" class="govuk-c-link">Default link</a>
+
 #### Macro
 
-      {% from "link/macro.njk" import govukLink %}
+    {{ govukLink({
+      "text": "Default link"
+    }) }}
 
-    {{- govukLink(
-      classes='govuk-c-link--back',
-      linkHref='',
-      linkText='Back')
-    -}}
+### Link--download
 
-    {{- govukLink(
-      classes='govuk-c-link--muted',
-      linkHref='',
-      linkText='Is there anything wrong with this page?')
-    -}}
+[Preview the link--download variant](http://govuk-frontend-review.herokuapp.com/components/link/download/preview)
 
-    {{- govukLink(
-      classes='govuk-c-link--download',
-      linkHref='',
-      linkText='Download')
-    -}}
+#### Markup
 
-    {{- govukLink(
-      classes='govuk-c-link--skip',
-      linkHref='',
-      linkText='Skip to main content')
-    -}}
+    <a href="#" class="govuk-c-link govuk-c-link--download">Download</a>
 
-## Variants
+#### Macro
+
+    {{ govukLink({
+      "text": "Download",
+      "classes": "govuk-c-link--download"
+    }) }}
+
+### Link--muted
+
+[Preview the link--muted variant](http://govuk-frontend-review.herokuapp.com/components/link/muted/preview)
+
+#### Markup
+
+    <a href="#" class="govuk-c-link govuk-c-link--muted">Is there anything wrong with this page?</a>
+
+#### Macro
+
+    {{ govukLink({
+      "text": "Is there anything wrong with this page?",
+      "classes": "govuk-c-link--muted"
+    }) }}
 
 ## Dependencies
 
@@ -79,7 +85,93 @@ To show the button image you need to configure your app to show these assets. Be
 
 If you are using Nunjucks,then macros take the following arguments
 
-<div>| Name | Type | Default | Required | Description |--- |--- |--- |--- |--- | linkHref | string | | Yes | The value of the link href attribute | linkText | string | | Yes | The link text | classes | string | | Yes | The modifier required for the link type | --back | --muted | --download | --skip</div>
+<div>
+
+<table class="govuk-c-table">
+
+<thead class="govuk-c-table__head">
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="col">Name</th>
+
+<th class="govuk-c-table__header" scope="col">Type</th>
+
+<th class="govuk-c-table__header" scope="col">Required</th>
+
+<th class="govuk-c-table__header" scope="col">Description</th>
+
+</tr>
+
+</thead>
+
+<tbody class="govuk-c-table__body">
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">classes</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">The available classes for the link: govuk-c-link--download, govuk-c-link--muted</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">text</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Text to use within the link</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">html</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">HTML to use within the link. If this is provided, the text argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">href</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">Yes</td>
+
+<td class="govuk-c-table__cell ">The value of the link href attribute</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">attributes</th>
+
+<td class="govuk-c-table__cell ">object</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor tag.</td>
+
+</tr>
+
+</tbody>
+
+</table>
+
+</div>
 
 ### Setting up Nunjucks views and paths
 
@@ -106,10 +198,6 @@ To update the latest version run:
 Guidelines can be found at [on our Github repository.](https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md "link to contributing guidelines on our github repository")
 
 ## Acknowledgements/credits
-
-*   GDS developers
-*   Jani Kraner
-*   Gemma Leigh
 
 ## License
 

--- a/src/components/link/_link.scss
+++ b/src/components/link/_link.scss
@@ -10,44 +10,6 @@
     text-decoration: underline;
   }
 
-  .govuk-c-link--back {
-    display: inline-block;
-    position: relative;
-    margin-top: $govuk-spacing-scale-3;
-    margin-bottom: $govuk-spacing-scale-3;
-    padding-left: 14px;
-    border-bottom: 1px solid $govuk-black;
-    color: $govuk-black;
-    background: file-url("icon-arrow-left.png") no-repeat 0 4px;
-    text-decoration: none;
-
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: $govuk-black;
-    }
-
-    // Back arrow - left pointing black arrow
-    &::before {
-      content: "";
-      display: block;
-
-      position: absolute;
-      top: 50%;
-      left: 0;
-
-      width: 0;
-      height: 0;
-
-      margin-top: -6px;
-
-      border-top: $govuk-spacing-scale-1 solid transparent;
-      border-right: 6px solid $govuk-black;
-      border-bottom: $govuk-spacing-scale-1 solid transparent;
-    }
-  }
-
   .govuk-c-link--muted {
     &:link,
     &:visited,

--- a/src/components/link/index.njk
+++ b/src/components/link/index.njk
@@ -6,13 +6,10 @@
 {# componentName #}
 
 {% block componentDescription %}
-Link component, with four variants:
+Link component, with 2 variants:
 
 {{ govukList({
   items: [
-    {
-      text: 'back link - a black underlined link with a left pointing arrow'
-    },
     {
       text: 'muted link - used for the “anything wrong with this page?” links'
     },
@@ -58,7 +55,7 @@ Link component, with four variants:
         text:'No'
       },
       {
-        text: 'The available classes for the link: govuk-c-link--back, govuk-c-link--download, govuk-c-link--muted'
+        text: 'The available classes for the link: govuk-c-link--download, govuk-c-link--muted'
       }
     ],
     [

--- a/src/components/link/link.yaml
+++ b/src/components/link/link.yaml
@@ -2,10 +2,6 @@ variants:
 - name: default
   data:
     text: Default link
-- name: back
-  data:
-    text: Back
-    classes: govuk-c-link--back
 - name: download
   data:
     text: Download

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -2,6 +2,7 @@
 @import "../../globals/scss/common";
 
 // Components
+@import "../../components/back-link/back-link";
 @import "../../components/breadcrumb/breadcrumb";
 @import "../../components/button/button";
 @import "../../components/checkbox/checkbox";


### PR DESCRIPTION
As per [Trello ticket](https://trello.com/c/8tAe1bNx/373-split-back-link-into-its-own-component) this PR:
* removes link--back variant from the link component
* creates a separate back-link component

This is stage one. Stage two is to update packages and publish the component. That can't be done without all the updates from source to go into packages and all published to npm