### PR TITLE
Style details component correctly, use border-based triangles for marker.

### DIFF
--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -1,24 +1,35 @@
 @import "../../globals/scss/common";
 
 @include exports("details") {
+
   .govuk-c-details {
     @include govuk-font-regular-19;
-
-    display: block;
+    @include govuk-text-colour;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 
-    clear: both;
+    display: block;
   }
 
   .govuk-c-details__summary {
+    // Make the focus outline shrink-wrap the text content of the summary
     display: inline-block;
 
+    // Absolutely position the marker against this element
     position: relative;
-    // TODO: Make margins under components consistent
-    margin-bottom: em($govuk-spacing-scale-1, 19px);
 
-    color: $govuk-blue;
+    margin-bottom: $govuk-spacing-scale-1;
+
+    // Allow for absolutely positioned marker and align with disclosed text
+    padding-left: $govuk-spacing-scale-4 + $govuk-border-width;
+
+    // Style the summary to look like a link...
+    color: $govuk-link-colour;
     cursor: pointer;
+  }
+
+  // ...but only underline the text, not the arrow
+  .govuk-c-details__summary-text {
+    text-decoration: underline;
   }
 
   .govuk-c-details__summary:hover {
@@ -26,29 +37,66 @@
   }
 
   .govuk-c-details__summary:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
+    // -1px offset fixes gap between background and outline in Firefox
+    outline: ($govuk-focus-width + 1px) solid $govuk-focus-colour;
+    outline-offset: -1px;
+    background: $govuk-focus-colour;
   }
 
-  // Underline only summary text (not the arrow)
-  .govuk-c-details__summary-text {
-    text-decoration: underline;
+  // Remove the default details marker so we can style our own consistently and
+  // ensure it displays in Firefox (see implementation.md for details)
+  .govuk-c-details__summary::-webkit-details-marker {
+    display: none;
   }
 
-  // Match fallback arrow spacing with -webkit default
-  .govuk-c-details__arrow {
-    margin-right: .35em;
-    font-style: normal;
+  // Append our own open / closed marker using a pseudo-element
+  .govuk-c-details__summary::before {
+    // Marker ('arrow') definition
+    $marker-size: 14px;
+    $marker-perpendicular: $marker-size / 2;
+
+    // Needs to be manually calculated when $marker-size changes to produce an
+    // equilateral triangle:
+    // sqrt(($marker-size * $marker-size) - ($marker-size / 2) * ($marker-size / 2))
+    $marker-longest-side: 12.1244px;
+
+    content: "";
+    position: absolute;
+
+    top: 0;
+    bottom: 0;
+    left: 0;
+
+    height: 0;
+
+    margin: auto;
+
+    // Ensure marker is rendered correctly if browser colours are overridden –
+    // without it the transparent borders become visible which results in a
+    // square.
+    clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
+
+    border-width: $marker-perpendicular 0 $marker-perpendicular $marker-longest-side;
+    border-style: solid;
+    border-color: transparent;
+    border-left-color: currentColor;
+
+    .govuk-c-details[open] > & {
+      clip-path: polygon(0% 0%, 50% 100%, 100% 0%);
+
+      border-width: $marker-longest-side $marker-perpendicular 0 $marker-perpendicular;
+      border-color: transparent;
+      border-top-color: currentColor;
+    }
   }
 
   .govuk-c-details__text {
-    // TODO: Make margins underneath components consistent
-    margin-bottom: em($govuk-spacing-scale-3, 19px);
-    padding: em($govuk-spacing-scale-3, 19px);
+    padding: $govuk-spacing-scale-3;
+    padding-left: $govuk-spacing-scale-4;
     border-left: $govuk-border-width solid $govuk-border-colour;
   }
 
   .govuk-c-details__text p {
-    // TODO: Make margins on paragraphs consistent
     margin-top: 0;
     margin-bottom: em($govuk-spacing-scale-4, 19px);
   }

--- a/src/components/details/details.js
+++ b/src/components/details/details.js
@@ -151,23 +151,6 @@
       // Create a circular reference from the summary back to its
       // parent details element, for convenience in the click handler
       details.__summary.__details = details
-
-      // If this is not a native implementation, create an arrow
-      // inside the summary
-      if (!NATIVE_DETAILS) {
-        var twisty = document.createElement('i')
-
-        if (openAttr === true) {
-          twisty.className = 'arrow arrow-open'
-          twisty.appendChild(document.createTextNode('\u25bc'))
-        } else {
-          twisty.className = 'arrow arrow-closed'
-          twisty.appendChild(document.createTextNode('\u25ba'))
-        }
-
-        details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
-        details.__summary.__twisty.setAttribute('aria-hidden', 'true')
-      }
     }
 
     // Define a statechange function that updates aria-expanded and style.display

--- a/src/components/details/implementation.md
+++ b/src/components/details/implementation.md
@@ -1,0 +1,43 @@
+## Implementation notes
+
+### Marker styling
+
+Firefox uses display: list-item to show the arrow marker for the summary
+element.
+
+Unfortunately we want to use `display: inline-block` to 'shrink-wrap' the focus
+outline around the summary text, which means that the arrow no longer shows up.
+
+Previously in GOV.UK Elements we resolved this by targeting Firefox specifically
+and reverting to `display: list-item`:
+
+```
+@-moz-document regexp('.*') {
+  details summary:not([tabindex]) {
+    // Allow duplicate properties, override the summary display property
+    // scss-lint:disable DuplicateProperty
+    display: list-item;
+    display: revert;
+  }
+}
+```
+
+However, `@-moz-document` has been removed in Firefox nightly as of 29th Nov
+2017 so with this in mind we have taken a different approach, hiding the
+browser's marker and injecting and styling our own one across all browsers
+instead.
+
+This also gives us more control over the styling of the marker, allowing us for
+example to align the summary and disclosed text correctly across all browsers.
+
+The downside of this approach is that older browsers that require a polyfill for
+the details element will display the marker even when Javascript is disabled.
+Whilst this is not perfect, it is a cosmetic issue and the user will still be
+able to access the disclosed content.
+
+For the arrows themselves, we originally tried using unicode glyphs –
+specifically \25B6 (Black right-pointing triangle) and 25BC (Black down-pointing
+triangle) but Android insists on substituting the the former for an emoji even
+when the \00FE0E modifier is applied. Sad face.
+
+Hence the border-based triangles we are using today.


### PR DESCRIPTION
This correctly sets the text colour for the disclosed text and adjusts the spacing so that the disclosed text is aligned with the summary.

It also styles the marker (arrow) using border-based triangles.

This allows us to consistently style the marker across browsers and resolves the issue with the Firefox marker disappearing because of our use of `display: inline-block`. For more details, see the implementation.md file added as part of this commit.

We also use clip-path to ensure that if browser colours are overridden the marker still appears as a triangle rather than turning into a square.

## Chrome

### Collapsed
<img width="1392" alt="screen shot 2017-12-08 at 09 18 01gmt" src="https://user-images.githubusercontent.com/121939/33759708-32353264-dbfb-11e7-81eb-ca7d61601fd1.png">

### Expanded 
<img width="1392" alt="screen shot 2017-12-08 at 09 18 04gmt" src="https://user-images.githubusercontent.com/121939/33759715-3994521a-dbfb-11e7-9380-10ee8557bd34.png">

### Focussed
<img width="1392" alt="screen shot 2017-12-08 at 09 18 08gmt" src="https://user-images.githubusercontent.com/121939/33759730-456b0dd6-dbfb-11e7-8d0a-8b0e85f90a27.png">

## IE9

![bs_win7_ie_9 0](https://user-images.githubusercontent.com/121939/33759646-01e94fb4-dbfb-11e7-8509-203078a140d4.jpg)

## IE10

![bs_win7_ie_10 0](https://user-images.githubusercontent.com/121939/33759656-07b19f82-dbfb-11e7-8c4e-8f916287b44e.jpg)

## IE11

![bs_win7_ie_11 0](https://user-images.githubusercontent.com/121939/33759661-0cb5e09c-dbfb-11e7-8ef1-01f9f5e58df2.jpg)

## Edge

![bs_win10_edge_16 0](https://user-images.githubusercontent.com/121939/33759769-6547e7e6-dbfb-11e7-8038-a1a2925e353f.jpg)

## Android 
![bs_realdroid_mobile_google pixel-8 0-1080x1920](https://user-images.githubusercontent.com/121939/33759790-73438878-dbfb-11e7-8f04-fc95b149b444.jpg)

## iOS
![bs_realios_mobile_iphone 6s-9 0](https://user-images.githubusercontent.com/121939/33759793-79100c22-dbfb-11e7-9ac6-93de36b7e400.jpg)

## Windows Phone
![bs_winphone_mobile_nokia lumia 930-8 1-1080x1920](https://user-images.githubusercontent.com/121939/33759796-80a3aa48-dbfb-11e7-8654-488d6bcf0405.jpg)

## Firefox (custom colours)

<img width="1392" alt="screen shot 2017-12-08 at 09 19 32gmt" src="https://user-images.githubusercontent.com/121939/33759806-88e94348-dbfb-11e7-8100-3ef40c4aacb3.png">
