### PR TITLE
Update override classes in examples/typography.

### DIFF
--- a/docs/coding-standards/css.md
+++ b/docs/coding-standards/css.md
@@ -72,7 +72,8 @@ Classes that override all other layers - for example to override the spacing or
 font size / line height on an element.
 
 - forms part of the @govuk-frontend/global package.
-- uses the prefix `govuk-!-` for its classes.
+- uses the prefix `govuk-!-` for its classes, eg. `govuk-!-mt-r8`; `r` indicates the class is responsive and `8` is the scale point; these are set in settings/spacing
+
 
 # Class naming convention
 

--- a/src/views/examples/typography/index.njk
+++ b/src/views/examples/typography/index.njk
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<div class="govuk-o-grid govuk-!-mt-8">
+<div class="govuk-o-grid govuk-!-mt-r9">
   <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
 
     <h1 class="govuk-heading-xl">
@@ -14,7 +14,7 @@
 
     <section>
       <div>
-        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings</h2>
+        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Headings</h2>
       </div>
       <div>
       <h1 class="govuk-heading-xl">govuk-heading-xl</h1>
@@ -32,8 +32,8 @@
 
     <!-- Headings with captions -->
 
-    <section class="govuk-!-mt-7">
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings with captions</h2>
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Headings with captions</h2>
       <div>
         <h1 class="govuk-heading-xl">
           <span class="govuk-caption-xl">govuk-caption-xl</span>
@@ -56,8 +56,8 @@
 
     <!-- Body text -->
 
-    <section class="govuk-!-mt-7">
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Body text</h2>
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Body text</h2>
       <div>
         <p class="govuk-body-l">govuk-body-l</p>
       </div>
@@ -74,35 +74,35 @@
 
     <!-- Overrides -->
 
-    <section class="govuk-!-mt-7">
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Overrides</h2>
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Overrides</h2>
 
       <h3 class="govuk-heading-m">Override font-size and line-height</h3>
 
       <!-- We have to add govuk-body to get new transport, but then we get
         margins, so we have to remove them -->
 
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-80">govuk-!-f-80</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-48">govuk-!-f-48</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-36">govuk-!-f-36</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-27">govuk-!-f-27</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-24">govuk-!-f-24</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-19">govuk-!-f-19</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-16">govuk-!-f-16</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-14">govuk-!-f-14</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-80">govuk-!-f-80</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-48">govuk-!-f-48</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-36">govuk-!-f-36</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-27">govuk-!-f-27</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-24">govuk-!-f-24</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-19">govuk-!-f-19</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-16">govuk-!-f-16</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-14">govuk-!-f-14</p>
 
 
-      <h3 class="govuk-heading-m govuk-!-mt-8">Override font weight.</h3>
+      <h3 class="govuk-heading-m govuk-!-mt-r9">Override font weight.</h3>
 
-      <p class="govuk-body govuk-!-m-0 govuk-!-w-regular">govuk-!-w-regular</p>
-      <p class="govuk-body govuk-!-m-0 govuk-!-w-bold">govuk-!-w-bold</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-w-regular">govuk-!-w-regular</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-w-bold">govuk-!-w-bold</p>
 
 
-      <h3 class="govuk-heading-m govuk-!-mt-8">Override both by combining classes</h3>
+      <h3 class="govuk-heading-m govuk-!-mt-r9">Override both by combining classes</h3>
 
-      <p class="govuk-body govuk-!-m-0 govuk-!-f-48 govuk-!-w-bold">govuk-!-f-48 + govuk-!-w-bold</p>
+      <p class="govuk-body govuk-!-m-r0 govuk-!-f-48 govuk-!-w-bold">govuk-!-f-48 + govuk-!-w-bold</p>
 
-      <h3 class="govuk-heading-m govuk-!-mt-8">Override typography classes</h3>
+      <h3 class="govuk-heading-m govuk-!-mt-r9">Override typography classes</h3>
 
       <h1 class="govuk-heading-xl govuk-!-f-80">govuk-heading-xl + govuk-!-f-80</h1>
 
@@ -112,8 +112,8 @@
 
     </section>
 
-    <section class="govuk-!-mt-7">
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Example content 1</h2>
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Example content 1</h2>
 
       <h1 class="govuk-heading-xl">Request information about a vehicle or its registered keeper from DVLA</h1>
 
@@ -196,8 +196,8 @@
       <p class="govuk-body-m">Don’t use these details for general enquiries - contact DVLA instead.</p>
     </section>
 
-    <section class="govuk-!-mt-7">
-      <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Example content 2</h2>
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Example content 2</h2>
 
       <h1 class="govuk-heading-xl">Apply for a Women’s Land Army or Women’s Timber Corps veterans badge</h1>
 


### PR DESCRIPTION
This was missed out from #368 as the typography classes changed.

Also update docs on override classes. 