### PR TITLE
Allow radio and checkboxes to have fieldsets

### DIFF
--- a/src/components/checkbox/checkbox.yaml
+++ b/src/components/checkbox/checkbox.yaml
@@ -1,21 +1,46 @@
 variants:
 - name: default
   data:
-    idPrefix: 'waste-types'
-    name: 'waste-types'
+    idPrefix: 'nationality'
+    name: 'nationality'
+    fieldset:
+      legendText: What is your nationality?
+      legendHintText: If you have dual nationality, select all options that are relevant to you.
     items:
-      -
-        value: 'waste-animal'
-        text: 'Waste from animal carcasses'
-      -
-        id: 'custom-id'
-        value: 'waste-mines'
-        text: 'Waste from mines or quarries'
-      -
-        value: 'waste-farm'
-        text: 'Farm or agricultural waste'
-        checked: true
-      -
-        value: 'waste-disabled'
-        text: 'Disabled checkbox option'
+      - value: 'british'
+        text: 'British'
+      - value: 'irish'
+        text: 'Irish'
+      - value: 'other'
+        text: 'Citizen of another country'
+
+- name: with-html
+  data:
+    fieldset:
+      legendHtml:
+        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      legendHintText: Select all that apply
+    items:
+      - value: animal
+        text: Waste from animal carcasses
+      - value: mines
+        text: Waste from mines or quarries
+      - value: farm
+        text: Farm or agricultural waste
+
+- name: without-fieldset
+  data:
+    items:
+      - value: "red"
+        text: 'Red'
+      - value: "green"
+        text: 'Green'
+      - value: "blue"
+        text: "Blue"
+
+- name: disabled
+  data:
+    items:
+      - value: disabled
+        text: Disabled option
         disabled: true

--- a/src/components/checkbox/checkbox.yaml
+++ b/src/components/checkbox/checkbox.yaml
@@ -30,6 +30,7 @@ variants:
 
 - name: without-fieldset
   data:
+    name: colours
     items:
       - value: "red"
         text: 'Red'
@@ -40,6 +41,7 @@ variants:
 
 - name: disabled
   data:
+    name: disabled-example
     items:
       - value: disabled
         text: Disabled option

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -33,6 +33,20 @@
   'rows' : [
     [
       {
+        text: 'fieldset'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/checkbox/index.njk
+++ b/src/components/checkbox/index.njk
@@ -67,7 +67,7 @@
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
         text: 'String to prefix id for each checkbox item if no id is specified on each item.'

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -1,16 +1,37 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
 {% from "label/macro.njk" import govukLabel %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{%- set innerHtml -%}
 {% for item in params.items %}
 <div class="govuk-c-checkbox
 {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <input class="govuk-c-checkbox__input" id="{% if item.id %}{{ item.id }}{% else %}{{params.idPrefix}}-{{loop.index}}{% endif %}" name="{{ params.name }}" type="checkbox" value="{{ item.value }}"
   {{-" checked" if item.checked }}
   {{-" disabled" if item.disabled }}>
-  {{- govukLabel({
+  {{ govukLabel({
     html: item.html,
     text: item.text,
     classes: 'govuk-c-checkbox__label',
     attributes: item.label.attributes,
     for: item.id if item.id else params.idPrefix+'-'+loop.index
-  }) -}}
+  }) | trim | indent(2) -}}
 </div>
 {% endfor %}
+{%- endset -%}
+
+{%- if params.fieldset -%}
+  {%- call govukFieldset({
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml,
+    legendHintText: params.fieldset.legendHintText,
+    legendHintHtml: params.fieldset.legendHintHtml,
+    errorMessage: params.errorMessage
+  }) -%}
+    {{- innerHtml | safe -}}
+  {%- endcall -%}
+{%- else -%}
+  {{- innerHtml | trim | safe -}}
+{%- endif -%}

--- a/src/components/checkbox/template.njk
+++ b/src/components/checkbox/template.njk
@@ -4,9 +4,11 @@
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {%- set innerHtml -%}
 {% for item in params.items %}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+{% set id = item.id if item.id else idPrefix + "-" + loop.index %}
 <div class="govuk-c-checkbox
 {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  <input class="govuk-c-checkbox__input" id="{% if item.id %}{{ item.id }}{% else %}{{params.idPrefix}}-{{loop.index}}{% endif %}" name="{{ params.name }}" type="checkbox" value="{{ item.value }}"
+  <input class="govuk-c-checkbox__input" id="{{ id }}" name="{{ params.name }}" type="checkbox" value="{{ item.value }}"
   {{-" checked" if item.checked }}
   {{-" disabled" if item.disabled }}>
   {{ govukLabel({
@@ -14,7 +16,7 @@
     text: item.text,
     classes: 'govuk-c-checkbox__label',
     attributes: item.label.attributes,
-    for: item.id if item.id else params.idPrefix+'-'+loop.index
+    for: id
   }) | trim | indent(2) -}}
 </div>
 {% endfor %}

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -38,7 +38,7 @@
         text: 'object'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
         text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -1,30 +1,40 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 {% from "input/macro.njk" import govukInput %}
-{% call govukFieldset({
-  classes: params.fieldset.classes,
-  attributes: params.fieldset.attributes,
-  legendText: params.fieldset.legendText,
-  legendHtml: params.fieldset.legendHtml,
-  legendHintText: params.fieldset.legendHintText,
-  legendHintHtml: params.fieldset.legendHintHtml,
-  errorMessage: params.errorMessage
-  }) %}
-  <div class="govuk-c-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {%- if params.id %} id="{{ params.id }}"{% endif %}>
-    {% for item in params.items %}
-    <div class="govuk-c-date-input__item govuk-c-date-input__item--{{ item.name }}">
-      {{ govukInput({
-        "label":{
-          "text": item.name | capitalize,
-          "classes": 'govuk-c-date-input__label'
-        },
-        "id": params.id + "-" + item.name,
-        "classes": "govuk-c-date-input__input " + item.classes,
-        "name": params.name + "-" + item.name,
-        "value": item.value
-      }) -}}
-    </div>
-    {% endfor %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{% set innerHtml %}
+<div class="govuk-c-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+  {%- if params.id %} id="{{ params.id }}"{% endif %}>
+  {% for item in params.items %}
+  <div class="govuk-c-date-input__item govuk-c-date-input__item--{{ item.name }}">
+    {{ govukInput({
+      "label":{
+        "text": item.name | capitalize,
+        "classes": 'govuk-c-date-input__label'
+      },
+      "id": params.id + "-" + item.name,
+      "classes": "govuk-c-date-input__input " + item.classes,
+      "name": params.name + "-" + item.name,
+      "value": item.value
+    }) | trim | indent(4) }}
   </div>
-{% endcall %}
+  {% endfor %}
+</div>
+{%- endset -%}
+
+{%- if params.fieldset -%}
+  {%- call govukFieldset({
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml,
+    legendHintText: params.fieldset.legendHintText,
+    legendHintHtml: params.fieldset.legendHintHtml,
+    errorMessage: params.errorMessage
+  }) -%}
+    {{- innerHtml | safe -}}
+  {%- endcall -%}
+{%- else -%}
+  {{- innerHtml | trim | safe -}}
+{%- endif -%}

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -20,12 +20,29 @@
     box-sizing: border-box; // 1
     display: table;         // 2
     max-width: 100%;        // 1
+    margin-bottom: $govuk-spacing-scale-4;
     padding: 0;
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;
 
     color: $govuk-text-colour;
     white-space: normal;    // 1
+
+    .govuk-heading-s {
+      margin-bottom: 0;
+    }
+
+    .govuk-heading-m {
+      margin-bottom: $govuk-spacing-scale-1;
+    }
+
+    .govuk-heading-l {
+      margin-bottom: $govuk-spacing-scale-2;
+    }
+
+    .govuk-heading-xl {
+      margin-bottom: $govuk-spacing-scale-3;
+    }
   }
 
   .govuk-c-fieldset__legend--bold {

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -36,10 +36,7 @@
       margin-bottom: $govuk-spacing-scale-1;
     }
 
-    .govuk-heading-l {
-      margin-bottom: $govuk-spacing-scale-2;
-    }
-
+    .govuk-heading-l,
     .govuk-heading-xl {
       margin-bottom: $govuk-spacing-scale-3;
     }

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -9,9 +9,9 @@
     <span class="govuk-c-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
     {% endif %}
     {% if params.errorMessage %}
-    {{ govukErrorMessage(params.errorMessage) -}}
+    {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
     {% endif %}
   </legend>
-{%- endif -%}
-{{ caller() if caller }} {# if statement allows usage of `call` to be optional #}
+{% endif %}
+  {{ caller() | trim | indent(2) if caller }} {#- if statement allows usage of `call` to be optional -#}
 </fieldset>

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -36,6 +36,20 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
   'rows' : [
     [
       {
+        text: 'fieldset'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/radio/index.njk
+++ b/src/components/radio/index.njk
@@ -70,7 +70,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
         text: 'String to prefix id for each radio item if no id is specified on each item.'

--- a/src/components/radio/radio.yaml
+++ b/src/components/radio/radio.yaml
@@ -1,21 +1,42 @@
 variants:
-  - name: default
-    data:
-      idPrefix: 'radio'
-      name: 'radio-group'
-      items:
-        -
-          value: 'waste-animal'
-          text: 'Waste from animal carcasses'
-        -
-          id: 'custom-id'
-          value: 'waste-mines'
-          text: 'Waste from mines or quarries'
-        -
-          value: 'waste-farm'
-          text: 'Farm or agricultural waste'
-          checked: true
-        -
-          value: 'waste-disabled'
-          text: 'Disabled radio option'
-          disabled: true
+- name: default
+  data:
+    idPrefix: 'example'
+    name: 'example'
+    fieldset:
+      legendText: Have you changed your name?
+      legendHintText:
+        This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+        checked: true
+
+- name: with-html
+  data:
+    idPrefix: 'housing-act'
+    name: 'housing-act'
+    fieldset:
+      legendHtml: <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+      legendHintText: Select one of the options below.
+    items:
+      - value: 'part-2'
+        html:
+          <span class="govuk-heading-s govuk-!-mb-1">Part 2 of the Housing Act 2004</span>
+          For properties that are 3 or more stories high and occupied by 5 or more people
+      - value: 'part-3'
+        html:
+          <span class="govuk-heading-s govuk-!-mb-1">Part 3 of the Housing Act 2004</span>
+          For properties that are within a geographical area defined by a local council
+
+- name: without-fieldset
+  data:
+    items:
+      - value: "red"
+        text: 'Red'
+      - value: "green"
+        text: 'Green'
+      - value: "blue"
+        text: "Blue"

--- a/src/components/radio/radio.yaml
+++ b/src/components/radio/radio.yaml
@@ -33,6 +33,7 @@ variants:
 
 - name: without-fieldset
   data:
+    name: colours
     items:
       - value: "red"
         text: 'Red'

--- a/src/components/radio/template.njk
+++ b/src/components/radio/template.njk
@@ -4,9 +4,11 @@
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {%- set innerHtml -%}
 {%- for item in params.items -%}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+{% set id = item.id if item.id else idPrefix + "-" + loop.index %}
 <div class="govuk-c-radio
 {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  <input class="govuk-c-radio__input" id="{% if item.id %}{{ item.id }}{% else %}{{params.idPrefix}}-{{loop.index}}{% endif %}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+  <input class="govuk-c-radio__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
   {{-" checked" if item.checked }}
   {{-" disabled" if item.disabled }}>
   {{ govukLabel({
@@ -14,7 +16,7 @@
     text: item.text,
     classes: 'govuk-c-radio__label',
     attributes: item.label.attributes,
-    for: item.id if item.id else params.idPrefix+'-'+loop.index
+    for: id
   }) | trim | indent(2) -}}
 </div>
 {% endfor -%}

--- a/src/components/radio/template.njk
+++ b/src/components/radio/template.njk
@@ -1,16 +1,37 @@
+{% from "fieldset/macro.njk" import govukFieldset %}
 {% from "label/macro.njk" import govukLabel %}
-{% for item in params.items %}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{%- set innerHtml -%}
+{%- for item in params.items -%}
 <div class="govuk-c-radio
 {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <input class="govuk-c-radio__input" id="{% if item.id %}{{ item.id }}{% else %}{{params.idPrefix}}-{{loop.index}}{% endif %}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
   {{-" checked" if item.checked }}
   {{-" disabled" if item.disabled }}>
-  {{- govukLabel({
+  {{ govukLabel({
     html: item.html,
     text: item.text,
     classes: 'govuk-c-radio__label',
     attributes: item.label.attributes,
     for: item.id if item.id else params.idPrefix+'-'+loop.index
-  }) -}}
+  }) | trim | indent(2) -}}
 </div>
-{% endfor %}
+{% endfor -%}
+{%- endset -%}
+
+{%- if params.fieldset -%}
+  {%- call govukFieldset({
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml,
+    legendHintText: params.fieldset.legendHintText,
+    legendHintHtml: params.fieldset.legendHintHtml,
+    errorMessage: params.errorMessage
+  }) -%}
+    {{- innerHtml | safe -}}
+  {%- endcall -%}
+{%- else -%}
+  {{- innerHtml | trim | safe -}}
+{%- endif -%}

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -46,6 +46,8 @@
     @include govuk-text-colour;
     @include govuk-font-bold-19;
 
+    display: block;
+
     margin-top: 0;
     margin-bottom: $govuk-spacing-scale-3;
 
@@ -61,7 +63,9 @@
     @include govuk-font-regular-27;
 
     display: block;
+
     margin-bottom: $govuk-spacing-scale-1;
+
     color: $govuk-secondary-text-colour;
   }
 
@@ -70,6 +74,7 @@
     @include govuk-font-regular-24;
 
     display: block;
+
     margin-bottom: $govuk-spacing-scale-1;
     color: $govuk-secondary-text-colour;
 
@@ -83,6 +88,7 @@
     @include govuk-font-regular-19;
 
     display: block;
+
     color: $govuk-secondary-text-colour;
   }
 


### PR DESCRIPTION
By passing a fieldset object as part of the component definition a fieldset will automatically be added that wraps the radio buttons or checkboxes.

To be consistent, this also makes fieldsets optional for the date input component.

Finally, it adds styling to reduce the margins of headings used when inside fieldset legends.

https://trello.com/c/HT8kvhSM/415-3-add-optional-fieldset-to-radio-checkbox-date-input-macro
https://trello.com/c/zOsvZn6P/384-3-allow-for-optional-larger-bolder-legend-text-within-the-fieldset-component