### PR TITLE
Correctly sort components and examples in lists

### DIFF
--- a/src/views/component-list.njk
+++ b/src/views/component-list.njk
@@ -5,7 +5,7 @@
     GOV.UK Frontend - Components
   </h1>
   <ul class="govuk-c-list">
-  {% for componentName, value in componentsDirectory %}
+  {% for componentName, value in componentsDirectory | dictsort %}
     <li><a href="/components/{{ componentName }}">{{ componentName | replace("-", " ") | capitalize }}</a></li>
   {% endfor %}
   </ul>

--- a/src/views/example-list.njk
+++ b/src/views/example-list.njk
@@ -5,7 +5,7 @@
     GOV.UK Frontend - Examples
   </h1>
   <ul class="govuk-c-list">
-  {% for exampleName, value in examplesDirectory %}
+  {% for exampleName, value in examplesDirectory | dictsort %}
     <li><a href="/examples/{{ exampleName }}">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
   {% endfor %}
   </ul>


### PR DESCRIPTION
Because these are defined as an object, their order is undefined which means every time you refresh the page they appear in a slightly different order.

Nunjucks has a built in filter 'dictsort' to handle this sort of problem, so applying that to both the component and example lists fixes it.