### PR TITLE
A few fixes for components with overridden colours

### DIFF
--- a/src/components/checkbox/_checkbox.scss
+++ b/src/components/checkbox/_checkbox.scss
@@ -40,7 +40,6 @@
   .govuk-c-checkbox__label {
     display: block;
     padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
-    border: 2px solid transparent;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -5,14 +5,18 @@
   .govuk-c-panel {
     @include govuk-font-regular-19;
 
-    @include mq($until: tablet) {
-      padding: $govuk-spacing-scale-6;
-    }
+    box-sizing: border-box;
 
     margin-bottom: $govuk-spacing-scale-3;
-    padding: $govuk-spacing-scale-7;
+    padding: $govuk-spacing-scale-7 - $govuk-border-width;
+
+    border: $govuk-border-width solid transparent;
 
     text-align: center;
+
+    @include mq($until: tablet) {
+      padding: $govuk-spacing-scale-6 - $govuk-border-width;
+    }
   }
 
   .govuk-c-panel--confirmation {

--- a/src/components/radio/_radio.scss
+++ b/src/components/radio/_radio.scss
@@ -47,7 +47,6 @@
   .govuk-c-radio__label {
     display: block;
     padding: em(8px, 19px) em($govuk-spacing-scale-3, 19px) em($govuk-spacing-scale-1, 19px);
-    border: 2px solid transparent;
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;


### PR DESCRIPTION
## Radio Buttons

Removes a transparent border from the radio button labels.

### Before

<img width="1392" alt="screen shot 2017-12-12 at 11 00 25" src="https://user-images.githubusercontent.com/121939/33881108-b3671824-df2b-11e7-9b6d-15e7685a957c.png">

### After

<img width="1392" alt="screen shot 2017-12-12 at 11 00 30" src="https://user-images.githubusercontent.com/121939/33881116-ba6681c8-df2b-11e7-97cb-f55c5ce5b859.png">

## Checkboxes

Removes a transparent border from the checkbox labels.

### Before
<img width="1392" alt="screen shot 2017-12-12 at 11 00 35" src="https://user-images.githubusercontent.com/121939/33881090-a363a398-df2b-11e7-928a-7910f9f26454.png">

### After
<img width="1392" alt="screen shot 2017-12-12 at 11 00 36" src="https://user-images.githubusercontent.com/121939/33881096-a853025e-df2b-11e7-8ded-299584f7ee69.png">

## Panel

Adds a transparent border which is made visible when users override colours.

### Before
<img width="1392" alt="screen shot 2017-12-12 at 11 00 18" src="https://user-images.githubusercontent.com/121939/33881067-8dd02fe2-df2b-11e7-8aa7-83acf3d0c8d9.png">

### After
<img width="1392" alt="screen shot 2017-12-12 at 11 00 21" src="https://user-images.githubusercontent.com/121939/33881070-939b28e6-df2b-11e7-845a-d6d9413d01ac.png">
