### PR TITLE
Fix IE9 full-width button on large devices

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -29,7 +29,7 @@
     -webkit-appearance: none;
 
     @include mq($from: tablet) {
-      width: initial;
+      width: auto;
     }
 
     // Set text colour depending on background colour


### PR DESCRIPTION
This PR prevent IE9 from rendering the button in full-width by setting the `width` to `auto`

Before
<img width="971" alt="screen shot 2017-12-13 at 17 08 34" src="https://user-images.githubusercontent.com/788096/33951716-a5b7f1c4-e027-11e7-8b22-d733f72f395c.png">

After
<img width="967" alt="screen shot 2017-12-13 at 17 10 10" src="https://user-images.githubusercontent.com/788096/33951798-dd452bfc-e027-11e7-8087-265894906452.png">

Note: we still have it full-width on IE8 because it doesn't support media queries and we're doing mobile-first CSS, but we'll use `sass-mq` to generate an IE8 friendly stylesheet to deal with that.