### PR TITLE
Correct grid behaviour on mobile

### DIFF
--- a/src/globals/scss/objects/_grid.scss
+++ b/src/globals/scss/objects/_grid.scss
@@ -7,7 +7,10 @@
 @mixin govuk-grid-item {
   box-sizing: border-box;
   padding: 0 $govuk-gutter-half;
-  float: left;
+
+  @include mq($from: tablet) {
+    float: left;
+  }
 }
 
 @include exports("grid") {


### PR DESCRIPTION
Floats should only be applied when the width is – otherwise, containers will shrink-wrap their content and may end up floated next to each other.

## Before
![screen shot 2017-12-13 at 17 12 16](https://user-images.githubusercontent.com/121939/33952109-b6db00bc-e028-11e7-9071-ed17aa685140.png)

## After
![screen shot 2017-12-13 at 17 12 43](https://user-images.githubusercontent.com/121939/33952111-b90167f0-e028-11e7-8bea-b32cae8faff7.png)
