### PR TITLE
Update fieldset component caller()

### DIFF
--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -1,3 +1,7 @@
+<div class="govuk-o-width-container">
+
+<div class="govuk-o-main-wrapper">
+
 # Fieldset
 
 ## Introduction
@@ -12,23 +16,89 @@ More information about when to use fieldset can be found on [GOV.UK Design Syste
 
 ### Component default
 
-[Preview the fieldset component.](http://govuk-frontend-review.herokuapp.com/components/fieldset/preview)
+[Preview the fieldset component](http://govuk-frontend-review.herokuapp.com/components/fieldset/preview)
 
 #### Markup
 
+    <fieldset class="govuk-c-fieldset">
+
+      <legend class="govuk-c-fieldset__legend">
+        Legend text goes here
+
+        <span class="govuk-c-fieldset__hint">Legend hint text goes here</span>
+
+      </legend>
+
+      </fieldset>
+
 #### Macro
 
-      {% from "fieldset/macro.njk" import govukFieldset %}
+    {{ govukFieldset({
+      "legendText": "Legend text goes here",
+      "legendHintText": "Legend hint text goes here"
+    }) }}
 
-    {{- govukFieldset(
-      classes='',
-      text='Legend text goes here',
-      hintText='Legend hint text goes here',
-      errorMessage='Error message goes here'
-      )
-    -}}
+### Fieldset--with-error-message
 
-## Variants
+[Preview the fieldset--with-error-message variant](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-error-message/preview)
+
+#### Markup
+
+    <fieldset class="govuk-c-fieldset">
+
+      <legend class="govuk-c-fieldset__legend">
+        Legend text goes here
+
+        <span class="govuk-c-fieldset__hint">Legend hint text goes here</span>
+
+        <span class="govuk-c-error-message">
+           Error message goes here
+        </span>
+
+      </legend>
+
+      </fieldset>
+
+#### Macro
+
+    {{ govukFieldset({
+      "legendText": "Legend text goes here",
+      "legendHintText": "Legend hint text goes here",
+      "errorMessage": {
+        "text": "Error message goes here"
+      }
+    }) }}
+
+### Fieldset--with-html-instead-of-text
+
+[Preview the fieldset--with-html-instead-of-text variant](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-html-instead-of-text/preview)
+
+#### Markup
+
+    <fieldset class="govuk-c-fieldset">
+
+      <legend class="govuk-c-fieldset__legend">
+        Legend text <i>goes</i> here
+
+        <span class="govuk-c-fieldset__hint">Legend hint text <i>goes</i> here</span>
+
+        <span class="govuk-c-error-message">
+           Error message <i>goes</i>  here
+        </span>
+
+      </legend>
+
+      </fieldset>
+
+#### Macro
+
+    {{ govukFieldset({
+      "legendHtml": "Legend text <i>goes</i> here",
+      "legendHintHtml": "Legend hint text <i>goes</i> here",
+      "errorMessage": {
+        "html": "Error message <i>goes</i>  here"
+      }
+    }) }}
 
 ## Dependencies
 
@@ -44,15 +114,17 @@ To consume the fieldset component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
+<pre>  `.pipe(sass({
+        includePaths: 'node_modules/'
+    }))` 
+  </pre>
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+<pre>  `app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))` 
+  </pre>
 
 ## Component arguments
 
@@ -104,6 +176,66 @@ If you are using Nunjucks,then macros take the following arguments
 
 </tr>
 
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">legendHtml</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Legend text</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">legendHintText</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">HTML to use within the legend element. If this is used, the legendText argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">legendHintHtml</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">HTML to use within the legend hint element. If this is used, the hintText argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">errorMessage</th>
+
+<td class="govuk-c-table__cell ">object</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Provide text or html key with values. See errorMessage component for more details.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">attributes</th>
+
+<td class="govuk-c-table__cell ">object</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Any extra HTML attributes (for example data attributes) to add to the fieldset container.</td>
+
+</tr>
+
 </tbody>
 
 </table>
@@ -114,11 +246,12 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-    nunjucks.configure('node_modules/@govuk-frontend`, {
-      autoescape: true,
-      cache: false,
-      express: app
-    })
+<pre>  `nunjucks.configure('node_modules/@govuk-frontend`, {
+    autoescape: true,
+    cache: false,
+    express: app
+  })` 
+  </pre>
 
 ## Getting updates
 
@@ -143,3 +276,7 @@ Guidelines can be found at [on our Github repository.](https://github.com/alphag
 ## License
 
 MIT
+
+</div>
+
+</div>

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -12,6 +12,6 @@
     {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
     {% endif %}
   </legend>
-{% endif %}
-  {{ caller() | trim | indent(2) if caller }} {#- if statement allows usage of `call` to be optional -#}
+  {% endif %}
+{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
 </fieldset>


### PR DESCRIPTION
Controlling whitespace when fieldset is consumed in other components has become very tricky.

Removing `trim` and and `indent` will allow exact positioning to be handled where fieldset is called from.

This will fix whitespace in https://github.com/alphagov/govuk-frontend/pull/388
but break it in date-input, which is getting fixed [here](https://github.com/alphagov/govuk-frontend/pull/391)
