### PR TITLE
Update date-input component

### DIFF
--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -1,3 +1,7 @@
+<div class="govuk-o-width-container">
+
+<div class="govuk-o-main-wrapper">
+
 # Date input
 
 ## Introduction
@@ -16,7 +20,7 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+      <fieldset class="govuk-c-fieldset">
 
       <legend class="govuk-c-fieldset__legend">
         What is your date of birth?
@@ -24,36 +28,39 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
         <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
         <span class="govuk-c-error-message">
-       Error message goes here
-    </span>
+           Error message goes here
+        </span>
 
       </legend>
+
       <div class="govuk-c-date-input" id="dob">
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day">
+            Day
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day" name="dob-day" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day" name="dob-day" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month">
+            Month
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month" name="dob-month" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month" name="dob-month" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year">
+            Year
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year" name="dob-year" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year" name="dob-year" type="text">
+        </div>
 
       </div>
-
-    </fieldset>
+      </fieldset>
 
 #### Macro
 
@@ -82,11 +89,11 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-errors
 
-[Preview the date-input--with-errors variant](http://govuk-frontend-review.herokuapp.com/components/date-input/date-input--with-errors/preview)
+[Preview the date-input--with-errors variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-errors/preview)
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+      <fieldset class="govuk-c-fieldset">
 
       <legend class="govuk-c-fieldset__legend">
         What is your date of birth?
@@ -94,36 +101,39 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
         <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
         <span class="govuk-c-error-message">
-       Error message goes here
-    </span>
+           Error message goes here
+        </span>
 
       </legend>
+
       <div class="govuk-c-date-input" id="dob-errors">
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-day">
+            Day
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-day" name="undefined-day" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-day" name="undefined-day" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-month">
+            Month
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-month" name="undefined-month" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-month" name="undefined-month" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-year">
+            Year
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-year" name="undefined-year" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-year" name="undefined-year" type="text">
+        </div>
 
       </div>
-
-    </fieldset>
+      </fieldset>
 
 #### Macro
 
@@ -154,11 +164,11 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-day-error
 
-[Preview the date-input--with-day-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/date-input--with-day-error/preview)
+[Preview the date-input--with-day-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-day-error/preview)
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+      <fieldset class="govuk-c-fieldset">
 
       <legend class="govuk-c-fieldset__legend">
         What is your date of birth?
@@ -166,36 +176,39 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
         <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
         <span class="govuk-c-error-message">
-       Error message goes here
-    </span>
+           Error message goes here
+        </span>
 
       </legend>
+
       <div class="govuk-c-date-input" id="dob-day-error">
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-day">
+            Day
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-month">
+            Month
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day-error-month" name="dob-day-error-month" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day-error-month" name="dob-day-error-month" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-year">
+            Year
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day-error-year" name="dob-day-error-year" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day-error-year" name="dob-day-error-year" type="text">
+        </div>
 
       </div>
-
-    </fieldset>
+      </fieldset>
 
 #### Macro
 
@@ -225,11 +238,11 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-month-error
 
-[Preview the date-input--with-month-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/date-input--with-month-error/preview)
+[Preview the date-input--with-month-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-month-error/preview)
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+      <fieldset class="govuk-c-fieldset">
 
       <legend class="govuk-c-fieldset__legend">
         What is your date of birth?
@@ -237,36 +250,39 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
         <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
         <span class="govuk-c-error-message">
-       Error message goes here
-    </span>
+           Error message goes here
+        </span>
 
       </legend>
+
       <div class="govuk-c-date-input" id="dob-month-error">
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-day">
+            Day
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month-error-day" name="dob-month-error-day" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month-error-day" name="dob-month-error-day" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-month">
+            Month
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-year">
+            Year
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month-error-year" name="dob-month-error-year" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-month-error-year" name="dob-month-error-year" type="text">
+        </div>
 
       </div>
-
-    </fieldset>
+      </fieldset>
 
 #### Macro
 
@@ -296,11 +312,11 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-year-error
 
-[Preview the date-input--with-year-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/date-input--with-year-error/preview)
+[Preview the date-input--with-year-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-year-error/preview)
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+      <fieldset class="govuk-c-fieldset">
 
       <legend class="govuk-c-fieldset__legend">
         What is your date of birth?
@@ -308,36 +324,39 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
         <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
         <span class="govuk-c-error-message">
-       Error message goes here
-    </span>
+           Error message goes here
+        </span>
 
       </legend>
+
       <div class="govuk-c-date-input" id="dob-year-error">
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-day">
+            Day
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year-error-day" name="dob-year-error-day" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year-error-day" name="dob-year-error-day" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-month">
+            Month
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year-error-month" name="dob-year-error-month" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-year-error-month" name="dob-year-error-month" type="text">
+        </div>
 
         <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label">
+          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-year">
+            Year
 
-    </label>
-    <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="text">
-    </div>
+          </label>
+          <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="text">
+        </div>
 
       </div>
-
-    </fieldset>
+      </fieldset>
 
 #### Macro
 
@@ -379,15 +398,17 @@ To consume the date-input component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-          includePaths: 'node_modules/'
-      }))
+<pre>  `.pipe(sass({
+        includePaths: 'node_modules/'
+    }))` 
+  </pre>
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+<pre>  `app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))` 
+  </pre>
 
 ## Component arguments
 
@@ -421,7 +442,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-c-table__cell ">object</td>
 
-<td class="govuk-c-table__cell ">Yes</td>
+<td class="govuk-c-table__cell ">No</td>
 
 <td class="govuk-c-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
 
@@ -485,11 +506,12 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-    nunjucks.configure('node_modules/@govuk-frontend`, {
-      autoescape: true,
-      cache: false,
-      express: app
-    })
+<pre>  `nunjucks.configure('node_modules/@govuk-frontend`, {
+    autoescape: true,
+    cache: false,
+    express: app
+  })` 
+  </pre>
 
 ## Getting updates
 
@@ -507,6 +529,14 @@ Guidelines can be found at [on our Github repository.](https://github.com/alphag
 
 ## Acknowledgements/credits
 
+*   GDS developers
+*   Jani Kraner
+*   Gemma Leigh
+
 ## License
 
 MIT
+
+</div>
+
+</div>

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -17,14 +17,14 @@
       "classes": "govuk-c-date-input__input " + item.classes,
       "name": params.name + "-" + item.name,
       "value": item.value
-    }) | trim | indent(4) }}
+    }) | indent(4) | trim }}
   </div>
   {% endfor %}
 </div>
-{%- endset -%}
+{% endset %}
 
-{%- if params.fieldset -%}
-  {%- call govukFieldset({
+{%- if params.fieldset %}
+  {% call govukFieldset({
     classes: params.fieldset.classes,
     attributes: params.fieldset.attributes,
     legendText: params.fieldset.legendText,
@@ -32,9 +32,9 @@
     legendHintText: params.fieldset.legendHintText,
     legendHintHtml: params.fieldset.legendHintHtml,
     errorMessage: params.errorMessage
-  }) -%}
-    {{- innerHtml | safe -}}
-  {%- endcall -%}
-{%- else -%}
-  {{- innerHtml | trim | safe -}}
-{%- endif -%}
+  }) %}
+  {{ innerHtml | indent(2) | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}


### PR DESCRIPTION
Update whitespace control to align with the fixed fieldset component, where [trim and indent have been removed](https://github.com/alphagov/govuk-frontend/pull/390)
