### PR TITLE
Add scoped prose styles

### DIFF
--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -36,6 +36,7 @@
 @import "core/links";
 @import "core/lists";
 @import "core/typography";
+@import "core/prose-scope";
 
 // Objects
 @import "objects/grid";

--- a/src/globals/scss/core/_prose-scope.scss
+++ b/src/globals/scss/core/_prose-scope.scss
@@ -1,0 +1,48 @@
+
+@include exports("prose-scope") {
+  .govuk-prose-scope {
+
+    // @extend inheritance
+
+    // Contextual heading and paragraph combinations are inherited
+    // through the use of @extend
+
+    h1 {
+      @extend .govuk-heading-xl;
+    }
+
+    h2 {
+      @extend .govuk-heading-l;
+    }
+
+    h3 {
+      @extend .govuk-heading-m;
+    }
+
+    h4 {
+      @extend .govuk-heading-s;
+    }
+
+    p {
+      @extend .govuk-body;
+    }
+
+    strong,
+    b {
+      @include govuk-typography-weight-bold;
+    }
+
+    ul,
+    ol {
+      @extend .govuk-list;
+    }
+
+    ol {
+      @extend .govuk-list--number;
+    }
+
+    ul {
+      @extend .govuk-list--bullet;
+    }
+  }
+}


### PR DESCRIPTION
Styles for generic page elements that are wrapped in .govuk-prose-scope
container element class.

Includes: 
* headings
* paragraphs
* heading and paragraph combinations
* links
* list styles (ul, and ol)

[Trello ticket](https://trello.com/c/lJ6jgFcN/374-5-define-a-prose-scope)