### PR TITLE
Fix variable scope

### DIFF
--- a/src/components/back-link/_back-link.scss
+++ b/src/components/back-link/_back-link.scss
@@ -48,12 +48,10 @@
   // Begin adjustments for font baseline offset
   // These should be removed when the font is updated with the correct baseline
 
-  .govuk-c-back-link {
+  .govuk-c-back-link:before {
     $offset: 1px;
 
-    &:before {
-      top: $offset * -1;
-      bottom: $offset;
-    }
+    top: $offset * -1;
+    bottom: $offset;
   }
 }


### PR DESCRIPTION
Because we currently use the `postcss-nested` plugin when copying Sass to the packages folder, we end up removing the nesting here and so we end up with $offset being defined in a different ruleset to where it's being used, which means it is not part of the same scope and we get an undefined variable error.

We need to revisit whether it makes sense to use this plugin, and make sure that we can identify issues like this sooner (rather than waiting until we try and build new packages) but for now let's fix the immediate issue.