### PR TITLE
Move and extend gulp:clean task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,9 +6,9 @@ const taskListing = require('gulp-task-listing')
 const runsequence = require('run-sequence')
 const taskArguments = require('./tasks/gulp/task-arguments')
 const nodemon = require('nodemon')
-const del = require('del')
 
 // Gulp sub-tasks
+require('./tasks/gulp/clean.js')
 require('./tasks/gulp/lint.js')
 require('./tasks/gulp/test-app.js')
 require('./tasks/gulp/test-components.js')
@@ -33,13 +33,6 @@ gulp.task('scripts', cb => {
 // --------------------------------------
 gulp.task('styles', cb => {
   runsequence('scss:lint', 'scss:compile', cb)
-})
-
-// Clean task for a specified folder ----
-// Removes all old files
-// --------------------------------------
-gulp.task('clean', function () {
-  return del([taskArguments.destination + '/**/*'])
 })
 
 // Copy icons task ----------------------
@@ -101,6 +94,7 @@ gulp.task('serve', ['watch'], () => {
 // -------------------------------------
 gulp.task('build:packages', cb => {
   runsequence(
+              'clean',
               'compile:components',
               'copy-files',
               'generate:readme',

--- a/tasks/gulp/clean.js
+++ b/tasks/gulp/clean.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const gulp = require('gulp')
+const taskArguments = require('./task-arguments')
+const del = require('del')
+
+// Clean task for a specified folder --------------------
+// Removes all old files, except for package.json
+// and README in all package
+// ------------------------------------------------------
+
+gulp.task('clean', () => {
+  let destination = taskArguments.destination
+
+  if (destination === 'packages') {
+    return del.sync([
+      `${destination}/**`,
+      `!${destination}`,
+      `!${destination}/*`,
+      `!${destination}/**/package.json`,
+      `!${destination}/all/README.md`
+    ])
+  } else {
+    return del.sync([
+      `${destination}/**/*`
+    ])
+  }
+})


### PR DESCRIPTION
With recent changes to frontend when a lot of the files were moved and folders deleted, we'd need to clean the packages folder before publishing, so that old files didn't get published as well.

We didn't want to lose all the package.json files and we didn't have the clean task setup for `packages` folder.
This PR:
* moves the clean task from gulpfile.js to it's own partial 
* extends the task so that it checks for the destination folder that is passed from the parent `npm run build:packages` or  `npm run build:dist` and either clean the whole whole `dist/` folder or keeps `package.json` files and `README.md` in `packages/all` 

https://trello.com/c/dsb17NNi/499-clean-packages-folder-before-building-new-packages