### PR TITLE
Update form alignment example

### DIFF
--- a/src/views/examples/form-alignment/index.njk
+++ b/src/views/examples/form-alignment/index.njk
@@ -29,8 +29,8 @@
 {% endblock %}
 
 {% block content %}
-<h1 class="govuk-u-heading-48">Form elements alignment</h1>
-<h2 class="govuk-u-heading-27">Input and button</h2>
+<h1 class="govuk-heading-xl">Form elements alignment</h1>
+<h2 class="govuk-heading-m">Input and button</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="govuk-c-input-a">
@@ -45,12 +45,12 @@
 </fieldset>
 </form>
 
-<h2 class="govuk-u-heading-27">Select and button</h2>
+<h2 class="govuk-heading-m">Select and button</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="select-box">This is the label text</label>
   <div class="govuk-u-w-half">
-    <select class="govuk-c-select-box" id="select-box" name="select-box">
+    <select class="govuk-c-select" id="select-box" name="select-box">
       <option>GOV.UK elements option 1</option>
       <option>GOV.UK elements option 2</option>
       <option>GOV.UK elements option 3</option>
@@ -62,7 +62,7 @@
 </fieldset>
 </form>
 
-<h2 class="govuk-u-heading-27">Input and select</h2>
+<h2 class="govuk-heading-m">Input and select</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <div class="govuk-u-w-half">
@@ -73,7 +73,7 @@
   </div>
   <div class="govuk-u-w-half">
     <label class="govuk-c-label" for="select-box">Select class</label>
-    <select class="govuk-c-select-box" id="select-box" name="select-box">
+    <select class="govuk-c-select" id="select-box" name="select-box">
       <option>NIC 1</option>
       <option>NIC 2</option>
       <option>NIC 3</option>
@@ -82,7 +82,7 @@
 </fieldset>
 </form>
 
-<h2 class="govuk-u-heading-27">Input and checkbox</h2>
+<h2 class="govuk-heading-m">Input and checkbox</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="govuk-c-input-a">
@@ -100,7 +100,7 @@
 </fieldset>
 </form>
 
-<h2 class="govuk-u-heading-27">Input and radio</h2>
+<h2 class="govuk-heading-m">Input and radio</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <label class="govuk-c-label" for="govuk-c-input-a">
@@ -118,7 +118,7 @@
 </fieldset>
 </form>
 
-<h2 class="govuk-u-heading-27">Radio, checkbox and button</h2>
+<h2 class="govuk-heading-m">Radio, checkbox and button</h2>
 <form action="/" method="post">
   <fieldset class="govuk-c-fieldset">
   <div class="govuk-u-w-quarter">
@@ -138,12 +138,4 @@
   </div>
 </fieldset>
 
-<h2 class="govuk-u-heading-27">Align text with button</h2>
-<form action="/" method="post">
-  <fieldset class="govuk-c-fieldset">
-    <input class="govuk-c-button" type="submit" value="Sign in with your Austrian identity">
-    <span class="govuk-text-align-button">on the Austrian identity website</span>
-</fieldset>
-<br><br><br><br><br>
-</form>
 {% endblock %}


### PR DESCRIPTION
Update the select box to use the updated class name since the select box was renamed to select, and use the latest typography classes.

https://trello.com/c/sePgu7Ua/510-fix-form-alignment-example-page