### PR TITLE
Rename ‘govuk-body-lede’ to ‘govuk-body-lead’

### DIFF
--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -118,7 +118,7 @@
   // Using extend to alias means we also inherit any contextual adjustments that
   // refer to the 'original' class name
 
-  .govuk-body-lede {
+  .govuk-body-lead {
     @extend .govuk-body-l;
   }
 

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -29,7 +29,7 @@
   {% if isReadme %}
   <h2 class="govuk-heading-l">Introduction</h2>
   {% endif %}
-  <p class="govuk-body-lede">
+  <p class="govuk-body-lead">
   {% block componentDescription %}
   {% endblock %}
   </p>
@@ -122,7 +122,7 @@
     <li>Jani Kraner</li>
     <li>Gemma Leigh</li>
   </ul>
-  
+
   <h2 class="govuk-heading-l">License</h2>
   <p class="govuk-body">MIT</p>
   {% endif %}


### PR DESCRIPTION
In the guidance we have standardised on lead rather than lede as it is seen to be the more generic term, with lede relating specifically to journalism. To ensure consistency between the guidance and the code, we should use the same term in the class name.

https://trello.com/c/eWpA6tm5/484-frontend-change-lead-paragraph-class-name-from-lede-to-lead