### PR TITLE
Add button hover colour

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -67,7 +67,7 @@
 
     &:hover,
     &:focus {
-      background-color: darken($govuk-button-colour, 5%);
+      background-color: $govuk-button-hover-colour;
     }
 
     &:active {

--- a/src/globals/scss/settings/_colours-applied.scss
+++ b/src/globals/scss/settings/_colours-applied.scss
@@ -4,6 +4,7 @@ $govuk-link-active-colour: $govuk-light-blue;
 $govuk-link-hover-colour: $govuk-light-blue;
 $govuk-link-visited-colour: #4c2c92;
 $govuk-button-colour: #00823b;
+$govuk-button-hover-colour: darken($govuk-button-colour, 5%);
 $govuk-button-colour-darken-15: darken($govuk-button-colour, 15%);
 $govuk-focus-colour: $govuk-yellow;
 $govuk-text-colour: $govuk-black;             // Standard text colour


### PR DESCRIPTION
This is the only colour on our documentation page that does not have a semantic name:

https://govuk-elements.herokuapp.com/colour/