### PR TITLE
Fix undefined classes in date input macro

### DIFF
--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -14,7 +14,7 @@
         "classes": 'govuk-c-date-input__label'
       },
       "id": params.id + "-" + item.name,
-      "classes": "govuk-c-date-input__input " + item.classes,
+      "classes": "govuk-c-date-input__input" + (" " + item.classes if item.classes),
       "name": params.name + "-" + item.name,
       "value": item.value
     }) | indent(4) | trim }}


### PR DESCRIPTION
When appending an undefined variable to an existing string, Nunjucks will add the string 'undefined' rather than failing silently. Because of this we need to test if item.classes is truthy when appending to avoid ending up with e.g.:

`<input class="govuk-c-input govuk-c-date-input__input undefined" id="dob-day" name="dob-day" type="text">`

https://trello.com/c/ZS93wLwG/532-fix-undefined-classes-when-using-date-macro-component