### PR TITLE
Remove documentation about macro text 'shortcuts'

### DIFF
--- a/docs/component-api.md
+++ b/docs/component-api.md
@@ -22,24 +22,6 @@ Example of implementing logic in a component template:
 
 Example shows that if `html` and `text` arguments are present, then `html` takes precedence over `text` and we are not escaping it.
 
-## Allow for text argument to be passed as a single argument
-When the users don't want to specify extra attributes we should allow them to call a component without having to pass an entire object.
-
-Example:
-
-`govukErrorMessage("Full name must be provided")`
-
-This is possible for components that rely only on `text` and `html` attributes.
-
-We do this in the macro so that if in the future we transpile the templates we do not have to worry about mimicking this functionality in other languages.
-
-Example of implementing this logic in a component macro:
-```
-{% if params|string === params %}
-  {% set params = { text: params } %}
-{% endif %}
-```
-
 ## Naming attributes
 We should use **camelCase** for naming attributes.
 


### PR DESCRIPTION
We opted to remove this functionality because it became too complicated to make it work consistently when macros were nested, but didn't update the documentation at the time.

As this is no longer something we should do, we should remove the documentation.