### PR TITLE
Add `width` classes

### DIFF
--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -47,3 +47,4 @@
 // Overrides
 @import "overrides/spacing";
 @import "overrides/typography";
+@import "overrides/width";

--- a/src/globals/scss/overrides/_width.scss
+++ b/src/globals/scss/overrides/_width.scss
@@ -1,0 +1,41 @@
+@include exports("width-overrides") {
+  .govuk-\!-width-three-quarters {
+    width: 100% !important;
+
+    @include mq($from: tablet) {
+      width: 75% !important;
+    }
+  }
+
+  .govuk-\!-width-two-thirds {
+    width: 100% !important;
+
+    @include mq($from: tablet) {
+      width: 66.66% !important;
+    }
+  }
+
+  .govuk-\!-width-one-half {
+    width: 100% !important;
+
+    @include mq($from: tablet) {
+      width: 50% !important;
+    }
+  }
+
+  .govuk-\!-width-one-third {
+    width: 100% !important;
+
+    @include mq($from: tablet) {
+      width: 33.33% !important;
+    }
+  }
+
+  .govuk-\!-width-one-quarter {
+    width: 100% !important;
+
+    @include mq($from: tablet) {
+      width: 25% !important;
+    }
+  }
+}

--- a/src/views/examples/form-alignment/index.njk
+++ b/src/views/examples/form-alignment/index.njk
@@ -137,5 +137,35 @@
     <input class="govuk-c-button" type="submit" value="Save and continue">
   </div>
 </fieldset>
+</form>
+
+<h2 class="govuk-heading-m">Input with govuk-!-width</h2>
+<fieldset class="govuk-c-fieldset">
+
+  <label class="govuk-c-label" for="govuk-!-width-one-quarter">
+    Input with govuk-!-width-one-quarter (25% width)
+  </label>
+  <input class="govuk-c-input govuk-!-width-one-quarter" id="govuk-!-width-one-quarter" type="text">
+
+  <label class="govuk-c-label" for="govuk-!-width-one-third">
+    Input with govuk-!-width-one-third (33% width)
+  </label>
+  <input class="govuk-c-input govuk-!-width-one-third" id="govuk-!-width-one-third" type="text">
+
+  <label class="govuk-c-label" for="govuk-!-width-one-half">
+    Input with govuk-!-width-one-half (50% width)
+  </label>
+  <input class="govuk-c-input govuk-!-width-one-half" id="govuk-!-width-one-half" type="text">
+
+  <label class="govuk-c-label" for="govuk-!-width-two-thirds">
+    Input with govuk-!-width-two-thirds (66% width)
+  </label>
+  <input class="govuk-c-input govuk-!-width-two-thirds" id="govuk-!-width-two-thirds" type="text">
+
+  <label class="govuk-c-label" for="govuk-!-width-three-quarters">
+    Input with govuk-!-width-width-three-quarters (75% width)
+  </label>
+  <input class="govuk-c-input govuk-!-width-three-quarters" id="govuk-!-width-three-quarters" type="text">
+</fielset>
 
 {% endblock %}


### PR DESCRIPTION
This PR
- Adds `width` classes, corresponding to `form-control` classes used in Elements but extending their use case
- Makes them into override classes because:
  - They need to be available to `input`, `select` and `textarea` components while overriding their width styles. Helpers do not override component styles
  - As overrides, they are also available to use cases such as setting width of text
- Makes naming of numbers in class names consistent with `govuk-o-grid`
- Adds examples to /examples/form-alignment (and close an unclosed `form` tag in the example above)
  
Trello ticket: https://trello.com/c/jEhFTAqY/458-add-width-form-control-in-elements-classes

Notes:

There is an [old comment](https://github.com/alphagov/govuk_elements/blob/master/assets/sass/elements/_forms.scss#L190) by Gemma in Elements about updating these form controls but it's not clear what that would have referred to. Just in case it jogs anyone's memory 🙂 
  