### PR TITLE
Fix focus outline style in Chrome and Safari

### DIFF
--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -4,8 +4,9 @@
 
   .govuk-c-error-summary {
     @include govuk-text-colour;
-
     @include govuk-responsive-padding($govuk-spacing-responsive-4);
+    @include govuk-focusable;
+
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
     @include mq($from: tablet) {
@@ -16,10 +17,6 @@
     @include ie-lte(6) {
       zoom: 1;
     }
-  }
-
-  .govuk-c-error-summary:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 
   .govuk-c-error-summary__title {

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -4,12 +4,8 @@
   .govuk-c-file-upload {
     @include govuk-font-regular-19;
     @include govuk-text-colour;
-
+    @include govuk-focusable;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-  }
-
-  .govuk-c-file-upload:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 
   .govuk-c-file-upload--error {

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -5,6 +5,7 @@
 @include exports("input") {
   .govuk-c-input {
     @include govuk-font-regular-19;
+    @include govuk-focusable;
 
     box-sizing: border-box;
     width: 100%;
@@ -30,10 +31,6 @@
 
   .govuk-c-input[type="number"] {
     -moz-appearance: textfield;
-  }
-
-  .govuk-c-input:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 
   .govuk-c-input--error {

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -8,6 +8,7 @@
       $govuk-font-19,
       $override-line-height: 1.25
     );
+    @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
     width: 100%;
@@ -16,11 +17,6 @@
 
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;
-  }
-
-  .govuk-c-select:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: 0;
   }
 
   .govuk-c-select option:active,

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -9,6 +9,7 @@
       $govuk-font-19,
       $override-line-height: 1.25
     );
+    @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
     display: block;
@@ -20,10 +21,6 @@
     border-radius: 0;
 
     -webkit-appearance: none;
-  }
-
-  .govuk-c-textarea:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
   }
 
   .govuk-c-textarea--error {

--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -27,6 +27,7 @@
 @import "helpers/arrow";
 @import "helpers/clearfix";
 @import "helpers/device-pixels";
+@import "helpers/focusable";
 @import "helpers/media-queries";
 @import "helpers/typography";
 @import "helpers/spacing";

--- a/src/globals/scss/helpers/_focusable.scss
+++ b/src/globals/scss/helpers/_focusable.scss
@@ -1,0 +1,6 @@
+@mixin govuk-focusable {
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+  }
+}


### PR DESCRIPTION
Chrome and Safari set outline-offset to -2px for focussed textareas, selects and inputs, so we need to reset to 0 so that the outline appears consistently outside of the border rather than overlaying it.

As part of this, move the focus style into a helper to avoid defining the focus style in multiple places.

https://trello.com/c/GwwOrcyB/539-focus-outline-style-should-be-offset-from-border-not-overlapping

## Input
<img width="1136" alt="input-before" src="https://user-images.githubusercontent.com/121939/34612645-87b5579a-f222-11e7-8148-7501a7cc5fea.png">

<img width="1136" alt="input-after" src="https://user-images.githubusercontent.com/121939/34612644-8796d68a-f222-11e7-8f58-31eb56f832b2.png">

## Textarea

<img width="1136" alt="textarea-before" src="https://user-images.githubusercontent.com/121939/34612650-88505a2e-f222-11e7-81a3-e615c8a6adf2.png">

<img width="1136" alt="textarea-after" src="https://user-images.githubusercontent.com/121939/34612649-8834ebae-f222-11e7-9641-82542229f88c.png">

## Select
No change - the select focus state already included `outline-offset: 0`

<img width="1136" alt="select-before" src="https://user-images.githubusercontent.com/121939/34612648-880b22a6-f222-11e7-9a46-a19c7a8985be.png">

<img width="1136" alt="select-after" src="https://user-images.githubusercontent.com/121939/34612646-87da564e-f222-11e7-8e2e-c9a94eef889c.png">

## Error Summary (no change)

No change - the user agent stylesheet does not set outline-offset for the focus state of a div.

<img width="1136" alt="error-summary-before" src="https://user-images.githubusercontent.com/121939/34612641-8735fc8e-f222-11e7-97e8-f30834def46d.png">

<img width="1136" alt="error-summary-after" src="https://user-images.githubusercontent.com/121939/34612640-871f18b6-f222-11e7-8438-00f9f6718f3e.png">

## File Upload (no change)

No change - the user agent stylesheet already resets outline-offset to `0` for the focus state of a input of type `file`.

<img width="1136" alt="file-upload-before" src="https://user-images.githubusercontent.com/121939/34612643-8772725e-f222-11e7-9942-71e11d9c34ec.png">

<img width="1136" alt="file-upload-after" src="https://user-images.githubusercontent.com/121939/34612642-87556ca4-f222-11e7-8dff-ea7e6d5a70c7.png">