### PR TITLE
Make buttons 40px high including box shadow

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -2,6 +2,9 @@
 
 @include exports("button") {
 
+  // Because the shadow (s0) is visually 'part of' the button, we need to reduce
+  // the height of the button to compensate by adjusting its padding (s1) and
+  // increase the bottom margin to include it (s2).
   $button-shadow-size: $govuk-border-width-form-element;
 
   .govuk-c-button {
@@ -16,8 +19,8 @@
     position: relative;
     width: 100%;
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-    padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2)) $govuk-spacing-scale-2;
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom", $adjustment: $button-shadow-size); // s2
+    padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2)) $govuk-spacing-scale-2; // s1
     border-width: $govuk-border-width-form-element;
     border-style: solid;
     border-radius: 0;
@@ -25,7 +28,7 @@
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
     background-color: $govuk-button-colour;
-    box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
+    box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15; // s0
     font-family: $govuk-font-stack;
     text-align: center;
     text-decoration: none;
@@ -96,9 +99,9 @@
 
     &:active {
       top: 0;
-      box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
+      box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15; // s0
       @include ie-lte(8) {
-        border-bottom: $button-shadow-size solid $govuk-button-colour-darken-15;
+        border-bottom: $button-shadow-size solid $govuk-button-colour-darken-15; // s0
       }
     }
   }
@@ -180,13 +183,13 @@
   $offset: 2;
 
   .govuk-c-button {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset);
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1);
+    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
+    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
   }
 
   .govuk-c-button--start {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset);
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1);
+    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
+    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
   }
 
 }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -11,7 +11,7 @@
     @include govuk-font-regular;
     @include govuk-typography-responsive(
       $govuk-font-19,
-      $override-line-height: 1
+      $override-line-height: 19px
     );
 
     box-sizing: border-box;

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -1,6 +1,9 @@
 @import "../../globals/scss/common";
 
 @include exports("button") {
+
+  $button-shadow-size: $govuk-border-width-form-element;
+
   .govuk-c-button {
     @include govuk-font-regular;
     @include govuk-typography-responsive(
@@ -14,7 +17,7 @@
     width: 100%;
     margin-top: 0;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-    padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element) $govuk-spacing-scale-2;
+    padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2)) $govuk-spacing-scale-2;
     border-width: $govuk-border-width-form-element;
     border-style: solid;
     border-radius: 0;
@@ -22,7 +25,7 @@
     outline: 1px solid transparent; // keep some button appearance when changing colour settings in browsers
     outline-offset: -1px; // fixes bug in Safari that outline width on focus is not overwritten, is reset to 0 on focus in govuk_template
     background-color: $govuk-button-colour;
-    box-shadow: 0 2px 0 $govuk-button-colour-darken-15;
+    box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
     font-family: $govuk-font-stack;
     text-align: center;
     text-decoration: none;
@@ -65,8 +68,8 @@
     }
 
     &:active {
-      top: $govuk-border-width-form-element;
-      box-shadow: 0 0 0 $govuk-button-colour;
+      top: $button-shadow-size;
+      box-shadow: none;
     }
 
     // Fix unwanted button padding in Firefox
@@ -93,9 +96,9 @@
 
     &:active {
       top: 0;
-      box-shadow: 0 $govuk-border-width-form-element 0 $govuk-button-colour-darken-15;
+      box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
       @include ie-lte(8) {
-        border-bottom: $govuk-border-width-form-element solid $govuk-button-colour-darken-15;
+        border-bottom: $button-shadow-size solid $govuk-button-colour-darken-15;
       }
     }
   }
@@ -126,9 +129,9 @@
 
     background-repeat: no-repeat;
     background-position: 100% 50%;
-    box-shadow: 0 $govuk-border-width-form-element 0 $govuk-button-colour-darken-15;
+    box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
     @include ie-lte(8) {
-      border-bottom: $govuk-border-width-form-element solid $govuk-button-colour-darken-15;
+      border-bottom: $button-shadow-size solid $govuk-button-colour-darken-15;
     }
   }
 
@@ -177,13 +180,13 @@
   $offset: 2;
 
   .govuk-c-button {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element + $offset);
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - $offset + 1);
+    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset);
+    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1);
   }
 
   .govuk-c-button--start {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element + $offset);
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - $offset + 1);
+    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset);
+    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1);
   }
 
 }

--- a/src/globals/scss/helpers/_spacing.scss
+++ b/src/globals/scss/helpers/_spacing.scss
@@ -4,22 +4,26 @@
 // Create responsive margins
 // Arguments:
 // $value = top \ right \ bottom \ left \ all
-@mixin govuk-responsive-margin($scale-map, $value: "all", $important: false) {
-  @include govuk-responsive-spacing($scale-map, "margin", $value, $important);
+@mixin govuk-responsive-margin($scale-map, $value: "all", $important: false, $adjustment: false) {
+  @include govuk-responsive-spacing($scale-map, "margin", $value, $important, $adjustment);
 }
 
 // // Create responsive padding
 // // Arguments:
 // // $value = top \ right \ bottom \ left \ all
-@mixin govuk-responsive-padding($scale-map, $value: "all", $important: false) {
-  @include govuk-responsive-spacing($scale-map, "padding", $value, $important);
+@mixin govuk-responsive-padding($scale-map, $value: "all", $important: false, $adjustment: false) {
+  @include govuk-responsive-spacing($scale-map, "padding", $value, $important, $adjustment);
 }
 
 //  Base mixin, also used by 'generate-spacing-overrides' mixin
-@mixin govuk-responsive-spacing($scale-map, $property, $value: "all", $important: false) {
+@mixin govuk-responsive-spacing($scale-map, $property, $value: "all", $important: false, $adjustment: false) {
 
   // Loop through each breakpoint
   @each $breakpoint, $breakpoint-value in $scale-map {
+
+    @if ($adjustment) {
+      $breakpoint-value: $breakpoint-value + $adjustment;
+    }
 
     // The 'null' breakpoint is for mobile.
     @if $breakpoint == null {


### PR DESCRIPTION
Because the shadow is visually 'part of' the button, we need to reduce the height of the button to compensate by adjusting its padding and increase the bottom margin to include it.

We also fix the line height at 40px which means that whilst the button font size reduces on a mobile breakpoint, the height of the element remains the same. This means that when we remove the use of `em` for the inputs we will end up with inputs and buttons having a consistent height of 40px at all breakpoints.

Until the use of `em` for inputs is removed, this currently looks worse on mobile because the inputs become shorter but the button now does not.

## Desktop

### Before
![screen shot 2018-01-09 at 09 55 27](https://user-images.githubusercontent.com/121939/34715123-70246fe0-f523-11e7-9945-0c1819032221.png)

### After
![screen shot 2018-01-09 at 09 56 08](https://user-images.githubusercontent.com/121939/34715131-7785045c-f523-11e7-803d-148c249e9784.png)

## Mobile
### Before
![screen shot 2018-01-09 at 09 55 38](https://user-images.githubusercontent.com/121939/34715137-7f39d24a-f523-11e7-9546-a27d17af8eac.png)

### After
![screen shot 2018-01-09 at 09 56 00](https://user-images.githubusercontent.com/121939/34715148-8854562a-f523-11e7-8fa9-1da38be8393c.png)

https://trello.com/c/03CyckKm/488-correct-button-height