### PR TITLE
Fix pseudo element click target corrections

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -84,6 +84,39 @@
     &:focus {
       outline: $govuk-focus-width solid $govuk-focus-colour;
     }
+
+    // The following adjustments do not work for <input type="button"> as
+    // non-container elements cannot include pseudo elements (i.e. ::before).
+
+    // Use a pseudo element to expand the click target area to include the
+    // button's shadow as well, in case users try to click it.
+    &::before {
+      content: "";
+      display: block;
+
+      position: absolute;
+
+      top: -$govuk-border-width-form-element;
+      right: -$govuk-border-width-form-element;
+      bottom: -($govuk-border-width-form-element + $button-shadow-size);
+      left: -$govuk-border-width-form-element;
+
+      background: transparent;
+    }
+
+    // When the button is active it is shifted down by $button-shadow-size to
+    // denote a 'pressed' state. If the user happened to click at the very top
+    // of the button, their mouse is no longer over the button (because it has
+    // 'moved beneath them') and so the click event is not fired.
+    //
+    // This corrects that by shifting the top of the pseudo element so that it
+    // continues to cover the area that the user originally clicked, which means
+    // the click event is still fired.
+    //
+    // 🎉
+    &:active::before {
+      top: -($govuk-border-width-form-element + $button-shadow-size);
+    }
   }
 
   .govuk-c-button--disabled,
@@ -135,31 +168,6 @@
     box-shadow: 0 $button-shadow-size 0 $govuk-button-colour-darken-15;
     @include ie-lte(8) {
       border-bottom: $button-shadow-size solid $govuk-button-colour-darken-15;
-    }
-  }
-
-  // making the click target bigger than the button
-  // (and fill the space made when the button moves)
-  .govuk-c-button:before {
-    content: "";
-    display: block;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 110%;
-    background: transparent;
-  }
-
-  .govuk-c-button:active:before {
-    top: -10%;
-    height: 120%;
-
-    // IE6 ignores the :before psuedo-class but applies the block to :active
-    // It therefore needs to be reset
-    @include ie(6) {
-      top: auto;
-      height: 100%;
     }
   }
 


### PR DESCRIPTION
The percentage based solution was not taking into account the borders which have been introduced since copying this from Elements, so it has been refactored to use calculated offsets instead.

Remove some IE6 specific logic as we no longer support this browser.

Nest the pseudo elements into their parent selector to group related items together.