### PR TITLE
Update padding on the tag component

### DIFF
--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -5,7 +5,7 @@
     @include govuk-font-bold-16;
 
     display: inline-block;
-    padding: $govuk-spacing-scale-1 $govuk-spacing-scale-1 0;
+    padding: $govuk-spacing-scale-1 8px 0;
 
     color: $govuk-white;
     background-color: $govuk-blue;


### PR DESCRIPTION
Tiny PR to update the padding left and right to 8px.
Sorry for the magic number but it looks more balanced visually than using 5px or 10px.

Haven't looked at top / bottom as it's font related