### PR TITLE
Fix to #421 - restore correct FE version for radios and checkboxes

### DIFF
--- a/packages/checkboxes/package.json
+++ b/packages/checkboxes/package.json
@@ -2,7 +2,7 @@
     "name": "@govuk-frontend/checkboxes",
     "version": "0.0.20-alpha",
     "dependencies": {
-      "@govuk-frontend/globals": "0.0.20-alpha",
-      "@govuk-frontend/label": "^0.0.20-alpha"
+      "@govuk-frontend/globals": "0.0.19-alpha",
+      "@govuk-frontend/label": "^0.0.19-alpha"
     }
 }

--- a/packages/radios/package.json
+++ b/packages/radios/package.json
@@ -2,7 +2,7 @@
   "name": "@govuk-frontend/radios",
   "version": "0.0.20-alpha",
   "dependencies": {
-    "@govuk-frontend/globals": "^0.0.20-alpha",
-    "@govuk-frontend/label": "^0.0.20-alpha"
+    "@govuk-frontend/globals": "^0.0.19-alpha",
+    "@govuk-frontend/label": "^0.0.19-alpha"
   }
 }


### PR DESCRIPTION
This restores the current FE version for `label` and `globals` in radios and checkboxes. Lerna will bump the version numbers for us, they shouldn't be changed manually as part of the publishing process.

Relates to #421 