### PR TITLE
Replace global link styling with core govuk-link class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 ## Unreleased
 
+Breaking changes:
+
+- The link styles in the core layer no longer style `a` elements directly, but
+  instead provide a `govuk-link` class which you will need to apply to links
+  individually. (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+
+New features:
+
+- The prose scope has been extended to style links, which means links within the
+  scope do not need the `govuk-link` class applied.
+  (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+- The muted link variant from the link component is now available as a core
+  class (`govuk-link--muted`).
+  (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+
 Fixes:
 
 - The error summary component allows users to pass HTML for an entry in the list
@@ -11,6 +26,15 @@ Fixes:
 - Error list entries in the error summary component no longer get wrapped in
   links when no `href` is provided.
   (PR [#428](https://github.com/alphagov/govuk-frontend/pull/428))
+- Remove redundant 'resets' for link print styles
+  (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+- The back link, breadcrumbs, error summary, previous / next and skip link
+  components have been updated to include explicit link styling, as they
+  previously relied on the global link styles.
+  (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+- Links within the review app and the examples have been updated to use the
+  `govuk-link` class.
+  (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
 
 ## 0.0.21-alpha (Breaking release)
 Skipped 0.0.20-alpha due to difficulties with publishing.

--- a/src/components/back-link/_back-link.scss
+++ b/src/components/back-link/_back-link.scss
@@ -4,6 +4,7 @@
 
   .govuk-c-back-link {
     @include govuk-font-regular-16;
+    @include govuk-focusable-fill;
 
     display: inline-block;
     position: relative;

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -103,6 +103,8 @@
   }
 
   .govuk-c-breadcrumbs__link {
+    @include govuk-focusable-fill;
+
     &:link,
     &:visited,
     &:hover,

--- a/src/components/cookie-banner/README.md
+++ b/src/components/cookie-banner/README.md
@@ -17,13 +17,13 @@ More information about when to use cookie-banner can be found on [GOV.UK Design 
 #### Markup
 
     <div class="govuk-c-cookie-banner js-cookie-banner">
-      <p class="govuk-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>
+      <p class="govuk-c-cookie-banner__message">GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" class="govuk-link">Find out more about cookies</a></p>
     </div>
 
 #### Macro
 
     {{ govukCookieBanner({
-      "html": "GOV.UK uses cookies to make the site simpler. <a href=\"https://www.gov.uk/help/cookies\">Find out more about cookies</a>"
+      "html": "GOV.UK uses cookies to make the site simpler. <a href=\"https://www.gov.uk/help/cookies\" class=\"govuk-link\">Find out more about cookies</a>"
     }) }}
 
 ## Dependencies

--- a/src/components/cookie-banner/cookie-banner.njk
+++ b/src/components/cookie-banner/cookie-banner.njk
@@ -1,5 +1,5 @@
 {% from "cookie-banner/macro.njk" import govukCookieBanner %}
 
 {{ govukCookieBanner({
-  'html': 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
+  'html': 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" class="govuk-link">Find out more about cookies</a>'
 }) }}

--- a/src/components/cookie-banner/cookie-banner.yaml
+++ b/src/components/cookie-banner/cookie-banner.yaml
@@ -1,4 +1,4 @@
 variants:
 - name: default
   data:
-    html: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>'
+    html: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" class="govuk-link">Find out more about cookies</a>'

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -42,6 +42,8 @@
   }
 
   .govuk-c-error-summary__list a {
+    @include govuk-focusable-fill;
+
     &:link,
     &:visited,
     &:hover,

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -21,7 +21,7 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
       alpha
     </strong>
     <span class="govuk-c-phase-banner__text">
-          This is a new service – your <a href="#">feedback</a> will help us to improve it.
+          This is a new service – your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
         </span>
       </p>
     </div>
@@ -32,7 +32,7 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
       "tag": {
         "text": "alpha"
       },
-      "html": "This is a new service – your <a href=\"#\">feedback</a> will help us to improve it."
+      "html": "This is a new service – your <a href=\"#\" class=\"govuk-link\">feedback</a> will help us to improve it."
     }) }}
 
 ### Phase-banner--tag-with-html
@@ -46,7 +46,7 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
       <i>alpha</i>
     </strong>
     <span class="govuk-c-phase-banner__text">
-          This is a new service – your <a href="#">feedback</a> will help us to improve it.
+          This is a new service – your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
         </span>
       </p>
     </div>
@@ -57,7 +57,7 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
       "tag": {
         "html": "<i>alpha</i>"
       },
-      "html": "This is a new service – your <a href=\"#\">feedback</a> will help us to improve it."
+      "html": "This is a new service – your <a href=\"#\" class=\"govuk-link\">feedback</a> will help us to improve it."
     }) }}
 
 ## Dependencies

--- a/src/components/phase-banner/phase-banner.njk
+++ b/src/components/phase-banner/phase-banner.njk
@@ -3,5 +3,5 @@
   "tag": {
     "text": "alpha"
   },
-  "html": 'This is a new service – your <a href="#">feedback</a> will help us to improve it.'
+  "html": 'This is a new service – your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
 }) }}

--- a/src/components/phase-banner/phase-banner.yaml
+++ b/src/components/phase-banner/phase-banner.yaml
@@ -3,9 +3,9 @@ variants:
     data:
       tag:
         text: alpha
-      html: This is a new service – your <a href="#">feedback</a> will help us to improve it.
+      html: This is a new service – your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
   - name: tag-with-html
     data:
       tag:
         html: <i>alpha</i>
-      html: This is a new service – your <a href="#">feedback</a> will help us to improve it.
+      html: This is a new service – your <a href="#" class="govuk-link">feedback</a> will help us to improve it.

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -43,6 +43,8 @@
   }
 
   .govuk-c-previous-next__link {
+    @include govuk-focusable-fill;
+
     display: block;
     padding: $govuk-spacing-scale-3;
     text-decoration: none;

--- a/src/components/previous-next/_previous-next.scss
+++ b/src/components/previous-next/_previous-next.scss
@@ -49,6 +49,10 @@
     padding: $govuk-spacing-scale-3;
     text-decoration: none;
 
+    &:link {
+      color: $govuk-link-colour;
+    }
+
     &:visited {
       color: $govuk-link-colour;
     }

--- a/src/components/skip-link/_skip-link.scss
+++ b/src/components/skip-link/_skip-link.scss
@@ -3,6 +3,7 @@
 @include exports("skip-link") {
   .govuk-c-skip-link {
     @include govuk-h-visually-hidden-focusable;
+    @include govuk-focusable-fill;
     @include govuk-font-regular-16;
 
     display: block;

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -2,6 +2,7 @@
 
   .govuk-link {
     @include govuk-font-regular;
+    @include govuk-focusable-fill;
 
     // Override the tap highlight colour (the color of the highlight that
     // appears when a link is tapped on some mobile devices). This is
@@ -22,11 +23,6 @@
 
     &:active {
       color: $govuk-link-active-colour;
-    }
-
-    &:focus {
-      outline: $govuk-focus-width solid $govuk-focus-colour;
-      background-color: $govuk-focus-colour;
     }
 
     @include mq($media-type: print) {

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -1,45 +1,58 @@
 @include exports("links") {
-  a:link {
-    color: $govuk-link-colour;
-  }
 
-  a:visited {
-    color: $govuk-link-visited-colour;
-  }
+  .govuk-link {
+    @include govuk-font-regular;
 
-  a:hover {
-    color: $govuk-link-hover-colour;
-  }
-
-  a:active {
-    color: $govuk-link-active-colour;
-  }
-
-  a {
+    // Override the tap highlight colour (the color of the highlight that
+    // appears when a link is tapped on some mobile devices). This is
+    // ever-so-slightly darker than the default.
     -webkit-tap-highlight-color: rgba($govuk-black, .3);
-  }
 
-  a:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    background-color: $govuk-focus-colour;
-  }
-
-  @include mq($media-type: print) {
-    a,
-    a:visited {
-      word-wrap: break-word;
+    &:link {
+      color: $govuk-link-colour;
     }
 
-    a[href^="/"]:after,
-    a[href^="http://"]:after,
-    a[href^="https://"]:after {
-      content: " (" attr(href) ")";
-      font-size: 90%;
+    &:visited {
+      color: $govuk-link-visited-colour;
     }
 
-    a[href^="javascript:"]:after,
-    a[href^="#"]:after {
-      content: "";
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:active {
+      color: $govuk-link-active-colour;
+    }
+
+    &:focus {
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+      background-color: $govuk-focus-colour;
+    }
+
+    @include mq($media-type: print) {
+
+      // When printing, append the the destination URL to the link text, as long
+      // as the URL starts with either `/`, `http://` or `https://`.
+      &[href^="/"],
+      &[href^="http://"],
+      &[href^="https://"] {
+        &::after {
+          content: " (" attr(href) ")";
+          font-size: 90%;
+
+          // Because the URLs may be very long, ensure that they may be broken
+          // at arbitrary points if there are no otherwise acceptable break
+          // points in the line
+          word-wrap: break-word;
+        }
+      }
+
+      a[href^="javascript:"],
+      a[href^="#"] {
+        &::after {
+          content: "";
+        }
+      }
     }
   }
 }

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -48,4 +48,23 @@
       }
     }
   }
+
+  // Muted link variant
+  //
+  // Used for secondary links on a page - the link will appear in muted colours
+  // regardless of visited state.
+  .govuk-link--muted {
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: $govuk-grey-1;
+    }
+
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable
+    &:focus {
+      color: $govuk-black;
+    }
+  }
 }

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -46,13 +46,6 @@
           word-wrap: break-word;
         }
       }
-
-      a[href^="javascript:"],
-      a[href^="#"] {
-        &::after {
-          content: "";
-        }
-      }
     }
   }
 }

--- a/src/globals/scss/core/_prose-scope.scss
+++ b/src/globals/scss/core/_prose-scope.scss
@@ -44,5 +44,9 @@
     ul {
       @extend .govuk-list--bullet;
     }
+
+    a {
+      @extend .govuk-link;
+    }
   }
 }

--- a/src/globals/scss/helpers/_focusable.scss
+++ b/src/globals/scss/helpers/_focusable.scss
@@ -1,6 +1,24 @@
+// Focusable helper
+//
+// Provides an additional outline to clearly indicate when the target element is
+// focussed. Used for interactive elements which themselves have some background
+// or border, such as most form elements.
 @mixin govuk-focusable {
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
     outline-offset: 0;
+  }
+}
+
+// Focusable with fill helper
+//
+// Provides an additional outline and background colour to clearly indicate when
+// the target element is focussed. Used for interactive text-based elements such
+// as links.
+@mixin govuk-focusable-fill {
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    background-color: $govuk-focus-colour;
   }
 }

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -35,7 +35,7 @@
 
   <h2 class="govuk-heading-l">Guidance</h2>
   <p class="govuk-body">
-    More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website">GOV.UK Design System</a>
+    More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website" class="govuk-link">GOV.UK Design System</a>
   </p>
 
   {% if isReadme %}
@@ -114,7 +114,7 @@
 
   <h2 class="govuk-heading-l">Contribution</h2>
   <p class="govuk-body">
-    Guidelines can be found at <a href="https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md" title="link to contributing guidelines on our github repository">on our Github repository.</a>
+    Guidelines can be found at <a href="https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md" title="link to contributing guidelines on our github repository" class="govuk-link">on our Github repository.</a>
   </p>
 
   <h2 class="govuk-heading-l">License</h2>
@@ -124,7 +124,7 @@
   {% if not isReadme %}
   <h2 class="govuk-heading-l">Installation and setup</h2>
   <p class="govuk-body">
-    <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{ componentName}}">
+    <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{ componentName}}" class="govuk-link">
       View the {{ componentName }} README on GitHub
     </a>
   </p>

--- a/src/views/examples/form-elements/index.njk
+++ b/src/views/examples/form-elements/index.njk
@@ -3,14 +3,14 @@
 {% block content %}
 <h1 class="govuk-u-bold-48">Form elements</h1>
 <ul>
-  <li><a href="#input">Label and text input</a></li>
-  <li><a href="#textarea">Label and textarea</a></li>
-  <li><a href="#radio-stacked">Fieldset, legend and radio buttons (stacked)</a></li>
-  <li><a href="#radio-inline">Fieldset, legend and radio buttons (inline - yes or no)</a></li>
-  <li><a href="#checkbox-stacked">Fieldset, legend and checkboxes (stacked)</a></li>
-  <li><a href="#date">Date pattern</a></li>
-  <li><a href="#select">Select box</a></li>
-  <li><a href="#file">File upload</a></li>
+  <li><a href="#input" class="govuk-link">Label and text input</a></li>
+  <li><a href="#textarea" class="govuk-link">Label and textarea</a></li>
+  <li><a href="#radio-stacked" class="govuk-link">Fieldset, legend and radio buttons (stacked)</a></li>
+  <li><a href="#radio-inline" class="govuk-link">Fieldset, legend and radio buttons (inline - yes or no)</a></li>
+  <li><a href="#checkbox-stacked" class="govuk-link">Fieldset, legend and checkboxes (stacked)</a></li>
+  <li><a href="#date" class="govuk-link">Date pattern</a></li>
+  <li><a href="#select" class="govuk-link">Select box</a></li>
+  <li><a href="#file" class="govuk-link">File upload</a></li>
 </ul>
 
 <form action="/" method="post">

--- a/src/views/examples/typography/index.njk
+++ b/src/views/examples/typography/index.njk
@@ -141,6 +141,18 @@
         <li>Confirmation</li>
       </ol>
     </section>
+
+    <!-- Body text -->
+
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Links</h2>
+      <div>
+        <p class="govuk-body">
+          <a href="#" class="govuk-link">govuk-link</a>
+        </p>
+      </div>
+    </section>
+
     <section class="govuk-!-mt-r8">
       <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Example content 1</h2>
 

--- a/src/views/examples/typography/index.njk
+++ b/src/views/examples/typography/index.njk
@@ -116,16 +116,16 @@
       <h3 class="govuk-heading-m">govuk-list</h3>
       <ul class="govuk-list govuk">
         <li>
-          <a href="#">Benefits calculators</a>
+          <a href="#" class="govuk-link">Benefits calculators</a>
         </li>
         <li>
-          <a href="#">Benefit overpayments</a>
+          <a href="#" class="govuk-link">Benefit overpayments</a>
         </li>
         <li>
-          <a href="#">Benefit fraud</a>
+          <a href="#" class="govuk-link">Benefit fraud</a>
         </li>
         <li>
-          <a href="#">More</a>
+          <a href="#" class="govuk-link">More</a>
         </li>
       </ul>
       <h3 class="govuk-heading-m">govuk-list + govuk-list--bullet</h3>
@@ -179,7 +179,7 @@
         <li>tracing people suspected of insurance fraud</li>
       </ul>
 
-      <p class="govuk-body-m">Private car parking management companies that give out parking tickets or trespass charge notices can only request information from <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> if they’re members of the <a rel="external" href="http://www.britishparking.co.uk">British Parking Association</a> or the <a rel="external" href="http://www.theipc.info">International Parking Community.</a></p>
+      <p class="govuk-body-m">Private car parking management companies that give out parking tickets or trespass charge notices can only request information from <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> if they’re members of the <a rel="external" href="http://www.britishparking.co.uk" class="govuk-link">British Parking Association</a> or the <a rel="external" href="http://www.theipc.info" class="govuk-link">International Parking Community.</a></p>
 
 
       <h3 class="govuk-heading-s">How to make a request</h3>
@@ -197,20 +197,20 @@
         <tbody class="govuk-c-table__body">
           <tr class="govuk-c-table__row">
             <td class="govuk-c-table__cell">An individual</td>
-            <td class="govuk-c-table__cell"><a href="/government/publications/v888-request-by-an-individual-for-information-about-a-vehicle">Form V888</a></td>
+            <td class="govuk-c-table__cell"><a href="/government/publications/v888-request-by-an-individual-for-information-about-a-vehicle" class="govuk-link">Form V888</a></td>
           </tr>
           <tr class="govuk-c-table__row">
             <td class="govuk-c-table__cell">A company</td>
-            <td class="govuk-c-table__cell"><a href="/government/publications/v8882-request-by-a-company-for-information-about-a-vehicle">Form V8882</a></td>
+            <td class="govuk-c-table__cell"><a href="/government/publications/v8882-request-by-a-company-for-information-about-a-vehicle" class="govuk-link">Form V8882</a></td>
           </tr>
           <tr class="govuk-c-table__row">
             <td class="govuk-c-table__cell">A company that issues parking or trespass charge notices</td>
-            <td class="govuk-c-table__cell"><a href="/government/publications/v8883-request-for-information-for-those-who-issue-a-parking-charge-notice">Form V8883</a></td>
+            <td class="govuk-c-table__cell"><a href="/government/publications/v8883-request-for-information-for-those-who-issue-a-parking-charge-notice" class="govuk-link">Form V8883</a></td>
           </tr>
         </tbody>
       </table>
 
-      <p class="govuk-body-m">You can download further information on <a href="/government/publications/giving-people-information-from-our-vehicle-record">requesting information from <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr></a>.</p>
+      <p class="govuk-body-m">You can download further information on <a href="/government/publications/giving-people-information-from-our-vehicle-record" class="govuk-link">requesting information from <abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr></a>.</p>
 
       <h3 class="govuk-heading-m">Information about you or your vehicle</h3>
       <p class="govuk-body-m">You can ask for information about your current vehicle or a vehicle that used to be registered in your name.</p>
@@ -228,7 +228,7 @@
 
       <p class="govuk-body-m">You can send your request to DVLA by email or post.</p>
 
-      <p class="govuk-body-m"><strong><abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> SAR Enquiries</strong><br><a href="mailto:SubjectAccess.Requests@dvla.gsi.gov.uk">SubjectAccess.Requests@dvla.gsi.gov.uk</a></p>
+      <p class="govuk-body-m"><strong><abbr title="Driver and Vehicle Licensing Agency">DVLA</abbr> SAR Enquiries</strong><br><a href="mailto:SubjectAccess.Requests@dvla.gsi.gov.uk" class="govuk-link">SubjectAccess.Requests@dvla.gsi.gov.uk</a></p>
 
       <p class="govuk-body-m">
         SAR Enquiries
@@ -257,7 +257,7 @@
 
       <h2 class="govuk-heading-l">How to apply</h2>
 
-      <p class="govuk-body-m">Fill in the <a href="/government/publications/women-s-land-army-and-timber-corps-veterans-badge-application-form"><abbr title="Women's Land Army">WLA</abbr> and <abbr title="Women's Timber Corps">WTC</abbr> veterans badge application form.</a></p>
+      <p class="govuk-body-m">Fill in the <a href="/government/publications/women-s-land-army-and-timber-corps-veterans-badge-application-form" class="govuk-link"><abbr title="Women's Land Army">WLA</abbr> and <abbr title="Women's Timber Corps">WTC</abbr> veterans badge application form.</a></p>
 
       <p class="govuk-body-m">You’ll need to give your date of birth, approximate dates of service in the <abbr title="Women's Land Army">WLA</abbr> or <abbr title="Women's Timber Corps">WTC</abbr>, and the location at which you (or your family member or spouse) were stationed.</p>
 
@@ -265,9 +265,9 @@
 
 
       <p class="govuk-body-m"><strong><abbr title="Department for Environment, Food and Rural Affairs">Defra</abbr></strong>
-      <a href="mailto:womenslandarmy@defra.gsi.gov.uk">womenslandarmy@defra.gsi.gov.uk</a><br>
+      <a href="mailto:womenslandarmy@defra.gsi.gov.uk" class="govuk-link">womenslandarmy@defra.gsi.gov.uk</a><br>
       Telephone: 0208 026 3078<br>
-      <a href="/call-charges">Find out about call charges</a></p>
+      <a href="/call-charges" class="govuk-link">Find out about call charges</a></p>
 
 
       <p class="govuk-body-m">

--- a/src/views/examples/typography/index.njk
+++ b/src/views/examples/typography/index.njk
@@ -151,6 +151,11 @@
           <a href="#" class="govuk-link">govuk-link</a>
         </p>
       </div>
+      <div>
+        <p class="govuk-body">
+          <a href="#" class="govuk-link govuk-link--muted">govuk-link govuk-link--muted</a>
+        </p>
+      </div>
     </section>
 
     <section class="govuk-!-mt-r8">

--- a/src/views/index.njk
+++ b/src/views/index.njk
@@ -13,7 +13,7 @@
 
         <ul class="govuk-list">
         {% for componentName, value in componentsDirectory | dictsort %}
-          <li><a href="/components/{{ componentName }}">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+          <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
         {% endfor %}
         </ul>
       </div>
@@ -23,7 +23,7 @@
 
         <ul class="govuk-list">
         {% for exampleName, value in examplesDirectory | dictsort %}
-          <li><a href="/examples/{{ exampleName }}">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+          <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
         {% endfor %}
         </ul>
       </div>

--- a/src/views/macros/showDefaultAndVariants.njk
+++ b/src/views/macros/showDefaultAndVariants.njk
@@ -20,7 +20,7 @@
 {% endif %}
 
 <p class="govuk-body">
-  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}">{{previewText}}</a>
+  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}" class="govuk-link">{{previewText}}</a>
 </p>
 
 <h4 class="govuk-heading-s">Markup</h4>


### PR DESCRIPTION
This changes the core link styling so that it is applied via classes, rather than styling a elements directly. This brings it into line with the way other core styling is applied, and enforces our principle that GOV.UK Frontend should not have opinions about basic HTML elements.

As part of this, we also need to update a number of components which previously relied on these global link styles, adding back link styling and focus states.

The prose scope has also been updated to apply the link styling to any links.

We also need to update both the examples in the Frontend app and the Frontend app itself to ensure the govuk-link class is applied to all links.

The muted link variant has been copied from the link component.

These changes make the link component redundant, which will be removed in a separate PR.

https://trello.com/c/Bl7Sukkw/530-move-links-into-frontend-core