### PR TITLE
Allow HTML to be passed to error summary list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 ## Unreleased
 
+Fixes:
+
+- The error summary component allows users to pass HTML for an entry in the list
+  again. (PR [#428](https://github.com/alphagov/govuk-frontend/pull/428))
+- Error list entries in the error summary component no longer get wrapped in
+  links when no `href` is provided.
+  (PR [#428](https://github.com/alphagov/govuk-frontend/pull/428))
+
 ## 0.0.21-alpha (Breaking release)
 Skipped 0.0.20-alpha due to difficulties with publishing.
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -29,11 +29,15 @@ More information about when to use error-summary can be found on [GOV.UK Design 
         <ul class="govuk-list govuk-c-error-summary__list">
 
           <li>
+
             <a href="#example-error-1">Descriptive link to the question with an error</a>
+
           </li>
 
           <li>
-            <a href="#example-error-1"></a>
+
+            <a href="#example-error-1">Descriptive link to the question with an error</a>
+
           </li>
 
         </ul>

--- a/src/components/error-summary/template.njk
+++ b/src/components/error-summary/template.njk
@@ -13,7 +13,11 @@
     <ul class="govuk-list govuk-c-error-summary__list">
     {% for item in params.errorList %}
       <li>
-        <a href="{{item.href}}">{{item.text}}</a>
+      {% if item.href %}
+        <a href="{{ item.href }}">{{ item.html | safe if item.html else item.text }}</a>
+      {% else %}
+        {{ item.html | safe if item.html else item.text }}
+      {% endif %}
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
This component used to call the list component, but when that was removed it was updated with a simple loop over the items array.

This updates the loop to allow users to pass HTML for an entry in the list, and also ensures that if they do not provide an href the text or html does not get wrapped in a link.

https://trello.com/c/rdyDJMlK/575-allow-html-to-be-passed-to-error-summary-list