### PR TITLE
Update Contributing and Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,13 @@ Fixes:
   previously relied on the global link styles.
   (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
 - Adjust `warning-text` icon by 1px for New Transport
+
+Internal:
+
 - Links within the review app and the examples have been updated to use the
   `govuk-link` class.
   (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
+- Improve documentation around contributing (PR [#433](https://github.com/alphagov/govuk-frontend/pull/433))
 
 ## 0.0.21-alpha (Breaking release)
 Skipped 0.0.20-alpha due to difficulties with publishing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,14 +45,26 @@ The folder structure should be:
       - component-name.js
       - README.md
 
+# Updating Changelog
+
+If you open a GitHub pull request on this repo, please update `CHANGELOG` to reflect your contribution.
+
+Add your entry under `Unreleased` as `Breaking change`, `New feature`, `Fix` or `Internal`.
+
+Please include a description of the work done and a link to the PR (see current `CHANGELOG` for the format).
+
+Include the modified `CHANGELOG` in the PR.
+
 
 # Versioning
 
-We use [Semantic Versioning](http://semver.org/).
+We are not using semantic versioning yet, we are going to talk about this soon.
+
+See `CHANGELOG` for more information.
 
 ## To release a new version
 
-To follow.
+See `docs/publishing`
 
 # Commit hygiene
 


### PR DESCRIPTION
This PR updates `CONTRIBUTING` and `CHANGELOG` with:

- Information on how to update `CHANGELOG`.
- New contribution category `Internal` (as suggested by @nickcolley).
- Tidy up of `Versioning` section in `CONTRIBUTING` to reflect the latest FE.