### PR TITLE
Update warning text README

### DIFF
--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -1,8 +1,8 @@
-#  Warning text
+# Warning text
 
 ## Introduction
 
-Use bold text with an exclamation icon if there are  consequences - for example, a fine or prison sentence.
+Use bold text with an exclamation icon if there are consequences - for example, a fine or prison sentence.
 
 ## Guidance
 
@@ -26,9 +26,9 @@ More information about when to use warning-text can be found on [GOV.UK Design S
 
 #### Macro
 
-    {{ govukwarningText({
+    {{ govukWarningText({
       "classes": null,
-      "warningText": "You can be fined up to £5,000 if you don’t register.",
+      "text": "You can be fined up to £5,000 if you don’t register.",
       "iconFallbackText": "Warning"
     }) }}
 
@@ -106,7 +106,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">warningText</th>
+<th class="govuk-c-table__header" scope="row">text</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">Yes</td>
+
+<td class="govuk-c-table__cell ">The text next to the icon</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">html</th>
 
 <td class="govuk-c-table__cell ">string</td>
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -27,7 +27,6 @@ More information about when to use warning-text can be found on [GOV.UK Design S
 #### Macro
 
     {{ govukWarningText({
-      "classes": null,
       "text": "You can be fined up to £5,000 if you don’t register.",
       "iconFallbackText": "Warning"
     }) }}

--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -4,7 +4,7 @@
 
 {# componentName #}
 {% block componentDescription %}
-  Use bold text with an exclamation icon if there are legal consequences - for example, a fine or prison sentence.
+  Use bold text with an exclamation icon if there are consequences - for example, a fine or prison sentence.
 {% endblock %}
 {# defaultAndVariants #}
 

--- a/src/components/warning-text/warning-text.yaml
+++ b/src/components/warning-text/warning-text.yaml
@@ -1,6 +1,5 @@
 variants:
   - name: default
     data:
-      classes:
       text: You can be fined up to £5,000 if you don’t register.
       iconFallbackText: Warning


### PR DESCRIPTION
In [#432](https://github.com/alphagov/govuk-frontend/pull/432) changes were made directly to README.md that should have been made in index.njk, mainly to update references to the component name, but also to change the 'description' to remove a reference to legal consequences.

This updates index.njk to include the change to the description and regenerates the readme with the correct whitespace and capitalisation as well as changes to the arguments table and to the macro example.