### PR TITLE
Rename 'variants' to 'examples'

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,23 +84,23 @@ app.get('/components/:component', function (req, res, next) {
   })
 })
 
-// Component variant preview
-app.get('/components/:component/:variant*?/preview', function (req, res, next) {
-  // Find the data for the specified variant (or the default variant)
+// Component example preview
+app.get('/components/:component/:example*?/preview', function (req, res, next) {
+  // Find the data for the specified example (or the default example)
   let componentName = req.params.component
-  let requestedVariantName = req.params.variant || 'default'
+  let requestedExampleName = req.params.example || 'default'
 
-  let variantConfig = res.locals.componentData.variants.find(
-    variant => variant.name === requestedVariantName
+  let exampleConfig = res.locals.componentData.examples.find(
+    example => example.name === requestedExampleName
   )
 
-  if (!variantConfig) {
+  if (!exampleConfig) {
     next()
   }
 
-  // Construct and evaluate the component with the data for this variant
+  // Construct and evaluate the component with the data for this example
   let macroName = helperFunctions.componentNameToMacroName(componentName)
-  let macroParameters = JSON.stringify(variantConfig.data, null, '\t')
+  let macroParameters = JSON.stringify(exampleConfig.data, null, '\t')
 
   res.locals.componentView = env.renderString(
     `{% from '${componentName}/macro.njk' import ${macroName} %}

--- a/src/components/back-link/back-link.yaml
+++ b/src/components/back-link/back-link.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     text: Back

--- a/src/components/back-link/index.njk
+++ b/src/components/back-link/index.njk
@@ -8,7 +8,7 @@
 Link back component, to go back a page.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -47,7 +47,7 @@ More information about when to use breadcrumbs can be found on [GOV.UK Design Sy
 
 ### Breadcrumbs--single-section
 
-[Preview the breadcrumbs--single-section variant](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/single-section/preview)
+[Preview the breadcrumbs--single-section example](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/single-section/preview)
 
 #### Markup
 
@@ -74,7 +74,7 @@ More information about when to use breadcrumbs can be found on [GOV.UK Design Sy
 
 ### Breadcrumbs--many-breadcrumbs
 
-[Preview the breadcrumbs--many-breadcrumbs variant](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/many-breadcrumbs/preview)
+[Preview the breadcrumbs--many-breadcrumbs example](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/many-breadcrumbs/preview)
 
 #### Markup
 
@@ -125,7 +125,7 @@ More information about when to use breadcrumbs can be found on [GOV.UK Design Sy
 
 ### Breadcrumbs--no-home-section
 
-[Preview the breadcrumbs--no-home-section variant](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/no-home-section/preview)
+[Preview the breadcrumbs--no-home-section example](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/no-home-section/preview)
 
 #### Markup
 
@@ -160,7 +160,7 @@ More information about when to use breadcrumbs can be found on [GOV.UK Design Sy
 
 ### Breadcrumbs--last-breadcrumb-is-current-page
 
-[Preview the breadcrumbs--last-breadcrumb-is-current-page variant](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/last-breadcrumb-is-current-page/preview)
+[Preview the breadcrumbs--last-breadcrumb-is-current-page example](http://govuk-frontend-review.herokuapp.com/components/breadcrumbs/last-breadcrumb-is-current-page/preview)
 
 #### Markup
 

--- a/src/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/components/breadcrumbs/breadcrumbs.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       items:

--- a/src/components/breadcrumbs/index.njk
+++ b/src/components/breadcrumbs/index.njk
@@ -10,7 +10,7 @@ The Breadcrumbs component helps users to understand where they are within a webs
 Please note, this component depends on @govuk-frontend/globals and @govuk-frontend/icons, which will automatically be installed with the package.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -29,7 +29,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--disabled
 
-[Preview the button--disabled variant](http://govuk-frontend-review.herokuapp.com/components/button/disabled/preview)
+[Preview the button--disabled example](http://govuk-frontend-review.herokuapp.com/components/button/disabled/preview)
 
 #### Markup
 
@@ -44,7 +44,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--link
 
-[Preview the button--link variant](http://govuk-frontend-review.herokuapp.com/components/button/link/preview)
+[Preview the button--link example](http://govuk-frontend-review.herokuapp.com/components/button/link/preview)
 
 #### Markup
 
@@ -61,7 +61,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--disabled-link
 
-[Preview the button--disabled-link variant](http://govuk-frontend-review.herokuapp.com/components/button/disabled-link/preview)
+[Preview the button--disabled-link example](http://govuk-frontend-review.herokuapp.com/components/button/disabled-link/preview)
 
 #### Markup
 
@@ -79,7 +79,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--start
 
-[Preview the button--start variant](http://govuk-frontend-review.herokuapp.com/components/button/start/preview)
+[Preview the button--start example](http://govuk-frontend-review.herokuapp.com/components/button/start/preview)
 
 #### Markup
 
@@ -94,7 +94,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--start-link
 
-[Preview the button--start-link variant](http://govuk-frontend-review.herokuapp.com/components/button/start-link/preview)
+[Preview the button--start-link example](http://govuk-frontend-review.herokuapp.com/components/button/start-link/preview)
 
 #### Markup
 
@@ -112,7 +112,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--button-with-html
 
-[Preview the button--button-with-html variant](http://govuk-frontend-review.herokuapp.com/components/button/button-with-html/preview)
+[Preview the button--button-with-html example](http://govuk-frontend-review.herokuapp.com/components/button/button-with-html/preview)
 
 #### Markup
 
@@ -129,7 +129,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--explicit-button
 
-[Preview the button--explicit-button variant](http://govuk-frontend-review.herokuapp.com/components/button/explicit-button/preview)
+[Preview the button--explicit-button example](http://govuk-frontend-review.herokuapp.com/components/button/explicit-button/preview)
 
 #### Markup
 
@@ -147,7 +147,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--button-with-value
 
-[Preview the button--button-with-value variant](http://govuk-frontend-review.herokuapp.com/components/button/button-with-value/preview)
+[Preview the button--button-with-value example](http://govuk-frontend-review.herokuapp.com/components/button/button-with-value/preview)
 
 #### Markup
 
@@ -166,7 +166,7 @@ Buttons are configured to perform an action and they can have a different look. 
 
 ### Button--non-submit-button
 
-[Preview the button--non-submit-button variant](http://govuk-frontend-review.herokuapp.com/components/button/non-submit-button/preview)
+[Preview the button--non-submit-button example](http://govuk-frontend-review.herokuapp.com/components/button/non-submit-button/preview)
 
 #### Markup
 

--- a/src/components/button/button.yaml
+++ b/src/components/button/button.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     text: Save and continue

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -18,7 +18,7 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 Buttons are configured to perform an action and they can have a different look. For example, they can be disabled until a valid action has been performed by the user.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -81,7 +81,7 @@ More information about when to use checkboxes can be found on [GOV.UK Design Sys
 
 ### Checkboxes--with-html
 
-[Preview the checkboxes--with-html variant](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-html/preview)
+[Preview the checkboxes--with-html example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-html/preview)
 
 #### Markup
 
@@ -148,7 +148,7 @@ More information about when to use checkboxes can be found on [GOV.UK Design Sys
 
 ### Checkboxes--without-fieldset
 
-[Preview the checkboxes--without-fieldset variant](http://govuk-frontend-review.herokuapp.com/components/checkboxes/without-fieldset/preview)
+[Preview the checkboxes--without-fieldset example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/without-fieldset/preview)
 
 #### Markup
 
@@ -202,7 +202,7 @@ More information about when to use checkboxes can be found on [GOV.UK Design Sys
 
 ### Checkboxes--disabled
 
-[Preview the checkboxes--disabled variant](http://govuk-frontend-review.herokuapp.com/components/checkboxes/disabled/preview)
+[Preview the checkboxes--disabled example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/disabled/preview)
 
 #### Markup
 

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     idPrefix: 'nationality'

--- a/src/components/checkboxes/index.njk
+++ b/src/components/checkboxes/index.njk
@@ -8,7 +8,7 @@
   Let users select one or more options.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/cookie-banner/cookie-banner.yaml
+++ b/src/components/cookie-banner/cookie-banner.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     html: 'GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" class="govuk-link">Find out more about cookies</a>'

--- a/src/components/cookie-banner/index.njk
+++ b/src/components/cookie-banner/index.njk
@@ -8,7 +8,7 @@
   GOV.UK cookie message, with link to cookie help page.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -85,7 +85,7 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-errors
 
-[Preview the date-input--with-errors variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-errors/preview)
+[Preview the date-input--with-errors example](http://govuk-frontend-review.herokuapp.com/components/date-input/with-errors/preview)
 
 #### Markup
 
@@ -160,7 +160,7 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-day-error
 
-[Preview the date-input--with-day-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-day-error/preview)
+[Preview the date-input--with-day-error example](http://govuk-frontend-review.herokuapp.com/components/date-input/with-day-error/preview)
 
 #### Markup
 
@@ -234,7 +234,7 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-month-error
 
-[Preview the date-input--with-month-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-month-error/preview)
+[Preview the date-input--with-month-error example](http://govuk-frontend-review.herokuapp.com/components/date-input/with-month-error/preview)
 
 #### Markup
 
@@ -308,7 +308,7 @@ More information about when to use date-input can be found on [GOV.UK Design Sys
 
 ### Date-input--with-year-error
 
-[Preview the date-input--with-year-error variant](http://govuk-frontend-review.herokuapp.com/components/date-input/with-year-error/preview)
+[Preview the date-input--with-year-error example](http://govuk-frontend-review.herokuapp.com/components/date-input/with-year-error/preview)
 
 #### Markup
 

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     id: 'dob'

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -7,7 +7,7 @@
   A component for entering dates, for example - date of birth.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -38,7 +38,7 @@ More information about when to use details can be found on [GOV.UK Design System
 
 ### Details--with-html
 
-[Preview the details--with-html variant](http://govuk-frontend-review.herokuapp.com/components/details/with-html/preview)
+[Preview the details--with-html example](http://govuk-frontend-review.herokuapp.com/components/details/with-html/preview)
 
 #### Markup
 

--- a/src/components/details/details.yaml
+++ b/src/components/details/details.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   
 - name: default
   data:

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -7,7 +7,7 @@
   Component for conditionally revealing content, using the details HTML element.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/error-message/error-message.yaml
+++ b/src/components/error-message/error-message.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     text: Error message about full name goes here

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -7,7 +7,7 @@
   Component to show a red error message - used for form validation.
   Use inside a label or legend.
 {% endblock %}
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/error-summary/error-summary.yaml
+++ b/src/components/error-summary/error-summary.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       titleText: Message to alert the user to a problem goes here

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -36,7 +36,7 @@ More information about when to use fieldset can be found on [GOV.UK Design Syste
 
 ### Fieldset--with-error-message
 
-[Preview the fieldset--with-error-message variant](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-error-message/preview)
+[Preview the fieldset--with-error-message example](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-error-message/preview)
 
 #### Markup
 
@@ -67,7 +67,7 @@ More information about when to use fieldset can be found on [GOV.UK Design Syste
 
 ### Fieldset--with-html-instead-of-text
 
-[Preview the fieldset--with-html-instead-of-text variant](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-html-instead-of-text/preview)
+[Preview the fieldset--with-html-instead-of-text example](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-html-instead-of-text/preview)
 
 #### Markup
 

--- a/src/components/fieldset/fieldset.yaml
+++ b/src/components/fieldset/fieldset.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     legendText: Legend text goes here

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -8,7 +8,7 @@
   The legend element represents a caption for the content of its parent fieldset.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -34,7 +34,7 @@ More information about when to use file-upload can be found on [GOV.UK Design Sy
 
 ### File-upload--with-hint-text
 
-[Preview the file-upload--with-hint-text variant](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-hint-text/preview)
+[Preview the file-upload--with-hint-text example](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-hint-text/preview)
 
 #### Markup
 
@@ -61,7 +61,7 @@ More information about when to use file-upload can be found on [GOV.UK Design Sy
 
 ### File-upload--with-error-message
 
-[Preview the file-upload--with-error-message variant](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-error-message/preview)
+[Preview the file-upload--with-error-message example](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-error-message/preview)
 
 #### Markup
 
@@ -95,7 +95,7 @@ More information about when to use file-upload can be found on [GOV.UK Design Sy
 
 ### File-upload--with-value-and-attributes
 
-[Preview the file-upload--with-value-and-attributes variant](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-value-and-attributes/preview)
+[Preview the file-upload--with-value-and-attributes example](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-value-and-attributes/preview)
 
 #### Markup
 

--- a/src/components/file-upload/file-upload.yaml
+++ b/src/components/file-upload/file-upload.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     id: file-upload-1

--- a/src/components/file-upload/index.njk
+++ b/src/components/file-upload/index.njk
@@ -1,5 +1,4 @@
 {% extends "component.njk" %}
-{% from "macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 
@@ -7,10 +6,6 @@
 
 {% block componentDescription %}
 The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick one or more files, to upload to a server.
-{% endblock %}
-
-{% block defaultAndVariants %}
-{{ showDefaultAndVariants(componentName, componentData) }}
 {% endblock %}
 
 {# override link to design system here if it's different to base url + componentName #}

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -34,7 +34,7 @@ More information about when to use input can be found on [GOV.UK Design System](
 
 ### Input--with-hint-text
 
-[Preview the input--with-hint-text variant](http://govuk-frontend-review.herokuapp.com/components/input/with-hint-text/preview)
+[Preview the input--with-hint-text example](http://govuk-frontend-review.herokuapp.com/components/input/with-hint-text/preview)
 
 #### Markup
 
@@ -61,7 +61,7 @@ More information about when to use input can be found on [GOV.UK Design System](
 
 ### Input--with-error-message
 
-[Preview the input--with-error-message variant](http://govuk-frontend-review.herokuapp.com/components/input/with-error-message/preview)
+[Preview the input--with-error-message example](http://govuk-frontend-review.herokuapp.com/components/input/with-error-message/preview)
 
 #### Markup
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -8,7 +8,7 @@
   A single-line text field.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       label:

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -34,7 +34,7 @@ More information about when to use label can be found on [GOV.UK Design System](
 
 ### Label--with bold text
 
-[Preview the label--with bold text variant](http://govuk-frontend-review.herokuapp.com/components/label/with bold text/preview)
+[Preview the label--with bold text example](http://govuk-frontend-review.herokuapp.com/components/label/with bold text/preview)
 
 #### Markup
 
@@ -57,7 +57,7 @@ More information about when to use label can be found on [GOV.UK Design System](
 
 ### Label--with error message
 
-[Preview the label--with error message variant](http://govuk-frontend-review.herokuapp.com/components/label/with error message/preview)
+[Preview the label--with error message example](http://govuk-frontend-review.herokuapp.com/components/label/with error message/preview)
 
 #### Markup
 

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -8,7 +8,7 @@
   Use labels for all form fields.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/label/label.yaml
+++ b/src/components/label/label.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       text: National Insurance number

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -34,7 +34,7 @@ More information about when to use panel can be found on [GOV.UK Design System](
 
 ### Panel--no-reference-number
 
-[Preview the panel--no-reference-number variant](http://govuk-frontend-review.herokuapp.com/components/panel/no-reference-number/preview)
+[Preview the panel--no-reference-number example](http://govuk-frontend-review.herokuapp.com/components/panel/no-reference-number/preview)
 
 #### Markup
 

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -6,7 +6,7 @@
 {% block componentDescription %}
   The confirmation panel has a turquoise background and white text. Used for transaction end pages, and Bank Holidays.
 {% endblock %}
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/panel/panel.yaml
+++ b/src/components/panel/panel.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     titleText: Application complete

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -37,7 +37,7 @@ More information about when to use phase-banner can be found on [GOV.UK Design S
 
 ### Phase-banner--tag-with-html
 
-[Preview the phase-banner--tag-with-html variant](http://govuk-frontend-review.herokuapp.com/components/phase-banner/tag-with-html/preview)
+[Preview the phase-banner--tag-with-html example](http://govuk-frontend-review.herokuapp.com/components/phase-banner/tag-with-html/preview)
 
 #### Markup
 

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -8,7 +8,7 @@
   A banner that indicates content is in alpha or beta phase with a description.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/phase-banner/phase-banner.yaml
+++ b/src/components/phase-banner/phase-banner.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       tag:

--- a/src/components/previous-next/README.md
+++ b/src/components/previous-next/README.md
@@ -67,7 +67,7 @@ More information about when to use previous-next can be found on [GOV.UK Design 
 
 ### Previous-next--no-next-page
 
-[Preview the previous-next--no-next-page variant](http://govuk-frontend-review.herokuapp.com/components/previous-next/no-next-page/preview)
+[Preview the previous-next--no-next-page example](http://govuk-frontend-review.herokuapp.com/components/previous-next/no-next-page/preview)
 
 #### Markup
 

--- a/src/components/previous-next/index.njk
+++ b/src/components/previous-next/index.njk
@@ -6,7 +6,7 @@
 {% block componentDescription %}
   Navigational links that allow users navigate within a series of pages.
 {% endblock %}
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/previous-next/previous-next.yaml
+++ b/src/components/previous-next/previous-next.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     previous:

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -70,7 +70,7 @@ More information about when to use radios can be found on [GOV.UK Design System]
 
 ### Radios--with-html
 
-[Preview the radios--with-html variant](http://govuk-frontend-review.herokuapp.com/components/radios/with-html/preview)
+[Preview the radios--with-html example](http://govuk-frontend-review.herokuapp.com/components/radios/with-html/preview)
 
 #### Markup
 
@@ -127,7 +127,7 @@ More information about when to use radios can be found on [GOV.UK Design System]
 
 ### Radios--without-fieldset
 
-[Preview the radios--without-fieldset variant](http://govuk-frontend-review.herokuapp.com/components/radios/without-fieldset/preview)
+[Preview the radios--without-fieldset example](http://govuk-frontend-review.herokuapp.com/components/radios/without-fieldset/preview)
 
 #### Markup
 

--- a/src/components/radios/index.njk
+++ b/src/components/radios/index.njk
@@ -11,7 +11,7 @@ Let users select a single option from a list.
 Please note, this component depends on @govuk-frontend/globals, which will automatically be installed with the package.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     idPrefix: 'example'

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -58,7 +58,7 @@ More information about when to use select can be found on [GOV.UK Design System]
 
 ### Select--with-hint-text-and-error
 
-[Preview the select--with-hint-text-and-error variant](http://govuk-frontend-review.herokuapp.com/components/select/with-hint-text-and-error/preview)
+[Preview the select--with-hint-text-and-error example](http://govuk-frontend-review.herokuapp.com/components/select/with-hint-text-and-error/preview)
 
 #### Markup
 

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -7,7 +7,7 @@
 The HTML <code>&lt;select&gt;</code> element represents a control that provides a menu of options.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     id: select-1

--- a/src/components/skip-link/index.njk
+++ b/src/components/skip-link/index.njk
@@ -9,7 +9,7 @@ Skip link component. Make skip links visible when they are tabbed to.
 You'll need to add correct id to your main content area, to ensure the skip link will work.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/skip-link/skip-link.yaml
+++ b/src/components/skip-link/skip-link.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
 - name: default
   data:
     text: Skip to main content

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -101,7 +101,7 @@ More information about when to use table can be found on [GOV.UK Design System](
 
 ### Table--table-with-head
 
-[Preview the table--table-with-head variant](http://govuk-frontend-review.herokuapp.com/components/table/table-with-head/preview)
+[Preview the table--table-with-head example](http://govuk-frontend-review.herokuapp.com/components/table/table-with-head/preview)
 
 #### Markup
 
@@ -215,7 +215,7 @@ More information about when to use table can be found on [GOV.UK Design System](
 
 ### Table--table-with-caption-and-head
 
-[Preview the table--table-with-caption-and-head variant](http://govuk-frontend-review.herokuapp.com/components/table/table-with-caption-and-head/preview)
+[Preview the table--table-with-caption-and-head example](http://govuk-frontend-review.herokuapp.com/components/table/table-with-caption-and-head/preview)
 
 #### Markup
 

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -8,7 +8,7 @@
   Table description.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/table/table.yaml
+++ b/src/components/table/table.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
  - name: default
    data:
      rows:

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -28,7 +28,7 @@ More information about when to use tag can be found on [GOV.UK Design System](ht
 
 ### Tag--with-html
 
-[Preview the tag--with-html variant](http://govuk-frontend-review.herokuapp.com/components/tag/with-html/preview)
+[Preview the tag--with-html example](http://govuk-frontend-review.herokuapp.com/components/tag/with-html/preview)
 
 #### Markup
 
@@ -44,7 +44,7 @@ More information about when to use tag can be found on [GOV.UK Design System](ht
 
 ### Tag--inactive
 
-[Preview the tag--inactive variant](http://govuk-frontend-review.herokuapp.com/components/tag/inactive/preview)
+[Preview the tag--inactive example](http://govuk-frontend-review.herokuapp.com/components/tag/inactive/preview)
 
 #### Markup
 

--- a/src/components/tag/index.njk
+++ b/src/components/tag/index.njk
@@ -6,7 +6,7 @@
 {% block componentDescription %}
   Phase tags are mostly used inside phase banners as an indication of the state of a project. It’s possible to use them outside phase banners, for example as part of a service header.
 {% endblock %}
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/tag/tag.yaml
+++ b/src/components/tag/tag.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
  - name: default
    data:
     text: alpha

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -39,7 +39,7 @@ More information about when to use textarea can be found on [GOV.UK Design Syste
 
 ### Textarea--with error message
 
-[Preview the textarea--with error message variant](http://govuk-frontend-review.herokuapp.com/components/textarea/with error message/preview)
+[Preview the textarea--with error message example](http://govuk-frontend-review.herokuapp.com/components/textarea/with error message/preview)
 
 #### Markup
 
@@ -68,7 +68,7 @@ More information about when to use textarea can be found on [GOV.UK Design Syste
 
 ### Textarea--with default value
 
-[Preview the textarea--with default value variant](http://govuk-frontend-review.herokuapp.com/components/textarea/with default value/preview)
+[Preview the textarea--with default value example](http://govuk-frontend-review.herokuapp.com/components/textarea/with default value/preview)
 
 #### Markup
 
@@ -94,7 +94,7 @@ More information about when to use textarea can be found on [GOV.UK Design Syste
 
 ### Textarea--with custom rows
 
-[Preview the textarea--with custom rows variant](http://govuk-frontend-review.herokuapp.com/components/textarea/with custom rows/preview)
+[Preview the textarea--with custom rows example](http://govuk-frontend-review.herokuapp.com/components/textarea/with custom rows/preview)
 
 #### Markup
 

--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -7,7 +7,7 @@
   A multi-line text field.
 {% endblock %}
 
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       name: more-detail

--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -6,7 +6,7 @@
 {% block componentDescription %}
   Use bold text with an exclamation icon if there are consequences - for example, a fine or prison sentence.
 {% endblock %}
-{# defaultAndVariants #}
+{# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
 {# {% set componentGuidanceLink = 'new link here' %} #}

--- a/src/components/warning-text/warning-text.yaml
+++ b/src/components/warning-text/warning-text.yaml
@@ -1,4 +1,4 @@
-variants:
+examples:
   - name: default
     data:
       text: You can be fined up to £5,000 if you don’t register.

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -44,7 +44,7 @@
   {% endif %}
 
   {% from "./macros/showExamples.njk" import showExamples %}
-  {% block defaultAndVariants %}
+  {% block examples %}
   {{ showExamples(componentName, componentData) }}
   {% endblock %}
 

--- a/src/views/component.njk
+++ b/src/views/component.njk
@@ -43,9 +43,9 @@
   <p class="govuk-body">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
   {% endif %}
 
-  {% from "./macros/showDefaultAndVariants.njk" import showDefaultAndVariants %}
+  {% from "./macros/showExamples.njk" import showExamples %}
   {% block defaultAndVariants %}
-  {{ showDefaultAndVariants(componentName, componentData) }}
+  {{ showExamples(componentName, componentData) }}
   {% endblock %}
 
   {% if isReadme %}

--- a/src/views/macros/showExamples.njk
+++ b/src/views/macros/showExamples.njk
@@ -2,7 +2,7 @@
 
 {% macro showExamples(componentName, componentData) %}
 
-{% for item in componentData.variants %}
+{% for item in componentData.examples %}
 {% if item.name == 'default' %}
   {% set itemName = 'Component default' %}
   {% set previewLink = "/components/" + componentName + "/preview" %}

--- a/src/views/macros/showExamples.njk
+++ b/src/views/macros/showExamples.njk
@@ -10,7 +10,7 @@
 {% else %}
   {% set itemName = componentName + '--' + item.name %}
   {% set previewLink = "/components/" + componentName + '/' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' variant' %}
+  {% set previewText = 'Preview the ' + itemName + ' example' %}
 {% endif %}
 
 <h3 class="govuk-heading-m">{{ itemName  | capitalize }}</h3>

--- a/src/views/macros/showExamples.njk
+++ b/src/views/macros/showExamples.njk
@@ -1,6 +1,6 @@
 {% from "./loadComponentTemplate.njk" import loadComponentTemplate %}
 
-{% macro showDefaultAndVariants(componentName, componentData) %}
+{% macro showExamples(componentName, componentData) %}
 
 {% for item in componentData.variants %}
 {% if item.name == 'default' %}


### PR DESCRIPTION
We use variants in the design system to mean a specific thing.

The things we are defining in the component YAML _includes_ variants but also covers things like disabled states, examples with longer text, examples with different parameters, etc.

We've previously had [feedback from GOV.UK Template Consolidation team](https://github.com/alphagov/govuk-frontend/pull/251#discussion_r142609795) based on research they had done.

https://trello.com/c/L1xSSrfb/268-rename-variants-to-examples-in-the-component-yaml-files