### PR TITLE
Simulate states in examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "nodemon": "^1.12.1",
     "oldie": "^1.3.0",
     "postcss-normalize": "^3.0.0",
+    "postcss-pseudo-classes": "^0.2.0",
     "request": "^2.83.0",
     "run-sequence": "^2.2.0",
     "standard": "^10.0.2",

--- a/src/components/button/button.yaml
+++ b/src/components/button/button.yaml
@@ -45,3 +45,21 @@ examples:
     name: add-another
     text: Add another
     type: button
+- name: button-active-state
+  readme: false
+  data:
+    name: focus
+    text: Hovered
+    classes: :active
+- name: button-hover-state
+  readme: false
+  data:
+    name: focus
+    text: Hovered
+    classes: :hover
+- name: button-focus-state
+  readme: false
+  data:
+    name: focus
+    text: Focussed
+    classes: :focus

--- a/src/views/examples/links/index.njk
+++ b/src/views/examples/links/index.njk
@@ -1,0 +1,47 @@
+{% extends "layout.njk" %}
+
+{% block content %}
+
+{% set variants = {
+  'Link': '',
+  'Muted Link': 'govuk-link--muted'
+} %}
+
+{% set states = {
+  'Link': ':link',
+  'Visited link': ':visited',
+  'Hovered link': ':hover',
+  'Active link': ':active',
+  'Focussed link': ':focus',
+  'Focussed visited link': ':focus :visited',
+  'Focussed hovered link': ':focus :hover',
+  'Focussed active link': ':focus :active'
+} %}
+
+<div class="govuk-o-grid govuk-!-mt-r9">
+  <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
+
+    <h1 class="govuk-heading-xl">
+      <span class="govuk-caption-xl">Links</span>
+      GOV.UK Frontend
+    </h1>
+
+  {% for variant_description, variant_class in variants %}
+
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l">{{ variant_description }}</h2>
+
+    {% for state_description, state_class in states %}
+      <p class="govuk-body">
+        <a href="#" class="govuk-link {{ variant_class }} {{ state_class }}">
+          {{ state_description}}
+        </a>
+      </p>
+    {% endfor %}
+    </section>
+  {% endfor %}
+
+  </div>
+</div>
+
+{% endblock %}

--- a/src/views/macros/showExamples.njk
+++ b/src/views/macros/showExamples.njk
@@ -3,35 +3,41 @@
 {% macro showExamples(componentName, componentData) %}
 
 {% for item in componentData.examples %}
-{% if item.name == 'default' %}
-  {% set itemName = 'Component default' %}
-  {% set previewLink = "/components/" + componentName + "/preview" %}
-  {% set previewText = 'Preview the ' + componentName + ' component' %}
-{% else %}
-  {% set itemName = componentName + '--' + item.name %}
-  {% set previewLink = "/components/" + componentName + '/' + item.name  + "/preview" %}
-  {% set previewText = 'Preview the ' + itemName + ' example' %}
-{% endif %}
 
-<h3 class="govuk-heading-m">{{ itemName  | capitalize }}</h3>
+  {# If generating the readme, skip any examples with readme: false #}
+  {% if not isReadme or item.readme !== false %}
 
-{% if not isReadme %}
-{{ loadComponentTemplate(componentName, item.data) }}
-{% endif %}
+    {% if item.name == 'default' %}
+      {% set itemName = 'Component default' %}
+      {% set previewLink = "/components/" + componentName + "/preview" %}
+      {% set previewText = 'Preview the ' + componentName + ' component' %}
+    {% else %}
+      {% set itemName = componentName + '--' + item.name %}
+      {% set previewLink = "/components/" + componentName + '/' + item.name  + "/preview" %}
+      {% set previewText = 'Preview the ' + itemName + ' example' %}
+    {% endif %}
 
-<p class="govuk-body">
-  <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}" class="govuk-link">{{previewText}}</a>
-</p>
+    <h3 class="govuk-heading-m">{{ itemName  | capitalize }}</h3>
 
-<h4 class="govuk-heading-s">Markup</h4>
-{% set componentHtml %}
-{{ loadComponentTemplate(componentName, item.data) }}
-{% endset %}
-<pre><code>{{- componentHtml | e -}}</code></pre>
+    {% if not isReadme %}
+    {{ loadComponentTemplate(componentName, item.data) }}
+    {% endif %}
 
-<h4 class="govuk-heading-s">Macro</h4>
-<pre><code>{% raw %}{{ {% endraw %}{{ componentName | componentNameToMacroName }}(
-  {{- item.data | dump(2) -}}
-){% raw %} }}{% endraw %}</code></pre>
+    <p class="govuk-body">
+      <a href="{% if isReadme %}http://govuk-frontend-review.herokuapp.com{% endif %}{{ previewLink }}" class="govuk-link">{{ previewText }}</a>
+    </p>
+
+    <h4 class="govuk-heading-s">Markup</h4>
+    {% set componentHtml %}
+    {{- loadComponentTemplate(componentName, item.data) }}
+    {% endset %}
+    <pre><code>{{- componentHtml | e -}}</code></pre>
+
+    <h4 class="govuk-heading-s">Macro</h4>
+    <pre><code>{% raw %}{{ {% endraw %}{{ componentName | componentNameToMacroName }}(
+      {{- item.data | dump(2) -}}
+    ){% raw %} }}{% endraw %}</code></pre>
+
+    {% endif %}
 {% endfor %}
 {% endmacro %}

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -14,6 +14,7 @@ const eol = require('gulp-eol')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
 const postcssnormalize = require('postcss-normalize')
+const postcsspseudoclasses = require('postcss-pseudo-classes')
 
 // Compile CSS and JS task --------------
 // --------------------------------------
@@ -29,7 +30,10 @@ gulp.task('scss:compile', () => {
       postcssnormalize
     ])))
     .pipe(gulpif(!isProduction, postcss([
-      autoprefixer
+      autoprefixer,
+      // Auto-generate 'companion' classes for pseudo-selector states - e.g. a
+      // :hover class you can use to simulate the hover state in the review app
+      postcsspseudoclasses
     ])))
     .pipe(gulpif(isProduction,
       rename({


### PR DESCRIPTION
This installs the postcss pseudo-classes plugin which automatically adds in ‘companion classes’ where pseudo-selectors are used. This allows us to add class names (`:hover`, `:visited`) to force the styling of a pseudo-selector, allowing us to easily preview these style states in the review app.

We only include it as part of the postcss step for 'non-production' builds – i.e. when building for the review app, not for the dist folder.

Examples that we add to simulate states to the component YAML definitions will be even less useful in the README than some of the examples we currently have, so this also makes it possible to exclude certain examples from READMEs.

Finally, it introduces two 'proof of concepts' - it adds state examples to the button component and introduces a new 'links' example which demonstrates the two link variants in all possible states.

https://trello.com/c/z6e7tVri/611-allow-examples-to-simulate-state-to-the-review-app