### PR TITLE
Allow extra attributes to be added to warning text

### DIFF
--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -82,7 +82,7 @@
         text: 'Yes'
       },
       {
-        text: 'The text next to the icon'
+        text: 'HTML for the warning text content. If this is provided, the text argument is ignored.'
       }
     ],
     [

--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -84,6 +84,20 @@
       {
         text: 'The text next to the icon'
       }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the textarea tag'
+      }
     ]
   ]
 })}}

--- a/src/components/warning-text/template.njk
+++ b/src/components/warning-text/template.njk
@@ -1,7 +1,8 @@
 {% from "warning-text/macro.njk" import govukWarningText -%}
 
-<div class="govuk-c-warning-text
-  {%- if params.classes %} {{ params.classes }}{% endif %}">
+<div class="govuk-c-warning-text {{- ' ' + params.classes if params.classes}}"
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor -%}
+  >
   <span class="govuk-c-warning-text__icon govuk-o-circle" aria-hidden="true">!</span>
   <strong class="govuk-c-warning-text__text">
     <span class="govuk-c-warning-text__assistive">{{ params.iconFallbackText }}</span>


### PR DESCRIPTION
As a bonus, improve the description for the `html` argument to make it clearer how it relates to the `text` argument.

https://trello.com/c/MrcWCSKx/621-warning-text-component-should-accept-additional-attributes