### PR TITLE
Add ‘no visited state' link variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Breaking changes:
 
 New features:
 
-- Button hover colour now has a semantic Sass name: $govuk-button-hover-colour (PR [#406](https://github.com/alphagov/govuk-frontend/pull/406))
+- Button hover colour now has a semantic Sass name: $govuk-button-hover-colour
+  (PR [#406](https://github.com/alphagov/govuk-frontend/pull/406))
+- A new link variant has been added which removes the visited state, for cases
+  where distinguishing between visited and unvisited links is not helpful
+  (PR [#446](https://github.com/alphagov/govuk-frontend/pull/446))
 
 Fixes:
 

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -63,4 +63,18 @@
       color: $govuk-black;
     }
   }
+
+  // 'No visited state' link variant
+  //
+  // Used in cases where it is not helpful to distinguish between visited and
+  // non-visited links.
+  //
+  // For example, navigation links to pages with dynamic content like admin
+  // dashboards. The content on the page is changing all the time, so the fact
+  // that you’ve visited it before is not important.
+  .govuk-link--no-visited-state {
+    &:visited {
+      color: $govuk-link-colour;
+    }
+  }
 }

--- a/src/views/examples/links/index.njk
+++ b/src/views/examples/links/index.njk
@@ -4,7 +4,8 @@
 
 {% set variants = {
   'Link': '',
-  'Muted Link': 'govuk-link--muted'
+  'Link with no visited state': 'govuk-link--no-visited-state',
+  'Muted link': 'govuk-link--muted'
 } %}
 
 {% set states = {


### PR DESCRIPTION
Add an ‘no visited state' link variant which can be used where it is not helpful to distinguish between visited and non-visited links.

For example, navigation links to pages with dynamic content like admin dashboards. The content on the page is changing all the time, so the fact that you’ve visited it before is not important.

Closes #297

https://trello.com/c/BF3hYuXJ/622-add-link-variant-for-links-with-no-visited-state