### PR TITLE
Error if responsive mixins don't get a map

### DIFF
--- a/src/globals/scss/helpers/_spacing.scss
+++ b/src/globals/scss/helpers/_spacing.scss
@@ -18,6 +18,16 @@
 //  Base mixin, also used by 'generate-spacing-overrides' mixin
 @mixin govuk-responsive-spacing($scale-map, $property, $value: "all", $important: false, $adjustment: false) {
 
+  // Ensure that $scale-map is actually a map - it's really easy to accidentally
+  // pass in a point from the non-responsive scale, in which case this mixin
+  // would otherwise no-op silently.
+  $actual-input-type: type-of($scale-map);
+  @if $actual-input-type != "map" {
+    @error "Expected a map of breakpoints from the responsive scale, but got a "
+    + "#{$actual-input-type}. Make sure you are using a point from the "
+    + "responsive spacing scale.";
+  }
+
   // Loop through each breakpoint
   @each $breakpoint, $breakpoint-value in $scale-map {
 

--- a/src/globals/scss/helpers/_typography.scss
+++ b/src/globals/scss/helpers/_typography.scss
@@ -72,6 +72,14 @@
 //        Generally Used to create override classes.
 
 @mixin govuk-typography-responsive($font-map, $override-line-height: false, $important: false) {
+
+  // Ensure that $font-map is actually a map
+  $actual-input-type: type-of($font-map);
+  @if $actual-input-type != "map" {
+    @error "Expected a map of breakpoints and font sizes, but got a "
+    + "#{$actual-input-type}. Make sure you are passing a font map.";
+  }
+
   @each $breakpoint, $breakpoint-map in $font-map {
     $font-size: map-get($breakpoint-map, "font-size") iff($important, !important);
     $line-height: map-get($breakpoint-map, "line-height") iff($important, !important);


### PR DESCRIPTION
Add validation to the responsive spacing and typography mixins that expects maps, and errors if a user incorrectly passes in another value (for example, a value from the non-responsive spacing scale)

GitHub and Sublime Text are both struggling to correctly syntax-highlight `@error` calls for some reason, but it does work…

https://trello.com/c/OjWgpYkt/463-throw-errors-when-fe-spacing-mixins-used-wrong