### PR TITLE
Date Input - Remove margin from inputs

### DIFF
--- a/src/components/date-input/_date-input.scss
+++ b/src/components/date-input/_date-input.scss
@@ -21,6 +21,10 @@
     padding-bottom: 2px;
   }
 
+  .govuk-c-date-input__input {
+    margin-bottom: 0;
+  }
+
   .govuk-c-date-input__item--year {
     width: 70px;
   }


### PR DESCRIPTION
The Date input component has double margins, one set on the the fieldset component, the other set on the input component.

This PR uses the existing but unused `govuk-c-date-input__input` class to remove the margin-bottom on these inputs.

**Before**
<img width="581" alt="screen shot 2018-01-22 at 13 56 21" src="https://user-images.githubusercontent.com/23356842/35224293-70762c0a-ff7c-11e7-9816-4182cd5439d7.png">

**After**
<img width="588" alt="screen shot 2018-01-22 at 13 56 04" src="https://user-images.githubusercontent.com/23356842/35224300-756a4174-ff7c-11e7-9d16-6681014c5091.png">


https://trello.com/c/8vemD70Q/527-date-input-text-input-inside-fieldset-has-double-margin