### PR TITLE
Add tests for `govuk-c-tag` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Internal:
   Special thanks to [@htmlandbacon](https://github.com/htmlandbacon) and [@tyom](https://github.com/tyom) for sharing their approaches.
   (PR [#455](https://github.com/alphagov/govuk-frontend/pull/455))
 - Add example of nested lists to typography and prose scope in review app (PR [#464](https://github.com/alphagov/govuk-frontend/pull/464))
+- Add tests for tag component (PR [#457](https://github.com/alphagov/govuk-frontend/pull/457))
+
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/src/components/tag/tag.yaml
+++ b/src/components/tag/tag.yaml
@@ -2,9 +2,6 @@ examples:
  - name: default
    data:
     text: alpha
- - name: with-html
-   data:
-    html: <i>alpha</i>
  - name: inactive
    data:
     text: alpha

--- a/src/components/tag/template.test.js
+++ b/src/components/tag/template.test.js
@@ -1,0 +1,66 @@
+/* globals describe, it, expect */
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('tag')
+
+describe('Tag', () => {
+  it('renders the default example with strong element and text', () => {
+    const { $ } = render('tag', examples.default)
+
+    const $component = $('.govuk-c-tag')
+    expect($component.get(0).tagName).toEqual('strong')
+    expect($component.text()).toContain('alpha')
+  })
+
+  it('renders classes', () => {
+    const { $ } = render('tag', {
+      classes: 'govuk-c-tag--inactive',
+      text: 'alpha'
+    })
+
+    const $component = $('.govuk-c-tag')
+    expect($component.hasClass('govuk-c-tag--inactive')).toBeTruthy()
+  })
+
+  it('renders custom text', () => {
+    const { $ } = render('tag', {
+      text: 'some-custom-text'
+    })
+
+    const $component = $('.govuk-c-tag')
+    expect($component.html()).toContain('some-custom-text')
+  })
+
+  it('renders escaped html when passed to text', () => {
+    const { $ } = render('tag', {
+      text: '<span>alpha</span>'
+    })
+
+    const $component = $('.govuk-c-tag')
+    expect($component.html()).toContain('&lt;span&gt;alpha&lt;/span&gt;')
+  })
+
+  it('renders html', () => {
+    const { $ } = render('tag', {
+      html: '<span>alpha</span>'
+    })
+
+    const $component = $('.govuk-c-tag')
+    expect($component.html()).toContain('<span>alpha</span>')
+  })
+
+  it('renders attributes', () => {
+    const { $ } = render('tag', {
+      attributes: {
+        'data-test': 'attribute',
+        'id': 'my-tag'
+      },
+      html: '<span>alpha</span>'
+    })
+
+    const $component = $('.govuk-c-tag')
+    expect($component.attr('data-test')).toEqual('attribute')
+    expect($component.attr('id')).toEqual('my-tag')
+  })
+})


### PR DESCRIPTION
Add Jest tests for `govuk-c-tag` component.

These test if the component:

- renders the default example with strong tag and text correctly
- renders classes correctly
- renders custom text correctly
- renders escaped html when passed to text
- renders html correctly
- renders attributes correctly

Remove tag `--with-html` example from FE review app. This follows our decision that examples from the component definition that are now redundant and no longer useful in the review app are removed.

Trello card: https://trello.com/c/2Mv7onR8/637-automated-tests-for-tag-component