### PR TITLE
Remove font weight from link styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Fixes:
 - Remove double margin from Date input component
   (PR [#451](https://github.com/alphagov/govuk-frontend/pull/451))
 - Add top margin for nested lists (PR [#464](https://github.com/alphagov/govuk-frontend/pull/464))
+- Remove regular font weight from link styles (PR [#469](https://github.com/alphagov/govuk-frontend/pull/469))
 
 
 Internal:

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -1,7 +1,7 @@
 @include exports("links") {
 
   .govuk-link {
-    @include govuk-font-regular;
+    @include govuk-typography-common;
     @include govuk-focusable-fill;
 
     // Override the tap highlight colour (the color of the highlight that


### PR DESCRIPTION
This PR removes font weight from link styles.

Because link styles used to include a regular font weight, including a link within a heading which you would expect to render as bold, or using some other element which inherits bold font weight would have its weight set to regular. This fixes that issue.

Once released, we'll be able to remove the styles set in this commit: https://github.com/alphagov/govuk-design-system/pull/141/commits/e7dc9414958647f2e3c37eeca2d251af5ac7480f

https://trello.com/c/1bhIr3Cu/647-link-styles-include-regular-font-weight