### PR TITLE
Add tests for breadcrumbs macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Internal:
 - Add example of nested lists to typography and prose scope in review app (PR [#464](https://github.com/alphagov/govuk-frontend/pull/464))
 - Add tests for tag component (PR [#457](https://github.com/alphagov/govuk-frontend/pull/457))
 - Add tests for button component (PR [#461](https://github.com/alphagov/govuk-frontend/pull/461))
+- Add tests for breadcrumbs component (PR [#461](https://github.com/alphagov/govuk-frontend/pull/461))
 
 
 ## 0.0.22-alpha (Breaking release)

--- a/src/components/breadcrumbs/template.test.js
+++ b/src/components/breadcrumbs/template.test.js
@@ -1,0 +1,125 @@
+/* globals describe, it, expect */
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('breadcrumbs')
+
+describe('Breadcrumbs', () => {
+  describe('by default', () => {
+    it('renders with classes', () => {
+      const { $ } = render('breadcrumbs', {
+        classes: 'app-c-breadcrumbs--custom-modifier'
+      })
+
+      const $component = $('.govuk-c-breadcrumbs')
+      expect($component.hasClass('app-c-breadcrumbs--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with attributes', () => {
+      const { $ } = render('breadcrumbs', {
+        attributes: {
+          'id': 'my-navigation',
+          'role': 'navigation'
+        }
+      })
+
+      const $component = $('.govuk-c-breadcrumbs')
+      expect($component.attr('id')).toEqual('my-navigation')
+      expect($component.attr('role')).toEqual('navigation')
+    })
+
+    it('renders with items', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'text': 'Section 1'
+          },
+          {
+            'text': 'Sub-section'
+          }
+        ]
+      })
+
+      const $items = $('.govuk-c-breadcrumbs__list-item')
+      expect($items.length).toEqual(2)
+    })
+
+    it('renders item with text', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'text': 'Section 1'
+          }
+        ]
+      })
+
+      const $item = $('.govuk-c-breadcrumbs__list-item')
+      expect($item.text()).toEqual('Section 1')
+    })
+
+    it('renders item with escaped entities in text', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'text': '<span>Section 1</span>'
+          }
+        ]
+      })
+
+      const $item = $('.govuk-c-breadcrumbs__list-item')
+      expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
+    })
+
+    it('renders item with html', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'html': '<em>Section 1</em>'
+          }
+        ]
+      })
+
+      const $item = $('.govuk-c-breadcrumbs__list-item')
+      expect($item.html()).toEqual('<em>Section 1</em>')
+    })
+
+    it('renders item with anchor', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'text': 'Section 1',
+            'href': '/section'
+          }
+        ]
+      })
+
+      const $anchor = $('.govuk-c-breadcrumbs__list-item a')
+      expect($anchor.get(0).tagName).toEqual('a')
+      expect($anchor.attr('class')).toEqual('govuk-c-breadcrumbs__link')
+      expect($anchor.attr('href')).toEqual('/section')
+      expect($anchor.text()).toEqual('Section 1')
+    })
+
+    it('renders item with html inside anchor', () => {
+      const { $ } = render('breadcrumbs', {
+        items: [
+          {
+            'html': '<em>Section 1</em>',
+            'href': '/section'
+          }
+        ]
+      })
+
+      const $anchor = $('.govuk-c-breadcrumbs__list-item a')
+      expect($anchor.html()).toEqual('<em>Section 1</em>')
+    })
+  })
+
+  describe('default example', () => {
+    it('renders 2 items', () => {
+      const { $ } = render('breadcrumbs', examples.default)
+      const $items = $('.govuk-c-breadcrumbs__list-item')
+      expect($items.length).toEqual(2)
+    })
+  })
+})


### PR DESCRIPTION
This PR:
- Adds tests to breadcrumbs component to ensure the markup is rendered correctly when providing arguments to the macro.
- Updates [CHANGELOG.MD](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

*Note to reviewers*: if you feel like any example should be removed, let me know.

[Trello Card](https://trello.com/c/V9ZbJRRZ)