### PR TITLE
Add test to check readme generation

### DIFF
--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -3,8 +3,8 @@
 const request = require('request')
 const cheerio = require('cheerio')
 
-const app = require('../app/app.js')
-const lib = require('../lib/file-helper')
+const app = require('../app.js')
+const lib = require('../../lib/file-helper')
 
 const requestParams = {
   url: 'http://localhost:3000/',

--- a/package.json
+++ b/package.json
@@ -20,9 +20,10 @@
     "heroku": "gulp compile:components --destination 'public' && gulp copy-assets --destination 'public' && node app/app.js",
     "build:packages": "node bin/check-nvmrc.js && gulp build:packages --destination 'packages' && npm run test:build:packages",
     "build:dist": "node bin/check-nvmrc.js && gulp build:dist --destination 'dist' --production && npm run test:build:dist",
-    "test": "standard && gulp compile:components --destination 'public' && gulp test && npm run test:app && npm run test:components",
-    "test:app": "jest test/ --forceExit # express server fails to end process",
+    "test": "standard && gulp compile:components --destination 'public' && gulp test && npm run test:app && npm run test:components && npm run test:generate:readme",
+    "test:app": "jest app/__tests__/app.test.js --forceExit # express server fails to end process",
     "test:components": "jest src/components/",
+    "test:generate:readme": "jest tasks/gulp/__tests__/check-generate-readme.test.js",
     "test:build:packages": "jest tasks/gulp/__tests__/after-build-packages.test.js",
     "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js"
   },
@@ -83,6 +84,8 @@
     "iOS 9"
   ],
   "jest": {
-    "snapshotSerializers": ["jest-serializer-html"]
+    "snapshotSerializers": [
+      "jest-serializer-html"
+    ]
   }
 }

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -68,6 +68,65 @@ More information about when to use radios can be found on [GOV.UK Design System]
       ]
     }) }}
 
+### Radios--with-disabled
+
+[Preview the radios--with-disabled example](http://govuk-frontend-review.herokuapp.com/components/radios/with-disabled/preview)
+
+#### Markup
+
+    <div class="govuk-c-radios">
+
+      <fieldset class="govuk-c-fieldset">
+
+        <legend class="govuk-c-fieldset__legend">
+          Have you changed your name?
+
+          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+
+        </legend>
+
+        <div class="govuk-c-radios__item">
+          <input class="govuk-c-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
+          <label class="govuk-c-label govuk-c-radios__label" for="example-disabled-1">
+            Yes
+
+          </label>
+        </div>
+
+        <div class="govuk-c-radios__item">
+          <input class="govuk-c-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
+          <label class="govuk-c-label govuk-c-radios__label" for="example-disabled-2">
+            No
+
+          </label>
+        </div>
+        </fieldset>
+
+    </div>
+
+#### Macro
+
+    {{ govukRadios({
+      "idPrefix": "example-disabled",
+      "name": "example-disabled",
+      "fieldset": {
+        "legendText": "Have you changed your name?",
+        "legendHintText": "This includes changing your last name or spelling your name differently."
+      },
+      "items": [
+        {
+          "value": "yes",
+          "text": "Yes",
+          "disabled": true
+        },
+        {
+          "value": "no",
+          "text": "No",
+          "disabled": true
+        }
+      ]
+    }) }}
+
 ### Radios--with-html
 
 [Preview the radios--with-html example](http://govuk-frontend-review.herokuapp.com/components/radios/with-html/preview)
@@ -175,6 +234,76 @@ More information about when to use radios can be found on [GOV.UK Design System]
         {
           "value": "blue",
           "text": "Blue"
+        }
+      ]
+    }) }}
+
+### Radios--with-extreme-fieldset
+
+[Preview the radios--with-extreme-fieldset example](http://govuk-frontend-review.herokuapp.com/components/radios/with-extreme-fieldset/preview)
+
+#### Markup
+
+    <div class="govuk-c-radios">
+
+      <fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
+
+        <legend class="govuk-c-fieldset__legend">
+          Have you changed your name?
+
+          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+
+          <span class="govuk-c-error-message">
+             Please select an option
+          </span>
+
+        </legend>
+
+        <div class="govuk-c-radios__item">
+          <input class="govuk-c-radios__input" id="example-1" name="example" type="radio" value="yes">
+          <label class="govuk-c-label govuk-c-radios__label" for="example-1">
+            Yes
+
+          </label>
+        </div>
+
+        <div class="govuk-c-radios__item">
+          <input class="govuk-c-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+          <label class="govuk-c-label govuk-c-radios__label" for="example-2">
+            No
+
+          </label>
+        </div>
+        </fieldset>
+
+    </div>
+
+#### Macro
+
+    {{ govukRadios({
+      "idPrefix": "example",
+      "name": "example",
+      "errorMessage": {
+        "text": "Please select an option"
+      },
+      "fieldset": {
+        "classes": "app-c-fieldset--custom-modifier",
+        "attributes": {
+          "data-attribute": "value",
+          "data-second-attribute": "second-value"
+        },
+        "legendText": "Have you changed your name?",
+        "legendHintText": "This includes changing your last name or spelling your name differently."
+      },
+      "items": [
+        {
+          "value": "yes",
+          "text": "Yes"
+        },
+        {
+          "value": "no",
+          "text": "No",
+          "checked": true
         }
       ]
     }) }}

--- a/tasks/gulp/__tests__/check-generate-readme.test.js
+++ b/tasks/gulp/__tests__/check-generate-readme.test.js
@@ -1,0 +1,75 @@
+/* globals describe, it, expect */
+
+const gulp = require('gulp')
+
+const fs = require('fs')
+const path = require('path')
+const util = require('util')
+
+const lib = require('../../../lib/file-helper')
+const configPaths = require('../../../config/paths.json')
+
+const readFile = util.promisify(fs.readFile)
+
+const gulpStart = (taskName) => {
+  return new Promise((resolve, reject) => {
+    try {
+      gulp.start(taskName, resolve)
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
+require('../generate-readme.js')
+
+describe('Generating READMEs', () => {
+  it('should have no dirty changes since they should be committed into source', done => {
+    const componentNames = lib.SrcComponentList.slice()
+
+    const getReadmeContents = () => {
+      return componentNames.map(name => {
+        const filePath = path.join(configPaths.components, name, 'README.md')
+        return readFile(filePath, 'utf8')
+          .then(data => {
+            return { name, data }
+          }).catch(error => {
+            throw error
+          })
+      })
+    }
+
+    let existingReadmeContents = ''
+
+    Promise
+      .all(getReadmeContents())
+      .then((readmeContents) => {
+        existingReadmeContents = readmeContents
+        return gulpStart('generate:readme')
+      })
+      .then(() => {
+        return Promise.all(getReadmeContents())
+      })
+      .then((readmeContents) => {
+        const dirtyReadmeNames =
+          readmeContents
+            .filter(readme => {
+              const matchingReadme = existingReadmeContents.find(existingReadme => {
+                return (existingReadme.name === readme.name)
+              })
+              const readmeIsDirty = (readme.data !== matchingReadme.data)
+              return readmeIsDirty
+            })
+            .map(readme => {
+              return readme.name
+            })
+            .join(', ')
+
+        expect(dirtyReadmeNames).toBeFalsy()
+        done()
+      })
+      .catch(error => {
+        throw error
+      })
+  })
+})


### PR DESCRIPTION
This is a bit complicated, not sure if there's something better we could do here.

Maybe we should just remove dynamic building of READMEs and do something else?

Currently fails because Travis is being run in v7 and `util.promisify` requires 8.x see https://github.com/alphagov/govuk-frontend/pull/462

This should fail because of the lack of checked in READMEs once the above is addressed.

Note: Currently passes after the second run, since it is not aware of git changes.