### PR TITLE
Add tests for `govuk-c-radios` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Internal:
 - Add tests for details component (PR [#480](https://github.com/alphagov/govuk-frontend/pull/480))
 - Add tests for warning text component (PR [#479](https://github.com/alphagov/govuk-frontend/pull/479))
 - Add tests for error-summary component (PR [#489](https://github.com/alphagov/govuk-frontend/pull/489))
+- Add tests for radios component (PR [#476](https://github.com/alphagov/govuk-frontend/pull/476))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -12,12 +12,24 @@ nunjucks.configure(configPaths.components, {
   lstripBlocks: true
 })
 
+/**
+ * Render a component's template for testing
+ * @param {string} componentName
+ * @param {string} params parameters that are used in the component template
+ * @returns {object} returns object that includes raw HTML (output) and
+ * also a cheerio (jQuery) instance of the template for easy DOM querying
+ */
 function render (componentName, params) {
   const output = nunjucks.render(componentName + '/template.njk', { params })
   const $ = cheerio.load(output)
   return { output, $ }
 }
 
+/**
+ * Get examples from a component's metadata file
+ * @param {string} componentName
+ * @returns {object} returns object that includes all examples at once
+ */
 function getExamples (componentName) {
   const file = fs.readFileSync(
     path.join(configPaths.components, componentName, `${componentName}.yaml`),
@@ -35,6 +47,16 @@ function getExamples (componentName) {
   return examples
 }
 
+/**
+ * Get the raw HTML representation of a component, and remove any other
+ * child elements that do not match the component.
+ * Relies on B.E.M naming ensuring that child components relating to a component
+ * are namespaced.
+ * @param {function} $ requires an instance of cheerio (jQuery) that includes the
+ * rendered component.
+ * @param {string} className the top level class 'Block' in B.E.M terminology
+ * @returns {string} returns HTML
+ */
 function htmlWithClassName ($, className) {
   const $component = $(className)
   const classSelector = className.replace('.', '')

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -16,13 +16,11 @@ nunjucks.configure(configPaths.components, {
  * Render a component's template for testing
  * @param {string} componentName
  * @param {string} params parameters that are used in the component template
- * @returns {object} returns object that includes raw HTML (output) and
- * also a cheerio (jQuery) instance of the template for easy DOM querying
+ * @returns {function} returns cheerio (jQuery) instance of the template for easy DOM querying
  */
 function render (componentName, params) {
   const output = nunjucks.render(componentName + '/template.njk', { params })
-  const $ = cheerio.load(output)
-  return { output, $ }
+  return cheerio.load(output)
 }
 
 /**

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -35,4 +35,12 @@ function getExamples (componentName) {
   return examples
 }
 
-module.exports = { render, getExamples }
+function htmlWithClassName ($, className) {
+  const $component = $(className)
+  const classSelector = className.replace('.', '')
+  // Remove all other elements that do not match this component
+  $component.find(`[class]:not([class^=${classSelector}])`).remove()
+  return $.html($component)
+}
+
+module.exports = { render, getExamples, htmlWithClassName }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "gulp-to-markdown": "^1.0.0",
     "gulp-uglify": "^3.0.0",
     "jest": "^22.1.4",
+    "jest-serializer-html": "^5.0.0",
     "js-yaml": "^3.10.0",
     "lerna": "^2.3.1",
     "merge-stream": "^1.0.1",
@@ -78,5 +79,8 @@
     "ie 8",
     "ie 9",
     "iOS 9"
-  ]
+  ],
+  "jest": {
+    "snapshotSerializers": ["jest-serializer-html"]
+  }
 }

--- a/src/components/back-link/template.test.js
+++ b/src/components/back-link/template.test.js
@@ -16,7 +16,7 @@ describe('back-link component', () => {
   })
 
   it('renders the default example with an anchor, href and text correctly', () => {
-    const { $ } = render('back-link', examples.default)
+    const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-c-back-link')
     expect($component.get(0).tagName).toEqual('a')
@@ -25,7 +25,7 @@ describe('back-link component', () => {
   })
 
   it('renders classes correctly', () => {
-    const { $ } = render('back-link', {
+    const $ = render('back-link', {
       classes: 'app-c-back-link--custom-class',
       href: '#',
       html: '<b>Back</b>'
@@ -36,7 +36,7 @@ describe('back-link component', () => {
   })
 
   it('renders custom text correctly', () => {
-    const { $ } = render('back-link', {
+    const $ = render('back-link', {
       href: '#',
       text: 'Home'
     })
@@ -46,7 +46,7 @@ describe('back-link component', () => {
   })
 
   it('renders escaped html when passed to text', () => {
-    const { $ } = render('back-link', {
+    const $ = render('back-link', {
       href: '#',
       text: '<b>Home</b>'
     })
@@ -56,7 +56,7 @@ describe('back-link component', () => {
   })
 
   it('renders html correctly', () => {
-    const { $ } = render('back-link', {
+    const $ = render('back-link', {
       href: '#',
       html: '<b>Back</b>'
     })
@@ -66,7 +66,7 @@ describe('back-link component', () => {
   })
 
   it('renders attributes correctly', () => {
-    const { $ } = render('back-link', {
+    const $ = render('back-link', {
       attributes: {
         'data-test': 'attribute',
         'aria-label': 'Back to home'

--- a/src/components/breadcrumbs/template.test.js
+++ b/src/components/breadcrumbs/template.test.js
@@ -7,7 +7,7 @@ const examples = getExamples('breadcrumbs')
 describe('Breadcrumbs', () => {
   describe('by default', () => {
     it('renders with classes', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         classes: 'app-c-breadcrumbs--custom-modifier'
       })
 
@@ -16,7 +16,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders with attributes', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         attributes: {
           'id': 'my-navigation',
           'role': 'navigation'
@@ -29,7 +29,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders with items', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'text': 'Section 1'
@@ -45,7 +45,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with text', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'text': 'Section 1'
@@ -58,7 +58,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with escaped entities in text', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'text': '<span>Section 1</span>'
@@ -71,7 +71,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with html', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'html': '<em>Section 1</em>'
@@ -84,7 +84,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with anchor', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'text': 'Section 1',
@@ -101,7 +101,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with html inside anchor', () => {
-      const { $ } = render('breadcrumbs', {
+      const $ = render('breadcrumbs', {
         items: [
           {
             'html': '<em>Section 1</em>',
@@ -117,7 +117,7 @@ describe('Breadcrumbs', () => {
 
   describe('default example', () => {
     it('renders 2 items', () => {
-      const { $ } = render('breadcrumbs', examples.default)
+      const $ = render('breadcrumbs', examples.default)
       const $items = $('.govuk-c-breadcrumbs__list-item')
       expect($items.length).toEqual(2)
     })

--- a/src/components/button/template.test.js
+++ b/src/components/button/template.test.js
@@ -7,7 +7,7 @@ const examples = getExamples('button')
 describe('Button', () => {
   describe('input[type=submit]', () => {
     it('renders the default example', () => {
-      const { $ } = render('button', examples.default)
+      const $ = render('button', examples.default)
 
       const $component = $('.govuk-c-button')
       expect($component.get(0).tagName).toEqual('input')
@@ -16,7 +16,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'input',
         attributes: {
           'aria-controls': 'example-id',
@@ -30,7 +30,7 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'input',
         classes: 'app-c-button--custom-modifier'
       })
@@ -40,7 +40,7 @@ describe('Button', () => {
     })
 
     it('renders with disabled', () => {
-      const { $ } = render('button', examples.disabled)
+      const $ = render('button', examples.disabled)
 
       const $component = $('.govuk-c-button')
       expect($component.attr('aria-disabled')).toEqual('true')
@@ -49,7 +49,7 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'input',
         name: 'start-now'
       })
@@ -59,7 +59,7 @@ describe('Button', () => {
     })
 
     it('renders with type', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'input',
         type: 'button'
       })
@@ -71,7 +71,7 @@ describe('Button', () => {
 
   describe('link', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'a',
         href: '/',
         text: 'Continue'
@@ -85,7 +85,7 @@ describe('Button', () => {
     })
 
     it('renders with hash href if no href passed', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'a'
       })
 
@@ -94,7 +94,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'a',
         attributes: {
           'aria-controls': 'example-id',
@@ -108,7 +108,7 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'a',
         classes: 'app-c-button--custom-modifier'
       })
@@ -118,7 +118,7 @@ describe('Button', () => {
     })
 
     it('renders with disabled', () => {
-      const { $ } = render('button', examples['disabled-link'])
+      const $ = render('button', examples['disabled-link'])
 
       const $component = $('.govuk-c-button')
       expect($component.hasClass('govuk-c-button--disabled')).toBeTruthy()
@@ -127,7 +127,7 @@ describe('Button', () => {
 
   describe('with explicit button set by "element"', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const { $ } = render('button', examples['explicit-button'])
+      const $ = render('button', examples['explicit-button'])
 
       const $component = $('.govuk-c-button')
       expect($component.get(0).tagName).toEqual('button')
@@ -135,7 +135,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         attributes: {
           'aria-controls': 'example-id',
@@ -149,7 +149,7 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         classes: 'app-c-button--custom-modifier'
       })
@@ -159,7 +159,7 @@ describe('Button', () => {
     })
 
     it('renders with disabled', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         disabled: true
       })
@@ -171,7 +171,7 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         name: 'start-now'
       })
@@ -181,7 +181,7 @@ describe('Button', () => {
     })
 
     it('renders with value', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         value: 'start'
       })
@@ -191,7 +191,7 @@ describe('Button', () => {
     })
 
     it('renders with html', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         html: 'Start <em>now</em>'
       })
@@ -201,7 +201,7 @@ describe('Button', () => {
     })
 
     it('renders with type', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         element: 'button',
         type: 'button',
         text: 'Start now'
@@ -214,7 +214,7 @@ describe('Button', () => {
 
   describe('implicitly as no "element" param is set', () => {
     it('renders a link if you pass an href', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         href: '/'
       })
 
@@ -223,7 +223,7 @@ describe('Button', () => {
     })
 
     it('renders a button if you pass html', () => {
-      const { $ } = render('button', {
+      const $ = render('button', {
         html: 'Start <em>now</em>'
       })
 
@@ -232,7 +232,7 @@ describe('Button', () => {
     })
 
     it('renders an input[type=submit] if you don\'t pass anything', () => {
-      const { $ } = render('button')
+      const $ = render('button')
 
       const $component = $('.govuk-c-button')
       expect($component.get(0).tagName).toEqual('input')

--- a/src/components/details/template.test.js
+++ b/src/components/details/template.test.js
@@ -6,14 +6,14 @@ const examples = getExamples('details')
 
 describe('Details', () => {
   it('renders a details element', () => {
-    const { $ } = render('details', examples.default)
+    const $ = render('details', examples.default)
 
     const $component = $('.govuk-c-details')
     expect($component.get(0).tagName).toEqual('details')
   })
 
   it('includes a nested summary', () => {
-    const { $ } = render('details', examples.default)
+    const $ = render('details', examples.default)
 
     // Look for the summary element _within_ the details element
     const $summary = $('.govuk-c-details .govuk-c-details__summary')
@@ -21,7 +21,7 @@ describe('Details', () => {
   })
 
   it('allows text to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       text: 'More about the greater than symbol (>)'
     })
 
@@ -30,7 +30,7 @@ describe('Details', () => {
   })
 
   it('allows HTML to be passed un-escaped', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       html: 'More about <b>bold text</b>'
     })
 
@@ -39,7 +39,7 @@ describe('Details', () => {
   })
 
   it('allows summary text to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       summaryText: 'The greater than symbol (>) is the best'
     })
 
@@ -48,7 +48,7 @@ describe('Details', () => {
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       summaryHtml: 'Use <b>bold text</b> sparingly'
     })
 
@@ -57,7 +57,7 @@ describe('Details', () => {
   })
 
   it('allows additional classes to be added to the details element', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       classes: 'some-additional-class'
     })
 
@@ -66,7 +66,7 @@ describe('Details', () => {
   })
 
   it('allows additional attributes to be added to the details element', () => {
-    const { $ } = render('details', {
+    const $ = render('details', {
       attributes: {
         'data-some-data-attribute': 'i-love-data',
         'another-attribute': 'true'

--- a/src/components/error-summary/template.test.js
+++ b/src/components/error-summary/template.test.js
@@ -6,35 +6,35 @@ const examples = getExamples('error-summary')
 
 describe('Error-summary', () => {
   it('aria-labelledby attribute matches the title id', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const ariaAttr = $('.govuk-c-error-summary').attr('aria-labelledby')
 
     expect(ariaAttr).toEqual('error-summary-title')
   })
 
   it('has role=alert attribute', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const roleAttr = $('.govuk-c-error-summary').attr('role')
 
     expect(roleAttr).toEqual('alert')
   })
 
   it('has the correct tabindex attribute to be focussed', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const tabindexAttr = $('.govuk-c-error-summary').attr('tabindex')
 
     expect(tabindexAttr).toEqual('-1')
   })
 
   it('renders title text', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const summaryTitle = $('.govuk-c-error-summary__title').text().trim()
 
     expect(summaryTitle).toEqual('Message to alert the user to a problem goes here')
   })
 
   it('allows title text to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       titleText: 'Alert, <em>alert</em>'
     })
 
@@ -43,7 +43,7 @@ describe('Error-summary', () => {
   })
 
   it('allows title HTML to be passed un-escaped', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       titleHtml: 'Alert, <em>alert</em>'
     })
 
@@ -52,14 +52,14 @@ describe('Error-summary', () => {
   })
 
   it('renders description text', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const summaryDescription = $('.govuk-c-error-summary__body p').text().trim()
 
     expect(summaryDescription).toEqual('Optional description of the errors and how to correct them')
   })
 
   it('allows description text to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       descriptionText: 'See errors below (▼)'
     })
 
@@ -68,7 +68,7 @@ describe('Error-summary', () => {
   })
 
   it('allows description HTML to be passed un-escaped', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       descriptionHtml: 'See <span>errors</span> below'
     })
 
@@ -77,7 +77,7 @@ describe('Error-summary', () => {
   })
 
   it('allows additional classes to be added to the error-summary component', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       classes: 'extra-class one-more-class'
     })
 
@@ -86,7 +86,7 @@ describe('Error-summary', () => {
   })
 
   it('allows additional attributes to be added to the error-summary component', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       attributes: {
         'first-attribute': 'true',
         'second-attribute': 'false'
@@ -99,35 +99,35 @@ describe('Error-summary', () => {
   })
 
   it('number of error items matches the number of items specified', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const errorList = $('.govuk-c-error-summary .govuk-c-error-summary__list li')
 
     expect(errorList).toHaveLength(2)
   })
 
   it('error list item is an anchor tag if href attribute is specified', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
 
     const errorItem = $('.govuk-c-error-summary .govuk-c-error-summary__list li:first-child')
     expect(errorItem.children().get(0).tagName).toEqual('a')
   })
 
   it('render anchor tag href attribute is correctly', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
 
     const errorItem = $('.govuk-c-error-summary .govuk-c-error-summary__list li:first-child a')
     expect(errorItem.attr('href')).toEqual('#example-error-1')
   })
 
   it('renders error item text', () => {
-    const { $ } = render('error-summary', examples.default)
+    const $ = render('error-summary', examples.default)
     const errorItemText = $('.govuk-c-error-summary .govuk-c-error-summary__list li:first-child').text().trim()
 
     expect(errorItemText).toEqual('Descriptive link to the question with an error')
   })
 
   it('allows error item HTML to be passed un-escaped', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       'errorList': [
         {
           'html': 'Descriptive link to the <b>question</b> with an error'
@@ -141,7 +141,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item text to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       'errorList': [
         {
           'text': 'Descriptive link to the <b>question</b> with an error'
@@ -155,7 +155,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       'errorList': [
         {
           'html': 'Descriptive link to the <b>question</b> with an error',
@@ -170,7 +170,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
-    const { $ } = render('error-summary', {
+    const $ = render('error-summary', {
       'errorList': [
         {
           'text': 'Descriptive link to the <b>question</b> with an error',

--- a/src/components/radios/__snapshots__/template.test.js.snap
+++ b/src/components/radios/__snapshots__/template.test.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Radios nested dependant components passes through fieldset params without breaking 1`] = `
+
+<span class="govuk-c-error-message">
+  Please select an option
+</span>
+
+`;
+
+exports[`Radios nested dependant components passes through fieldset params without breaking 2`] = `
+
+<fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier"
+          data-attribute="value"
+          data-second-attribute="second-value"
+>
+  <legend class="govuk-c-fieldset__legend">
+    Have you changed your name?
+    <span class="govuk-c-fieldset__hint">
+      This includes changing your last name or spelling your name differently.
+    </span>
+  </legend>
+</fieldset>
+
+`;
+
+exports[`Radios nested dependant components passes through html fieldset params without breaking 1`] = `
+
+<fieldset class="govuk-c-fieldset">
+  <legend class="govuk-c-fieldset__legend">
+    Have &lt;b&gt;you&lt;/b&gt; changed your name?
+    <span class="govuk-c-fieldset__hint">
+      This
+      <b>
+        includes
+      </b>
+      changing your last name or spelling your name differently.
+    </span>
+  </legend>
+</fieldset>
+
+`;
+
+exports[`Radios nested dependant components passes through label params without breaking 1`] = `
+
+<label class="govuk-c-label govuk-c-radios__label"
+       data-attribute="value"
+       data-second-attribute="second-value"
+       for="example-name-1"
+>
+  <b>
+    Yes
+  </b>
+</label>
+<label class="govuk-c-label govuk-c-radios__label"
+       for="example-name-2"
+>
+  &lt;b&gt;No&lt;/b&gt;
+</label>
+
+`;

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -14,6 +14,22 @@ examples:
         text: No
         checked: true
 
+- name: with-disabled
+  data:
+    idPrefix: 'example-disabled'
+    name: 'example-disabled'
+    fieldset:
+      legendText: Have you changed your name?
+      legendHintText:
+        This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+        disabled: true
+      - value: no
+        text: No
+        disabled: true
+
 - name: with-html
   data:
     idPrefix: 'housing-act'

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -57,3 +57,24 @@ examples:
         text: 'Green'
       - value: "blue"
         text: "Blue"
+
+- name: with-extreme-fieldset
+  data:
+    idPrefix: 'example'
+    name: 'example'
+    errorMessage:
+      text: 'Please select an option'
+    fieldset:
+      classes: 'app-c-fieldset--custom-modifier'
+      attributes:
+        'data-attribute': 'value'
+        'data-second-attribute': 'second-value'
+      legendText: Have you changed your name?
+      legendHintText:
+        This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+        checked: true

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -1,0 +1,187 @@
+/* globals describe, it, expect */
+
+const { render } = require('../../../lib/jest-helpers')
+
+describe('Radios', () => {
+  it('render example with minimum required name and items', () => {
+    const { $ } = render('radios', {
+      name: 'example-name',
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes'
+        },
+        {
+          value: 'no',
+          text: 'No'
+        }
+      ]
+    })
+
+    const $component = $('.govuk-c-radios')
+
+    const $firstInput = $component.find('.govuk-c-radios__item:first-child input')
+    const $firstLabel = $component.find('.govuk-c-radios__item:first-child label')
+    expect($firstInput.attr('name')).toEqual('example-name')
+    expect($firstInput.val()).toEqual('yes')
+    expect($firstLabel.text()).toContain('Yes')
+
+    const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
+    const $lastLabel = $component.find('.govuk-c-radios__item:last-child label')
+    expect($lastInput.attr('name')).toEqual('example-name')
+    expect($lastInput.val()).toEqual('no')
+    expect($lastLabel.text()).toContain('No')
+  })
+
+  it('render classes', () => {
+    const { $ } = render('radios', {
+      name: 'example-name',
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes'
+        },
+        {
+          value: 'no',
+          text: 'No'
+        }
+      ],
+      classes: 'app-c-radios--custom-modifier'
+    })
+
+    const $component = $('.govuk-c-radios')
+
+    expect($component.hasClass('app-c-radios--custom-modifier')).toBeTruthy()
+  })
+
+  it('render attributes', () => {
+    const { $ } = render('radios', {
+      name: 'example-name',
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes'
+        },
+        {
+          value: 'no',
+          text: 'No'
+        }
+      ],
+      attributes: {
+        'data-attribute': 'value',
+        'data-second-attribute': 'second-value'
+      }
+    })
+
+    const $component = $('.govuk-c-radios')
+
+    expect($component.attr('data-attribute')).toEqual('value')
+    expect($component.attr('data-second-attribute')).toEqual('second-value')
+  })
+
+  describe('items', () => {
+    it('render a matching label and input using name by default', () => {
+      const { $ } = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          },
+          {
+            value: 'no',
+            text: 'No'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-c-radios')
+
+      const $firstInput = $component.find('.govuk-c-radios__item:first-child input')
+      const $firstLabel = $component.find('.govuk-c-radios__item:first-child label')
+      expect($firstInput.attr('id')).toEqual('example-name-1')
+      expect($firstLabel.attr('for')).toEqual('example-name-1')
+
+      const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
+      const $lastLabel = $component.find('.govuk-c-radios__item:last-child label')
+      expect($lastInput.attr('id')).toEqual('example-name-2')
+      expect($lastLabel.attr('for')).toEqual('example-name-2')
+    })
+
+    it('render a matching label and input using custom idPrefix', () => {
+      const { $ } = render('radios', {
+        idPrefix: 'custom',
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          },
+          {
+            value: 'no',
+            text: 'No'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-c-radios')
+
+      const $firstInput = $component.find('.govuk-c-radios__item:first-child input')
+      const $firstLabel = $component.find('.govuk-c-radios__item:first-child label')
+      expect($firstInput.attr('id')).toEqual('custom-1')
+      expect($firstLabel.attr('for')).toEqual('custom-1')
+
+      const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
+      const $lastLabel = $component.find('.govuk-c-radios__item:last-child label')
+      expect($lastInput.attr('id')).toEqual('custom-2')
+      expect($lastLabel.attr('for')).toEqual('custom-2')
+    })
+
+    it('render disabled', () => {
+      const { $ } = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes',
+            disabled: true
+          },
+          {
+            value: 'no',
+            text: 'No',
+            disabled: true
+          }
+        ]
+      })
+
+      const $component = $('.govuk-c-radios')
+
+      const $firstInput = $component.find('.govuk-c-radios__item:first-child input')
+      expect($firstInput.attr('disabled')).toEqual('disabled')
+
+      const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
+      expect($lastInput.attr('disabled')).toEqual('disabled')
+    })
+
+    it('render checked', () => {
+      const { $ } = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          },
+          {
+            value: 'no',
+            text: 'No',
+            checked: true
+          }
+        ]
+      })
+
+      const $component = $('.govuk-c-radios')
+      const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
+      expect($lastInput.attr('checked')).toEqual('checked')
+    })
+  })
+})

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -6,7 +6,7 @@ const examples = getExamples('radios')
 
 describe('Radios', () => {
   it('render example with minimum required name and items', () => {
-    const { $ } = render('radios', {
+    const $ = render('radios', {
       name: 'example-name',
       items: [
         {
@@ -36,7 +36,7 @@ describe('Radios', () => {
   })
 
   it('render classes', () => {
-    const { $ } = render('radios', {
+    const $ = render('radios', {
       name: 'example-name',
       items: [
         {
@@ -57,7 +57,7 @@ describe('Radios', () => {
   })
 
   it('render attributes', () => {
-    const { $ } = render('radios', {
+    const $ = render('radios', {
       name: 'example-name',
       items: [
         {
@@ -83,7 +83,7 @@ describe('Radios', () => {
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         name: 'example-name',
         items: [
           {
@@ -111,7 +111,7 @@ describe('Radios', () => {
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         idPrefix: 'custom',
         name: 'example-name',
         items: [
@@ -140,7 +140,7 @@ describe('Radios', () => {
     })
 
     it('render disabled', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         name: 'example-name',
         items: [
           {
@@ -166,7 +166,7 @@ describe('Radios', () => {
     })
 
     it('render checked', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         name: 'example-name',
         items: [
           {
@@ -189,7 +189,7 @@ describe('Radios', () => {
 
   describe('nested dependant components', () => {
     it('passes through label params without breaking', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         name: 'example-name',
         items: [
           {
@@ -214,14 +214,14 @@ describe('Radios', () => {
     })
 
     it('passes through fieldset params without breaking', () => {
-      const { $ } = render('radios', examples['with-extreme-fieldset'])
+      const $ = render('radios', examples['with-extreme-fieldset'])
 
       expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
       expect(htmlWithClassName($, '.govuk-c-fieldset')).toMatchSnapshot()
     })
 
     it('passes through html fieldset params without breaking', () => {
-      const { $ } = render('radios', {
+      const $ = render('radios', {
         name: 'example-name',
         items: [
           {

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -1,6 +1,8 @@
 /* globals describe, it, expect */
 
-const { render } = require('../../../lib/jest-helpers')
+const { render, getExamples, htmlWithClassName } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('radios')
 
 describe('Radios', () => {
   it('render example with minimum required name and items', () => {
@@ -182,6 +184,62 @@ describe('Radios', () => {
       const $component = $('.govuk-c-radios')
       const $lastInput = $component.find('.govuk-c-radios__item:last-child input')
       expect($lastInput.attr('checked')).toEqual('checked')
+    })
+  })
+
+  describe('nested dependant components', () => {
+    it('passes through label params without breaking', () => {
+      const { $ } = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            html: '<b>Yes</b>',
+            label: {
+              attributes: {
+                'data-attribute': 'value',
+                'data-second-attribute': 'second-value'
+              }
+            }
+          },
+          {
+            value: 'no',
+            text: '<b>No</b>',
+            checked: true
+          }
+        ]
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-radios__label')).toMatchSnapshot()
+    })
+
+    it('passes through fieldset params without breaking', () => {
+      const { $ } = render('radios', examples['with-extreme-fieldset'])
+
+      expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
+      expect(htmlWithClassName($, '.govuk-c-fieldset')).toMatchSnapshot()
+    })
+
+    it('passes through html fieldset params without breaking', () => {
+      const { $ } = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          },
+          {
+            value: 'no',
+            text: 'No'
+          }
+        ],
+        fieldset: {
+          legendText: 'Have <b>you</b> changed your name?',
+          legendHintHtml: 'This <b>includes</b> changing your last name or spelling your name differently.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-fieldset')).toMatchSnapshot()
     })
   })
 })

--- a/src/components/tag/template.test.js
+++ b/src/components/tag/template.test.js
@@ -6,7 +6,7 @@ const examples = getExamples('tag')
 
 describe('Tag', () => {
   it('renders the default example with strong element and text', () => {
-    const { $ } = render('tag', examples.default)
+    const $ = render('tag', examples.default)
 
     const $component = $('.govuk-c-tag')
     expect($component.get(0).tagName).toEqual('strong')
@@ -14,7 +14,7 @@ describe('Tag', () => {
   })
 
   it('renders classes', () => {
-    const { $ } = render('tag', {
+    const $ = render('tag', {
       classes: 'govuk-c-tag--inactive',
       text: 'alpha'
     })
@@ -24,7 +24,7 @@ describe('Tag', () => {
   })
 
   it('renders custom text', () => {
-    const { $ } = render('tag', {
+    const $ = render('tag', {
       text: 'some-custom-text'
     })
 
@@ -33,7 +33,7 @@ describe('Tag', () => {
   })
 
   it('renders escaped html when passed to text', () => {
-    const { $ } = render('tag', {
+    const $ = render('tag', {
       text: '<span>alpha</span>'
     })
 
@@ -42,7 +42,7 @@ describe('Tag', () => {
   })
 
   it('renders html', () => {
-    const { $ } = render('tag', {
+    const $ = render('tag', {
       html: '<span>alpha</span>'
     })
 
@@ -51,7 +51,7 @@ describe('Tag', () => {
   })
 
   it('renders attributes', () => {
-    const { $ } = render('tag', {
+    const $ = render('tag', {
       attributes: {
         'data-test': 'attribute',
         'id': 'my-tag'

--- a/src/components/warning-text/template.test.js
+++ b/src/components/warning-text/template.test.js
@@ -6,28 +6,28 @@ const examples = getExamples('warning-text')
 
 describe('Warning text', () => {
   it('renders the default example with text', () => {
-    const { $ } = render('warning-text', examples.default)
+    const $ = render('warning-text', examples.default)
 
     const $component = $('.govuk-c-warning-text')
     expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
   })
 
   it('renders the default example with assistive text', () => {
-    const { $ } = render('warning-text', examples.default)
+    const $ = render('warning-text', examples.default)
 
     const $assistiveText = $('.govuk-c-warning-text__assistive')
     expect($assistiveText.text()).toEqual('Warning')
   })
 
   it('hides the icon from screen readers using the aria-hidden attribute', () => {
-    const { $ } = render('warning-text', examples.default)
+    const $ = render('warning-text', examples.default)
 
     const $icon = $('.govuk-c-warning-text__icon')
     expect($icon.attr('aria-hidden')).toEqual('true')
   })
 
   it('renders classes', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       classes: 'govuk-c-warning-text--custom-class',
       text: 'Warning text'
     })
@@ -37,7 +37,7 @@ describe('Warning text', () => {
   })
 
   it('renders custom text', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       text: 'Some custom warning text'
     })
     const $component = $('.govuk-c-warning-text')
@@ -45,7 +45,7 @@ describe('Warning text', () => {
   })
 
   it('renders custom assistive text', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       iconFallbackText: 'Some custom fallback text'
     })
     const $assistiveText = $('.govuk-c-warning-text__assistive')
@@ -53,7 +53,7 @@ describe('Warning text', () => {
   })
 
   it('renders escaped html when passed to text', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       text: '<span>Some custom warning text</span>'
     })
 
@@ -62,7 +62,7 @@ describe('Warning text', () => {
   })
 
   it('renders html', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       html: '<span>Some custom warning text</span>'
     })
 
@@ -71,7 +71,7 @@ describe('Warning text', () => {
   })
 
   it('renders attributes', () => {
-    const { $ } = render('warning-text', {
+    const $ = render('warning-text', {
       attributes: {
         'data-test': 'attribute',
         'id': 'my-warning-text'


### PR DESCRIPTION
- includes new example disabled radios
- includes new example with all fieldset params set

Uses snapshot testing to test the dependant components - Label and Fieldset.
This ensures that all values that can be passed through the Radio components params through to
either component is tested, and if we change the behavour in either the Label or Fieldset component
we will see a change to confirm in this component.

Snapshot testing makes use of a [custom serializer](https://github.com/rayrutjes/jest-serializer-html) to make the diffs easy to read

As part of https://trello.com/c/G8rFbXWB/641-automated-tests-for-radios-component