### PR TITLE
Remove redundant border div from details component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Fixes:
   (PR [#451](https://github.com/alphagov/govuk-frontend/pull/451))
 - Add top margin for nested lists (PR [#464](https://github.com/alphagov/govuk-frontend/pull/464))
 - Remove regular font weight from link styles (PR [#469](https://github.com/alphagov/govuk-frontend/pull/469))
+- Remove redundant 'govuk-c-border' div from the details component
+  (PR [#481](https://github.com/alphagov/govuk-frontend/pull/481))
 
 
 Internal:

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -22,10 +22,8 @@ More information about when to use details can be found on [GOV.UK Design System
           Help with nationality
         </span>
       </summary>
-      <div class="govuk-c-border govuk-c-border--left-narrow">
-        <div class="govuk-c-details__text">
-          We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
-        </div>
+      <div class="govuk-c-details__text">
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
       </div>
     </details>
 
@@ -48,9 +46,8 @@ More information about when to use details can be found on [GOV.UK Design System
           Where to find your National Insurance Number
         </span>
       </summary>
-      <div class="govuk-c-border govuk-c-border--left-narrow">
-        <div class="govuk-c-details__text">
-          Your National Insurance number can be found on
+      <div class="govuk-c-details__text">
+        Your National Insurance number can be found on
     <ul>
       <li>your National Insurance card</li>
       <li>your payslip</li>
@@ -59,7 +56,6 @@ More information about when to use details can be found on [GOV.UK Design System
       <li>tax return</li>
     </ul>
 
-        </div>
       </div>
     </details>
 

--- a/src/components/details/template.njk
+++ b/src/components/details/template.njk
@@ -4,9 +4,7 @@
       {{ params.summaryHtml | safe if params.summaryHtml else params.summaryText }}
     </span>
   </summary>
-  <div class="govuk-c-border govuk-c-border--left-narrow">
-    <div class="govuk-c-details__text">
-      {{ params.html | safe if params.html else params.text }}
-    </div>
+  <div class="govuk-c-details__text">
+    {{ params.html | safe if params.html else params.text }}
   </div>
 </details>


### PR DESCRIPTION
This div was included when the original component was created in 2e6769a but as far as I can tell has never actually done anything. There are no other mentions of the string “govuk-c-border” within the src directory.

Verified by inspecting the element in Chrome to ensure that the element did not have any styling applied and by manually comparing the component before and after removal.

I also ran `git log -p -S "govuk-c-border" -- . ':(exclude)*README.md' ':(exclude)dist' ':(exclude)packages’` and grepped the output for mentions of govuk-c-border in stylesheets.

https://trello.com/c/ULH6d6Zr/676-remove-redundant-govuk-c-border-div-from-details-component