### PR TITLE
Remove README content from review app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ Internal:
   (PR [#427](https://github.com/alphagov/govuk-frontend/pull/427))
 - Improve documentation around publishing (PR [#430](https://github.com/alphagov/govuk-frontend/pull/430))
 - Improve documentation around contributing (PR [#433](https://github.com/alphagov/govuk-frontend/pull/433))
+- Remove readme content from review app (PR [#482](https://github.com/alphagov/govuk-frontend/pull/482))
 
 ## 0.0.21-alpha (Breaking release)
 Skipped 0.0.20-alpha due to difficulties with publishing.

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -1,3 +1,4 @@
+{% set componentName = componentPath %}
 {% extends "layout-debug.njk" %}
 
 {% block content %}
@@ -9,7 +10,6 @@
   {% include componentName +"/"+ componentName +".njk" ignore missing %}
 {% endset %}
 
-{% if not isReadme %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {{ govukBreadcrumbs({
@@ -19,121 +19,15 @@
   ]
 }) }}
 <div class="govuk-o-main-wrapper">
-{% endif %}
   <h1 class="govuk-heading-xl">
   {% block componentName %}
-  {{ componentName | replace("-", " ") | capitalize }}
+  {{ componentNameHuman }}
   {% endblock %}
   </h1>
-
-  {% if isReadme %}
-  <h2 class="govuk-heading-l">Introduction</h2>
-  {% endif %}
-  <p class="govuk-body-lead">
-  {% block componentDescription %}
-  {% endblock %}
-  </p>
-
-  {% if componentGuidanceLink %}
-  <h2 class="govuk-heading-l">Guidance</h2>
-  <p class="govuk-body">
-    Find out when to use the {{ componentNameHuman }} component in your service in the <a href="{{- componentGuidanceLink -}}" class="govuk-link">GOV.UK Design System</a>.
-  </p>
-  {% endif %}
-
-  {% if isReadme %}
-  <h2 class="govuk-heading-l">Quick start examples</h2>
-  <p class="govuk-body">{% block componentHtmlUsageWriteup %}{% endblock %}</p>
-  {% endif %}
 
   {% from "showExamples.njk" import showExamples %}
   {% block examples %}
   {{ showExamples(componentName, componentData) }}
   {% endblock %}
-
-  {% if isReadme %}
-  <h2 class="govuk-heading-l">Dependencies</h2>
-
-  <p class="govuk-body">To consume the {{ componentName }} component you must be running npm version 5 or above. </p>
-
-  <p class="govuk-body">{% block componentDependencies %}{% endblock %}</p>
-
-  <h2 class="govuk-heading-l">Installation</h2>
-
-  <pre><code>
-  npm install --save @govuk-frontend/{{ componentName }}
-  </code></pre>
-
-  <h2 class="govuk-heading-l">Requirements</h2>
-  <h3 class="govuk-heading-m">Build tool configuration</h3>
-  <p class="govuk-body">When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp</p>
-  <pre><code>
-  .pipe(sass({
-    includePaths: 'node_modules/'
-  }))
-  </code></pre>
-
-
-  <h3 class="govuk-heading-m">Static asset path configuration</h3>
-  <p class="govuk-body">To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:</p>
-
-  <pre><code>
-  app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
-  </code></pre>
-  {% endif %}
-
-  <h2 class="govuk-heading-l">Component arguments</h2>
-  <p class="govuk-body">If you are using Nunjucks,then macros take the following arguments</p>
-
-  {% from "table/macro.njk" import govukTable %}
-  {% block componentArguments %}
-  {% endblock %}
-
-  {% if isReadme %}
-  <h3 class="govuk-heading-m">Setting up Nunjucks views and paths</h3>
-  <p class="govuk-body">Below is an example setup using express configure views:</p>
-
-  <pre><code>
-  nunjucks.configure('node_modules/@govuk-frontend', {
-    autoescape: true,
-    cache: false,
-    express: app
-  })
-  </code></pre>
-
-  <h2 class="govuk-heading-l">Getting updates</h2>
-
-  <p class="govuk-body">To check whether you have the latest version of the button run:</p>
-
-  <pre><code>
-  npm outdated @govuk-frontend/{{ componentName }}
-  </code></pre>
-
-  <p class="govuk-body">To update the latest version run:</p>
-
-  <pre><code>
-  npm update @govuk-frontend/{{ componentName }}
-  </code></pre>
-
-  <h2 class="govuk-heading-l">Contribution</h2>
-  <p class="govuk-body">
-    Guidelines can be found at <a href="https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md" title="link to contributing guidelines on our github repository" class="govuk-link">on our Github repository.</a>
-  </p>
-
-  <h2 class="govuk-heading-l">License</h2>
-  <p class="govuk-body">MIT</p>
-  {% endif %}
-
-  {% if not isReadme %}
-  <h2 class="govuk-heading-l">Installation and setup</h2>
-  <p class="govuk-body">
-    <a href="https://github.com/alphagov/govuk-frontend/tree/master/src/components/{{ componentName}}" class="govuk-link">
-      View the {{ componentName }} README on GitHub
-    </a>
-  </p>
-
-</div>
-
-{% endif %}
 
 {% endblock %}

--- a/app/views/layouts/readme.njk
+++ b/app/views/layouts/readme.njk
@@ -1,0 +1,96 @@
+{% set componentName = componentPath %}
+{% set componentNameHuman = componentName | replace("-", " ") | capitalize %}
+{% set componentGuidanceLink = componentGuidanceLink | default('https://govuk-design-system-production.cloudapps.digital/components/' + componentName)%}
+<h1>
+{% block componentName %}
+{{ componentNameHuman }}
+{% endblock %}
+</h1>
+
+<h2>Introduction</h2>
+{% block componentDescription %}
+{% endblock %}
+
+{% if componentGuidanceLink %}
+<h2>Guidance</h2>
+<p>
+  Find out when to use the {{ componentNameHuman }} component in your service in the <a href="{{- componentGuidanceLink -}}" class="govuk-link">GOV.UK Design System</a>.
+</p>
+{% endif %}
+
+<h2>Quick start examples</h2>
+<p>{% block componentHtmlUsageWriteup %}{% endblock %}</p>
+
+{% from "showExamples.njk" import showExamples %}
+{% block examples %}
+{{ showExamples(componentName, componentData) }}
+{% endblock %}
+
+<h2>Dependencies</h2>
+
+<p>To consume the {{ componentName }} component you must be running npm version 5 or above. </p>
+
+<p>{% block componentDependencies %}{% endblock %}</p>
+
+<h2>Installation</h2>
+
+<pre><code>
+npm install --save @govuk-frontend/{{ componentName }}
+</code></pre>
+
+<h2>Requirements</h2>
+<h3>Build tool configuration</h3>
+<p>When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp</p>
+<pre><code>
+.pipe(sass({
+  includePaths: 'node_modules/'
+}))
+</code></pre>
+
+
+<h3>Static asset path configuration</h3>
+<p>To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:</p>
+
+<pre><code>
+app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+</code></pre>
+
+<h2>Component arguments</h2>
+<p>If you are using Nunjucks,then macros take the following arguments</p>
+
+{% from "table/macro.njk" import govukTable %}
+{% block componentArguments %}
+{% endblock %}
+
+<h3>Setting up Nunjucks views and paths</h3>
+<p>Below is an example setup using express configure views:</p>
+
+<pre><code>
+nunjucks.configure('node_modules/@govuk-frontend', {
+  autoescape: true,
+  cache: false,
+  express: app
+})
+</code></pre>
+
+<h2>Getting updates</h2>
+
+<p>To check whether you have the latest version of the button run:</p>
+
+<pre><code>
+npm outdated @govuk-frontend/{{ componentName }}
+</code></pre>
+
+<p>To update the latest version run:</p>
+
+<pre><code>
+npm update @govuk-frontend/{{ componentName }}
+</code></pre>
+
+<h2>Contribution</h2>
+<p>
+  Guidelines can be found at <a href="https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md" title="link to contributing guidelines on our github repository" class="govuk-link">on our Github repository.</a>
+</p>
+
+<h2>License</h2>
+<p>MIT</p>

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -31,7 +31,7 @@ To consume the back-link component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/back-link
+    npm install --save @govuk-frontend/back-link
 
 ## Requirements
 
@@ -39,15 +39,15 @@ To consume the back-link component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -141,21 +141,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/back-link
+    npm outdated @govuk-frontend/back-link
 
 To update the latest version run:
 
-      npm update @govuk-frontend/back-link
+    npm update @govuk-frontend/back-link
 
 ## Contribution
 

--- a/src/components/back-link/index.njk
+++ b/src/components/back-link/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -206,7 +206,7 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 
 ## Installation
 
-      npm install --save @govuk-frontend/breadcrumbs
+    npm install --save @govuk-frontend/breadcrumbs
 
 ## Requirements
 
@@ -214,15 +214,15 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -328,21 +328,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/breadcrumbs
+    npm outdated @govuk-frontend/breadcrumbs
 
 To update the latest version run:
 
-      npm update @govuk-frontend/breadcrumbs
+    npm update @govuk-frontend/breadcrumbs
 
 ## Contribution
 

--- a/src/components/breadcrumbs/index.njk
+++ b/src/components/breadcrumbs/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -138,7 +138,7 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 
 ## Installation
 
-      npm install --save @govuk-frontend/button
+    npm install --save @govuk-frontend/button
 
 ## Requirements
 
@@ -146,15 +146,15 @@ Please note, this component depends on @govuk-frontend/globals and @govuk-fronte
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -308,21 +308,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/button
+    npm outdated @govuk-frontend/button
 
 To update the latest version run:
 
-      npm update @govuk-frontend/button
+    npm update @govuk-frontend/button
 
 ## Contribution
 

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -342,7 +342,7 @@ To consume the checkboxes component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/checkboxes
+    npm install --save @govuk-frontend/checkboxes
 
 ## Requirements
 
@@ -350,15 +350,15 @@ To consume the checkboxes component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -524,21 +524,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/checkboxes
+    npm outdated @govuk-frontend/checkboxes
 
 To update the latest version run:
 
-      npm update @govuk-frontend/checkboxes
+    npm update @govuk-frontend/checkboxes
 
 ## Contribution
 

--- a/src/components/checkboxes/index.njk
+++ b/src/components/checkboxes/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -386,7 +386,7 @@ To consume the date-input component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/date-input
+    npm install --save @govuk-frontend/date-input
 
 ## Requirements
 
@@ -394,15 +394,15 @@ To consume the date-input component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -520,21 +520,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/date-input
+    npm outdated @govuk-frontend/date-input
 
 To update the latest version run:
 
-      npm update @govuk-frontend/date-input
+    npm update @govuk-frontend/date-input
 
 ## Contribution
 

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -72,7 +72,7 @@ To consume the details component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/details
+    npm install --save @govuk-frontend/details
 
 ## Requirements
 
@@ -80,15 +80,15 @@ To consume the details component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -194,21 +194,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/details
+    npm outdated @govuk-frontend/details
 
 To update the latest version run:
 
-      npm update @govuk-frontend/details
+    npm update @govuk-frontend/details
 
 ## Contribution
 

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -32,7 +32,7 @@ To consume the error-message component you must be running npm version 5 or abov
 
 ## Installation
 
-      npm install --save @govuk-frontend/error-message
+    npm install --save @govuk-frontend/error-message
 
 ## Requirements
 
@@ -40,15 +40,15 @@ To consume the error-message component you must be running npm version 5 or abov
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -130,21 +130,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/error-message
+    npm outdated @govuk-frontend/error-message
 
 To update the latest version run:
 
-      npm update @govuk-frontend/error-message
+    npm update @govuk-frontend/error-message
 
 ## Contribution
 

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -68,7 +68,7 @@ To consume the error-summary component you must be running npm version 5 or abov
 
 ## Installation
 
-      npm install --save @govuk-frontend/error-summary
+    npm install --save @govuk-frontend/error-summary
 
 ## Requirements
 
@@ -76,15 +76,15 @@ To consume the error-summary component you must be running npm version 5 or abov
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -202,21 +202,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/error-summary
+    npm outdated @govuk-frontend/error-summary
 
 To update the latest version run:
 
-      npm update @govuk-frontend/error-summary
+    npm update @govuk-frontend/error-summary
 
 ## Contribution
 

--- a/src/components/error-summary/index.njk
+++ b/src/components/error-summary/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -71,7 +71,7 @@ To consume the fieldset component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/fieldset
+    npm install --save @govuk-frontend/fieldset
 
 ## Requirements
 
@@ -79,15 +79,15 @@ To consume the fieldset component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -205,21 +205,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/fieldset
+    npm outdated @govuk-frontend/fieldset
 
 To update the latest version run:
 
-      npm update @govuk-frontend/fieldset
+    npm update @govuk-frontend/fieldset
 
 ## Contribution
 

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -125,7 +125,7 @@ To consume the file-upload component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/file-upload
+    npm install --save @govuk-frontend/file-upload
 
 ## Requirements
 
@@ -133,15 +133,15 @@ To consume the file-upload component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -259,21 +259,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/file-upload
+    npm outdated @govuk-frontend/file-upload
 
 To update the latest version run:
 
-      npm update @govuk-frontend/file-upload
+    npm update @govuk-frontend/file-upload
 
 ## Contribution
 

--- a/src/components/file-upload/index.njk
+++ b/src/components/file-upload/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -99,7 +99,7 @@ To consume the input component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/input
+    npm install --save @govuk-frontend/input
 
 ## Requirements
 
@@ -107,15 +107,15 @@ To consume the input component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -233,21 +233,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/input
+    npm outdated @govuk-frontend/input
 
 To update the latest version run:
 
-      npm update @govuk-frontend/input
+    npm update @govuk-frontend/input
 
 ## Contribution
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -86,7 +86,7 @@ To consume the label component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/label
+    npm install --save @govuk-frontend/label
 
 ## Requirements
 
@@ -94,15 +94,15 @@ To consume the label component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -232,21 +232,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/label
+    npm outdated @govuk-frontend/label
 
 To update the latest version run:
 
-      npm update @govuk-frontend/label
+    npm update @govuk-frontend/label
 
 ## Contribution
 

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -38,7 +38,7 @@ To consume the panel component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/panel
+    npm install --save @govuk-frontend/panel
 
 ## Requirements
 
@@ -46,15 +46,15 @@ To consume the panel component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -160,21 +160,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/panel
+    npm outdated @govuk-frontend/panel
 
 To update the latest version run:
 
-      npm update @govuk-frontend/panel
+    npm update @govuk-frontend/panel
 
 ## Contribution
 

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -41,7 +41,7 @@ To consume the phase-banner component you must be running npm version 5 or above
 
 ## Installation
 
-      npm install --save @govuk-frontend/phase-banner
+    npm install --save @govuk-frontend/phase-banner
 
 ## Requirements
 
@@ -49,15 +49,15 @@ To consume the phase-banner component you must be running npm version 5 or above
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -151,21 +151,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/phase-banner
+    npm outdated @govuk-frontend/phase-banner
 
 To update the latest version run:
 
-      npm update @govuk-frontend/phase-banner
+    npm update @govuk-frontend/phase-banner
 
 ## Contribution
 

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -316,7 +316,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
 
 ## Installation
 
-      npm install --save @govuk-frontend/radios
+    npm install --save @govuk-frontend/radios
 
 ## Requirements
 
@@ -324,15 +324,15 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -498,21 +498,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/radios
+    npm outdated @govuk-frontend/radios
 
 To update the latest version run:
 
-      npm update @govuk-frontend/radios
+    npm update @govuk-frontend/radios
 
 ## Contribution
 

--- a/src/components/radios/index.njk
+++ b/src/components/radios/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -118,7 +118,7 @@ To consume the select component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/select
+    npm install --save @govuk-frontend/select
 
 ## Requirements
 
@@ -126,15 +126,15 @@ To consume the select component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -300,21 +300,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/select
+    npm outdated @govuk-frontend/select
 
 To update the latest version run:
 
-      npm update @govuk-frontend/select
+    npm update @govuk-frontend/select
 
 ## Contribution
 

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -31,7 +31,7 @@ To consume the skip-link component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/skip-link
+    npm install --save @govuk-frontend/skip-link
 
 ## Requirements
 
@@ -39,15 +39,15 @@ To consume the skip-link component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -141,21 +141,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/skip-link
+    npm outdated @govuk-frontend/skip-link
 
 To update the latest version run:
 
-      npm update @govuk-frontend/skip-link
+    npm update @govuk-frontend/skip-link
 
 ## Contribution
 

--- a/src/components/skip-link/index.njk
+++ b/src/components/skip-link/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -338,7 +338,7 @@ To consume the table component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/table
+    npm install --save @govuk-frontend/table
 
 ## Requirements
 
@@ -346,15 +346,15 @@ To consume the table component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -532,21 +532,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/table
+    npm outdated @govuk-frontend/table
 
 To update the latest version run:
 
-      npm update @govuk-frontend/table
+    npm update @govuk-frontend/table
 
 ## Contribution
 

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -49,7 +49,7 @@ To consume the tag component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/tag
+    npm install --save @govuk-frontend/tag
 
 ## Requirements
 
@@ -57,15 +57,15 @@ To consume the tag component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -147,21 +147,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/tag
+    npm outdated @govuk-frontend/tag
 
 To update the latest version run:
 
-      npm update @govuk-frontend/tag
+    npm update @govuk-frontend/tag
 
 ## Contribution
 

--- a/src/components/tag/index.njk
+++ b/src/components/tag/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -121,7 +121,7 @@ To consume the textarea component you must be running npm version 5 or above.
 
 ## Installation
 
-      npm install --save @govuk-frontend/textarea
+    npm install --save @govuk-frontend/textarea
 
 ## Requirements
 
@@ -129,15 +129,15 @@ To consume the textarea component you must be running npm version 5 or above.
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -267,21 +267,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/textarea
+    npm outdated @govuk-frontend/textarea
 
 To update the latest version run:
 
-      npm update @govuk-frontend/textarea
+    npm update @govuk-frontend/textarea
 
 ## Contribution
 

--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -37,7 +37,7 @@ To consume the warning-text component you must be running npm version 5 or above
 
 ## Installation
 
-      npm install --save @govuk-frontend/warning-text
+    npm install --save @govuk-frontend/warning-text
 
 ## Requirements
 
@@ -45,15 +45,15 @@ To consume the warning-text component you must be running npm version 5 or above
 
 When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
 
-      .pipe(sass({
-        includePaths: 'node_modules/'
-      }))
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
 
 ### Static asset path configuration
 
 To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
 
-      app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
 
 ## Component arguments
 
@@ -147,21 +147,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 Below is an example setup using express configure views:
 
-      nunjucks.configure('node_modules/@govuk-frontend', {
-        autoescape: true,
-        cache: false,
-        express: app
-      })
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
 
 ## Getting updates
 
 To check whether you have the latest version of the button run:
 
-      npm outdated @govuk-frontend/warning-text
+    npm outdated @govuk-frontend/warning-text
 
 To update the latest version run:
 
-      npm update @govuk-frontend/warning-text
+    npm update @govuk-frontend/warning-text
 
 ## Contribution
 

--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -1,4 +1,10 @@
-{% extends "component.njk" %}
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
 
 {# Commented out blocks below inherit from views/component.njk #}
 


### PR DESCRIPTION
This PR
- removes the component description, guidance and table of arguments from
the component view within the review app. This just leaves the component title and the examples.

- creates a separate template in app/views for generating README files
- adds logic to each component's `index.njk` file to extend the appropriate templates based on the `isReadme: true` parameter that is we pass to  the nunjucks enviroment.

Trello: https://trello.com/c/rUJHVyt3/612-remove-readme-content-from-components-view-in-review-app

Note: this is until we move all content into YAML file and remove component `index.njk` files