### PR TITLE
Add govuk-section-break to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ New features:
 - The responsive spacing and typography mixins will now throw an error if you
   try to use them with anything other than a spacing or font map respectively.
   (PR [#447](https://github.com/alphagov/govuk-frontend/pull/447))
+- Add thematic break to typography and prose scope. This class is added to an
+  `<hr>`, adds margin (xl, l and m). There is also an option to make the `<hr>` 
+  border visible or invisible. (PR [#483](https://github.com/alphagov/govuk-frontend/pull/483))
 
 Fixes:
 

--- a/app/views/examples/prose-scope/index.njk
+++ b/app/views/examples/prose-scope/index.njk
@@ -72,6 +72,16 @@
         <li>This is the third and final item in the ordered list.</li>
       </ol>
 
+      <hr>
+
+      <h2>An H2 after a thematic break</h2>
+
+      <p>
+        A paragraph. This includes even more text to give a good representation
+        of a more average length paragraph. That way you can see more than one
+        line wrapping.
+      </p>
+
     </div>
 
   </div>

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -418,6 +418,88 @@
 
     </section>
 
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Section breaks - Not-visible</h2>
+
+      <h2 class="govuk-heading-l">Topic A1</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <h2 class="govuk-heading-l">Topic A2</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break--xl">
+
+      <h2 class="govuk-heading-l">Topic B (govuk-section-break--xl above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break--l">
+
+      <h2 class="govuk-heading-l">Topic C (govuk-section-break--l above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break--m">
+
+      <h2 class="govuk-heading-l">Topic D (govuk-section-break--m above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+    </section>
+
+    <section class="govuk-!-mt-r8">
+      <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Section breaks - Visible</h2>
+
+      <h2 class="govuk-heading-l">Topic A1</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <h2 class="govuk-heading-l">Topic A2</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--xl">
+
+      <h2 class="govuk-heading-l">Topic B (govuk-section-break--xl above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--l">
+
+      <h2 class="govuk-heading-l">Topic C (govuk-section-break--l above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--m">
+
+      <h2 class="govuk-heading-l">Topic D (govuk-section-break--m above)</h2>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+      <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
+
+    </section>
+
 
   </div>
 </div>

--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -38,6 +38,7 @@
 @import "core/lists";
 @import "core/typography";
 @import "core/prose-scope";
+@import "core/section-break";
 
 // Objects
 @import "objects/grid";

--- a/src/globals/scss/core/_prose-scope.scss
+++ b/src/globals/scss/core/_prose-scope.scss
@@ -48,5 +48,10 @@
     a {
       @extend .govuk-link;
     }
+
+    hr {
+      @extend .govuk-section-break__visible;
+      @extend .govuk-section-break--xl;
+    }
   }
 }

--- a/src/globals/scss/core/_section-break.scss
+++ b/src/globals/scss/core/_section-break.scss
@@ -1,0 +1,27 @@
+@include exports("section-break") {
+
+  .govuk-section-break {
+    margin: 0;
+    border: 0;
+  }
+
+  .govuk-section-break--xl {
+    @include govuk-responsive-margin($govuk-spacing-responsive-8, "top");
+    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
+  }
+
+  .govuk-section-break--l {
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+  }
+
+  .govuk-section-break--m {
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "top");
+    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+  }
+
+  .govuk-section-break__visible {
+    border: 1px solid $govuk-border-colour;
+  }
+
+}


### PR DESCRIPTION
Sometimes there is a need to visually separate parts of a page on top of the existing typographic hierarchy.

This class is added to an `<hr>`, adds margin (xl, l and m).
There is also an option to make the `<hr>` border visible or invisible. 

##Examples
### Not visible
![screen shot 2018-01-30 at 11 53 16](https://user-images.githubusercontent.com/23356842/35565730-9a0054b6-05b6-11e8-8ed4-a12ced907185.png)

###Visible
![screen shot 2018-01-30 at 11 56 28](https://user-images.githubusercontent.com/23356842/35565729-99de436c-05b6-11e8-844b-2670cf1a2ca9.png)

## Example usage
The section below the Start button on a start page is achieved by adding margin to the Start button.

This conceptually feels like a new section of the page.

![screen shot 2018-01-30 at 12 01 38](https://user-images.githubusercontent.com/23356842/35565792-e0b96e4c-05b6-11e8-9236-292a4da3e569.png)

### Related
How this might work with `<section>`

As part of https://trello.com/c/8LRu4psv/515-add-styling-for-horizontal-rules