### PR TITLE
WIP - Do not merge - Add error highlighting

### DIFF
--- a/app/views/examples/error-messages/index.njk
+++ b/app/views/examples/error-messages/index.njk
@@ -1,0 +1,337 @@
+{% extends "layout.njk" %}
+
+{% block styles %}
+<style>
+  .app-u-w-full {
+    width: 100%;
+  }
+
+  .app-u-w-half {
+    width: 50%;
+    float: left;
+  }
+
+  .app-u-w-third {
+    width: 33.33333333%;
+    float: left;
+  }
+
+  .app-u-w-quarter {
+    width: 25%;
+    float: left;
+  }
+
+  .app-u-w-two-thirds {
+    width: 66.66666667%;
+    float: left;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+
+{% from "fieldset/macro.njk" import govukFieldset %}
+{% from "label/macro.njk" import govukLabel %}
+{% from "input/macro.njk" import govukInput %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "select/macro.njk" import govukSelect %}
+{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from 'radios/macro.njk' import govukRadios %}
+{% from 'textarea/macro.njk' import govukTextarea %}
+
+<h1 class="govuk-heading-xl">Error messages</h1>
+
+
+<form action="/" method="post">
+  <h2 class="govuk-heading-m">Simple input</h2>
+
+  {{ govukInput({
+    label: {
+      "text": "National Insurance Number"
+    },
+    id: "input-1",
+    name: "test-name",
+    error: {
+      active: true,
+      message: {
+        text: "Error message goes here"
+      }
+    }
+  }) }}
+
+  <h2 class="govuk-heading-m">Multiple inputs with shared error message</h2>
+
+    {# Use fieldset to wrap around components and render collective error #}
+    {% call govukFieldset({
+      legendText: "User address",
+      error: {
+        active: true,
+        text: "Address not found"
+      }
+    }) %}
+      {# Passing below to fieldset to render #}
+      {{ govukInput({
+        label: {
+          "text": "Street"
+        },
+        id: "input-2",
+        name: "test-name",
+        error: {
+          active: false,
+          message: {
+            text: "Error message goes here"
+          }
+        }
+      }) }}
+      {{ govukInput({
+        label: {
+          "text": "Town"
+        },
+        id: "input-3",
+        name: "test-name",
+        error: {
+          active: false,
+          message: {
+            text: "Error message goes here"
+          }
+        }
+      }) }}
+      {{ govukInput({
+        label: {
+          "text": "City"
+        },
+        id: "input-4",
+        name: "test-name",
+        error: {
+          active: false,
+          message: {
+            text: "Error message goes here"
+          }
+        }
+      }) }}
+    {# end fieldset render #}
+    {% endcall %}
+
+    <h2 class="govuk-heading-m">Radios with error message</h2>
+
+    {{ govukRadios({
+      fieldset: {
+        legendHtml: "<h3 class=\"govuk-heading-m\">How do you want to be contacted?</h3>",
+         error: {
+          active: true,
+          text: "Please select an option"
+        }
+      },
+      idPrefix: "radio-stacked",
+      name: "radio-stacked",
+      items: [
+        {
+          value: "email",
+          text: "Email"
+        },
+        {
+          value: "phone",
+          text: "Phone"
+        },
+        {
+          value: "text",
+          text: "Text message"
+        }
+      ]
+    }) }}
+
+    <h2 class="govuk-heading-m">Checkboxes with error message</h2>
+
+    <span id="checkboxes-stacked"></span>
+    {{ govukCheckboxes({
+      fieldset: {
+        legendHtml: "<h3 class=\"govuk-heading-m\">What type of waste do you want to dispose of?</h3>",
+         error: {
+          active: true,
+          text: "Select type of waste"
+        }
+      },
+      idPrefix: "checkboxes-stacked",
+      name: "checkboxes-stacked",
+      items: [
+        {
+          value: "waste-animal",
+          text: "Waste from animal carcasses"
+        },
+        {
+          value: "waste-mines",
+          text: "Waste from mines or quarries"
+        },
+        {
+          value: "waste-other",
+          text: "Waste from other"
+        }
+      ]
+    }) }}
+
+    <h2 class="govuk-heading-m">Date input with error message</h2>
+
+    {{- govukDateInput({
+      fieldset: {
+        legendText: 'What is your date of birth?',
+        legendHintText: 'For example, 31 3 1980',
+        error: {
+         active: true,
+         text: "Select date"
+        }
+      },
+      errorMessage: {
+        text: 'Error message goes here'
+      },
+      id: 'dob',
+      name: 'dob',
+      items:[
+        {
+          name: 'day',
+          classes: 'govuk-c-input--error'
+        },
+        {
+          name: 'month',
+          classes: 'govuk-c-input--error'
+        },
+        {
+          name: 'year',
+          classes: 'govuk-c-input--error'
+        }
+      ]
+      })
+    -}}
+
+    <h2 class="govuk-heading-m">Select with error message</h2>
+
+    {{ govukSelect({
+      id: "select-1",
+      name: "select-1",
+      label: {
+        html: "Label text goes here"
+      },
+      error: {
+        active: true,
+        message: {
+          html: "<i>Error message goes here</i>"
+        }
+      },
+      items: [
+        {
+          value: 1,
+          text: "GOV.UK frontend option 1"
+        },
+        {
+          value: 2,
+          text: "GOV.UK frontend option 2",
+          selected: true
+        },
+        {
+          value: 3,
+          text: "GOV.UK frontend option 3"
+        }
+      ]
+    }) }}
+
+    <h2 class="govuk-heading-m">Textarea with error message</h2>
+
+    {{ govukTextarea({
+      id: "more-detail",
+      name: "more-detail",
+      label: {
+        text: "Can you provide more detail?",
+        hintText: "Don't include personal or financial information, eg your National Insurance number or credit card details."
+      },
+      error: {
+        active: true,
+        message: {
+          text: "You must provide an explanation"
+        }
+      }
+    })
+    }}
+
+    <h2 class="govuk-heading-m">Select and button</h2>
+
+    {% call govukFieldset({
+      legendText: "User address",
+      error: {
+        active: true,
+        text: "Address not found"
+      }
+    }) %}
+      <div class="app-u-w-half">
+        {{ govukSelect({
+          "id": "select-box",
+          "name": "select-box",
+          "items": [
+            {
+              "value": 1,
+              "text": "GOV.UK elements option 1"
+            },
+            {
+              "value": 2,
+              "text": "GOV.UK elements option 2"
+            },
+            {
+              "value": 3,
+              "text": "GOV.UK elements option 3"
+            }
+          ]
+        }) }}
+      </div>
+      <div class="app-u-w-half">
+        {{ govukButton({
+          "text": "Save and continue"
+        }) }}
+      </div>
+    {%- endcall %}
+
+    <h2 class="govuk-heading-m">Radios, checkboxes and button</h2>
+
+
+
+    {% call govukFieldset({
+      legendText: "User address",
+      error: {
+        active: true,
+        text: "Address not found"
+      }
+    }) %}
+
+      <div class="app-u-w-quarter">
+        {{ govukCheckboxes({
+          "idPrefix": "radio-checkboxes-button__checkboxes",
+          "name": "radio-checkboxes-button__checkboxes",
+          "items": [
+            {
+              "value": "2017-2018",
+              "text": "2017 / 2018"
+            }
+          ]
+        }) }}
+      </div>
+      <div class="app-u-w-quarter">
+        {{ govukRadios({
+          "idPrefix": "radio-checkboxes-button__radios",
+          "name": "radio-group",
+          "items": [
+            {
+              "value": "na",
+              "text": "Not applicable"
+            }
+          ]
+        }) }}
+      </div>
+      <div class="app-u-w-half">
+        {{ govukButton({
+          "text": "Save and continue"
+        }) }}
+      </div>
+    {%- endcall %}
+
+
+</form>
+
+{% endblock %}

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -6,6 +6,7 @@
 
     display: block;
     position: relative;
+    min-height: 40px;
 
     margin-bottom: $govuk-spacing-scale-2;
     padding: 0 0 0 em(40px, 19px);

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -46,3 +46,21 @@ examples:
       - value: disabled
         text: Disabled option
         disabled: true
+
+- name: errors
+  data:
+    idPrefix: 'nationality'
+    name: 'nationality'
+    fieldset:
+      legendText: What is your nationality?
+      legendHintText: If you have dual nationality, select all options that are relevant to you.
+      error:
+        active: true
+        text: Error message goes here
+    items:
+      - value: 'british'
+        text: 'British'
+      - value: 'irish'
+        text: 'Irish'
+      - value: 'other'
+        text: 'Citizen of another country'

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -31,6 +31,10 @@
     legendHtml: params.fieldset.legendHtml,
     legendHintText: params.fieldset.legendHintText,
     legendHintHtml: params.fieldset.legendHintHtml,
+    error: {
+      active: params.fieldset.error.active,
+      text: params.fieldset.error.text
+    },
     errorMessage: params.errorMessage
   }) %}
   {{ innerHtml | trim | safe }}

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -31,6 +31,10 @@
     legendHtml: params.fieldset.legendHtml,
     legendHintText: params.fieldset.legendHintText,
     legendHintHtml: params.fieldset.legendHintHtml,
+    error: {
+      active: params.fieldset.error.active,
+      text: params.fieldset.error.text
+    },
     errorMessage: params.errorMessage
   }) %}
   {{ innerHtml | indent(2) | trim | safe }}

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -11,6 +11,11 @@
     @include govuk-h-clearfix;
   }
 
+  .govuk-c-fieldset--error {
+    padding-left: 15px;
+    border-left: 5px solid $govuk-red;
+  }
+
   .govuk-c-fieldset__legend {
     @include govuk-font-regular-19;
 

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,6 +1,6 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 
-<fieldset class="govuk-c-fieldset
+<fieldset class="govuk-c-fieldset {%- if params.error.active %} govuk-c-fieldset--error{% endif %}
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.legendHtml or params.legendText %}
   <legend class="govuk-c-fieldset__legend">
@@ -8,8 +8,8 @@
     {% if params.legendHintText or params.legendHintHtml %}
     <span class="govuk-c-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
     {% endif %}
-    {% if params.errorMessage %}
-    {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
+    {% if params.error.active %}
+    {{ govukErrorMessage(params.error) | trim | indent(4) -}}
     {% endif %}
   </legend>
   {% endif %}

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -19,5 +19,7 @@ examples:
         hintHtml: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-3
       name: test-name-3
-      errorMessage:
-        text: Error message goes here
+      error:
+        active: true
+        message:
+          text: Error message goes here

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,16 +1,20 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
-
-<input class="govuk-c-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
-{%- if params.value %} value="{{ params.value}}"{% endif %}
-{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+<div class="govuk-form-group {%- if params.error.active %} govuk-form-group--error{% endif %}">
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    for: params.id,
+    error: {
+      active: params.error.active,
+      message: params.error.message
+    }
+  }) -}}
+  <input class="govuk-c-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.error.active %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
+  {%- if params.value %} value="{{ params.value}}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+</div>

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -9,7 +9,7 @@
     {{ params.hintHtml | safe if params.hintHtml else params.hintText }}
   </span>
   {% endif %}
-  {% if params.errorMessage %}
-  {{ govukErrorMessage(params.errorMessage) -}}
+  {% if params.error.active %}
+  {{ govukErrorMessage(params.error.message) -}}
   {% endif %}
 </label>

--- a/src/components/radios/__snapshots__/template.test.js.snap
+++ b/src/components/radios/__snapshots__/template.test.js.snap
@@ -10,7 +10,7 @@ exports[`Radios nested dependant components passes through fieldset params witho
 
 exports[`Radios nested dependant components passes through fieldset params without breaking 2`] = `
 
-<fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier"
+<fieldset class="govuk-c-fieldset govuk-c-fieldset--error app-c-fieldset--custom-modifier"
           data-attribute="value"
           data-second-attribute="second-value"
 >

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -62,8 +62,6 @@ examples:
   data:
     idPrefix: 'example'
     name: 'example'
-    errorMessage:
-      text: 'Please select an option'
     fieldset:
       classes: 'app-c-fieldset--custom-modifier'
       attributes:
@@ -72,6 +70,9 @@ examples:
       legendText: Have you changed your name?
       legendHintText:
         This includes changing your last name or spelling your name differently.
+      error:
+        active: true
+        text: 'Please select an option'
     items:
       - value: yes
         text: Yes

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -31,7 +31,10 @@
     legendHtml: params.fieldset.legendHtml,
     legendHintText: params.fieldset.legendHintText,
     legendHintHtml: params.fieldset.legendHintHtml,
-    errorMessage: params.errorMessage
+    error: {
+      active: params.fieldset.error.active,
+      text: params.fieldset.error.text
+    }
   }) %}
   {{ innerHtml | trim | safe }}
   {% endcall %}

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -24,8 +24,10 @@ examples:
     label:
       hintHtml: Hint message <i>goes</i> here
       html: Label text <i>goes</i> here
-    errorMessage:
-      html: <i>Error message goes here</i>
+    error:
+      active: true
+      message:
+        html: <i>Error message goes here</i>
     items:
       -
         value: 1

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -1,20 +1,27 @@
 {% from "label/macro.njk" import govukLabel %}
-{%- if params.label %}
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
-{% endif -%}
 
-<select class="govuk-c-select
-  {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-{% for item in params.items %}
-  <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
-{% endfor %}
-</select>
+<div class="govuk-form-group {%- if params.error.active %} govuk-form-group--error{% endif %}">
+
+  {%- if params.label %}
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    for: params.id,
+    error: {
+      active: params.error.active,
+      message: params.error.message
+    }
+  }) -}}
+  {% endif -%}
+
+  <select class="govuk-c-select
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.error.active %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% for item in params.items %}
+    <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
+  {% endfor %}
+  </select>
+</div>

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -2,15 +2,21 @@
 
 {#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
+<div class="govuk-form-group {%- if params.error.active %} govuk-form-group--error{% endif %}">
 
-<textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-c-textarea {{- ' govuk-c-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    for: params.id,
+    error: {
+      active: params.error.active,
+      message: params.error.message
+    }
+  }) -}}
+
+  <textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-c-textarea {{- ' govuk-c-textarea--error' if params.error.active}} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
+</div>

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -14,8 +14,10 @@ examples:
       id: no-ni-reason
       label:
         text: Why can't you provide a National Insurance number?
-      errorMessage:
-        text: You must provide an explanation
+      error:
+        active: true
+        message:
+          text: You must provide an explanation
 
   - name: with default value
     data:

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -157,4 +157,10 @@
     }
   }
 
+  // Form group error style
+  .govuk-form-group--error {
+    padding-left: 15px;
+    border-left: 5px solid $govuk-red;
+  }
+
 }


### PR DESCRIPTION
This PR adds examples of error messages for form components. **It's not a complete proposed solution** but rather something for @dashouse to review before he's off for holibobs. I'm not working this afternoon so happy for @nickcolley to pick this up.

There are several alignment issues and as @dashouse said before, we might need to move the margins from inside the inputs to the `form-group` wrapper. It would be awesome @dashouse if you could decide our approach to those 🙌  

An issue I ran into was how to set an error state, not the actual error message, in components. I've tried an approach of resolving that here but this might well need a wider discussion with the team.

Features:
- Update fieldset to accept error state and render an error class
- Add error state to `input`, `textarea`, `select` and allow them to pass error state to `label`.
Also add outer error class wrapper (`form-group`) to add error style. Add error styling to form element error if error state is true, rather than checking for existence of error message.
if error message is set.
- Add error state to `radios`, `checkboxes` and `date-input` and allow them to pass to this to `fieldset`.
- Add the error styling with two different classes `fieldset` for those components that already use it (for `radios`, `checkboxes` and `date-input`) and `form-group` for those that didn't have a wrapper (`input`, `textarea`, `select`). It might be better to make the `form-group` class component specific but then again it might be good to abstract it out into something that the user can apply themselves to custom form errors. Up for discussion although I'm now actually leaning towards the former (the option I *didn't* implement 😛 ) because there are now are two places where error classes get added in `input`, `textarea`, `select` and a single wrapper class could manage them both.
- Add examples of the different error messages for form components to `/examples/error-messages`

This doesn't update all component previews, or any READMEs and component argument tables as we need to settle on an approach first before updating all those.

Note: Please review in [`/examples/error-messages`](https://govuk-frontend-review-pr-494.herokuapp.com/examples/error-messages). It might be easier to look at the commits which separate the work out into smaller chunks.