### PR TITLE
Add tests for date input macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Internal:
 - Add tests for error-summary component (PR [#489](https://github.com/alphagov/govuk-frontend/pull/489))
 - Add tests for radios component (PR [#476](https://github.com/alphagov/govuk-frontend/pull/476))
 - Add tests for input component (PR [#478](https://github.com/alphagov/govuk-frontend/pull/478))
+- Add tests for date-input component (PR [#495](https://github.com/alphagov/govuk-frontend/pull/495))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -430,25 +430,49 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">fieldset</th>
+<th class="govuk-c-table__header" scope="row">classes</th>
 
-<td class="govuk-c-table__cell ">object</td>
+<td class="govuk-c-table__cell ">string</td>
 
 <td class="govuk-c-table__cell ">No</td>
 
-<td class="govuk-c-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
+<td class="govuk-c-table__cell ">Optional additional classes</td>
 
 </tr>
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">errorMessage</th>
+<th class="govuk-c-table__header" scope="row">id</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Optional id. This is used for the main component and to compose the items' ids.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">name</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Optional name. This is used to compose the items' names.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">attributes</th>
 
 <td class="govuk-c-table__cell ">object</td>
 
 <td class="govuk-c-table__cell ">No</td>
 
-<td class="govuk-c-table__cell ">Optional error message. See errorMessage component.</td>
+<td class="govuk-c-table__cell ">Any extra HTML attributes (for example data attributes) to add to the date div tag.</td>
 
 </tr>
 
@@ -466,25 +490,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">classes</th>
-
-<td class="govuk-c-table__cell ">string</td>
-
-<td class="govuk-c-table__cell ">No</td>
-
-<td class="govuk-c-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-c-table__row">
-
-<th class="govuk-c-table__header" scope="row">attributes</th>
+<th class="govuk-c-table__header" scope="row">errorMessage</th>
 
 <td class="govuk-c-table__cell ">object</td>
 
 <td class="govuk-c-table__cell ">No</td>
 
-<td class="govuk-c-table__cell ">Any extra HTML attributes (for example data attributes) to add to the date div tag.</td>
+<td class="govuk-c-table__cell ">Optional error message. See errorMessage component.</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">fieldset</th>
+
+<td class="govuk-c-table__cell ">object</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
 
 </tr>
 

--- a/src/components/date-input/__snapshots__/template.test.js.snap
+++ b/src/components/date-input/__snapshots__/template.test.js.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Date input nested dependant components passes through label params without breaking 1`] = `
+
+<label class="govuk-c-label govuk-c-date-input__label"
+       for="dob-day"
+>
+  Day
+</label>
+<label class="govuk-c-label govuk-c-date-input__label"
+       for="dob-month"
+>
+  Month
+</label>
+<label class="govuk-c-label govuk-c-date-input__label"
+       for="dob-year"
+>
+  Year
+</label>
+
+`;
+
+exports[`Date input passes through fieldset params without breaking 1`] = `
+
+<span class="govuk-c-error-message">
+  Error message goes here
+</span>
+
+`;
+
+exports[`Date input passes through fieldset params without breaking 2`] = `
+
+<fieldset class="govuk-c-fieldset">
+  <legend class="govuk-c-fieldset__legend">
+    What is your date of birth?
+    <span class="govuk-c-fieldset__hint">
+      For example, 31 3 1980
+    </span>
+  </legend>
+</fieldset>
+
+`;
+
+exports[`Date input passes through html fieldset params without breaking 1`] = `
+
+<fieldset class="govuk-c-fieldset">
+  <legend class="govuk-c-fieldset__legend">
+    What is your
+    <b>
+      date of birth
+    </b>
+    ?
+    <span class="govuk-c-fieldset__hint">
+      For example,
+      <b>
+        31 3 1980
+      </b>
+    </span>
+  </legend>
+</fieldset>
+
+`;

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -32,21 +32,49 @@
   'rows': [
     [
       {
-        text: 'fieldset'
+        text: 'classes'
       },
       {
-        text: 'object'
+        text: 'string'
       },
       {
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+        text: 'Optional additional classes'
       }
     ],
     [
       {
-        text: 'errorMessage'
+        text: 'id'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional id. This is used for the main component and to compose the items\' ids.'
+      }
+    ],
+    [
+      {
+        text: 'name'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional name. This is used to compose the items\' names.'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
       },
       {
         text: 'object'
@@ -55,7 +83,7 @@
         text: 'No'
       },
       {
-        text: 'Optional error message. See errorMessage component.'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the date div tag.'
       }
     ],
     [
@@ -74,21 +102,7 @@
     ],
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
-        text: 'attributes'
+        text: 'errorMessage'
       },
       {
         text: 'object'
@@ -97,7 +111,21 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the date div tag.'
+        text: 'Optional error message. See errorMessage component.'
+      }
+    ],
+    [
+      {
+        text: 'fieldset'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
       }
     ]
   ]

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -1,0 +1,196 @@
+/* globals describe, it, expect */
+
+const { render, getExamples, htmlWithClassName } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('date-input')
+
+describe('Date input', () => {
+  describe('by default', () => {
+    it('renders with classes', () => {
+      const $ = render('date-input', {
+        classes: 'app-c-date-input--custom-modifier'
+      })
+
+      const $component = $('.govuk-c-date-input')
+      expect($component.hasClass('app-c-date-input--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with id', () => {
+      const $ = render('date-input', {
+        id: 'my-date-input'
+      })
+
+      const $component = $('.govuk-c-date-input')
+      expect($component.attr('id')).toEqual('my-date-input')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('date-input', {
+        attributes: {
+          'data-attribute': 'my data value'
+        }
+      })
+
+      const $component = $('.govuk-c-date-input')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+
+    it('renders with items', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $items = $('.govuk-c-date-input__item')
+      expect($items.length).toEqual(3)
+    })
+
+    it('renders item with capitalised label text', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-c-date-input__item:first-child')
+      expect($firstItems.text().trim()).toEqual('Day')
+    })
+
+    it('renders item with implicit class for label', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-c-date-input__item:first-child label')
+      expect($firstItems.hasClass('govuk-c-date-input__label')).toBeTruthy()
+    })
+
+    it('renders item with implicit class for input', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-c-date-input__item:first-child input')
+      expect($firstItems.hasClass('govuk-c-date-input__input')).toBeTruthy()
+    })
+
+    it('renders item with suffixed name for input', () => {
+      const $ = render('date-input', {
+        name: 'my-date-input',
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-c-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('my-date-input-day')
+    })
+
+    it('renders item with suffixed id for input', () => {
+      const $ = render('date-input', {
+        id: 'my-date-input',
+        items: [
+          {
+            'name': 'day'
+          },
+          {
+            'name': 'month'
+          },
+          {
+            'name': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-c-date-input__item:first-child input')
+      expect($firstItems.attr('id')).toEqual('my-date-input-day')
+    })
+  })
+
+  describe('nested dependant components', () => {
+    it('passes through label params without breaking', () => {
+      const $ = render('date-input', examples['default'])
+
+      expect(htmlWithClassName($, '.govuk-c-date-input__label')).toMatchSnapshot()
+    })
+  })
+
+  it('passes through fieldset params without breaking', () => {
+    const $ = render('date-input', examples['default'])
+
+    expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
+    expect(htmlWithClassName($, '.govuk-c-fieldset')).toMatchSnapshot()
+  })
+
+  it('passes through html fieldset params without breaking', () => {
+    const $ = render('date-input', {
+      id: 'dob',
+      name: 'dob',
+      fieldset: {
+        legendHtml: 'What is your <b>date of birth</b>?',
+        legendHintHtml: 'For example, <b>31 3 1980</b>'
+      },
+      errorMessage: {
+        text: 'Error message goes here'
+      },
+      items: [
+        {
+          name: 'day'
+        },
+        {
+          name: 'month'
+        },
+        {
+          name: 'year'
+        }
+      ]
+    })
+
+    expect(htmlWithClassName($, '.govuk-c-fieldset')).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
This PR:
- Adds tests to input component to ensure the markup is rendered correctly when providing arguments to the macro;
- Updates table of argument by adding missing `name` attribute, documenting `id` and ordering them;
- Updates [CHANGELOG.MD](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

[Trello Card](https://trello.com/c/yNRZrcNC)