### PR TITLE
Add tests for textarea macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Internal:
 - Add tests for radios component (PR [#476](https://github.com/alphagov/govuk-frontend/pull/476))
 - Add tests for input component (PR [#478](https://github.com/alphagov/govuk-frontend/pull/478))
 - Add tests for date-input component (PR [#495](https://github.com/alphagov/govuk-frontend/pull/495))
+- Add tests for textarea component (PR [#497](https://github.com/alphagov/govuk-frontend/pull/497))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/src/components/textarea/__snapshots__/template.test.js.snap
+++ b/src/components/textarea/__snapshots__/template.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Textarea with dependant components renders with error message 1`] = `
+
+<span class="govuk-c-error-message">
+  Error message
+</span>
+
+`;
+
+exports[`Textarea with dependant components renders with label 1`] = `
+
+<label class="govuk-c-label"
+       for="my-textarea"
+>
+  Full address
+</label>
+
+`;

--- a/src/components/textarea/template.test.js
+++ b/src/components/textarea/template.test.js
@@ -1,0 +1,116 @@
+/* globals describe, it, expect */
+
+const { render, htmlWithClassName } = require('../../../lib/jest-helpers')
+
+describe('Textarea', () => {
+  describe('by default', () => {
+    it('renders with classes', () => {
+      const $ = render('textarea', {
+        classes: 'app-c-textarea--custom-modifier'
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.hasClass('app-c-textarea--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with id', () => {
+      const $ = render('textarea', {
+        id: 'my-textarea'
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.attr('id')).toEqual('my-textarea')
+    })
+
+    it('renders with name', () => {
+      const $ = render('textarea', {
+        name: 'my-textarea-name'
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.attr('name')).toEqual('my-textarea-name')
+    })
+
+    it('renders with rows', () => {
+      const $ = render('textarea', {
+        rows: '4'
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.attr('rows')).toEqual('4')
+    })
+
+    it('renders with default number of rows', () => {
+      const $ = render('textarea')
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.attr('rows')).toEqual('5')
+    })
+
+    it('renders with value', () => {
+      const $ = render('textarea', {
+        value: '221B Baker Street\nLondon\nNW1 6XE\n'
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('textarea', {
+        attributes: {
+          'data-attribute': 'my data value'
+        }
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+  })
+
+  describe('with dependant components', () => {
+    it('renders with label', () => {
+      const $ = render('textarea', {
+        id: 'my-textarea',
+        label: {
+          'text': 'Full address'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-label')).toMatchSnapshot()
+    })
+
+    it('renders label with "for" attribute reffering the textarea "id"', () => {
+      const $ = render('textarea', {
+        id: 'my-textarea',
+        label: {
+          'text': 'Full address'
+        }
+      })
+
+      const $label = $('.govuk-c-label')
+      expect($label.attr('for')).toEqual('my-textarea')
+    })
+
+    it('renders with error message', () => {
+      const $ = render('textarea', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
+    })
+
+    it('has error class when rendered with error message', () => {
+      const $ = render('textarea', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-c-textarea')
+      expect($component.hasClass('govuk-c-textarea--error')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
This PR:
- Adds tests to textarea component to ensure the markup is rendered correctly when providing arguments to the macro;
- Updates [CHANGELOG.MD](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

[Trello Card](https://trello.com/c/OMxt1vUN)