### PR TITLE
Add javascript linting extension docs for Visual Studio Code

### DIFF
--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -28,6 +28,12 @@ Install [linter-js-standard](https://atom.io/packages/linter-js-standard).
 
 For automatic formatting, install [standard-formatter](https://atom.io/packages/standard-formatter). For snippets, install [standardjs-snippets](https://atom.io/packages/standardjs-snippets).
 
+### Visual Studio Code
+
+Install [vscode-standardjs](https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs). It includes support for automatic formatting.
+
+For snippets, install [vscode-standardjs-snippets](https://marketplace.visualstudio.com/items?itemName=capaj.vscode-standardjs-snippets).
+
 ### Other editors
 
 There are [official guides for most of the popular editors](http://standardjs.com/index.html#text-editor-plugins).


### PR DESCRIPTION
This is to make the plugin for VS Code more prominent as more and more people are using it.