### PR TITLE
Add tests for file upload macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Internal:
 - Add tests for textarea component (PR [#497](https://github.com/alphagov/govuk-frontend/pull/497))
 - Add tests for panel component (PR [#500](https://github.com/alphagov/govuk-frontend/pull/500))
 - Add tests for skip-link component (PR [#498](https://github.com/alphagov/govuk-frontend/pull/498))
+- Add tests for file-upload component (PR [#504](https://github.com/alphagov/govuk-frontend/pull/504))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/src/components/file-upload/__snapshots__/template.test.js.snap
+++ b/src/components/file-upload/__snapshots__/template.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`File upload with dependant components renders with error message 1`] = `
+
+<span class="govuk-c-error-message">
+  Error message
+</span>
+
+`;
+
+exports[`File upload with dependant components renders with label 1`] = `
+
+<label class="govuk-c-label"
+       for="my-file-upload"
+>
+  Full address
+</label>
+
+`;

--- a/src/components/file-upload/template.test.js
+++ b/src/components/file-upload/template.test.js
@@ -1,0 +1,100 @@
+/* globals describe, it, expect */
+
+const { render, htmlWithClassName } = require('../../../lib/jest-helpers')
+
+describe('File upload', () => {
+  describe('by default', () => {
+    it('renders with classes', () => {
+      const $ = render('file-upload', {
+        classes: 'app-c-file-upload--custom-modifier'
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.hasClass('app-c-file-upload--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with id', () => {
+      const $ = render('file-upload', {
+        id: 'my-file-upload'
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.attr('id')).toEqual('my-file-upload')
+    })
+
+    it('renders with name', () => {
+      const $ = render('file-upload', {
+        name: 'my-file-upload-name'
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.attr('name')).toEqual('my-file-upload-name')
+    })
+
+    it('renders with value', () => {
+      const $ = render('file-upload', {
+        value: 'C:/fakepath'
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.val()).toEqual('C:/fakepath')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('file-upload', {
+        attributes: {
+          'data-attribute': 'my data value'
+        }
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+  })
+
+  describe('with dependant components', () => {
+    it('renders with label', () => {
+      const $ = render('file-upload', {
+        id: 'my-file-upload',
+        label: {
+          'text': 'Full address'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-label')).toMatchSnapshot()
+    })
+
+    it('renders label with "for" attribute reffering the file-upload "id"', () => {
+      const $ = render('file-upload', {
+        id: 'my-file-upload',
+        label: {
+          'text': 'Full address'
+        }
+      })
+
+      const $label = $('.govuk-c-label')
+      expect($label.attr('for')).toEqual('my-file-upload')
+    })
+
+    it('renders with error message', () => {
+      const $ = render('file-upload', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
+    })
+
+    it('has error class when rendered with error message', () => {
+      const $ = render('file-upload', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-c-file-upload')
+      expect($component.hasClass('govuk-c-file-upload--error')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
This PR:
- Adds tests to file upload component to ensure the markup is rendered correctly when providing arguments to the macro;
- Updates [CHANGELOG.MD](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

[Trello Card](https://trello.com/c/WUdwotYU)