### PR TITLE
Add tests for select macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,8 @@ Fixes:
 - Remove regular font weight from link styles (PR [#469](https://github.com/alphagov/govuk-frontend/pull/469))
 - Remove redundant 'govuk-c-border' div from the details component
   (PR [#481](https://github.com/alphagov/govuk-frontend/pull/481))
-
+- Add `govuk-c-select--error` modifier class to the select component instead of relying on `govuk-c-input--error` (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
+- Allow error message and hint text to be passed to a select component without requiring a label parameter (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 
 Internal:
 
@@ -54,6 +55,7 @@ Internal:
 - Add tests for phase-banner component (PR [#505](https://github.com/alphagov/govuk-frontend/pull/505))
 - Add tests for label component component (PR [#508](https://github.com/alphagov/govuk-frontend/pull/508))
 - Add tests for fieldset component (PR [#509](https://github.com/alphagov/govuk-frontend/pull/509))
+- Add tests for select component (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -74,7 +74,7 @@ More information about when to use select can be found on [GOV.UK Design System]
     </span>
 
     </label>
-    <select class="govuk-c-select govuk-c-input--error" id="select-2" name="select-2">
+    <select class="govuk-c-select govuk-c-select--error" id="select-2" name="select-2">
 
       <option value="1">GOV.UK frontend option 1</option>
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -270,30 +270,6 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">hintText</th>
-
-<td class="govuk-c-table__cell ">string</td>
-
-<td class="govuk-c-table__cell ">No</td>
-
-<td class="govuk-c-table__cell ">Optional text to use as a hint</td>
-
-</tr>
-
-<tr class="govuk-c-table__row">
-
-<th class="govuk-c-table__header" scope="row">hintHtml</th>
-
-<td class="govuk-c-table__cell ">string</td>
-
-<td class="govuk-c-table__cell ">No</td>
-
-<td class="govuk-c-table__cell ">Optional HTML to use as a hint. If this is provided, the hintText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-c-table__row">
-
 <th class="govuk-c-table__header" scope="row">errorMessage</th>
 
 <td class="govuk-c-table__cell ">string</td>

--- a/src/components/select/__snapshots__/template.test.js.snap
+++ b/src/components/select/__snapshots__/template.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Select with dependant components renders with error message 1`] = `
+
+<span class="govuk-c-error-message">
+  Error message
+</span>
+
+`;
+
+exports[`Select with dependant components renders with label 1`] = `
+
+<label class="govuk-c-label"
+       for="my-select"
+>
+  National Insurance number
+</label>
+
+`;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -26,4 +26,8 @@
     background-color: $govuk-blue;
   }
 
+  .govuk-c-select--error {
+    border: $govuk-border-width-error solid $govuk-error-colour;
+  }
+
 }

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -158,34 +158,6 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'hintText'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional text to use as a hint'
-      }
-    ],
-    [
-      {
-        text: 'hintHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional HTML to use as a hint. If this is provided, the hintText argument will be ignored.'
-      }
-    ],
-    [
-      {
         text: 'errorMessage'
       },
       {

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -13,7 +13,7 @@
 {% endif -%}
 
 <select class="govuk-c-select
-  {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
 {% for item in params.items %}
   <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
 {% endfor %}

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -1,5 +1,5 @@
 {% from "label/macro.njk" import govukLabel %}
-{%- if params.label %}
+
 {{- govukLabel({
   html: params.label.html,
   text: params.label.text,
@@ -10,7 +10,6 @@
   errorMessage: params.errorMessage,
   for: params.id
 }) -}}
-{% endif -%}
 
 <select class="govuk-c-select
   {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>

--- a/src/components/select/template.test.js
+++ b/src/components/select/template.test.js
@@ -1,0 +1,178 @@
+/* globals describe, it, expect */
+
+const { render, htmlWithClassName } = require('../../../lib/jest-helpers')
+
+describe('Select', () => {
+  describe('by default', () => {
+    it('renders with classes', () => {
+      const $ = render('select', {
+        classes: 'app-c-select--custom-modifier'
+      })
+
+      const $component = $('.govuk-c-select')
+      expect($component.hasClass('app-c-select--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with id', () => {
+      const $ = render('select', {
+        id: 'my-select'
+      })
+
+      const $component = $('.govuk-c-select')
+      expect($component.attr('id')).toEqual('my-select')
+    })
+
+    it('renders with name', () => {
+      const $ = render('select', {
+        name: 'my-select-name'
+      })
+
+      const $component = $('.govuk-c-select')
+      expect($component.attr('name')).toEqual('my-select-name')
+    })
+
+    it('renders with items', () => {
+      const $ = render('select', {
+        items: [
+          {
+            'text': 'Option 1'
+          },
+          {
+            'text': 'Options 2'
+          }
+        ]
+      })
+      const $items = $('.govuk-c-select option')
+      expect($items.length).toEqual(2)
+    })
+
+    it('renders item with value', () => {
+      const $ = render('select', {
+        value: '2',
+        items: [
+          {
+            'value': '1',
+            'text': 'Option 1'
+          },
+          {
+            'value': '2',
+            'text': 'Options 2'
+          }
+        ]
+      })
+
+      const $firstItem = $('.govuk-c-select option:first-child')
+      expect($firstItem.attr('value')).toEqual('1')
+    })
+
+    it('renders item with text', () => {
+      const $ = render('select', {
+        value: '2',
+        items: [
+          {
+            'text': 'Option 1'
+          },
+          {
+            'text': 'Options 2'
+          }
+        ]
+      })
+
+      const $firstItem = $('.govuk-c-select option:first-child')
+      expect($firstItem.text()).toEqual('Option 1')
+    })
+
+    it('renders item with selected', () => {
+      const $ = render('select', {
+        value: '2',
+        items: [
+          {
+            'text': 'Option 1',
+            'selected': true
+          },
+          {
+            'text': 'Options 2'
+          }
+        ]
+      })
+
+      const $firstItem = $('.govuk-c-select option:first-child')
+      expect($firstItem.attr('selected')).toBeTruthy()
+    })
+
+    it('renders item with disabled', () => {
+      const $ = render('select', {
+        value: '2',
+        items: [
+          {
+            text: 'Option 1',
+            disabled: true
+          },
+          {
+            text: 'Options 2'
+          }
+        ]
+      })
+
+      const $firstItem = $('.govuk-c-select option:first-child')
+      expect($firstItem.attr('disabled')).toBeTruthy()
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('select', {
+        attributes: {
+          'data-attribute': 'my data value'
+        }
+      })
+
+      const $component = $('.govuk-c-select')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+  })
+
+  describe('with dependant components', () => {
+    it('renders with label', () => {
+      const $ = render('select', {
+        id: 'my-select',
+        label: {
+          'text': 'National Insurance number'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-label')).toMatchSnapshot()
+    })
+
+    it('renders label with "for" attribute reffering the select "id"', () => {
+      const $ = render('select', {
+        id: 'my-select',
+        label: {
+          'text': 'Label text'
+        }
+      })
+
+      const $label = $('.govuk-c-label')
+      expect($label.attr('for')).toEqual('my-select')
+    })
+
+    it('renders with error message', () => {
+      const $ = render('select', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-c-error-message')).toMatchSnapshot()
+    })
+
+    it('has error class when rendered with error message', () => {
+      const $ = render('select', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-c-select')
+      expect($component.hasClass('govuk-c-select--error')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
This PR:
- Adds tests to select component to ensure the markup is rendered correctly when providing arguments to the macro;
- Updates [CHANGELOG.MD](https://github.com/alphagov/govuk-frontend/blob/master/CHANGELOG.md).

[Trello Card](https://trello.com/c/3R8USRGF)