### PR TITLE
Update flatten path to include _snapshots_ folder

### DIFF
--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -63,7 +63,7 @@ gulp.task('copy-files', () => {
   .pipe(components) // replace import in scss files and flatten folder (e.g remove components/)
   .pipe(gulpif(isPackages, replace('../../globals/scss', '@govuk-frontend/globals')))
   .pipe(gulpif(isPackages, replace('../', '@govuk-frontend/')))
-  .pipe(gulpif(!isProduction, flatten({includeParents: -1})))
+  .pipe(gulpif(!isProduction, flatten({subPath: [1, 3]})))
   .pipe(components.restore)
   .pipe(gulp.dest(taskArguments.destination + '/'))
 })


### PR DESCRIPTION
If we want to publish test files and _snapshots_ with them then `flatten` path needs to be amended to include that folder as well.

This is primarily until we update the build pipeline where we wouldn't need to flatten the folders.

NOTE: If we don't want to include tests and _shapshots_ then the copy tasks needs to be amended to exclude those files and copy test to be update to account for the missing files