### PR TITLE
Add error highlighting to form components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,10 @@ Fixes:
 - Add `govuk-c-select--error` modifier class to the select component instead of relying on `govuk-c-input--error` (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Allow error message and hint text to be passed to a select component without requiring a label parameter (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Define size of inputs etc in `px` rather than `em`. (PR [#491](https://github.com/alphagov/govuk-frontend/pull/491))
-- Remove scope=row attribute from non-th elements (PR [527](https://github.com/alphagov/govuk-frontend/pull/527)) 
+- Remove scope=row attribute from non-th elements (PR [527](https://github.com/alphagov/govuk-frontend/pull/527))
+- Form components and fieldset now include `govuk-o-form-group` that sets left
+border for errors and a bottom margin. Add example of form errors to preview app
+(PR [#591](https://github.com/alphagov/govuk-frontend/pull/591))
 
 Internal:
 

--- a/app/views/examples/error-messages/index.njk
+++ b/app/views/examples/error-messages/index.njk
@@ -1,0 +1,248 @@
+{% extends "layout.njk" %}
+
+{% block styles %}
+<style>
+  .app-u-w-full {
+    width: 100%;
+  }
+
+  .app-u-w-half {
+    width: 50%;
+    float: left;
+  }
+
+  .app-u-w-third {
+    width: 33.33333333%;
+    float: left;
+  }
+
+  .app-u-w-quarter {
+    width: 25%;
+    float: left;
+  }
+
+  .app-u-w-two-thirds {
+    width: 66.66666667%;
+    float: left;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+
+{% from "fieldset/macro.njk" import govukFieldset %}
+{% from "label/macro.njk" import govukLabel %}
+{% from "input/macro.njk" import govukInput %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "select/macro.njk" import govukSelect %}
+{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from 'radios/macro.njk' import govukRadios %}
+{% from 'textarea/macro.njk' import govukTextarea %}
+
+<h1 class="govuk-heading-xl">Error messages</h1>
+
+
+<form action="/" method="post">
+  <h2 class="govuk-heading-m">Simple input</h2>
+
+  {{ govukInput({
+    label: {
+      text: "National Insurance Number",
+      hintText: "It’s on your National Insurance card, benefit letter,
+      payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    id: "input-1",
+    name: "test-name",
+    errorMessage: {
+      text: "National Insurance Number"
+    }
+  }) }}
+
+  <h2 class="govuk-heading-m">Multiple inputs</h2>
+
+  {# Use fieldset to wrap around components and render collective error #}
+  {% call govukFieldset({
+    legendText: "User address"
+  }) %}
+    {# Passing below to fieldset to render #}
+    {{ govukInput({
+      label: {
+        "text": "Street"
+      },
+      id: "input-2",
+      name: "test-name",
+      errorMessage: {
+        text: "Enter valid street name"
+      }
+    }) }}
+    {{ govukInput({
+      label: {
+        "text": "Town"
+      },
+      id: "input-3",
+      name: "test-name"
+    }) }}
+    {{ govukInput({
+      label: {
+        "text": "City"
+      },
+      id: "input-4",
+      name: "test-name"
+    }) }}
+  {# end fieldset render #}
+  {% endcall %}
+
+  <h2 class="govuk-heading-m">Radios with error message</h2>
+
+  {{ govukRadios({
+    fieldset: {
+      legendHtml: "<h3 class=\"govuk-heading-m\">How do you want to be contacted?</h3>"
+    },
+    errorMessage: {
+      text: "Please select an option"
+    },
+    idPrefix: "radio-stacked",
+    name: "radio-stacked",
+    items: [
+      {
+        value: "email",
+        text: "Email"
+      },
+      {
+        value: "phone",
+        text: "Phone"
+      },
+      {
+        value: "text",
+        text: "Text message"
+      }
+    ]
+  }) }}
+
+  <h2 class="govuk-heading-m">Checkboxes with error message</h2>
+
+  {{ govukCheckboxes({
+    fieldset: {
+      legendHtml: "<h3 class=\"govuk-heading-m\">What type of waste do you want to dispose of?</h3>"
+    },
+    errorMessage: {
+      text: "Please select an option"
+    },
+    idPrefix: "checkboxes-stacked",
+    name: "checkboxes-stacked",
+    items: [
+      {
+        value: "waste-animal",
+        text: "Waste from animal carcasses"
+      },
+      {
+        value: "waste-mines",
+        text: "Waste from mines or quarries"
+      },
+      {
+        value: "waste-other",
+        text: "Waste from other"
+      }
+    ]
+  }) }}
+
+  <h2 class="govuk-heading-m">Date input with shared error message</h2>
+
+  {{- govukDateInput({
+    fieldset: {
+      legendText: 'What is your date of birth?',
+      legendHintText: 'For example, 31 3 1980'
+    },
+    errorMessage: {
+      text: 'Error message goes here'
+    },
+    id: 'dob',
+    name: 'dob',
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  -}}
+
+  <h2 class="govuk-heading-m">Date input with single error message</h2>
+
+  {{- govukDateInput({
+    fieldset: {
+      legendText: 'What is your date of birth?',
+      legendHintText: 'For example, 31 3 1980'
+    },
+    errorMessage: {
+      text: 'Day not valid'
+    },
+    id: 'dob',
+    name: 'dob',
+    items:[
+      {
+        name: 'day',
+        classes: 'govuk-c-input--error'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  -}}
+
+  <h2 class="govuk-heading-m">Select with error message</h2>
+
+  {{ govukSelect({
+    "id": "select-1",
+    "name": "select-1",
+    "label": {
+      "html": "Label text goes here"
+    },
+    "errorMessage": {
+      text: "Error message goes here"
+    },
+    "items": [
+      {
+        "value": 1,
+        "text": "GOV.UK frontend option 1"
+      },
+      {
+        "value": 2,
+        "text": "GOV.UK frontend option 2",
+        "selected": true
+      },
+      {
+        "value": 3,
+        "text": "GOV.UK frontend option 3"
+      }
+    ]
+    }) }}
+
+  <h2 class="govuk-heading-m">Textarea with error message</h2>
+
+  {{ govukTextarea({
+    id: "more-detail",
+    name: "more-detail",
+    label: {
+      text: "Can you provide more detail?",
+      hintText: "Don't include personal or financial information, eg your National Insurance number or credit card details."
+    },
+    "errorMessage": {
+      text: "Error message goes here"
+    }
+    })
+  }}
+
+</form>
+
+{% endblock %}

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -18,14 +18,15 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
     <div class="govuk-c-checkboxes">
 
-      <fieldset class="govuk-c-fieldset">
+      <div class="govuk-o-form-group">
+        <fieldset class="govuk-c-fieldset">
 
-        <legend class="govuk-c-fieldset__legend">
-          What is your nationality?
+          <legend class="govuk-c-fieldset__legend">
+            What is your nationality?
 
-          <span class="govuk-c-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
+            <span class="govuk-c-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-checkboxes__item">
           <input class="govuk-c-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
@@ -51,6 +52,7 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -142,14 +144,15 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
     <div class="govuk-c-checkboxes">
 
-      <fieldset class="govuk-c-fieldset">
+      <div class="govuk-o-form-group">
+        <fieldset class="govuk-c-fieldset">
 
-        <legend class="govuk-c-fieldset__legend">
-          <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+          <legend class="govuk-c-fieldset__legend">
+            <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
 
-          <span class="govuk-c-fieldset__hint">Select all that apply</span>
+            <span class="govuk-c-fieldset__hint">Select all that apply</span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-checkboxes__item">
           <input class="govuk-c-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
@@ -175,6 +178,7 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -263,18 +267,19 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
     <div class="govuk-c-checkboxes">
 
-      <fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
+      <div class="govuk-o-form-group govuk-o-form-group--error">
+        <fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
 
-        <legend class="govuk-c-fieldset__legend">
-          What is your nationality?
+          <legend class="govuk-c-fieldset__legend">
+            What is your nationality?
 
-          <span class="govuk-c-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
+            <span class="govuk-c-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
 
-          <span class="govuk-c-error-message">
+            <span class="govuk-c-error-message">
             Please select an option
           </span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-checkboxes__item">
           <input class="govuk-c-checkboxes__input" id="example-1" name="example" type="checkbox" value="british">
@@ -300,6 +305,7 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -332,6 +338,79 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
         {
           "value": "other",
           "text": "Citizen of another country"
+        }
+      ]
+    }) }}
+
+### Checkboxes--with-error
+
+[Preview the checkboxes--with-error example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-error/preview)
+
+#### Markup
+
+    <div class="govuk-c-checkboxes">
+
+      <div class="govuk-o-form-group govuk-o-form-group--error">
+        <fieldset class="govuk-c-fieldset">
+
+          <legend class="govuk-c-fieldset__legend">
+            <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+
+            <span class="govuk-c-error-message">
+            Please select an option
+          </span>
+
+          </legend>
+
+        <div class="govuk-c-checkboxes__item">
+          <input class="govuk-c-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
+          <label class="govuk-c-label govuk-c-checkboxes__label" for="undefined-1">
+            Waste from animal carcasses
+
+          </label>
+        </div>
+
+        <div class="govuk-c-checkboxes__item">
+          <input class="govuk-c-checkboxes__input" id="undefined-2" name="" type="checkbox" value="mines">
+          <label class="govuk-c-label govuk-c-checkboxes__label" for="undefined-2">
+            Waste from mines or quarries
+
+          </label>
+        </div>
+
+        <div class="govuk-c-checkboxes__item">
+          <input class="govuk-c-checkboxes__input" id="undefined-3" name="" type="checkbox" value="farm">
+          <label class="govuk-c-label govuk-c-checkboxes__label" for="undefined-3">
+            Farm or agricultural waste
+
+          </label>
+        </div>
+        </fieldset>
+      </div>
+
+    </div>
+
+#### Macro
+
+    {{ govukCheckboxes({
+      "errorMessage": {
+        "text": "Please select an option"
+      },
+      "fieldset": {
+        "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+      },
+      "items": [
+        {
+          "value": "animal",
+          "text": "Waste from animal carcasses"
+        },
+        {
+          "value": "mines",
+          "text": "Waste from mines or quarries"
+        },
+        {
+          "value": "farm",
+          "text": "Farm or agricultural waste"
         }
       ]
     }) }}

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -7,6 +7,8 @@
     display: block;
     position: relative;
 
+    min-height: $govuk-spacing-scale-7;
+
     margin-bottom: $govuk-spacing-scale-2;
     padding: 0 0 0 40px;
 
@@ -25,8 +27,8 @@
     top: 0;
     left: 0;
 
-    width: 40px;
-    height: 40px;
+    width: $govuk-spacing-scale-7;
+    height: $govuk-spacing-scale-7;
 
     cursor: pointer;
 
@@ -52,8 +54,8 @@
     position: absolute;
     top: 0;
     left: 0;
-    width: 40px;
-    height: 40px;
+    width: $govuk-spacing-scale-7;
+    height: $govuk-spacing-scale-7;
     border: $govuk-border-width-form-element solid $govuk-text-colour;
     background: transparent;
 

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -72,3 +72,18 @@ examples:
         text: 'Irish'
       - value: 'other'
         text: 'Citizen of another country'
+
+- name: with-error
+  data:
+    errorMessage:
+      text: 'Please select an option'
+    fieldset:
+      legendHtml:
+        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+    items:
+      - value: animal
+        text: Waste from animal carcasses
+      - value: mines
+        text: Waste from mines or quarries
+      - value: farm
+        text: Farm or agricultural waste

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -16,47 +16,52 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
+      <div class="govuk-o-form-group govuk-o-form-group--error">
       <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+        <legend class="govuk-c-fieldset__legend">
+          What is your date of birth?
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+          <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Error message goes here
         </span>
 
-      </legend>
+        </legend>
 
       <div class="govuk-c-date-input" id="dob">
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-day">
             Day
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-day" name="dob-day" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-month">
             Month
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-month" name="dob-month" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-year">
             Year
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-year" name="dob-year" type="text">
-        </div>
+          </div>
+          </div>
 
-      </div>
+        </div>
       </fieldset>
+    </div>
 
 #### Macro
 
@@ -89,47 +94,52 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
+      <div class="govuk-o-form-group govuk-o-form-group--error">
       <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+        <legend class="govuk-c-fieldset__legend">
+          What is your date of birth?
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+          <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Error message goes here
         </span>
 
-      </legend>
+        </legend>
 
       <div class="govuk-c-date-input" id="dob-errors">
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-day">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-day">
             Day
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-day" name="undefined-day" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-month">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-month">
             Month
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-month" name="undefined-month" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-year">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-errors-year">
             Year
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-errors-year" name="undefined-year" type="text">
-        </div>
+          </div>
+          </div>
 
-      </div>
+        </div>
       </fieldset>
+    </div>
 
 #### Macro
 
@@ -164,47 +174,52 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
+      <div class="govuk-o-form-group govuk-o-form-group--error">
       <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+        <legend class="govuk-c-fieldset__legend">
+          What is your date of birth?
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+          <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Error message goes here
         </span>
 
-      </legend>
+        </legend>
 
       <div class="govuk-c-date-input" id="dob-day-error">
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-day">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-day">
             Day
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-day-error-day" name="dob-day-error-day" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-month">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-month">
             Month
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-day-error-month" name="dob-day-error-month" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-year">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-day-error-year">
             Year
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-day-error-year" name="dob-day-error-year" type="text">
-        </div>
+          </div>
+          </div>
 
-      </div>
+        </div>
       </fieldset>
+    </div>
 
 #### Macro
 
@@ -238,47 +253,52 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
+      <div class="govuk-o-form-group govuk-o-form-group--error">
       <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+        <legend class="govuk-c-fieldset__legend">
+          What is your date of birth?
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+          <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Error message goes here
         </span>
 
-      </legend>
+        </legend>
 
       <div class="govuk-c-date-input" id="dob-month-error">
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-day">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-day">
             Day
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-month-error-day" name="dob-month-error-day" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-month">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-month">
             Month
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-month-error-month" name="dob-month-error-month" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-year">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-month-error-year">
             Year
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-month-error-year" name="dob-month-error-year" type="text">
-        </div>
+          </div>
+          </div>
 
-      </div>
+        </div>
       </fieldset>
+    </div>
 
 #### Macro
 
@@ -312,47 +332,52 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
+      <div class="govuk-o-form-group govuk-o-form-group--error">
       <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your date of birth?
+        <legend class="govuk-c-fieldset__legend">
+          What is your date of birth?
 
-        <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
+          <span class="govuk-c-fieldset__hint">For example, 31 3 1980</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Error message goes here
         </span>
 
-      </legend>
+        </legend>
 
       <div class="govuk-c-date-input" id="dob-year-error">
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-day">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--day">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-day">
             Day
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-year-error-day" name="dob-year-error-day" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-month">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--month">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-month">
             Month
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input" id="dob-year-error-month" name="dob-year-error-month" type="text">
-        </div>
+          </div>
+          </div>
 
-        <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
-          <label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-year">
+          <div class="govuk-c-date-input__item govuk-c-date-input__item--year">
+            <div class="govuk-o-form-group"><label class="govuk-c-label govuk-c-date-input__label" for="dob-year-error-year">
             Year
 
           </label>
           <input class="govuk-c-input govuk-c-date-input__input govuk-c-input--error" id="dob-year-error-year" name="dob-year-error-year" type="text">
-        </div>
+          </div>
+          </div>
 
-      </div>
+        </div>
       </fieldset>
+    </div>
 
 #### Macro
 

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -3,24 +3,24 @@
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
-<div class="govuk-c-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
-  {%- if params.id %} id="{{ params.id }}"{% endif %}>
-  {% for item in params.items %}
-  <div class="govuk-c-date-input__item govuk-c-date-input__item--{{ item.name }}">
-    {{ govukInput({
-      "label":{
-        "text": item.name | capitalize,
-        "classes": 'govuk-c-date-input__label'
-      },
-      "id": params.id + "-" + item.name,
-      "classes": "govuk-c-date-input__input" + (" " + item.classes if item.classes),
-      "name": params.name + "-" + item.name,
-      "value": item.value
-    }) | indent(4) | trim }}
-  </div>
+  <div class="govuk-c-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
+    {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+    {%- if params.id %} id="{{ params.id }}"{% endif %}>
+    {% for item in params.items %}
+    <div class="govuk-c-date-input__item govuk-c-date-input__item--{{ item.name }}">
+      {{ govukInput({
+        "label":{
+          "text": item.name | capitalize,
+          "classes": 'govuk-c-date-input__label'
+        },
+        "id": params.id + "-" + item.name,
+        "classes": "govuk-c-date-input__input" + (" " + item.classes if item.classes),
+        "name": params.name + "-" + item.name,
+        "value": item.value
+      }) | indent(4) | trim }}
+    </div>
   {% endfor %}
-</div>
+  </div>
 {% endset %}
 
 {%- if params.fieldset %}
@@ -33,7 +33,7 @@
     legendHintHtml: params.fieldset.legendHintHtml,
     errorMessage: params.errorMessage
   }) %}
-  {{ innerHtml | indent(2) | trim | safe }}
+  {{- innerHtml | indent(2) | trim | safe }}
   {% endcall %}
 {% else %}
   {{ innerHtml | trim | safe }}

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -10,7 +10,7 @@
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
     @include mq($from: tablet) {
-      border: $govuk-border-width-tablet solid $govuk-error-colour;
+      border: $govuk-border-width solid $govuk-error-colour;
     }
 
     // TODO: Fix IE < 8

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -16,16 +16,18 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+    <div class="govuk-o-form-group">
+      <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your address?
+        <legend class="govuk-c-fieldset__legend">
+          What is your address?
 
-        <span class="govuk-c-fieldset__hint">For example, 10 Downing Street</span>
+          <span class="govuk-c-fieldset__hint">For example, 10 Downing Street</span>
 
-      </legend>
+        </legend>
 
-    </fieldset>
+      </fieldset>
+    </div>
 
 #### Macro
 
@@ -40,20 +42,22 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <fieldset class="govuk-c-fieldset">
+    <div class="govuk-o-form-group govuk-o-form-group--error">
+      <fieldset class="govuk-c-fieldset">
 
-      <legend class="govuk-c-fieldset__legend">
-        What is your address?
+        <legend class="govuk-c-fieldset__legend">
+          What is your address?
 
-        <span class="govuk-c-fieldset__hint">For example, 10 Downing Street</span>
+          <span class="govuk-c-fieldset__hint">For example, 10 Downing Street</span>
 
-        <span class="govuk-c-error-message">
+          <span class="govuk-c-error-message">
           Please fill in the street input
         </span>
 
-      </legend>
+        </legend>
 
-    </fieldset>
+      </fieldset>
+    </div>
 
 #### Macro
 

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -2,10 +2,7 @@
 
 @include exports("fieldset") {
   .govuk-c-fieldset {
-    margin: 0 0 $govuk-spacing-scale-4;
-    @include mq($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-6;
-    }
+    margin: 0;
     padding: 0;
     border: 0;
     @include govuk-h-clearfix;

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -1,17 +1,19 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 
-<fieldset class="govuk-c-fieldset
-  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  {% if params.legendHtml or params.legendText %}
-  <legend class="govuk-c-fieldset__legend">
-    {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
-    {% if params.legendHintText or params.legendHintHtml %}
-    <span class="govuk-c-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
+<div class="govuk-o-form-group {%- if params.errorMessage %} govuk-o-form-group--error{% endif %}">
+  <fieldset class="govuk-c-fieldset
+    {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {% if params.legendHtml or params.legendText %}
+    <legend class="govuk-c-fieldset__legend">
+      {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+      {% if params.legendHintText or params.legendHintHtml %}
+      <span class="govuk-c-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
+      {% endif %}
+      {% if params.errorMessage %}
+      {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
+      {% endif %}
+    </legend>
     {% endif %}
-    {% if params.errorMessage %}
-    {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
-    {% endif %}
-  </legend>
-  {% endif %}
-{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
-</fieldset>
+  {{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
+  </fieldset>
+</div>

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -16,11 +16,12 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <label class="govuk-c-label" for="file-upload-1">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="file-upload-1">
       Upload a file
 
     </label>
     <input type="file" id="file-upload-1" name="file-upload-1" class="govuk-c-file-upload">
+    </div>
 
 #### Macro
 
@@ -38,7 +39,7 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <label class="govuk-c-label" for="file-upload-2">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="file-upload-2">
       Upload your photo
 
       <span class="govuk-c-label__hint">
@@ -47,6 +48,7 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
     </label>
     <input type="file" id="file-upload-2" name="file-upload-2" class="govuk-c-file-upload">
+    </div>
 
 #### Macro
 
@@ -65,7 +67,7 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <label class="govuk-c-label" for="file-upload-3">
+    <div class="govuk-o-form-group govuk-o-form-group--error"><label class="govuk-c-label" for="file-upload-3">
       Upload a file
 
       <span class="govuk-c-label__hint">
@@ -78,6 +80,7 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
     </label>
     <input type="file" id="file-upload-3" name="file-upload-3" class="govuk-c-file-upload govuk-c-file-upload--error">
+    </div>
 
 #### Macro
 
@@ -99,11 +102,12 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <label class="govuk-c-label" for="file-upload-4">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="file-upload-4">
       Upload a photo
 
     </label>
     <input type="file" id="file-upload-4" name="file-upload-4" value="C:\fakepath\myphoto.jpg" class="govuk-c-file-upload" accept=".jpg, .jpeg, .png">
+    </div>
 
 #### Macro
 

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -9,6 +9,6 @@
   }
 
   .govuk-c-file-upload--error {
-    border: $govuk-border-width-error solid $govuk-error-colour;
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 }

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -5,7 +5,6 @@
     @include govuk-font-regular-19;
     @include govuk-text-colour;
     @include govuk-focusable;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
   .govuk-c-file-upload--error {

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,16 +1,18 @@
 {% from "label/macro.njk" import govukLabel %}
 
 {#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
+<div class="govuk-o-form-group {%- if params.errorMessage %} govuk-o-form-group--error{% endif %}">
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    errorMessage: params.errorMessage,
+    for: params.id
+  }) -}}
 
-<input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-c-file-upload {{- ' govuk-c-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  <input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-c-file-upload {{- ' govuk-c-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+</div>

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -16,11 +16,12 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <label class="govuk-c-label" for="input-1">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="input-1">
       National Insurance number
 
     </label>
     <input class="govuk-c-input" id="input-1" name="test-name" type="text">
+    </div>
 
 #### Macro
 
@@ -38,7 +39,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <label class="govuk-c-label" for="input-2">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="input-2">
       National insurance number
 
       <span class="govuk-c-label__hint">
@@ -47,6 +48,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     </label>
     <input class="govuk-c-input" id="input-2" name="test-name-2" type="text">
+    </div>
 
 #### Macro
 
@@ -65,7 +67,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <label class="govuk-c-label" for="input-3">
+    <div class="govuk-o-form-group govuk-o-form-group--error"><label class="govuk-c-label" for="input-3">
       National Insurance number
 
       <span class="govuk-c-label__hint">
@@ -78,6 +80,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     </label>
     <input class="govuk-c-input govuk-c-input--error" id="input-3" name="test-name-3" type="text">
+    </div>
 
 #### Macro
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -11,7 +11,6 @@
     width: 100%;
     height: 40px;
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 
     padding: $govuk-spacing-scale-1;
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -34,7 +34,7 @@
   }
 
   .govuk-c-input--error {
-    border: $govuk-border-width-error solid $govuk-error-colour;
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 
 }

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,16 +1,19 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
+<div class="govuk-o-form-group {%- if params.errorMessage %} govuk-o-form-group--error{% endif %}">
 
-<input class="govuk-c-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
-{%- if params.value %} value="{{ params.value}}"{% endif %}
-{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    errorMessage: params.errorMessage,
+    for: params.id
+  }) -}}
+
+  <input class="govuk-c-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-c-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="text"
+  {%- if params.value %} value="{{ params.value}}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+</div>

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -18,14 +18,15 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
     <div class="govuk-c-radios">
 
-      <fieldset class="govuk-c-fieldset">
+      <div class="govuk-o-form-group">
+        <fieldset class="govuk-c-fieldset">
 
-        <legend class="govuk-c-fieldset__legend">
-          Have you changed your name?
+          <legend class="govuk-c-fieldset__legend">
+            Have you changed your name?
 
-          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+            <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-radios__item">
           <input class="govuk-c-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -43,6 +44,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -76,14 +78,15 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
     <div class="govuk-c-radios">
 
-      <fieldset class="govuk-c-fieldset">
+      <div class="govuk-o-form-group">
+        <fieldset class="govuk-c-fieldset">
 
-        <legend class="govuk-c-fieldset__legend">
-          Have you changed your name?
+          <legend class="govuk-c-fieldset__legend">
+            Have you changed your name?
 
-          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+            <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-radios__item">
           <input class="govuk-c-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
@@ -101,6 +104,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -135,14 +139,15 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
     <div class="govuk-c-radios">
 
-      <fieldset class="govuk-c-fieldset">
+      <div class="govuk-o-form-group">
+        <fieldset class="govuk-c-fieldset">
 
-        <legend class="govuk-c-fieldset__legend">
-          <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+          <legend class="govuk-c-fieldset__legend">
+            <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
 
-          <span class="govuk-c-fieldset__hint">Select one of the options below.</span>
+            <span class="govuk-c-fieldset__hint">Select one of the options below.</span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-radios__item">
           <input class="govuk-c-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
@@ -160,6 +165,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 
@@ -246,18 +252,19 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
     <div class="govuk-c-radios">
 
-      <fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
+      <div class="govuk-o-form-group govuk-o-form-group--error">
+        <fieldset class="govuk-c-fieldset app-c-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
 
-        <legend class="govuk-c-fieldset__legend">
-          Have you changed your name?
+          <legend class="govuk-c-fieldset__legend">
+            Have you changed your name?
 
-          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+            <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-          <span class="govuk-c-error-message">
+            <span class="govuk-c-error-message">
             Please select an option
           </span>
 
-        </legend>
+          </legend>
 
         <div class="govuk-c-radios__item">
           <input class="govuk-c-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -275,6 +282,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </label>
         </div>
         </fieldset>
+      </div>
 
     </div>
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -14,8 +14,8 @@
     clear: left;
   }
 
-  .govuk-c-radios__item :last-child,
-  .govuk-c-radios__item :last-of-type {
+  .govuk-c-radios__item:last-child,
+  .govuk-c-radios__item:last-of-type {
     margin-bottom: 0;
   }
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -8,6 +8,8 @@
 
     position: relative;
 
+    min-height: $govuk-spacing-scale-7;
+
     margin-bottom: $govuk-spacing-scale-2;
     padding: 0 0 0 $govuk-spacing-scale-7;
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -16,19 +16,20 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
 
 #### Markup
 
-    <label class="govuk-c-label" for="select-1">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="select-1">
       Label text goes here
 
     </label>
     <select class="govuk-c-select" id="select-1" name="select-1">
 
-      <option value="1">GOV.UK frontend option 1</option>
+        <option value="1">GOV.UK frontend option 1</option>
 
-      <option value="2" selected>GOV.UK frontend option 2</option>
+        <option value="2" selected>GOV.UK frontend option 2</option>
 
-      <option value="3" disabled>GOV.UK frontend option 3</option>
+        <option value="3" disabled>GOV.UK frontend option 3</option>
 
-    </select>
+      </select>
+    </div>
 
 #### Macro
 
@@ -62,7 +63,7 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
 
 #### Markup
 
-    <label class="govuk-c-label" for="select-2">
+    <div class="govuk-o-form-group govuk-o-form-group--error"><label class="govuk-c-label" for="select-2">
       Label text goes here
 
       <span class="govuk-c-label__hint">
@@ -76,13 +77,14 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
     </label>
     <select class="govuk-c-select govuk-c-select--error" id="select-2" name="select-2">
 
-      <option value="1">GOV.UK frontend option 1</option>
+        <option value="1">GOV.UK frontend option 1</option>
 
-      <option value="2">GOV.UK frontend option 2</option>
+        <option value="2">GOV.UK frontend option 2</option>
 
-      <option value="3">GOV.UK frontend option 3</option>
+        <option value="3">GOV.UK frontend option 3</option>
 
-    </select>
+      </select>
+    </div>
 
 #### Macro
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -27,7 +27,7 @@
   }
 
   .govuk-c-select--error {
-    border: $govuk-border-width-error solid $govuk-error-colour;
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 
 }

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -13,7 +13,6 @@
     box-sizing: border-box; // should this be global?
     width: 100%;
     height: 40px;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
 
     padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-text-colour;

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -1,19 +1,23 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
 
-<select class="govuk-c-select
-  {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-{% for item in params.items %}
-  <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
-{% endfor %}
-</select>
+<div class="govuk-o-form-group {%- if params.errorMessage %} govuk-o-form-group--error{% endif %}">
+
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    errorMessage: params.errorMessage,
+    for: params.id
+  }) -}}
+
+  <select class="govuk-c-select
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-c-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% for item in params.items %}
+    <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
+  {% endfor %}
+  </select>
+</div>

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -16,7 +16,7 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <label class="govuk-c-label" for="more-detail">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="more-detail">
       Can you provide more detail?
 
       <span class="govuk-c-label__hint">
@@ -25,6 +25,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
     </label>
     <textarea id="more-detail" name="more-detail" rows="5" class="govuk-c-textarea"></textarea>
+
+    </div>
 
 #### Macro
 
@@ -43,7 +45,7 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <label class="govuk-c-label" for="no-ni-reason">
+    <div class="govuk-o-form-group govuk-o-form-group--error"><label class="govuk-c-label" for="no-ni-reason">
       Why can&#39;t you provide a National Insurance number?
 
       <span class="govuk-c-error-message">
@@ -52,6 +54,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
     </label>
     <textarea id="no-ni-reason" name="no-ni-reason" rows="5" class="govuk-c-textarea govuk-c-textarea--error"></textarea>
+
+    </div>
 
 #### Macro
 
@@ -72,7 +76,7 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <label class="govuk-c-label" for="full-address">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="full-address">
       Full address
 
     </label>
@@ -80,6 +84,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
     London
     NW1 6XE
     </textarea>
+
+    </div>
 
 #### Macro
 
@@ -98,11 +104,13 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <label class="govuk-c-label" for="full-address">
+    <div class="govuk-o-form-group"><label class="govuk-c-label" for="full-address">
       Full address
 
     </label>
     <textarea id="full-address" name="address" rows="8" class="govuk-c-textarea"></textarea>
+
+    </div>
 
 #### Macro
 

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -24,6 +24,6 @@
   }
 
   .govuk-c-textarea--error {
-    border: $govuk-border-width-error solid $govuk-error-colour;
+    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 }

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,16 +1,21 @@
 {% from "label/macro.njk" import govukLabel %}
 
-{#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
 
-{{- govukLabel({
-  html: params.label.html,
-  text: params.label.text,
-  hintText: params.label.hintText,
-  hintHtml: params.label.hintHtml,
-  classes: params.label.classes,
-  attributes: params.label.attributes,
-  errorMessage: params.errorMessage,
-  for: params.id
-}) -}}
+<div class="govuk-o-form-group {%- if params.errorMessage %} govuk-o-form-group--error{% endif %}">
 
-<textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-c-textarea {{- ' govuk-c-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
+  {#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
+
+  {{- govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    hintText: params.label.hintText,
+    hintHtml: params.label.hintHtml,
+    classes: params.label.classes,
+    attributes: params.label.attributes,
+    errorMessage: params.errorMessage,
+    for: params.id
+  }) -}}
+
+  <textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-c-textarea {{- ' govuk-c-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
+
+</div>

--- a/src/globals/scss/_common.scss
+++ b/src/globals/scss/_common.scss
@@ -41,6 +41,7 @@
 @import "core/section-break";
 
 // Objects
+@import "objects/form-group";
 @import "objects/grid";
 @import "objects/main-wrapper";
 @import "objects/shapes";

--- a/src/globals/scss/objects/_form-group.scss
+++ b/src/globals/scss/objects/_form-group.scss
@@ -10,7 +10,7 @@
 
   .govuk-o-form-group--error {
     padding-left: $govuk-spacing-scale-3;
-    border-left: $govuk-border-width solid $govuk-red;
+    border-left: $govuk-border-width-form-group-error solid $govuk-error-colour;
 
     .govuk-o-form-group {
       // Reset error styles in nested form groups that might have error class

--- a/src/globals/scss/objects/_form-group.scss
+++ b/src/globals/scss/objects/_form-group.scss
@@ -1,0 +1,21 @@
+@include exports("form-group") {
+
+  .govuk-o-form-group {
+    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+
+    .govuk-o-form-group:last-of-type {
+      margin-bottom: 0; // Remove margin from last item in nested groups
+    }
+  }
+
+  .govuk-o-form-group--error {
+    padding-left: $govuk-spacing-scale-3;
+    border-left: $govuk-border-width solid $govuk-red;
+
+    .govuk-o-form-group {
+      // Reset error styles in nested form groups that might have error class
+      padding: 0;
+      border: 0;
+    }
+  }
+}

--- a/src/globals/scss/settings/_measurements.scss
+++ b/src/globals/scss/settings/_measurements.scss
@@ -5,13 +5,13 @@ $govuk-gutter: $govuk-spacing-scale-6;
 $govuk-gutter-half: $govuk-gutter / 2;
 
 // Border widths
-$govuk-border-width-mobile: 4px;
-$govuk-border-width-tablet: 5px;
-$govuk-border-width-form-element: 2px;
-$govuk-border-width-error: 4px;
-
 $govuk-border-width: 5px;
 $govuk-border-width-wide: 10px;
+
+$govuk-border-width-mobile: 4px;
+$govuk-border-width-form-element: 2px;
+$govuk-border-width-form-element-error: 4px;
+$govuk-border-width-form-group-error: $govuk-border-width;
 
 // Focus
 $govuk-focus-width: 3px;


### PR DESCRIPTION
This PR adds the left error border from Elements to form components by:

- Adding another CSS variable for error border to settings. Also simplifies the border variables somewhat by removing the tablet specific ones and moving the default ones above the more specific border widths.
- Adding a `govuk-o-form-group` object that is used for adding the left error border to form elements, and also for grouping larger groups of form elements to add left error border.
- Wrapping all form elements in `govuk-o-form-group`
- Making checkbox and radios containers the height of children - @alex-ju, I’m aware you had some concerns about this approach. The issue is that the radios/checkboxes are absolutely positioned. We can’t adjust the line height of the text next to them to match the checkboxes height as the text might wrap. Instead we’re using padding to vertically centre the content which throws it off by a pixel or so. For that reason setting the height of the parent which can’t “see” the height of the absolutely positioned content inside fixes this (I know this a bit rambly, happy to talk about this in the office if I’m not making sense 🙂  )
- Adding example of error to preview app for checkboxes component
- Adding examples to preview app in examples/error-messages
- Replacing https://github.com/alphagov/govuk-frontend/pull/494 with a better approach

I used overrides to remove button margin (last two examples) as it doesn’t feel right to handle button margins in the `form-group` styles, having buttons inside form-groups seems like a bit of an edge case. But open to thoughts on this.

Note: Please review in `/examples/error-messages`. It might be easier to look at the commits which separate the work out into smaller chunks. 

_Optional reading, not related to this PR: If you view the page on mobile, there is an issue with margins in the last example. We remove the bottom margin of last-of-type on radios and checkboxes but if you place the item inside a grid item for instance, that rule will apply to all of them and on mobile this is an issue when things stack. I’ll raise another PR for this once I've spoken to @dashouse ._

https://trello.com/c/ioB6wNUq/670-5-add-highlighting-of-errors-to-form-components