### PR TITLE
Remove cookie-banner and previous-next from examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 Breaking changes:
 
 - Remove Cookie-banner and Previous-next components
-  (PR [#488](https://github.com/alphagov/govuk-frontend/pull/488))
+  (PR [#488](https://github.com/alphagov/govuk-frontend/pull/488), PR [#523](https://github.com/alphagov/govuk-frontend/pull/523))
 
 New features:
 
@@ -20,7 +20,7 @@ New features:
   try to use them with anything other than a spacing or font map respectively.
   (PR [#447](https://github.com/alphagov/govuk-frontend/pull/447))
 - Add thematic break to typography and prose scope. This class is added to an
-  `<hr>`, adds margin (xl, l and m). There is also an option to make the `<hr>` 
+  `<hr>`, adds margin (xl, l and m). There is also an option to make the `<hr>`
   border visible or invisible. (PR [#483](https://github.com/alphagov/govuk-frontend/pull/483))
 
 Fixes:
@@ -61,6 +61,7 @@ Internal:
 - Add tests for fieldset component (PR [#509](https://github.com/alphagov/govuk-frontend/pull/509))
 - Add tests for select component (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Add tests for checkboxes component (PR [#513](https://github.com/alphagov/govuk-frontend/pull/513))
+- Add tests to make sure the examples pages render without errors [#523](https://github.com/alphagov/govuk-frontend/pull/523)
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -6,8 +6,57 @@ const cheerio = require('cheerio')
 const app = require('../app.js')
 const lib = require('../../lib/file-helper')
 
-const requestParams = {
+const requestParamsHomepage = {
   url: 'http://localhost:3000/',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleAllComponents = {
+  url: 'http://localhost:3000/examples/all-components',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleFormAlignment = {
+  url: 'http://localhost:3000/examples/form-alignment',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleFormElements = {
+  url: 'http://localhost:3000/examples/form-elements',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleGrid = {
+  url: 'http://localhost:3000/examples/grid',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleLinks = {
+  url: 'http://localhost:3000/examples/links',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleProseScope = {
+  url: 'http://localhost:3000/examples/prose-scope',
+  headers: {
+    'Content-Type': 'text/plain'
+  }
+}
+
+const requestParamsExampleTypography = {
+  url: 'http://localhost:3000/examples/typography',
   headers: {
     'Content-Type': 'text/plain'
   }
@@ -24,26 +73,91 @@ describe('frontend app', () => {
     server.close(done)
   })
 
-  it('should resolve with a http status code of 200', done => {
-    request.get(requestParams, (err, res) => {
-      expect(res.statusCode).toEqual(200)
-      done(err)
+  describe('homepage', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsHomepage, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+
+    it('should resolve with a ‘Content-Type’ header of "text/html"', done => {
+      request.get(requestParamsHomepage, (err, res) => {
+        expect(res.headers['content-type']).toContain('text/html')
+        done(err)
+      })
+    })
+
+    it('should display the list of components', done => {
+      request.get(requestParamsHomepage, (err, res) => {
+        let $ = cheerio.load(res.body)
+        let componentsList = $('li a[href^="/components/"]').get()
+        expect(componentsList.length).toEqual(lib.SrcComponentList.length)
+        done(err)
+      })
     })
   })
 
-  it('should resolve with a ‘Content-Type’ header of "text/html"', done => {
-    request.get(requestParams, (err, res) => {
-      expect(res.headers['content-type']).toContain('text/html')
-      done(err)
+  describe('all components examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleAllComponents, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
     })
   })
 
-  it('should display the list of components', done => {
-    request.get(requestParams, (err, res) => {
-      let $ = cheerio.load(res.body)
-      let componentsList = $('li a[href^="/components/"]').get()
-      expect(componentsList.length).toEqual(lib.SrcComponentList.length)
-      done(err)
+  describe('form alignment examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleFormAlignment, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+  })
+
+  describe('form elements examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleFormElements, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+  })
+
+  describe('grid examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleGrid, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+  })
+
+  describe('links examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleLinks, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+  })
+
+  describe('prose scope examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleProseScope, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
+    })
+  })
+
+  describe('typography examples', () => {
+    it('should resolve with a http status code of 200', done => {
+      request.get(requestParamsExampleTypography, (err, res) => {
+        expect(res.statusCode).toEqual(200)
+        done(err)
+      })
     })
   })
 })

--- a/app/views/examples/all-components/index.njk
+++ b/app/views/examples/all-components/index.njk
@@ -5,7 +5,6 @@
   {% include "breadcrumbs/breadcrumbs.njk" %}
   {% include "button/button.njk" %}
   {% include "checkboxes/checkboxes.njk" %}
-  {% include "cookie-banner/cookie-banner.njk" %}
   {% include "date-input/date-input.njk" %}
   {% include "details/details.njk" %}
   {% include "error-message/error-message.njk" %}
@@ -16,7 +15,6 @@
   {% include "label/label.njk" %}
   {% include "panel/panel.njk" %}
   {% include "phase-banner/phase-banner.njk" %}
-  {% include "previous-next/previous-next.njk" %}
   {% include "radios/radios.njk" %}
   {% include "select/select.njk" %}
   {% include "skip-link/skip-link.njk" %}


### PR DESCRIPTION
This is completing #488 

Add tests to make sure the example pages render with a 200 code, so we can catch this kind of omissions. 