### PR TITLE
Remove tablet border variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Fixes:
 - Add `govuk-c-select--error` modifier class to the select component instead of relying on `govuk-c-input--error` (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Allow error message and hint text to be passed to a select component without requiring a label parameter (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Define size of inputs etc in `px` rather than `em`. (PR [#491](https://github.com/alphagov/govuk-frontend/pull/491))
+- Remove tablet border variable (PR [#524](https://github.com/alphagov/govuk-frontend/pull/524))
 
 Internal:
 

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -10,7 +10,7 @@
     border: $govuk-border-width-mobile solid $govuk-error-colour;
 
     @include mq($from: tablet) {
-      border: $govuk-border-width-tablet solid $govuk-error-colour;
+      border: $govuk-border-width solid $govuk-error-colour;
     }
 
     // TODO: Fix IE < 8

--- a/src/globals/scss/settings/_measurements.scss
+++ b/src/globals/scss/settings/_measurements.scss
@@ -6,7 +6,6 @@ $govuk-gutter-half: $govuk-gutter / 2;
 
 // Border widths
 $govuk-border-width-mobile: 4px;
-$govuk-border-width-tablet: 5px;
 $govuk-border-width-form-element: 2px;
 $govuk-border-width-error: 4px;
 


### PR DESCRIPTION
As discussed in #519, there are too many variables for setting borders.

Discussed with @dashouse - we can remove the one for tablet. It's only used by the error summary which can fall back on the standard border variable. 