### PR TITLE
Remove scope=row attribute from non-th elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Fixes:
 - Add `govuk-c-select--error` modifier class to the select component instead of relying on `govuk-c-input--error` (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Allow error message and hint text to be passed to a select component without requiring a label parameter (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Define size of inputs etc in `px` rather than `em`. (PR [#491](https://github.com/alphagov/govuk-frontend/pull/491))
+- Remove scope=row attribute from non-th elements (PR [527](https://github.com/alphagov/govuk-frontend/pull/527)) 
 
 Internal:
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -22,7 +22,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">January</td>
+          <td class="govuk-c-table__cell">January</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£85</td>
 
@@ -32,7 +32,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">February</td>
+          <td class="govuk-c-table__cell">February</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£75</td>
 
@@ -42,7 +42,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">March</td>
+          <td class="govuk-c-table__cell">March</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£165</td>
 
@@ -123,7 +123,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">January</td>
+          <td class="govuk-c-table__cell">January</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£85</td>
 
@@ -133,7 +133,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">February</td>
+          <td class="govuk-c-table__cell">February</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£75</td>
 
@@ -143,7 +143,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
         <tr class="govuk-c-table__row">
 
-          <td class="govuk-c-table__cell" scope="row">March</td>
+          <td class="govuk-c-table__cell">March</td>
 
           <td class="govuk-c-table__cell govuk-c-table__cell--numeric">£165</td>
 

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -26,7 +26,7 @@
       <td class="govuk-c-table__cell
       {%- if cell.format %} govuk-c-table__cell--{{ cell.format }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %} scope="row">{{ cell.html | safe if cell.html else cell.text }}</td>
+      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% else %}
       <td class="govuk-c-table__cell {% if cell.format %}govuk-c-table__cell--{{ cell.format }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}


### PR DESCRIPTION
In HTML5 scope attribute should only be used on `<th>` elements according to https://dequeuniversity.com/rules/axe/1.1/scope

This PR removes the wrongly placed scope attribute on `<td>`s
Fixes #526 