### PR TITLE
Update links to Design System from READMEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ Internal:
 - Add tests for select component (PR [#506](https://github.com/alphagov/govuk-frontend/pull/506))
 - Add tests for checkboxes component (PR [#513](https://github.com/alphagov/govuk-frontend/pull/513))
 - Add tests to make sure the examples pages render without errors [#523](https://github.com/alphagov/govuk-frontend/pull/523)
+- Add correct links to the guidance in the Design System in component READMEs
+  (PR [#528](https://github.com/alphagov/govuk-frontend/pull/528))
 
 ## 0.0.22-alpha (Breaking release)
 

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -3,6 +3,7 @@
 {% block content %}
 
 {% set componentName = componentPath %}
+{% set componentNameHuman = componentName | replace("-", " ") | capitalize %}
 {% set componentGuidanceLink = componentGuidanceLink | default('https://govuk-design-system-production.cloudapps.digital/components/' + componentName)%}
 {% set htmlMarkup %}
   {% include componentName +"/"+ componentName +".njk" ignore missing %}
@@ -14,7 +15,7 @@
 {{ govukBreadcrumbs({
   "items": [
     { text: 'GOV.UK Frontend', href: '/' },
-    { text: componentName | replace("-", " ") | capitalize }
+    { text: componentNameHuman }
   ]
 }) }}
 <div class="govuk-o-main-wrapper">
@@ -36,7 +37,7 @@
   {% if componentGuidanceLink %}
   <h2 class="govuk-heading-l">Guidance</h2>
   <p class="govuk-body">
-    More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Guidance on the use of {{ componentName | replace("-", " ") | capitalize }} on GOV.UK Design System" class="govuk-link">GOV.UK Design System</a>.
+    Find out when to use the {{ componentNameHuman }} component in your service in the <a href="{{- componentGuidanceLink -}}" class="govuk-link">GOV.UK Design System</a>.
   </p>
   {% endif %}
 

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -36,7 +36,7 @@
   {% if componentGuidanceLink %}
   <h2 class="govuk-heading-l">Guidance</h2>
   <p class="govuk-body">
-    More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website" class="govuk-link">GOV.UK Design System</a>
+    More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Guidance on the use of {{ componentName | replace("-", " ") | capitalize }} on GOV.UK Design System" class="govuk-link">GOV.UK Design System</a>.
   </p>
   {% endif %}
 

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -33,10 +33,12 @@
   {% endblock %}
   </p>
 
+  {% if componentGuidanceLink %}
   <h2 class="govuk-heading-l">Guidance</h2>
   <p class="govuk-body">
     More information about when to use {{ componentName }} can be found on <a href="{{- componentGuidanceLink -}}" title="Link to read guidance on the use of {{ componentName }} on Gov.uk Design system website" class="govuk-link">GOV.UK Design System</a>
   </p>
+  {% endif %}
 
   {% if isReadme %}
   <h2 class="govuk-heading-l">Quick start examples</h2>

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -3,7 +3,7 @@
 {% block content %}
 
 {% set componentName = componentPath %}
-{% set componentGuidanceLink = componentGuidanceLink | default('http://www.linktodesignsystem.com/' + componentName)%}
+{% set componentGuidanceLink = componentGuidanceLink | default('https://govuk-design-system-production.cloudapps.digital/components/' + componentName)%}
 {% set htmlMarkup %}
   {% include componentName +"/"+ componentName +".njk" ignore missing %}
 {% endset %}

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -6,7 +6,7 @@ Link back component, to go back a page.
 
 ## Guidance
 
-More information about when to use back-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/back-link "Link to read guidance on the use of back-link on Gov.uk Design system website")
+More information about when to use back-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/back-link "Guidance on the use of Back link on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -6,7 +6,7 @@ Link back component, to go back a page.
 
 ## Guidance
 
-More information about when to use back-link can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/back-link "Link to read guidance on the use of back-link on Gov.uk Design system website")
+More information about when to use back-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/back-link "Link to read guidance on the use of back-link on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -6,7 +6,7 @@ Link back component, to go back a page.
 
 ## Guidance
 
-More information about when to use back-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/back-link "Guidance on the use of Back link on GOV.UK Design System").
+Find out when to use the Back link component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/back-link).
 
 ## Quick start examples
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -6,7 +6,7 @@ The Breadcrumbs component helps users to understand where they are within a webs
 
 ## Guidance
 
-More information about when to use breadcrumbs can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/breadcrumbs "Guidance on the use of Breadcrumbs on GOV.UK Design System").
+Find out when to use the Breadcrumbs component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/breadcrumbs).
 
 ## Quick start examples
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -6,7 +6,7 @@ The Breadcrumbs component helps users to understand where they are within a webs
 
 ## Guidance
 
-More information about when to use breadcrumbs can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/breadcrumbs "Link to read guidance on the use of breadcrumbs on Gov.uk Design system website")
+More information about when to use breadcrumbs can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/breadcrumbs "Link to read guidance on the use of breadcrumbs on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -6,7 +6,7 @@ The Breadcrumbs component helps users to understand where they are within a webs
 
 ## Guidance
 
-More information about when to use breadcrumbs can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/breadcrumbs "Link to read guidance on the use of breadcrumbs on Gov.uk Design system website")
+More information about when to use breadcrumbs can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/breadcrumbs "Guidance on the use of Breadcrumbs on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -6,7 +6,7 @@ A button is an element that allows users to carry out an action on a GOV.UK page
 
 ## Guidance
 
-More information about when to use button can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/button "Guidance on the use of Button on GOV.UK Design System").
+Find out when to use the Button component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/button).
 
 ## Quick start examples
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -6,7 +6,7 @@ A button is an element that allows users to carry out an action on a GOV.UK page
 
 ## Guidance
 
-More information about when to use button can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/button "Link to read guidance on the use of button on Gov.uk Design system website")
+More information about when to use button can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/button "Link to read guidance on the use of button on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -6,7 +6,7 @@ A button is an element that allows users to carry out an action on a GOV.UK page
 
 ## Guidance
 
-More information about when to use button can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/button "Link to read guidance on the use of button on Gov.uk Design system website")
+More information about when to use button can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/button "Guidance on the use of Button on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -6,7 +6,7 @@ Let users select one or more options.
 
 ## Guidance
 
-More information about when to use checkboxes can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/checkboxes "Link to read guidance on the use of checkboxes on Gov.uk Design system website")
+More information about when to use checkboxes can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/checkboxes "Guidance on the use of Checkboxes on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -6,7 +6,7 @@ Let users select one or more options.
 
 ## Guidance
 
-More information about when to use checkboxes can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/checkboxes "Guidance on the use of Checkboxes on GOV.UK Design System").
+Find out when to use the Checkboxes component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/checkboxes).
 
 ## Quick start examples
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -6,7 +6,7 @@ Let users select one or more options.
 
 ## Guidance
 
-More information about when to use checkboxes can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/checkboxes "Link to read guidance on the use of checkboxes on Gov.uk Design system website")
+More information about when to use checkboxes can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/checkboxes "Link to read guidance on the use of checkboxes on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -6,7 +6,7 @@ A component for entering dates, for example - date of birth.
 
 ## Guidance
 
-More information about when to use date-input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/date-input "Link to read guidance on the use of date-input on Gov.uk Design system website")
+More information about when to use date-input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/date-input "Guidance on the use of Date input on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -6,7 +6,7 @@ A component for entering dates, for example - date of birth.
 
 ## Guidance
 
-More information about when to use date-input can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/date-input "Link to read guidance on the use of date-input on Gov.uk Design system website")
+More information about when to use date-input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/date-input "Link to read guidance on the use of date-input on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -6,7 +6,7 @@ A component for entering dates, for example - date of birth.
 
 ## Guidance
 
-More information about when to use date-input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/date-input "Guidance on the use of Date input on GOV.UK Design System").
+Find out when to use the Date input component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/date-input).
 
 ## Quick start examples
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -6,7 +6,7 @@ Component for conditionally revealing content, using the details HTML element.
 
 ## Guidance
 
-More information about when to use details can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/details "Guidance on the use of Details on GOV.UK Design System").
+Find out when to use the Details component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/details).
 
 ## Quick start examples
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -6,7 +6,7 @@ Component for conditionally revealing content, using the details HTML element.
 
 ## Guidance
 
-More information about when to use details can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/details "Link to read guidance on the use of details on Gov.uk Design system website")
+More information about when to use details can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/details "Link to read guidance on the use of details on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -6,7 +6,7 @@ Component for conditionally revealing content, using the details HTML element.
 
 ## Guidance
 
-More information about when to use details can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/details "Link to read guidance on the use of details on Gov.uk Design system website")
+More information about when to use details can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/details "Guidance on the use of Details on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -6,7 +6,7 @@ Component to show a red error message - used for form validation. Use inside a l
 
 ## Guidance
 
-More information about when to use error-message can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-message "Guidance on the use of Error message on GOV.UK Design System").
+Find out when to use the Error message component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-message).
 
 ## Quick start examples
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -6,7 +6,7 @@ Component to show a red error message - used for form validation. Use inside a l
 
 ## Guidance
 
-More information about when to use error-message can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-message "Link to read guidance on the use of error-message on Gov.uk Design system website")
+More information about when to use error-message can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-message "Guidance on the use of Error message on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -6,7 +6,7 @@ Component to show a red error message - used for form validation. Use inside a l
 
 ## Guidance
 
-More information about when to use error-message can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-message "Link to read guidance on the use of error-message on Gov.uk Design system website")
+More information about when to use error-message can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-message "Link to read guidance on the use of error-message on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -6,7 +6,7 @@ Component to show an error summary box - used at the top of the page, to summari
 
 ## Guidance
 
-More information about when to use error-summary can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-summary "Guidance on the use of Error summary on GOV.UK Design System").
+Find out when to use the Error summary component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-summary).
 
 ## Quick start examples
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -6,7 +6,7 @@ Component to show an error summary box - used at the top of the page, to summari
 
 ## Guidance
 
-More information about when to use error-summary can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-summary "Link to read guidance on the use of error-summary on Gov.uk Design system website")
+More information about when to use error-summary can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-summary "Guidance on the use of Error summary on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -6,7 +6,7 @@ Component to show an error summary box - used at the top of the page, to summari
 
 ## Guidance
 
-More information about when to use error-summary can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/error-summary "Link to read guidance on the use of error-summary on Gov.uk Design system website")
+More information about when to use error-summary can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/error-summary "Link to read guidance on the use of error-summary on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -6,7 +6,7 @@ The fieldset element is used to group several controls within a web form. The le
 
 ## Guidance
 
-More information about when to use fieldset can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/fieldset "Link to read guidance on the use of fieldset on Gov.uk Design system website")
+More information about when to use fieldset can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/fieldset "Link to read guidance on the use of fieldset on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -6,7 +6,7 @@ The fieldset element is used to group several controls within a web form. The le
 
 ## Guidance
 
-More information about when to use fieldset can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/fieldset "Link to read guidance on the use of fieldset on Gov.uk Design system website")
+More information about when to use fieldset can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/fieldset "Guidance on the use of Fieldset on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -6,7 +6,7 @@ The fieldset element is used to group several controls within a web form. The le
 
 ## Guidance
 
-More information about when to use fieldset can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/fieldset "Guidance on the use of Fieldset on GOV.UK Design System").
+Find out when to use the Fieldset component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/fieldset).
 
 ## Quick start examples
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -6,7 +6,7 @@ The HTML `<input>` element with type="file" lets a user pick one or more files, 
 
 ## Guidance
 
-More information about when to use file-upload can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/file-upload "Guidance on the use of File upload on GOV.UK Design System").
+Find out when to use the File upload component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/file-upload).
 
 ## Quick start examples
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -6,7 +6,7 @@ The HTML `<input>` element with type="file" lets a user pick one or more files, 
 
 ## Guidance
 
-More information about when to use file-upload can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/file-upload "Link to read guidance on the use of file-upload on Gov.uk Design system website")
+More information about when to use file-upload can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/file-upload "Guidance on the use of File upload on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -6,7 +6,7 @@ The HTML `<input>` element with type="file" lets a user pick one or more files, 
 
 ## Guidance
 
-More information about when to use file-upload can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/file-upload "Link to read guidance on the use of file-upload on Gov.uk Design system website")
+More information about when to use file-upload can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/file-upload "Link to read guidance on the use of file-upload on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/input "Link to read guidance on the use of input on Gov.uk Design system website")
+More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input "Link to read guidance on the use of input on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-More information about when to use input can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/input "Link to read guidance on the use of input on Gov.uk Design system website")
+More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/input "Link to read guidance on the use of input on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input "Link to read guidance on the use of input on Gov.uk Design system website")
+More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input "Guidance on the use of Input on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-More information about when to use input can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input "Guidance on the use of Input on GOV.UK Design System").
+Find out when to use the Input component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input).
 
 ## Quick start examples
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -11,7 +11,7 @@
 {# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
-{# {% set componentGuidanceLink = 'new link here' %} #}
+{% set componentGuidanceLink = 'https://govuk-design-system-production.cloudapps.digital/components/text-input' %}
 
 {% block componentArguments %}
 {{ govukTable({

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -4,10 +4,6 @@
 
 Use labels for all form fields.
 
-## Guidance
-
-More information about when to use label can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/label "Link to read guidance on the use of label on Gov.uk Design system website")
-
 ## Quick start examples
 
 ### Component default

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -6,7 +6,7 @@ Use labels for all form fields.
 
 ## Guidance
 
-More information about when to use label can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/label "Link to read guidance on the use of label on Gov.uk Design system website")
+More information about when to use label can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/label "Link to read guidance on the use of label on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -11,7 +11,7 @@
 {# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
-{# {% set componentGuidanceLink = 'new link here' %} #}
+{% set componentGuidanceLink = false %}
 
 {% block componentArguments %}
 {{ govukTable({

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -6,7 +6,7 @@ The confirmation panel has a turquoise background and white text. Used for trans
 
 ## Guidance
 
-More information about when to use panel can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/panel "Guidance on the use of Panel on GOV.UK Design System").
+Find out when to use the Panel component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/panel).
 
 ## Quick start examples
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -6,7 +6,7 @@ The confirmation panel has a turquoise background and white text. Used for trans
 
 ## Guidance
 
-More information about when to use panel can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/panel "Link to read guidance on the use of panel on Gov.uk Design system website")
+More information about when to use panel can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/panel "Link to read guidance on the use of panel on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -6,7 +6,7 @@ The confirmation panel has a turquoise background and white text. Used for trans
 
 ## Guidance
 
-More information about when to use panel can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/panel "Link to read guidance on the use of panel on Gov.uk Design system website")
+More information about when to use panel can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/panel "Guidance on the use of Panel on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -6,7 +6,7 @@ A banner that indicates content is in alpha or beta phase with a description.
 
 ## Guidance
 
-More information about when to use phase-banner can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/phase-banner "Link to read guidance on the use of phase-banner on Gov.uk Design system website")
+More information about when to use phase-banner can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/phase-banner "Link to read guidance on the use of phase-banner on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -6,7 +6,7 @@ A banner that indicates content is in alpha or beta phase with a description.
 
 ## Guidance
 
-More information about when to use phase-banner can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/phase-banner "Guidance on the use of Phase banner on GOV.UK Design System").
+Find out when to use the Phase banner component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/phase-banner).
 
 ## Quick start examples
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -6,7 +6,7 @@ A banner that indicates content is in alpha or beta phase with a description.
 
 ## Guidance
 
-More information about when to use phase-banner can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/phase-banner "Link to read guidance on the use of phase-banner on Gov.uk Design system website")
+More information about when to use phase-banner can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/phase-banner "Guidance on the use of Phase banner on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -6,7 +6,7 @@ Let users select a single option from a list.
 
 ## Guidance
 
-More information about when to use radios can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/radios "Link to read guidance on the use of radios on Gov.uk Design system website")
+More information about when to use radios can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/radios "Guidance on the use of Radios on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -6,7 +6,7 @@ Let users select a single option from a list.
 
 ## Guidance
 
-More information about when to use radios can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/radios "Link to read guidance on the use of radios on Gov.uk Design system website")
+More information about when to use radios can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/radios "Link to read guidance on the use of radios on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -6,7 +6,7 @@ Let users select a single option from a list.
 
 ## Guidance
 
-More information about when to use radios can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/radios "Guidance on the use of Radios on GOV.UK Design System").
+Find out when to use the Radios component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/radios).
 
 ## Quick start examples
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -6,7 +6,7 @@ The HTML `<select>` element represents a control that provides a menu of options
 
 ## Guidance
 
-More information about when to use select can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/select "Guidance on the use of Select on GOV.UK Design System").
+Find out when to use the Select component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/select).
 
 ## Quick start examples
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -6,7 +6,7 @@ The HTML `<select>` element represents a control that provides a menu of options
 
 ## Guidance
 
-More information about when to use select can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/select "Link to read guidance on the use of select on Gov.uk Design system website")
+More information about when to use select can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/select "Link to read guidance on the use of select on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -6,7 +6,7 @@ The HTML `<select>` element represents a control that provides a menu of options
 
 ## Guidance
 
-More information about when to use select can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/select "Link to read guidance on the use of select on Gov.uk Design system website")
+More information about when to use select can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/select "Guidance on the use of Select on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -6,7 +6,7 @@ Skip link component. Make skip links visible when they are tabbed to. You'll nee
 
 ## Guidance
 
-More information about when to use skip-link can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/skip-link "Link to read guidance on the use of skip-link on Gov.uk Design system website")
+More information about when to use skip-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/skip-link "Link to read guidance on the use of skip-link on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -6,7 +6,7 @@ Skip link component. Make skip links visible when they are tabbed to. You'll nee
 
 ## Guidance
 
-More information about when to use skip-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/skip-link "Link to read guidance on the use of skip-link on Gov.uk Design system website")
+More information about when to use skip-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/skip-link "Guidance on the use of Skip link on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -6,7 +6,7 @@ Skip link component. Make skip links visible when they are tabbed to. You'll nee
 
 ## Guidance
 
-More information about when to use skip-link can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/skip-link "Guidance on the use of Skip link on GOV.UK Design System").
+Find out when to use the Skip link component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/skip-link).
 
 ## Quick start examples
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -6,7 +6,7 @@ Table description.
 
 ## Guidance
 
-More information about when to use table can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/table "Guidance on the use of Table on GOV.UK Design System").
+Find out when to use the Table component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/table).
 
 ## Quick start examples
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -6,7 +6,7 @@ Table description.
 
 ## Guidance
 
-More information about when to use table can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/table "Link to read guidance on the use of table on Gov.uk Design system website")
+More information about when to use table can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/table "Guidance on the use of Table on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -6,7 +6,7 @@ Table description.
 
 ## Guidance
 
-More information about when to use table can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/table "Link to read guidance on the use of table on Gov.uk Design system website")
+More information about when to use table can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/table "Link to read guidance on the use of table on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -6,7 +6,7 @@ Phase tags are mostly used inside phase banners as an indication of the state of
 
 ## Guidance
 
-More information about when to use tag can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/tag "Link to read guidance on the use of tag on Gov.uk Design system website")
+More information about when to use tag can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/tag "Guidance on the use of Tag on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -6,7 +6,7 @@ Phase tags are mostly used inside phase banners as an indication of the state of
 
 ## Guidance
 
-More information about when to use tag can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/tag "Guidance on the use of Tag on GOV.UK Design System").
+Find out when to use the Tag component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/tag).
 
 ## Quick start examples
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -6,7 +6,7 @@ Phase tags are mostly used inside phase banners as an indication of the state of
 
 ## Guidance
 
-More information about when to use tag can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/tag "Link to read guidance on the use of tag on Gov.uk Design system website")
+More information about when to use tag can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/tag "Link to read guidance on the use of tag on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -6,7 +6,7 @@ A multi-line text field.
 
 ## Guidance
 
-More information about when to use textarea can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/textarea "Link to read guidance on the use of textarea on Gov.uk Design system website")
+More information about when to use textarea can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/textarea "Link to read guidance on the use of textarea on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -6,7 +6,7 @@ A multi-line text field.
 
 ## Guidance
 
-More information about when to use textarea can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/textarea "Guidance on the use of Textarea on GOV.UK Design System").
+Find out when to use the Textarea component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/textarea).
 
 ## Quick start examples
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -6,7 +6,7 @@ A multi-line text field.
 
 ## Guidance
 
-More information about when to use textarea can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/textarea "Link to read guidance on the use of textarea on Gov.uk Design system website")
+More information about when to use textarea can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/textarea "Guidance on the use of Textarea on GOV.UK Design System").
 
 ## Quick start examples
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -6,7 +6,7 @@ Use bold text with an exclamation icon if there are consequences - for example, 
 
 ## Guidance
 
-More information about when to use warning-text can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/warning-text "Guidance on the use of Warning text on GOV.UK Design System").
+Find out when to use the Warning text component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/warning-text).
 
 ## Quick start examples
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -6,7 +6,7 @@ Use bold text with an exclamation icon if there are consequences - for example, 
 
 ## Guidance
 
-More information about when to use warning-text can be found on [GOV.UK Design System](http://www.linktodesignsystem.com/warning-text "Link to read guidance on the use of warning-text on Gov.uk Design system website")
+More information about when to use warning-text can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/warning-text "Link to read guidance on the use of warning-text on Gov.uk Design system website")
 
 ## Quick start examples
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -6,7 +6,7 @@ Use bold text with an exclamation icon if there are consequences - for example, 
 
 ## Guidance
 
-More information about when to use warning-text can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/warning-text "Link to read guidance on the use of warning-text on Gov.uk Design system website")
+More information about when to use warning-text can be found on [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/warning-text "Guidance on the use of Warning text on GOV.UK Design System").
 
 ## Quick start examples
 


### PR DESCRIPTION
Update the links from each component README to the relevant page in the current private-alpha 'production' Design System.

Remove the link to guidance from the label component, which does not have corresponding guidance in the Design System.

Improve the title text to use the human-friendly version of the component name ("Back link" rather than "back-link") and to remove a redundant "Link to read " from the start.

Add a full-stop to the end of the sentence.