### PR TITLE
Use govuk-text-colour mixin for fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Note: We're not following semantic versioning yet, we are going to talk about this soon.
 
+## Unreleased
+
+Fixes:
+
+- Fieldset legends now correctly use 'full black' text colour when printed
+  (PR [#544](https://github.com/alphagov/govuk-frontend/pull/544)
+
 ## 0.0.23-alpha (Breaking release)
 
 Breaking changes:

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -10,6 +10,7 @@
 
   .govuk-c-fieldset__legend {
     @include govuk-font-regular-19;
+    @include govuk-text-colour;
 
     // Fix legend text wrapping in Edge and IE
     // 1. IE9-11 & Edge 12-13
@@ -22,7 +23,6 @@
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;
 
-    color: $govuk-text-colour;
     white-space: normal;    // 1
 
     .govuk-heading-s {


### PR DESCRIPTION
This ensures that the fieldset gets the correct behaviour associated with other text-coloured elements. For example, at the minute print media uses ‘full black’ (#000) for other text colour elements, and this is not being applied here.