### PR TITLE
Fix incorrect selector in 'section break'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 ## Unreleased
 
+Breaking changes:
+
+- The class `.govuk-section-break__visible` has been renamed to
+  `.govuk-section-break--visible` as it is a modifier, not an element.
+  (PR [#547](https://github.com/alphagov/govuk-frontend/pull/547)
+
 Fixes:
 
 - Fieldset legends now correctly use 'full black' text colour when printed

--- a/src/globals/scss/core/_section-break.scss
+++ b/src/globals/scss/core/_section-break.scss
@@ -20,7 +20,7 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
-  .govuk-section-break__visible {
+  .govuk-section-break--visible {
     border: 1px solid $govuk-border-colour;
   }
 


### PR DESCRIPTION
The visible class is a modifier and so should be separated from the block using double dashes (--) rather than double underscores (__) which signifies an element.