### PR TITLE
Fix Sass compilation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,7 @@ gulp.task('test', cb => {
   runsequence(
               'js:lint',
               'scss:lint',
+              'scss:compile',
               cb)
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5618,6 +5618,45 @@
         }
       }
     },
+    "gulp-plumber": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.2.0.tgz",
+      "integrity": "sha512-L/LJftsbKoHbVj6dN5pvMsyJn9jYI0wT0nMg3G6VZhDac4NesezecYTi8/48rHi+yEic3sUpw6jlSc7qNWh32A==",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "fancy-log": "1.3.2",
+        "plugin-error": "0.1.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
+      }
+    },
     "gulp-postcss": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gulp-filter": "^5.0.0",
     "gulp-flatten": "^0.3.1",
     "gulp-nunjucks": "^3.0.0",
+    "gulp-plumber": "^1.2.0",
     "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",

--- a/src/globals/scss/core/_prose-scope.scss
+++ b/src/globals/scss/core/_prose-scope.scss
@@ -50,7 +50,7 @@
     }
 
     hr {
-      @extend .govuk-section-break__visible;
+      @extend .govuk-section-break--visible;
       @extend .govuk-section-break--xl;
     }
   }

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -3,6 +3,7 @@
 const gulp = require('gulp')
 const configPaths = require('../../config/paths.json')
 const sass = require('gulp-sass')
+const plumber = require('gulp-plumber')
 const postcss = require('gulp-postcss')
 const autoprefixer = require('autoprefixer')
 const merge = require('merge-stream')
@@ -21,9 +22,19 @@ const postcsspseudoclasses = require('postcss-pseudo-classes')
 
 const isProduction = taskArguments.isProduction
 
+const errorHandler = function (error) {
+  // Log the error to the console
+  console.error(error.message)
+
+  // Ensure the task we're running exits with an error code
+  this.once('finish', () => process.exit(1))
+  this.emit('end')
+}
+
 gulp.task('scss:compile', () => {
   let compile = gulp.src(configPaths.globalScss + 'govuk-frontend.scss')
-    .pipe(sass().on('error', sass.logError))
+    .pipe(plumber(errorHandler))
+    .pipe(sass())
     .pipe(gulpif(isProduction, postcss([
       autoprefixer,
       cssnano,
@@ -43,7 +54,8 @@ gulp.task('scss:compile', () => {
     .pipe(gulp.dest(taskArguments.destination + '/css/'))
 
   let compileOldIe = gulp.src(configPaths.globalScss + 'govuk-frontend-oldie.scss')
-    .pipe(sass().on('error', sass.logError))
+    .pipe(plumber(errorHandler))
+    .pipe(sass())
     .pipe(gulpif(isProduction, postcss([
       autoprefixer,
       cssnano,


### PR DESCRIPTION
- [x] Ensure the scss:compile gulp task exits with an error code when sass compilation fails.
- [x] Run scss:compile as part of the test task to ensure that the Sass compiles correctly - this should result in CI failing d4b5bfb.
- [x] Fix the failing compilation – this should result in feaf2a3 passing again.