### PR TITLE
Use placeholders when @​extend'ing in prose scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ Fixes:
   borders, rather than relying on inheriting it
   (PR [#551](https://github.com/alphagov/govuk-frontend/pull/551)
 
+Internal:
+
+- The 'prose scope' has been updated to extend only placeholder classes. The
+  corresponding classes the prose scope extends have been updated to provide a
+  placeholder class and separately create the concrete class. This allows us
+  to be specific about which occurrences of the class are meant to be extended.
+  (PR [#550](https://github.com/alphagov/govuk-frontend/pull/550)
+- The sass-lint config has been updated to prevent the use of `@extend` with
+  concrete classes.
+  (PR [#550](https://github.com/alphagov/govuk-frontend/pull/550)
+
 ## 0.0.23-alpha (Breaking release)
 
 Breaking changes:

--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -235,7 +235,7 @@ rules:
 
   # Rule placeholder-in-extend will enforce whether extends should only include placeholder selectors.
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-in-extend.md
-  placeholder-in-extend: 0
+  placeholder-in-extend: 2
 
   # Rule placeholder-name-format will enforce a convention for placeholder names.
   # https://github.com/sasstools/sass-lint/blob/master/docs/rules/placeholder-name-format.md

--- a/src/globals/scss/core/_links.scss
+++ b/src/globals/scss/core/_links.scss
@@ -1,6 +1,10 @@
 @include exports("links") {
 
-  .govuk-link {
+  // We use placeholder classes here so that we can @extend from the prose scope
+  // without also applying every other occurrence of the .govuk-link selector to
+  // the prose scope.
+
+  %govuk-link {
     @include govuk-typography-common;
     @include govuk-focusable-fill;
 
@@ -43,6 +47,10 @@
         }
       }
     }
+  }
+
+  .govuk-link {
+    @extend %govuk-link;
   }
 
   // Muted link variant

--- a/src/globals/scss/core/_lists.scss
+++ b/src/globals/scss/core/_lists.scss
@@ -1,6 +1,10 @@
 @include exports("lists") {
 
-  .govuk-list {
+  // We use a placeholder class here so that we can @extend from the prose scope
+  // without also applying every other occurrence of the .govuk-list selector to
+  // the prose scope.
+
+  %govuk-list {
     @include govuk-font-regular-19;
     @include govuk-text-colour;
     margin-top: 0;
@@ -8,18 +12,19 @@
     padding-left: 0;
     list-style-type: none;
 
-    .govuk-list { // Margin for nested lists
+    // Add a top margin for nested lists
+    %govuk-list {
       margin-top: $govuk-spacing-scale-2;
     }
   }
 
-  .govuk-list > li {
+  %govuk-list > li {
     @include mq($from: tablet) {
       margin-bottom: $govuk-spacing-scale-1;
     }
   }
 
-  .govuk-list a {
+  %govuk-list a {
     &:link {
       color: $govuk-link-colour;
     }
@@ -37,18 +42,30 @@
     }
   }
 
-  .govuk-list--bullet {
+  .govuk-list {
+    @extend %govuk-list;
+  }
+
+  %govuk-list--bullet {
     padding-left: $govuk-spacing-scale-4;
 
     list-style-type: disc;
   }
 
-  .govuk-list--number {
+  .govuk-list--bullet {
+    @extend %govuk-list--bullet;
+  }
+
+  %govuk-list--number {
     // TODO: Fix IE < 8
     @include ie-lte(7) {
       padding-left: $govuk-spacing-scale-6; //used to be 28
     }
     padding-left: $govuk-spacing-scale-4;
     list-style-type: decimal;
+  }
+
+  .govuk-list--number {
+    @extend %govuk-list--number;
   }
 }

--- a/src/globals/scss/core/_prose-scope.scss
+++ b/src/globals/scss/core/_prose-scope.scss
@@ -8,23 +8,23 @@
     // through the use of @extend
 
     h1 {
-      @extend .govuk-heading-xl;
+      @extend %govuk-heading-xl;
     }
 
     h2 {
-      @extend .govuk-heading-l;
+      @extend %govuk-heading-l;
     }
 
     h3 {
-      @extend .govuk-heading-m;
+      @extend %govuk-heading-m;
     }
 
     h4 {
-      @extend .govuk-heading-s;
+      @extend %govuk-heading-s;
     }
 
     p {
-      @extend .govuk-body;
+      @extend %govuk-body-m;
     }
 
     strong,
@@ -34,24 +34,25 @@
 
     ul,
     ol {
-      @extend .govuk-list;
+      @extend %govuk-list;
     }
 
     ol {
-      @extend .govuk-list--number;
+      @extend %govuk-list--number;
     }
 
     ul {
-      @extend .govuk-list--bullet;
+      @extend %govuk-list--bullet;
     }
 
     a {
-      @extend .govuk-link;
+      @extend %govuk-link;
     }
 
     hr {
-      @extend .govuk-section-break--visible;
-      @extend .govuk-section-break--xl;
+      @extend %govuk-section-break;
+      @extend %govuk-section-break--visible;
+      @extend %govuk-section-break--xl;
     }
   }
 }

--- a/src/globals/scss/core/_section-break.scss
+++ b/src/globals/scss/core/_section-break.scss
@@ -1,27 +1,52 @@
 @include exports("section-break") {
 
-  .govuk-section-break {
+  // We use placeholder classes here so that we can @extend from the prose scope
+
+  %govuk-section-break {
     margin: 0;
     border: 0;
   }
 
-  .govuk-section-break--xl {
+  .govuk-section-break {
+    @extend %govuk-section-break;
+  }
+
+  // Sizes
+
+  %govuk-section-break--xl {
     @include govuk-responsive-margin($govuk-spacing-responsive-8, "top");
     @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
   }
 
-  .govuk-section-break--l {
+  .govuk-section-break--xl {
+    @extend %govuk-section-break--xl;
+  }
+
+  %govuk-section-break--l {
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
-  .govuk-section-break--m {
+  .govuk-section-break--l {
+    @extend %govuk-section-break--l;
+  }
+
+  %govuk-section-break--m {
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "top");
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
-  .govuk-section-break--visible {
+  .govuk-section-break--m {
+    @extend %govuk-section-break--m;
+  }
+
+  // Visible variant
+
+  %govuk-section-break--visible {
     border: 1px solid $govuk-border-colour;
   }
 
+  .govuk-section-break--visible {
+    @extend %govuk-section-break--visible;
+  }
 }

--- a/src/globals/scss/core/_typography.scss
+++ b/src/globals/scss/core/_typography.scss
@@ -1,8 +1,12 @@
 @include exports("typography") {
 
+  // We use placeholder classes here so that we can @extend from the prose scope
+  // without also applying every other occurrence of the typography selectors to
+  // the prose scope.
+
   // Headings
 
-  .govuk-heading-xl {
+  %govuk-heading-xl {
     @include govuk-text-colour;
     @include govuk-font-bold-48;
 
@@ -12,7 +16,11 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
   }
 
-  .govuk-heading-l {
+  .govuk-heading-xl {
+    @extend %govuk-heading-xl;
+  }
+
+  %govuk-heading-l {
     @include govuk-text-colour;
     @include govuk-font-bold-36;
 
@@ -20,10 +28,13 @@
 
     margin-top: 0;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-
   }
 
-  .govuk-heading-m {
+  .govuk-heading-l {
+    @extend %govuk-heading-l;
+  }
+
+  %govuk-heading-m {
     @include govuk-text-colour;
     @include govuk-font-bold-24;
 
@@ -33,7 +44,11 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
-  .govuk-heading-s {
+  .govuk-heading-m {
+    @extend %govuk-heading-m;
+  }
+
+  %govuk-heading-s {
     @include govuk-text-colour;
     @include govuk-font-bold-19;
 
@@ -43,7 +58,14 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
+  .govuk-heading-s {
+    @extend %govuk-heading-s;
+  }
+
   // Captions to be used inside headings
+  //
+  // As these are not used in the prose scope, there is no need to use
+  // placeholder classes.
 
   .govuk-caption-xl {
     @include govuk-text-colour;
@@ -81,7 +103,7 @@
 
   // Body (paragraphs)
 
-  .govuk-body-l {
+  %govuk-body-l {
     @include govuk-text-colour;
     @include govuk-font-regular-24;
 
@@ -89,7 +111,11 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
   }
 
-  .govuk-body-m {
+  .govuk-body-l {
+    @extend %govuk-body-l;
+  }
+
+  %govuk-body-m {
     @include govuk-text-colour;
     @include govuk-font-regular-19;
 
@@ -97,7 +123,11 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
-  .govuk-body-s {
+  .govuk-body-m {
+    @extend %govuk-body-m;
+  }
+
+  %govuk-body-s {
     @include govuk-text-colour;
     @include govuk-font-regular-16;
 
@@ -105,12 +135,20 @@
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
   }
 
-  .govuk-body-xs {
+  .govuk-body-s {
+    @extend %govuk-body-s;
+  }
+
+  %govuk-body-xs {
     @include govuk-text-colour;
     @include govuk-font-regular-14;
 
     margin-top: 0;
     @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+  }
+
+  .govuk-body-xs {
+    @extend %govuk-body-xs;
   }
 
   // Usage aliases
@@ -119,18 +157,21 @@
   // refer to the 'original' class name
 
   .govuk-body-lead {
-    @extend .govuk-body-l;
+    @extend %govuk-body-l;
   }
 
   .govuk-body {
-    @extend .govuk-body-m;
+    @extend %govuk-body-m;
   }
 
   // Contextual adjustments
+  //
+  // Because these adjustments are made to the placeholder classes, they will
+  // be inherited by the prose scope as well.
 
-  // Add top padding to headings that appear directly after paragraphs
+  // Add top padding to headings that appear directly after paragraphs.
 
-  .govuk-body-l  + .govuk-heading-l {
+  %govuk-body-l  + %govuk-heading-l {
     padding-top: $govuk-spacing-scale-1;
 
     @include mq($from: tablet) {
@@ -138,23 +179,22 @@
     }
   }
 
-  .govuk-body-m  + .govuk-heading-l,
-  .govuk-body-s  + .govuk-heading-l,
-  .govuk-list + .govuk-heading-l {
+  %govuk-body-m  + %govuk-heading-l,
+  %govuk-body-s  + %govuk-heading-l,
+  %govuk-list + %govuk-heading-l {
     @include govuk-responsive-padding($govuk-spacing-responsive-4, "top");
   }
 
-  .govuk-body-m + .govuk-heading-m,
-  .govuk-body-s + .govuk-heading-m,
-  .govuk-list + .govuk-heading-m,
-  .govuk-body-m + .govuk-heading-s,
-  .govuk-body-s + .govuk-heading-s,
-  .govuk-list + .govuk-heading-s {
+  %govuk-body-m + %govuk-heading-m,
+  %govuk-body-s + %govuk-heading-m,
+  %govuk-list + %govuk-heading-m,
+  %govuk-body-m + %govuk-heading-s,
+  %govuk-body-s + %govuk-heading-s,
+  %govuk-list + %govuk-heading-s {
     padding-top: $govuk-spacing-scale-1;
 
     @include mq($from: tablet) {
       padding-top: $govuk-spacing-scale-2;
     }
   }
-
 }


### PR DESCRIPTION
This updates the prose scope (and the things the prose scope depends on) such that we only ever @​extend [placeholder selectors](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#placeholder_selectors_foo).

This abstraction gives us control over which occurrences of the selector are included by the @​extend. Without this change, occurrences of e.g. the heading classes within the fieldset component are also ending up being ‘applied’ to the prose scope, leading to selectors like `.govuk-c-fieldset__legend .govuk-prose-scope h4` in the CSS. This makes no sense, as the prose scope should never be used within the fieldset legend.

With this change, only occurrences of the _placeholder selectors_ are 'included' when @​extend’ing. This means that as we define e.g. the typographic contextual adjustments at the placeholder level and these _will_ be applied to the prose scope, but other references to the concrete classes will have no effect on the prose scope.

It also changes the linting rules to enforce that `@​extends` can only be used to extend placeholder classes.

## Difference in generated CSS

Reversal of simple selectors in compound .govuk-link / attribute selectors:

```diff
<     .govuk-link[href^="/"]::after, .govuk-prose-scope a[href^="/"]::after, .govuk-link[href^="http://"]::after, .govuk-prose-scope a[href^="http://"]::after, .govuk-link[href^="https://"]::after, .govuk-prose-scope a[href^="https://"]::after,
< .govuk-link[href^="http.\://"]::after,
---
>     [href^="/"].govuk-link::after, .govuk-prose-scope a[href^="/"]::after, [href^="http://"].govuk-link::after, .govuk-prose-scope a[href^="http://"]::after, [href^="https://"].govuk-link::after, .govuk-prose-scope a[href^="https://"]::after,
> [href^="http.\://"].govuk-link::after,
```

```diff
< .govuk-link[href^="https.\://"]::after,
---
> [href^="https.\://"].govuk-link::after,
```

Change in whitespace around selectors:

```diff
< .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, .govuk-prose-scope p + .govuk-heading-l, .govuk-prose-scope .govuk-body-m + h2, .govuk-prose-scope .govuk-body + h2, .govuk-prose-scope p + h2,
< .govuk-body-s + .govuk-heading-l, .govuk-prose-scope
< .govuk-body-s + h2,
< .govuk-list + .govuk-heading-l, .govuk-prose-scope ul + .govuk-heading-l,
< .govuk-prose-scope ol + .govuk-heading-l, .govuk-prose-scope
< .govuk-list + h2, .govuk-prose-scope ul + h2, .govuk-prose-scope ol + h2 {
---
> .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, .govuk-prose-scope p + .govuk-heading-l, .govuk-prose-scope .govuk-body-m + h2, .govuk-prose-scope .govuk-body + h2, .govuk-prose-scope p + h2, .govuk-body-s + .govuk-heading-l, .govuk-prose-scope .govuk-body-s + h2, .govuk-list + .govuk-heading-l, .govuk-prose-scope ul + .govuk-heading-l,
> .govuk-prose-scope ol + .govuk-heading-l, .govuk-prose-scope .govuk-list + h2, .govuk-prose-scope ul + h2, .govuk-prose-scope ol + h2 {
```

```diff
<     .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, .govuk-prose-scope p + .govuk-heading-l, .govuk-prose-scope .govuk-body-m + h2, .govuk-prose-scope .govuk-body + h2, .govuk-prose-scope p + h2,
<     .govuk-body-s + .govuk-heading-l, .govuk-prose-scope
<     .govuk-body-s + h2,
<     .govuk-list + .govuk-heading-l, .govuk-prose-scope ul + .govuk-heading-l,
<     .govuk-prose-scope ol + .govuk-heading-l, .govuk-prose-scope
<     .govuk-list + h2, .govuk-prose-scope ul + h2, .govuk-prose-scope ol + h2 {
---
>     .govuk-body-m + .govuk-heading-l, .govuk-body + .govuk-heading-l, .govuk-prose-scope p + .govuk-heading-l, .govuk-prose-scope .govuk-body-m + h2, .govuk-prose-scope .govuk-body + h2, .govuk-prose-scope p + h2, .govuk-body-s + .govuk-heading-l, .govuk-prose-scope .govuk-body-s + h2, .govuk-list + .govuk-heading-l, .govuk-prose-scope ul + .govuk-heading-l,
>     .govuk-prose-scope ol + .govuk-heading-l, .govuk-prose-scope .govuk-list + h2, .govuk-prose-scope ul + h2, .govuk-prose-scope ol + h2 {
```

```diff
< .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, .govuk-prose-scope p + .govuk-heading-m, .govuk-prose-scope .govuk-body-m + h3, .govuk-prose-scope .govuk-body + h3, .govuk-prose-scope p + h3,
< .govuk-body-s + .govuk-heading-m, .govuk-prose-scope
< .govuk-body-s + h3,
< .govuk-list + .govuk-heading-m, .govuk-prose-scope ul + .govuk-heading-m,
< .govuk-prose-scope ol + .govuk-heading-m, .govuk-prose-scope
< .govuk-list + h3, .govuk-prose-scope ul + h3, .govuk-prose-scope ol + h3,
< .govuk-body-m + .govuk-heading-s, .govuk-body + .govuk-heading-s, .govuk-prose-scope p + .govuk-heading-s, .govuk-prose-scope
< .govuk-body-m + h4, .govuk-prose-scope .govuk-body + h4, .govuk-prose-scope p + h4,
< .govuk-body-s + .govuk-heading-s, .govuk-prose-scope
< .govuk-body-s + h4,
< .govuk-list + .govuk-heading-s, .govuk-prose-scope ul + .govuk-heading-s,
< .govuk-prose-scope ol + .govuk-heading-s, .govuk-prose-scope
< .govuk-list + h4, .govuk-prose-scope ul + h4, .govuk-prose-scope ol + h4 {
---
> .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, .govuk-prose-scope p + .govuk-heading-m, .govuk-prose-scope .govuk-body-m + h3, .govuk-prose-scope .govuk-body + h3, .govuk-prose-scope p + h3, .govuk-body-s + .govuk-heading-m, .govuk-prose-scope .govuk-body-s + h3, .govuk-list + .govuk-heading-m, .govuk-prose-scope ul + .govuk-heading-m,
> .govuk-prose-scope ol + .govuk-heading-m, .govuk-prose-scope .govuk-list + h3, .govuk-prose-scope ul + h3, .govuk-prose-scope ol + h3, .govuk-body-m + .govuk-heading-s, .govuk-body + .govuk-heading-s, .govuk-prose-scope p + .govuk-heading-s, .govuk-prose-scope .govuk-body-m + h4, .govuk-prose-scope .govuk-body + h4, .govuk-prose-scope p + h4, .govuk-body-s + .govuk-heading-s, .govuk-prose-scope .govuk-body-s + h4, .govuk-list + .govuk-heading-s, .govuk-prose-scope ul + .govuk-heading-s,
> .govuk-prose-scope ol + .govuk-heading-s, .govuk-prose-scope .govuk-list + h4, .govuk-prose-scope ul + h4, .govuk-prose-scope ol + h4 {
```

```diff
<     .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, .govuk-prose-scope p + .govuk-heading-m, .govuk-prose-scope .govuk-body-m + h3, .govuk-prose-scope .govuk-body + h3, .govuk-prose-scope p + h3,
<     .govuk-body-s + .govuk-heading-m, .govuk-prose-scope
<     .govuk-body-s + h3,
<     .govuk-list + .govuk-heading-m, .govuk-prose-scope ul + .govuk-heading-m,
<     .govuk-prose-scope ol + .govuk-heading-m, .govuk-prose-scope
<     .govuk-list + h3, .govuk-prose-scope ul + h3, .govuk-prose-scope ol + h3,
<     .govuk-body-m + .govuk-heading-s, .govuk-body + .govuk-heading-s, .govuk-prose-scope p + .govuk-heading-s, .govuk-prose-scope
<     .govuk-body-m + h4, .govuk-prose-scope .govuk-body + h4, .govuk-prose-scope p + h4,
<     .govuk-body-s + .govuk-heading-s, .govuk-prose-scope
<     .govuk-body-s + h4,
<     .govuk-list + .govuk-heading-s, .govuk-prose-scope ul + .govuk-heading-s,
<     .govuk-prose-scope ol + .govuk-heading-s, .govuk-prose-scope
<     .govuk-list + h4, .govuk-prose-scope ul + h4, .govuk-prose-scope ol + h4 {
---
>     .govuk-body-m + .govuk-heading-m, .govuk-body + .govuk-heading-m, .govuk-prose-scope p + .govuk-heading-m, .govuk-prose-scope .govuk-body-m + h3, .govuk-prose-scope .govuk-body + h3, .govuk-prose-scope p + h3, .govuk-body-s + .govuk-heading-m, .govuk-prose-scope .govuk-body-s + h3, .govuk-list + .govuk-heading-m, .govuk-prose-scope ul + .govuk-heading-m,
>     .govuk-prose-scope ol + .govuk-heading-m, .govuk-prose-scope .govuk-list + h3, .govuk-prose-scope ul + h3, .govuk-prose-scope ol + h3, .govuk-body-m + .govuk-heading-s, .govuk-body + .govuk-heading-s, .govuk-prose-scope p + .govuk-heading-s, .govuk-prose-scope .govuk-body-m + h4, .govuk-prose-scope .govuk-body + h4, .govuk-prose-scope p + h4, .govuk-body-s + .govuk-heading-s, .govuk-prose-scope .govuk-body-s + h4, .govuk-list + .govuk-heading-s, .govuk-prose-scope ul + .govuk-heading-s,
>     .govuk-prose-scope ol + .govuk-heading-s, .govuk-prose-scope .govuk-list + h4, .govuk-prose-scope ul + h4, .govuk-prose-scope ol + h4 {
```

Addition of `.govuk-prose-scope` hr here now that it extends `%govuk-section-break`:

```diff
< .govuk-section-break {
---
> .govuk-prose-scope hr, .govuk-section-break {
```

Re-ordering of selectors:

```diff
< .govuk-section-break--xl, .govuk-prose-scope hr {
---
> .govuk-prose-scope hr, .govuk-section-break--xl {
```

```diff
<     .govuk-section-break--xl, .govuk-prose-scope hr {
---
>     .govuk-prose-scope hr, .govuk-section-break--xl {

```diff
<     .govuk-section-break--xl, .govuk-prose-scope hr {
---
>     .govuk-prose-scope hr, .govuk-section-break--xl {
```

```diff
< .govuk-section-break--visible, .govuk-prose-scope hr {
---
> .govuk-prose-scope hr, .govuk-section-break--visible {
```

Removal of non-sensical prose scope adjustments for fieldset component :tada::

```diff
<   .govuk-c-fieldset__legend .govuk-heading-s, .govuk-c-fieldset__legend .govuk-prose-scope h4, .govuk-prose-scope .govuk-c-fieldset__legend h4 {
---
>   .govuk-c-fieldset__legend .govuk-heading-s {
```

```diff
<   .govuk-c-fieldset__legend .govuk-heading-m, .govuk-c-fieldset__legend .govuk-prose-scope h3, .govuk-prose-scope .govuk-c-fieldset__legend h3 {
---
>   .govuk-c-fieldset__legend .govuk-heading-m {
```

```diff
<   .govuk-c-fieldset__legend .govuk-heading-l, .govuk-c-fieldset__legend .govuk-prose-scope h2, .govuk-prose-scope .govuk-c-fieldset__legend h2,
<   .govuk-c-fieldset__legend .govuk-heading-xl,
<   .govuk-c-fieldset__legend .govuk-prose-scope h1, .govuk-prose-scope
<   .govuk-c-fieldset__legend h1 {
---
>   .govuk-c-fieldset__legend .govuk-heading-l,
>   .govuk-c-fieldset__legend .govuk-heading-xl {
```