### PR TITLE
Remove show mq from dist compilation

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const fs = require('fs')
+const util = require('util')
 const configPaths = require('../config/paths.json')
 
 // Read component list from various sources
@@ -58,8 +59,11 @@ const expectedPackagesFilesForComponent = componentName => {
 exports.expectedPackagesFilesForComponent = expectedPackagesFilesForComponent
 
 // Read the contents of a file from a given path
-const readFileContents = (filePath) => {
-  const contents = fs.readFileSync(filePath, 'utf8')
-  return contents
+const readFile = util.promisify(fs.readFile)
+async function readFileContents (filePath) {
+  const content = await readFile(filePath, 'utf-8')
+  console.log(content)
+  return content
 }
+
 exports.readFileContents = readFileContents

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -56,3 +56,10 @@ const expectedPackagesFilesForComponent = componentName => {
   return srcComponentFiles.sort()
 }
 exports.expectedPackagesFilesForComponent = expectedPackagesFilesForComponent
+
+// Read the contents of a file from a given path
+const readFileContents = (filePath) => {
+  const contents = fs.readFileSync(filePath, 'utf8')
+  return contents
+}
+exports.readFileContents = readFileContents

--- a/src/globals/scss/govuk-frontend-oldie.scss
+++ b/src/globals/scss/govuk-frontend-oldie.scss
@@ -8,5 +8,5 @@ $mq-responsive: false;
 // uses the IE helpers in globals/_helpers.scss
 $is-ie: true;
 $ie-version: 8;
-
+$mq-show-breakpoints: ();
 @import "govuk-frontend";

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -1,3 +1,11 @@
+// sass-lint:disable no-css-comments
+// start:devonly
+// If you want to display the currently active breakpoint in the top
+// right corner of your site during development, add the breakpoints
+// to this list, ordered by width, e.g. (mobile, tablet, desktop).
+$mq-show-breakpoints: (mobile, tablet, desktop);
+// end:devonly
+
 // Settings
 @import "../../globals/scss/common";
 

--- a/src/globals/scss/govuk-frontend.scss
+++ b/src/globals/scss/govuk-frontend.scss
@@ -3,7 +3,11 @@
 // If you want to display the currently active breakpoint in the top
 // right corner of your site during development, add the breakpoints
 // to this list, ordered by width, e.g. (mobile, tablet, desktop).
+<<<<<<< HEAD
 $mq-show-breakpoints: (mobile, tablet, desktop);
+=======
+$mq-show-breakpoints: (mobile, tablet, desktop) !default;
+>>>>>>> 62605a59cbbf11cadc391923d2274d11a1ff9a6d
 // end:devonly
 
 // Settings

--- a/src/globals/scss/settings/_media-queries.scss
+++ b/src/globals/scss/settings/_media-queries.scss
@@ -54,12 +54,3 @@ $mq-breakpoints: (
 // be used as the target width when outputting a static stylesheet
 // (i.e. when $mq-responsive is set to 'false').
 $mq-static-breakpoint: desktop;
-
-// sass-lint:disable no-css-comments
-// for dev and preview only
-//start:devonly
-// If you want to display the currently active breakpoint in the top
-// right corner of your site during development, add the breakpoints
-// to this list, ordered by width, e.g. (mobile, tablet, desktop).
-$mq-show-breakpoints: (mobile, tablet, desktop);
-//end:devonly

--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
-
+const path = require('path')
 const lib = require('../../../lib/file-helper')
+const configPaths = require('../../../config/paths.json')
 
 describe('building dist/', () => {
   describe('when running copy-to-destination', () => {
@@ -23,5 +24,17 @@ describe('building dist/', () => {
 
   lib.SrcComponentList.forEach((componentName) => {
     defineTestsForComponent(componentName)
+  })
+  describe('when compiling css to dist', () => {
+    let version = require(path.join('../../../', configPaths.packages, 'all/package.json')).version
+    const FrontendCssFile = lib.readFileContents(path.join(configPaths.dist, 'css/', `govuk-frontend-${version}.min.css`))
+    const FrontendCssOldIeFile = lib.readFileContents(path.join(configPaths.dist, 'css/', `govuk-frontend-oldie-${version}.min.css`))
+
+    it('standard css file should not contain current media query displayed on body element', () => {
+      expect(FrontendCssFile).not.toMatch(/body:before{content:/)
+    })
+    it('legacy css file should not contain current media query displayed on body element', () => {
+      expect(FrontendCssOldIeFile).not.toMatch(/body:before{content:/)
+    })
   })
 })

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -16,6 +16,7 @@ const rename = require('gulp-rename')
 const cssnano = require('cssnano')
 const postcssnormalize = require('postcss-normalize')
 const postcsspseudoclasses = require('postcss-pseudo-classes')
+const replace = require('gulp-replace')
 
 // Compile CSS and JS task --------------
 // --------------------------------------
@@ -34,6 +35,8 @@ const errorHandler = function (error) {
 gulp.task('scss:compile', () => {
   let compile = gulp.src(configPaths.globalScss + 'govuk-frontend.scss')
     .pipe(plumber(errorHandler))
+    .pipe(gulpif(isProduction, replace('// start:devonly', '/*start:devonly')))
+    .pipe(gulpif(isProduction, replace('// end:devonly', 'end:devonly*/')))
     .pipe(sass())
     .pipe(gulpif(isProduction, postcss([
       autoprefixer,
@@ -55,6 +58,8 @@ gulp.task('scss:compile', () => {
 
   let compileOldIe = gulp.src(configPaths.globalScss + 'govuk-frontend-oldie.scss')
     .pipe(plumber(errorHandler))
+    .pipe(gulpif(isProduction, replace('// start:devonly', '/*start:devonly')))
+    .pipe(gulpif(isProduction, replace('// end:devonly', 'end:devonly*/')))
     .pipe(sass())
     .pipe(gulpif(isProduction, postcss([
       autoprefixer,

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -32,8 +32,8 @@ gulp.task('copy-files', () => {
     '!' + configPaths.src + 'components/**/*.{yml,yaml}'
   ])
   .pipe(scssFiles)
-  .pipe(replace('//start:devonly', '/*start:devonly'))
-  .pipe(replace('//end:devonly', 'end:devonly*/'))
+  .pipe(replace('// start:devonly', '/*start:devonly'))
+  .pipe(replace('// end:devonly', 'end:devonly*/'))
   .pipe(postcss([
     // postcssnormalize,
     autoprefixer,


### PR DESCRIPTION
Move `$mq-show-breakpoints` from globals to govuk-frontend scss entry point.
This way we can comment it out for dist compilation and keep it for dev/review site.
Importers can then also enable it for their app.

This is not the best solution at the moment, as we have a single entry point for review/dev, packages and dist compilation.

As mentioned in #556 and by Ollie on Slack, when we move to separate entry points for the app and distribution then we can set the variable that includes `$mq-show-breakpoints` for dev only.