### PR TITLE
Remove dev styling from compiled css and update pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ New features:
   (PR [#551](https://github.com/alphagov/govuk-frontend/pull/551)
 
 Fixes:
+- Removes media query display on body from compiled CSS
+  (PR [#560](https://github.com/alphagov/govuk-frontend/pull/560)
 
 - Fieldset legends now correctly use 'full black' text colour when printed
   (PR [#544](https://github.com/alphagov/govuk-frontend/pull/544)

--- a/app/assets/scss/app-old-ie.scss
+++ b/app/assets/scss/app-old-ie.scss
@@ -1,0 +1,5 @@
+// If you want to display the currently active breakpoint in the top
+// right corner of your site during development, add the breakpoints
+// to this list, ordered by width, e.g. (mobile, tablet, desktop).
+$mq-show-breakpoints: (desktop);
+@import "../../../src/all/all-old-ie";

--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -1,0 +1,5 @@
+// If you want to display the currently active breakpoint in the top
+// right corner of your site during development, add the breakpoints
+// to this list, ordered by width, e.g. (mobile, tablet, desktop).
+$mq-show-breakpoints: (mobile, tablet, desktop);
+@import "../../../src/all/all";

--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -6,9 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>GOV.UK Frontend</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/public/css/govuk-frontend.css">
+  <link rel="stylesheet" href="/public/css/app.css">
   <!--[if IE 8]>
-  <link rel="stylesheet" href="/public/css/govuk-frontend-old-ie.css">
+  <link rel="stylesheet" href="/public/css/app-old-ie.css">
   <![endif]-->
   <style>
     body {

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -54,3 +54,10 @@ const expectedPackagesFilesForComponent = componentName => {
   return srcComponentFiles.sort()
 }
 exports.expectedPackagesFilesForComponent = expectedPackagesFilesForComponent
+
+// Read the contents of a file from a given path
+const readFileContents = filePath => {
+  return fs.readFileSync(filePath, 'utf8')
+}
+
+exports.readFileContents = readFileContents

--- a/package-lock.json
+++ b/package-lock.json
@@ -922,12 +922,6 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "binaryextensions": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.1.tgz",
-      "integrity": "sha1-HmN0iLNbWL2l9HdL+WpSEqjJB1U=",
-      "dev": true
-    },
     "block-elements": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/block-elements/-/block-elements-1.2.0.tgz",
@@ -5667,17 +5661,6 @@
       "integrity": "sha1-OtRCh2PwXidk3sHGfYaNsnVoeBc=",
       "dev": true
     },
-    "gulp-replace": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.4.tgz",
-      "integrity": "sha1-aaZ5FLvRPFYr/xT1BKQDeWqg2qk=",
-      "dev": true,
-      "requires": {
-        "istextorbinary": "1.0.2",
-        "readable-stream": "2.3.3",
-        "replacestream": "4.0.3"
-      }
-    },
     "gulp-sass": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
@@ -6914,16 +6897,6 @@
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
-      }
-    },
-    "istextorbinary": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
-      "integrity": "sha1-rOGTVNGpoBc+/rEITOD4ewrX3s8=",
-      "dev": true,
-      "requires": {
-        "binaryextensions": "1.0.1",
-        "textextensions": "1.0.2"
       }
     },
     "jest": {
@@ -13716,17 +13689,6 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
-    "replacestream": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
-      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1",
-        "readable-stream": "2.3.3"
-      }
-    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
@@ -15342,12 +15304,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
-    "textextensions": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
-      "integrity": "sha1-ZUhjk+4fK7A5pgy7oFsLaL2VAdI=",
       "dev": true
     },
     "throat": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "gulp-plumber": "^1.2.0",
     "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",
-    "gulp-replace": "^0.5.4",
     "gulp-sass": "^3.1.0",
     "gulp-sass-lint": "^1.3.4",
     "gulp-standard": "^10.0.0",

--- a/src/globals/settings/_media-queries.scss
+++ b/src/globals/settings/_media-queries.scss
@@ -54,12 +54,3 @@ $mq-breakpoints: (
 // be used as the target width when outputting a static stylesheet
 // (i.e. when $mq-responsive is set to 'false').
 $mq-static-breakpoint: desktop;
-
-// sass-lint:disable no-css-comments
-// for dev and preview only
-//start:devonly
-// If you want to display the currently active breakpoint in the top
-// right corner of your site during development, add the breakpoints
-// to this list, ordered by width, e.g. (mobile, tablet, desktop).
-$mq-show-breakpoints: (mobile, tablet, desktop);
-//end:devonly

--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -1,6 +1,7 @@
 /* eslint-env jest */
-
+const path = require('path')
 const lib = require('../../../lib/file-helper')
+const configPaths = require('../../../config/paths.json')
 
 describe('building dist/', () => {
   describe('when running copy-to-destination', () => {
@@ -23,5 +24,17 @@ describe('building dist/', () => {
 
   lib.SrcComponentList.forEach((componentName) => {
     defineTestsForComponent(componentName)
+  })
+  describe('when compiling css to dist', () => {
+    let version = require(path.join('../../../', configPaths.packages, 'all/package.json')).version
+    const FrontendCssFile = lib.readFileContents(path.join(configPaths.dist, 'css/', `govuk-frontend-${version}.min.css`))
+    const FrontendCssOldIeFile = lib.readFileContents(path.join(configPaths.dist, 'css/', `govuk-frontend-old-ie-${version}.min.css`))
+
+    it('standard css file should not contain current media query displayed on body element', () => {
+      expect(FrontendCssFile).not.toMatch(/body:before{content:/)
+    })
+    it('legacy css file should not contain current media query displayed on body element', () => {
+      expect(FrontendCssOldIeFile).not.toMatch(/body:before{content:/)
+    })
   })
 })

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -31,9 +31,12 @@ const errorHandler = function (error) {
   this.once('finish', () => process.exit(1))
   this.emit('end')
 }
+// different entry points for both streams below and depending on destination flag
+const compileStyleshet = isDist ? configPaths.app + 'assets/scss/govuk-frontend.scss' : configPaths.app + 'assets/scss/app.scss'
+const compileOldIeStyleshet = isDist ? configPaths.app + 'assets/scss/govuk-frontend-old-ie.scss' : configPaths.app + 'assets/scss/app-old-ie.scss'
 
 gulp.task('scss:compile', () => {
-  let compile = gulp.src(configPaths.app + 'assets/scss/govuk-frontend.scss')
+  let compile = gulp.src(compileStyleshet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
     // minify css add vendor prefixes and normalize to compiled css
@@ -55,7 +58,7 @@ gulp.task('scss:compile', () => {
     ))
     .pipe(gulp.dest(taskArguments.destination + '/css/'))
 
-  let compileOldIe = gulp.src(configPaths.app + 'assets/scss/govuk-frontend-old-ie.scss')
+  let compileOldIe = gulp.src(compileOldIeStyleshet)
     .pipe(plumber(errorHandler))
     .pipe(sass())
     // minify css add vendor prefixes and normalize to compiled css

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -21,9 +21,6 @@ gulp.task('copy-files', () => {
     '!' + configPaths.src + '**/*.{yml,yaml}'
   ])
   .pipe(scssFiles)
-  // in dev mq show current media query. in production we block-comment it
-  .pipe(replace('//start:devonly', '/*start:devonly'))
-  .pipe(replace('//end:devonly', 'end:devonly*/'))
   .pipe(postcss([
     autoprefixer
   ], {syntax: require('postcss-scss')}))

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -5,7 +5,6 @@ const configPaths = require('../../config/paths.json')
 const postcss = require('gulp-postcss')
 const autoprefixer = require('autoprefixer')
 const taskArguments = require('./task-arguments')
-const replace = require('gulp-replace')
 const filter = require('gulp-filter')
 const gulpif = require('gulp-if')
 


### PR DESCRIPTION
We don't want dev specific css in compiled output in `dist`, as observed in user research.
This PR addresses this by:
- creating separate app only sass entry points where `$mq-show-breakpoints` is included
- updates app layout template to reference app*.css files
- modifying `scss:compile` task to use either `app*.scss` or `govuk-frontend*.scss` files as source for compilation
- adding test to check for presence of that string in compiled stylesheets

Additionally:
 - removes magic commenting with `gulp-replace` and gulp-replaces from dependencies
- adds a file helper function to read contents of a file for a given path

the flow is now as follows:
- if `dev` then compile app*.scss with mq-show-breapointsand anthing else we might want to include in teh review app
- if `dist` then compile govuk-frontend*.scss without mq-show-breakpoints

This should also address #556 

https://trello.com/c/woTnvOTx/801-remove-active-breakpoint-debug-helper-from-dist-css