### PR TITLE
Update example of govuk-section-break__visible

### DIFF
--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -474,7 +474,7 @@
 
       <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
 
-      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--xl">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
 
       <h2 class="govuk-heading-l">Topic B (govuk-section-break--xl above)</h2>
 
@@ -482,7 +482,7 @@
 
       <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
 
-      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--l">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
       <h2 class="govuk-heading-l">Topic C (govuk-section-break--l above)</h2>
 
@@ -490,7 +490,7 @@
 
       <p class="govuk-body">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body</p>
 
-      <hr class="govuk-section-break govuk-section-break__visible govuk-section-break--m">
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
 
       <h2 class="govuk-heading-l">Topic D (govuk-section-break--m above)</h2>
 


### PR DESCRIPTION
Update example of `govuk-section-break__visible` new class name `govuk-section-break--visible` in the review app's Typography page.