### PR TITLE
Minor fixes to release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Internal:
 - The button component Sass has been restructured so that e.g. pseudo-selectors
   are consistently nested within their parents
   (PR [#552](https://github.com/alphagov/govuk-frontend/pull/552))
+- Fixes for the release process
+(PR [#567](https://github.com/alphagov/govuk-frontend/pull/567))
 
 ## 0.0.24-alpha (Breaking release)
 

--- a/bin/npm-publish.sh
+++ b/bin/npm-publish.sh
@@ -5,7 +5,7 @@ PACKAGE=$(node -p "require('./package.json').name")
 VERSION=$(node -p "require('./package.json').version")
 PUBLISHED=$(npm info $PACKAGE@$VERSION version)
 
-if [ $VERSION == $PUBLISHED ]; then
+if [ "$VERSION" == "$PUBLISHED" ]; then
   echo "⚠️ $PACKAGE@$VERSION is already published!"
 else
   echo "📦 Publishing: $PACKAGE@$VERSION"

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -19,8 +19,8 @@ if [ $ERROR_CODE != 0 ]; then
 else
     # if you cancel lerna publish, it exists with 0 and it doesnt update package.json files so
     # we exit because package.json file hasn't changed. Otherwise commit changes.
-   if [ $LATEST_PUBLISHED_TAG == $TAG ]; then
-        echo "⚠️ Nothing to commit. Run lerna publish again."
+   if [ "$LATEST_PUBLISHED_TAG" == "$TAG" ]; then
+        echo "⚠️ Nothing to commit. Rerun the step."
         exit 1;
     else
         git add . &&

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -7,7 +7,7 @@ set -e
 # ! npm team ls developers | grep -q $NPM_USER
 
 NPM_USER=$(npm whoami)
-if ! [ "govuk-patterns-and-tools" = $NPM_USER ]; then
+if ! [ "govuk-patterns-and-tools" == "$NPM_USER" ]; then
   echo "⚠️ FAILURE: You are not logged in with the correct user."
   exit 1
 fi
@@ -22,7 +22,7 @@ ALL_PACKAGE_VERSION=$(node -p "require('./packages/all/package.json').version")
 TAG="v$ALL_PACKAGE_VERSION"
 LATEST_PUBLISHED_TAG=$(git describe --abbrev=0 --tags)
 
-if [ $LATEST_PUBLISHED_TAG == $TAG ]; then
+if [ "$LATEST_PUBLISHED_TAG" == "$TAG" ]; then
     echo "⚠️ Tag $TAG already exists"
     exit 1
 else

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -22,7 +22,7 @@ scripts in the current directory.*
 
 2. Update `CHANGELOG` version heading with the next version number.
 
-3. Run `npm run prerelease` task.
+3. Run `npm run pre-release` task.
   This will:
   - run `npm build:packages` that copies any changes from`src/component-name` to `packages/component-name` and runs `after-build-packages.test.js` test 
   to ensure the contents of `packages` matches `src`.
@@ -47,11 +47,12 @@ scripts in the current directory.*
 4. Create a pull request for these changes. When reviewing the PR check version of compile assets and check release notes for the changes made.
 
 5. Once the pull request is approved, merge to **master** and run `npm run release` in **master**. 
+
   This will:
   - check if you're logged in to NPM as the correct user. If not, it will abort.
   - run `npm publish` for each package if the package hasn't been published yet
-    (the currect version matches the version on NPM)
-  - `git tag v<version>` if current git tag doesn't match latest published tag 
+    (check that the currect version matches the version on NPM)
+  - run `git tag v<version>` to create a new tag if current git tag doesn't match latest published tag 
   - push the tag to remote with `git push --tags`
   - create a zip file of the `dist` directory with
     `git archive -o ./release-<version>.zip HEAD:dist`

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "start": "gulp dev",
     "heroku": "gulp copy-assets && node app/app.js",
-    "prerelease": "node bin/check-nvmrc.js && ./bin/pre-release.sh",
+    "pre-release": "node bin/check-nvmrc.js && ./bin/pre-release.sh",
     "release": "node bin/check-nvmrc.js && ./bin/release.sh",
     "build:packages": "node bin/check-nvmrc.js && gulp build:packages --destination 'packages' && npm run test:build:packages",
     "build:dist": "node bin/check-nvmrc.js && gulp build:dist --destination 'dist' && npm run test:build:dist",


### PR DESCRIPTION
We've found that `prerelease` is automatically triggered when running `npm run release` which don't want to do at the moment, as we want to have a pull request step in between.
This PR fixes this by using `pre-release` keyword to avoid that. Also updates publishing documentation to reflect those changes.
Also minor fix to correctly check if logged in to NPM with the correct user.