### PR TITLE
Remove express handling of 404 and 500

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -150,28 +150,4 @@ app.get('/robots.txt', function (req, res) {
   res.send('User-agent: *\nDisallow: /')
 })
 
-// Since this is the last non-error-handling middleware, we assume 404, as nothing else responded.
-app.use(function (req, res, next) {
-  res.status(404)
-  res.format({
-    html: function () {
-      res.render('http-error', { error: 'Page not found', message: 'If you entered a web address please check it was correct.', url: req.url })
-    },
-    json: function () {
-      res.json({ error: 'Not found' })
-    },
-    default: function () {
-      res.type('txt').send('Not found')
-    }
-  })
-  next()
-})
-
-// Error-handling middleware, take the same form require an arity of 4.
-// When connect has an error, it will invoke ONLY error-handling middleware
-app.use(function (err, req, res, next) {
-  res.status(err.status || 500)
-  res.render('http-error', { error: 'Internal server error', message: err })
-})
-
 module.exports = server


### PR DESCRIPTION
Before
<img width="575" alt="screen shot 2018-03-09 at 18 06 33" src="https://user-images.githubusercontent.com/2445413/37223430-6328572e-23c8-11e8-97fc-20cce22296a1.png">

After
<img width="1061" alt="screen shot 2018-03-09 at 18 06 45" src="https://user-images.githubusercontent.com/2445413/37223431-6341076a-23c8-11e8-95fb-501bb9393544.png">

These swallowed errors and are not required for a development server.
Without we get a full stack trace which is much easier to debug issues with.

I could not figure out how to stop Nunjucks from crashing the application at runtime since it works in it's own environment. 😢 