### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,96 @@
+# Code of conduct for GOV.UK Design System (including GOV.UK Frontend)
+
+Contributors to the repositories owned by the [GOV.UK Design System team](https://github.com/topics/design-system-team)
+hosted in `alphagov` are expected to follow the Contributor Covenant Code of
+Conduct, and those working within Government are also expected to follow the Civil Service Code 
+
+## Civil Service Code
+
+The [Civil Service Code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code)
+
+## Contributor Covenant Code of Conduct
+
+> Note: 
+> * where the code of conduct says "project" we mean the GOV.UK Design System, 
+and all repositories [tagged with the topic 'design-system-team'](https://github.com/topics/design-system-team). 
+> * where the code of conduct says "maintainer" we mean the GDS - GOV.UK Design System team
+> * where the code of conduct says "leadership" we mean both GDS - GOV.UK Design System team, line managers, and other leadership within GDS
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+### Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at govuk-design-system-support@digital.cabinet-office.gov.uk. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+This Code of Conduct is adapted from our master [Code of Conduct](https://github.com/alphagov/code-of-conduct)
+
+Changes:
+
+- change the enforcement email address to one owned by GOV.UK Design System team.
+- scoped to GOV.UK Design System team owned repositories only, refer to original Code of Conduct for any other repositories.


### PR DESCRIPTION
This PR adds a code of conduct that we can use across our projects.

It's a fork to make sure we can enforce the Code of Conduct properly.

If this is contentious we could scope this individually to each project.

Thoughts welcome.

Alternatively I'm trying to track down who owns the current email address, we may be able to use that instead.