### PR TITLE
Add Code of Conduct file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/code-of-conduct).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,9 @@
 
 We're not ready for contributions yet, this document exists as a guide for those working on govuk-frontend.
 
+## Code of Conduct
+Please read [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) before contributing.
+
 ## Running locally
 
 You'll need [Git](https://help.github.com/articles/set-up-git/) and [Node.js](https://nodejs.org/en/) installed to get this project running.


### PR DESCRIPTION
Defers to the master Code of Conduct, which I have confirmed we can action based on
Oliver Byford (@36degrees) being one of the mailing list members.

I'm currently writing a Request for Comments document which I'd like to be able to point at this Code of Conduct when talking about feedback.