### PR TITLE
Update `govuk-main-wrapper` object and add a large varient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Breaking changes:
   `govuk-c-radios--inline` which will automatically make all the radio buttons
   within that block inline.
   (PR [#607](https://github.com/alphagov/govuk-frontend/pull/607))
-  
+
+New features:
+- Add `govuk-main-wrapper--l` a variant of the main page wrapper to use when a design does not include back links, breadcrumbs or phase banners (PR [#602](https://github.com/alphagov/govuk-frontend/pull/602))
+
 Internal:
 - Update check script for new components and tweak docs
-  (PR [#589](https://github.com/alphagov/govuk-frontend/pull/589)) 
+  (PR [#589](https://github.com/alphagov/govuk-frontend/pull/589))
 
 ## 0.0.26-alpha (Breaking release)
 

--- a/src/globals/objects/_main-wrapper.scss
+++ b/src/globals/objects/_main-wrapper.scss
@@ -1,4 +1,4 @@
-// Example usage:
+// Example usage with Breadcrumbs, phase banners, back links:
 // <div class="govuk-o-width-container">
 //   <!-- Breadcrumbs, phase banners, back links are placed in here. -->
 //   <div class="govuk-o-main-wrapper">
@@ -6,17 +6,32 @@
 //            to the top / bottom -->
 //   </div>
 // </div>
+//
+// Example usage without Breadcrumbs, phase banners, back links:
+// <div class="govuk-o-width-container">
+//   <div class="govuk-main-wrapper govuk-o-main-wrapper--l">
+//       <!-- Wrapper for the main content of your page which applies padding
+//            to the top / bottom -->
+//   </div>
+// </div>
+
 
 @mixin govuk-main-wrapper {
-  padding: $govuk-spacing-scale-3 0;
+  @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
+  @include govuk-responsive-padding($govuk-spacing-responsive-6, "bottom");
+}
 
-  @include mq($from: tablet) {
-    padding: $govuk-spacing-scale-6 0;
-  }
+// Use govuk-main-wrapper--l when you page does not have Breadcrumbs, phase banners or back links
+@mixin govuk-main-wrapper--l {
+  @include govuk-responsive-padding($govuk-spacing-responsive-8, "top");
 }
 
 @include govuk-exports("main-wrapper") {
   .govuk-o-main-wrapper {
     @include govuk-main-wrapper;
+  }
+
+  .govuk-o-main-wrapper--l {
+    @include govuk-main-wrapper--l;
   }
 }


### PR DESCRIPTION
This PR:
- Updates the `govuk-main-wrapper` class to use the responsive spacing mixin, rather than the fixed spacing scale with media queries.
- Adds a large variant of `govuk-main-wrapper` (`govuk-main-wrapper--l`) for use on pages where there is no Back link, Breadcrumb or Phase banner. This applies some more space to the top and bottom of the page.

With breadcrumb
![screen shot 2018-03-13 at 11 54 47](https://user-images.githubusercontent.com/23356842/37341175-6346036c-26b8-11e8-8bba-f93a11be2ee9.png)

Without breadcrumb (standard `govuk-main-wrapper`
![screen shot 2018-03-13 at 11 55 09](https://user-images.githubusercontent.com/23356842/37341192-71c2939c-26b8-11e8-9f79-9a4a9c65cc6a.png)

Without breadcrumb (using `govuk-main-wrapper--l`)
![screen shot 2018-03-13 at 11 55 27](https://user-images.githubusercontent.com/23356842/37341204-7c79a82a-26b8-11e8-9782-14d9a33219bd.png)
