### PR TITLE
Fix typo in class name - Radios HTML example

### DIFF
--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -152,7 +152,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           <div class="govuk-c-radios__item">
             <input class="govuk-c-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
             <label class="govuk-c-label govuk-c-radios__label" for="housing-act-1">
-            <span class="govuk-heading-s govuk-!-mb-1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
+            <span class="govuk-heading-s govuk-!-mb-r1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
 
           </label>
           </div>
@@ -160,7 +160,7 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           <div class="govuk-c-radios__item">
             <input class="govuk-c-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
             <label class="govuk-c-label govuk-c-radios__label" for="housing-act-2">
-            <span class="govuk-heading-s govuk-!-mb-1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+            <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
 
           </label>
           </div>
@@ -181,11 +181,11 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "items": [
         {
           "value": "part-2",
-          "html": "<span class=\"govuk-heading-s govuk-!-mb-1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
+          "html": "<span class=\"govuk-heading-s govuk-!-mb-r1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
         },
         {
           "value": "part-3",
-          "html": "<span class=\"govuk-heading-s govuk-!-mb-1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
+          "html": "<span class=\"govuk-heading-s govuk-!-mb-r1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
         }
       ]
     }) }}

--- a/src/radios/radios.yaml
+++ b/src/radios/radios.yaml
@@ -40,11 +40,11 @@ examples:
     items:
       - value: 'part-2'
         html:
-          <span class="govuk-heading-s govuk-!-mb-1">Part 2 of the Housing Act 2004</span>
+          <span class="govuk-heading-s govuk-!-mb-r1">Part 2 of the Housing Act 2004</span>
           For properties that are 3 or more stories high and occupied by 5 or more people
       - value: 'part-3'
         html:
-          <span class="govuk-heading-s govuk-!-mb-1">Part 3 of the Housing Act 2004</span>
+          <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span>
           For properties that are within a geographical area defined by a local council
 
 - name: without-fieldset


### PR DESCRIPTION
The HTML example uses `govuk-!-mb-1` not `govuk-!-mb-r1`