### PR TITLE
Fix margin on example iframes

### DIFF
--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -14,6 +14,9 @@
   <link rel="stylesheet" href="/public/css/app-old-ie.css">
   <![endif]-->
   <style>
+    .app-iframe-in-component-preview {
+      margin: 15px;
+    }
     /* Injected into the preview page, that is then put in an iframe */
     .app-iframe-in-component-preview {}
 


### PR DESCRIPTION
This fixes the bug introduced by #603

iframe container previously had an inline style of `body { margin: 15px }` which was removed as it was applying a 15px margin to the `<body>` of all layouts.

This caused a bug where the contents flowed outside of their iframe so the inline margin declaration has been put back in using the specific class name of the container.