### PR TITLE
Include component previews using absolute URLs

### DIFF
--- a/app/views/partials/showExamples.njk
+++ b/app/views/partials/showExamples.njk
@@ -10,17 +10,17 @@
 
     {% if item.name == 'default' %}
       {% set itemName = 'Component default' %}
-      {% set previewLink = componentName + "/preview" %}
+      {% set previewLink = '/components/' + componentName + "/preview" %}
       {% set previewText = 'Preview the ' + componentName + ' component' %}
     {% else %}
       {% set itemName = componentName + '--' + item.name %}
-      {% set previewLink = componentName + '/' + item.name  + "/preview" %}
+      {% set previewLink = '/components/' + componentName + '/' + item.name  + "/preview" %}
       {% set previewText = 'Preview the ' + itemName + ' example' %}
     {% endif %}
 
     {% if isReadme %}
       <h3>{{ itemName  | capitalize }}</h3>
-      <a href="http://govuk-frontend-review.herokuapp.com/components/{{ previewLink }}">{{ previewText }}</a>
+      <a href="http://govuk-frontend-review.herokuapp.com{{ previewLink }}">{{ previewText }}</a>
       {% include "code.njk" %}
     {% else %}
       <section aria-labelledby="heading-{{ itemName}}">


### PR DESCRIPTION
Without this change, if you view a component with a URL that includes a trailing slash, the browser will try and load the previews relative to that path, so e.g. /components/checkboxes/checkboxes/preview.

The chances of this happening are increased when developing locally on a port that might also be used to run the Design System, as the Design System appears to return 301 redirects from trailing-slash-less URLs to their slashed counterparts, and the browser will cache these redirects and apply them to Frontend. This can be hard to debug.

(PS This is Ollie pretending to be Dave 👋 )