### PR TITLE
Fix inline radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Note: We're not following semantic versioning yet, we are going to talk about this soon.
 
+## Unreleased
+
+Breaking changes:
+
+- Removed an (undocumented) modifier `govuk-c-radio__item--inline` which made
+  radio buttons inline, in favour of a new block-level modifier
+  `govuk-c-radios--inline` which will automatically make all the radio buttons
+  within that block inline.
+  (PR [#607](https://github.com/alphagov/govuk-frontend/pull/607))
+
 ## 0.0.26-alpha (Breaking release)
 
 Breaking changes:

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -70,6 +70,67 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Radios--inline
+
+[Preview the radios--inline example](http://govuk-frontend-review.herokuapp.com/components/radios/inline/preview)
+
+#### Markup
+
+      <div class="govuk-o-form-group">
+      <fieldset class="govuk-c-fieldset">
+
+        <legend class="govuk-c-fieldset__legend">
+          Have you changed your name?
+
+          <span class="govuk-c-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+
+        </legend>
+
+      <div class="govuk-c-radios govuk-c-radios--inline">
+
+          <div class="govuk-c-radios__item">
+            <input class="govuk-c-radios__input" id="example-1" name="example" type="radio" value="yes">
+            <label class="govuk-c-label govuk-c-radios__label" for="example-1">
+            Yes
+
+          </label>
+          </div>
+
+          <div class="govuk-c-radios__item">
+            <input class="govuk-c-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+            <label class="govuk-c-label govuk-c-radios__label" for="example-2">
+            No
+
+          </label>
+          </div>
+
+        </div>
+      </fieldset>
+    </div>
+
+#### Macro
+
+    {{ govukRadios({
+      "idPrefix": "example",
+      "classes": "govuk-c-radios--inline",
+      "name": "example",
+      "fieldset": {
+        "legendText": "Have you changed your name?",
+        "legendHintText": "This includes changing your last name or spelling your name differently."
+      },
+      "items": [
+        {
+          "value": "yes",
+          "text": "Yes"
+        },
+        {
+          "value": "no",
+          "text": "No",
+          "checked": true
+        }
+      ]
+    }) }}
+
 ### Radios--with-disabled
 
 [Preview the radios--with-disabled example](http://govuk-frontend-review.herokuapp.com/components/radios/with-disabled/preview)

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -21,12 +21,6 @@
     margin-bottom: 0;
   }
 
-  .govuk-c-radios__item--inline {
-    margin-right: $govuk-spacing-scale-4;
-    float: left;
-    clear: none;
-  }
-
   .govuk-c-radios__input {
     position: absolute;
 
@@ -104,5 +98,16 @@
 
   .govuk-c-radios__input:disabled + .govuk-c-radios__label {
     opacity: .5;
+  }
+
+  // Inline variant
+  .govuk-c-radios--inline {
+    @include govuk-h-clearfix;
+
+    .govuk-c-radios__item {
+      margin-right: $govuk-spacing-scale-4;
+      float: left;
+      clear: none;
+    }
   }
 }

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -102,12 +102,14 @@
 
   // Inline variant
   .govuk-c-radios--inline {
-    @include govuk-h-clearfix;
+    @include mq ($from: tablet) {
+      @include govuk-h-clearfix;
 
-    .govuk-c-radios__item {
-      margin-right: $govuk-spacing-scale-4;
-      float: left;
-      clear: none;
+      .govuk-c-radios__item {
+        margin-right: $govuk-spacing-scale-4;
+        float: left;
+        clear: none;
+      }
     }
   }
 }

--- a/src/radios/radios.yaml
+++ b/src/radios/radios.yaml
@@ -14,6 +14,22 @@ examples:
         text: No
         checked: true
 
+- name: inline
+  data:
+    idPrefix: 'example'
+    classes: 'govuk-c-radios--inline'
+    name: 'example'
+    fieldset:
+      legendText: Have you changed your name?
+      legendHintText:
+        This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+        checked: true
+
 - name: with-disabled
   data:
     idPrefix: 'example-disabled'


### PR DESCRIPTION
Turns out we do actually have a style for inline radios, it's just not documented or easy to apply. (h/t to @dashouse for spotting this…)

<img width="632" alt="screen shot 2018-03-15 at 09 31 17" src="https://user-images.githubusercontent.com/121939/37454890-a6dc6d1a-2833-11e8-8abc-8a6501e1918b.png">

Introduce a modifier at the block level which makes all radios within that block inline. You can’t add classes to the individual radio items using the macro, and it doesn’t really make sense to require the modifier to be applied to every individual element.

Add an example of inline radios so that they are represented in the review app.

Update the readme.