### PR TITLE
Defend against a:link:focus in GOV.UK Template

### DIFF
--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -12,6 +12,7 @@
 {% set variants = {
   'Link': '',
   'Link with no visited state': 'govuk-link--no-visited-state',
+  'Text link': 'govuk-link--text-colour',
   'Muted link': 'govuk-link--muted'
 } %}
 
@@ -42,7 +43,7 @@
 
       {% for state_description, state_class in states %}
         <p class="govuk-body">
-          <a href="#" class="govuk-link {{ variant_class }} {{ state_class }}">
+          <a href="/" class="govuk-link {{ variant_class }} {{ state_class }}">
             {{ state_description}}
           </a>
         </p>

--- a/src/back-link/_back-link.scss
+++ b/src/back-link/_back-link.scss
@@ -22,10 +22,18 @@
     // Underline is provided by a bottom border
     text-decoration: none;
 
+    // Override link colour to use text colour
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // the skip link does not end up with dark blue text when focussed. (1)
     &:link,
     &:visited,
     &:hover,
-    &:active {
+    &:active,
+    &:focus,
+    &:link:focus {
       @include govuk-text-colour;
     }
 

--- a/src/back-link/_back-link.scss
+++ b/src/back-link/_back-link.scss
@@ -4,7 +4,8 @@
 
   .govuk-c-back-link {
     @include govuk-font-regular-16;
-    @include govuk-focusable-fill;
+    @include govuk-link-common;
+    @include govuk-link-style-text;
 
     display: inline-block;
     position: relative;
@@ -21,21 +22,6 @@
 
     // Underline is provided by a bottom border
     text-decoration: none;
-
-    // Override link colour to use text colour
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // the skip link does not end up with dark blue text when focussed. (1)
-    &:link,
-    &:visited,
-    &:hover,
-    &:active,
-    &:focus,
-    &:link:focus {
-      @include govuk-text-colour;
-    }
 
     // Prepend left pointing arrow
     &:before {

--- a/src/breadcrumbs/_breadcrumbs.scss
+++ b/src/breadcrumbs/_breadcrumbs.scss
@@ -103,21 +103,7 @@
   }
 
   .govuk-c-breadcrumbs__link {
-    @include govuk-focusable-fill;
-
-    // Override link colour to use text colour
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // the skip link does not end up with dark blue text when focussed. (1)
-    &:link,
-    &:visited,
-    &:hover,
-    &:active,
-    &:focus,
-    &:link:focus {
-      color: $govuk-text-colour;
-    }
+    @include govuk-link-common;
+    @include govuk-link-style-text;
   }
 }

--- a/src/breadcrumbs/_breadcrumbs.scss
+++ b/src/breadcrumbs/_breadcrumbs.scss
@@ -105,10 +105,18 @@
   .govuk-c-breadcrumbs__link {
     @include govuk-focusable-fill;
 
+    // Override link colour to use text colour
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // the skip link does not end up with dark blue text when focussed. (1)
     &:link,
     &:visited,
     &:hover,
-    &:active {
+    &:active,
+    &:focus,
+    &:link:focus {
       color: $govuk-text-colour;
     }
   }

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -38,7 +38,14 @@
     }
 
     // Ensure that any global link styles are overridden
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // unvisited links styled as buttons do not end up with dark blue text when
+    // focussed. (1)
     &:link,
+    &:link:focus, // 1
     &:visited,
     &:active,
     &:hover {

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -38,19 +38,23 @@
     }
 
     // Ensure that any global link styles are overridden
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // unvisited links styled as buttons do not end up with dark blue text when
-    // focussed. (1)
     &:link,
-    &:link:focus, // 1
     &:visited,
     &:active,
     &:hover {
       color: $govuk-button-text-colour;
       text-decoration: none;
+    }
+
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors so
+    // so that unvisited links styled as buttons do not end up with dark blue
+    // text when focussed.
+    @include govuk-compatibility(govuk_template) {
+      &:link:focus {
+        color: $govuk-button-text-colour;
+      }
     }
 
     // Fix unwanted button padding in Firefox

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -56,10 +56,9 @@
       text-decoration: underline;
     }
 
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // the links do not end up with dark blue text when focussed.
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors.
     @include govuk-compatibility(govuk_template) {
       &:link:focus {
         color: $govuk-error-colour;

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -57,7 +57,7 @@
     &:hover,
     &:active,
     &:focus,
-    &:link:focus // 1 {
+    &:link:focus { // 1
       color: $govuk-error-colour;
       text-decoration: underline;
     }

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -47,19 +47,23 @@
     @include govuk-typography-weight-bold;
 
     // Override default link styling to use error colour
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // the links do not end up with dark blue text when focussed. (1)
     &:link,
     &:visited,
     &:hover,
     &:active,
-    &:focus,
-    &:link:focus { // 1
+    &:focus {
       color: $govuk-error-colour;
       text-decoration: underline;
+    }
+
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // the links do not end up with dark blue text when focussed.
+    @include govuk-compatibility(govuk_template) {
+      &:link:focus {
+        color: $govuk-error-colour;
+      }
     }
   }
 

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -44,13 +44,20 @@
 
   .govuk-c-error-summary__list a {
     @include govuk-focusable-fill;
+    @include govuk-typography-weight-bold;
 
+    // Override default link styling to use error colour
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // the links do not end up with dark blue text when focussed. (1)
     &:link,
     &:visited,
     &:hover,
-    &:active {
-      @include govuk-typography-weight-bold;
-
+    &:active,
+    &:focus,
+    &:link:focus // 1 {
       color: $govuk-error-colour;
       text-decoration: underline;
     }

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -45,10 +45,9 @@
       color: $govuk-text-colour;
     }
 
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // unvisited footer links do not end up with dark blue text when focussed.
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors.
     @include govuk-compatibility(govuk_template) {
       &:link:focus {
         @include govuk-text-colour;

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -39,6 +39,17 @@
     &:active {
       color: $govuk-footer-link-hover;
     }
+
+    // Use text colour when focussed
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // unvisited footer links do not end up with dark blue text when focussed.
+    &:focus,
+    &:link:focus {
+      color: $govuk-text-colour;
+    }
   }
 
   .govuk-c-footer__section-break {

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -41,14 +41,18 @@
     }
 
     // Use text colour when focussed
-    //
+    &:focus {
+      color: $govuk-text-colour;
+    }
+
     // GOV.UK Template includes a specific a:link:focus selector designed to
     // make unvisited links a slightly darker blue when focussed, so we need to
     // override the text colour for that combination of selectors so so that
     // unvisited footer links do not end up with dark blue text when focussed.
-    &:focus,
-    &:link:focus {
-      color: $govuk-text-colour;
+    @include govuk-compatibility(govuk_template) {
+      &:link:focus {
+        @include govuk-text-colour;
+      }
     }
   }
 

--- a/src/globals/_common.scss
+++ b/src/globals/_common.scss
@@ -8,6 +8,7 @@
 @import "settings/colours-palette";
 @import "settings/colours-organisations";
 @import "settings/colours-applied";
+@import "settings/compatibility";
 @import "settings/spacing";
 @import "settings/measurements";
 @import "settings/typography-font-stacks";
@@ -17,6 +18,7 @@
 @import "settings/paths";
 
 // Tools
+@import "tools/compatibility";
 @import "tools/exports";
 @import "tools/file-url";
 @import "tools/iff";

--- a/src/globals/core/_links.scss
+++ b/src/globals/core/_links.scss
@@ -67,7 +67,13 @@
 
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable
-    &:focus {
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // muted links does not end up with dark blue text when focussed. (1)
+    &:focus,
+    &:link:focus { //1
       color: $govuk-black;
     }
   }

--- a/src/globals/core/_links.scss
+++ b/src/globals/core/_links.scss
@@ -70,8 +70,7 @@
 
   // alphagov/govuk_template includes a specific a:link:focus selector designed
   // to make unvisited links a slightly darker blue when focussed, so we need to
-  // override the text colour for that combination of selectors so so that muted
-  // links do not end up with dark blue text when focussed.
+  // override the text colour for that combination of selectors.
   @include govuk-compatibility(govuk_template) {
     &:link:focus {
       @include govuk-text-colour;
@@ -102,10 +101,9 @@
     @include govuk-text-colour;
   }
 
-  // GOV.UK Template includes a specific a:link:focus selector designed to
-  // make unvisited links a slightly darker blue when focussed, so we need to
-  // override the text colour for that combination of selectors so so that
-  // the back link does not end up with dark blue text when focussed.
+  // alphagov/govuk_template includes a specific a:link:focus selector designed
+  // to make unvisited links a slightly darker blue when focussed, so we need to
+  // override the text colour for that combination of selectors.
   @include govuk-compatibility(govuk_template) {
     &:link:focus {
       @include govuk-text-colour;

--- a/src/globals/core/_links.scss
+++ b/src/globals/core/_links.scss
@@ -1,84 +1,171 @@
+/// Common link mixin
+///
+/// Provides the typography and focus state, regardless of link style.
+@mixin govuk-link-common {
+  @include govuk-typography-common;
+  @include govuk-focusable-fill;
+
+  // Override the tap highlight colour (the color of the highlight that
+  // appears when a link is tapped on some mobile devices). This is
+  // ever-so-slightly darker than the default.
+  -webkit-tap-highlight-color: rgba($govuk-black, .3);
+}
+
+/// Default link style mixin
+///
+/// Provides the default unvisited, visited, hover and active states for links.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-c-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-muted;
+///   }
+@mixin govuk-link-style-default {
+  &:link {
+    color: $govuk-link-colour;
+  }
+
+  &:visited {
+    color: $govuk-link-visited-colour;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+  }
+}
+
+/// Muted style link mixin
+///
+/// Used for secondary links on a page - the link will appear in muted colours
+/// regardless of visited state.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-c-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-muted;
+///   }
+@mixin govuk-link-style-muted {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    color: $govuk-grey-1;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-text-colour;
+  }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector designed
+  // to make unvisited links a slightly darker blue when focussed, so we need to
+  // override the text colour for that combination of selectors so so that muted
+  // links do not end up with dark blue text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      @include govuk-text-colour;
+    }
+  }
+}
+
+/// Text style link mixin
+///
+/// Overrides the colour of links to match the text colour. Generally used by
+/// navigation components, such as breadcrumbs or the back link.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-c-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-text;
+///   }
+@mixin govuk-link-style-text($include-common-styles: true) {
+  // Override link colour to use text colour
+  &:link,
+  &:visited,
+  &:hover,
+  &:active,
+  &:focus {
+    @include govuk-text-colour;
+  }
+
+  // GOV.UK Template includes a specific a:link:focus selector designed to
+  // make unvisited links a slightly darker blue when focussed, so we need to
+  // override the text colour for that combination of selectors so so that
+  // the back link does not end up with dark blue text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      @include govuk-text-colour;
+    }
+  }
+}
+
+/// Print friendly link mixin
+///
+/// When printing, append the the destination URL to the link text, as long
+/// as the URL starts with either `/`, `http://` or `https://`.
+@mixin govuk-link-print-friendly {
+  @include mq($media-type: print) {
+
+    &[href^="/"],
+    &[href^="http://"],
+    &[href^="https://"] {
+      &::after {
+        content: " (" attr(href) ")";
+        font-size: 90%;
+
+        // Because the URLs may be very long, ensure that they may be broken
+        // at arbitrary points if there are no otherwise acceptable break
+        // points in the line
+        word-wrap: break-word;
+      }
+    }
+  }
+}
+
+// Export placeholders and concrete classes
+
 @include govuk-exports("links") {
 
-  // We use placeholder classes here so that we can @extend from the prose scope
+  // We use a placeholder class here so that we can @extend from the prose scope
   // without also applying every other occurrence of the .govuk-link selector to
   // the prose scope.
 
   %govuk-link {
-    @include govuk-typography-common;
-    @include govuk-focusable-fill;
-
-    // Override the tap highlight colour (the color of the highlight that
-    // appears when a link is tapped on some mobile devices). This is
-    // ever-so-slightly darker than the default.
-    -webkit-tap-highlight-color: rgba($govuk-black, .3);
-
-    &:link {
-      color: $govuk-link-colour;
-    }
-
-    &:visited {
-      color: $govuk-link-visited-colour;
-    }
-
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
-
-    &:active {
-      color: $govuk-link-active-colour;
-    }
-
-    @include mq($media-type: print) {
-
-      // When printing, append the the destination URL to the link text, as long
-      // as the URL starts with either `/`, `http://` or `https://`.
-      &[href^="/"],
-      &[href^="http://"],
-      &[href^="https://"] {
-        &::after {
-          content: " (" attr(href) ")";
-          font-size: 90%;
-
-          // Because the URLs may be very long, ensure that they may be broken
-          // at arbitrary points if there are no otherwise acceptable break
-          // points in the line
-          word-wrap: break-word;
-        }
-      }
-    }
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+    @include govuk-link-print-friendly;
   }
 
   .govuk-link {
     @extend %govuk-link;
   }
 
-  // Muted link variant
-  //
-  // Used for secondary links on a page - the link will appear in muted colours
-  // regardless of visited state.
-  .govuk-link--muted {
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: $govuk-grey-1;
-    }
+  // Variant classes should always be used in conjunction with the .govuk-link
+  // class, so we do not need the common link styles as they will be inherited.
 
-    // When focussed, the text colour needs to be darker to ensure that colour
-    // contrast is still acceptable
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // muted links does not end up with dark blue text when focussed. (1)
-    &:focus,
-    &:link:focus { //1
-      color: $govuk-black;
-    }
+  .govuk-link--muted {
+    @include govuk-link-style-muted;
   }
 
-  // 'No visited state' link variant
+  .govuk-link--text-colour {
+    @include govuk-link-style-text;
+  }
+
+  // 'No visited state' link mixin
   //
   // Used in cases where it is not helpful to distinguish between visited and
   // non-visited links.
@@ -86,6 +173,9 @@
   // For example, navigation links to pages with dynamic content like admin
   // dashboards. The content on the page is changing all the time, so the fact
   // that you’ve visited it before is not important.
+  //
+  // This is not abstracted as a mixin because it does not provide states for
+  // all pseudo-selectors so it does not make sense to use it in composition.
   .govuk-link--no-visited-state {
     &:visited {
       color: $govuk-link-colour;

--- a/src/globals/settings/_compatibility.scss
+++ b/src/globals/settings/_compatibility.scss
@@ -1,0 +1,34 @@
+// We default these settings to true so that if they are missed we opt for a
+// mild performance hit over a potential broken experience for the end-user.
+
+/// Compatibility Mode: alphagov/govuk_frontend_toolkit
+///
+/// @type Boolean True if used in a project that also includes
+///               alphagov/govuk_frontend_toolkit.
+
+$govuk-compatibility-govukfrontendtoolkit: true !default;
+
+/// Compatibility Mode: alphagov/govuk_template
+///
+/// @type Boolean True if used in a project that also includes
+///               alphagov/govuk_template
+
+$govuk-compatibility-govuktemplate: true !default;
+
+/// Compatibility Mode: alphagov/govuk_elements
+///
+/// @type Boolean True if used in a project that also includes
+///               alphagov/govuk_elements
+
+$govuk-compatibility-govukelements: true !default;
+
+/// Compatibility Product Map
+///
+/// @type Map Map of product names to their settings that we can use to lookup
+///           states from within the `@govuk-compatibility` mixin.
+
+$govuk-compatibility: (
+  govuk_frontend_toolkit: $govuk-compatibility-govukfrontendtoolkit,
+  govuk_template: $govuk-compatibility-govuktemplate,
+  govuk_elements: $govuk-compatibility-govukelements,
+);

--- a/src/globals/tools/_compatibility.scss
+++ b/src/globals/tools/_compatibility.scss
@@ -1,0 +1,30 @@
+/// Conditional Compatibility Mixin
+///
+/// Selectively output a block (available to the mixin as @content) if a given
+/// $product is also identified as being used in the project.
+///
+/// This can then be used to include styles that are only needed to override
+/// styles provided by those other products (e.g. where govuk_template has a
+/// very specific link selector that otherwise affects buttons).
+///
+/// @example scss
+///   // Override .my-class if GOV.UK Template is also being used
+///   @include govuk-compatibility(govuk_template) {
+///     .my-class {
+///       color: inherit;
+///     }
+///   }
+///
+/// @param String Name of product that we are defending against.
+///
+/// @throw If product name is not recognised
+
+@mixin govuk-compatibility($product) {
+  @if map-has-key($govuk-compatibility, $product) {
+    @if map-get($govuk-compatibility, $product) == true {
+      @content;
+    }
+  } @else {
+    @error "Non existent compatibility product '#{$product}'";
+  }
+}

--- a/src/skip-link/_skip-link.scss
+++ b/src/skip-link/_skip-link.scss
@@ -10,8 +10,16 @@
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
 
     // Default link colour doesn't have enough contrast against the focus colour
-    &:focus,
-    &:visited {
+    //
+    // GOV.UK Template includes a specific a:link:focus selector designed to
+    // make unvisited links a slightly darker blue when focussed, so we need to
+    // override the text colour for that combination of selectors so so that
+    // the skip link does not end up with dark blue text when focussed. (1)
+    &:link,
+    &:link:focus, // 1
+    &:visited,
+    &:active,
+    &:hover {
       color: $govuk-text-colour;
     }
   }

--- a/src/skip-link/_skip-link.scss
+++ b/src/skip-link/_skip-link.scss
@@ -3,24 +3,11 @@
 @include govuk-exports("skip-link") {
   .govuk-c-skip-link {
     @include govuk-h-visually-hidden-focusable;
-    @include govuk-focusable-fill;
+    @include govuk-link-common;
+    @include govuk-link-style-text;
     @include govuk-font-regular-16;
 
     display: block;
     padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
-
-    // Default link colour doesn't have enough contrast against the focus colour
-    //
-    // GOV.UK Template includes a specific a:link:focus selector designed to
-    // make unvisited links a slightly darker blue when focussed, so we need to
-    // override the text colour for that combination of selectors so so that
-    // the skip link does not end up with dark blue text when focussed. (1)
-    &:link,
-    &:link:focus, // 1
-    &:visited,
-    &:active,
-    &:hover {
-      color: $govuk-text-colour;
-    }
   }
 }


### PR DESCRIPTION
GOV.UK Template includes [a specific `a:link:focus` selector](https://github.com/alphagov/govuk_template/blob/73cf50c02ae335159ae241387d2ddd61f50d1b23/source/assets/stylesheets/_accessibility.scss#L63-L66) designed to make unvisited links a slightly darker blue when focussed, so we need to override the text colour for that combination of selectors so that the links within the various components do not end up with dark blue text when focussed when that is not the desired behaviour.

https://trello.com/c/rD8KRQle/816-remove-blue-colour-on-unvisited-button-coming-from-govuk-template
https://trello.com/c/fOiHvIjh/817-remove-blue-colour-on-unvisited-back-link-coming-from-govuk-template
https://trello.com/c/N3sczGfq/818-remove-blue-colour-on-unvisited-muted-link-coming-from-govuk-template
