### PR TITLE
Add details script

### DIFF
--- a/src/details/README.md
+++ b/src/details/README.md
@@ -34,6 +34,32 @@ Find out when to use the Details component in your service in the [GOV.UK Design
       "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
     }) }}
 
+### Details--expanded
+
+[Preview the details--expanded example](http://govuk-frontend-review.herokuapp.com/components/details/expanded/preview)
+
+#### Markup
+
+    <details id="help-with-nationality" class="govuk-c-details" open>
+      <summary class="govuk-c-details__summary">
+        <span class="govuk-c-details__summary-text">
+          Help with nationality
+        </span>
+      </summary>
+      <div class="govuk-c-details__text">
+        We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.
+      </div>
+    </details>
+
+#### Macro
+
+    {{ govukDetails({
+      "id": "help-with-nationality",
+      "summaryText": "Help with nationality",
+      "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post.",
+      "open": true
+    }) }}
+
 ### Details--with-html
 
 [Preview the details--with-html example](http://govuk-frontend-review.herokuapp.com/components/details/with-html/preview)
@@ -164,6 +190,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
+<th class="govuk-c-table__header" scope="row">id</th>
+
+<td class="govuk-c-table__cell ">string</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">Optional id</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
 <th class="govuk-c-table__header" scope="row">classes</th>
 
 <td class="govuk-c-table__cell ">string</td>
@@ -171,6 +209,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-c-table__cell ">No</td>
 
 <td class="govuk-c-table__cell ">Optional additional classes</td>
+
+</tr>
+
+<tr class="govuk-c-table__row">
+
+<th class="govuk-c-table__header" scope="row">open</th>
+
+<td class="govuk-c-table__cell ">boolean</td>
+
+<td class="govuk-c-table__cell ">No</td>
+
+<td class="govuk-c-table__cell ">If true, details will be expanded.</td>
 
 </tr>
 

--- a/src/details/_details.scss
+++ b/src/details/_details.scss
@@ -50,7 +50,7 @@
   }
 
   // Append our own open / closed marker using a pseudo-element
-  .govuk-c-details__summary::before {
+  .govuk-c-details__summary:before {
     content: "";
     position: absolute;
 

--- a/src/details/details.js
+++ b/src/details/details.js
@@ -213,23 +213,6 @@
         // Create a circular reference from the summary back to its
         // parent details element, for convenience in the click handler
         details.__summary.__details = details
-
-        // If this is not a native implementation, create an arrow
-        // inside the summary
-        if (!GOVUK_FRONTEND.details.NATIVE_DETAILS) {
-          var twisty = document.createElement('i')
-
-          if (openAttr === true) {
-            twisty.className = 'arrow arrow-open'
-            twisty.appendChild(document.createTextNode('\u25bc'))
-          } else {
-            twisty.className = 'arrow arrow-closed'
-            twisty.appendChild(document.createTextNode('\u25ba'))
-          }
-
-          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
-          details.__summary.__twisty.setAttribute('aria-hidden', 'true')
-        }
       }
 
       // Bind an event to handle summary elements
@@ -262,12 +245,6 @@
           summary.__details.removeAttribute('open')
         }
       }
-
-      if (summary.__twisty) {
-        summary.__twisty.firstChild.nodeValue = (expanded ? '\u25ba' : '\u25bc')
-        summary.__twisty.setAttribute('class', (expanded ? 'arrow arrow-closed' : 'arrow arrow-open'))
-      }
-
       return true
     },
 

--- a/src/details/details.js
+++ b/src/details/details.js
@@ -4,165 +4,208 @@
 // FF Support for HTML5's <details> and <summary>
 // https://bugzilla.mozilla.org/show_bug.cgi?id=591737
 
-;(function () {
+// http://www.sitepoint.com/fixing-the-details-element/
+
+;(function (global) {
   'use strict'
 
-  var NATIVE_DETAILS = typeof document.createElement('details').open === 'boolean'
-  var KEY_ENTER = 13
-  var KEY_SPACE = 32
+  var GOVUK = global.GOVUK || {}
 
-  // Add event construct for modern browsers or IE
-  // which fires the callback with a pre-converted target reference
-  function addEvent (node, type, callback) {
-    if (node.addEventListener) {
-      node.addEventListener(type, function (e) {
-        callback(e, e.target)
-      }, false)
-    } else if (node.attachEvent) {
-      node.attachEvent('on' + type, function (e) {
-        callback(e, e.srcElement)
-      })
-    }
-  }
+  GOVUK.details = {
+    NATIVE_DETAILS: typeof document.createElement('details').open === 'boolean',
+    KEY_ENTER: 13,
+    KEY_SPACE: 32,
 
-  // Cross-browser character code / key pressed
-  function charCode (e) {
-    return (typeof e.which === 'number') ? e.which : e.keyCode
-  }
+    // Create a started flag so we can prevent the initialisation
+    // function firing from both DOMContentLoaded and window.onload
+    started: false,
 
-  // Cross-browser preventing default action
-  function preventDefault (e) {
-    if (e.preventDefault) {
-      e.preventDefault()
-    } else {
-      e.returnValue = false
-    }
-  }
+    // Add event construct for modern browsers or IE
+    // which fires the callback with a pre-converted target reference
+    addEvent: function (node, type, callback) {
+      if (node.addEventListener) {
+        node.addEventListener(type, function (e) {
+          callback(e, e.target)
+        }, false)
+      } else if (node.attachEvent) {
+        node.attachEvent('on' + type, function (e) {
+          callback(e, e.srcElement)
+        })
+      }
+    },
 
-  // Handle cross-modal click events
-  function addClickEvent (node, callback) {
-    addEvent(node, 'keypress', function (e, target) {
-      // When the key gets pressed - check if it is enter or space
-      if (charCode(e) === KEY_ENTER || charCode(e) === KEY_SPACE) {
-        if (target.nodeName.toLowerCase() === 'summary') {
-          // Prevent space from scrolling the page
-          // and enter from submitting a form
-          preventDefault(e)
-          // Click to let the click event do all the necessary action
-          if (target.click) {
-            target.click()
-          } else {
-            // except Safari 5.1 and under don't support .click() here
-            callback(e, target)
+    removeEvent: function (node, type) {
+      if (node.removeEventListener) {
+        node.removeEventListener(type, function (e) {
+        }, false)
+      } else if (node.detachEvent) {
+        node.detachEvent('on' + type, function (e) {
+        })
+      }
+    },
+
+    // Cross-browser character code / key pressed
+    charCode: function (e) {
+      return (typeof e.which === 'number') ? e.which : e.keyCode
+    },
+
+    // Cross-browser preventing default action
+    preventDefault: function (e) {
+      if (e.preventDefault) {
+        e.preventDefault()
+      } else {
+        e.returnValue = false
+      }
+    },
+
+    // Handle cross-modal click events
+    addClickEvent: function (node, callback) {
+      GOVUK.details.addEvent(node, 'keypress', function (e, target) {
+        // When the key gets pressed - check if it is enter or space
+        if (GOVUK.details.charCode(e) === GOVUK.details.KEY_ENTER || GOVUK.details.charCode(e) === GOVUK.details.KEY_SPACE) {
+          if (target.nodeName.toLowerCase() === 'summary') {
+            // Prevent space from scrolling the page
+            // and enter from submitting a form
+            GOVUK.details.preventDefault(e)
+            // Click to let the click event do all the necessary action
+            if (target.click) {
+              target.click()
+            } else {
+              // except Safari 5.1 and under don't support .click() here
+              callback(e, target)
+            }
           }
         }
-      }
-    })
+      })
 
-    // Prevent keyup to prevent clicking twice in Firefox when using space key
-    addEvent(node, 'keyup', function (e, target) {
-      if (charCode(e) === KEY_SPACE) {
-        if (target.nodeName === 'SUMMARY') {
-          preventDefault(e)
+      // Prevent keyup to prevent clicking twice in Firefox when using space key
+      GOVUK.details.addEvent(node, 'keyup', function (e, target) {
+        if (GOVUK.details.charCode(e) === GOVUK.details.KEY_SPACE) {
+          if (target.nodeName === 'SUMMARY') {
+            GOVUK.details.preventDefault(e)
+          }
+        }
+      })
+
+      GOVUK.details.addEvent(node, 'click', function (e, target) {
+        callback(e, target)
+      })
+    },
+
+    // Get the nearest ancestor element of a node that matches a given tag name
+    getAncestor: function (node, match) {
+      do {
+        if (!node || node.nodeName.toLowerCase() === match) {
+          break
+        }
+        node = node.parentNode
+      } while (node)
+
+      return node
+    },
+
+    // Initialisation function
+    addDetailsPolyfill: function (list, container) {
+      container = container || document.body
+      // If this has already happened, just return
+      // else set the flag so it doesn't happen again
+      if (GOVUK.details.started) {
+        return
+      }
+      GOVUK.details.started = true
+      // Get the collection of details elements, but if that's empty
+      // then we don't need to bother with the rest of the scripting
+      if ((list = container.getElementsByTagName('details')).length === 0) {
+        return
+      }
+      // else iterate through them to apply their initial state
+      var n = list.length
+      var i = 0
+      for (i; i < n; i++) {
+        var details = list[i]
+
+        // Save shortcuts to the inner summary and content elements
+        details.__summary = details.getElementsByTagName('summary').item(0)
+        details.__content = details.getElementsByTagName('div').item(0)
+
+        if (!details.__summary || !details.__content) {
+          return
+        }
+        // If the content doesn't have an ID, assign it one now
+        // which we'll need for the summary's aria-controls assignment
+        if (!details.__content.id) {
+          details.__content.id = 'details-content-' + i
+        }
+
+        // Add ARIA role="group" to details
+        details.setAttribute('role', 'group')
+
+        // Add role=button to summary
+        details.__summary.setAttribute('role', 'button')
+
+        // Add aria-controls
+        details.__summary.setAttribute('aria-controls', details.__content.id)
+
+        // Set tabIndex so the summary is keyboard accessible for non-native elements
+        // http://www.saliences.com/browserBugs/tabIndex.html
+        if (!GOVUK.details.NATIVE_DETAILS) {
+          details.__summary.tabIndex = 0
+        }
+
+        // Detect initial open state
+        var openAttr = details.getAttribute('open') !== null
+        if (openAttr === true) {
+          details.__summary.setAttribute('aria-expanded', 'true')
+          details.__content.setAttribute('aria-hidden', 'false')
+        } else {
+          details.__summary.setAttribute('aria-expanded', 'false')
+          details.__content.setAttribute('aria-hidden', 'true')
+          if (!GOVUK.details.NATIVE_DETAILS) {
+            details.__content.style.display = 'none'
+          }
+        }
+
+        // Create a circular reference from the summary back to its
+        // parent details element, for convenience in the click handler
+        details.__summary.__details = details
+
+        // If this is not a native implementation, create an arrow
+        // inside the summary
+        if (!GOVUK.details.NATIVE_DETAILS) {
+          var twisty = document.createElement('i')
+
+          if (openAttr === true) {
+            twisty.className = 'arrow arrow-open'
+            twisty.appendChild(document.createTextNode('\u25bc'))
+          } else {
+            twisty.className = 'arrow arrow-closed'
+            twisty.appendChild(document.createTextNode('\u25ba'))
+          }
+
+          details.__summary.__twisty = details.__summary.insertBefore(twisty, details.__summary.firstChild)
+          details.__summary.__twisty.setAttribute('aria-hidden', 'true')
         }
       }
-    })
 
-    addEvent(node, 'click', function (e, target) {
-      callback(e, target)
-    })
-  }
-
-  // Get the nearest ancestor element of a node that matches a given tag name
-  function getAncestor (node, match) {
-    do {
-      if (!node || node.nodeName.toLowerCase() === match) {
-        break
-      }
-      node = node.parentNode
-    } while (node)
-
-    return node
-  }
-
-  // Create a started flag so we can prevent the initialisation
-  // function firing from both DOMContentLoaded and window.onload
-  var started = false
-
-  // Initialisation function
-  function addDetailsPolyfill (list) {
-    // If this has already happened, just return
-    // else set the flag so it doesn't happen again
-    if (started) {
-      return
-    }
-    started = true
-
-    // Get the collection of details elements, but if that's empty
-    // then we don't need to bother with the rest of the scripting
-    if ((list = document.getElementsByTagName('details')).length === 0) {
-      return
-    }
-
-    // else iterate through them to apply their initial state
-    var n = list.length
-    var i = 0
-    for (i; i < n; i++) {
-      var details = list[i]
-
-      // Save shortcuts to the inner summary and content elements
-      details.__summary = details.getElementsByTagName('summary').item(0)
-      details.__content = details.getElementsByTagName('div').item(0)
-
-      // If the content doesn't have an ID, assign it one now
-      // which we'll need for the summary's aria-controls assignment
-      if (!details.__content.id) {
-        details.__content.id = 'details-content-' + i
-      }
-
-      // Add ARIA role="group" to details
-      details.setAttribute('role', 'group')
-
-      // Add role=button to summary
-      details.__summary.setAttribute('role', 'button')
-
-      // Add aria-controls
-      details.__summary.setAttribute('aria-controls', details.__content.id)
-
-      // Set tabIndex so the summary is keyboard accessible for non-native elements
-      // http://www.saliences.com/browserBugs/tabIndex.html
-      if (!NATIVE_DETAILS) {
-        details.__summary.tabIndex = 0
-      }
-
-      // Detect initial open state
-      var openAttr = details.getAttribute('open') !== null
-      if (openAttr === true) {
-        details.__summary.setAttribute('aria-expanded', 'true')
-        details.__content.setAttribute('aria-hidden', 'false')
-      } else {
-        details.__summary.setAttribute('aria-expanded', 'false')
-        details.__content.setAttribute('aria-hidden', 'true')
-        if (!NATIVE_DETAILS) {
-          details.__content.style.display = 'none'
+      // Bind a click event to handle summary elements
+      GOVUK.details.addClickEvent(container, function (e, summary) {
+        if (!(summary = GOVUK.details.getAncestor(summary, 'summary'))) {
+          return true
         }
-      }
-
-      // Create a circular reference from the summary back to its
-      // parent details element, for convenience in the click handler
-      details.__summary.__details = details
-    }
+        return GOVUK.details.statechange(summary)
+      })
+    },
 
     // Define a statechange function that updates aria-expanded and style.display
     // Also update the arrow position
-    function statechange (summary) {
+    statechange: function (summary) {
       var expanded = summary.__details.__summary.getAttribute('aria-expanded') === 'true'
       var hidden = summary.__details.__content.getAttribute('aria-hidden') === 'true'
 
       summary.__details.__summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
       summary.__details.__content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'))
 
-      if (!NATIVE_DETAILS) {
+      if (!GOVUK.details.NATIVE_DETAILS) {
         summary.__details.__content.style.display = (expanded ? 'none' : '')
 
         var hasOpenAttr = summary.__details.getAttribute('open') !== null
@@ -179,20 +222,19 @@
       }
 
       return true
+    },
+
+    destroy: function (node) {
+      GOVUK.details.removeEvent(node, 'click')
+    },
+
+    // Bind two load events for modern and older browsers
+    // If the first one fires it will set a flag to block the second one
+    // but if it's not supported then the second one will fire
+    init: function ($container) {
+      GOVUK.details.addEvent(document, 'DOMContentLoaded', GOVUK.details.addDetailsPolyfill)
+      GOVUK.details.addEvent(window, 'load', GOVUK.details.addDetailsPolyfill)
     }
-
-    // Bind a click event to handle summary elements
-    addClickEvent(document, function (e, summary) {
-      if (!(summary = getAncestor(summary, 'summary'))) {
-        return true
-      }
-      return statechange(summary)
-    })
   }
-
-  // Bind two load events for modern and older browsers
-  // If the first one fires it will set a flag to block the second one
-  // but if it's not supported then the second one will fire
-  addEvent(document, 'DOMContentLoaded', addDetailsPolyfill)
-  addEvent(window, 'load', addDetailsPolyfill)
-})()
+  global.GOVUK = GOVUK
+})(window)

--- a/src/details/details.test.js
+++ b/src/details/details.test.js
@@ -91,4 +91,56 @@ describe('/components/details', () => {
       })
     })
   })
+
+  describe('/components/details/expanded/preview', () => {
+    it('should indicate the expanded state of the summary using aria-expanded', async () => {
+      await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+      const summaryAriaExpanded = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-expanded'))
+      expect(summaryAriaExpanded).toBe('true')
+    })
+
+    it('should indicate the visible state of the content using aria-hidden', async () => {
+      await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+      const hiddenContainerAriaHidden = await page.evaluate(() => document.body.getElementsByTagName('details')[0].querySelectorAll('div')[0].getAttribute('aria-hidden'))
+      expect(hiddenContainerAriaHidden).toBe('false')
+    })
+
+    it('should indicate the open state of the content', async () => {
+      await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+      const detailsOpen = await page.evaluate(() => document.body.getElementsByTagName('details')[0].getAttribute('open'))
+      expect(detailsOpen).not.toBeNull()
+    })
+
+    describe('when details is triggered', () => {
+      it('should indicate the expanded state of the summary using aria-expanded', async () => {
+        await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const summaryAriaExpanded = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-expanded'))
+        expect(summaryAriaExpanded).toBe('false')
+      })
+
+      it('should indicate the visible state of the content using aria-hidden', async () => {
+        await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const hiddenContainerAriaHidden = await page.evaluate(() => document.body.getElementsByTagName('details')[0].querySelectorAll('div')[0].getAttribute('aria-hidden'))
+        expect(hiddenContainerAriaHidden).toBe('true')
+      })
+
+      it('should indicate the open state of the content', async () => {
+        await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const detailsOpen = await page.evaluate(() => document.body.getElementsByTagName('details')[0].getAttribute('open'))
+        expect(detailsOpen).toBeNull()
+      })
+    })
+  })
 })

--- a/src/details/details.test.js
+++ b/src/details/details.test.js
@@ -1,0 +1,94 @@
+/**
+ * @jest-environment ./lib/puppeteer/environment.js
+ */
+/* eslint-env jest */
+
+let browser
+let page
+let baseUrl = 'http://localhost:3000'
+
+beforeAll(async (done) => {
+  browser = global.__BROWSER__
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('/components/details', () => {
+  describe('/components/details/preview', () => {
+    it('should add to summary the button role', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const summaryRole = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('role'))
+      expect(summaryRole).toBe('button')
+    })
+
+    it('should set the element controlled by the summary using aria-controls', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const summaryAriaControls = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-controls'))
+      expect(summaryAriaControls).toBe('details-content-0')
+    })
+
+    it('should set the expanded state of the summary to false using aria-expanded', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const summaryAriaExpanded = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-expanded'))
+      expect(summaryAriaExpanded).toBe('false')
+    })
+
+    it('should add a unique id to the hidden content in order to be controlled by the summary', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const hiddenContainerId = await page.evaluate(() => document.body.getElementsByTagName('details')[0].querySelectorAll('div')[0].getAttribute('id'))
+      expect(hiddenContainerId).toBe('details-content-0')
+    })
+
+    it('should present the content as hidden using aria-hidden', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const hiddenContainerAriaHidden = await page.evaluate(() => document.body.getElementsByTagName('details')[0].querySelectorAll('div')[0].getAttribute('aria-hidden'))
+      expect(hiddenContainerAriaHidden).toBe('true')
+    })
+
+    it('should indicate the open state of the content', async () => {
+      await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+      const detailsOpen = await page.evaluate(() => document.body.getElementsByTagName('details')[0].getAttribute('open'))
+      expect(detailsOpen).toBeNull()
+    })
+
+    describe('when details is triggered', () => {
+      it('should indicate the expanded state of the summary using aria-expanded', async () => {
+        await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const summaryAriaExpanded = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-expanded'))
+        expect(summaryAriaExpanded).toBe('true')
+      })
+
+      it('should indicate the visible state of the content using aria-hidden', async () => {
+        await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const hiddenContainerAriaHidden = await page.evaluate(() => document.body.getElementsByTagName('details')[0].querySelectorAll('div')[0].getAttribute('aria-hidden'))
+        expect(hiddenContainerAriaHidden).toBe('false')
+      })
+
+      it('should indicate the open state of the content', async () => {
+        await page.goto(baseUrl + '/components/details/preview', { waitUntil: 'load' })
+
+        await page.click('summary')
+
+        const detailsOpen = await page.evaluate(() => document.body.getElementsByTagName('details')[0].getAttribute('open'))
+        expect(detailsOpen).not.toBeNull()
+      })
+    })
+  })
+})

--- a/src/details/details.yaml
+++ b/src/details/details.yaml
@@ -1,5 +1,5 @@
 examples:
-  
+
 - name: default
   data:
     summaryText: Help with nationality
@@ -7,6 +7,15 @@ examples:
       We need to know your nationality so we can work out which elections
       you’re entitled to vote in. If you can’t provide your nationality,
       you’ll have to send copies of identity documents through the post.
+- name: expanded
+  data:
+    id: help-with-nationality
+    summaryText: Help with nationality
+    text:
+      We need to know your nationality so we can work out which elections
+      you’re entitled to vote in. If you can’t provide your nationality,
+      you’ll have to send copies of identity documents through the post.
+    open: true
 - name: with-html
   data:
     summaryText: Where to find your National Insurance Number

--- a/src/details/index.njk
+++ b/src/details/index.njk
@@ -95,6 +95,20 @@
     ],
     [
       {
+        text: 'id'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional id'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {
@@ -105,6 +119,20 @@
       },
       {
         text: 'Optional additional classes'
+      }
+    ],
+    [
+      {
+        text: 'open'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'If true, details will be expanded.'
       }
     ],
     [

--- a/src/details/template.njk
+++ b/src/details/template.njk
@@ -1,4 +1,4 @@
-<details class="govuk-c-details {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+<details {%- if params.id %} id="{{params.id}}"{% endif %} class="govuk-c-details {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} {{- " open" if params.open }}>
   <summary class="govuk-c-details__summary">
     <span class="govuk-c-details__summary-text">
       {{ params.summaryHtml | safe if params.summaryHtml else params.summaryText }}

--- a/src/globals/helpers/_shape-arrow.scss
+++ b/src/globals/helpers/_shape-arrow.scss
@@ -41,22 +41,22 @@
     clip-path: polygon(50% 0%, 0% 100%, 100% 100%); // 3
 
     border-width: 0 $perpendicular $height $perpendicular;
-    border-bottom-color: currentColor; // 2
+    border-bottom-color: inherit; // 2
   } @else if $direction == "right" {
     clip-path: polygon(0% 0%, 100% 50%, 0% 100%); // 3
 
     border-width: $perpendicular 0 $perpendicular $height;
-    border-left-color: currentColor; // 2
+    border-left-color: inherit; // 2
   } @else if $direction == "down" {
     clip-path: polygon(0% 0%, 50% 100%, 100% 0%); // 3
 
     border-width: $height $perpendicular 0 $perpendicular;
-    border-top-color: currentColor; // 2
+    border-top-color: inherit; // 2
   } @else if $direction == "left" {
     clip-path: polygon(0% 50%, 100% 100%, 100% 0%); // 3
 
     border-width: $perpendicular $height $perpendicular 0;
-    border-right-color: currentColor; // 2
+    border-right-color: inherit; // 2
   } @else {
     @error "Invalid arrow direction: expected `up`, `right`, `down` or `left`, got `#{$direction}`";
   }


### PR DESCRIPTION
This PR:
- [x] adds [details.polyfill.js](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/details.polyfill.js) from [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit/)
- [x] rewrites the code in plain javascript and following the [JavaScript style guide](https://github.com/alphagov/styleguides/blob/master/js.md)
- [x] relies on CSS to recreate the arrow when the `details` element it is not natively supported by the browser
- [x] add tests to make sure the script works as expected (regarding ARIA attributes)

## Manual tests
### Browsers
- [x] IE8+
- [x] Latest Safari, Chrome, Firefox, Edge

<details>
<summary>IE8</summary>

![details-ie8-closed](https://user-images.githubusercontent.com/788096/37531966-97027012-2935-11e8-8a33-752c468e8ee4.png)
![details-ie8-opened](https://user-images.githubusercontent.com/788096/37531967-9719d57c-2935-11e8-87f9-3e524d133c3d.png)

</details>

<details>
<summary>IE9</summary>

![details-ie9-closed](https://user-images.githubusercontent.com/788096/37531976-9e9f1cee-2935-11e8-9f59-5ad56c42a3e7.png)
![details-ie9-opened](https://user-images.githubusercontent.com/788096/37531977-9ebabd64-2935-11e8-883c-94085e531329.png)

</details>

<details>
<summary>IE10</summary>

<img width="450" alt="details-ie10-closed" src="https://user-images.githubusercontent.com/788096/37531988-a3a9f588-2935-11e8-8d26-97b96aed54fe.png">
<img width="450" alt="details-ie10-opened" src="https://user-images.githubusercontent.com/788096/37531989-a3c8ff14-2935-11e8-9624-61c713097b2e.png">

</details>

<details>
<summary>IE11</summary>

<img width="450" alt="details-ie11-closed" src="https://user-images.githubusercontent.com/788096/37531995-ab88e4ee-2935-11e8-8c99-91549d514237.png">
<img width="450" alt="details-ie11-opened" src="https://user-images.githubusercontent.com/788096/37531996-abb627e2-2935-11e8-83f1-ad0db2ea22bd.png">

</details>

<details>
<summary>Firefox 58 with custom colours</summary>

<img width="370" alt="details-ff58-custom-colors-closed" src="https://user-images.githubusercontent.com/788096/37532002-b2fecc16-2935-11e8-8324-37651c30b005.png">
<img width="370" alt="details-ff58-custom-colors-opened" src="https://user-images.githubusercontent.com/788096/37532003-b3180f8c-2935-11e8-8640-64b663b507f1.png">

</details>

### AT testing
- [x] Custom colours
- [x] VoiceOver
**Notes:**
With `details.js`it announces _collapsed button/expanded button_.
Without `details.js`:
  - VoiceOver on Chrome announces _disclosure triangle_ regardless of state
  - VoiceOver on Safari announces _collapsed summary/expanded summary_
- [x] JAWS17/18
**Notes:**
With `details.js` on IE11/Firefox52 announces _button collapsed/expanded_.
- [x] NDVA
**Notes:**
With `details.js` on Firefox52/IE11 announces _button collapsed/expanded_.
- [x] Dragon

## Automated tests
- [x] Jest integration tests written

[Trello card](https://trello.com/c/9KxfhUKO)