### PR TITLE
DNM: Update GOV.UK Frontend to new colour palette

### DIFF
--- a/src/details/_details.scss
+++ b/src/details/_details.scss
@@ -40,6 +40,7 @@
     // -1px offset fixes gap between background and outline in Firefox
     outline: ($govuk-focus-width + 1px) solid $govuk-focus-colour;
     outline-offset: -1px;
+    color: $govuk-black;
     background: $govuk-focus-colour;
   }
 

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -54,6 +54,11 @@
       color: $govuk-error-colour;
       text-decoration: underline;
     }
+
+    &:active,
+    &:focus {
+      color: $govuk-text-colour;
+    }
   }
 
 }

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -2,9 +2,9 @@
 
 @include govuk-exports("footer") {
 
-  $govuk-footer-background: $govuk-grey-3;
-  $govuk-footer-border-top: #a1acb2;
-  $govuk-footer-border: $govuk-grey-2;
+  $govuk-footer-background: $govuk-light-grey;
+  $govuk-footer-border-top: $govuk-dark-grey;
+  $govuk-footer-border: $govuk-border-colour;
   $govuk-footer-text: #454a4c;
   $govuk-footer-link: $govuk-footer-text;
   $govuk-footer-link-hover: #171819;

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -5,9 +5,9 @@
   $govuk-footer-background: $govuk-light-grey;
   $govuk-footer-border-top: $govuk-dark-grey;
   $govuk-footer-border: $govuk-border-colour;
-  $govuk-footer-text: #454a4c;
+  $govuk-footer-text: $govuk-dark-grey;
   $govuk-footer-link: $govuk-footer-text;
-  $govuk-footer-link-hover: #171819;
+  $govuk-footer-link-hover: darken($govuk-dark-grey, 15%);
 
   // Based on the `govuk-file-url("govuk-crest-2x.png");` image dimensions.
   $govuk-footer-crest-image-width-2x: 250px;
@@ -22,7 +22,7 @@
     @include govuk-responsive-padding($govuk-spacing-responsive-7, "top");
     @include govuk-responsive-padding($govuk-spacing-responsive-5, "bottom");
 
-    border-top: 1px solid $govuk-footer-border-top;
+    border-top: 1px solid $govuk-border-colour;
     color: $govuk-footer-text;
     background: $govuk-footer-background;
   }

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -5,9 +5,9 @@
   $govuk-footer-background: $govuk-light-grey;
   $govuk-footer-border-top: $govuk-dark-grey;
   $govuk-footer-border: $govuk-border-colour;
-  $govuk-footer-text: $govuk-dark-grey;
+  $govuk-footer-text: #454a4c;
   $govuk-footer-link: $govuk-footer-text;
-  $govuk-footer-link-hover: darken($govuk-dark-grey, 15%);
+  $govuk-footer-link-hover: darken($govuk-footer-text, 15%);
 
   // Based on the `govuk-file-url("govuk-crest-2x.png");` image dimensions.
   $govuk-footer-crest-image-width-2x: 250px;

--- a/src/globals/core/_links.scss
+++ b/src/globals/core/_links.scss
@@ -15,18 +15,27 @@
 
     &:link {
       color: $govuk-link-colour;
+      text-decoration-color: $govuk-light-blue;
     }
 
     &:visited {
       color: $govuk-link-visited-colour;
+      text-decoration-color: $govuk-link-visited-colour;
     }
 
     &:hover {
       color: $govuk-link-hover-colour;
+      text-decoration-color: $govuk-link-hover-colour;
     }
 
     &:active {
       color: $govuk-link-active-colour;
+      text-decoration-color: $govuk-link-active-colour;
+    }
+
+    &:focus {
+      color: $govuk-black;
+      text-decoration-color: $govuk-black;
     }
 
     @include mq($media-type: print) {
@@ -62,13 +71,15 @@
     &:visited,
     &:hover,
     &:active {
-      color: $govuk-grey-1;
+      color: $govuk-dark-grey;
+      text-decoration-color: $govuk-border-colour;
     }
 
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable
     &:focus {
       color: $govuk-black;
+      text-decoration-color: $govuk-black;
     }
   }
 
@@ -83,6 +94,12 @@
   .govuk-link--no-visited-state {
     &:visited {
       color: $govuk-link-colour;
+      text-decoration-color: $govuk-light-blue;
+    }
+
+    &:focus {
+      color: $govuk-black;
+      text-decoration-color: $govuk-black;
     }
   }
 }

--- a/src/globals/settings/_colours-applied.scss
+++ b/src/globals/settings/_colours-applied.scss
@@ -12,14 +12,14 @@ $govuk-print-text-colour: #000000;
 //
 // Used for 'muted' text, help text, etc.
 
-$govuk-secondary-text-colour: $govuk-grey-1;
+$govuk-secondary-text-colour: $govuk-dark-grey;
 
 // Links
 
 $govuk-link-colour: $govuk-blue;
-$govuk-link-visited-colour: #4c2c92;
+$govuk-link-visited-colour: $govuk-purple;
 $govuk-link-hover-colour: $govuk-light-blue;
-$govuk-link-active-colour: $govuk-light-blue;
+$govuk-link-active-colour: $govuk-black;
 
 // Focus colour
 //
@@ -38,7 +38,7 @@ $govuk-error-colour: $govuk-red;
 //
 // Used for borders, separators, rules, keylines etc.
 
-$govuk-border-colour: $govuk-grey-2;
+$govuk-border-colour: darken($govuk-light-grey, 25%);
 
 // Used for form inputs and controls
 
@@ -46,7 +46,7 @@ $govuk-input-border-colour: $govuk-black;
 
 // Buttons
 
-$govuk-button-colour: #00823b;
+$govuk-button-colour: $govuk-green;
 $govuk-button-hover-colour: darken($govuk-button-colour, 5%);
 $govuk-button-shadow-colour: darken($govuk-button-colour, 15%);
 $govuk-button-text-colour: $govuk-white;

--- a/src/globals/settings/_colours-applied.scss
+++ b/src/globals/settings/_colours-applied.scss
@@ -1,3 +1,7 @@
+// Brand
+
+$govuk-mainstream-brand: $govuk-blue;
+
 // Text colour
 
 $govuk-text-colour: $govuk-black;
@@ -17,8 +21,8 @@ $govuk-secondary-text-colour: $govuk-dark-grey;
 // Links
 
 $govuk-link-colour: $govuk-blue;
-$govuk-link-visited-colour: $govuk-purple;
-$govuk-link-hover-colour: $govuk-light-blue;
+$govuk-link-visited-colour: $govuk-dark-blue;
+$govuk-link-hover-colour: $govuk-dark-blue;
 $govuk-link-active-colour: $govuk-black;
 
 // Focus colour
@@ -38,7 +42,7 @@ $govuk-error-colour: $govuk-red;
 //
 // Used for borders, separators, rules, keylines etc.
 
-$govuk-border-colour: darken($govuk-light-grey, 25%);
+$govuk-border-colour: $govuk-mid-grey;
 
 // Used for form inputs and controls
 

--- a/src/globals/settings/_colours-palette.scss
+++ b/src/globals/settings/_colours-palette.scss
@@ -1,7 +1,6 @@
 // Brand colours
 $govuk-blue: #1d70b8;
 $govuk-green: #00703c;
-$govuk-yellow: #ffdd00;
 
 // Standard palette, greys
 $govuk-black: #0b0c0c;
@@ -13,4 +12,5 @@ $govuk-white: #ffffff;
 // UI colours
 $govuk-red: #d4351c;
 $govuk-light-blue: #5694ca;
-$govuk-dark-blue: #265189 ;
+$govuk-dark-blue: #265189;
+$govuk-yellow: #ffdd00;

--- a/src/globals/settings/_colours-palette.scss
+++ b/src/globals/settings/_colours-palette.scss
@@ -1,6 +1,6 @@
 // Brand colours
 $govuk-blue: #1d70b8;
-$govuk-green: #04663a;
+$govuk-green: #00703c;
 $govuk-yellow: #ffdd00;
 
 // Standard palette, greys
@@ -11,6 +11,6 @@ $govuk-light-grey: #f3f2f1;
 $govuk-white: #ffffff;
 
 // UI colours
-$govuk-red: #c55200;
+$govuk-red: #d4351c;
 $govuk-light-blue: #5694ca;
 $govuk-dark-blue: #265189 ;

--- a/src/globals/settings/_colours-palette.scss
+++ b/src/globals/settings/_colours-palette.scss
@@ -1,18 +1,16 @@
 // Brand colours
 $govuk-blue: #1d70b8;
-$govuk-mainstream-brand: $govuk-blue;
 $govuk-green: #04663a;
 $govuk-yellow: #ffdd00;
 
 // Standard palette, greys
 $govuk-black: #0b0c0c;
-$govuk-light-grey: #f3f2f1;
 $govuk-dark-grey: #6f777b;
+$govuk-mid-grey: #b1b4b6;
+$govuk-light-grey: #f3f2f1;
 $govuk-white: #ffffff;
 
 // UI colours
-$govuk-red: #b10e1e; // Errors
-$govuk-light-blue: #2b8cc4; // Link hover
-$govuk-light-green: #00823b; // Old button colour
-$govuk-purple: #4c2c92; // Visited
-
+$govuk-red: #c55200;
+$govuk-light-blue: #5694ca;
+$govuk-dark-blue: #265189 ;

--- a/src/globals/settings/_colours-palette.scss
+++ b/src/globals/settings/_colours-palette.scss
@@ -1,55 +1,18 @@
 // Brand colours
-$govuk-blue: #005ea5;
+$govuk-blue: #1d70b8;
 $govuk-mainstream-brand: $govuk-blue;
-
-// Standard palette, colours
-$govuk-purple: #2e358b;
-$govuk-purple-50: #9799c4;
-$govuk-purple-25: #d5d6e7;
-$govuk-mauve: #6f72af;
-$govuk-mauve-50: #b7b9d7;
-$govuk-mauve-25: #e2e2ef;
-$govuk-fuchsia: #912b88;
-$govuk-fuchsia-50: #c994c3;
-$govuk-fuchsia-25: #e9d4e6;
-$govuk-pink: #d53880;
-$govuk-pink-50: #eb9bbe;
-$govuk-pink-25: #f6d7e5;
-$govuk-baby-pink: #f499be;
-$govuk-baby-pink-50: #faccdf;
-$govuk-baby-pink-25: #fdebf2;
-$govuk-red: #b10e1e;
-$govuk-red-50: #d9888c;
-$govuk-red-25: #efcfd1;
-$govuk-mellow-red: #df3034;
-$govuk-mellow-red-50: #ef9998;
-$govuk-mellow-red-25: #f9d6d6;
-$govuk-orange: #f47738;
-$govuk-orange-50: #fabb96;
-$govuk-orange-25: #fde4d4;
-$govuk-brown: #b58840;
-$govuk-brown-50: #dac39c;
-$govuk-brown-25: #f0e7d7;
-$govuk-yellow: #ffbf47;
-$govuk-yellow-50: #ffdf94;
-$govuk-yellow-25: #fff2d3;
-$govuk-grass-green: #85994b;
-$govuk-grass-green-50: #c2cca3;
-$govuk-grass-green-25: #e7ebda;
-$govuk-green: #006435;
-$govuk-green-50: #7fb299;
-$govuk-green-25: #cce0d6;
-$govuk-turquoise: #28a197;
-$govuk-turquoise-50: #95d0cb;
-$govuk-turquoise-25: #d5ecea;
-$govuk-light-blue: #2b8cc4;
-$govuk-light-blue-50: #96c6e2;
-$govuk-light-blue-25: #d5e8f3;
+$govuk-green: #04663a;
+$govuk-yellow: #ffdd00;
 
 // Standard palette, greys
 $govuk-black: #0b0c0c;
-$govuk-grey-1: #6f777b;
-$govuk-grey-2: #bfc1c3;
-$govuk-grey-3: #dee0e2;
-$govuk-grey-4: #f8f8f8;
+$govuk-light-grey: #f3f2f1;
+$govuk-dark-grey: #6f777b;
 $govuk-white: #ffffff;
+
+// UI colours
+$govuk-red: #b10e1e; // Errors
+$govuk-light-blue: #2b8cc4; // Link hover
+$govuk-light-green: #00823b; // Old button colour
+$govuk-purple: #4c2c92; // Visited
+

--- a/src/panel/_panel.scss
+++ b/src/panel/_panel.scss
@@ -21,7 +21,7 @@
 
   .govuk-c-panel--confirmation {
     color: $govuk-white;
-    background: $govuk-turquoise;
+    background: $govuk-green;
   }
 
   .govuk-c-panel__title {

--- a/src/tag/_tag.scss
+++ b/src/tag/_tag.scss
@@ -20,6 +20,6 @@
   }
 
   .govuk-c-tag--inactive {
-    background-color: $govuk-grey-1;
+    background-color: $govuk-light-grey;
   }
 }


### PR DESCRIPTION
# GOV.UK colour palette update

Updated based on colour palette proposal from Mark Hurrell (Head of Design for GOV.UK)

- The current colour palette has been simplified to a set of core colours with specific usage
- The values of the core colours have also been updated
- Some of simplification has an effect on the design of components and core styles - for example the focus state of links have changed to always be `$govuk-black` on `$govuk-yellow`

## New colour palette

```
// Brand colours
$govuk-blue: #1d70b8;
$govuk-green: #00703c;

// Standard palette, greys
$govuk-black: #0b0c0c;
$govuk-dark-grey: #6f777b;
$govuk-mid-grey: #b1b4b6;
$govuk-light-grey: #f3f2f1;
$govuk-white: #ffffff;

// UI colours
$govuk-red: #d4351c;
$govuk-light-blue: #5694ca;
$govuk-dark-blue: #265189;
$govuk-yellow: #ffdd00;
```

## Visual examples in context of GOV.UK Frontend components

![colour-paleete-update](https://user-images.githubusercontent.com/23356842/38022905-bcf46c3e-3278-11e8-81ae-00c767426ecc.jpg)

## Preview changes
https://govuk-frontend-review-pr-611.herokuapp.com/

