### PR TITLE
Update documentation based on user research findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Breaking changes:
   `govuk-c-radios--inline` which will automatically make all the radio buttons
   within that block inline.
   (PR [#607](https://github.com/alphagov/govuk-frontend/pull/607))
+- Prefix `$global-images` variable (PR [#617](https://github.com/alphagov/govuk-frontend/pull/615))
 
 New features:
 - Add `govuk-main-wrapper--l` a variant of the main page wrapper to use when a design does not include back links, breadcrumbs or phase banners (PR [#602](https://github.com/alphagov/govuk-frontend/pull/602))
@@ -31,6 +32,12 @@ Internal:
 
 - Make Sass imports less broad
   (PR [#617](https://github.com/alphagov/govuk-frontend/pull/617))
+
+- Update project README with user research findings (PR [#617](https://github.com/alphagov/govuk-frontend/pull/615))
+
+- Update component READMEs to use `import` statement (PR [#617](https://github.com/alphagov/govuk-frontend/pull/615))
+
+- Update component READMEs to use `import` statement (PR [#617](https://github.com/alphagov/govuk-frontend/pull/615))
 
 ## 0.0.26-alpha (Breaking release)
 

--- a/app/views/partials/code.njk
+++ b/app/views/partials/code.njk
@@ -3,6 +3,8 @@
 <pre><code class="govuk-!-f-16">{{- componentHtml | e -}}</code></pre>
 
 <h4 class="govuk-heading-s">Macro</h4>
-<pre class="govuk-!-mb-r0 govuk-!-f-16"><code>{% raw %}{{ {% endraw %}{{ componentName | componentNameToMacroName }}(
+<pre class="govuk-!-mb-r0 govuk-!-f-16"><code>{% raw %}{%{% endraw %} from '{{ componentName }}/macro.njk' import {{ componentName | componentNameToMacroName }} {% raw %}%}{% endraw %}
+
+{% raw %}{{ {% endraw %}{{ componentName | componentNameToMacroName }}(
   {{- item.data | dump(2) -}}
   ){% raw %} }}{% endraw %}</code></pre>

--- a/src/back-link/README.md
+++ b/src/back-link/README.md
@@ -20,6 +20,8 @@ Find out when to use the Back link component in your service in the [GOV.UK Desi
 
 #### Macro
 
+    {% from 'back-link/macro.njk' import govukBackLink %}
+
     {{ govukBackLink({
       "href": "https://gov.uk",
       "text": "Back"

--- a/src/breadcrumbs/README.md
+++ b/src/breadcrumbs/README.md
@@ -32,6 +32,8 @@ Find out when to use the Breadcrumbs component in your service in the [GOV.UK De
 
 #### Macro
 
+    {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
+
     {{ govukBreadcrumbs({
       "items": [
         {
@@ -62,6 +64,8 @@ Find out when to use the Breadcrumbs component in your service in the [GOV.UK De
     </div>
 
 #### Macro
+
+    {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
 
     {{ govukBreadcrumbs({
       "items": [
@@ -101,6 +105,8 @@ Find out when to use the Breadcrumbs component in your service in the [GOV.UK De
     </div>
 
 #### Macro
+
+    {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
 
     {{ govukBreadcrumbs({
       "items": [
@@ -145,6 +151,8 @@ Find out when to use the Breadcrumbs component in your service in the [GOV.UK De
 
 #### Macro
 
+    {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
+
     {{ govukBreadcrumbs({
       "items": [
         {
@@ -181,6 +189,8 @@ Find out when to use the Breadcrumbs component in your service in the [GOV.UK De
     </div>
 
 #### Macro
+
+    {% from 'breadcrumbs/macro.njk' import govukBreadcrumbs %}
 
     {{ govukBreadcrumbs({
       "items": [

--- a/src/button/README.md
+++ b/src/button/README.md
@@ -22,6 +22,8 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Macro
 
+    {% from 'button/macro.njk' import govukButton %}
+
     {{ govukButton({
       "text": "Save and continue"
     }) }}
@@ -35,6 +37,8 @@ Buttons are configured to perform an action and they can have a different look. 
     <input value="Disabled button" type="submit" disabled="disabled" aria-disabled="true" class="govuk-c-button govuk-c-button--disabled">
 
 #### Macro
+
+    {% from 'button/macro.njk' import govukButton %}
 
     {{ govukButton({
       "text": "Disabled button",
@@ -53,6 +57,8 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Macro
 
+    {% from 'button/macro.njk' import govukButton %}
+
     {{ govukButton({
       "text": "Link button",
       "href": "/"
@@ -69,6 +75,8 @@ Buttons are configured to perform an action and they can have a different look. 
     </a>
 
 #### Macro
+
+    {% from 'button/macro.njk' import govukButton %}
 
     {{ govukButton({
       "text": "Disabled link button",
@@ -88,6 +96,8 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Macro
 
+    {% from 'button/macro.njk' import govukButton %}
+
     {{ govukButton({
       "text": "Start now link button",
       "href": "/",
@@ -106,6 +116,8 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Macro
 
+    {% from 'button/macro.njk' import govukButton %}
+
     {{ govukButton({
       "element": "button",
       "name": "start-now",
@@ -123,6 +135,8 @@ Buttons are configured to perform an action and they can have a different look. 
     </button>
 
 #### Macro
+
+    {% from 'button/macro.njk' import govukButton %}
 
     {{ govukButton({
       "element": "button",

--- a/src/checkboxes/README.md
+++ b/src/checkboxes/README.md
@@ -58,6 +58,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Macro
 
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
+
     {{ govukCheckboxes({
       "idPrefix": "nationality",
       "name": "nationality",
@@ -116,6 +118,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
       </div>
 
 #### Macro
+
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
       "name": "colours",
@@ -184,6 +188,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Macro
 
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
+
     {{ govukCheckboxes({
       "fieldset": {
         "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>",
@@ -240,6 +246,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
       </div>
 
 #### Macro
+
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
       "name": "colours",
@@ -310,6 +318,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     </div>
 
 #### Macro
+
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
       "idPrefix": "example",
@@ -391,6 +401,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     </div>
 
 #### Macro
+
+    {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
       "errorMessage": {

--- a/src/date-input/README.md
+++ b/src/date-input/README.md
@@ -61,6 +61,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Macro
 
+    {% from 'date-input/macro.njk' import govukDateInput %}
+
     {{ govukDateInput({
       "id": "dob",
       "name": "dob",
@@ -135,6 +137,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
     </div>
 
 #### Macro
+
+    {% from 'date-input/macro.njk' import govukDateInput %}
 
     {{ govukDateInput({
       "id": "dob-errors",
@@ -216,6 +220,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Macro
 
+    {% from 'date-input/macro.njk' import govukDateInput %}
+
     {{ govukDateInput({
       "id": "dob-day-error",
       "name": "dob-day-error",
@@ -295,6 +301,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Macro
 
+    {% from 'date-input/macro.njk' import govukDateInput %}
+
     {{ govukDateInput({
       "id": "dob-month-error",
       "name": "dob-month-error",
@@ -373,6 +381,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
     </div>
 
 #### Macro
+
+    {% from 'date-input/macro.njk' import govukDateInput %}
 
     {{ govukDateInput({
       "id": "dob-year-error",

--- a/src/details/README.md
+++ b/src/details/README.md
@@ -29,6 +29,8 @@ Find out when to use the Details component in your service in the [GOV.UK Design
 
 #### Macro
 
+    {% from 'details/macro.njk' import govukDetails %}
+
     {{ govukDetails({
       "summaryText": "Help with nationality",
       "text": "We need to know your nationality so we can work out which elections you’re entitled to vote in. If you can’t provide your nationality, you’ll have to send copies of identity documents through the post."
@@ -52,6 +54,8 @@ Find out when to use the Details component in your service in the [GOV.UK Design
     </details>
 
 #### Macro
+
+    {% from 'details/macro.njk' import govukDetails %}
 
     {{ govukDetails({
       "id": "help-with-nationality",
@@ -86,6 +90,8 @@ Find out when to use the Details component in your service in the [GOV.UK Design
     </details>
 
 #### Macro
+
+    {% from 'details/macro.njk' import govukDetails %}
 
     {{ govukDetails({
       "summaryText": "Where to find your National Insurance Number",

--- a/src/error-message/README.md
+++ b/src/error-message/README.md
@@ -22,6 +22,8 @@ Find out when to use the Error message component in your service in the [GOV.UK 
 
 #### Macro
 
+    {% from 'error-message/macro.njk' import govukErrorMessage %}
+
     {{ govukErrorMessage({
       "text": "Error message about full name goes here"
     }) }}

--- a/src/error-summary/README.md
+++ b/src/error-summary/README.md
@@ -46,6 +46,8 @@ Find out when to use the Error summary component in your service in the [GOV.UK 
 
 #### Macro
 
+    {% from 'error-summary/macro.njk' import govukErrorSummary %}
+
     {{ govukErrorSummary({
       "titleText": "Message to alert the user to a problem goes here",
       "descriptionText": "Optional description of the errors and how to correct them",

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -31,6 +31,8 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
 #### Macro
 
+    {% from 'fieldset/macro.njk' import govukFieldset %}
+
     {{ govukFieldset({
       "legendText": "What is your address?",
       "legendHintText": "For example, 10 Downing Street"
@@ -60,6 +62,8 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
     </div>
 
 #### Macro
+
+    {% from 'fieldset/macro.njk' import govukFieldset %}
 
     {{ govukFieldset({
       "legendText": "What is your address?",

--- a/src/file-upload/README.md
+++ b/src/file-upload/README.md
@@ -25,6 +25,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Macro
 
+    {% from 'file-upload/macro.njk' import govukFileUpload %}
+
     {{ govukFileUpload({
       "id": "file-upload-1",
       "name": "file-upload-1",
@@ -51,6 +53,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
     </div>
 
 #### Macro
+
+    {% from 'file-upload/macro.njk' import govukFileUpload %}
 
     {{ govukFileUpload({
       "id": "file-upload-2",
@@ -84,6 +88,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Macro
 
+    {% from 'file-upload/macro.njk' import govukFileUpload %}
+
     {{ govukFileUpload({
       "id": "file-upload-3",
       "name": "file-upload-3",
@@ -110,6 +116,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
     </div>
 
 #### Macro
+
+    {% from 'file-upload/macro.njk' import govukFileUpload %}
 
     {{ govukFileUpload({
       "id": "file-upload-4",

--- a/src/footer/README.md
+++ b/src/footer/README.md
@@ -56,6 +56,8 @@ Find out when to use the Footer component in your service in the [GOV.UK Design 
 
 #### Macro
 
+    {% from 'footer/macro.njk' import govukFooter %}
+
     {{ govukFooter({}) }}
 
 ## Dependencies

--- a/src/globals/settings/_paths.scss
+++ b/src/globals/settings/_paths.scss
@@ -1,2 +1,2 @@
 // Set the path to your images folder
-$global-images: "/icons/" !default;
+$govuk-global-images: "/icons/" !default;

--- a/src/globals/tools/_file-url.scss
+++ b/src/globals/tools/_file-url.scss
@@ -1,5 +1,5 @@
 // Prefixes a given filename with the defined images path
 
 @function govuk-file-url($file) {
-  @return url($global-images + $file);
+  @return url($govuk-global-images + $file);
 }

--- a/src/input/README.md
+++ b/src/input/README.md
@@ -25,6 +25,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Macro
 
+    {% from 'input/macro.njk' import govukInput %}
+
     {{ govukInput({
       "label": {
         "text": "National Insurance number"
@@ -51,6 +53,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
     </div>
 
 #### Macro
+
+    {% from 'input/macro.njk' import govukInput %}
 
     {{ govukInput({
       "label": {
@@ -83,6 +87,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
     </div>
 
 #### Macro
+
+    {% from 'input/macro.njk' import govukInput %}
 
     {{ govukInput({
       "label": {

--- a/src/label/README.md
+++ b/src/label/README.md
@@ -23,6 +23,8 @@ Use labels for all form fields.
 
 #### Macro
 
+    {% from 'label/macro.njk' import govukLabel %}
+
     {{ govukLabel({
       "text": "National Insurance number",
       "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
@@ -44,6 +46,8 @@ Use labels for all form fields.
     </label>
 
 #### Macro
+
+    {% from 'label/macro.njk' import govukLabel %}
 
     {{ govukLabel({
       "classes": "govuk-c-label--bold",
@@ -71,6 +75,8 @@ Use labels for all form fields.
     </label>
 
 #### Macro
+
+    {% from 'label/macro.njk' import govukLabel %}
 
     {{ govukLabel({
       "text": "National Insurance number",

--- a/src/panel/README.md
+++ b/src/panel/README.md
@@ -27,6 +27,8 @@ Find out when to use the Panel component in your service in the [GOV.UK Design S
 
 #### Macro
 
+    {% from 'panel/macro.njk' import govukPanel %}
+
     {{ govukPanel({
       "titleText": "Application complete",
       "text": "Your reference number: HDJ2123F"

--- a/src/phase-banner/README.md
+++ b/src/phase-banner/README.md
@@ -28,6 +28,8 @@ Find out when to use the Phase banner component in your service in the [GOV.UK D
 
 #### Macro
 
+    {% from 'phase-banner/macro.njk' import govukPhaseBanner %}
+
     {{ govukPhaseBanner({
       "tag": {
         "text": "alpha"

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -50,6 +50,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Macro
 
+    {% from 'radios/macro.njk' import govukRadios %}
+
     {{ govukRadios({
       "idPrefix": "example",
       "name": "example",
@@ -109,6 +111,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
     </div>
 
 #### Macro
+
+    {% from 'radios/macro.njk' import govukRadios %}
 
     {{ govukRadios({
       "idPrefix": "example",
@@ -171,6 +175,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Macro
 
+    {% from 'radios/macro.njk' import govukRadios %}
+
     {{ govukRadios({
       "idPrefix": "example-disabled",
       "name": "example-disabled",
@@ -232,6 +238,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Macro
 
+    {% from 'radios/macro.njk' import govukRadios %}
+
     {{ govukRadios({
       "idPrefix": "housing-act",
       "name": "housing-act",
@@ -286,6 +294,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       </div>
 
 #### Macro
+
+    {% from 'radios/macro.njk' import govukRadios %}
 
     {{ govukRadios({
       "name": "colours",
@@ -348,6 +358,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
     </div>
 
 #### Macro
+
+    {% from 'radios/macro.njk' import govukRadios %}
 
     {{ govukRadios({
       "idPrefix": "example",

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -33,6 +33,8 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
 
 #### Macro
 
+    {% from 'select/macro.njk' import govukSelect %}
+
     {{ govukSelect({
       "id": "select-1",
       "name": "select-1",
@@ -87,6 +89,8 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
     </div>
 
 #### Macro
+
+    {% from 'select/macro.njk' import govukSelect %}
 
     {{ govukSelect({
       "id": "select-2",

--- a/src/skip-link/README.md
+++ b/src/skip-link/README.md
@@ -20,6 +20,8 @@ Find out when to use the Skip link component in your service in the [GOV.UK Desi
 
 #### Macro
 
+    {% from 'skip-link/macro.njk' import govukSkipLink %}
+
     {{ govukSkipLink({
       "text": "Skip to main content",
       "href": "#content"

--- a/src/table/README.md
+++ b/src/table/README.md
@@ -55,6 +55,8 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
 #### Macro
 
+    {% from 'table/macro.njk' import govukTable %}
+
     {{ govukTable({
       "rows": [
         [
@@ -155,6 +157,8 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
     </table>
 
 #### Macro
+
+    {% from 'table/macro.njk' import govukTable %}
 
     {{ govukTable({
       "head": [
@@ -271,6 +275,8 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
     </table>
 
 #### Macro
+
+    {% from 'table/macro.njk' import govukTable %}
 
     {{ govukTable({
       "caption": "Caption 1 : Months and rates",

--- a/src/tag/README.md
+++ b/src/tag/README.md
@@ -22,6 +22,8 @@ Find out when to use the Tag component in your service in the [GOV.UK Design Sys
 
 #### Macro
 
+    {% from 'tag/macro.njk' import govukTag %}
+
     {{ govukTag({
       "text": "alpha"
     }) }}
@@ -37,6 +39,8 @@ Find out when to use the Tag component in your service in the [GOV.UK Design Sys
     </strong>
 
 #### Macro
+
+    {% from 'tag/macro.njk' import govukTag %}
 
     {{ govukTag({
       "text": "alpha",

--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -30,6 +30,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Macro
 
+    {% from 'textarea/macro.njk' import govukTextarea %}
+
     {{ govukTextarea({
       "name": "more-detail",
       "id": "more-detail",
@@ -58,6 +60,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
     </div>
 
 #### Macro
+
+    {% from 'textarea/macro.njk' import govukTextarea %}
 
     {{ govukTextarea({
       "name": "no-ni-reason",
@@ -89,6 +93,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Macro
 
+    {% from 'textarea/macro.njk' import govukTextarea %}
+
     {{ govukTextarea({
       "id": "full-address",
       "name": "address",
@@ -113,6 +119,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
     </div>
 
 #### Macro
+
+    {% from 'textarea/macro.njk' import govukTextarea %}
 
     {{ govukTextarea({
       "id": "full-address",

--- a/src/warning-text/README.md
+++ b/src/warning-text/README.md
@@ -26,6 +26,8 @@ Find out when to use the Warning text component in your service in the [GOV.UK D
 
 #### Macro
 
+    {% from 'warning-text/macro.njk' import govukWarningText %}
+
     {{ govukWarningText({
       "text": "You can be fined up to £5,000 if you don’t register.",
       "iconFallbackText": "Warning"


### PR DESCRIPTION
This PR updates the main README with the following:
- Improve docs around Sass paths
- Improve docs around static assets; add guidance on how to use `$global-images` to set images path 
- Document the difference between the `govuk-frontend.min.css` and
`govuk-frontend-old-ie.min.css`. 
- Wrap ` [latest version].min.css` in the "Include assets" example in a conditional comment so that IE8 doesn't download two stylesheets - if we want to do this, `layout.njk` should be updated to do the same
- Document minimum version of Nunjucks in macros: 3.0.0 (2.5.2 and earlier throw up an error due to whitespacing being handled differently [thanks Alex!])
- Document mimimum version of node.js required: 8.3.0 (8.2.0 and earlier throw up console errors)
- General: When writing guidance don't specify a technology or make it clear it's an example
- Clarify what DS is and that it contains a demo

This PR updates the component READMEs with the following:
- Add Nunjucks import macro statement 

Other
- Prefix `$global-images` variable in `settings/_paths.scss`

Note: 
- I've split the main README changes into separate commits to make them easier to review but I'll squash them into one commit before merging this.
- I'll update the changelog once the changes have been approved.

https://trello.com/c/dTNV2ggW/833-update-govuk-frontend-readme-based-on-feedback-from-user-research