### PR TITLE
Make Sass imports less broad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Internal:
 - Explain npm link
 (PR [#624](https://github.com/alphagov/govuk-frontend/pull/624))
 
+- Make Sass imports less broad
+  (PR [#617](https://github.com/alphagov/govuk-frontend/pull/617))
+
 ## 0.0.26-alpha (Breaking release)
 
 Breaking changes:

--- a/src/back-link/_back-link.scss
+++ b/src/back-link/_back-link.scss
@@ -1,4 +1,22 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/shape-arrow";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/core/links";
 
 @include govuk-exports("back-link") {
 

--- a/src/breadcrumbs/_breadcrumbs.scss
+++ b/src/breadcrumbs/_breadcrumbs.scss
@@ -1,4 +1,24 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/tools/legacy-ie";
+
+@import "../globals/helpers/clearfix";
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/focusable";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/core/links";
 
 @include govuk-exports("breadcrumbs") {
 

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -1,4 +1,25 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/device-pixels";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/core/links";
 
 @include govuk-exports("button") {
 

--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -1,4 +1,7 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+
+@import "../fieldset/fieldset";
+@import "../label/label";
 
 @include govuk-exports("checkboxes") {
   .govuk-c-checkboxes__item {

--- a/src/date-input/_date-input.scss
+++ b/src/date-input/_date-input.scss
@@ -1,4 +1,7 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
 @import "../label/label";
 @import "../input/input";
 @import "../error-message/error-message";

--- a/src/details/_details.scss
+++ b/src/details/_details.scss
@@ -1,4 +1,19 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/shape-arrow";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("details") {
 

--- a/src/error-message/_error-message.scss
+++ b/src/error-message/_error-message.scss
@@ -1,4 +1,15 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+
+@import "../globals/helpers/media-queries";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("error-message") {
   .govuk-c-error-message {

--- a/src/error-summary/_error-summary.scss
+++ b/src/error-summary/_error-summary.scss
@@ -1,4 +1,24 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/focusable";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/core/lists";
 
 @include govuk-exports("error-summary") {
 

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -1,4 +1,21 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../error-message/error-message";
+
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/clearfix";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/media-queries";
+
+@import "../globals/objects/form-group";
+
+
+
+
 
 @include govuk-exports("fieldset") {
   .govuk-c-fieldset {

--- a/src/file-upload/_file-upload.scss
+++ b/src/file-upload/_file-upload.scss
@@ -1,4 +1,11 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+
+@import "../label/label";
+
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/focusable";
 
 @include govuk-exports("file-upload") {
   .govuk-c-file-upload {

--- a/src/footer/_footer.scss
+++ b/src/footer/_footer.scss
@@ -1,4 +1,23 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/device-pixels";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("footer") {
 

--- a/src/input/_input.scss
+++ b/src/input/_input.scss
@@ -1,6 +1,9 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../fieldset/fieldset";
 @import "../label/label";
 @import "../error-message/error-message";
+
+@import "../globals/helpers/focusable";
 
 @include govuk-exports("input") {
   .govuk-c-input {

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -1,4 +1,6 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+
+@import "../error-message/error-message";
 
 @include govuk-exports("label") {
   .govuk-c-label {

--- a/src/panel/_panel.scss
+++ b/src/panel/_panel.scss
@@ -1,4 +1,18 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("panel") {
 

--- a/src/phase-banner/_phase-banner.scss
+++ b/src/phase-banner/_phase-banner.scss
@@ -1,4 +1,4 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
 @import "../tag/tag";
 
 @include govuk-exports("phase-banner") {

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -1,4 +1,7 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+
+@import "../fieldset/fieldset";
+@import "../label/label";
 
 @include govuk-exports("radios") {
   .govuk-c-radios__item {

--- a/src/select/_select.scss
+++ b/src/select/_select.scss
@@ -1,5 +1,14 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+
 @import "../label/label";
+
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/spacing";
+
+@import "../globals/objects/form-group";
 
 @include govuk-exports("select") {
   .govuk-c-select {

--- a/src/skip-link/_skip-link.scss
+++ b/src/skip-link/_skip-link.scss
@@ -1,4 +1,23 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/compatibility";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/compatibility";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/visually-hidden";
+@import "../globals/helpers/media-queries";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/core/links";
 
 @include govuk-exports("skip-link") {
   .govuk-c-skip-link {

--- a/src/table/_table.scss
+++ b/src/table/_table.scss
@@ -1,4 +1,19 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/iff";
+@import "../globals/tools/px-to-em";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/spacing";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("table") {
   .govuk-c-table {

--- a/src/tag/_tag.scss
+++ b/src/tag/_tag.scss
@@ -1,4 +1,17 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/legacy-ie";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+
+@import "../globals/helpers/media-queries";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("tag") {
   .govuk-c-tag {

--- a/src/textarea/_textarea.scss
+++ b/src/textarea/_textarea.scss
@@ -1,6 +1,16 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/iff";
+
 @import "../label/label";
-@import "../error-message/error-message";
+
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/spacing";
+
+@import "../globals/objects/form-group";
+
 
 @include govuk-exports("textarea") {
   .govuk-c-textarea {

--- a/src/warning-text/_warning-text.scss
+++ b/src/warning-text/_warning-text.scss
@@ -1,4 +1,21 @@
-@import "../globals/common";
+@import "../globals/tools/exports";
+@import "../globals/tools/iff";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
+
+@import "../globals/helpers/media-queries";
+@import "../globals/helpers/spacing";
+@import "../globals/helpers/visually-hidden";
+
+@import "../globals/objects/shapes";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @include govuk-exports("warning-text") {
 


### PR DESCRIPTION
This PR replaces `globals/common` import in each component with only the necessary partials.
There is already a test that checks if individual component Sass files compile.

Note: i've placed typography partials at the end of imports to make it a bit easier to do the work of making typography imports conditional.

https://trello.com/c/unO51Rno/830-make-sass-imports-dependencies-less-broad