### PR TITLE
Configure nunjucks and express to give more meaningful errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Internal:
 - Update check script for new components and tweak docs
   (PR [#589](https://github.com/alphagov/govuk-frontend/pull/589))
 
+- Expose more meaningful errors in dev
+  (PR [#621](https://github.com/alphagov/govuk-frontend/pull/621))
+  
+
 ## 0.0.26-alpha (Breaking release)
 
 Breaking changes:

--- a/app/app.js
+++ b/app/app.js
@@ -20,6 +20,8 @@ const appViews = [
 
 // Configure nunjucks
 let env = nunjucks.configure(appViews, {
+  dev: true, // returns the full trace from the error point
+  throwOnUndefined: true, // makes the system throw errors if trying to output a null or undefined value
   autoescape: true, // output with dangerous characters are escaped automatically
   express: app, // the express app that nunjucks should install to
   noCache: true, // never use a cache and recompile templates each time
@@ -149,5 +151,16 @@ app.get('/robots.txt', function (req, res) {
   res.type('text/plain')
   res.send('User-agent: *\nDisallow: /')
 })
+
+// expose the error in combination with nunjucks env options
+// next() fires before res.send() so in order to catch the error
+// it needs to be wrapped in setTimeout
+if (process.env.NODE_ENV !== 'production') {
+  process.once('uncaughtException', () => {
+    setTimeout(() => {
+      process.exit(1)
+    }, 100)
+  })
+}
 
 module.exports = server


### PR DESCRIPTION
Addresses #614 

Before
<img width="1230" alt="screen shot 2018-03-27 at 15 53 35" src="https://user-images.githubusercontent.com/3758555/37975552-7f9da540-31d7-11e8-919d-3540ed86a225.png">


After
<img width="1230" alt="screen shot 2018-03-27 at 15 55 19" src="https://user-images.githubusercontent.com/3758555/37975559-81fcc5aa-31d7-11e8-9d25-f7eeca5b2aa8.png">