### PR TITLE
Filter out files from component list

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,12 +1,23 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
+
 const configPaths = require('../config/paths.json')
 
-// Read component list from various sources
+// Generate component list from source directory, excluding anything that's not
+// a directory (for example, .DS_Store files)
 exports.SrcComponentList = fs.readdirSync(configPaths.src)
-exports.SrcFilteredComponentList = fs.readdirSync(configPaths.src).filter(file => (file !== 'all' && file !== 'globals' && file !== 'icons'))
+  .filter(file => fs.statSync(path.join(configPaths.src, file)).isDirectory())
+
+// Filter out directories that do no correspond to components
+exports.SrcFilteredComponentList = exports.SrcComponentList
+  .filter(file => !['all', 'globals', 'icons'].includes(file))
+
+// Generate list of components in dist folder
 exports.DistComponentList = fs.readdirSync(configPaths.dist + 'components/')
+
+// Generate list of packages
 exports.PackagesComponentList = fs.readdirSync(configPaths.packages)
 
 // List all the files for a given component in dist/components


### PR DESCRIPTION
Currently if you have e.g. a .DS_Store file in the src directory it is included in the expected list of components and your tests will fail.

Update the file helper to filter out anything that’s not a directory from this list, and make it clearer what the various exported lists represent.