### PR TITLE
Make radio and checkbox labels inline blocks

### DIFF
--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -44,7 +44,7 @@
   }
 
   .govuk-c-checkboxes__label {
-    display: block;
+    display: inline-block;
     padding: 8px $govuk-spacing-scale-3 $govuk-spacing-scale-1;
     cursor: pointer;
     // remove 300ms pause on mobile

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -45,7 +45,7 @@
   }
 
   .govuk-c-radios__label {
-    display: block;
+    display: inline-block;
     padding: 8px $govuk-spacing-scale-3 $govuk-spacing-scale-1;
     cursor: pointer;
     // remove 300ms pause on mobile


### PR DESCRIPTION
Make radio and checkbox inline blocks so that the effective click area only extends to the label. Without this change, the labels extend to the full width of the container which means the clicks apparently in space on the right hand side activate the inputs.

## Before

![before](https://user-images.githubusercontent.com/121939/38416819-eb9f93b2-398d-11e8-8ff6-54dd46d6f7ac.gif)


## After

![after](https://user-images.githubusercontent.com/121939/38416821-ef2b2d20-398d-11e8-9f3a-dd0bd09feb52.gif)

## Testing

Tested in:

- [X] Internet Explorer 8
- [X] Internet Explorer 9
- [X] Internet Explorer 10
- [X] Internet Explorer 11
- [X] Edge 16
- [X] Google Chrome 65 (Mac)
- [X] Mozilla Firefox 59 (Mac)
- [X] Safari 11 (Mac)
- [X] Internet Explorer, Windows Phone 8.1
- [X] Safari, iOS 9 (Simulated, iPhone 6S)
- [X] Safari, iOS 11.3 (Physical, iPhone X)
- [X] Android Google Chrome (Simulated, Samsung Galaxy S8)
- [X] Samsung Internet (Simulated, Samsung Galaxy S8)

Fixes #543 