### PR TITLE
Update SassMQ import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Breaking changes:
   details.
   (PR [#631](https://github.com/alphagov/govuk-frontend/pull/631))
 - Rename captionSize table argument to captionClasses ([PR #643](https://github.com/alphagov/govuk-frontend/pull/643))
+- Update SassMQ import path (PR [#637](https://github.com/alphagov/govuk-frontend/pull/637))
 
 Fixes:
 - Link styles, as well as links within the  back-link, breadcrumbs, button,


### PR DESCRIPTION
In certain use cases as outlined in #636 the way we were importing SassMQ wasn't resolving correctly.
This change should fix that.
- Updated path in `src/globals/helpers/_media-queries.scss`
- `includePaths: 'node_modules'` added to gulp compilation task
- `includePaths: 'node_modules'` added to node-sass configuration in tests
- Changelog updated