### PR TITLE
Rename captionSize table argument to captionClasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Breaking changes:
   update it to reference the new variable $govuk-is-ie8 – see the README for
   details.
   (PR [#631](https://github.com/alphagov/govuk-frontend/pull/631))
+- Rename captionSize table argument to captionClasses ([PR #643](https://github.com/alphagov/govuk-frontend/pull/643))
 
 Fixes:
 - Link styles, as well as links within the  back-link, breadcrumbs, button,

--- a/src/table/README.md
+++ b/src/table/README.md
@@ -225,7 +225,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
     <table class="govuk-c-table">
 
-      <caption class="govuk-c-table__caption govuk-heading-l">Caption 1 : Months and rates</caption>
+      <caption class="govuk-c-table__caption govuk-heading-m">Caption 1 : Months and rates</caption>
 
       <thead class="govuk-c-table__head">
         <tr class="govuk-c-table__row">
@@ -280,7 +280,7 @@ Find out when to use the Table component in your service in the [GOV.UK Design S
 
     {{ govukTable({
       "caption": "Caption 1 : Months and rates",
-      "captionSize": "govuk-heading-l",
+      "captionClasses": "govuk-heading-m",
       "firstCellIsHeader": true,
       "head": [
         {
@@ -412,13 +412,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-c-table__row">
 
-<th class="govuk-c-table__header" scope="row">captionSize</th>
+<th class="govuk-c-table__header" scope="row">captionClasses</th>
 
 <td class="govuk-c-table__cell ">string</td>
 
 <td class="govuk-c-table__cell ">No</td>
 
-<td class="govuk-c-table__cell ">Optional caption text size. Class should correspond to the available heading classes.</td>
+<td class="govuk-c-table__cell ">Optional classes for caption text size. Class should correspond to the available typography heading classes.</td>
 
 </tr>
 

--- a/src/table/index.njk
+++ b/src/table/index.njk
@@ -67,7 +67,7 @@
     ],
     [
       {
-        text: 'captionSize'
+        text: 'captionClasses'
       },
       {
         text: 'string'
@@ -76,7 +76,7 @@
         text: 'No'
       },
       {
-        text: 'Optional caption text size. Class should correspond to the available heading classes.'
+        text: 'Optional classes for caption text size. Class should correspond to the available typography heading classes.'
       }
     ],
     [

--- a/src/table/table.yaml
+++ b/src/table/table.yaml
@@ -50,7 +50,7 @@ examples:
  - name: table-with-caption-and-head
    data:
      caption: "Caption 1 : Months and rates"
-     captionSize: govuk-heading-l
+     captionClasses: govuk-heading-m
      firstCellIsHeader: true
      head:
        - text: Month you apply

--- a/src/table/template.njk
+++ b/src/table/template.njk
@@ -2,7 +2,7 @@
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.caption %}
   <caption class="govuk-c-table__caption
-  {%- if params.captionSize %} {{ params.captionSize }}{% endif %}">{{ params.caption }}</caption>
+  {%- if params.captionClasses %} {{ params.captionClasses }}{% endif %}">{{ params.caption }}</caption>
   {% endif %}
   {% if params.head %}
   <thead class="govuk-c-table__head">

--- a/src/table/template.test.js
+++ b/src/table/template.test.js
@@ -54,7 +54,7 @@ describe('Table', () => {
     const $ = render('table', examples['table-with-caption-and-head'])
     const $caption = $('.govuk-c-table__caption')
 
-    expect($caption.hasClass('govuk-heading-l')).toBeTruthy()
+    expect($caption.hasClass('govuk-heading-m')).toBeTruthy()
   })
 
   it('renders first cell in every row as a <th> element with correct `govuk-c-table__header` class and `scope=row` attribute', () => {


### PR DESCRIPTION
Also
- update table of arguments
- update readme.md
- update class provide to make the heading size smaller
(and inline with Elements)
- update tests
- update changelog

Trello: https://trello.com/c/0NJ1zzEK/882-1-rename-tables-captionsize-to-captionclasses