### PR TITLE
Revert "Add description / definition list"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,6 @@ New features:
 - The back link, breadcrumbs and skip link have been updated to use the
   text style link mixin
   (PR [#609](https://github.com/alphagov/govuk-frontend/pull/609))
-- Add basic <dl> styling
-  (PR [#638](https://github.com/alphagov/govuk-frontend/pull/638))
 - Add limited width inputs
 - Add Webpack as js bundler
   (PR [#619](https://github.com/alphagov/govuk-frontend/pull/619))

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -150,18 +150,6 @@
           <li>Payment</li>
           <li>Confirmation</li>
         </ol>
-
-        <h3 class="govuk-heading-m">govuk-list + govuk-list--description</h3>
-        <dl class="govuk-list govuk-list--description">
-          <dt>Term</dt>
-          <dd>Description</dd>
-          <dt>Term</dt>
-          <dd>Description</dd>
-          <dd>Description</dd>
-          <dt>Term</dt>
-          <dd>Description</dd>
-        </dl>
-
         <h3 class="govuk-heading-m">Nested govuk-list 1</h3>
         <ul class="govuk-list govuk-list--number">
           <li><a class="govuk-link" href="#">Download kit</a></li>

--- a/src/globals/core/_lists.scss
+++ b/src/globals/core/_lists.scss
@@ -64,25 +64,4 @@
   .govuk-list--number {
     @extend %govuk-list--number;
   }
-
-  %govuk-list--description > dt {
-    @include govuk-font-bold;
-  }
-
-  %govuk-list--description > dt {
-    // margin-top is applied to the dt as the last dd in each dt cannot be targeted.
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "top");
-  }
-
-  %govuk-list--description > dt:first-child {
-    margin-top: 0;
-  }
-
-  %govuk-list--description > dd {
-    margin-left: 0;
-  }
-
-  .govuk-list--description {
-    @extend %govuk-list--description;
-  }
 }


### PR DESCRIPTION
This reverts the merge into master of https://github.com/alphagov/govuk-frontend/pull/638

Why? After some more discussions, it appears there's a need for a variant of the definition list from the above PR that reverses the bold styles. It makes sense to make definition list into a thing of its own that doesn't use `govuk-list`. We want to get this version of FE out so pulling this out of master and we'll investigate definition lists in more detail in due course.