### PR TITLE
Remove redundant font-family rule in button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 ## Unreleased
 
+Fixes:
+
+- Remove redundant font-family declaration from the button component – this will
+  also fix an issue where the button uses New Transport when printed instead of
+  falling back to the print stack as expected.
+  (PR [#650](https://github.com/alphagov/govuk-frontend/pull/650))
+
+
 Internal
 - Update publishing docs (PR [#651](https://github.com/alphagov/govuk-frontend/pull/651)) 
 

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -48,7 +48,6 @@
     color: $govuk-button-text-colour;
     background-color: $govuk-button-colour;
     box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
-    font-family: $govuk-font-stack;
     text-align: center;
     vertical-align: top;
     cursor: pointer;


### PR DESCRIPTION
Remove explicit font-family definition from the button scss. We don't need it because we get it as part of the included `govuk-font-regular` mixin which defines the font for us.

This will remove a redundant duplicated font-family rule and also mean that the button will correctly fall back to the print font when printed.

Hat tip to @dashouse for spotting this 👀 