### PR TITLE
Update main doc file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ lerna-debug.log
 axeReports/
 public/
 packages/**/package-lock.json
+examples/**/package-lock.json
 *.zip

--- a/README.md
+++ b/README.md
@@ -95,6 +95,64 @@ After resolving the import paths you can import GOV.UK Frontend by using:
 @import "@govuk-frontend/button/button";
 ```
 
+### Import JavaScript
+
+You need to import the GOV.UK Frontend scripts into the main JavaScript file in your project.
+
+To import and initialise all components that require JavaScript, add the below to your main JavaScript file:
+```JS
+import All from '@govuk-frontend/all/all'
+```
+
+To import an individual component (for example a button), add the below to your main JavaScript file:
+```JS
+import Button from '@govuk-frontend/button/button'
+```
+
+Use the following to initialise the button component:
+
+```JS
+new Button().init()
+```
+
+Note: The import syntax you should use depends on the JavaScript module format used by your bundler. For example, if it is using `CommonJS`, use
+
+```JS
+require('@govuk-frontend/all/all')
+```
+
+#### Polyfills
+A JavaScript polyfill provides functionality on older browsers or assistive technology that do not natively support it.
+
+The polyfills provided with GOV.UK Frontend aim to fix usability and accessibility issues. If there is a JavaScript included in the component directory, it is important to import and initialise it in your project to ensure that all users can properly use the component (see [Import Javscript](#import-javascript)).  
+
+Examples of GOV.UK Frontend polyfills:
+1. Links styled to look like buttons lack button behaviour. The polyfill script will allow them to be triggered with a space key after they’ve been focused, to match standard buttons.
+2. Details component polyfill includes accessibility enhancements to ensure that the user is given appropriate information about the state (collapsed/expanded) of the component. The polyfill also makes the component behave correctly on IE8.
+
+#### Bundling JavaScript
+The JavaScript included in GOV.UK Frontend components are in [UMD (Universal Module Definition)](https://github.com/umdjs/umd) format which makes it compatible with AMD (Asynchronous module definition) and CommonJS.
+
+##### Include with Webpack 4
+Here's an example of setting up [`webpack.config.js`](examples/webpack/webpack.config.js) in your project
+
+##### Include with Gulp and Rollup
+You can configure Gulp and Rollup as part of your build process using the [gulp-better-rollup](https://www.npmjs.com/package/gulp-better-rollup) plugin. Below is an example:
+
+```JS
+gulp.task('compile', () => {
+  return gulp.src('./js/*.js')
+    .pipe(rollup({
+      // Legacy mode is required for IE8 support
+      legacy: true
+    }))
+    .pipe(uglify())
+    .pipe(gulp.dest('./js'));
+})
+
+```
+(If you compile JavaScript in your project, your build tasks will already include something similar to the above task - in that case, you will just need to pipe `rollup` to it.)
+
 ### Import images and icons
 
 In order to import GOV.UK Frontend images and icons to your project, you should configure your application to reference or copy the relevant GOV.UK Frontend assets.
@@ -133,7 +191,7 @@ Download the latest versions of the following assets and include them in your pr
 
 ## Include assets
 
-Add the CSS and JavaScript code to your HTML template:
+Add the CSS and JavaScript code to your HTML template (this assumes you've copied the files to `/assets` in your project):
 
 ```html
 <!DOCTYPE html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,71 +2,161 @@
 
 ## Coding standards
 
-Coding standards for [CSS](coding-standards/css.md) and [JavaScript](coding-standards/js.md).
+- [Component API](component-api.md)
+- [Components](components.md)
+- [CSS](coding-standards/css.md)
+- [IE8 support](legacy-ie.md)
+- [JavaScript](coding-standards/js.md)
 
-Support for [older versions of IE](legacy-ie.md).
+## Installing
 
-## Directory structure
+Clone the repository
 
-## /config
+```
+git clone git@github.com:alphagov/govuk-frontend.git
+```
 
-Config files for scss lint and for the govuk-frontend application.
+Install dependencies
 
-## /dist
+```
+npm install
+```
 
-Standalone builds of govuk-frontend. Provides a way to consume govuk-frontend without having to use npm.
+## Running
 
-## /docs
+```
+npm start
+```
+By default the app runs on port 3000, so the app will be available at: http://localhost:3000
 
-Project documentation.
+See [development and publishing tasks](development-and-publish-tasks.md) for more information about the npm scripts.
 
-## /packages
+## Application architecture
 
-npm packages of globals and components.
+- `app/`
 
-## /packages/all  
+  [Express](https://github.com/expressjs/express) application to preview components; also referred to as _preview app_.
 
-Consume all of govuk-frontend through a single package.
+  - `assets/`
 
-## /packages/globals
+    App-specific assets.
 
-All packages depend on this package, it contains shared dependencies of all components - colours, font-face, media queries, typography and vars.
+  - `views/`
 
-## /packages/<package-name>
+    [Nunjucks](https://github.com/mozilla/nunjucks) template files.
 
-Individual packages - these depend on each other (dependencies are listed in package.json) and also the globals package.
+    - `examples/`
 
-### /packages/<package-name>/CHANGELOG.md 
+      Examples of components usage in various contexts. You can access these examples from the home page of the preview app.
 
-Changes made to a package listed per version.
+    - `layouts/`
 
-### /packages/<package-name>/LICENSE
+      Generic layout templates used to render preview app pages.
 
-Package license.
+    - `partials/`
 
-### /packages/<package-name>/README.md
+      Reusable blocks of template code.
 
-Package README showing the basic API and usage instructions.
+- `bin/`
 
-### /packages/<package-name>/package.json 
+  Binary/executable files (i.e. bash scripts) mainly used in the [publishing process]((publishing.md)).
 
-npm package definition for a package.
-States package dependencies.
-Package version is managed by Lerna.js
+- `config/`
 
-## /src
+  Configuration files for the preview app, [sass-lint](https://github.com/sasstools/sass-lint) and [Jest](https://github.com/facebook/jest).
 
-The development area for govuk-frontend.
 
-### /src/globals
+- `dist/` **contains auto-generated files**
 
-Images
+  Standalone builds of govuk-frontend. Provides a way to consume govuk-frontend without using npm.
 
-Scss source files.
+- `docs/`
 
-### /src/components
+  Documentation files.
 
-Component source files.
+- `lib/`
 
-[Component documentation](components.md)
-[Npm scripts and gulp taks](development-and-publish-tasks.md)
+  Application modules and helpers.
+
+- `packages/` **contains auto-generated files**
+
+  packages published on npm.
+
+  - `all/`
+
+    Consume all of govuk-frontend through a single package.
+
+  - `globals/`
+
+    All packages depend on this package, it contains shared dependencies of all components (e.g. colours, font-face, media queries, typography and vars).
+
+  - `[component-name]/`
+
+    Individual packages - these depend on each other (dependencies are listed in package.json) and also the globals package.
+
+    - `CHANGELOG.md`
+
+      Changes made to a package listed per version.
+
+    - `LICENSE`
+
+      Package license.
+
+    - `README.md`
+
+      Package README showing the basic API and usage instructions.
+
+    - `package.json`
+
+      npm definition for a package; states package dependencies.
+
+- `src/`
+
+  Source files.
+
+  - `all/`
+
+    Import all scripts and styles.
+
+  - `globals/`
+
+    Generic scripts, style definitions and mixins.
+
+  - `icons/`
+
+    Image assets.
+
+  - `[component-name]/`
+
+    Component-specific source files.
+
+- `tasks/`
+
+  Application modules and helpers.
+
+
+### Auto-generated directories  
+
+- `aXeReports/`
+
+  Output of [aXe](https://github.com/dequelabs/axe-core) tests.
+
+- `public/`
+
+  Assets built for the preview app.
+
+## Testing and linting
+
+```
+npm test
+```
+
+Running all tests will trigger [standard](https://github.com/standard/standard) and [sass-lint](https://github.com/sasstools/sass-lint) for lint and [Jest](https://github.com/facebook/jest) for unit and functional tests.
+
+## Deploying
+You can [run the preview app locally](#running) or deploy it straight to a Heroku instance.
+
+An existing Heroku instance can be found at: [http://govuk-frontend-review.herokuapp.com/](http://govuk-frontend-review.herokuapp.com/)
+
+## Publishing
+You need npm credentials to publish a new release. For the detailed publishing process see the [publishing  documentation](publishing.md).

--- a/examples/webpack/assets/main.js
+++ b/examples/webpack/assets/main.js
@@ -1,0 +1,3 @@
+import Button from '@govuk-frontend/button/button'
+
+new Button().init()

--- a/examples/webpack/index.html
+++ b/examples/webpack/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>GOV.UK Frontend</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="../../public/css/app.css">
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
+  <script src="/vendor/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
+  <!--[if IE 8]>
+  <link rel="stylesheet" href="/public/css/app-old-ie.css">
+  <![endif]-->
+</head>
+<body>
+  <div class="govuk-width-container">
+    <div class="app-whitespace-highlight">
+      <a href="/" role="button" class="govuk-button">Link button</a>
+    </div>
+  </div>
+  <!--script src="../../../public/all/all.js"></script-->
+  <script src="public/main.js"></script>
+</body>
+</html>

--- a/examples/webpack/package.json
+++ b/examples/webpack/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "webpack-boilerplate",
+  "description": "Webpack4 boilerplate consuming govuk-frontend",
+  "scripts": {
+    "dev": "cross-env NODE_ENV=dev webpack-dev-server --progress --mode development --config webpack.config.js",
+    "build": "webpack -p --progress --mode production --config webpack.config.js"
+  },
+  "dependencies": {
+    "@govuk-frontend/all": "*"
+  },
+  "devDependencies": {
+    "babel-core": "^6.26.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-es3": "^1.0.1",
+    "clean-webpack-plugin": "0.1.19",
+    "cross-env": "5.1.4",
+    "css-loader": "0.28.11",
+    "file-loader": "1.1.11",
+    "html-webpack-plugin": "3.2.0",
+    "node-sass": "^4.7.2",
+    "sass-loader": "7.0.1",
+    "style-loader": "0.20.3",
+    "uglifyjs-webpack-plugin": "^1.2.4",
+    "url-loader": "1.0.1",
+    "webpack": "4.6.0",
+    "webpack-cli": "2.0.14",
+    "webpack-dev-server": "3.1.3",
+    "webpack-merge": "4.1.2"
+  }
+}

--- a/examples/webpack/webpack.config.js
+++ b/examples/webpack/webpack.config.js
@@ -1,0 +1,51 @@
+const path = require('path')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+
+const config = {
+  mode: 'production',
+  devtool: 'source-map',
+  optimization: {
+    minimizer: [
+      new UglifyJsPlugin({
+        cache: true,
+        parallel: true,
+        sourceMap: true,
+        uglifyOptions: {
+          compress: {
+            ie8: true,
+            warnings: false
+          },
+          mangle: {
+            ie8: true
+          },
+          output: {
+            comments: false,
+            ie8: true
+          }
+        }
+      })
+    ]
+  },
+  entry: './assets/main.js',
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['env', 'es3']
+          }
+        }
+      }
+    ]
+  },
+  output: {
+    path: path.resolve(__dirname, 'public'),
+    filename: '[name].js',
+    sourceMapFilename: '[name].js.map'
+  }
+}
+
+module.exports = config


### PR DESCRIPTION
Update documentation
- [x] Update main documentation file to reflect current architecture.
- [x] Update main readme file to explain how to import, build and use JavaScript from `govuk-frontend`

Links for reviewers:
- main documentation file [/docs/index.md](https://github.com/alphagov/govuk-frontend/blob/46c084f41c96ff87ea5b97607ddc11a8ce350f07/docs/index.md)
- main readme file [README.md](https://github.com/alphagov/govuk-frontend/blob/16489413b9548da57599a0c6267897d305dd0be9/README.md)

Trello card:
- https://trello.com/c/qSxJW8Z4