### PR TITLE
Exclude test files and snapshots folders from copy task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Internal:
 - Wrap `app.css` in conditional comments in review app layout (PR [#653](https://github.com/alphagov/govuk-frontend/pull/653))
 - Fix missing code highlight and remove duplicate layout
 (PR [#663](https://github.com/alphagov/govuk-frontend/pull/663))
+- Exclude test related files from `dist/` and `packages/` copy task 
+(PR [#662](https://github.com/alphagov/govuk-frontend/pull/662))
 
 ## 0.0.28-alpha (Breaking release)
 

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -16,9 +16,10 @@ const isDist = taskArguments.destination === 'dist' || false
 gulp.task('copy-files', () => {
   return gulp.src([
     configPaths.src + '**/*',
-    '!' + configPaths.src + '**/*.js',
+    '!' + configPaths.src + '**/*.{test,js}',
     '!' + configPaths.src + '**/index.njk',
-    '!' + configPaths.src + '**/*.{yml,yaml}'
+    '!' + configPaths.src + '**/*.{yml,yaml}',
+    '!' + configPaths.src + '**/__snapshots__/**'
   ])
   .pipe(scssFiles)
   .pipe(postcss([


### PR DESCRIPTION
Currently tests that run after copy to `packages` or `dist` throw the following error:
```
 10 obsolete snapshot files found, run npm run test:build:packages -- -u to remove them..
```
As paths in tests are very specific and wouldn't work for consumers, we can avoid packaging them.


