### PR TITLE
Simplify grid syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Breaking change:
 
   As a result of this, we're removing these prefixes from our codebase.
 
+- Simplify grid syntax and introduce grid-row and column mixins.
+  ([PR #665](https://github.com/alphagov/govuk-frontend/pull/665))
+  Based on user research feedback we have simplified the grid classes
+  to a more consise naming structure. We have also introduced two mixins
+  to help generate additional or custom grid styles and widths.
+
 Fixes:
 
 - Remove redundant font-family declaration from the button component – this will

--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -11,69 +11,93 @@
 
 <main id="content" role="main" class="govuk-main-wrapper">
   <h1 class="govuk-heading-l">Example: Grid layout</h1>
-  <div class="govuk-grid">
-    <div class="govuk-grid__item govuk-grid__item--two-thirds">
+  <div class="govuk-layout-row">
+    <div class="govuk-layout-col-two-thirds">
       <h2 class="govuk-heading-m">Two thirds</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-third">
+    <div class="govuk-layout-col-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-third">
+    <div class="govuk-layout-col-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-third">
+    <div class="govuk-layout-col-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-third">
+    <div class="govuk-layout-col-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-half">
+    <div class="govuk-layout-col-one-half">
       <h2 class="govuk-heading-m">One half</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-half">
+    <div class="govuk-layout-col-one-half">
       <h2 class="govuk-heading-m">One half</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-quarter">
+    <div class="govuk-layout-col-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-quarter">
+    <div class="govuk-layout-col-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-quarter">
+    <div class="govuk-layout-col-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-grid__item govuk-grid__item--one-quarter">
+    <div class="govuk-layout-col-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-layout-col-three-quarters">
+      <h2 class="govuk-heading-m">Three-quarters</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-layout-col-one-quarter">
+      <h2 class="govuk-heading-m">One quarter</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-layout-col-one-third on-desktop-one-quarter">
+      <h2 class="govuk-heading-m">100% on mobile, 33% on tablet, 25% on desktop</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-layout-col-two-thirds on-desktop-three-quarters">
+    <h2 class="govuk-heading-m">100% on mobile, 66% on tablet, 75% on desktop</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>

--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -24,6 +24,8 @@
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
+  </div>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
@@ -42,6 +44,8 @@
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
+  </div>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">One half</h2>
       <p class="govuk-body">
@@ -54,6 +58,8 @@
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
+  </div>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
@@ -78,6 +84,8 @@
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
+  </div>
+  <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
       <h2 class="govuk-heading-m">Three-quarters</h2>
       <p class="govuk-body">

--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -11,93 +11,81 @@
 
 <main id="content" role="main" class="govuk-main-wrapper">
   <h1 class="govuk-heading-l">Example: Grid layout</h1>
-  <div class="govuk-layout-row">
-    <div class="govuk-layout-col-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Two thirds</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-third">
+    <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-third">
+    <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-third">
+    <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-third">
+    <div class="govuk-grid-column-one-third">
       <h2 class="govuk-heading-m">One third</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-half">
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">One half</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-half">
+    <div class="govuk-grid-column-one-half">
       <h2 class="govuk-heading-m">One half</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-three-quarters">
+    <div class="govuk-grid-column-three-quarters">
       <h2 class="govuk-heading-m">Three-quarters</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>
     </div>
-    <div class="govuk-layout-col-one-quarter">
+    <div class="govuk-grid-column-one-quarter">
       <h2 class="govuk-heading-m">One quarter</h2>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-layout-col-one-third on-desktop-one-quarter">
-      <h2 class="govuk-heading-m">100% on mobile, 33% on tablet, 25% on desktop</h2>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-layout-col-two-thirds on-desktop-three-quarters">
-    <h2 class="govuk-heading-m">100% on mobile, 66% on tablet, 75% on desktop</h2>
       <p class="govuk-body">
         This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
       </p>

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -29,8 +29,8 @@
 
 <main class="govuk-main-wrapper">
 
-  <div class="govuk-grid">
-    <div class="govuk-grid__item govuk-grid__item--two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
         Links

--- a/app/views/examples/prose-scope/index.njk
+++ b/app/views/examples/prose-scope/index.njk
@@ -11,8 +11,8 @@
 
 <main class="govuk-main-wrapper">
 
-  <div class="govuk-grid">
-    <div class="govuk-grid__item govuk-grid__item--two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">
         Prose scope
       </h1>

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -13,8 +13,8 @@
 
 <main class="govuk-main-wrapper">
 
-  <div class="govuk-grid">
-    <div class="govuk-grid__item govuk-grid__item--two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
       <h1 class="govuk-heading-xl">
         Typography

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -6,9 +6,9 @@
       GOV.UK Frontend
     </h1>
 
-    <div class="govuk-grid">
+    <div class="govuk-grid-row">
 
-      <div class="govuk-grid__item govuk-grid__item--one-half">
+      <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">Components</h2>
 
         <ul class="govuk-list">
@@ -18,7 +18,7 @@
         </ul>
       </div>
 
-      <div class="govuk-grid__item govuk-grid__item--one-half">
+      <div class="govuk-grid-column-one-half">
         <h2 class="govuk-heading-m">Examples</h2>
 
         <ul class="govuk-list">

--- a/src/globals/_common.scss
+++ b/src/globals/_common.scss
@@ -40,6 +40,7 @@
 @import "helpers/typography";
 @import "helpers/spacing";
 @import "helpers/visually-hidden";
+@import "helpers/grid";
 
 // Core
 @import "core/links";

--- a/src/globals/helpers/_grid.scss
+++ b/src/globals/helpers/_grid.scss
@@ -1,0 +1,89 @@
+// default map of available grid column widths
+$grid-widths: (
+  one-quarter: 25%,
+  one-third: 33.3333%,
+  one-half: 50%,
+  two-thirds: 66.6666%,
+  three-quarters: 75%,
+  full: 100%
+) !default;
+
+// helper funtion to get the value from map
+@function grid-width($key) {
+  @if map-has-key($grid-widths, $key) {
+    @return map-get($grid-widths, $key);
+  }
+
+  @error "Unknown `#{$key}` in $grid-width.";
+}
+
+// Mixin to generate grid row styles
+// Creates a grid row class with a standardised margin.
+// Usage:
+// Default:
+// @include govuk-grid-row;
+//
+// Optional: Provide a custom grid row class:
+// @include govuk-grid-row("app-grid");
+
+@mixin govuk-grid-row($class: null) {
+  $class: "govuk-grid-row" !default;
+
+  .#{$class} {
+    @include govuk-clearfix;
+    margin-right: - ($govuk-gutter-half);
+    margin-left: - ($govuk-gutter-half);
+  }
+}
+
+// A mixin to generate grid column styles
+// Creates a cross browser grid column with a class of '.govuk-grid-column' by default
+// and a standardised gutter between the columns.
+// Common widths are predefined above as keywords in the `$grid-widths` map.
+// By default their width chnages from 100% to specified width at 'tablet' breakpoint,
+// but that can be configured to be any other breapoint by using the `$at` argument.
+//
+// Arguments:
+// @param $class: "govuk-grid-column" (default) 
+// @param $width: one-quarter | one-third | one-half | two-third | three-quarters | full (default)
+// @param $float: left (default) | right 
+// @param $at: mobile | tablet (default) | desktop | any custom breapoint in px or em
+//
+// Usage:
+// Default:
+// @include govuk-grid-column(two-thirds)
+//
+// Custom class:
+// @include govuk-grid-column(one-half, $class: "test-column");
+//
+// Change breakpoint where width percentage is applied:
+// @include govuk-grid-column(one-half, $at: desktop);
+//
+// Change float direction:
+// @include govuk-grid-column(one-half, $float: right);
+
+@mixin govuk-grid-column(
+  $width: null,
+  $float: null,
+  $at: null,
+  $class: null) {
+
+  $class: "govuk-grid-column" !default;
+
+  $width: if($width != null, $width, full);
+  $float: if($float != null, $float, left) !default;
+  $at: if($at != null, $at, tablet) !default;
+
+
+  .#{$class}-#{$width} {
+    box-sizing: border-box;
+    @if $at != desktop {
+      width: 100%;
+    }
+    padding: 0 $govuk-gutter-half;
+    @include mq($from: $at) {
+      width: grid-width($width);
+      float: $float;
+    }
+  }
+}

--- a/src/globals/helpers/grid.test.js
+++ b/src/globals/helpers/grid.test.js
@@ -1,0 +1,247 @@
+/* eslint-env jest */
+
+const util = require('util')
+const outdent = require('outdent')
+
+const configPaths = require('../../../config/paths.json')
+
+const sass = require('node-sass')
+const sassRender = util.promisify(sass.render)
+
+const sassConfig = {
+  includePaths: [ configPaths.src ],
+  outputStyle: 'nested'
+}
+describe('grid system', () => {
+  const sassImports = `
+    @import "globals/tools/exports";
+    @import "globals/settings/spacing";
+    @import "globals/settings/measurements";
+    @import "globals/helpers/grid";
+    @import "globals/helpers/media-queries";
+  `
+  describe('grid-width function', () => {
+    it('outputs the specified key value from the map of widths', async () => {
+      const sass = `
+        @import "globals/helpers/grid";
+
+        .foo {
+          content: grid-width(one-quarter);
+        }`
+
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css.toString().trim()).toBe(outdent`
+      .foo {
+        content: 25%; }`)
+    })
+
+    it('throws an error that the specified key does not exist in the map of widths', async () => {
+      const sass = `
+        @import "globals/helpers/grid";
+
+        $value: grid-width(seven-fiths);
+        `
+
+      await expect(sassRender({ data: sass, ...sassConfig }))
+       .rejects
+       .toThrow('Unknown `seven-fiths` in $grid-width.')
+    })
+  })
+
+  describe('@govuk-grid-row mixin', () => {
+    it('outputs default defined styles for .govuk-grid-row class', async () => {
+      const sass = `
+        ${sassImports}
+        @import "globals/helpers/clearfix";
+
+        @include govuk-grid-row();
+        `
+
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-clearfix:after {
+          content: \"\";
+          display: block;
+          clear: both; }
+
+        .govuk-grid-row {
+          margin-right: -15px;
+          margin-left: -15px; }
+          .govuk-grid-row:after {
+            content: \"\";
+            display: block;
+            clear: both; }`)
+    })
+    it('outputs styles for the specified class', async () => {
+      const sass = `
+        ${sassImports}
+        @import "globals/helpers/clearfix";
+
+        @include govuk-grid-row('app-grid-row');
+        `
+
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-clearfix:after {
+          content: \"\";
+          display: block;
+          clear: both; }
+
+        .app-grid-row {
+          margin-right: -15px;
+          margin-left: -15px; }
+          .app-grid-row:after {
+            content: \"\";
+            display: block;
+            clear: both; }
+        `)
+    })
+  })
+
+  describe('@govuk-grid-column mixin', () => {
+    it('outputs default full width styles for .govuk-grid-column class', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column();
+        `
+
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-full {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 46.25em) {
+            .govuk-grid-column-full {
+              width: 100%;
+              float: left; } }`)
+    })
+
+    it('outputs specified width styles for .govuk-grid-column class', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column(two-thirds);
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-two-thirds {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 46.25em) {
+            .govuk-grid-column-two-thirds {
+              width: 66.6666%;
+              float: left; } }
+        `)
+    })
+
+    it('outputs specified width styles for the defined class', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column(three-quarters, $class:'large-columnumn');
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .large-columnumn-three-quarters {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 46.25em) {
+            .large-columnumn-three-quarters {
+              width: 75%;
+              float: left; } }
+        `)
+    })
+
+    it('outputs the correct width styles for the defined breakpoint in media queries map', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column(one-quarter, $at: desktop);
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-quarter {
+          box-sizing: border-box;
+          padding: 0 15px; }
+          @media (min-width: 61.25em) {
+            .govuk-grid-column-one-quarter {
+              width: 25%;
+              float: left; } }
+        `)
+    })
+    it('outputs the correct width styles for the custom defined breakpoint', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column(one-quarter, $at: 500px);
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-quarter {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 31.25em) {
+            .govuk-grid-column-one-quarter {
+              width: 25%;
+              float: left; } }
+        `)
+    })
+
+    it('outputs float:right as specified with the $float argument', async () => {
+      const sass = `
+        ${sassImports}
+
+        @include govuk-grid-column(one-half, $float: right);
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-half {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 46.25em) {
+            .govuk-grid-column-one-half {
+              width: 50%;
+              float: right; } }
+        `)
+    })
+  })
+})

--- a/src/globals/objects/_grid.scss
+++ b/src/globals/objects/_grid.scss
@@ -1,53 +1,10 @@
-@mixin govuk-grid {
-  @include govuk-clearfix;
-  margin-right: - ($govuk-gutter-half);
-  margin-left: - ($govuk-gutter-half);
-}
-
-@mixin govuk-grid-item {
-  box-sizing: border-box;
-  padding: 0 $govuk-gutter-half;
-
-  @include mq($from: tablet) {
-    float: left;
-  }
-}
-
-@include govuk-exports("grid") {
-
-  .govuk-grid {
-    @include govuk-grid;
-  }
-
-  .govuk-grid__item {
-    @include govuk-grid-item;
-  }
-
-  .govuk-grid__item--full {
-    width: 100%;
-  }
-
-  .govuk-grid__item--one-half {
-    @include mq($from: tablet) {
-      width: percentage(1 / 2);
-    }
-  }
-
-  .govuk-grid__item--one-third {
-    @include mq($from: tablet) {
-      width: percentage(1 / 3);
-    }
-  }
-
-  .govuk-grid__item--two-thirds {
-    @include mq($from: tablet) {
-      width: percentage(2 / 3);
-    }
-  }
-
-  .govuk-grid__item--one-quarter {
-    @include mq($from: tablet) {
-      width: percentage(1 / 4);
-    }
-  }
+@include govuk-exports("govuk-grid") {
+  //most common usage
+  @include govuk-grid-row;
+  @include govuk-grid-column(one-quarter);
+  @include govuk-grid-column(one-third);
+  @include govuk-grid-column(one-half);
+  @include govuk-grid-column(two-thirds);
+  @include govuk-grid-column(three-quarters);
+  @include govuk-grid-column(full);
 }


### PR DESCRIPTION
Simplify grid classes based on user feedback
- Propose new class names:
```
.govuk-grid-row
.govuk-grid-column-   one-quarter, one-third, one-half, three-quarters, three-thirds, full
```
- created a map of common widths that is used to generate classes
- classes are using words, not numbers
- parameter `$at` describes when the fraction percentage kicks in

Default usage:
```
// row
@include govuk-grid-row;
// row with a custom class
@include govuk-grid-row("app-row);

// columns
@include govuk-grid-column(one-quarter);
@include govuk-grid-column(one-third);
@include govuk-grid-column(one-half);
@include govuk-grid-column(two-thirds);
@include govuk-grid-column(three-quarters);
@include govuk-grid-column(full); or  @include govuk-grid-column();
```
Define when percentage kicks in:
```
@include govuk-grid-column(three-quarters, $at: desktop)
```
Specify a custom class:
```
@include govuk-grid-column(one-quarter, $class: "app-grid");
```

- Updated example grid page: 
https://govuk-frontend-review-pr-665.herokuapp.com/examples/grid

Note: the column mixin is similar to the Frontend toolkit one
https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/_grid_layout.scss#L93

- Update all references in the review app

Trello ticket: https://trello.com/c/jjWZkDe0/865-5-simplify-the-grid-syntax