### PR TITLE
Remove cursor: pointer from buttons as standard

### DIFF
--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -50,7 +50,6 @@
     box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
     text-align: center;
     vertical-align: top;
-    cursor: pointer;
     -webkit-appearance: none;
 
     @include mq($from: tablet) {


### PR DESCRIPTION
Remove cursor: pointer from buttons as standard. This is common practice but against all best practices I'm aware of, including all browser vendor defaults, W3C and many OS HCI guidelines.

Source:

https://medium.com/simple-human/buttons-shouldnt-have-a-hand-cursor-b11e99ca374b