### PR TITLE
Add test to check if sass in packages compiles when copied over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ Internal:
 (PR [#663](https://github.com/alphagov/govuk-frontend/pull/663))
 - Exclude test related files from `dist/` and `packages/` copy task 
 (PR [#662](https://github.com/alphagov/govuk-frontend/pull/662))
+- Add test to check if Sass in packages compiles correctly after the `build:packages` task
+(PR [#669](https://github.com/alphagov/govuk-frontend/pull/669))
 
 ## 0.0.28-alpha (Breaking release)
 

--- a/tasks/gulp/__tests__/after-build-packages.test.js
+++ b/tasks/gulp/__tests__/after-build-packages.test.js
@@ -1,6 +1,13 @@
 /* eslint-env jest */
 
+const path = require('path')
+const util = require('util')
+const sass = require('node-sass')
+
 const lib = require('../../../lib/file-helper')
+const configPaths = require('../../../config/paths.json')
+
+const sassRender = util.promisify(sass.render)
 
 describe('building packages/', () => {
   describe('when running copy-to-destination', () => {
@@ -25,5 +32,12 @@ describe('building packages/', () => {
 
   lib.SrcComponentList.forEach((componentName) => {
     defineTestsForComponent(componentName)
+  })
+
+  describe('after running copy-to-destination', () => {
+    it('scss files should compile without throwing an exeption', async () => {
+      const allScssFile = path.join(configPaths.packages, 'all', '_all.scss')
+      await sassRender({ file: allScssFile })
+    })
   })
 })


### PR DESCRIPTION
As part of the recommendation from the Incident review.

Expanding the current test after building packages to check if Sass compiles.