### PR TITLE
Reinstate focus outline for radios and checkboxes on IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Fixes:
   falling back to the print stack as expected.
   (PR [#650](https://github.com/alphagov/govuk-frontend/pull/650))
 
+- Reinstate focus outline for radios and checkboxes on IE8
+  (PR [#670](https://github.com/alphagov/govuk-frontend/pull/670))
+
 New features:
 
 - We're now using ES6 Modules and [rollup](https://rollupjs.org/guide/en) to distribute our JavaScript. (PR [#652](https://github.com/alphagov/govuk-frontend/pull/652))

--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -41,6 +41,13 @@
       margin: 0;
       opacity: 0;
     }
+
+    // add focus outline to input element for IE8
+    @include govuk-if-ie8 {
+      &:focus {
+        outline: $govuk-focus-width solid $govuk-focus-colour;
+      }
+    }
   }
 
   .govuk-checkboxes__label {

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -42,6 +42,13 @@
       margin: 0;
       opacity: 0;
     }
+
+    // add focus outline to input element for IE8
+    @include govuk-if-ie8 {
+      &:focus {
+        outline: $govuk-focus-width solid $govuk-focus-colour;
+      }
+    }
   }
 
   .govuk-radios__label {


### PR DESCRIPTION
Missed from Elements

Elements:
![screen shot 2018-04-24 at 09 15 18](https://user-images.githubusercontent.com/3758555/39175032-2da1519e-47a1-11e8-94bb-2d22ff55d824.png)
![screen shot 2018-04-24 at 09 19 12](https://user-images.githubusercontent.com/3758555/39175036-2df86402-47a1-11e8-9409-be60c70965f4.png)

Frontend before:
![screen shot 2018-04-24 at 09 16 45](https://user-images.githubusercontent.com/3758555/39175034-2dcac27c-47a1-11e8-9256-d1d91137cc1d.png)
![screen shot 2018-04-24 at 09 27 56](https://user-images.githubusercontent.com/3758555/39175283-ce67c298-47a1-11e8-98ed-580f353ea77b.png)


Frontend after:
![screen shot 2018-04-24 at 09 15 36](https://user-images.githubusercontent.com/3758555/39175247-b6a8ac8a-47a1-11e8-9a6a-daab1a217a39.png)

![screen shot 2018-04-24 at 09 17 58](https://user-images.githubusercontent.com/3758555/39175197-9f691906-47a1-11e8-86ea-c2c5f4249909.png)

