### PR TITLE
Focus error summary on window load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,11 @@ New features:
 - Checkboxes and Radios conditional reveal
 (PR [#616](https://github.com/alphagov/govuk-frontend/pull/616))
 
-- Vendor-in SassMQ functionality, write tests and remove external dependency 
+- Vendor-in SassMQ functionality, write tests and remove external dependency
   (PR [#657](https://github.com/alphagov/govuk-frontend/pull/657))
+
+- Focus Error Summary on window load
+    (PR [#671](https://github.com/alphagov/govuk-frontend/pull/671))
 
 Internal:
 
@@ -48,7 +51,7 @@ Internal:
 - Wrap `app.css` in conditional comments in review app layout (PR [#653](https://github.com/alphagov/govuk-frontend/pull/653))
 - Fix missing code highlight and remove duplicate layout
 (PR [#663](https://github.com/alphagov/govuk-frontend/pull/663))
-- Exclude test related files from `dist/` and `packages/` copy task 
+- Exclude test related files from `dist/` and `packages/` copy task
 (PR [#662](https://github.com/alphagov/govuk-frontend/pull/662))
 - Add test to check if Sass in packages compiles correctly after the `build:packages` task
 (PR [#669](https://github.com/alphagov/govuk-frontend/pull/669))

--- a/src/all/all.js
+++ b/src/all/all.js
@@ -1,8 +1,9 @@
 import { nodeListForEach } from '../globals/common'
 
 import Button from '../button/button'
-import Details from '../details/details'
 import Checkboxes from '../checkboxes/checkboxes'
+import Details from '../details/details'
+import ErrorSummary from '../error-summary/error-summary'
 import Radios from '../radios/radios'
 
 export function initAll () {
@@ -13,6 +14,10 @@ export function initAll () {
   nodeListForEach($checkboxes, function ($checkbox) {
     new Checkboxes($checkbox).init()
   })
+
+  // Find first Error Summary module to enhance.
+  var $errorSummary = document.querySelector('[data-module="error-summary"]')
+  new ErrorSummary($errorSummary).init()
 
   var $radios = document.querySelectorAll('[data-module="radios"]')
   nodeListForEach($radios, function ($radio) {

--- a/src/error-summary/README.md
+++ b/src/error-summary/README.md
@@ -16,7 +16,7 @@ Find out when to use the Error summary component in your service in the [GOV.UK 
 
 #### Markup
 
-    <div class="govuk-error-summary optional-extra-class" aria-labelledby="error-summary-title" role="alert" tabindex="-1">
+    <div class="govuk-error-summary optional-extra-class" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
       <h2 class="govuk-error-summary__title" id="error-summary-title">
         Message to alert the user to a problem goes here
       </h2>

--- a/src/error-summary/error-summary.js
+++ b/src/error-summary/error-summary.js
@@ -1,0 +1,15 @@
+function ErrorSummary ($module) {
+  this.$module = $module
+}
+
+ErrorSummary.prototype.init = function () {
+  var $module = this.$module
+  if (!$module) {
+    return
+  }
+  window.addEventListener('load', function () {
+    $module.focus()
+  })
+}
+
+export default ErrorSummary

--- a/src/error-summary/error-summary.js
+++ b/src/error-summary/error-summary.js
@@ -1,3 +1,5 @@
+import '../globals/polyfills/Event' // addEventListener
+
 function ErrorSummary ($module) {
   this.$module = $module
 }

--- a/src/error-summary/error-summary.test.js
+++ b/src/error-summary/error-summary.test.js
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment ./lib/puppeteer/environment.js
+ */
+/* eslint-env jest */
+
+const configPaths = require('../../config/paths.json')
+const PORT = configPaths.ports.test
+
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+
+beforeAll(async (done) => {
+  browser = global.__BROWSER__
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
+describe('Error Summary', () => {
+  it('is automatically focused when the page loads', async () => {
+    await page.goto(baseUrl + '/components/error-summary/preview', { waitUntil: 'load' })
+
+    const moduleName = await page.evaluate(() => document.activeElement.dataset.module)
+    expect(moduleName).toBe('error-summary')
+  })
+})

--- a/src/error-summary/error-summary.yaml
+++ b/src/error-summary/error-summary.yaml
@@ -1,3 +1,6 @@
+accessibilityCriteria: |
+  - Must be focused when the page loads
+
 examples:
   - name: default
     data:

--- a/src/error-summary/template.njk
+++ b/src/error-summary/template.njk
@@ -1,6 +1,6 @@
 <div class="govuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}" aria-labelledby="error-summary-title" role="alert" tabindex="-1"
-  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="error-summary">
   <h2 class="govuk-error-summary__title" id="error-summary-title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h2>


### PR DESCRIPTION
This adds functionality to focus the error summary component when the page loads.

This helps users of assistive technologies recognise and get out of situations when they've encountered an error in their submission.

This re-implements [functionality in GOV.UK Elements](https://github.com/alphagov/govuk_elements/blob/5b6dc246861dbd2e821e62d153e6eb962830e1af/assets/javascripts/application.js#L25), but avoids re-implementing the logic to set `event.preventDefault()` on links clicked.

It's not clear why this was done, my assumption is that it's done to avoid cluttering the URL with anchor hashes but I'm not including this as we're not sure.

## Testing

### Browser testing

<details>
  <summary>Testing with browsers (✅)</summary>
  
  This table is based on https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in

| Operating system | Browser                                           | Result |
|-------------------|----------------------------------|--------|
| Windows                | Internet Explorer 8-10                   |     ✅    |
|                                | Internet Explorer 11                        |     ✅    |
|                                | Edge (latest versions)                    |     ✅    |
|                                | Google Chrome (latest versions)  |     ✅    |
|                                | Mozilla Firefox (latest versions)    |     ✅    |
| macOS                   | Safari 9+                                        |     ✅     |
|                                | Google Chrome (latest versions ) |     ✅    |
|                                | Mozilla Firefox (latest versions)    |     ✅    |
| iOS                         | Safari 9.3+                                     |      ✅    |
|                                | Google Chrome (latest versions   |     ✅     |
| Android                  | Mozilla Firefox (latest versions)    |     ✅     |
|                                | Google Chrome (latest versions)  |     ✅     |
| Windows Phone    | Internet Explorer (latest versions) |     ✅     |
</details>

### Accessibility

<details>
  <summary>Testing with colours overriden (N/A)</summary>

  This is based on https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
  
  N/A
</details>

<details>
  <summary>Testing with assistive technologies (✅)</summary>

  This table is based on https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies

| Software                             | Version          | Browser                                                    | Result |
|---------------------------|--------------|----------------------------------------|-------|
| JAWS                                  | 15 or later      | Internet Explorer 11                                  |    ✅ Reads out alert heading        |
| ZoomText                            | 10.11 or later | Internet Explorer 11                                  |    N/A      |
| Dragon NaturallySpeaking | 11 or later      | Internet Explorer 11                                  |    N/A      |
| NVDA                                   | 2016 or later | Mozilla Firefox (latest versions)              |     ✅ Reads out entire alert, and announces the component as a landmark       |
| VoiceOver  Mac OSX          | N/A                | Safari 10 (or higher) on Mac OS X 10.10 |    ✅"You are currently on an alert" Same behaviour as GOV.UK Elements        |
| VoiceOver iOS                    | N/A                 | iOS 10.3 (or higher)                                 |      ✅      |

</details>

---

https://trello.com/c/UzvIbXmM/775-2-automatically-focus-the-error-summary

