### PR TITLE
Update JavaScript style guide

### DIFF
--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -1,61 +1,168 @@
-# JavaScript
+# JavaScript style guide
+## Files
+JavaScript files have the same name as the component's folder name. Test files have a `.test` suffix placed before the file extension.
 
-# Linting
+```
+checkboxes
+├── checkboxes.js
+└── checkboxes.test.js
+```
+## Skeleton
+
+```js
+import { nodeListForEach } from '../globals/common'
+
+function Checkboxes ($module) {
+  ...
+}
+
+Checkboxes.prototype.init = function () {
+  ...
+}
+
+export default Checkboxes
+```
+## Comments
+
+Use `/** ... */` for multi-line comments. Include a description, specify types and values for all parameters and return values.
+
+```js
+/**
+* Get the nearest ancestor element of a node that matches a given tag name
+* @param {object} node element
+* @param {string} match tag name (e.g. div)
+* @return {object} ancestor element
+*/
+
+function (node, match) {
+  ...
+  return ancestor
+}
+```
+
+Use `//` for single line comments. Place single line comments on a newline above the subject of the comment.
+
+Use `// FIXME:` to annotate problems.
+
+Use `// TODO:` to annotate solutions to problems.
+
+## Constructors and methods
+
+Use the prototype design pattern to structure your code.
+
+Create a constructor and define any variables that the object needs
+
+```
+function Checkboxes ($module) {
+  ...
+}
+```
+
+Assign methods to the prototype object. Do not overwrite the prototype with a new object as this makes inheritance impossible.
+
+```js
+// bad
+Checkboxes.prototype = {
+  init: function () {
+    ...
+  }
+}
+
+// good
+Checkboxes.prototype.init = function () {
+  ...
+}
+```
+
+When initialising an object, use the `new` keyword.
+
+```js
+// bad
+var myCheckbox = Checkbox().init()
+
+// good
+var myCheckbox = new Checkbox().init()
+```
+## Modules
+
+Use ES6 modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
+
+```js
+import { nodeListForEach } from '../globals/common'
+...
+export default Checkboxes
+```
+
+Avoid using wildcard (`import * as nodeListForEach`) imports.
+
+Prefer default export over named export.
+
+## Polyfilling
+
+If you’re new to polyfilling make sure to read https://remysharp.com/2010/10/08/what-is-a-polyfill
+
+Before GOV.UK Frontend our projects used jQuery for a few main things: DOM interactions, events and data manipulation.
+
+We’re taking a step back from jQuery due to its lack of support for the browsers we support, its large file size, lack of security updates and from conversations with the community.
+
+We’re instead opting to write standard ES5 JavaScript, that we polyfill where necessary.
+
+This means places where we would use [`$.each`](http://api.jquery.com/jquery.each/) we’re instead using [`.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) and polyfill the missing gaps.
+
+We use polyfills provided by the Financial Times' [Polyfill service](https://polyfill.io).
+
+This approach ensures that multiple polyfills can be sourced from this service with more confidence they’ll work without conflicting with each other.
+
+The Polyfill service does not do runtime detection in browsers and instead opts to do this on the server via user-agent sniffing, it ships only the code needed for that browser which means newer browsers don’t have to run anything. We could investigate lazy-loading in the future, but for now we’re doing a bundled approach based on the lowest common denominator.
+
+We are vendoring these polyfills to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN.
+
+So we detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
+
+We hope that our approach can be automated or moved into a reusable npm package, based on their [npm package](https://github.com/Financial-Times/polyfill-service#library).
+### Example: Polyfilling ‘addEventListener’ usage
+
+1. Determine if the feature needs to be polyfilled
+
+You can use resources such as [caniuse.com](https://caniuse.com/) and [developer.mozilla.org](https://developer.mozilla.org/en-US/) to check feature support.
+
+In this example we’ve looked at [caniuse addEventListener](https://caniuse.com/#search=addEventListener) and seen that it’s not supported in IE8.
+
+2. Use polyfill.io service to generate the polyfill required
+You can [use the library](https://github.com/Financial-Times/polyfill-service#getpolyfillsoptions-method) to do this or [use their CDN](https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always) directly: `https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always`
+
+Then save this in the same structure that is used in the main project (https://github.com/Financial-Times/polyfill-service/tree/master/packages/polyfill-library/polyfills)
+
+3. Use polyfill.io service to get detection script
+
+We need to make sure we only run the polyfills if they’re needed.
+
+So we can grab the associated detection code from
+https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+
+4. Put everything together
+
+```js
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+    var detect = (
+      // code goes here ...
+    )
+
+    if (detect) return
+
+    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
+    // code goes here ...
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});
+```
+## Formatting
 
 GOV.UK Frontend uses [standardjs](http://standardjs.com/), an opinionated JavaScript linter. All JavaScript files follow its conventions, and it runs on CI to ensure that new pull requests are in line with them.
 
-## Running standard manually
-
-To check the whole codebase, run:
-
-```bash
-npm run lint
-```
-
-## Running standard in your editor
-
-Easier than running standard manually is to install it as a plugin in your editor. This way, it will run automatically while you work, catching errors as they happen on a per-file basis.
-
-### Sublime Text
-
-Using [Package Control](https://packagecontrol.io/), install [SublimeLinter](http://www.sublimelinter.com/en/latest/) and [SublimeLinter-contrib-standard](https://packagecontrol.io/packages/SublimeLinter-contrib-standard).
-
-For automatic formatting on save, install [StandardFormat](https://packagecontrol.io/packages/StandardFormat).
-
-### Atom
-
-Install [linter-js-standard](https://atom.io/packages/linter-js-standard).
-
-For automatic formatting, install [standard-formatter](https://atom.io/packages/standard-formatter). For snippets, install [standardjs-snippets](https://atom.io/packages/standardjs-snippets).
-
-### Visual Studio Code
-
-Install [vscode-standardjs](https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs). It includes support for automatic formatting.
-
-For snippets, install [vscode-standardjs-snippets](https://marketplace.visualstudio.com/items?itemName=capaj.vscode-standardjs-snippets).
-
-### Other editors
-
-There are [official guides for most of the popular editors](http://standardjs.com/index.html#text-editor-plugins).
-
-## Do I need to respect this?
-
-If you want to submit a pull request to the govuk-frontend, your code will need to pass the linter.
-
-If you're just using the prototype kit in a separate project, then no, you aren't forced to use standard, or any other linter for that matter. Just write code as you would normally.
-
-## Why lint?
-
-Automated linting ensures project-wide consistency and limits (ideally eliminates) bikeshedding discussions involving spacing, naming conventions, quotes, and others during the pull request review process. It frees the reviewer to focus on the actual substance rather than stylistic issues.
-
-More importantly, linting will catch some low hanging programmer errors, such as calling an undefined function or assigning a value and then never reading it. These allow the programmer to catch some bugs before having to test the code.
-
-## Why standard?
-
-Linting rules can be a contentious subject, and a lot of them are down to personal preference. The core idea of standard is to be opinionated and limit the amount of initial bikeshedding discussions around which linting rules to pick, because in the end, it's not as important which rules you pick as it is to just be consistent about it. This is why we chose standard: because we want to be consistent about how we write code, but don't want to spend unnecessary time picking different rules (which all have valid points).
-
 The standard docs have a [complete list of rules and some reasoning behind them](http://standardjs.com/rules.html).
 
-Standard is also [widely used (warning: large file)](https://github.com/feross/standard-packages/blob/master/all.json) (which means community familiarity) and has a [good ecosystem of plugins](http://standardjs.com/awesome.html).
+Read more about [running standard manually or in your editor](https://github.com/alphagov/styleguides/blob/master/js.md#linting).
 
-If we decide to move away from it, standard is effectively just a preconfigured bundle of eslint, so it can easily be replaced by switching to a generic `.eslintrc` setup.
+

--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -115,7 +115,7 @@ This approach ensures that multiple polyfills can be sourced from this service w
 
 The Polyfill service does not do runtime detection in browsers and instead opts to do this on the server via user-agent sniffing. It only ships the code needed for that browser, which means newer browsers don’t have to run anything. We may investigate lazy-loading in the future, but for now we’re using a bundled approach based on the lowest common denominator.
 
-We are vendoring these polyfills to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN. By doing this we can detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
+We are including these polyfills in our codebase to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN. By doing this we can detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
 
 We hope that our approach can be automated or moved into a reusable npm package, based on the Financial Times [npm package](https://github.com/Financial-Times/polyfill-service#library).
 ### Example: Polyfilling ‘addEventListener’ usage
@@ -162,5 +162,3 @@ GOV.UK Frontend uses [standardjs](http://standardjs.com/), an opinionated JavaSc
 The standard docs have a [complete list of rules and some reasoning behind them](http://standardjs.com/rules.html).
 
 Read more about [running standard manually or in your editor](https://github.com/alphagov/styleguides/blob/master/js.md#linting).
-
-

--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -24,7 +24,7 @@ export default Checkboxes
 ```
 ## Comments
 
-Use `/** ... */` for multi-line comments. Include a description, specify types and values for all parameters and return values.
+Use `/** ... */` for multi-line comments. Include a description, and specify types and values for all parameters and return values.
 
 ```js
 /**
@@ -40,7 +40,7 @@ function (node, match) {
 }
 ```
 
-Use `//` for single line comments. Place single line comments on a newline above the subject of the comment.
+Use `//` for single-line comments. Place single-line comments on a new line above the subject of the comment.
 
 Use `// FIXME:` to annotate problems.
 
@@ -50,7 +50,7 @@ Use `// TODO:` to annotate solutions to problems.
 
 Use the prototype design pattern to structure your code.
 
-Create a constructor and define any variables that the object needs
+Create a constructor and define any variables that the object needs.
 
 ```
 function Checkboxes ($module) {
@@ -95,31 +95,29 @@ export default Checkboxes
 
 Avoid using wildcard (`import * as nodeListForEach`) imports.
 
-Prefer default export over named export.
+Use default export over named export.
 
 ## Polyfilling
 
-If you’re new to polyfilling make sure to read https://remysharp.com/2010/10/08/what-is-a-polyfill
+If you’re new to polyfilling, start by reading [this explanation](https://remysharp.com/2010/10/08/what-is-a-polyfill).
 
-Before GOV.UK Frontend our projects used jQuery for a few main things: DOM interactions, events and data manipulation.
+Before GOV.UK Frontend, our projects used jQuery for: DOM interactions, events and data manipulation.
 
 We’re taking a step back from jQuery due to its lack of support for the browsers we support, its large file size, lack of security updates and from conversations with the community.
 
-We’re instead opting to write standard ES5 JavaScript, that we polyfill where necessary.
+We’re now writing standard ES5 JavaScript instead, that we polyfill where necessary.
 
-This means places where we would use [`$.each`](http://api.jquery.com/jquery.each/) we’re instead using [`.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) and polyfill the missing gaps.
+This means that in places where we would have previously used [`$.each`](http://api.jquery.com/jquery.each/) we’re using [`.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) instead and polyfilling the missing gaps.
 
 We use polyfills provided by the Financial Times' [Polyfill service](https://polyfill.io).
 
-This approach ensures that multiple polyfills can be sourced from this service with more confidence they’ll work without conflicting with each other.
+This approach ensures that multiple polyfills can be sourced from this service with greater confidence that they’ll work without conflicting with each other.
 
-The Polyfill service does not do runtime detection in browsers and instead opts to do this on the server via user-agent sniffing, it ships only the code needed for that browser which means newer browsers don’t have to run anything. We could investigate lazy-loading in the future, but for now we’re doing a bundled approach based on the lowest common denominator.
+The Polyfill service does not do runtime detection in browsers and instead opts to do this on the server via user-agent sniffing. It only ships the code needed for that browser, which means newer browsers don’t have to run anything. We may investigate lazy-loading in the future, but for now we’re using a bundled approach based on the lowest common denominator.
 
-We are vendoring these polyfills to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN.
+We are vendoring these polyfills to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN. By doing this we can detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
 
-So we detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
-
-We hope that our approach can be automated or moved into a reusable npm package, based on their [npm package](https://github.com/Financial-Times/polyfill-service#library).
+We hope that our approach can be automated or moved into a reusable npm package, based on the Financial Times [npm package](https://github.com/Financial-Times/polyfill-service#library).
 ### Example: Polyfilling ‘addEventListener’ usage
 
 1. Determine if the feature needs to be polyfilled
@@ -137,7 +135,7 @@ Then save this in the same structure that is used in the main project (https://g
 
 We need to make sure we only run the polyfills if they’re needed.
 
-So we can grab the associated detection code from
+We can take the associated detection code from
 https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
 
 4. Put everything together

--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -13,11 +13,11 @@ checkboxes
 import { nodeListForEach } from '../globals/common'
 
 function Checkboxes ($module) {
-  ...
+  // code goes here
 }
 
 Checkboxes.prototype.init = function () {
-  ...
+  // code goes here
 }
 
 export default Checkboxes
@@ -35,7 +35,7 @@ Use `/** ... */` for multi-line comments. Include a description, and specify typ
 */
 
 function (node, match) {
-  ...
+  // code goes here
   return ancestor
 }
 ```
@@ -52,9 +52,9 @@ Use the prototype design pattern to structure your code.
 
 Create a constructor and define any variables that the object needs.
 
-```
+```js
 function Checkboxes ($module) {
-  ...
+  // code goes here
 }
 ```
 
@@ -64,13 +64,13 @@ Assign methods to the prototype object. Do not overwrite the prototype with a ne
 // bad
 Checkboxes.prototype = {
   init: function () {
-    ...
+    // code goes here
   }
 }
 
 // good
 Checkboxes.prototype.init = function () {
-  ...
+  // code goes here
 }
 ```
 
@@ -89,7 +89,7 @@ Use ES6 modules (`import`/`export`) over a non-standard module system. You can a
 
 ```js
 import { nodeListForEach } from '../globals/common'
-...
+// code goes here
 export default Checkboxes
 ```
 
@@ -101,9 +101,9 @@ Use default export over named export.
 
 If you’re new to polyfilling, start by reading [this explanation](https://remysharp.com/2010/10/08/what-is-a-polyfill).
 
-Before GOV.UK Frontend, our projects used jQuery for: DOM interactions, events and data manipulation.
+Before GOV.UK Frontend, our projects used jQuery for DOM interactions, events and data manipulation.
 
-We’re taking a step back from jQuery due to its lack of support for the browsers we support, its large file size, lack of security updates and from conversations with the community.
+We’re taking a step back from jQuery due to its large file size, lack of security updates and support for version 1.x (which is needed for supporting Internet Explorer 8) and from conversations with the community.
 
 We’re now writing standard ES5 JavaScript instead, that we polyfill where necessary.
 
@@ -145,13 +145,13 @@ https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfil
 
     // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
     var detect = (
-      // code goes here ...
+      // code goes here
     )
 
     if (detect) return
 
     // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
-    // code goes here ...
+    // code goes here
 
 }).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});
 ```

--- a/docs/coding-standards/js.md
+++ b/docs/coding-standards/js.md
@@ -1,5 +1,7 @@
 # JavaScript style guide
+
 ## Files
+
 JavaScript files have the same name as the component's folder name. Test files have a `.test` suffix placed before the file extension.
 
 ```
@@ -7,6 +9,7 @@ checkboxes
 ├── checkboxes.js
 └── checkboxes.test.js
 ```
+
 ## Skeleton
 
 ```js
@@ -22,6 +25,7 @@ Checkboxes.prototype.init = function () {
 
 export default Checkboxes
 ```
+
 ## Comments
 
 Use `/** ... */` for multi-line comments. Include a description, and specify types and values for all parameters and return values.
@@ -83,6 +87,7 @@ var myCheckbox = Checkbox().init()
 // good
 var myCheckbox = new Checkbox().init()
 ```
+
 ## Modules
 
 Use ES6 modules (`import`/`export`) over a non-standard module system. You can always transpile to your preferred module system.
@@ -99,62 +104,16 @@ Use default export over named export.
 
 ## Polyfilling
 
-If you’re new to polyfilling, start by reading [this explanation](https://remysharp.com/2010/10/08/what-is-a-polyfill).
+If you need to support older browsers, import the necessary [polyfills](/src/globals/polyfills) and they will be added to the environment when the feature is not supported.
 
-Before GOV.UK Frontend, our projects used jQuery for DOM interactions, events and data manipulation.
-
-We’re taking a step back from jQuery due to its large file size, lack of security updates and support for version 1.x (which is needed for supporting Internet Explorer 8) and from conversations with the community.
-
-We’re now writing standard ES5 JavaScript instead, that we polyfill where necessary.
-
-This means that in places where we would have previously used [`$.each`](http://api.jquery.com/jquery.each/) we’re using [`.forEach`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) instead and polyfilling the missing gaps.
-
-We use polyfills provided by the Financial Times' [Polyfill service](https://polyfill.io).
-
-This approach ensures that multiple polyfills can be sourced from this service with greater confidence that they’ll work without conflicting with each other.
-
-The Polyfill service does not do runtime detection in browsers and instead opts to do this on the server via user-agent sniffing. It only ships the code needed for that browser, which means newer browsers don’t have to run anything. We may investigate lazy-loading in the future, but for now we’re using a bundled approach based on the lowest common denominator.
-
-We are including these polyfills in our codebase to avoid any [single point of failure](https://en.wikipedia.org/wiki/Single_point_of_failure) issues that could arise from relying on a CDN. By doing this we can detect if polyfills are needed at runtime, which results in all browsers getting the same polyfill bundle.
-
-We hope that our approach can be automated or moved into a reusable npm package, based on the Financial Times [npm package](https://github.com/Financial-Times/polyfill-service#library).
-### Example: Polyfilling ‘addEventListener’ usage
-
-1. Determine if the feature needs to be polyfilled
-
-You can use resources such as [caniuse.com](https://caniuse.com/) and [developer.mozilla.org](https://developer.mozilla.org/en-US/) to check feature support.
-
-In this example we’ve looked at [caniuse addEventListener](https://caniuse.com/#search=addEventListener) and seen that it’s not supported in IE8.
-
-2. Use polyfill.io service to generate the polyfill required
-You can [use the library](https://github.com/Financial-Times/polyfill-service#getpolyfillsoptions-method) to do this or [use their CDN](https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always) directly: `https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always`
-
-Then save this in the same structure that is used in the main project (https://github.com/Financial-Times/polyfill-service/tree/master/packages/polyfill-library/polyfills)
-
-3. Use polyfill.io service to get detection script
-
-We need to make sure we only run the polyfills if they’re needed.
-
-We can take the associated detection code from
-https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
-
-4. Put everything together
+For example, if you want to polyfill `addEventListener` for IE8, import the Event polyfills.
 
 ```js
-(function(undefined) {
-
-    // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
-    var detect = (
-      // code goes here
-    )
-
-    if (detect) return
-
-    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
-    // code goes here
-
-}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});
+import '../globals/polyfills/Event'
 ```
+
+If you need polyfills for features that are not yet included in this project, please see the following guide on [how to add polyfills](/docs/polyfilling.md).
+
 ## Formatting
 
 GOV.UK Frontend uses [standardjs](http://standardjs.com/), an opinionated JavaScript linter. All JavaScript files follow its conventions, and it runs on CI to ensure that new pull requests are in line with them.

--- a/docs/polyfilling.md
+++ b/docs/polyfilling.md
@@ -1,0 +1,39 @@
+## Polyfilling
+
+The following example shows how to add a polyfill for `addEventListener`.
+
+1. Determine if the feature needs to be polyfilled
+
+You can use resources such as [caniuse.com](https://caniuse.com/) and [developer.mozilla.org](https://developer.mozilla.org/en-US/) to check feature support.
+
+In this example we’ve looked at [caniuse addEventListener](https://caniuse.com/#search=addEventListener) and seen that it’s not supported in IE8.
+
+2. Use polyfill.io service to generate the polyfill required
+You can [use the library](https://github.com/Financial-Times/polyfill-service#getpolyfillsoptions-method) to do this or [use their CDN](https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always) directly: `https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always`
+
+Then save this in the same structure that is used in the main project (https://github.com/Financial-Times/polyfill-service/tree/master/packages/polyfill-library/polyfills)
+
+3. Use polyfill.io service to get detection script
+
+We need to make sure we only run the polyfills if they’re needed.
+
+We can take the associated detection code from
+https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+
+4. Put everything together
+
+```js
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+    var detect = (
+      // code goes here
+    )
+
+    if (detect) return
+
+    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always
+    // code goes here
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});
+```


### PR DESCRIPTION
This PR:
- adds the minimum set of rules regarding:
  - files (and file naming)
  - comments
  - code structure (constructors and methods)
  - modules
  - polyfilling (and the polyfill process - thanks @nickcolley for elaborating the approach 💯)
  - formatting
- removes the linter setup documentation and points to the [GOV.UK styleguides repository](https://github.com/alphagov/styleguides/blob/master/js.md#linting)
