### PR TITLE
Disable code syntax highlighting in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Internal:
 (PR [#662](https://github.com/alphagov/govuk-frontend/pull/662))
 - Add test to check if Sass in packages compiles correctly after the `build:packages` task
 (PR [#669](https://github.com/alphagov/govuk-frontend/pull/669))
+- Disable code syntax highlighting in IE8
+(PR [#675](https://github.com/alphagov/govuk-frontend/pull/675))
 
 ## 0.0.28-alpha (Breaking release)
 

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -7,6 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="/public/css/app.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js"></script>
   <!--<![endif]-->
   <!--[if lt IE 9]>
   <script src="/vendor/html5-shiv/html5shiv.js"></script>
@@ -14,8 +16,6 @@
   <!--[if IE 8]>
   <link rel="stylesheet" href="/public/css/app-old-ie.css">
   <![endif]-->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js"></script>
   {% block styles %}
   {% endblock %}
 </head>


### PR DESCRIPTION
Prism will throw syntax errors making it hard to test IE8 JavaScript.