### PR TITLE
Move error message and hint out of labels and legends

### DIFF
--- a/src/all/_all.scss
+++ b/src/all/_all.scss
@@ -13,6 +13,7 @@
 @import "../fieldset/fieldset";
 @import "../file-upload/file-upload";
 @import "../footer/footer";
+@import "../hint/hint";
 @import "../input/input";
 @import "../label/label";
 @import "../panel/panel";

--- a/src/checkboxes/README.md
+++ b/src/checkboxes/README.md
@@ -16,17 +16,17 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          What is your nationality?
+      <legend class="govuk-fieldset__legend">
+        What is your nationality?
 
-          <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
+        <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-checkboxes">
+    <div class="govuk-checkboxes">
 
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
@@ -53,7 +53,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -89,7 +90,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-checkboxes">
+    <div class="govuk-form-group">
+        <div class="govuk-checkboxes">
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
@@ -116,6 +118,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
         </div>
 
       </div>
+
+    </div>
 
 #### Macro
 
@@ -146,17 +150,17 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      <legend class="govuk-fieldset__legend">
+        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
 
-          <span class="govuk-fieldset__hint">Select all that apply</span>
+        <span class="govuk-fieldset__hint">Select all that apply</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-checkboxes">
+    <div class="govuk-checkboxes">
 
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
@@ -183,7 +187,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -217,7 +222,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-checkboxes">
+    <div class="govuk-form-group">
+        <div class="govuk-checkboxes">
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
@@ -244,6 +250,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
         </div>
 
       </div>
+
+    </div>
 
 #### Macro
 
@@ -273,21 +281,21 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset app-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-error" data-attribute="value" data-second-attribute="second-value">
 
-        <legend class="govuk-fieldset__legend">
-          What is your nationality?
+      <legend class="govuk-fieldset__legend">
+        What is your nationality?
 
-          <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
+        <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
 
-          <span class="govuk-error-message">
-          Please select an option
-        </span>
+      </legend>
 
-        </legend>
+    <span id="example-error" class="govuk-error-message">
+        Please select an option
+      </span>
 
-      <div class="govuk-checkboxes">
+        <div class="govuk-checkboxes">
 
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="british">
@@ -314,7 +322,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -358,19 +367,19 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset" aria-describedby="undefined-error">
 
-        <legend class="govuk-fieldset__legend">
-          <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      <legend class="govuk-fieldset__legend">
+        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
 
-          <span class="govuk-error-message">
-          Please select an option
-        </span>
+      </legend>
 
-        </legend>
+    <span id="undefined-error" class="govuk-error-message">
+        Please select an option
+      </span>
 
-      <div class="govuk-checkboxes">
+        <div class="govuk-checkboxes">
 
           <div class="govuk-checkboxes__item">
             <input class="govuk-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
@@ -397,7 +406,8 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro

--- a/src/checkboxes/README.md
+++ b/src/checkboxes/README.md
@@ -17,43 +17,42 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="nationality-hint">
 
       <legend class="govuk-fieldset__legend">
         What is your nationality?
-
-        <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
-
       </legend>
 
-    <div class="govuk-checkboxes">
+      <span id="nationality-hint" class="govuk-hint">
+        If you have dual nationality, select all options that are relevant to you.
+      </span>
 
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
-            <label class="govuk-label govuk-checkboxes__label" for="nationality-1">
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="nationality-1" name="nationality" type="checkbox" value="british">
+          <label class="govuk-label govuk-checkboxes__label" for="nationality-1">
             British
-
           </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="nationality-2" name="nationality" type="checkbox" value="irish">
-            <label class="govuk-label govuk-checkboxes__label" for="nationality-2">
-            Irish
-
-          </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="nationality-3" name="nationality" type="checkbox" value="other">
-            <label class="govuk-label govuk-checkboxes__label" for="nationality-3">
-            Citizen of another country
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="nationality-2" name="nationality" type="checkbox" value="irish">
+          <label class="govuk-label govuk-checkboxes__label" for="nationality-2">
+            Irish
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="nationality-3" name="nationality" type="checkbox" value="other">
+          <label class="govuk-label govuk-checkboxes__label" for="nationality-3">
+            Citizen of another country
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -65,8 +64,10 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
       "idPrefix": "nationality",
       "name": "nationality",
       "fieldset": {
-        "legendText": "What is your nationality?",
-        "legendHintText": "If you have dual nationality, select all options that are relevant to you."
+        "legendText": "What is your nationality?"
+      },
+      "hint": {
+        "text": "If you have dual nationality, select all options that are relevant to you."
       },
       "items": [
         {
@@ -91,30 +92,28 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-        <div class="govuk-checkboxes">
+
+      <div class="govuk-checkboxes">
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
           <label class="govuk-label govuk-checkboxes__label" for="colours-1">
-          Red
-
-        </label>
+            Red
+          </label>
         </div>
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-2" name="colours" type="checkbox" value="green">
           <label class="govuk-label govuk-checkboxes__label" for="colours-2">
-          Green
-
-        </label>
+            Green
+          </label>
         </div>
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue" disabled>
           <label class="govuk-label govuk-checkboxes__label" for="colours-3">
-          Blue
-
-        </label>
+            Blue
+          </label>
         </div>
 
       </div>
@@ -151,43 +150,42 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
 
       <legend class="govuk-fieldset__legend">
         <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
-
-        <span class="govuk-fieldset__hint">Select all that apply</span>
-
       </legend>
 
-    <div class="govuk-checkboxes">
+      <span id="waste-hint" class="govuk-hint">
+        Select all that apply
+      </span>
 
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-1">
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-1">
             Waste from animal carcasses
-
           </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-2" name="" type="checkbox" value="mines">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-2">
-            Waste from mines or quarries
-
-          </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-3" name="" type="checkbox" value="farm">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-3">
-            Farm or agricultural waste
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+            Waste from mines or quarries
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+            Farm or agricultural waste
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -196,9 +194,12 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
+      "name": "waste",
       "fieldset": {
-        "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>",
-        "legendHintText": "Select all that apply"
+        "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+      },
+      "hint": {
+        "text": "Select all that apply"
       },
       "items": [
         {
@@ -223,30 +224,28 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-        <div class="govuk-checkboxes">
+
+      <div class="govuk-checkboxes">
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-1" name="colours" type="checkbox" value="red">
           <label class="govuk-label govuk-checkboxes__label" for="colours-1">
-          Red
-
-        </label>
+            Red
+          </label>
         </div>
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-2" name="colours" type="checkbox" value="green">
           <label class="govuk-label govuk-checkboxes__label" for="colours-2">
-          Green
-
-        </label>
+            Green
+          </label>
         </div>
 
         <div class="govuk-checkboxes__item">
           <input class="govuk-checkboxes__input" id="colours-3" name="colours" type="checkbox" value="blue">
           <label class="govuk-label govuk-checkboxes__label" for="colours-3">
-          Blue
-
-        </label>
+            Blue
+          </label>
         </div>
 
       </div>
@@ -282,47 +281,46 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-error" data-attribute="value" data-second-attribute="second-value">
+
+      <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-hint example-error" data-attribute="value" data-second-attribute="second-value">
 
       <legend class="govuk-fieldset__legend">
         What is your nationality?
-
-        <span class="govuk-fieldset__hint">If you have dual nationality, select all options that are relevant to you.</span>
-
       </legend>
 
-    <span id="example-error" class="govuk-error-message">
+      <span id="example-hint" class="govuk-hint">
+        If you have dual nationality, select all options that are relevant to you.
+      </span>
+
+      <span id="example-error" class="govuk-error-message">
         Please select an option
       </span>
 
-        <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes">
 
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="british">
-            <label class="govuk-label govuk-checkboxes__label" for="example-1">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="example-1" name="example" type="checkbox" value="british">
+          <label class="govuk-label govuk-checkboxes__label" for="example-1">
             British
-
           </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="example-2" name="example" type="checkbox" value="irish">
-            <label class="govuk-label govuk-checkboxes__label" for="example-2">
-            Irish
-
-          </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="example-3" name="example" type="checkbox" value="other">
-            <label class="govuk-label govuk-checkboxes__label" for="example-3">
-            Citizen of another country
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="example-2" name="example" type="checkbox" value="irish">
+          <label class="govuk-label govuk-checkboxes__label" for="example-2">
+            Irish
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="example-3" name="example" type="checkbox" value="other">
+          <label class="govuk-label govuk-checkboxes__label" for="example-3">
+            Citizen of another country
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -333,17 +331,19 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     {{ govukCheckboxes({
       "idPrefix": "example",
       "name": "example",
-      "errorMessage": {
-        "text": "Please select an option"
-      },
       "fieldset": {
         "classes": "app-fieldset--custom-modifier",
         "attributes": {
           "data-attribute": "value",
           "data-second-attribute": "second-value"
         },
-        "legendText": "What is your nationality?",
-        "legendHintText": "If you have dual nationality, select all options that are relevant to you."
+        "legendText": "What is your nationality?"
+      },
+      "hint": {
+        "text": "If you have dual nationality, select all options that are relevant to you."
+      },
+      "errorMessage": {
+        "text": "Please select an option"
       },
       "items": [
         {
@@ -368,45 +368,42 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset" aria-describedby="undefined-error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="waste-error">
 
       <legend class="govuk-fieldset__legend">
         <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
-
       </legend>
 
-    <span id="undefined-error" class="govuk-error-message">
+      <span id="waste-error" class="govuk-error-message">
         Please select an option
       </span>
 
-        <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes">
 
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-1" name="" type="checkbox" value="animal">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-1">
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-1">
             Waste from animal carcasses
-
           </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-2" name="" type="checkbox" value="mines">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-2">
-            Waste from mines or quarries
-
-          </label>
-          </div>
-
-          <div class="govuk-checkboxes__item">
-            <input class="govuk-checkboxes__input" id="undefined-3" name="" type="checkbox" value="farm">
-            <label class="govuk-label govuk-checkboxes__label" for="undefined-3">
-            Farm or agricultural waste
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+            Waste from mines or quarries
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+            Farm or agricultural waste
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -415,6 +412,7 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     {% from 'checkboxes/macro.njk' import govukCheckboxes %}
 
     {{ govukCheckboxes({
+      "name": "waste",
       "errorMessage": {
         "text": "Please select an option"
       },
@@ -493,7 +491,31 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
+<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText). See fieldset component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">errorMessage</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/checkboxes/__snapshots__/template.test.js.snap
@@ -47,22 +47,22 @@ exports[`Checkboxes nested dependant components passes through label params with
 
 `;
 
-exports[`Checkboxes nested dependant components renders the error message 1`] = `
-
-<span id="example-error"
-      class="govuk-error-message"
->
-  Please select an option
-</span>
-
-`;
-
-exports[`Checkboxes nested dependant components renders the hint 1`] = `
+exports[`Checkboxes when they include a hint renders the hint 1`] = `
 
 <span id="example-hint"
       class="govuk-hint"
 >
   If you have dual nationality, select all options that are relevant to you.
+</span>
+
+`;
+
+exports[`Checkboxes when they include an error message renders the error message 1`] = `
+
+<span id="example-error"
+      class="govuk-error-message"
+>
+  Please select an option
 </span>
 
 `;

--- a/src/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/checkboxes/__snapshots__/template.test.js.snap
@@ -3,15 +3,12 @@
 exports[`Checkboxes nested dependant components passes through fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
-          aria-describedby="example-error"
+          aria-describedby="example-hint example-error"
           data-attribute="value"
           data-second-attribute="second-value"
 >
   <legend class="govuk-fieldset__legend">
     What is your nationality?
-    <span class="govuk-fieldset__hint">
-      If you have dual nationality, select all options that are relevant to you.
-    </span>
   </legend>
 </fieldset>
 
@@ -21,14 +18,11 @@ exports[`Checkboxes nested dependant components passes through html fieldset par
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend">
-    What is your &lt;b&gt;nationality&lt;/b&gt;?
-    <span class="govuk-fieldset__hint">
-      If you have dual nationality,
-      <b>
-        select all options
-      </b>
-      that are relevant to you.
-    </span>
+    What is your
+    <b>
+      nationality
+    </b>
+    ?
   </legend>
 </fieldset>
 
@@ -59,6 +53,16 @@ exports[`Checkboxes nested dependant components renders the error message 1`] = 
       class="govuk-error-message"
 >
   Please select an option
+</span>
+
+`;
+
+exports[`Checkboxes nested dependant components renders the hint 1`] = `
+
+<span id="example-hint"
+      class="govuk-hint"
+>
+  If you have dual nationality, select all options that are relevant to you.
 </span>
 
 `;

--- a/src/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/checkboxes/__snapshots__/template.test.js.snap
@@ -2,15 +2,8 @@
 
 exports[`Checkboxes nested dependant components passes through fieldset params without breaking 1`] = `
 
-<span class="govuk-error-message">
-  Please select an option
-</span>
-
-`;
-
-exports[`Checkboxes nested dependant components passes through fieldset params without breaking 2`] = `
-
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
+          aria-describedby="example-error"
           data-attribute="value"
           data-second-attribute="second-value"
 >
@@ -57,5 +50,15 @@ exports[`Checkboxes nested dependant components passes through label params with
 >
   &lt;b&gt;Option 2&lt;/b&gt;
 </label>
+
+`;
+
+exports[`Checkboxes nested dependant components renders the error message 1`] = `
+
+<span id="example-error"
+      class="govuk-error-message"
+>
+  Please select an option
+</span>
 
 `;

--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -1,8 +1,10 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/ie8";
+@import "../globals/settings/measurements";
 
 @import "../error-message/error-message";
 @import "../fieldset/fieldset";
+@import "../hint/hint";
 @import "../label/label";
 
 @include govuk-exports("checkboxes") {

--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -1,6 +1,7 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/ie8";
 
+@import "../error-message/error-message";
 @import "../fieldset/fieldset";
 @import "../label/label";
 

--- a/src/checkboxes/_checkboxes.scss
+++ b/src/checkboxes/_checkboxes.scss
@@ -1,5 +1,6 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/ie8";
+@import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
 @import "../error-message/error-message";

--- a/src/checkboxes/checkboxes.yaml
+++ b/src/checkboxes/checkboxes.yaml
@@ -15,7 +15,8 @@ examples:
     name: 'nationality'
     fieldset:
       legendText: What is your nationality?
-      legendHintText: If you have dual nationality, select all options that are relevant to you.
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
     items:
       - value: 'british'
         text: 'British'
@@ -38,10 +39,12 @@ examples:
 
 - name: with-html
   data:
+    name: waste
     fieldset:
       legendHtml:
         <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
-      legendHintText: Select all that apply
+    hint:
+      text: Select all that apply
     items:
       - value: animal
         text: Waste from animal carcasses
@@ -65,16 +68,16 @@ examples:
   data:
     idPrefix: 'example'
     name: 'example'
-    errorMessage:
-      text: 'Please select an option'
     fieldset:
       classes: 'app-fieldset--custom-modifier'
       attributes:
         'data-attribute': 'value'
         'data-second-attribute': 'second-value'
       legendText: What is your nationality?
-      legendHintText:
-        If you have dual nationality, select all options that are relevant to you.
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
+    errorMessage:
+      text: 'Please select an option'
     items:
       - value: 'british'
         text: 'British'
@@ -85,6 +88,7 @@ examples:
 
 - name: with-error
   data:
+    name: waste
     errorMessage:
       text: 'Please select an option'
     fieldset:

--- a/src/checkboxes/index.njk
+++ b/src/checkboxes/index.njk
@@ -48,7 +48,35 @@
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+        text: 'Arguments for the fieldset component (e.g. legendText). See fieldset component.'
+      }
+    ],
+    [
+      {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
+        text: 'errorMessage'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/checkboxes/template.njk
+++ b/src/checkboxes/template.njk
@@ -1,5 +1,14 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
 {% from "label/macro.njk" import govukLabel %}
+
+{# If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well #}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+
+{# a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 {% set isConditional = false %}
 {% for item in params.items %}
@@ -10,11 +19,21 @@
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
+  {% if params.errorMessage %}
+    {% set errorId = idPrefix + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="checkboxes"{% endif -%}>
     {% for item in params.items %}
-    {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
     {% set conditionalId = "conditional-" + id %}
     <div class="govuk-checkboxes__item">
@@ -39,18 +58,20 @@
   </div>
 {% endset %}
 
-{%- if params.fieldset %}
-  {% call govukFieldset({
-    classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml,
-    legendHintText: params.fieldset.legendHintText,
-    legendHintHtml: params.fieldset.legendHintHtml,
-    errorMessage: params.errorMessage
-  }) %}
-  {{- innerHtml | indent(2) | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
+  {%- if params.fieldset %}
+    {% call govukFieldset({
+      describedBy: describedBy,
+      classes: params.fieldset.classes,
+      attributes: params.fieldset.attributes,
+      legendText: params.fieldset.legendText,
+      legendHtml: params.fieldset.legendHtml,
+      legendHintText: params.fieldset.legendHintText,
+      legendHintHtml: params.fieldset.legendHintHtml
+    }) %}
+    {{- innerHtml | indent(2) | trim | safe }}
+    {% endcall %}
+  {% else %}
+    {{ innerHtml | trim | safe }}
+  {% endif %}
+</div>

--- a/src/checkboxes/template.njk
+++ b/src/checkboxes/template.njk
@@ -1,13 +1,14 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# If an id 'prefix' is not passed, fall back to using the name attribute
-   instead. We need this for error messages and hints as well #}
+{#- If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
 
-{# a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
 
 {% set isConditional = false %}
@@ -19,17 +20,27 @@
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
-  {% if params.errorMessage %}
-    {% set errorId = idPrefix + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
+{% if params.hint %}
+  {% set hintId = idPrefix + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = idPrefix + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="checkboxes"{% endif -%}>
@@ -47,7 +58,7 @@
         classes: 'govuk-checkboxes__label',
         attributes: item.label.attributes,
         for: id
-      }) | indent(4) | trim }}
+      }) | indent(6) | trim }}
     </div>
     {% if item.conditional %}
       <div class="govuk-checkboxes__conditional" id="{{ conditionalId }}">
@@ -56,22 +67,20 @@
     {% endif %}
     {% endfor %}
   </div>
-{% endset %}
+{% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-  {%- if params.fieldset %}
-    {% call govukFieldset({
-      describedBy: describedBy,
-      classes: params.fieldset.classes,
-      attributes: params.fieldset.attributes,
-      legendText: params.fieldset.legendText,
-      legendHtml: params.fieldset.legendHtml,
-      legendHintText: params.fieldset.legendHintText,
-      legendHintHtml: params.fieldset.legendHintHtml
-    }) %}
-    {{- innerHtml | indent(2) | trim | safe }}
-    {% endcall %}
-  {% else %}
-    {{ innerHtml | trim | safe }}
-  {% endif %}
+{% if params.fieldset %}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
 </div>

--- a/src/checkboxes/template.test.js
+++ b/src/checkboxes/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('checkboxes')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Checkboxes', () => {
   it('default example passes accessibility tests', async () => {
@@ -228,58 +229,7 @@ describe('Checkboxes', () => {
     expect($lastConditional.html()).toContain('Conditional content')
   })
 
-  describe('nested dependant components', () => {
-    it('have correct nesting order', () => {
-      const $ = render('checkboxes', examples['with-extreme-fieldset'])
-
-      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
-      expect($component.length).toBeTruthy()
-    })
-
-    it('passes through label params without breaking', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            html: '<b>Option 1</b>',
-            label: {
-              attributes: {
-                'data-attribute': 'value',
-                'data-second-attribute': 'second-value'
-              }
-            }
-          },
-          {
-            value: '2',
-            text: '<b>Option 2</b>',
-            checked: true
-          }
-        ]
-      })
-
-      expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
-    })
-
-    it('renders the hint', () => {
-      const $ = render('checkboxes', examples['with-extreme-fieldset'])
-
-      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-    })
-
-    it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('checkboxes', examples['with-extreme-fieldset'])
-
-      const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
-    })
-
+  describe('when they include an error message', () => {
     it('renders the error message', () => {
       const $ = render('checkboxes', examples['with-extreme-fieldset'])
 
@@ -337,6 +287,78 @@ describe('Checkboxes', () => {
 
       expect($fieldset.attr('aria-describedby'))
         .toMatch(errorMessageId)
+    })
+  })
+
+  describe('when they include a hint', () => {
+    it('renders the hint', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the fieldset as "described by" the hint', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+    })
+  })
+
+  describe('when they include both a hint and an error message', () => {
+    it('associates the fieldset as described by both the hint and the error message', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
+  describe('nested dependant components', () => {
+    it('have correct nesting order', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
+      expect($component.length).toBeTruthy()
+    })
+
+    it('passes through label params without breaking', () => {
+      const $ = render('checkboxes', {
+        name: 'example-name',
+        items: [
+          {
+            value: '1',
+            html: '<b>Option 1</b>',
+            label: {
+              attributes: {
+                'data-attribute': 'value',
+                'data-second-attribute': 'second-value'
+              }
+            }
+          },
+          {
+            value: '2',
+            text: '<b>Option 2</b>',
+            checked: true
+          }
+        ]
+      })
+
+      expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {

--- a/src/checkboxes/template.test.js
+++ b/src/checkboxes/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('checkboxes')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Checkboxes', () => {
   it('default example passes accessibility tests', async () => {
     const $ = render('checkboxes', examples.default)
@@ -259,10 +261,68 @@ describe('Checkboxes', () => {
       expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
     })
 
-    it('passes through fieldset params without breaking', () => {
+    it('renders the error message', () => {
       const $ = render('checkboxes', examples['with-extreme-fieldset'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('uses the idPrefix for the error message id if provided', () => {
+      const $ = render('checkboxes', {
+        name: 'name-of-checkboxes',
+        errorMessage: {
+          text: 'Please select an option'
+        },
+        idPrefix: 'id-prefix',
+        items: [
+          {
+            value: 'animal',
+            text: 'Waste from animal carcasses'
+          }
+        ]
+      })
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+    })
+
+    it('falls back to using the name for the error message id', () => {
+      const $ = render('checkboxes', {
+        name: 'name-of-checkboxes',
+        errorMessage: {
+          text: 'Please select an option'
+        },
+        items: [
+          {
+            value: 'animal',
+            text: 'Waste from animal carcasses'
+          }
+        ]
+      })
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('name-of-checkboxes-error')
+    })
+
+    it('associates the fieldset as "described by" the error message', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
+    it('passes through fieldset params without breaking', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 

--- a/src/checkboxes/template.test.js
+++ b/src/checkboxes/template.test.js
@@ -261,6 +261,25 @@ describe('Checkboxes', () => {
       expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
     })
 
+    it('renders the hint', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the fieldset as "described by" the hint', () => {
+      const $ = render('checkboxes', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+    })
+
     it('renders the error message', () => {
       const $ = render('checkboxes', examples['with-extreme-fieldset'])
 
@@ -340,8 +359,7 @@ describe('Checkboxes', () => {
           }
         ],
         fieldset: {
-          legendText: 'What is your <b>nationality</b>?',
-          legendHintHtml: 'If you have dual nationality, <b>select all options</b> that are relevant to you.'
+          legendHtml: 'What is your <b>nationality</b>?'
         }
       })
 

--- a/src/date-input/README.md
+++ b/src/date-input/README.md
@@ -17,8 +17,7 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-
-      <fieldset class="govuk-fieldset" aria-describedby="dob-hint">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-hint" role="group">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
@@ -98,8 +97,7 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-
-      <fieldset class="govuk-fieldset" aria-describedby="dob-errors-hint dob-errors-error">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-errors-hint dob-errors-error" role="group">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
@@ -188,8 +186,7 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-
-      <fieldset class="govuk-fieldset" aria-describedby="dob-day-error-hint dob-day-error-error">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-day-error-hint dob-day-error-error" role="group">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
@@ -277,8 +274,7 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-
-      <fieldset class="govuk-fieldset" aria-describedby="dob-month-error-hint dob-month-error-error">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-month-error-hint dob-month-error-error" role="group">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
@@ -366,8 +362,7 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-
-      <fieldset class="govuk-fieldset" aria-describedby="dob-year-error-hint dob-year-error-error">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-year-error-hint dob-year-error-error" role="group">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?

--- a/src/date-input/README.md
+++ b/src/date-input/README.md
@@ -17,49 +17,51 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="dob-hint">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
-
-        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
-
       </legend>
 
-    <div class="govuk-date-input" id="dob">
+      <span id="dob-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
 
-          <div class="govuk-date-input__item govuk-date-input__item--day">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day">
-            Day
+      <div class="govuk-date-input" id="dob">
 
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--day">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-day">
+              Day
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--month">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-month">
-            Month
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--month">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-month">
+              Month
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--year">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-year">
-            Year
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--year">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-year">
+              Year
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
           </div>
-          </div>
-
         </div>
-        </fieldset>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -71,8 +73,10 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob",
       "name": "dob",
       "fieldset": {
-        "legendText": "What is your date of birth?",
-        "legendHintText": "For example, 31 3 1980"
+        "legendText": "What is your date of birth?"
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
       },
       "items": [
         {
@@ -94,53 +98,55 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset" aria-describedby="dob-errors-error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="dob-errors-hint dob-errors-error">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
-
-        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
-
       </legend>
 
-    <span id="dob-errors-error" class="govuk-error-message">
+      <span id="dob-errors-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
+
+      <span id="dob-errors-error" class="govuk-error-message">
         Error message goes here
       </span>
 
-        <div class="govuk-date-input" id="dob-errors">
+      <div class="govuk-date-input" id="dob-errors">
 
-          <div class="govuk-date-input__item govuk-date-input__item--day">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-errors-day">
-            Day
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--day">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-errors-day">
+              Day
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-day" name="undefined-day" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--month">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-errors-month">
-            Month
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--month">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-errors-month">
+              Month
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-month" name="undefined-month" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--year">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-errors-year">
-            Year
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--year">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-errors-year">
+              Year
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-year" name="undefined-year" type="number" pattern="[0-9]*">
           </div>
-          </div>
-
         </div>
-        </fieldset>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -151,8 +157,10 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
     {{ govukDateInput({
       "id": "dob-errors",
       "fieldset": {
-        "legendText": "What is your date of birth?",
-        "legendHintText": "For example, 31 3 1980"
+        "legendText": "What is your date of birth?"
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
       },
       "errorMessage": {
         "text": "Error message goes here"
@@ -180,53 +188,55 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset" aria-describedby="dob-day-error-error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="dob-day-error-hint dob-day-error-error">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
-
-        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
-
       </legend>
 
-    <span id="dob-day-error-error" class="govuk-error-message">
+      <span id="dob-day-error-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
+
+      <span id="dob-day-error-error" class="govuk-error-message">
         Error message goes here
       </span>
 
-        <div class="govuk-date-input" id="dob-day-error">
+      <div class="govuk-date-input" id="dob-day-error">
 
-          <div class="govuk-date-input__item govuk-date-input__item--day">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day-error-day">
-            Day
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--day">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-day-error-day">
+              Day
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--month">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day-error-month">
-            Month
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--month">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-day-error-month">
+              Month
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--year">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day-error-year">
-            Year
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--year">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-day-error-year">
+              Year
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
           </div>
-          </div>
-
         </div>
-        </fieldset>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -238,8 +248,10 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-day-error",
       "name": "dob-day-error",
       "fieldset": {
-        "legendText": "What is your date of birth?",
-        "legendHintText": "For example, 31 3 1980"
+        "legendText": "What is your date of birth?"
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
       },
       "errorMessage": {
         "text": "Error message goes here"
@@ -265,53 +277,55 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset" aria-describedby="dob-month-error-error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="dob-month-error-hint dob-month-error-error">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
-
-        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
-
       </legend>
 
-    <span id="dob-month-error-error" class="govuk-error-message">
+      <span id="dob-month-error-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
+
+      <span id="dob-month-error-error" class="govuk-error-message">
         Error message goes here
       </span>
 
-        <div class="govuk-date-input" id="dob-month-error">
+      <div class="govuk-date-input" id="dob-month-error">
 
-          <div class="govuk-date-input__item govuk-date-input__item--day">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-month-error-day">
-            Day
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--day">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-month-error-day">
+              Day
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--month">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-month-error-month">
-            Month
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--month">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-month-error-month">
+              Month
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--year">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-month-error-year">
-            Year
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--year">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-month-error-year">
+              Year
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
           </div>
-          </div>
-
         </div>
-        </fieldset>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -323,8 +337,10 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-month-error",
       "name": "dob-month-error",
       "fieldset": {
-        "legendText": "What is your date of birth?",
-        "legendHintText": "For example, 31 3 1980"
+        "legendText": "What is your date of birth?"
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
       },
       "errorMessage": {
         "text": "Error message goes here"
@@ -350,53 +366,55 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset" aria-describedby="dob-year-error-error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="dob-year-error-hint dob-year-error-error">
 
       <legend class="govuk-fieldset__legend">
         What is your date of birth?
-
-        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
-
       </legend>
 
-    <span id="dob-year-error-error" class="govuk-error-message">
+      <span id="dob-year-error-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
+
+      <span id="dob-year-error-error" class="govuk-error-message">
         Error message goes here
       </span>
 
-        <div class="govuk-date-input" id="dob-year-error">
+      <div class="govuk-date-input" id="dob-year-error">
 
-          <div class="govuk-date-input__item govuk-date-input__item--day">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-year-error-day">
-            Day
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--day">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-year-error-day">
+              Day
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--month">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-year-error-month">
-            Month
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--month">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-year-error-month">
+              Month
+            </label>
 
             <input class="govuk-input govuk-date-input__input" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
           </div>
-          </div>
+        </div>
 
-          <div class="govuk-date-input__item govuk-date-input__item--year">
-            <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-year-error-year">
-            Year
-
-          </label>
+        <div class="govuk-date-input__item govuk-date-input__item--year">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-year-error-year">
+              Year
+            </label>
 
             <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
           </div>
-          </div>
-
         </div>
-        </fieldset>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -408,8 +426,10 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-year-error",
       "name": "dob-year-error",
       "fieldset": {
-        "legendText": "What is your date of birth?",
-        "legendHintText": "For example, 31 3 1980"
+        "legendText": "What is your date of birth?"
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
       },
       "errorMessage": {
         "text": "Error message goes here"

--- a/src/date-input/README.md
+++ b/src/date-input/README.md
@@ -16,24 +16,25 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          What is your date of birth?
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
 
-          <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
+        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-date-input" id="dob">
+    <div class="govuk-date-input" id="dob">
 
           <div class="govuk-date-input__item govuk-date-input__item--day">
             <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day">
             Day
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -42,7 +43,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Month
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -51,12 +53,14 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Year
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
           </div>
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -89,28 +93,29 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset" aria-describedby="dob-errors-error">
 
-        <legend class="govuk-fieldset__legend">
-          What is your date of birth?
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
 
-          <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
+        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
 
-          <span class="govuk-error-message">
-          Error message goes here
-        </span>
+      </legend>
 
-        </legend>
+    <span id="dob-errors-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-      <div class="govuk-date-input" id="dob-errors">
+        <div class="govuk-date-input" id="dob-errors">
 
           <div class="govuk-date-input__item govuk-date-input__item--day">
             <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-errors-day">
             Day
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-day" name="undefined-day" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-day" name="undefined-day" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -119,7 +124,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Month
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-month" name="undefined-month" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-month" name="undefined-month" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -128,12 +134,14 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Year
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-year" name="undefined-year" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-year" name="undefined-year" type="number" pattern="[0-9]*">
           </div>
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -171,28 +179,29 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset" aria-describedby="dob-day-error-error">
 
-        <legend class="govuk-fieldset__legend">
-          What is your date of birth?
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
 
-          <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
+        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
 
-          <span class="govuk-error-message">
-          Error message goes here
-        </span>
+      </legend>
 
-        </legend>
+    <span id="dob-day-error-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-      <div class="govuk-date-input" id="dob-day-error">
+        <div class="govuk-date-input" id="dob-day-error">
 
           <div class="govuk-date-input__item govuk-date-input__item--day">
             <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-day-error-day">
             Day
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -201,7 +210,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Month
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -210,12 +220,14 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Year
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
           </div>
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -252,28 +264,29 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset" aria-describedby="dob-month-error-error">
 
-        <legend class="govuk-fieldset__legend">
-          What is your date of birth?
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
 
-          <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
+        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
 
-          <span class="govuk-error-message">
-          Error message goes here
-        </span>
+      </legend>
 
-        </legend>
+    <span id="dob-month-error-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-      <div class="govuk-date-input" id="dob-month-error">
+        <div class="govuk-date-input" id="dob-month-error">
 
           <div class="govuk-date-input__item govuk-date-input__item--day">
             <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-month-error-day">
             Day
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -282,7 +295,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Month
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -291,12 +305,14 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Year
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
           </div>
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -333,28 +349,29 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset" aria-describedby="dob-year-error-error">
 
-        <legend class="govuk-fieldset__legend">
-          What is your date of birth?
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
 
-          <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
+        <span class="govuk-fieldset__hint">For example, 31 3 1980</span>
 
-          <span class="govuk-error-message">
-          Error message goes here
-        </span>
+      </legend>
 
-        </legend>
+    <span id="dob-year-error-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-      <div class="govuk-date-input" id="dob-year-error">
+        <div class="govuk-date-input" id="dob-year-error">
 
           <div class="govuk-date-input__item govuk-date-input__item--day">
             <div class="govuk-form-group"><label class="govuk-label govuk-date-input__label" for="dob-year-error-day">
             Day
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -363,7 +380,8 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Month
 
           </label>
-          <input class="govuk-input govuk-date-input__input" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
           </div>
           </div>
 
@@ -372,12 +390,14 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
             Year
 
           </label>
-          <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
+
+            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
           </div>
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro

--- a/src/date-input/__snapshots__/template.test.js.snap
+++ b/src/date-input/__snapshots__/template.test.js.snap
@@ -24,6 +24,7 @@ exports[`Date input passes through fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset"
           aria-describedby="dob-hint"
+          role="group"
 >
   <legend class="govuk-fieldset__legend">
     What is your date of birth?
@@ -36,6 +37,7 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset"
           aria-describedby="dob-error"
+          role="group"
 >
   <legend class="govuk-fieldset__legend">
     What is your

--- a/src/date-input/__snapshots__/template.test.js.snap
+++ b/src/date-input/__snapshots__/template.test.js.snap
@@ -50,22 +50,22 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
 
 `;
 
-exports[`Date input renders the error message 1`] = `
-
-<span id="dob-errors-error"
-      class="govuk-error-message"
->
-  Error message goes here
-</span>
-
-`;
-
-exports[`Date input renders the hint 1`] = `
+exports[`Date input when it includes a hint renders the hint 1`] = `
 
 <span id="dob-errors-hint"
       class="govuk-hint"
 >
   For example, 31 3 1980
+</span>
+
+`;
+
+exports[`Date input when it includes an error message renders the error message 1`] = `
+
+<span id="dob-errors-error"
+      class="govuk-error-message"
+>
+  Error message goes here
 </span>
 
 `;

--- a/src/date-input/__snapshots__/template.test.js.snap
+++ b/src/date-input/__snapshots__/template.test.js.snap
@@ -22,12 +22,11 @@ exports[`Date input nested dependant components passes through label params with
 
 exports[`Date input passes through fieldset params without breaking 1`] = `
 
-<fieldset class="govuk-fieldset">
+<fieldset class="govuk-fieldset"
+          aria-describedby="dob-hint"
+>
   <legend class="govuk-fieldset__legend">
     What is your date of birth?
-    <span class="govuk-fieldset__hint">
-      For example, 31 3 1980
-    </span>
   </legend>
 </fieldset>
 
@@ -44,12 +43,6 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
       date of birth
     </b>
     ?
-    <span class="govuk-fieldset__hint">
-      For example,
-      <b>
-        31 3 1980
-      </b>
-    </span>
   </legend>
 </fieldset>
 
@@ -61,6 +54,16 @@ exports[`Date input renders the error message 1`] = `
       class="govuk-error-message"
 >
   Error message goes here
+</span>
+
+`;
+
+exports[`Date input renders the hint 1`] = `
+
+<span id="dob-errors-hint"
+      class="govuk-hint"
+>
+  For example, 31 3 1980
 </span>
 
 `;

--- a/src/date-input/__snapshots__/template.test.js.snap
+++ b/src/date-input/__snapshots__/template.test.js.snap
@@ -35,15 +35,9 @@ exports[`Date input passes through fieldset params without breaking 1`] = `
 
 exports[`Date input passes through html fieldset params without breaking 1`] = `
 
-<span class="govuk-error-message">
-  Error message goes here
-</span>
-
-`;
-
-exports[`Date input passes through html fieldset params without breaking 2`] = `
-
-<fieldset class="govuk-fieldset">
+<fieldset class="govuk-fieldset"
+          aria-describedby="dob-error"
+>
   <legend class="govuk-fieldset__legend">
     What is your
     <b>
@@ -58,5 +52,15 @@ exports[`Date input passes through html fieldset params without breaking 2`] = `
     </span>
   </legend>
 </fieldset>
+
+`;
+
+exports[`Date input renders the error message 1`] = `
+
+<span id="dob-errors-error"
+      class="govuk-error-message"
+>
+  Error message goes here
+</span>
 
 `;

--- a/src/date-input/_date-input.scss
+++ b/src/date-input/_date-input.scss
@@ -1,8 +1,13 @@
+@import "../globals/helpers/clearfix";
 @import "../globals/tools/exports";
 @import "../globals/tools/iff";
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
 
 @import "../error-message/error-message";
 @import "../input/input";
+@import "../hint/hint";
 @import "../label/label";
 
 @include govuk-exports("date-input") {

--- a/src/date-input/_date-input.scss
+++ b/src/date-input/_date-input.scss
@@ -1,9 +1,9 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/iff";
 
-@import "../label/label";
-@import "../input/input";
 @import "../error-message/error-message";
+@import "../input/input";
+@import "../label/label";
 
 @include govuk-exports("date-input") {
   .govuk-date-input {

--- a/src/date-input/date-input.yaml
+++ b/src/date-input/date-input.yaml
@@ -5,7 +5,8 @@ examples:
     name: 'dob'
     fieldset:
       legendText: 'What is your date of birth?'
-      legendHintText: 'For example, 31 3 1980'
+    hint:
+      text: 'For example, 31 3 1980'
     items:
       -
         name: 'day'
@@ -18,7 +19,8 @@ examples:
     id: 'dob-errors'
     fieldset:
       legendText: 'What is your date of birth?'
-      legendHintText: 'For example, 31 3 1980'
+    hint:
+      text: 'For example, 31 3 1980'
     errorMessage:
       text: 'Error message goes here'
     items:
@@ -37,7 +39,8 @@ examples:
     name: 'dob-day-error'
     fieldset:
       legendText: 'What is your date of birth?'
-      legendHintText: 'For example, 31 3 1980'
+    hint:
+      text: 'For example, 31 3 1980'
     errorMessage:
       text: 'Error message goes here'
     items:
@@ -54,7 +57,8 @@ examples:
     name: 'dob-month-error'
     fieldset:
       legendText: 'What is your date of birth?'
-      legendHintText: 'For example, 31 3 1980'
+    hint:
+      text: 'For example, 31 3 1980'
     errorMessage:
       text: 'Error message goes here'
     items:
@@ -71,7 +75,8 @@ examples:
     name: 'dob-year-error'
     fieldset:
       legendText: 'What is your date of birth?'
-      legendHintText: 'For example, 31 3 1980'
+    hint:
+      text: 'For example, 31 3 1980'
     errorMessage:
       text: 'Error message goes here'
     items:

--- a/src/date-input/template.njk
+++ b/src/date-input/template.njk
@@ -1,28 +1,35 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
+{% from "hint/macro.njk" import govukHint %}
 {% from "input/macro.njk" import govukInput %}
 
-{# If an id 'prefix' is not passed, fall back to using the name attribute
-   instead. We need this for error messages and hints as well #}
-{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
-
-{# a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
-  {% if params.errorMessage %}
-    {% set errorId = params.id + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
@@ -41,26 +48,24 @@
         "attributes": {
           "pattern": "[0-9]*"
         }
-      }) | indent(4) | trim }}
+      }) | indent(6) | trim }}
     </div>
   {% endfor %}
   </div>
 {% endset %}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-  {%- if params.fieldset %}
-    {% call govukFieldset({
-      describedBy: describedBy,
-      classes: params.fieldset.classes,
-      attributes: params.fieldset.attributes,
-      legendText: params.fieldset.legendText,
-      legendHtml: params.fieldset.legendHtml,
-      legendHintText: params.fieldset.legendHintText,
-      legendHintHtml: params.fieldset.legendHintHtml
-    }) %}
-    {{- innerHtml | indent(2) | trim | safe }}
-    {% endcall %}
-  {% else %}
-    {{ innerHtml | trim | safe }}
-  {% endif %}
+{% if params.fieldset %}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
 </div>

--- a/src/date-input/template.njk
+++ b/src/date-input/template.njk
@@ -56,10 +56,16 @@
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
 {% if params.fieldset %}
+{#- We override the fieldset's role to 'group' because otherwise JAWS does not
+    announce the description for a fieldset comprised of text inputs, but
+    adding the role to the fieldset always makes the output overly verbose for
+    radio buttons or checkboxes. -#}
   {% call govukFieldset({
     describedBy: describedBy,
     classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
+    attributes: {
+      role: 'group'
+    },
     legendText: params.fieldset.legendText,
     legendHtml: params.fieldset.legendHtml
   }) %}

--- a/src/date-input/template.njk
+++ b/src/date-input/template.njk
@@ -1,8 +1,28 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
 {% from "input/macro.njk" import govukInput %}
 
+{# If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well #}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+
+{# a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
+  {% if params.errorMessage %}
+    {% set errorId = params.id + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
@@ -27,18 +47,20 @@
   </div>
 {% endset %}
 
-{%- if params.fieldset %}
-  {% call govukFieldset({
-    classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml,
-    legendHintText: params.fieldset.legendHintText,
-    legendHintHtml: params.fieldset.legendHintHtml,
-    errorMessage: params.errorMessage
-  }) %}
-  {{- innerHtml | indent(2) | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
+  {%- if params.fieldset %}
+    {% call govukFieldset({
+      describedBy: describedBy,
+      classes: params.fieldset.classes,
+      attributes: params.fieldset.attributes,
+      legendText: params.fieldset.legendText,
+      legendHtml: params.fieldset.legendHtml,
+      legendHintText: params.fieldset.legendHintText,
+      legendHintHtml: params.fieldset.legendHintHtml
+    }) %}
+    {{- innerHtml | indent(2) | trim | safe }}
+    {% endcall %}
+  {% else %}
+    {{ innerHtml | trim | safe }}
+  {% endif %}
+</div>

--- a/src/date-input/template.test.js
+++ b/src/date-input/template.test.js
@@ -188,6 +188,14 @@ describe('Date input', () => {
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('id')).toEqual('my-date-input-day')
     })
+
+    it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
+      const $ = render('date-input', examples['with-errors'])
+
+      const $fieldset = $('.govuk-fieldset')
+
+      expect($fieldset.attr('role')).toEqual('group')
+    })
   })
 
   describe('when it includes a hint', () => {

--- a/src/date-input/template.test.js
+++ b/src/date-input/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('date-input')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Date input', () => {
   it('default example passes accessibility tests', async () => {
@@ -189,6 +190,73 @@ describe('Date input', () => {
     })
   })
 
+  describe('when it includes a hint', () => {
+    it('renders the hint', () => {
+      const $ = render('date-input', examples['with-errors'])
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the fieldset as "described by" the hint', () => {
+      const $ = render('date-input', examples['with-errors'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes an error message', () => {
+    it('renders the error message', () => {
+      const $ = render('date-input', examples['with-errors'])
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('uses the id as a prefix for the error message id', () => {
+      const $ = render('date-input', examples['with-errors'])
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('dob-errors-error')
+    })
+
+    it('associates the fieldset as "described by" the error message', () => {
+      const $ = render('date-input', examples['with-errors'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+  })
+
+  describe('when they include both a hint and an error message', () => {
+    it('associates the fieldset as described by both the hint and the error message', () => {
+      const $ = render('date-input', examples['with-errors'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('date-input', examples['default'])
@@ -202,52 +270,6 @@ describe('Date input', () => {
 
       expect(htmlWithClassName($, '.govuk-date-input__label')).toMatchSnapshot()
     })
-  })
-
-  it('renders the hint', () => {
-    const $ = render('date-input', examples['with-errors'])
-    expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-  })
-
-  it('associates the fieldset as "described by" the hint', () => {
-    const $ = render('date-input', examples['with-errors'])
-
-    const $fieldset = $('.govuk-fieldset')
-    const $hint = $('.govuk-hint')
-
-    const hintId = new RegExp(
-      WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-    )
-
-    expect($fieldset.attr('aria-describedby'))
-      .toMatch(hintId)
-  })
-
-  it('renders the error message', () => {
-    const $ = render('date-input', examples['with-errors'])
-    expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-  })
-
-  it('uses the id as a prefix for the error message id', () => {
-    const $ = render('date-input', examples['with-errors'])
-
-    const $errorMessage = $('.govuk-error-message')
-
-    expect($errorMessage.attr('id')).toEqual('dob-errors-error')
-  })
-
-  it('associates the fieldset as "described by" the error message', () => {
-    const $ = render('date-input', examples['with-errors'])
-
-    const $fieldset = $('.govuk-fieldset')
-    const $errorMessage = $('.govuk-error-message')
-
-    const errorMessageId = new RegExp(
-      WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-    )
-
-    expect($fieldset.attr('aria-describedby'))
-      .toMatch(errorMessageId)
   })
 
   it('passes through fieldset params without breaking', () => {

--- a/src/date-input/template.test.js
+++ b/src/date-input/template.test.js
@@ -204,6 +204,25 @@ describe('Date input', () => {
     })
   })
 
+  it('renders the hint', () => {
+    const $ = render('date-input', examples['with-errors'])
+    expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+  })
+
+  it('associates the fieldset as "described by" the hint', () => {
+    const $ = render('date-input', examples['with-errors'])
+
+    const $fieldset = $('.govuk-fieldset')
+    const $hint = $('.govuk-hint')
+
+    const hintId = new RegExp(
+      WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+    )
+
+    expect($fieldset.attr('aria-describedby'))
+      .toMatch(hintId)
+  })
+
   it('renders the error message', () => {
     const $ = render('date-input', examples['with-errors'])
     expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()

--- a/src/date-input/template.test.js
+++ b/src/date-input/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('date-input')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Date input', () => {
   it('default example passes accessibility tests', async () => {
     const $ = render('date-input', examples.default)
@@ -202,6 +204,33 @@ describe('Date input', () => {
     })
   })
 
+  it('renders the error message', () => {
+    const $ = render('date-input', examples['with-errors'])
+    expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+  })
+
+  it('uses the id as a prefix for the error message id', () => {
+    const $ = render('date-input', examples['with-errors'])
+
+    const $errorMessage = $('.govuk-error-message')
+
+    expect($errorMessage.attr('id')).toEqual('dob-errors-error')
+  })
+
+  it('associates the fieldset as "described by" the error message', () => {
+    const $ = render('date-input', examples['with-errors'])
+
+    const $fieldset = $('.govuk-fieldset')
+    const $errorMessage = $('.govuk-error-message')
+
+    const errorMessageId = new RegExp(
+      WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+    )
+
+    expect($fieldset.attr('aria-describedby'))
+      .toMatch(errorMessageId)
+  })
+
   it('passes through fieldset params without breaking', () => {
     const $ = render('date-input', examples['default'])
 
@@ -232,7 +261,6 @@ describe('Date input', () => {
       ]
     })
 
-    expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
   })
 })

--- a/src/error-message/error-message.yaml
+++ b/src/error-message/error-message.yaml
@@ -1,3 +1,17 @@
+accessibilityCriteria: |
+  When used with a single input, the error message MUST:
+  - be announced by screen readers when the input is focussed
+
+  When used with a group of multiple inputs (such as within a fieldset), the
+  error message MUST:
+  - be announced by screen readers when focussing the first input within the
+    group (first in this case refers to the focus order, not the DOM - if the
+    user is traversing backwards through the page then this would be the last
+    input within the group in the DOM)
+
+  When used with a group of multiple inputs, the error message SHOULD NOT:
+  - be announced every time for each individual input
+
 examples:
 - name: default
   data:

--- a/src/error-message/template.njk
+++ b/src/error-message/template.njk
@@ -1,3 +1,3 @@
-<span class="govuk-error-message{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+<span {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-error-message{%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
   {{ params.html | safe if params.html else params.text }}
 </span>

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -20,9 +20,6 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
       <legend class="govuk-fieldset__legend">
         What is your address?
-
-        <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
-
       </legend>
 
     </fieldset>
@@ -32,37 +29,7 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
     {% from 'fieldset/macro.njk' import govukFieldset %}
 
     {{ govukFieldset({
-      "legendText": "What is your address?",
-      "legendHintText": "For example, 10 Downing Street"
-    }) }}
-
-### Fieldset--with-error-message
-
-[Preview the fieldset--with-error-message example](http://govuk-frontend-review.herokuapp.com/components/fieldset/with-error-message/preview)
-
-#### Markup
-
-    <fieldset class="govuk-fieldset">
-
-      <legend class="govuk-fieldset__legend">
-        What is your address?
-
-        <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
-
-      </legend>
-
-    </fieldset>
-
-#### Macro
-
-    {% from 'fieldset/macro.njk' import govukFieldset %}
-
-    {{ govukFieldset({
-      "legendText": "What is your address?",
-      "legendHintText": "For example, 10 Downing Street",
-      "errorMessage": {
-        "text": "Please fill in the street input"
-      }
+      "legendText": "What is your address?"
     }) }}
 
 ## Dependencies
@@ -146,42 +113,6 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Legend text</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">legendHintText</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the legend element. If this is used, the legendText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">legendHintHtml</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the legend hint element. If this is used, the hintText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">errorMessage</th>
-
-<td class="govuk-table__cell ">object</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Provide text or html key with values. See errorMessage component for more details.</td>
 
 </tr>
 

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -16,18 +16,16 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          What is your address?
+      <legend class="govuk-fieldset__legend">
+        What is your address?
 
-          <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
+        <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
 
-        </legend>
+      </legend>
 
-      </fieldset>
-    </div>
+    </fieldset>
 
 #### Macro
 
@@ -44,22 +42,16 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset">
+    <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          What is your address?
+      <legend class="govuk-fieldset__legend">
+        What is your address?
 
-          <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
+        <span class="govuk-fieldset__hint">For example, 10 Downing Street</span>
 
-          <span class="govuk-error-message">
-          Please fill in the street input
-        </span>
+      </legend>
 
-        </legend>
-
-      </fieldset>
-    </div>
+    </fieldset>
 
 #### Macro
 

--- a/src/fieldset/__snapshots__/template.test.js.snap
+++ b/src/fieldset/__snapshots__/template.test.js.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`fieldset dependant components passes through errorMessage params without breaking 1`] = `
-
-<span class="govuk-error-message">
-  Please fill in the street input
-</span>
-
-`;

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -1,8 +1,6 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/iff";
 
-@import "../error-message/error-message";
-
 @import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
@@ -11,10 +9,6 @@
 @import "../globals/helpers/media-queries";
 
 @import "../globals/objects/form-group";
-
-
-
-
 
 @include govuk-exports("fieldset") {
   .govuk-fieldset {

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -1,12 +1,19 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/iff";
 
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
 @import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
 @import "../globals/helpers/clearfix";
 @import "../globals/helpers/spacing";
 @import "../globals/helpers/media-queries";
+
+@import "../globals/helpers/typography";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
 
 @import "../globals/objects/form-group";
 
@@ -52,13 +59,4 @@
   .govuk-fieldset__legend--bold {
     @include govuk-typography-weight-bold;
   }
-
-  // Hint text sits inside a legend, to be read by AT
-  .govuk-fieldset__hint {
-    @include govuk-typography-weight-regular;
-
-    display: block;
-    color: $govuk-secondary-text-colour;
-  }
-
 }

--- a/src/fieldset/fieldset.yaml
+++ b/src/fieldset/fieldset.yaml
@@ -2,10 +2,3 @@ examples:
 - name: default
   data:
     legendText: What is your address?
-    legendHintText: For example, 10 Downing Street
-- name: with-error-message
-  data:
-    legendText: What is your address?
-    legendHintText: For example, 10 Downing Street
-    errorMessage:
-      text: 'Please fill in the street input'

--- a/src/fieldset/index.njk
+++ b/src/fieldset/index.njk
@@ -81,48 +81,6 @@
     ],
     [
       {
-        text: 'legendHintText'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the legend element. If this is used, the legendText argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'legendHintHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the legend hint element. If this is used, the hintText argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'errorMessage'
-      },
-      {
-        text: 'object'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Provide text or html key with values. See errorMessage component for more details.'
-      }
-    ],
-    [
-      {
         text: 'attributes'
       },
       {

--- a/src/fieldset/template.njk
+++ b/src/fieldset/template.njk
@@ -1,19 +1,14 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-  <fieldset class="govuk-fieldset
-    {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-    {% if params.legendHtml or params.legendText %}
-    <legend class="govuk-fieldset__legend">
-      {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
-      {% if params.legendHintText or params.legendHintHtml %}
-      <span class="govuk-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
-      {% endif %}
-      {% if params.errorMessage %}
-      {{ govukErrorMessage(params.errorMessage) | trim | indent(4) -}}
-      {% endif %}
-    </legend>
+<fieldset class="govuk-fieldset
+  {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {% if params.legendHtml or params.legendText %}
+  <legend class="govuk-fieldset__legend">
+    {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+    {% if params.legendHintText or params.legendHintHtml %}
+    <span class="govuk-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
     {% endif %}
-  {{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
-  </fieldset>
-</div>
+  </legend>
+  {% endif %}
+{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
+</fieldset>

--- a/src/fieldset/template.njk
+++ b/src/fieldset/template.njk
@@ -5,9 +5,6 @@
   {% if params.legendHtml or params.legendText %}
   <legend class="govuk-fieldset__legend">
     {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
-    {% if params.legendHintText or params.legendHintHtml %}
-    <span class="govuk-fieldset__hint">{{ params.legendHintHtml | safe if params.legendHintHtml else params.legendHintText }}</span>
-    {% endif %}
   </legend>
   {% endif %}
 {{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}

--- a/src/fieldset/template.test.js
+++ b/src/fieldset/template.test.js
@@ -2,7 +2,7 @@
 
 const { axe } = require('jest-axe')
 
-const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpers')
+const { render, getExamples } = require('../../lib/jest-helpers')
 
 const examples = getExamples('fieldset')
 
@@ -64,39 +64,6 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is <b>your</b> address?')
   })
 
-  it('renders legendHintText using markup that is semantic', () => {
-    const $ = render('fieldset', {
-      legendText: 'What is your address?',
-      legendHintText: 'For example, 10 Downing Street'
-    })
-
-    const $component = $('.govuk-fieldset')
-    const $hint = $component.find('.govuk-fieldset__hint')
-    expect($hint.html()).toEqual('For example, 10 Downing Street')
-  })
-
-  it('renders escaped legendHintText when passing html', () => {
-    const $ = render('fieldset', {
-      legendText: 'What is your address?',
-      legendHintText: 'For example, <b>10 Downing Street</b>'
-    })
-
-    const $component = $('.govuk-fieldset')
-    const $hint = $component.find('.govuk-fieldset__hint')
-    expect($hint.html()).toEqual('For example, &lt;b&gt;10 Downing Street&lt;/b&gt;')
-  })
-
-  it('renders legendHintHtml', () => {
-    const $ = render('fieldset', {
-      legendText: 'What is your address?',
-      legendHintHtml: 'For example, <b>10 Downing Street</b>'
-    })
-
-    const $component = $('.govuk-fieldset')
-    const $hint = $component.find('.govuk-fieldset__hint')
-    expect($hint.html()).toEqual('For example, <b>10 Downing Street</b>')
-  })
-
   it('renders attributes', () => {
     const $ = render('fieldset', {
       attributes: {
@@ -108,20 +75,5 @@ describe('fieldset', () => {
     const $component = $('.govuk-fieldset')
     expect($component.attr('data-attribute')).toEqual('value')
     expect($component.attr('data-another-attribute')).toEqual('another-value')
-  })
-
-  describe('dependant components', () => {
-    it('have correct nesting order', () => {
-      const $ = render('fieldset', examples['with-error-message'])
-
-      const $component = $('.govuk-form-group > .govuk-fieldset')
-      expect($component.length).toBeTruthy()
-    })
-
-    it('passes through errorMessage params without breaking', () => {
-      const $ = render('fieldset', examples['with-error-message'])
-
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-    })
   })
 })

--- a/src/file-upload/README.md
+++ b/src/file-upload/README.md
@@ -20,7 +20,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       Upload a file
 
     </label>
-    <input type="file" id="file-upload-1" name="file-upload-1" class="govuk-file-upload">
+
+      <input type="file" id="file-upload-1" name="file-upload-1" class="govuk-file-upload">
     </div>
 
 #### Macro
@@ -49,7 +50,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       </span>
 
     </label>
-    <input type="file" id="file-upload-2" name="file-upload-2" class="govuk-file-upload">
+
+      <input type="file" id="file-upload-2" name="file-upload-2" class="govuk-file-upload">
     </div>
 
 #### Macro
@@ -78,12 +80,13 @@ Find out when to use the File upload component in your service in the [GOV.UK De
         Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       </span>
 
-      <span class="govuk-error-message">
+    </label>
+
+        <span id="file-upload-3-error" class="govuk-error-message">
       Error message goes here
     </span>
 
-    </label>
-    <input type="file" id="file-upload-3" name="file-upload-3" class="govuk-file-upload govuk-file-upload--error">
+      <input type="file" id="file-upload-3" name="file-upload-3" class="govuk-file-upload govuk-file-upload--error" aria-describedby="file-upload-3-error">
     </div>
 
 #### Macro
@@ -112,7 +115,8 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       Upload a photo
 
     </label>
-    <input type="file" id="file-upload-4" name="file-upload-4" value="C:\fakepath\myphoto.jpg" class="govuk-file-upload" accept=".jpg, .jpeg, .png">
+
+      <input type="file" id="file-upload-4" name="file-upload-4" value="C:\fakepath\myphoto.jpg" class="govuk-file-upload" accept=".jpg, .jpeg, .png">
     </div>
 
 #### Macro

--- a/src/file-upload/README.md
+++ b/src/file-upload/README.md
@@ -16,12 +16,12 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="file-upload-1">
-      Upload a file
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="file-upload-1">
+        Upload a file
+      </label>
 
-    </label>
-
-      <input type="file" id="file-upload-1" name="file-upload-1" class="govuk-file-upload">
+      <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
     </div>
 
 #### Macro
@@ -42,16 +42,16 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="file-upload-2">
-      Upload your photo
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="file-upload-2">
+        Upload your photo
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="file-upload-2-hint" class="govuk-hint">
         Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       </span>
 
-    </label>
-
-      <input type="file" id="file-upload-2" name="file-upload-2" class="govuk-file-upload">
+      <input class="govuk-file-upload" id="file-upload-2" name="file-upload-2" type="file" aria-describedby="file-upload-2-hint">
     </div>
 
 #### Macro
@@ -62,8 +62,10 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       "id": "file-upload-2",
       "name": "file-upload-2",
       "label": {
-        "text": "Upload your photo",
-        "hintText": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
+        "text": "Upload your photo"
+      },
+      "hint": {
+        "text": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
       }
     }) }}
 
@@ -73,20 +75,20 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <div class="govuk-form-group govuk-form-group--error"><label class="govuk-label" for="file-upload-3">
-      Upload a file
+    <div class="govuk-form-group govuk-form-group--error">
+      <label class="govuk-label" for="file-upload-3">
+        Upload a file
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="file-upload-3-hint" class="govuk-hint">
         Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
       </span>
 
-    </label>
+      <span id="file-upload-3-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-        <span id="file-upload-3-error" class="govuk-error-message">
-      Error message goes here
-    </span>
-
-      <input type="file" id="file-upload-3" name="file-upload-3" class="govuk-file-upload govuk-file-upload--error" aria-describedby="file-upload-3-error">
+      <input class="govuk-file-upload govuk-file-upload--error" id="file-upload-3" name="file-upload-3" type="file" aria-describedby="file-upload-3-hint file-upload-3-error">
     </div>
 
 #### Macro
@@ -97,8 +99,10 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       "id": "file-upload-3",
       "name": "file-upload-3",
       "label": {
-        "text": "Upload a file",
-        "hintText": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
+        "text": "Upload a file"
+      },
+      "hint": {
+        "text": "Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto."
       },
       "errorMessage": {
         "text": "Error message goes here"
@@ -111,12 +115,12 @@ Find out when to use the File upload component in your service in the [GOV.UK De
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="file-upload-4">
-      Upload a photo
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="file-upload-4">
+        Upload a photo
+      </label>
 
-    </label>
-
-      <input type="file" id="file-upload-4" name="file-upload-4" value="C:\fakepath\myphoto.jpg" class="govuk-file-upload" accept=".jpg, .jpeg, .png">
+      <input class="govuk-file-upload" id="file-upload-4" name="file-upload-4" type="file" value="C:\fakepath\myphoto.jpg" accept=".jpg, .jpeg, .png">
     </div>
 
 #### Macro
@@ -233,13 +237,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the error message component</td>
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/file-upload/__snapshots__/template.test.js.snap
+++ b/src/file-upload/__snapshots__/template.test.js.snap
@@ -10,6 +10,8 @@ exports[`File upload with dependant components renders with error message 1`] = 
 
 `;
 
+exports[`File upload with dependant components renders with hint 1`] = `""`;
+
 exports[`File upload with dependant components renders with label 1`] = `
 
 <label class="govuk-label"

--- a/src/file-upload/__snapshots__/template.test.js.snap
+++ b/src/file-upload/__snapshots__/template.test.js.snap
@@ -1,6 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`File upload with dependant components renders with error message 1`] = `
+exports[`File upload when it includes a hint renders with hint 1`] = `""`;
+
+exports[`File upload when it includes an error message renders with error message 1`] = `
 
 <span id="file-upload-with-error-error"
       class="govuk-error-message"
@@ -9,8 +11,6 @@ exports[`File upload with dependant components renders with error message 1`] = 
 </span>
 
 `;
-
-exports[`File upload with dependant components renders with hint 1`] = `""`;
 
 exports[`File upload with dependant components renders with label 1`] = `
 

--- a/src/file-upload/__snapshots__/template.test.js.snap
+++ b/src/file-upload/__snapshots__/template.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`File upload with dependant components renders with error message 1`] = `
 
-<span class="govuk-error-message">
+<span id="file-upload-with-error-error"
+      class="govuk-error-message"
+>
   Error message
 </span>
 

--- a/src/file-upload/_file-upload.scss
+++ b/src/file-upload/_file-upload.scss
@@ -1,5 +1,6 @@
 @import "../globals/tools/exports";
 
+@import "../error-message/error-message";
 @import "../label/label";
 
 @import "../globals/settings/spacing";

--- a/src/file-upload/_file-upload.scss
+++ b/src/file-upload/_file-upload.scss
@@ -1,12 +1,13 @@
+@import "../globals/helpers/focusable";
 @import "../globals/tools/exports";
-
-@import "../error-message/error-message";
-@import "../label/label";
-
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
 @import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
-@import "../globals/helpers/focusable";
+@import "../error-message/error-message";
+@import "../hint/hint";
+@import "../label/label";
 
 @include govuk-exports("file-upload") {
   .govuk-file-upload {

--- a/src/file-upload/file-upload.yaml
+++ b/src/file-upload/file-upload.yaml
@@ -11,14 +11,16 @@ examples:
     name: file-upload-2
     label:
       text: Upload your photo
-      hintText: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+    hint:
+      text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
 - name: with-error-message
   data:
     id: file-upload-3
     name: file-upload-3
     label:
       text: Upload a file
-      hintText: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+    hint:
+      text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
     errorMessage:
       text: Error message goes here
 - name: with-value-and-attributes

--- a/src/file-upload/index.njk
+++ b/src/file-upload/index.njk
@@ -94,6 +94,20 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
     ],
     [
       {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
         text: 'errorMessage'
       },
       {
@@ -103,7 +117,7 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
         text: 'No'
       },
       {
-        text: 'Arguments for the error message component'
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/file-upload/template.njk
+++ b/src/file-upload/template.njk
@@ -1,33 +1,41 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# a record of other elements that we need to associate with the input using 
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
-
-{#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-
-  {{- govukLabel({
+  {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
-    hintText: params.label.hintText,
-    hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
     for: params.id
-  }) -}}
-
-  {% if params.errorMessage %}
-    {% set errorId = params.id + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
-  <input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-file-upload {{- ' govuk-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
+  {%- if params.value %} value="{{ params.value }}"{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 </div>

--- a/src/file-upload/template.njk
+++ b/src/file-upload/template.njk
@@ -1,4 +1,9 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "label/macro.njk" import govukLabel %}
+
+{# a record of other elements that we need to associate with the input using 
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 {#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
@@ -10,9 +15,19 @@
     hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
-    errorMessage: params.errorMessage,
     for: params.id
   }) -}}
 
-  <input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-file-upload {{- ' govuk-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {% if params.errorMessage %}
+    {% set errorId = params.id + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
+  <input type="file" id="{{ params.id }}" name="{{ params.name }}" {%- if params.value %} value="{{ params.value }}"{% endif %} class="govuk-file-upload {{- ' govuk-file-upload--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 </div>

--- a/src/file-upload/template.test.js
+++ b/src/file-upload/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('file-upload')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('File upload', () => {
   describe('by default', () => {
@@ -65,6 +66,106 @@ describe('File upload', () => {
     })
   })
 
+  describe('when it includes a hint', () => {
+    it('renders with hint', () => {
+      const $ = render('file-upload', {
+        id: 'file-upload-with-hint',
+        errorMessage: {
+          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the hint', () => {
+      const $ = render('file-upload', {
+        id: 'file-upload-with-hint',
+        hint: {
+          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
+        }
+      })
+
+      const $component = $('.govuk-file-upload')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes an error message', () => {
+    it('renders with error message', () => {
+      const $ = render('file-upload', {
+        id: 'file-upload-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the error message', () => {
+      const $ = render('file-upload', {
+        id: 'input-with-error',
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-file-upload')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
+    it('includes the error class on the component', () => {
+      const $ = render('file-upload', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-file-upload')
+      expect($component.hasClass('govuk-file-upload--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes both a hint and an error message', () => {
+    it('associates the input as described by both the hint and the error message', () => {
+      const $ = render('file-upload', {
+        id: 'input-with-error',
+        errorMessage: {
+          'text': 'Error message'
+        },
+        hint: {
+          'text': 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-file-upload')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('file-upload', {
@@ -98,77 +199,6 @@ describe('File upload', () => {
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('my-file-upload')
-    })
-
-    it('renders with hint', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-hint',
-        errorMessage: {
-          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-    })
-
-    it('associates the input as "described by" the hint', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-hint',
-        hint: {
-          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
-        }
-      })
-
-      const $component = $('.govuk-file-upload')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($component.attr('aria-describedby'))
-        .toMatch(hintId)
-    })
-
-    it('renders with error message', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-    })
-
-    it('associates the input as "described by" the error message', () => {
-      const $ = render('file-upload', {
-        id: 'input-with-error',
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-file-upload')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
-    })
-
-    it('has error class when rendered with error message', () => {
-      const $ = render('file-upload', {
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-file-upload')
-      expect($component.hasClass('govuk-file-upload--error')).toBeTruthy()
     })
   })
 })

--- a/src/file-upload/template.test.js
+++ b/src/file-upload/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('file-upload')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('File upload', () => {
   describe('by default', () => {
     it('passes accessibility tests', async () => {
@@ -67,7 +69,7 @@ describe('File upload', () => {
     it('have correct nesting order', () => {
       const $ = render('file-upload', {
         errorMessage: {
-          'text': 'Error message'
+          text: 'Error message'
         }
       })
 
@@ -79,7 +81,7 @@ describe('File upload', () => {
       const $ = render('file-upload', {
         id: 'my-file-upload',
         label: {
-          'text': 'Full address'
+          text: 'Full address'
         }
       })
 
@@ -90,7 +92,7 @@ describe('File upload', () => {
       const $ = render('file-upload', {
         id: 'my-file-upload',
         label: {
-          'text': 'Full address'
+          text: 'Full address'
         }
       })
 
@@ -100,12 +102,32 @@ describe('File upload', () => {
 
     it('renders with error message', () => {
       const $ = render('file-upload', {
+        id: 'file-upload-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the error message', () => {
+      const $ = render('file-upload', {
+        id: 'input-with-error',
         errorMessage: {
           'text': 'Error message'
         }
       })
 
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+      const $component = $('.govuk-file-upload')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(errorMessageId)
     })
 
     it('has error class when rendered with error message', () => {

--- a/src/file-upload/template.test.js
+++ b/src/file-upload/template.test.js
@@ -100,6 +100,36 @@ describe('File upload', () => {
       expect($label.attr('for')).toEqual('my-file-upload')
     })
 
+    it('renders with hint', () => {
+      const $ = render('file-upload', {
+        id: 'file-upload-with-hint',
+        errorMessage: {
+          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the hint', () => {
+      const $ = render('file-upload', {
+        id: 'file-upload-with-hint',
+        hint: {
+          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
+        }
+      })
+
+      const $component = $('.govuk-file-upload')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+
     it('renders with error message', () => {
       const $ = render('file-upload', {
         id: 'file-upload-with-error',

--- a/src/globals/helpers/_clearfix.scss
+++ b/src/globals/helpers/_clearfix.scss
@@ -1,3 +1,5 @@
+@import "../tools/exports";
+
 // Mixin to clear floats
 @mixin govuk-clearfix {
   &:after {

--- a/src/hint/README.md
+++ b/src/hint/README.md
@@ -1,0 +1,183 @@
+# Hint
+
+## Introduction
+
+Use hint text for supporting contextual help
+
+## Quick start examples
+
+### Component default
+
+[Preview the hint component](http://govuk-frontend-review.herokuapp.com/components/hint/preview)
+
+#### Markup
+
+    <span class="govuk-hint">
+      It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+    </span>
+
+#### Macro
+
+    {% from 'hint/macro.njk' import govukHint %}
+
+    {{ govukHint({
+      "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+    }) }}
+
+### Hint--with html
+
+[Preview the hint--with html example](http://govuk-frontend-review.herokuapp.com/components/hint/with html/preview)
+
+#### Markup
+
+    <span class="govuk-hint">
+      It’s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>. For example, ‘QQ 12 34 56 C’.
+    </span>
+
+#### Macro
+
+    {% from 'hint/macro.njk' import govukHint %}
+
+    {{ govukHint({
+      "html": "It’s on your National Insurance card, benefit letter, payslip or <a class=\"govuk-link\" href=\"#\">P60</a>. For example, ‘QQ 12 34 56 C’."
+    }) }}
+
+## Dependencies
+
+To consume the hint component you must be running npm version 5 or above.
+
+## Installation
+
+    npm install --save @govuk-frontend/hint
+
+## Requirements
+
+### Build tool configuration
+
+When compiling the Sass files you'll need to define includePaths to reference the node_modules directory. Below is a sample configuration using gulp
+
+    .pipe(sass({
+      includePaths: 'node_modules/'
+    }))
+
+### Static asset path configuration
+
+To show the button image you need to configure your app to show these assets. Below is a sample configuration using Express js:
+
+    app.use('/public', express.static(path.join(__dirname, '/node_modules/@govuk-frontend/icons')))
+
+## Component arguments
+
+If you are using Nunjucks,then macros take the following arguments
+
+<table class="govuk-table">
+
+<thead class="govuk-table__head">
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="col">Name</th>
+
+<th class="govuk-table__header" scope="col">Type</th>
+
+<th class="govuk-table__header" scope="col">Required</th>
+
+<th class="govuk-table__header" scope="col">Description</th>
+
+</tr>
+
+</thead>
+
+<tbody class="govuk-table__body">
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">id</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">The id of the hint</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">text</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text to use within the hint</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">HTML to use within the hint. If this is provided, the text argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the hint span tag.</td>
+
+</tr>
+
+</tbody>
+
+</table>
+
+### Setting up Nunjucks views and paths
+
+Below is an example setup using express configure views:
+
+    nunjucks.configure('node_modules/@govuk-frontend', {
+      autoescape: true,
+      cache: false,
+      express: app
+    })
+
+## Getting updates
+
+To check whether you have the latest version of the button run:
+
+    npm outdated @govuk-frontend/hint
+
+To update the latest version run:
+
+    npm update @govuk-frontend/hint
+
+## Contribution
+
+Guidelines can be found at [on our Github repository.](https://github.com/alphagov/govuk-frontend/blob/master/CONTRIBUTING.md "link to contributing guidelines on our github repository")
+
+## License
+
+MIT

--- a/src/hint/_hint.scss
+++ b/src/hint/_hint.scss
@@ -1,0 +1,19 @@
+@import "../globals/helpers/typography";
+@import "../globals/helpers/media-queries";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
+@import "../globals/tools/exports";
+
+@include govuk-exports("hint") {
+  .govuk-hint {
+    @include govuk-font-regular-19;
+
+    display: block;
+    color: $govuk-secondary-text-colour;
+  }
+}

--- a/src/hint/hint.njk
+++ b/src/hint/hint.njk
@@ -1,0 +1,7 @@
+{% from "hint/macro.njk" import govukHint %}
+
+{{ govukHint({
+  text: "It’s on your National Insurance card, benefit letter, payslip or P60.
+    For example, ‘QQ 12 34 56 C’.",
+  id: "hint-id"
+}) }}

--- a/src/hint/hint.yaml
+++ b/src/hint/hint.yaml
@@ -1,3 +1,17 @@
+accessibilityCriteria: |
+  When used with a single input, the hint MUST:
+  - be announced by screen readers when the input is focussed
+
+  When used with a group of multiple inputs (such as within a fieldset), the
+  hint MUST:
+  - be announced by screen readers when focussing the first input within the
+    group (first in this case refers to the focus order, not the DOM - if the
+    user is traversing backwards through the page then this would be the last
+    input within the group in the DOM)
+
+  When used with a group of multiple inputs, the hint SHOULD NOT:
+  - be announced every time for each individual input
+
 examples:
   - name: default
     data:

--- a/src/hint/hint.yaml
+++ b/src/hint/hint.yaml
@@ -1,0 +1,9 @@
+examples:
+  - name: default
+    data:
+      text: 'It’s on your National Insurance card, benefit letter, payslip or P60.
+        For example, ‘QQ 12 34 56 C’.'
+  - name: with html
+    data:
+      html: 'It’s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.
+        For example, ‘QQ 12 34 56 C’.'

--- a/src/hint/index.njk
+++ b/src/hint/index.njk
@@ -1,0 +1,112 @@
+{% if isReadme %}
+  {% set parentTemplate = "readme.njk"  %}
+{% else %}
+  {% set parentTemplate = "component.njk"  %}
+{% endif %}
+
+{% extends parentTemplate %}
+
+{# Commented out blocks below inherit from views/component.njk #}
+
+{# componentName #}
+
+{% block componentDescription %}
+  Use hint text for supporting contextual help
+{% endblock %}
+
+{# examples #}
+
+{# override link to design system here if it's different to base url + componentName #}
+{% set componentGuidanceLink = false %}
+
+{% block componentArguments %}
+{{ govukTable({
+  'firstCellIsHeader': true,
+  'head' : [
+    {
+      text: 'Name'
+    },
+    {
+      text: 'Type'
+    },
+    {
+      text: 'Required'
+    },
+    {
+      text: 'Description'
+    }
+  ],
+  'rows' : [
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes'
+      }
+    ],
+    [
+      {
+        text: 'id'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'The id of the hint'
+      }
+    ],
+    [
+      {
+        text: 'text'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Text to use within the hint'
+      }
+    ],
+    [
+      {
+        text: 'html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'HTML to use within the hint. If this is provided, the text argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the hint span tag.'
+      }
+    ]
+  ]
+})}}
+{% endblock %}

--- a/src/hint/macro.njk
+++ b/src/hint/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukHint(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/hint/template.njk
+++ b/src/hint/template.njk
@@ -1,0 +1,4 @@
+<span {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-hint {%- if params.classes %} {{ params.classes }}{% endif %}"
+{%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {{ params.html | safe if params.html else params.text }}
+</span>

--- a/src/hint/template.test.js
+++ b/src/hint/template.test.js
@@ -1,0 +1,65 @@
+/* eslint-env jest */
+
+const { axe } = require('jest-axe')
+
+const { render, getExamples } = require('../../lib/jest-helpers')
+
+const examples = getExamples('hint')
+
+describe('Hint', () => {
+  describe('by default', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('hint', examples.default)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders with classes', () => {
+      const $ = render('hint', {
+        classes: 'app-hint--custom-modifier'
+      })
+
+      const $component = $('.govuk-hint')
+      expect($component.hasClass('app-hint--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with id', () => {
+      const $ = render('hint', {
+        id: 'my-hint'
+      })
+
+      const $component = $('.govuk-hint')
+      expect($component.attr('id')).toEqual('my-hint')
+    })
+
+    it('allows text to be passed whilst escaping HTML entities', () => {
+      const $ = render('hint', {
+        text: 'Unexpected <strong>bold text</strong> in body'
+      })
+
+      const content = $('.govuk-hint').html().trim()
+      expect(content).toEqual('Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body')
+    })
+
+    it('allows HTML to be passed un-escaped', () => {
+      const $ = render('hint', {
+        html: 'Unexpected <b>bold text</b> in body copy'
+      })
+
+      const content = $('.govuk-hint').html().trim()
+      expect(content).toEqual('Unexpected <b>bold text</b> in body copy')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('hint', {
+        attributes: {
+          'data-attribute': 'my data value'
+        }
+      })
+
+      const $component = $('.govuk-hint')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+  })
+})

--- a/src/input/README.md
+++ b/src/input/README.md
@@ -16,10 +16,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="input-1">
-      National Insurance number
-
-    </label>
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-1">
+        National Insurance number
+      </label>
 
       <input class="govuk-input" id="input-1" name="test-name" type="text">
     </div>
@@ -42,16 +42,16 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="input-2">
-      National insurance number
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-2">
+        National insurance number
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="input-2-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-    </label>
-
-      <input class="govuk-input" id="input-2" name="test-name-2" type="text">
+      <input class="govuk-input" id="input-2" name="test-name-2" type="text" aria-describedby="input-2-hint">
     </div>
 
 #### Macro
@@ -60,8 +60,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     {{ govukInput({
       "label": {
-        "text": "National insurance number",
-        "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-2",
       "name": "test-name-2"
@@ -73,20 +75,20 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group govuk-form-group--error"><label class="govuk-label" for="input-3">
-      National Insurance number
+    <div class="govuk-form-group govuk-form-group--error">
+      <label class="govuk-label" for="input-3">
+        National Insurance number
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="input-3-hint" class="govuk-hint">
         It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-    </label>
+      <span id="input-3-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-        <span id="input-3-error" class="govuk-error-message">
-      Error message goes here
-    </span>
-
-      <input class="govuk-input govuk-input--error" id="input-3" name="test-name-3" type="text" aria-describedby="input-3-error">
+      <input class="govuk-input govuk-input--error" id="input-3" name="test-name-3" type="text" aria-describedby="input-3-hint input-3-error">
     </div>
 
 #### Macro
@@ -95,8 +97,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     {{ govukInput({
       "label": {
-        "text": "National Insurance number",
-        "hintHtml": "It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "National Insurance number"
+      },
+      "hint": {
+        "html": "It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-3",
       "name": "test-name-3",
@@ -111,16 +115,16 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="input-2">
-      National insurance number
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-2">
+        National insurance number
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="input-2-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-    </label>
-
-      <input class="govuk-input govuk-input--width-10" id="input-2" name="test-name-4" type="text">
+      <input class="govuk-input govuk-input--width-10" id="input-2" name="test-name-4" type="text" aria-describedby="input-2-hint">
     </div>
 
 #### Macro
@@ -129,8 +133,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     {{ govukInput({
       "label": {
-        "text": "National insurance number",
-        "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-2",
       "name": "test-name-4",
@@ -143,16 +149,16 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="input-2">
-      National insurance number
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-2">
+        National insurance number
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="input-2-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-    </label>
-
-      <input class="govuk-input govuk-input--width-20" id="input-2" name="test-name-5" type="text">
+      <input class="govuk-input govuk-input--width-20" id="input-2" name="test-name-5" type="text" aria-describedby="input-2-hint">
     </div>
 
 #### Macro
@@ -161,8 +167,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     {{ govukInput({
       "label": {
-        "text": "National insurance number",
-        "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-2",
       "name": "test-name-5",
@@ -175,16 +183,16 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="input-2">
-      National insurance number
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-2">
+        National insurance number
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="input-2-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-    </label>
-
-      <input class="govuk-input govuk-input--width-30" id="input-2" name="test-name-6" type="text">
+      <input class="govuk-input govuk-input--width-30" id="input-2" name="test-name-6" type="text" aria-describedby="input-2-hint">
     </div>
 
 #### Macro
@@ -193,8 +201,10 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 
     {{ govukInput({
       "label": {
-        "text": "National insurance number",
-        "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-2",
       "name": "test-name-6",
@@ -311,13 +321,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional error message</td>
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/input/README.md
+++ b/src/input/README.md
@@ -20,7 +20,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       National Insurance number
 
     </label>
-    <input class="govuk-input" id="input-1" name="test-name" type="text">
+
+      <input class="govuk-input" id="input-1" name="test-name" type="text">
     </div>
 
 #### Macro
@@ -49,7 +50,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       </span>
 
     </label>
-    <input class="govuk-input" id="input-2" name="test-name-2" type="text">
+
+      <input class="govuk-input" id="input-2" name="test-name-2" type="text">
     </div>
 
 #### Macro
@@ -78,12 +80,13 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
         It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <span class="govuk-error-message">
+    </label>
+
+        <span id="input-3-error" class="govuk-error-message">
       Error message goes here
     </span>
 
-    </label>
-    <input class="govuk-input govuk-input--error" id="input-3" name="test-name-3" type="text">
+      <input class="govuk-input govuk-input--error" id="input-3" name="test-name-3" type="text" aria-describedby="input-3-error">
     </div>
 
 #### Macro
@@ -116,7 +119,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       </span>
 
     </label>
-    <input class="govuk-input govuk-input--width-10" id="input-2" name="test-name-4" type="text">
+
+      <input class="govuk-input govuk-input--width-10" id="input-2" name="test-name-4" type="text">
     </div>
 
 #### Macro
@@ -147,7 +151,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       </span>
 
     </label>
-    <input class="govuk-input govuk-input--width-20" id="input-2" name="test-name-5" type="text">
+
+      <input class="govuk-input govuk-input--width-20" id="input-2" name="test-name-5" type="text">
     </div>
 
 #### Macro
@@ -178,7 +183,8 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       </span>
 
     </label>
-    <input class="govuk-input govuk-input--width-30" id="input-2" name="test-name-6" type="text">
+
+      <input class="govuk-input govuk-input--width-30" id="input-2" name="test-name-6" type="text">
     </div>
 
 #### Macro

--- a/src/input/__snapshots__/template.test.js.snap
+++ b/src/input/__snapshots__/template.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`Input with dependant components renders with error message 1`] = `
 
-<span class="govuk-error-message">
+<span id="input-with-error-error"
+      class="govuk-error-message"
+>
   Error message
 </span>
 

--- a/src/input/__snapshots__/template.test.js.snap
+++ b/src/input/__snapshots__/template.test.js.snap
@@ -10,6 +10,16 @@ exports[`Input with dependant components renders with error message 1`] = `
 
 `;
 
+exports[`Input with dependant components renders with hint 1`] = `
+
+<span id="input-with-hint-hint"
+      class="govuk-hint"
+>
+  It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+</span>
+
+`;
+
 exports[`Input with dependant components renders with label 1`] = `
 
 <label class="govuk-label"

--- a/src/input/__snapshots__/template.test.js.snap
+++ b/src/input/__snapshots__/template.test.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Input with dependant components renders with error message 1`] = `
-
-<span id="input-with-error-error"
-      class="govuk-error-message"
->
-  Error message
-</span>
-
-`;
-
-exports[`Input with dependant components renders with hint 1`] = `
+exports[`Input when it includes a hint renders the hint 1`] = `
 
 <span id="input-with-hint-hint"
       class="govuk-hint"
 >
   It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+</span>
+
+`;
+
+exports[`Input when it includes an error message renders the error message 1`] = `
+
+<span id="input-with-error-error"
+      class="govuk-error-message"
+>
+  Error message
 </span>
 
 `;

--- a/src/input/_input.scss
+++ b/src/input/_input.scss
@@ -1,9 +1,8 @@
 @import "../globals/tools/exports";
-@import "../fieldset/fieldset";
-@import "../label/label";
-@import "../error-message/error-message";
-
 @import "../globals/helpers/focusable";
+
+@import "../error-message/error-message";
+@import "../label/label";
 
 @include govuk-exports("input") {
   .govuk-input {

--- a/src/input/_input.scss
+++ b/src/input/_input.scss
@@ -1,7 +1,12 @@
-@import "../globals/tools/exports";
 @import "../globals/helpers/focusable";
+@import "../globals/tools/exports";
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
 
 @import "../error-message/error-message";
+@import "../hint/hint";
 @import "../label/label";
 
 @include govuk-exports("input") {

--- a/src/input/index.njk
+++ b/src/input/index.njk
@@ -109,6 +109,20 @@
     ],
     [
       {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
         text: 'errorMessage'
       },
       {
@@ -118,7 +132,7 @@
         text: 'No'
       },
       {
-        text: 'Optional error message'
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/input/input.yaml
+++ b/src/input/input.yaml
@@ -9,14 +9,16 @@ examples:
     data:
       label:
         text: National insurance number
-        hintText: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-2
       name: test-name-2
   - name: with-error-message
     data:
       label:
         text: National Insurance number
-        hintHtml: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      hint:
+        html: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-3
       name: test-name-3
       errorMessage:
@@ -25,7 +27,8 @@ examples:
     data:
       label:
         text: National insurance number
-        hintText: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-2
       name: test-name-4
       classes: govuk-input--width-10
@@ -33,7 +36,8 @@ examples:
     data:
       label:
         text: National insurance number
-        hintText: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-2
       name: test-name-5
       classes: govuk-input--width-20
@@ -41,7 +45,8 @@ examples:
     data:
       label:
         text: National insurance number
-        hintText: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-2
       name: test-name-6
       classes: govuk-input--width-30

--- a/src/input/template.njk
+++ b/src/input/template.njk
@@ -1,4 +1,9 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "label/macro.njk" import govukLabel %}
+
+{# a record of other elements that we need to associate with the input using 
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
 
@@ -9,11 +14,22 @@
     hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
-    errorMessage: params.errorMessage,
     for: params.id
   }) -}}
 
+  {% if params.errorMessage %}
+    {% set errorId = params.id + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
   {%- if params.value %} value="{{ params.value}}"{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
 </div>

--- a/src/input/template.njk
+++ b/src/input/template.njk
@@ -1,33 +1,39 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# a record of other elements that we need to associate with the input using 
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
-
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-
-  {{- govukLabel({
+  {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
-    hintText: params.label.hintText,
-    hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
     for: params.id
-  }) -}}
-
-  {% if params.errorMessage %}
-    {% set errorId = params.id + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}

--- a/src/input/template.test.js
+++ b/src/input/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('input')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Input', () => {
   describe('by default', () => {
     it('passes accessibility tests', async () => {
@@ -117,12 +119,32 @@ describe('Input', () => {
 
     it('renders with error message', () => {
       const $ = render('input', {
+        id: 'input-with-error',
         errorMessage: {
           'text': 'Error message'
         }
       })
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the error message', () => {
+      const $ = render('input', {
+        id: 'input-with-error',
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $input = $('.govuk-input')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(errorMessageId)
     })
 
     it('has error class when rendered with error message', () => {

--- a/src/input/template.test.js
+++ b/src/input/template.test.js
@@ -117,6 +117,36 @@ describe('Input', () => {
       expect($label.attr('for')).toEqual('my-input')
     })
 
+    it('renders with hint', () => {
+      const $ = render('input', {
+        id: 'input-with-hint',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the hint', () => {
+      const $ = render('input', {
+        id: 'input-with-hint',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      const $input = $('.govuk-input')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+
     it('renders with error message', () => {
       const $ = render('input', {
         id: 'input-with-error',

--- a/src/input/template.test.js
+++ b/src/input/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('input')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Input', () => {
   describe('by default', () => {
@@ -81,6 +82,105 @@ describe('Input', () => {
     })
   })
 
+  describe('when it includes a hint', () => {
+    it('renders the hint', () => {
+      const $ = render('input', {
+        id: 'input-with-hint',
+        hint: {
+          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the hint', () => {
+      const $ = render('input', {
+        id: 'input-with-hint',
+        hint: {
+          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      const $input = $('.govuk-input')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes an error message', () => {
+    it('renders the error message', () => {
+      const $ = render('input', {
+        id: 'input-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the input as "described by" the error message', () => {
+      const $ = render('input', {
+        id: 'input-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      const $input = $('.govuk-input')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
+    it('includes the error class on the input', () => {
+      const $ = render('input', {
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-input')
+      expect($component.hasClass('govuk-input--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes both a hint and an error message', () => {
+    it('associates the input as described by both the hint and the error message', () => {
+      const $ = render('input', {
+        errorMessage: {
+          text: 'Error message'
+        },
+        hint: {
+          text: 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-input')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('input', {
@@ -115,77 +215,6 @@ describe('Input', () => {
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('my-input')
-    })
-
-    it('renders with hint', () => {
-      const $ = render('input', {
-        id: 'input-with-hint',
-        hint: {
-          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-    })
-
-    it('associates the input as "described by" the hint', () => {
-      const $ = render('input', {
-        id: 'input-with-hint',
-        hint: {
-          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
-
-      const $input = $('.govuk-input')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($input.attr('aria-describedby'))
-        .toMatch(hintId)
-    })
-
-    it('renders with error message', () => {
-      const $ = render('input', {
-        id: 'input-with-error',
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-    })
-
-    it('associates the input as "described by" the error message', () => {
-      const $ = render('input', {
-        id: 'input-with-error',
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $input = $('.govuk-input')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
-    })
-
-    it('has error class when rendered with error message', () => {
-      const $ = render('input', {
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-input')
-      expect($component.hasClass('govuk-input--error')).toBeTruthy()
     })
   })
 })

--- a/src/label/README.md
+++ b/src/label/README.md
@@ -55,37 +55,6 @@ Use labels for all form fields.
       "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
     }) }}
 
-### Label--with error message
-
-[Preview the label--with error message example](http://govuk-frontend-review.herokuapp.com/components/label/with error message/preview)
-
-#### Markup
-
-    <label class="govuk-label">
-      National Insurance number
-
-      <span class="govuk-label__hint">
-        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
-      </span>
-
-      <span class="govuk-error-message">
-      Error message goes here
-    </span>
-
-    </label>
-
-#### Macro
-
-    {% from 'label/macro.njk' import govukLabel %}
-
-    {{ govukLabel({
-      "text": "National Insurance number",
-      "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.",
-      "errorMessage": {
-        "text": "Error message goes here"
-      }
-    }) }}
-
 ## Dependencies
 
 To consume the label component you must be running npm version 5 or above.

--- a/src/label/README.md
+++ b/src/label/README.md
@@ -14,11 +14,6 @@ Use labels for all form fields.
 
     <label class="govuk-label">
       National Insurance number
-
-      <span class="govuk-label__hint">
-        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
-      </span>
-
     </label>
 
 #### Macro
@@ -26,8 +21,7 @@ Use labels for all form fields.
     {% from 'label/macro.njk' import govukLabel %}
 
     {{ govukLabel({
-      "text": "National Insurance number",
-      "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      "text": "National Insurance number"
     }) }}
 
 ### Label--with bold text
@@ -38,11 +32,6 @@ Use labels for all form fields.
 
     <label class="govuk-label govuk-label--bold">
       National Insurance number
-
-      <span class="govuk-label__hint">
-        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
-      </span>
-
     </label>
 
 #### Macro
@@ -51,8 +40,7 @@ Use labels for all form fields.
 
     {{ govukLabel({
       "classes": "govuk-label--bold",
-      "text": "National Insurance number",
-      "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      "text": "National Insurance number"
     }) }}
 
 ## Dependencies
@@ -148,42 +136,6 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">The value of the for attribute, the id of the input the label is associated with</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">hintText</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional text to use as a hint</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">hintHtml</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional HTML to use as a hint. If this is provided, the hintText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">errorMessage</th>
-
-<td class="govuk-table__cell ">object</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional error message. See errorMessage component.</td>
 
 </tr>
 

--- a/src/label/__snapshots__/template.test.js.snap
+++ b/src/label/__snapshots__/template.test.js.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Label with dependant components renders the error message text 1`] = `
-
-<span class="govuk-error-message">
-  Error message goes here
-</span>
-
-`;

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -1,3 +1,12 @@
+@import "../globals/helpers/typography";
+@import "../globals/helpers/media-queries";
+
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
+@import "../globals/settings/typography-font-stacks";
+@import "../globals/settings/typography-font";
+@import "../globals/settings/typography-responsive";
+
 @import "../globals/tools/exports";
 
 @include govuk-exports("label") {
@@ -10,13 +19,5 @@
 
   .govuk-label--bold {
     @include govuk-typography-weight-bold;
-  }
-
-  // Hint text sits inside a label, to be read by AT
-  .govuk-label__hint {
-    @include govuk-typography-weight-regular;
-
-    display: block;
-    color: $govuk-secondary-text-colour;
   }
 }

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -1,7 +1,5 @@
 @import "../globals/tools/exports";
 
-@import "../error-message/error-message";
-
 @include govuk-exports("label") {
   .govuk-label {
     @include govuk-font-regular-19;

--- a/src/label/index.njk
+++ b/src/label/index.njk
@@ -95,48 +95,6 @@
     ],
     [
       {
-        text: 'hintText'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional text to use as a hint'
-      }
-    ],
-    [
-      {
-        text: 'hintHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional HTML to use as a hint. If this is provided, the hintText argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'errorMessage'
-      },
-      {
-        text: 'object'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional error message. See errorMessage component.'
-      }
-    ],
-    [
-      {
         text: 'attributes'
       },
       {

--- a/src/label/label.njk
+++ b/src/label/label.njk
@@ -1,7 +1,6 @@
 {% from "label/macro.njk" import govukLabel %}
 
 {{ govukLabel({
-  "text": "National Insurance number",
-  "hintText": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+  "text": "National Insurance number"
 }
 ) }}

--- a/src/label/label.yaml
+++ b/src/label/label.yaml
@@ -2,11 +2,7 @@ examples:
   - name: default
     data:
       text: National Insurance number
-      hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.'
   - name: with bold text
     data:
       classes: govuk-label--bold
       text: National Insurance number
-      hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.'

--- a/src/label/label.yaml
+++ b/src/label/label.yaml
@@ -10,10 +10,3 @@ examples:
       text: National Insurance number
       hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
         For example, ‘QQ 12 34 56 C’.'
-  - name: with error message
-    data:
-      text: National Insurance number
-      hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60.
-        For example, ‘QQ 12 34 56 C’.'
-      errorMessage:
-        text: Error message goes here

--- a/src/label/template.njk
+++ b/src/label/template.njk
@@ -1,5 +1,3 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-
 <label class="govuk-label{%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
   {%- if params.for %} for="{{ params.for }}"{% endif %}>
@@ -8,8 +6,5 @@
   <span class="govuk-label__hint">
     {{ params.hintHtml | safe if params.hintHtml else params.hintText }}
   </span>
-  {% endif %}
-  {% if params.errorMessage %}
-  {{ govukErrorMessage(params.errorMessage) -}}
   {% endif %}
 </label>

--- a/src/label/template.njk
+++ b/src/label/template.njk
@@ -2,9 +2,4 @@
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
   {%- if params.for %} for="{{ params.for }}"{% endif %}>
   {{ params.html | safe if params.html else params.text }}
-  {% if params.hintText or params.hintHtml %}
-  <span class="govuk-label__hint">
-    {{ params.hintHtml | safe if params.hintHtml else params.hintText }}
-  </span>
-  {% endif %}
 </label>

--- a/src/label/template.test.js
+++ b/src/label/template.test.js
@@ -58,13 +58,6 @@ describe('Label', () => {
       expect(labelText).toEqual('National Insurance number <em>NINO</em>')
     })
 
-    it('renders label hint text', () => {
-      const $ = render('label', examples.default)
-      const labelHintText = $('.govuk-label__hint').text().trim()
-
-      expect(labelHintText).toEqual('It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.')
-    })
-
     it('renders for attribute if specified', () => {
       const $ = render('label', {
         for: '#dummy-input'
@@ -72,24 +65,6 @@ describe('Label', () => {
 
       const labelForAttr = $('.govuk-label').attr('for')
       expect(labelForAttr).toEqual('#dummy-input')
-    })
-
-    it('allows label hint text to be passed whilst escaping HTML entities', () => {
-      const $ = render('label', {
-        hintText: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, <strong>QQ 12 34 56 C</strong>.'
-      })
-
-      const labelHintText = $('.govuk-label__hint').html().trim()
-      expect(labelHintText).toEqual('It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &lt;strong&gt;QQ 12 34 56 C&lt;/strong&gt;.')
-    })
-
-    it('allows label hint HTML to be passed un-escaped', () => {
-      const $ = render('label', {
-        hintHtml: 'It is on your National Insurance card, benefit letter, payslip or P60. For example, <strong>QQ 12 34 56 C</strong>.'
-      })
-
-      const labelHintText = $('.govuk-label__hint').html().trim()
-      expect(labelHintText).toEqual('It is on your National Insurance card, benefit letter, payslip or P60. For example, <strong>QQ 12 34 56 C</strong>.')
     })
 
     it('allows additional attributes to be added to the component', () => {

--- a/src/label/template.test.js
+++ b/src/label/template.test.js
@@ -2,7 +2,7 @@
 
 const { axe } = require('jest-axe')
 
-const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpers')
+const { render, getExamples } = require('../../lib/jest-helpers')
 
 const examples = getExamples('label')
 
@@ -103,14 +103,6 @@ describe('Label', () => {
       const $component = $('.govuk-label')
       expect($component.attr('first-attribute')).toEqual('true')
       expect($component.attr('second-attribute')).toEqual('false')
-    })
-  })
-  describe('with dependant components', () => {
-    it('renders the error message text', () => {
-      const $ = render('error-message', {
-        text: 'Error message goes here'
-      })
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
   })
 })

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -16,17 +16,17 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          Have you changed your name?
+      <legend class="govuk-fieldset__legend">
+        Have you changed your name?
 
-          <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-radios">
+    <div class="govuk-radios">
 
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -45,7 +45,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -78,17 +79,17 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          Have you changed your name?
+      <legend class="govuk-fieldset__legend">
+        Have you changed your name?
 
-          <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-radios govuk-radios--inline">
+    <div class="govuk-radios govuk-radios--inline">
 
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -107,7 +108,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -141,17 +143,17 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          Have you changed your name?
+      <legend class="govuk-fieldset__legend">
+        Have you changed your name?
 
-          <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-radios">
+    <div class="govuk-radios">
 
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
@@ -170,7 +172,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -204,17 +207,17 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-form-group">
-      <fieldset class="govuk-fieldset">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
 
-        <legend class="govuk-fieldset__legend">
-          <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+      <legend class="govuk-fieldset__legend">
+        <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
 
-          <span class="govuk-fieldset__hint">Select one of the options below.</span>
+        <span class="govuk-fieldset__hint">Select one of the options below.</span>
 
-        </legend>
+      </legend>
 
-      <div class="govuk-radios">
+    <div class="govuk-radios">
 
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
@@ -233,7 +236,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro
@@ -265,7 +269,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-radios">
+    <div class="govuk-form-group">
+        <div class="govuk-radios">
 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
@@ -292,6 +297,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
         </div>
 
       </div>
+
+    </div>
 
 #### Macro
 
@@ -321,21 +328,21 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 
 #### Markup
 
-      <div class="govuk-form-group govuk-form-group--error">
-      <fieldset class="govuk-fieldset app-fieldset--custom-modifier" data-attribute="value" data-second-attribute="second-value">
+    <div class="govuk-form-group govuk-form-group--error">
+        <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-error" data-attribute="value" data-second-attribute="second-value">
 
-        <legend class="govuk-fieldset__legend">
-          Have you changed your name?
+      <legend class="govuk-fieldset__legend">
+        Have you changed your name?
 
-          <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
+        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
 
-          <span class="govuk-error-message">
-          Please select an option
-        </span>
+      </legend>
 
-        </legend>
+    <span id="example-error" class="govuk-error-message">
+        Please select an option
+      </span>
 
-      <div class="govuk-radios">
+        <div class="govuk-radios">
 
           <div class="govuk-radios__item">
             <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
@@ -354,7 +361,8 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           </div>
 
         </div>
-      </fieldset>
+        </fieldset>
+
     </div>
 
 #### Macro

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -17,35 +17,35 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="example-hint">
 
       <legend class="govuk-fieldset__legend">
         Have you changed your name?
-
-        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
-
       </legend>
 
-    <div class="govuk-radios">
+      <span id="example-hint" class="govuk-hint">
+        This includes changing your last name or spelling your name differently.
+      </span>
 
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
-            <label class="govuk-label govuk-radios__label" for="example-1">
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+          <label class="govuk-label govuk-radios__label" for="example-1">
             Yes
-
           </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
-            <label class="govuk-label govuk-radios__label" for="example-2">
-            No
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+          <label class="govuk-label govuk-radios__label" for="example-2">
+            No
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -57,8 +57,10 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "example",
       "name": "example",
       "fieldset": {
-        "legendText": "Have you changed your name?",
-        "legendHintText": "This includes changing your last name or spelling your name differently."
+        "legendText": "Have you changed your name?"
+      },
+      "hint": {
+        "text": "This includes changing your last name or spelling your name differently."
       },
       "items": [
         {
@@ -80,35 +82,35 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="example-hint">
 
       <legend class="govuk-fieldset__legend">
         Have you changed your name?
-
-        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
-
       </legend>
 
-    <div class="govuk-radios govuk-radios--inline">
+      <span id="example-hint" class="govuk-hint">
+        This includes changing your last name or spelling your name differently.
+      </span>
 
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
-            <label class="govuk-label govuk-radios__label" for="example-1">
+      <div class="govuk-radios govuk-radios--inline">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+          <label class="govuk-label govuk-radios__label" for="example-1">
             Yes
-
           </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
-            <label class="govuk-label govuk-radios__label" for="example-2">
-            No
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+          <label class="govuk-label govuk-radios__label" for="example-2">
+            No
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -121,8 +123,10 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "classes": "govuk-radios--inline",
       "name": "example",
       "fieldset": {
-        "legendText": "Have you changed your name?",
-        "legendHintText": "This includes changing your last name or spelling your name differently."
+        "legendText": "Have you changed your name?"
+      },
+      "hint": {
+        "text": "This includes changing your last name or spelling your name differently."
       },
       "items": [
         {
@@ -144,35 +148,35 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="example-disabled-hint">
 
       <legend class="govuk-fieldset__legend">
         Have you changed your name?
-
-        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
-
       </legend>
 
-    <div class="govuk-radios">
+      <span id="example-disabled-hint" class="govuk-hint">
+        This includes changing your last name or spelling your name differently.
+      </span>
 
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
-            <label class="govuk-label govuk-radios__label" for="example-disabled-1">
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-disabled-1" name="example-disabled" type="radio" value="yes" disabled>
+          <label class="govuk-label govuk-radios__label" for="example-disabled-1">
             Yes
-
           </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
-            <label class="govuk-label govuk-radios__label" for="example-disabled-2">
-            No
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-disabled-2" name="example-disabled" type="radio" value="no" disabled>
+          <label class="govuk-label govuk-radios__label" for="example-disabled-2">
+            No
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -184,8 +188,10 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "example-disabled",
       "name": "example-disabled",
       "fieldset": {
-        "legendText": "Have you changed your name?",
-        "legendHintText": "This includes changing your last name or spelling your name differently."
+        "legendText": "Have you changed your name?"
+      },
+      "hint": {
+        "text": "This includes changing your last name or spelling your name differently."
       },
       "items": [
         {
@@ -208,35 +214,35 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-        <fieldset class="govuk-fieldset">
+
+      <fieldset class="govuk-fieldset" aria-describedby="housing-act-hint">
 
       <legend class="govuk-fieldset__legend">
         <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
-
-        <span class="govuk-fieldset__hint">Select one of the options below.</span>
-
       </legend>
 
-    <div class="govuk-radios">
+      <span id="housing-act-hint" class="govuk-hint">
+        Select one of the options below.
+      </span>
 
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
-            <label class="govuk-label govuk-radios__label" for="housing-act-1">
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
+          <label class="govuk-label govuk-radios__label" for="housing-act-1">
             <span class="govuk-heading-s govuk-!-mb-r1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
-
           </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
-            <label class="govuk-label govuk-radios__label" for="housing-act-2">
-            <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
+          <label class="govuk-label govuk-radios__label" for="housing-act-2">
+            <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -248,8 +254,10 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "housing-act",
       "name": "housing-act",
       "fieldset": {
-        "legendHtml": "<h1 class=\"govuk-heading-l\">Which part of the Housing Act was your licence issued under?</h1>",
-        "legendHintText": "Select one of the options below."
+        "legendHtml": "<h1 class=\"govuk-heading-l\">Which part of the Housing Act was your licence issued under?</h1>"
+      },
+      "hint": {
+        "text": "Select one of the options below."
       },
       "items": [
         {
@@ -270,30 +278,28 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-        <div class="govuk-radios">
+
+      <div class="govuk-radios">
 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="colours-1" name="colours" type="radio" value="red">
           <label class="govuk-label govuk-radios__label" for="colours-1">
-          Red
-
-        </label>
+            Red
+          </label>
         </div>
 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="colours-2" name="colours" type="radio" value="green">
           <label class="govuk-label govuk-radios__label" for="colours-2">
-          Green
-
-        </label>
+            Green
+          </label>
         </div>
 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="colours-3" name="colours" type="radio" value="blue">
           <label class="govuk-label govuk-radios__label" for="colours-3">
-          Blue
-
-        </label>
+            Blue
+          </label>
         </div>
 
       </div>
@@ -329,39 +335,39 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-        <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-error" data-attribute="value" data-second-attribute="second-value">
+
+      <fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-hint example-error" data-attribute="value" data-second-attribute="second-value">
 
       <legend class="govuk-fieldset__legend">
         Have you changed your name?
-
-        <span class="govuk-fieldset__hint">This includes changing your last name or spelling your name differently.</span>
-
       </legend>
 
-    <span id="example-error" class="govuk-error-message">
+      <span id="example-hint" class="govuk-hint">
+        This includes changing your last name or spelling your name differently.
+      </span>
+
+      <span id="example-error" class="govuk-error-message">
         Please select an option
       </span>
 
-        <div class="govuk-radios">
+      <div class="govuk-radios">
 
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
-            <label class="govuk-label govuk-radios__label" for="example-1">
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-1" name="example" type="radio" value="yes">
+          <label class="govuk-label govuk-radios__label" for="example-1">
             Yes
-
           </label>
-          </div>
-
-          <div class="govuk-radios__item">
-            <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
-            <label class="govuk-label govuk-radios__label" for="example-2">
-            No
-
-          </label>
-          </div>
-
         </div>
-        </fieldset>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-2" name="example" type="radio" value="no" checked>
+          <label class="govuk-label govuk-radios__label" for="example-2">
+            No
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
 
     </div>
 
@@ -381,8 +387,10 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           "data-attribute": "value",
           "data-second-attribute": "second-value"
         },
-        "legendText": "Have you changed your name?",
-        "legendHintText": "This includes changing your last name or spelling your name differently."
+        "legendText": "Have you changed your name?"
+      },
+      "hint": {
+        "text": "This includes changing your last name or spelling your name differently."
       },
       "items": [
         {
@@ -455,7 +463,31 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
+<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText). See fieldset component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">errorMessage</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/radios/__snapshots__/template.test.js.snap
+++ b/src/radios/__snapshots__/template.test.js.snap
@@ -3,15 +3,12 @@
 exports[`Radios nested dependant components passes through fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
-          aria-describedby="example-error"
+          aria-describedby="example-hint example-error"
           data-attribute="value"
           data-second-attribute="second-value"
 >
   <legend class="govuk-fieldset__legend">
     Have you changed your name?
-    <span class="govuk-fieldset__hint">
-      This includes changing your last name or spelling your name differently.
-    </span>
   </legend>
 </fieldset>
 
@@ -21,14 +18,11 @@ exports[`Radios nested dependant components passes through html fieldset params 
 
 <fieldset class="govuk-fieldset">
   <legend class="govuk-fieldset__legend">
-    Have &lt;b&gt;you&lt;/b&gt; changed your name?
-    <span class="govuk-fieldset__hint">
-      This
-      <b>
-        includes
-      </b>
-      changing your last name or spelling your name differently.
-    </span>
+    Have
+    <b>
+      you
+    </b>
+    changed your name?
   </legend>
 </fieldset>
 
@@ -59,6 +53,16 @@ exports[`Radios nested dependant components renders the error message 1`] = `
       class="govuk-error-message"
 >
   Please select an option
+</span>
+
+`;
+
+exports[`Radios nested dependant components renders the hint 1`] = `
+
+<span id="example-hint"
+      class="govuk-hint"
+>
+  This includes changing your last name or spelling your name differently.
 </span>
 
 `;

--- a/src/radios/__snapshots__/template.test.js.snap
+++ b/src/radios/__snapshots__/template.test.js.snap
@@ -47,22 +47,22 @@ exports[`Radios nested dependant components passes through label params without 
 
 `;
 
-exports[`Radios nested dependant components renders the error message 1`] = `
-
-<span id="example-error"
-      class="govuk-error-message"
->
-  Please select an option
-</span>
-
-`;
-
-exports[`Radios nested dependant components renders the hint 1`] = `
+exports[`Radios when they include a hint renders the hint 1`] = `
 
 <span id="example-hint"
       class="govuk-hint"
 >
   This includes changing your last name or spelling your name differently.
+</span>
+
+`;
+
+exports[`Radios when they include an error message renders the error message 1`] = `
+
+<span id="example-error"
+      class="govuk-error-message"
+>
+  Please select an option
 </span>
 
 `;

--- a/src/radios/__snapshots__/template.test.js.snap
+++ b/src/radios/__snapshots__/template.test.js.snap
@@ -2,15 +2,8 @@
 
 exports[`Radios nested dependant components passes through fieldset params without breaking 1`] = `
 
-<span class="govuk-error-message">
-  Please select an option
-</span>
-
-`;
-
-exports[`Radios nested dependant components passes through fieldset params without breaking 2`] = `
-
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
+          aria-describedby="example-error"
           data-attribute="value"
           data-second-attribute="second-value"
 >
@@ -57,5 +50,15 @@ exports[`Radios nested dependant components passes through label params without 
 >
   &lt;b&gt;No&lt;/b&gt;
 </label>
+
+`;
+
+exports[`Radios nested dependant components renders the error message 1`] = `
+
+<span id="example-error"
+      class="govuk-error-message"
+>
+  Please select an option
+</span>
 
 `;

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -1,8 +1,12 @@
+@import "../globals/helpers/clearfix";
 @import "../globals/tools/exports";
 @import "../globals/tools/ie8";
+@import "../globals/settings/spacing";
+@import "../globals/settings/measurements";
 
 @import "../error-message/error-message";
 @import "../fieldset/fieldset";
+@import "../hint/hint";
 @import "../label/label";
 
 @include govuk-exports("radios") {

--- a/src/radios/_radios.scss
+++ b/src/radios/_radios.scss
@@ -1,6 +1,7 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/ie8";
 
+@import "../error-message/error-message";
 @import "../fieldset/fieldset";
 @import "../label/label";
 

--- a/src/radios/index.njk
+++ b/src/radios/index.njk
@@ -51,7 +51,35 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+        text: 'Arguments for the fieldset component (e.g. legendText). See fieldset component.'
+      }
+    ],
+    [
+      {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
+        text: 'errorMessage'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/radios/radios.yaml
+++ b/src/radios/radios.yaml
@@ -15,8 +15,8 @@ examples:
     name: 'example'
     fieldset:
       legendText: Have you changed your name?
-      legendHintText:
-        This includes changing your last name or spelling your name differently.
+    hint:
+      text: This includes changing your last name or spelling your name differently.
     items:
       - value: yes
         text: Yes
@@ -31,8 +31,8 @@ examples:
     name: 'example'
     fieldset:
       legendText: Have you changed your name?
-      legendHintText:
-        This includes changing your last name or spelling your name differently.
+    hint:
+      text: This includes changing your last name or spelling your name differently.
     items:
       - value: yes
         text: Yes
@@ -46,8 +46,8 @@ examples:
     name: 'example-disabled'
     fieldset:
       legendText: Have you changed your name?
-      legendHintText:
-        This includes changing your last name or spelling your name differently.
+    hint:
+      text: This includes changing your last name or spelling your name differently.
     items:
       - value: yes
         text: Yes
@@ -62,7 +62,8 @@ examples:
     name: 'housing-act'
     fieldset:
       legendHtml: <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
-      legendHintText: Select one of the options below.
+    hint:
+      text: Select one of the options below.
     items:
       - value: 'part-2'
         html:
@@ -96,8 +97,8 @@ examples:
         'data-attribute': 'value'
         'data-second-attribute': 'second-value'
       legendText: Have you changed your name?
-      legendHintText:
-        This includes changing your last name or spelling your name differently.
+    hint:
+      text: This includes changing your last name or spelling your name differently.
     items:
       - value: yes
         text: Yes

--- a/src/radios/template.njk
+++ b/src/radios/template.njk
@@ -1,13 +1,14 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# If an id 'prefix' is not passed, fall back to using the name attribute
-   instead. We need this for error messages and hints as well #}
+{#- If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
 
-{# a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
 
 {% set isConditional = false %}
@@ -19,17 +20,27 @@
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
-  {% if params.errorMessage %}
-    {% set errorId = idPrefix + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
+{% if params.hint %}
+  {% set hintId = idPrefix + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = idPrefix + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="radios"{% endif -%}>
@@ -47,7 +58,7 @@
         classes: 'govuk-radios__label',
         attributes: item.label.attributes,
         for: id
-      }) | indent(4) | trim }}
+      }) | indent(6) | trim }}
     </div>
     {% if item.conditional %}
       <div class="govuk-radios__conditional" id="{{ conditionalId }}">
@@ -56,22 +67,20 @@
     {% endif %}
     {% endfor %}
   </div>
-{% endset %}
+{% endset -%}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-  {%- if params.fieldset %}
-    {% call govukFieldset({
-      describedBy: describedBy,
-      classes: params.fieldset.classes,
-      attributes: params.fieldset.attributes,
-      legendText: params.fieldset.legendText,
-      legendHtml: params.fieldset.legendHtml,
-      legendHintText: params.fieldset.legendHintText,
-      legendHintHtml: params.fieldset.legendHintHtml
-    }) %}
-    {{- innerHtml | indent(2) | trim | safe }}
-    {% endcall %}
-  {% else %}
-    {{ innerHtml | trim | safe }}
-  {% endif %}
+{% if params.fieldset %}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legendText: params.fieldset.legendText,
+    legendHtml: params.fieldset.legendHtml
+  }) %}
+  {{ innerHtml | trim | safe }}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{% endif %}
 </div>

--- a/src/radios/template.njk
+++ b/src/radios/template.njk
@@ -1,5 +1,14 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "fieldset/macro.njk" import govukFieldset %}
 {% from "label/macro.njk" import govukLabel %}
+
+{# If an id 'prefix' is not passed, fall back to using the name attribute
+   instead. We need this for error messages and hints as well #}
+{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+
+{# a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 {% set isConditional = false %}
 {% for item in params.items %}
@@ -10,11 +19,21 @@
 
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
+  {% if params.errorMessage %}
+    {% set errorId = idPrefix + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="radios"{% endif -%}>
     {% for item in params.items %}
-    {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
     {% set conditionalId = "conditional-" + id %}
     <div class="govuk-radios__item">
@@ -39,18 +58,20 @@
   </div>
 {% endset %}
 
-{%- if params.fieldset %}
-  {% call govukFieldset({
-    classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml,
-    legendHintText: params.fieldset.legendHintText,
-    legendHintHtml: params.fieldset.legendHintHtml,
-    errorMessage: params.errorMessage
-  }) %}
-  {{- innerHtml | indent(2) | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
+  {%- if params.fieldset %}
+    {% call govukFieldset({
+      describedBy: describedBy,
+      classes: params.fieldset.classes,
+      attributes: params.fieldset.attributes,
+      legendText: params.fieldset.legendText,
+      legendHtml: params.fieldset.legendHtml,
+      legendHintText: params.fieldset.legendHintText,
+      legendHintHtml: params.fieldset.legendHintHtml
+    }) %}
+    {{- innerHtml | indent(2) | trim | safe }}
+    {% endcall %}
+  {% else %}
+    {{ innerHtml | trim | safe }}
+  {% endif %}
+</div>

--- a/src/radios/template.test.js
+++ b/src/radios/template.test.js
@@ -258,6 +258,25 @@ describe('Radios', () => {
       expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
     })
 
+    it('renders the hint', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the fieldset as "described by" the hint', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+    })
+
     it('renders the error message', () => {
       const $ = render('radios', examples['with-extreme-fieldset'])
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
@@ -336,8 +355,7 @@ describe('Radios', () => {
           }
         ],
         fieldset: {
-          legendText: 'Have <b>you</b> changed your name?',
-          legendHintHtml: 'This <b>includes</b> changing your last name or spelling your name differently.'
+          legendHtml: 'Have <b>you</b> changed your name?'
         }
       })
 

--- a/src/radios/template.test.js
+++ b/src/radios/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('radios')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Radios', () => {
   it('default example passes accessibility tests', async () => {
@@ -225,39 +226,7 @@ describe('Radios', () => {
     })
   })
 
-  describe('nested dependant components', () => {
-    it('have correct nesting order', () => {
-      const $ = render('radios', examples['with-extreme-fieldset'])
-
-      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
-      expect($component.length).toBeTruthy()
-    })
-
-    it('passes through label params without breaking', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            html: '<b>Yes</b>',
-            label: {
-              attributes: {
-                'data-attribute': 'value',
-                'data-second-attribute': 'second-value'
-              }
-            }
-          },
-          {
-            value: 'no',
-            text: '<b>No</b>',
-            checked: true
-          }
-        ]
-      })
-
-      expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
-    })
-
+  describe('when they include a hint', () => {
     it('renders the hint', () => {
       const $ = render('radios', examples['with-extreme-fieldset'])
 
@@ -276,7 +245,9 @@ describe('Radios', () => {
 
       expect($fieldset.attr('aria-describedby')).toMatch(hintId)
     })
+  })
 
+  describe('when they include an error message', () => {
     it('renders the error message', () => {
       const $ = render('radios', examples['with-extreme-fieldset'])
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
@@ -333,6 +304,57 @@ describe('Radios', () => {
 
       expect($fieldset.attr('aria-describedby'))
         .toMatch(errorMessageId)
+    })
+  })
+
+  describe('when they include both a hint and an error message', () => {
+    it('associates the fieldset as described by both the hint and the error message', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
+  describe('nested dependant components', () => {
+    it('have correct nesting order', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+
+      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
+      expect($component.length).toBeTruthy()
+    })
+
+    it('passes through label params without breaking', () => {
+      const $ = render('radios', {
+        name: 'example-name',
+        items: [
+          {
+            value: 'yes',
+            html: '<b>Yes</b>',
+            label: {
+              attributes: {
+                'data-attribute': 'value',
+                'data-second-attribute': 'second-value'
+              }
+            }
+          },
+          {
+            value: 'no',
+            text: '<b>No</b>',
+            checked: true
+          }
+        ]
+      })
+
+      expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {

--- a/src/radios/template.test.js
+++ b/src/radios/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('radios')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Radios', () => {
   it('default example passes accessibility tests', async () => {
     const $ = render('radios', examples.default)
@@ -256,10 +258,67 @@ describe('Radios', () => {
       expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
     })
 
+    it('renders the error message', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('uses the idPrefix for the error message id if provided', () => {
+      const $ = render('radios', {
+        name: 'name-of-radios',
+        errorMessage: {
+          text: 'Have you changed your name?'
+        },
+        idPrefix: 'id-prefix',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          }
+        ]
+      })
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+    })
+
+    it('falls back to using the name for the error message id', () => {
+      const $ = render('radios', {
+        name: 'name-of-radios',
+        errorMessage: {
+          text: 'Have you changed your name?'
+        },
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          }
+        ]
+      })
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('name-of-radios-error')
+    })
+
+    it('associates the fieldset as "described by" the error message', () => {
+      const $ = render('radios', examples['with-extreme-fieldset'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
     it('passes through fieldset params without breaking', () => {
       const $ = render('radios', examples['with-extreme-fieldset'])
 
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -16,10 +16,10 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="select-1">
-      Label text goes here
-
-    </label>
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="select-1">
+        Label text goes here
+      </label>
 
       <select class="govuk-select" id="select-1" name="select-1">
 
@@ -66,20 +66,20 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
 
 #### Markup
 
-    <div class="govuk-form-group govuk-form-group--error"><label class="govuk-label" for="select-2">
-      Label text goes here
+    <div class="govuk-form-group govuk-form-group--error">
+      <label class="govuk-label" for="select-2">
+        Label text goes here
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="select-2-hint" class="govuk-hint">
         Hint text goes here
       </span>
 
-    </label>
+      <span id="select-2-error" class="govuk-error-message">
+        Error message goes here
+      </span>
 
-        <span id="select-2-error" class="govuk-error-message">
-      Error message goes here
-    </span>
-
-      <select class="govuk-select govuk-select--error" id="select-2" name="select-2" aria-describedby="select-2-error">
+      <select class="govuk-select govuk-select--error" id="select-2" name="select-2" aria-describedby="select-2-hint select-2-error">
 
         <option value="1">GOV.UK frontend option 1</option>
 
@@ -98,8 +98,10 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
       "id": "select-2",
       "name": "select-2",
       "label": {
-        "hintText": "Hint text goes here",
         "text": "Label text goes here"
+      },
+      "hint": {
+        "text": "Hint text goes here"
       },
       "errorMessage": {
         "text": "Error message goes here"
@@ -278,13 +280,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">errorMessage</th>
+<th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional error message. See errorMessage component.</td>
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">errorMessage</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -20,7 +20,8 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
       Label text goes here
 
     </label>
-    <select class="govuk-select" id="select-1" name="select-1">
+
+      <select class="govuk-select" id="select-1" name="select-1">
 
         <option value="1">GOV.UK frontend option 1</option>
 
@@ -72,12 +73,13 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
         Hint text goes here
       </span>
 
-      <span class="govuk-error-message">
+    </label>
+
+        <span id="select-2-error" class="govuk-error-message">
       Error message goes here
     </span>
 
-    </label>
-    <select class="govuk-select govuk-select--error" id="select-2" name="select-2">
+      <select class="govuk-select govuk-select--error" id="select-2" name="select-2" aria-describedby="select-2-error">
 
         <option value="1">GOV.UK frontend option 1</option>
 

--- a/src/select/__snapshots__/template.test.js.snap
+++ b/src/select/__snapshots__/template.test.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Select with dependant components renders with error message 1`] = `
-
-<span id="select-with-error-error"
-      class="govuk-error-message"
->
-  Error message
-</span>
-
-`;
-
-exports[`Select with dependant components renders with hint 1`] = `
+exports[`Select when it includes a hint renders the hint 1`] = `
 
 <span id="select-with-hint-hint"
       class="govuk-hint"
 >
   Hint text goes here
+</span>
+
+`;
+
+exports[`Select when it includes an error message renders with error message 1`] = `
+
+<span id="select-with-error-error"
+      class="govuk-error-message"
+>
+  Error message
 </span>
 
 `;

--- a/src/select/__snapshots__/template.test.js.snap
+++ b/src/select/__snapshots__/template.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`Select with dependant components renders with error message 1`] = `
 
-<span class="govuk-error-message">
+<span id="select-with-error-error"
+      class="govuk-error-message"
+>
   Error message
 </span>
 

--- a/src/select/__snapshots__/template.test.js.snap
+++ b/src/select/__snapshots__/template.test.js.snap
@@ -10,6 +10,16 @@ exports[`Select with dependant components renders with error message 1`] = `
 
 `;
 
+exports[`Select with dependant components renders with hint 1`] = `
+
+<span id="select-with-hint-hint"
+      class="govuk-hint"
+>
+  Hint text goes here
+</span>
+
+`;
+
 exports[`Select with dependant components renders with label 1`] = `
 
 <label class="govuk-label"

--- a/src/select/_select.scss
+++ b/src/select/_select.scss
@@ -1,14 +1,13 @@
+@import "../globals/helpers/focusable";
 @import "../globals/tools/exports";
-
-@import "../label/label";
-
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
 @import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
-@import "../globals/helpers/focusable";
-@import "../globals/helpers/spacing";
-
-@import "../globals/objects/form-group";
+@import "../error-message/error-message";
+@import "../hint/hint";
+@import "../label/label";
 
 @include govuk-exports("select") {
   .govuk-select {

--- a/src/select/index.njk
+++ b/src/select/index.njk
@@ -164,16 +164,30 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'errorMessage'
+        text: 'hint'
       },
       {
-        text: 'string'
+        text: 'object'
       },
       {
         text: 'No'
       },
       {
-        text: 'Optional error message. See errorMessage component.'
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
+        text: 'errorMessage'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/select/select.yaml
+++ b/src/select/select.yaml
@@ -22,8 +22,9 @@ examples:
     id: select-2
     name: select-2
     label:
-      hintText: Hint text goes here
       text: Label text goes here
+    hint:
+      text: Hint text goes here
     errorMessage:
       text: Error message goes here
     items:

--- a/src/select/template.njk
+++ b/src/select/template.njk
@@ -1,33 +1,39 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# a record of other elements that we need to associate with the input using 
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
-
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-
-  {{- govukLabel({
+  {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
-    hintText: params.label.hintText,
-    hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
     for: params.id
-  }) -}}
-
-  {% if params.errorMessage %}
-    {% set errorId = params.id + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
   <select class="govuk-select
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}

--- a/src/select/template.njk
+++ b/src/select/template.njk
@@ -1,5 +1,9 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "label/macro.njk" import govukLabel %}
 
+{# a record of other elements that we need to associate with the input using 
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
 
@@ -10,12 +14,22 @@
     hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
-    errorMessage: params.errorMessage,
     for: params.id
   }) -}}
 
+  {% if params.errorMessage %}
+    {% set errorId = params.id + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
   <select class="govuk-select
-    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
     <option value="{{ item.value }}"{{" selected" if item.selected}}{{" disabled" if item.disabled}}>{{ item.text }}</option>
   {% endfor %}

--- a/src/select/template.test.js
+++ b/src/select/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('select')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Select', () => {
   describe('by default', () => {
     it('passes accessibility tests', async () => {
@@ -46,10 +48,10 @@ describe('Select', () => {
       const $ = render('select', {
         items: [
           {
-            'text': 'Option 1'
+            text: 'Option 1'
           },
           {
-            'text': 'Options 2'
+            text: 'Options 2'
           }
         ]
       })
@@ -63,11 +65,11 @@ describe('Select', () => {
         items: [
           {
             'value': '1',
-            'text': 'Option 1'
+            text: 'Option 1'
           },
           {
             'value': '2',
-            'text': 'Options 2'
+            text: 'Options 2'
           }
         ]
       })
@@ -81,10 +83,10 @@ describe('Select', () => {
         value: '2',
         items: [
           {
-            'text': 'Option 1'
+            text: 'Option 1'
           },
           {
-            'text': 'Options 2'
+            text: 'Options 2'
           }
         ]
       })
@@ -98,11 +100,11 @@ describe('Select', () => {
         value: '2',
         items: [
           {
-            'text': 'Option 1',
+            text: 'Option 1',
             'selected': true
           },
           {
-            'text': 'Options 2'
+            text: 'Options 2'
           }
         ]
       })
@@ -146,10 +148,10 @@ describe('Select', () => {
       const $ = render('select', {
         id: 'nesting-order',
         label: {
-          'text': 'National Insurance number'
+          text: 'National Insurance number'
         },
         errorMessage: {
-          'text': 'Error message'
+          text: 'Error message'
         }
       })
 
@@ -161,7 +163,7 @@ describe('Select', () => {
       const $ = render('select', {
         id: 'my-select',
         label: {
-          'text': 'National Insurance number'
+          text: 'National Insurance number'
         }
       })
 
@@ -172,7 +174,7 @@ describe('Select', () => {
       const $ = render('select', {
         id: 'my-select',
         label: {
-          'text': 'Label text'
+          text: 'Label text'
         }
       })
 
@@ -182,18 +184,38 @@ describe('Select', () => {
 
     it('renders with error message', () => {
       const $ = render('select', {
+        id: 'select-with-error',
         errorMessage: {
-          'text': 'Error message'
+          text: 'Error message'
         }
       })
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
+    it('associates the select as "described by" the error message', () => {
+      const $ = render('select', {
+        id: 'select-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      const $input = $('.govuk-select')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
     it('has error class when rendered with error message', () => {
       const $ = render('select', {
         errorMessage: {
-          'text': 'Error message'
+          text: 'Error message'
         }
       })
 

--- a/src/select/template.test.js
+++ b/src/select/template.test.js
@@ -182,6 +182,36 @@ describe('Select', () => {
       expect($label.attr('for')).toEqual('my-select')
     })
 
+    it('renders with hint', () => {
+      const $ = render('select', {
+        id: 'select-with-hint',
+        hint: {
+          'text': 'Hint text goes here'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the select as "described by" the hint', () => {
+      const $ = render('select', {
+        id: 'select-with-hint',
+        hint: {
+          'text': 'Hint text goes here'
+        }
+      })
+
+      const $select = $('.govuk-select')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($select.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+
     it('renders with error message', () => {
       const $ = render('select', {
         id: 'select-with-error',

--- a/src/select/template.test.js
+++ b/src/select/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('select')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Select', () => {
   describe('by default', () => {
@@ -143,6 +144,105 @@ describe('Select', () => {
     })
   })
 
+  describe('when it includes a hint', () => {
+    it('renders the hint', () => {
+      const $ = render('select', {
+        id: 'select-with-hint',
+        hint: {
+          'text': 'Hint text goes here'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the select as "described by" the hint', () => {
+      const $ = render('select', {
+        id: 'select-with-hint',
+        hint: {
+          'text': 'Hint text goes here'
+        }
+      })
+
+      const $select = $('.govuk-select')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($select.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes an error message', () => {
+    it('renders with error message', () => {
+      const $ = render('select', {
+        id: 'select-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the select as "described by" the error message', () => {
+      const $ = render('select', {
+        id: 'select-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      const $input = $('.govuk-select')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($input.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
+    it('adds the error class to the select', () => {
+      const $ = render('select', {
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-select')
+      expect($component.hasClass('govuk-select--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes both a hint and an error message', () => {
+    it('associates the select as described by both the hint and the error message', () => {
+      const $ = render('select', {
+        errorMessage: {
+          text: 'Error message'
+        },
+        hint: {
+          text: 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-select')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('select', {
@@ -180,77 +280,6 @@ describe('Select', () => {
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('my-select')
-    })
-
-    it('renders with hint', () => {
-      const $ = render('select', {
-        id: 'select-with-hint',
-        hint: {
-          'text': 'Hint text goes here'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-    })
-
-    it('associates the select as "described by" the hint', () => {
-      const $ = render('select', {
-        id: 'select-with-hint',
-        hint: {
-          'text': 'Hint text goes here'
-        }
-      })
-
-      const $select = $('.govuk-select')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($select.attr('aria-describedby'))
-        .toMatch(hintId)
-    })
-
-    it('renders with error message', () => {
-      const $ = render('select', {
-        id: 'select-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-    })
-
-    it('associates the select as "described by" the error message', () => {
-      const $ = render('select', {
-        id: 'select-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
-
-      const $input = $('.govuk-select')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
-    })
-
-    it('has error class when rendered with error message', () => {
-      const $ = render('select', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-select')
-      expect($component.hasClass('govuk-select--error')).toBeTruthy()
     })
   })
 })

--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -16,17 +16,16 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="more-detail">
-      Can you provide more detail?
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="more-detail">
+        Can you provide more detail?
+      </label>
 
-      <span class="govuk-label__hint">
+      <span id="more-detail-hint" class="govuk-hint">
         Don&#39;t include personal or financial information, eg your National Insurance number or credit card details.
       </span>
 
-    </label>
-
-      <textarea id="more-detail" name="more-detail" rows="5" class="govuk-textarea"></textarea>
-
+      <textarea class="govuk-textarea" id="more-detail" name="more-detail" rows="5" aria-describedby="more-detail-hint"></textarea>
     </div>
 
 #### Macro
@@ -37,8 +36,10 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
       "name": "more-detail",
       "id": "more-detail",
       "label": {
-        "text": "Can you provide more detail?",
-        "hintText": "Don't include personal or financial information, eg your National Insurance number or credit card details."
+        "text": "Can you provide more detail?"
+      },
+      "hint": {
+        "text": "Don't include personal or financial information, eg your National Insurance number or credit card details."
       }
     }) }}
 
@@ -48,17 +49,16 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group govuk-form-group--error"><label class="govuk-label" for="no-ni-reason">
-      Why can&#39;t you provide a National Insurance number?
+    <div class="govuk-form-group govuk-form-group--error">
+      <label class="govuk-label" for="no-ni-reason">
+        Why can&#39;t you provide a National Insurance number?
+      </label>
 
-    </label>
+      <span id="no-ni-reason-error" class="govuk-error-message">
+        You must provide an explanation
+      </span>
 
-        <span id="no-ni-reason-error" class="govuk-error-message">
-      You must provide an explanation
-    </span>
-
-      <textarea id="no-ni-reason" name="no-ni-reason" rows="5" class="govuk-textarea govuk-textarea--error" aria-describedby="no-ni-reason-error"></textarea>
-
+      <textarea class="govuk-textarea govuk-textarea--error" id="no-ni-reason" name="no-ni-reason" rows="5" aria-describedby="no-ni-reason-error"></textarea>
     </div>
 
 #### Macro
@@ -82,16 +82,15 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="full-address">
-      Full address
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="full-address">
+        Full address
+      </label>
 
-    </label>
-
-      <textarea id="full-address" name="address" rows="5" class="govuk-textarea">221B Baker Street
+      <textarea class="govuk-textarea" id="full-address" name="address" rows="5">221B Baker Street
     London
     NW1 6XE
     </textarea>
-
     </div>
 
 #### Macro
@@ -113,13 +112,12 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
 
 #### Markup
 
-    <div class="govuk-form-group"><label class="govuk-label" for="full-address">
-      Full address
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="full-address">
+        Full address
+      </label>
 
-    </label>
-
-      <textarea id="full-address" name="address" rows="8" class="govuk-textarea"></textarea>
-
+      <textarea class="govuk-textarea" id="full-address" name="address" rows="8"></textarea>
     </div>
 
 #### Macro
@@ -257,13 +255,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See hint component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the error message component</td>
+<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 

--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -24,7 +24,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
       </span>
 
     </label>
-    <textarea id="more-detail" name="more-detail" rows="5" class="govuk-textarea"></textarea>
+
+      <textarea id="more-detail" name="more-detail" rows="5" class="govuk-textarea"></textarea>
 
     </div>
 
@@ -50,12 +51,13 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
     <div class="govuk-form-group govuk-form-group--error"><label class="govuk-label" for="no-ni-reason">
       Why can&#39;t you provide a National Insurance number?
 
-      <span class="govuk-error-message">
+    </label>
+
+        <span id="no-ni-reason-error" class="govuk-error-message">
       You must provide an explanation
     </span>
 
-    </label>
-    <textarea id="no-ni-reason" name="no-ni-reason" rows="5" class="govuk-textarea govuk-textarea--error"></textarea>
+      <textarea id="no-ni-reason" name="no-ni-reason" rows="5" class="govuk-textarea govuk-textarea--error" aria-describedby="no-ni-reason-error"></textarea>
 
     </div>
 
@@ -84,7 +86,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
       Full address
 
     </label>
-    <textarea id="full-address" name="address" rows="5" class="govuk-textarea">221B Baker Street
+
+      <textarea id="full-address" name="address" rows="5" class="govuk-textarea">221B Baker Street
     London
     NW1 6XE
     </textarea>
@@ -114,7 +117,8 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
       Full address
 
     </label>
-    <textarea id="full-address" name="address" rows="8" class="govuk-textarea"></textarea>
+
+      <textarea id="full-address" name="address" rows="8" class="govuk-textarea"></textarea>
 
     </div>
 

--- a/src/textarea/__snapshots__/template.test.js.snap
+++ b/src/textarea/__snapshots__/template.test.js.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Textarea with dependant components renders with error message 1`] = `
-
-<span id="textarea-with-error-error"
-      class="govuk-error-message"
->
-  Error message
-</span>
-
-`;
-
-exports[`Textarea with dependant components renders with hint 1`] = `
+exports[`Textarea when it includes a hint renders with hint 1`] = `
 
 <span id="textarea-with-error-hint"
       class="govuk-hint"
 >
   It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+</span>
+
+`;
+
+exports[`Textarea when it includes an error message renders with error message 1`] = `
+
+<span id="textarea-with-error-error"
+      class="govuk-error-message"
+>
+  Error message
 </span>
 
 `;

--- a/src/textarea/__snapshots__/template.test.js.snap
+++ b/src/textarea/__snapshots__/template.test.js.snap
@@ -10,6 +10,16 @@ exports[`Textarea with dependant components renders with error message 1`] = `
 
 `;
 
+exports[`Textarea with dependant components renders with hint 1`] = `
+
+<span id="textarea-with-error-hint"
+      class="govuk-hint"
+>
+  It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+</span>
+
+`;
+
 exports[`Textarea with dependant components renders with label 1`] = `
 
 <label class="govuk-label"

--- a/src/textarea/__snapshots__/template.test.js.snap
+++ b/src/textarea/__snapshots__/template.test.js.snap
@@ -2,7 +2,9 @@
 
 exports[`Textarea with dependant components renders with error message 1`] = `
 
-<span class="govuk-error-message">
+<span id="textarea-with-error-error"
+      class="govuk-error-message"
+>
   Error message
 </span>
 

--- a/src/textarea/_textarea.scss
+++ b/src/textarea/_textarea.scss
@@ -1,6 +1,7 @@
 @import "../globals/tools/exports";
 @import "../globals/tools/iff";
 
+@import "../error-message/error-message";
 @import "../label/label";
 
 @import "../globals/settings/spacing";

--- a/src/textarea/_textarea.scss
+++ b/src/textarea/_textarea.scss
@@ -1,17 +1,14 @@
+@import "../globals/helpers/focusable";
+@import "../globals/helpers/spacing";
 @import "../globals/tools/exports";
-@import "../globals/tools/iff";
-
-@import "../error-message/error-message";
-@import "../label/label";
-
+@import "../globals/settings/colours-palette";
+@import "../globals/settings/colours-applied";
 @import "../globals/settings/spacing";
 @import "../globals/settings/measurements";
 
-@import "../globals/helpers/focusable";
-@import "../globals/helpers/spacing";
-
-@import "../globals/objects/form-group";
-
+@import "../error-message/error-message";
+@import "../hint/hint";
+@import "../label/label";
 
 @include govuk-exports("textarea") {
   .govuk-textarea {

--- a/src/textarea/index.njk
+++ b/src/textarea/index.njk
@@ -122,6 +122,20 @@
     ],
     [
       {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the hint component (e.g. text). See hint component.'
+      }
+    ],
+    [
+      {
         text: 'errorMessage'
       },
       {
@@ -131,7 +145,7 @@
         text: 'No'
       },
       {
-        text: 'Arguments for the error message component'
+        text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
       }
     ],
     [

--- a/src/textarea/template.njk
+++ b/src/textarea/template.njk
@@ -1,5 +1,9 @@
+{% from "error-message/macro.njk" import govukErrorMessage -%}
 {% from "label/macro.njk" import govukLabel %}
 
+{# a record of other elements that we need to associate with the input using 
+   aria-describedby – for example hints or error messages #}
+{% set describedBy = "" %}
 
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
 
@@ -12,10 +16,20 @@
     hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
-    errorMessage: params.errorMessage,
     for: params.id
   }) -}}
 
-  <textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
+  {% if params.errorMessage %}
+    {% set errorId = params.id + '-error' %}
+    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+    {{ govukErrorMessage({
+      id: errorId,
+      classes: params.errorMessage.classes,
+      html: params.errorMessage.html,
+      text: params.errorMessage.text
+    }) -}}
+  {% endif %}
+
+  <textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
 
 </div>

--- a/src/textarea/template.njk
+++ b/src/textarea/template.njk
@@ -1,35 +1,40 @@
 {% from "error-message/macro.njk" import govukErrorMessage -%}
+{% from "hint/macro.njk" import govukHint %}
 {% from "label/macro.njk" import govukLabel %}
 
-{# a record of other elements that we need to associate with the input using 
-   aria-describedby – for example hints or error messages #}
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
-
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
-
-  {#- Include label passing all label parameters, merging in `for` and `errorMessage` #}
-
-  {{- govukLabel({
+  {{ govukLabel({
     html: params.label.html,
     text: params.label.text,
-    hintText: params.label.hintText,
-    hintHtml: params.label.hintHtml,
     classes: params.label.classes,
     attributes: params.label.attributes,
     for: params.id
-  }) -}}
-
-  {% if params.errorMessage %}
-    {% set errorId = params.id + '-error' %}
-    {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-    {{ govukErrorMessage({
-      id: errorId,
-      classes: params.errorMessage.classes,
-      html: params.errorMessage.html,
-      text: params.errorMessage.text
-    }) -}}
-  {% endif %}
-
-  <textarea id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}" class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
-
+  }) | indent(2) | trim }}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text
+  }) | indent(2) | trim }}
+{% endif %}
+  <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
 </div>

--- a/src/textarea/template.test.js
+++ b/src/textarea/template.test.js
@@ -6,6 +6,8 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 
 const examples = getExamples('textarea')
 
+const WORD_BOUNDARY = '\\b'
+
 describe('Textarea', () => {
   describe('by default', () => {
     it('passes accessibility tests', async () => {
@@ -120,12 +122,32 @@ describe('Textarea', () => {
 
     it('renders with error message', () => {
       const $ = render('textarea', {
+        id: 'textarea-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the textarea as "described by" the error message', () => {
+      const $ = render('textarea', {
+        id: 'input-with-error',
         errorMessage: {
           'text': 'Error message'
         }
       })
 
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+      const $component = $('.govuk-textarea')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(errorMessageId)
     })
 
     it('has error class when rendered with error message', () => {

--- a/src/textarea/template.test.js
+++ b/src/textarea/template.test.js
@@ -120,6 +120,36 @@ describe('Textarea', () => {
       expect($label.attr('for')).toEqual('my-textarea')
     })
 
+    it('renders with hint', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the textarea as "described by" the hint', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      const $textarea = $('.govuk-textarea')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($textarea.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+
     it('renders with error message', () => {
       const $ = render('textarea', {
         id: 'textarea-with-error',
@@ -133,7 +163,7 @@ describe('Textarea', () => {
 
     it('associates the textarea as "described by" the error message', () => {
       const $ = render('textarea', {
-        id: 'input-with-error',
+        id: 'textarea-with-error',
         errorMessage: {
           'text': 'Error message'
         }

--- a/src/textarea/template.test.js
+++ b/src/textarea/template.test.js
@@ -7,6 +7,7 @@ const { render, getExamples, htmlWithClassName } = require('../../lib/jest-helpe
 const examples = getExamples('textarea')
 
 const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
 
 describe('Textarea', () => {
   describe('by default', () => {
@@ -81,6 +82,105 @@ describe('Textarea', () => {
     })
   })
 
+  describe('when it includes a hint', () => {
+    it('renders with hint', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    it('associates the textarea as "described by" the hint', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        hint: {
+          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
+        }
+      })
+
+      const $textarea = $('.govuk-textarea')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($textarea.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes an error message', () => {
+    it('renders with error message', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        errorMessage: {
+          text: 'Error message'
+        }
+      })
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    it('associates the textarea as "described by" the error message', () => {
+      const $ = render('textarea', {
+        id: 'textarea-with-error',
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-textarea')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(errorMessageId)
+    })
+
+    it('adds the error class to the textarea', () => {
+      const $ = render('textarea', {
+        errorMessage: {
+          'text': 'Error message'
+        }
+      })
+
+      const $component = $('.govuk-textarea')
+      expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
+    })
+  })
+
+  describe('when it includes both a hint and an error message', () => {
+    it('associates the textarea as described by both the hint and the error message', () => {
+      const $ = render('textarea', {
+        errorMessage: {
+          'text': 'Error message'
+        },
+        hint: {
+          'text': 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-textarea')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
+
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('textarea', {
@@ -118,77 +218,6 @@ describe('Textarea', () => {
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('my-textarea')
-    })
-
-    it('renders with hint', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        hint: {
-          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
-    })
-
-    it('associates the textarea as "described by" the hint', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        hint: {
-          'text': 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
-
-      const $textarea = $('.govuk-textarea')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($textarea.attr('aria-describedby'))
-        .toMatch(hintId)
-    })
-
-    it('renders with error message', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
-
-      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
-    })
-
-    it('associates the textarea as "described by" the error message', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-textarea')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
-    })
-
-    it('has error class when rendered with error message', () => {
-      const $ = render('textarea', {
-        errorMessage: {
-          'text': 'Error message'
-        }
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
   })
 })

--- a/src/textarea/textarea.yaml
+++ b/src/textarea/textarea.yaml
@@ -5,8 +5,9 @@ examples:
       id: more-detail
       label:
         text: Can you provide more detail?
-        hintText: Don't include personal or financial information, eg your
-                  National Insurance number or credit card details.
+      hint:
+        text: Don't include personal or financial information, eg your
+              National Insurance number or credit card details.
 
   - name: with error message
     data:


### PR DESCRIPTION
This PR moves error messages and hints out of legends and labels, instead associating them with the input using `aria-describedby`.

https://govuk-frontend-review-pr-681.herokuapp.com/

https://trello.com/c/6JHtnTfC

Co-authored with @36degrees.

## Background

For question pages that follow the 'one-thing-per-page' format, the question being asked functions as both the label for the question and the H1 for the page.

<img width="870" alt="screen shot 2018-05-03 at 13 09 09" src="https://user-images.githubusercontent.com/121939/39575642-36cf2a5a-4ed3-11e8-946b-236bb9dc35f5.png">

This was previously achieved by putting the question in the H1 but duplicating it within a _visually hidden label or legend_. This was functional, but resulted in the question being read twice by screen readers. Anika [did a lot of research into this and made changes to Elements to remove the duplication](https://github.com/alphagov/govuk_elements/pull/507).

The way this currently works is:

- putting the `<h1>` _inside_ the legend of a fieldset (`<legend><h1>Question</h1></legend>`); or
- wrapping the `<label>` in an `<h1>` (`<h1><label>Question</label></h1>`)

The reason that the nesting differs is that fieldsets allow '[phrasing content](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#Phrasing_content) and headings' as permitted content (since https://github.com/w3c/html/issues/724) but labels only allow for 'phrasing content', so a heading inside a label is technically invalid.

There are a few issues that we would like to address to make this approach work correctly in GOV.UK Frontend:

- If the form field has associated hint text and an error message then these become _part of the h1_ for the page as well.
- because the hint and error message are part of the label, clicking them focusses the input. This confuses things if the hint or error message contain a link – for example to additional guidance or resources.
- it is difficult to make the relationship between the question and the hint and error message consistent with the `fieldset`, because of the inconsistency in the markup.

Having explored a number of options (including [questioning whether the HTML spec should allow headings inside labels](https://github.com/w3c/html/issues/1270)), we've settled on moving the hint and error message outside of the label / legend and associating them with `aria-describedby` as [has been previously suggested](https://github.com/alphagov/govuk_elements/issues/574) - it resolves the first two issues and makes it considerably easier to tackle the third.

Unfortunately Voiceover on macOS will not announce the hint or error message when focussing the field. This is not ideal, but every approach (including the current approach of nesting them inside the label) had issues in at least one combination of technologies, so we have opted to go with the approach that seemed the most 'semantically correct', which is to treat the error message and hints as part of the 'description' of the field as per [the ARIA spec](https://www.w3.org/TR/wai-aria-1.1/#aria-describedby):

> The aria-labelledby attribute is similar to the aria-describedby in that both reference other elements to calculate a text alternative, but a label should be concise, where a description is intended to provide more verbose information.

~~We will file an issue with Apple if we can not find it already recorded as a bug.~~

[We have filed a bug report with Apple for this issue](https://bugs.webkit.org/show_bug.cgi?id=185246).

We considered using different approaches for different scenarios (for example, only using `aria-describedby` if the `legend` or `label` sits inside a heading, or using different implementations depending on whether we are dealing with a `legend` or a `label`). However, we concluded that there were a number of benefits to having a consistent approach, as: 

- assistive technologies should announce the field(s) in a consistent manner regardless of the field type or page structure
- it reduces the likelihood of service teams introducing errors when implementing
- it reduces the complexity of the logic required in the macros for the different components

### Detailed changes

- moves errorMessage component out of label (for every component that uses a label)
- moves errorMessage component out of legend  (for every component that uses a fieldset)
- adds a Hint component (similar with the errorMessage component; up for discussions if this component should be treated separately in the Design System)
- moves hint out of label (for every component that uses a label)
- moves hint out of legend  (for every component that uses a fieldset)
- updates SCSS dependencies for each updated component
- update tests to reflect the changes mentioned above
- add a dependency on `/tools/exports` to `helpers/clearfix` in order to pass the _Individual components should compile individual SCSS files without throwing exceptions_

### To be done in future PRs:
- update the styling (one obvious issue is the bottom spacing on the legend, which visually separates it from the hint and the error message)
  <img width="244" alt="screen shot 2018-05-03 at 11 01 15" src="https://user-images.githubusercontent.com/788096/39570862-9b7e394e-4ec1-11e8-98c8-830dfe7f98dc.png">
- handle the headings in labels and legends


## Appendix: Results of testing with assistive technologies

### Current approach (nesting error and hint inside of legend or label)

#### Input with `<label>`

❗️When the `<label>` is nested inside a heading, the hint and error message also become part of the heading.

❗️It is difficult to make the relationship between the question and the hint and error message consistent with the `fieldset`, because of the inconsistency in the markup.

<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> "National insurance number It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number edit text
> 
> You are currently on a text field, inside of HTML content. To enter text in this field, type. To exit this web area, press Control-Option-Shift-Up Arrow."
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>✅ Voiceover + Safari (iOS 11)</summary>  

Voiceover announces:

> National insurance number It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, text field.
> 
> Double tap to edit.
</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>✅ Voiceover + Safari (iOS 10)</summary>  

Voiceover announces:

> National insurance number It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, text field.
> 
> Double tap to edit.
</details>


<!-- Voiceover + iOS 9 -->

<details>
<summary>✅ Voiceover + Safari (iOS 9)</summary>  

Voiceover announces:

> National insurance number It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, text field.
>
> Double tap to edit."
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> National insurance number. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number. Edit. Blank.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> National insurance number.
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
> Enter your national insurance number.
> Edit. Type in text.
</details>



#### Fieldset with `<legend>`

Very strange issue in JAWS18 where the hint and error message are not announced. Other than that, this works OK – because the heading is inside the legend (unlike label) the hint and error message can sit outside of the page heading. (Update: This appears to have been fixed in JAWS 2018)

<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> "Yes, radio button, 1 of 2, Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.
>
> You are currently on a radio button, 1 of 2, inside of a group. To select this option…"
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>✅ Voiceover + Safari (iOS 11)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.

Then, for each input:

> Yes, radio button, 1 of 2.
</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>✅ Voiceover + Safari (iOS 10)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.

Then, for each input:

> Yes, radio button, 1 of 2.
</details>


<!-- Voiceover + iOS 9 -->

<details>
<summary>✅ Voiceover + Safari (iOS 9)</summary>  

For each input, Voiceover announces:

> Yes, radio button, 1 of 2. This includes changing your last name or spelling your name differently. Choose yes or no.

iOS 9 does not seem to announce `<fieldset>` legends for inputs.
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> Have you changed your name?
> This includes changing your last name or spelling your name differently.
> Choose yes or no. Grouping.
> Yes, radio button, not checked, 1 of 2.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>❗️ JAWS18 + IE11</summary>

JAWS announces:

> Have you changed your name?
> Yes, radio button, not checked.

Hint and error message are not announced despite being part of the legend. Absolutely no idea what's going on here. Tested this with the current implementation in Elements and the same thing happens.
</details>


### Associating error and hint with `aria-describedby`

Seems like the 'correct' implementation semantically. Some slight quirks in the way this is announced, e.g. JAWS puts the description between "Edit" and "Type in text" which seems disjointed.

For legends, we should associate the hint and error message with the fieldset, not the individual inputs.

#### Input with `<label>`

<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> National insurance number, edit text
>  
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, You are currently on a text field, inside of HTML content. To enter text in this field, type. To exit this web area, press Control-Option-Shift-Up Arrow.
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>✅ Voiceover + Safari (iOS 11)</summary>  

Voiceover announces:

> National insurance number, text field
> 
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, double tap to edit
</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>✅ Voiceover + Safari (iOS 10)</summary>  

Voiceover announces:

> National insurance number, text field
> 
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, double tap to edit
</details>


<!-- Voiceover + iOS 9 -->

<details>
<summary>✅ Voiceover + Safari (iOS 9)</summary>  

Voiceover announces:

> National insurance number, text field
> 
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number, double tap to edit
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> National insurance number. Edit. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number. Blank.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> National insurance number. Edit. Use JAWS key + alt + r to read descriptive text.
It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
Enter your national insurance number.
Type in text.

(includes JAWS commands)
</details>



#### Fieldset with `<legend>`, `aria-describedby` on each `<input>`


<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> Yes, radio button, 1 of 2, Have you changed your name?

This includes changing your last name or spelling your name differently. Choose yes or no. You are currently on a radio button, 1 of 2, inside of a group. To select this option…
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 11)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name?

Then, for each input:

> Yes, radio button, 1 of 2. This includes changing your last name or spelling your name differently. Choose yes or no.

Hint and error message are always announced when focussing the input, but the legend is only announced when entering the fieldset. This behaviour may be confusing as the hint is unlikely to make sense without the question being announced. It's also overly verbose.

</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 10)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name?

Then, for each input:

> Yes, radio button, 1 of 2. This includes changing your last name or spelling your name differently. Choose yes or no.

Hint and error message are always announced when focussing the input, but the legend is only announced when entering the fieldset. This behaviour may be confusing as the hint is unlikely to make sense without the question being announced. It's also overly verbose.

</details>

<!-- Voiceover + iOS 9 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 9)</summary>  

For each input, Voiceover announces:

> Yes, radio button, 1 of 2. This includes changing your last name or spelling your name differently. Choose yes or no.

iOS 9 does not seem to announce `<fieldset>` legends for inputs.
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> "Have you changed your name? Grouping.
> Yes, radio button, not checked.
> This includes changing your last name or spelling your name differently. Choose yes or number. 1 of 2."

There is a minor bug here ([reported](https://github.com/nvaccess/nvda/issues/8255)) where no is announced as number, but it is a side effect of the ordering.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> "Have you changed your name?
Yes, radio button, not checked. This includes changing your last name or spelling your name differently.
Choose yes or no."
</details>



#### Fieldset with `<legend>`, `aria-describedby` on the `<fieldset>`


<!-- Voiceover + Safari -->

<details>
<summary>❗️ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> Yes, radio button, 1 of 2, Have you changed your name?
> 
> You are currently on a radio button, 1 of 2, inside of a group. To select this option…

The error message and hint are not announced.
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>✅ Voiceover + Safari (iOS 11)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name?
>
> This includes changing your last name or spelling your name differently. Choose yes or no.""

Then, for each input:

> Yes, radio button, 1 of 2.

</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>✅ Voiceover + Safari (iOS 10)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name?
>
> This includes changing your last name or spelling your name differently. Choose yes or no.""

Then, for each input:

> Yes, radio button, 1 of 2.

</details>

<!-- Voiceover + iOS 9 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 9)</summary>  

For each input, Voiceover announces:

> Yes, radio button, unticked, 1 of 2.

iOS 9 does not seem to announce `<fieldset>` legends for inputs.
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> "Have you changed your name? Grouping.
> Yes, radio button, not checked.
> This includes changing your last name or spelling your name differently. Choose yes or number. 1 of 2."

There is a minor bug here where no is announced as number, but it is a side effect of the ordering.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> "Have you changed your name?
Yes, radio button, not checked. This includes changing your last name or spelling your name differently.
Choose yes or no."
</details>





### Associating error and hint with `aria-labelledby`

According to the ARIA spec, a label should be concise, where a description is intended to provide more verbose information. This suggests that aria-labelledby is not the right implementation for the hint and error message, as they do not label the field and cannot really be considered 'concise'.

#### Input with `<label>`

<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> "National insurance number It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number edit text

> You are currently on a text field, inside of HTML content. To enter text in this field, type. To exit this web area, press Control-Option-Shift-Up Arrow."
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 11)</summary>  

Voiceover announces:

> National insurance number, text field, double tap to edit.

A [bug in iOS](https://bugs.webkit.org/show_bug.cgi?id=172464) means that if a label is associated with a field, that label will override any aria defined label.
</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 10)</summary>  

Voiceover announces:

> National insurance number, text field, double tap to edit.

A [bug in iOS](https://bugs.webkit.org/show_bug.cgi?id=172464) means that if a label is associated with a field, that label will override any aria defined label.
</details>


<!-- Voiceover + iOS 9 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 9)</summary>  

Voiceover announces:

> National insurance number, text field, double tap to edit.

A [bug in iOS](https://bugs.webkit.org/show_bug.cgi?id=172464) means that if a label is associated with a field, that label will override any aria defined label.
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> National insurance number. It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’. Enter your national insurance number. Edit. Blank.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> "National insurance number.
> It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
> Enter your national insurance number.
> Edit. Type in text."

(includes JAWS commands)
</details>



#### Fieldset with `<legend>`


<!-- Voiceover + Safari -->

<details>
<summary>✅ Voiceover + Safari (Mac OS X El Capitan)</summary>

Voiceover announces:

> "Yes, radio button, 1 of 2, Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.
> 
> You are currently on a radio button, 1 of 2, inside of a group. To select this option…"
</details>


<!-- Voiceover + iOS 11 -->

<details>
<summary>✅ Voiceover + Safari (iOS 11)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.

Then, for each input:

> Yes, radio button, 1 of 2.

</details>


<!-- Voiceover + iOS 10 -->

<details>
<summary>✅️ Voiceover + Safari (iOS 10)</summary>  

When entering the fieldset (e.g. navigating backwards through the document)", Voiceover announces:

> Have you changed your name? This includes changing your last name or spelling your name differently. Choose yes or no.

Then, for each input:

> Yes, radio button, 1 of 2.

</details>

<!-- Voiceover + iOS 9 -->

<details>
<summary>❗️ Voiceover + Safari (iOS 9)</summary>  

For each input, Voiceover announces:

> Yes, radio button, 1 of 2. This includes changing your last name or spelling your name differently. Choose yes or no.

iOS 9 does not seem to announce `<fieldset>` legends for inputs.
</details>


<!-- NVDA + Firefox -->

<details>
<summary>✅ NVDA + Firefox</summary>

NVDA announces:

> Have you changed your name?
> This includes changing your last name or spelling your name differently.
> Choose yes or no. Grouping.
> Yes, radio button, not checked, 1 of 2.

</details>


<!-- JAWS18 + IE11 -->

<details>
<summary>✅ JAWS18 + IE11</summary>

JAWS announces:

> "Have you changed your name?
> This includes changing your last name or spelling your name differently.
> Choose yes or no.
> Have you changed your name?
> Yes, radio button, not checked."
</details>

