### PR TITLE
Section break styles fix when used with Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Fixes:
 - Reinstate focus outline for radios and checkboxes on IE8
   (PR [#670](https://github.com/alphagov/govuk-frontend/pull/670))
 
+- Fix section break styles when used with GOV.UK Elements
+  ([PR #682](https://github.com/alphagov/govuk-frontend/pull/682))
+
 New features:
 
 - We're now using ES6 Modules and [rollup](https://rollupjs.org/guide/en) to distribute our JavaScript. (PR [#652](https://github.com/alphagov/govuk-frontend/pull/652))

--- a/src/globals/core/_section-break.scss
+++ b/src/globals/core/_section-break.scss
@@ -5,6 +5,12 @@
   %govuk-section-break {
     margin: 0;
     border: 0;
+
+    // fix double-width section break and forced visible section break
+    // when combined with styles from alphagov/elements
+    @include govuk-compatibility(govuk_elements) {
+      height: 0;
+    }
   }
 
   .govuk-section-break {


### PR DESCRIPTION
`<hr>` styling in Elements has background and height
set, whereas in Frontend we're using border bottom.

To fix, `height:0` was added in a compatibility conditional include.

This fixes both the thickness and the fact that styles from Elements were making invisible section breaks visible
Before:
![screen shot 2018-05-04 at 14 14 37](https://user-images.githubusercontent.com/3758555/39629921-a5deaed4-4fa5-11e8-8cbb-e74628016537.png)

After:
![screen shot 2018-05-04 at 14 14 55](https://user-images.githubusercontent.com/3758555/39629928-a98ff7b8-4fa5-11e8-93c8-0bcf40003f08.png)

Elements styles causing non-visible section break to be visible:

![screen shot 2018-05-08 at 09 06 28](https://user-images.githubusercontent.com/3758555/39745459-36bd9a72-529f-11e8-8c15-5e6292ea4a82.png)


Ticket: https://trello.com/c/Sc7RtFZK/815-remove-section-break-border-coming-from-elements