### PR TITLE
Make `button` element the default instead of `input` for button macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Breaking change:
   to a more consise naming structure. We have also introduced two mixins
   to help generate additional or custom grid styles and widths.
 
+- Make `button` element the default instead of `input` for button macro
+  ([PR #683](https://github.com/alphagov/govuk-frontend/pull/683))
+  We are making `button` the default, however since the `button` element is buggy in IE6 / IE7, we are allowing input to be used if required.
+
 Fixes:
 
 - Remove redundant font-family declaration from the button component – this will

--- a/src/button/README.md
+++ b/src/button/README.md
@@ -18,7 +18,9 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Markup
 
-    <input value="Save and continue" type="submit" class="govuk-button">
+    <button type="submit" class="govuk-button">
+      Save and continue
+    </button>
 
 #### Macro
 
@@ -34,7 +36,9 @@ Buttons are configured to perform an action and they can have a different look. 
 
 #### Markup
 
-    <input value="Disabled button" type="submit" disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled">
+    <button type="submit" disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled">
+      Disabled button
+    </button>
 
 #### Macro
 
@@ -104,43 +108,39 @@ Buttons are configured to perform an action and they can have a different look. 
       "classes": "govuk-button--start"
     }) }}
 
-### Button--explicit-button
+### Button--explicit-input-button
 
-[Preview the button--explicit-button example](http://govuk-frontend-review.herokuapp.com/components/button/explicit-button/preview)
+[Preview the button--explicit-input-button example](http://govuk-frontend-review.herokuapp.com/components/button/explicit-input-button/preview)
 
 #### Markup
 
-    <button name="start-now" type="submit" class="govuk-button">
-      Start now
-    </button>
+    <input value="Start now" name="start-now" type="submit" class="govuk-button">
 
 #### Macro
 
     {% from 'button/macro.njk' import govukButton %}
 
     {{ govukButton({
-      "element": "button",
+      "element": "input",
       "name": "start-now",
       "text": "Start now"
     }) }}
 
-### Button--explicit-button-disabled
+### Button--explicit-input-button-disabled
 
-[Preview the button--explicit-button-disabled example](http://govuk-frontend-review.herokuapp.com/components/button/explicit-button-disabled/preview)
+[Preview the button--explicit-input-button-disabled example](http://govuk-frontend-review.herokuapp.com/components/button/explicit-input-button-disabled/preview)
 
 #### Markup
 
-    <button type="submit" disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled">
-      Explicit button disabled
-    </button>
+    <input value="Explicit input button disabled" type="submit" disabled="disabled" aria-disabled="true" class="govuk-button govuk-button--disabled">
 
 #### Macro
 
     {% from 'button/macro.njk' import govukButton %}
 
     {{ govukButton({
-      "element": "button",
-      "text": "Explicit button disabled",
+      "element": "input",
+      "text": "Explicit input button disabled",
       "disabled": true
     }) }}
 

--- a/src/button/button.yaml
+++ b/src/button/button.yaml
@@ -20,15 +20,15 @@ examples:
     text: Start now link button
     href: /
     classes: 'govuk-button--start'
-- name: explicit-button
+- name: explicit-input-button
   data:
-    element: button
+    element: input
     name: start-now
     text: Start now
-- name: explicit-button-disabled
+- name: explicit-input-button-disabled
   data:
-    element: button
-    text: Explicit button disabled
+    element: input
+    text: Explicit input button disabled
     disabled: true
 - name: button-active-state
   description: Simulate triggering the :active CSS pseudo-class, not available in the production build.

--- a/src/button/template.njk
+++ b/src/button/template.njk
@@ -5,10 +5,8 @@
 {% else %}
   {% if params.href %}
     {% set element = 'a' %}
-  {% elseif params.html %}
-    {% set element = 'button' %}
   {% else %}
-    {% set element = 'input' %}
+    {% set element = 'button' %}
   {% endif %}
 {% endif %}
 

--- a/src/button/template.test.js
+++ b/src/button/template.test.js
@@ -14,19 +14,18 @@ describe('Button', () => {
     expect(results).toHaveNoViolations()
   })
 
-  describe('input[type=submit]', () => {
+  describe('button element', () => {
     it('renders the default example', () => {
       const $ = render('button', examples.default)
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('input')
-      expect($component.attr('type')).toEqual('submit')
-      expect($component.val()).toEqual('Save and continue')
+      expect($component.get(0).tagName).toEqual('button')
+      expect($component.text()).toContain('Save and continue')
     })
 
     it('renders with attributes', () => {
       const $ = render('button', {
-        element: 'input',
+        element: 'button',
         attributes: {
           'aria-controls': 'example-id',
           'data-tracking-dimension': '123'
@@ -40,7 +39,7 @@ describe('Button', () => {
 
     it('renders with classes', () => {
       const $ = render('button', {
-        element: 'input',
+        element: 'button',
         classes: 'app-button--custom-modifier'
       })
 
@@ -59,7 +58,7 @@ describe('Button', () => {
 
     it('renders with name', () => {
       const $ = render('button', {
-        element: 'input',
+        element: 'button',
         name: 'start-now'
       })
 
@@ -69,7 +68,7 @@ describe('Button', () => {
 
     it('renders with type', () => {
       const $ = render('button', {
-        element: 'input',
+        element: 'button',
         type: 'button'
       })
 
@@ -100,6 +99,26 @@ describe('Button', () => {
 
       const $component = $('.govuk-button')
       expect($component.attr('href')).toEqual('#')
+    })
+
+    it('renders with value', () => {
+      const $ = render('button', {
+        element: 'button',
+        value: 'start'
+      })
+
+      const $component = $('.govuk-button')
+      expect($component.attr('value')).toEqual('start')
+    })
+
+    it('renders with html', () => {
+      const $ = render('button', {
+        element: 'button',
+        html: 'Start <em>now</em>'
+      })
+
+      const $component = $('.govuk-button')
+      expect($component.html()).toContain('Start <em>now</em>')
     })
 
     it('renders with attributes', () => {
@@ -134,18 +153,18 @@ describe('Button', () => {
     })
   })
 
-  describe('with explicit button set by "element"', () => {
+  describe('with explicit input button set by "element"', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const $ = render('button', examples['explicit-button'])
+      const $ = render('button', examples['explicit-input-button'])
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('button')
+      expect($component.get(0).tagName).toEqual('input')
       expect($component.attr('type')).toEqual('submit')
     })
 
     it('renders with attributes', () => {
       const $ = render('button', {
-        element: 'button',
+        element: 'input',
         attributes: {
           'aria-controls': 'example-id',
           'data-tracking-dimension': '123'
@@ -159,7 +178,7 @@ describe('Button', () => {
 
     it('renders with classes', () => {
       const $ = render('button', {
-        element: 'button',
+        element: 'input',
         classes: 'app-button--custom-modifier'
       })
 
@@ -169,7 +188,7 @@ describe('Button', () => {
 
     it('renders with disabled', () => {
       const $ = render('button', {
-        element: 'button',
+        element: 'input',
         disabled: true
       })
 
@@ -181,7 +200,7 @@ describe('Button', () => {
 
     it('renders with name', () => {
       const $ = render('button', {
-        element: 'button',
+        element: 'input',
         name: 'start-now'
       })
 
@@ -189,29 +208,9 @@ describe('Button', () => {
       expect($component.attr('name')).toEqual('start-now')
     })
 
-    it('renders with value', () => {
-      const $ = render('button', {
-        element: 'button',
-        value: 'start'
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.attr('value')).toEqual('start')
-    })
-
-    it('renders with html', () => {
-      const $ = render('button', {
-        element: 'button',
-        html: 'Start <em>now</em>'
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.html()).toContain('Start <em>now</em>')
-    })
-
     it('renders with type', () => {
       const $ = render('button', {
-        element: 'button',
+        element: 'input',
         type: 'button',
         text: 'Start now'
       })
@@ -240,11 +239,11 @@ describe('Button', () => {
       expect($component.get(0).tagName).toEqual('button')
     })
 
-    it('renders an input[type=submit] if you don\'t pass anything', () => {
+    it('renders a button if you don\'t pass anything', () => {
       const $ = render('button', {})
 
       const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('input')
+      expect($component.get(0).tagName).toEqual('button')
       expect($component.attr('type')).toEqual('submit')
     })
   })


### PR DESCRIPTION
We are making `button` the default, however since the `button` element is buggy in IE6 / IE7, we are allowing input to be used if required.

Thanks @quis for the original issue on GOV.UK Elements :)

Context: https://github.com/alphagov/govuk_elements/pull/593

Trello: https://trello.com/c/gITiuXcS/765-use-button-by-default-for-buttons-rather-than-input-typebutton