### PR TITLE
Better define relationship between headings, error message and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,80 @@ Breaking changes:
   to force JAWS 18 to announce the error message and hint.
   ([PR #681](https://github.com/alphagov/govuk-frontend/pull/681))
 
+- The label component now accepts an `isPageHeading` argument which determines
+  whether the label itself should be wrapped in an h1:
+
+  ```html
+  <h1 class="govuk-label-wrapper">
+    <label class="govuk-label">What is your National Insurance number?</label>
+  </h1>
+  ```
+
+  The `.govuk-label-wrapper` removes the margins from the heading so that the
+  presence of the `h1` has no effect on the styling of the label.
+
+  ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
+
+
+- Added new modifier classes for labels to allow you to create a label that
+  visually corresponds to the equivalent heading class (for example, a
+  `.govuk-label--xl` will have the same font size and weight as a
+  `.govuk-heading-xl`)
+
+  ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
+
+
+- The arguments for a fieldset's legend have been rolled up into an object. For
+  example, the following macro call:
+
+  ```
+  {{ govukFieldset({
+    legendText: "What is your date of birth?"
+  }) }}
+  ```
+
+  would now be:
+
+  ```
+  {{ govukFieldset({
+    legend: {
+      text: "What is your date of birth?"
+    }
+  }) }}
+  ```
+
+  The `legend` object can also accept new `classes` and `arguments` 
+
+  Components that use the fieldset component have been updated to reflect these
+  changes.
+
+  ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
+
+
+- The fieldset component has a new parameter legend.isPageHeading, which defines
+  whether the legend text should be wrapped in an h1:
+
+  ```html
+  <legend class="govuk-fieldset__legend">
+    <h1 class="govuk-fieldset__heading">Have you changed your name?</h1>
+  </legend>
+  ```
+
+  The `.govuk-fieldset__heading` class ensures that the `<h1>` inherits its
+  properties from the legend, so that the presence of the `h1` has no effect on
+  its styling.
+
+  ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
+
+
+- Added new modifier classes for legends to allow you to create a legend that
+  visually corresponds to the equivalent heading class (for example, a
+  `.govuk-fieldset__legend--xl` will have the same font size and weight as a
+  `.govuk-heading-xl`)
+
+  ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
+
+
 - Remove -c -o -h layer prefixes
   ([PR #644](https://github.com/alphagov/govuk-frontend/pull/644))
   In user research and in feedback from Private Beta partners we

--- a/app/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/app/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -33,12 +33,21 @@
   }) }}
 
   {{ govukDateInput({
-      fieldset: {
-      legendHtml: '<h1 class="govuk-heading-xl">What is your date of birth?</h1>',
-      legendHintText: 'For example, 31 3 1980'
-    },
     id: 'dob',
     name: 'dob',
+    fieldset: {
+      legend: {
+        text: 'What is your date of birth?',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
     items:[
       {
         name: 'day'
@@ -49,10 +58,7 @@
       {
         name: 'year'
       }
-    ],
-    errorMessage: {
-      text: "You must provide your date of birth"
-    }
+    ]
     })
   }}
 

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -1,0 +1,3268 @@
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "button/macro.njk" import govukButton %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from 'radios/macro.njk' import govukRadios %}
+{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from 'input/macro.njk' import govukInput %}
+
+{% extends "layout.njk" %}
+
+{% block content %}
+
+{{ govukBackLink({
+  "href": "/",
+  "text": "Back"
+}) }}
+
+<main class="govuk-main-wrapper">
+
+  <h1 class="govuk-heading-xl">Labels, legends and headings</h1>
+
+  <h2 class="govuk-heading-l">Text input</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--xl",
+      isPageHeading: true,
+      classes: 'govuk-label--xl '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--l",
+      isPageHeading: true,
+      classes: 'govuk-label--l '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--m",
+      isPageHeading: true,
+      classes: 'govuk-label--m '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--s",
+      isPageHeading: true,
+      classes: 'govuk-label--s '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> No class",
+      isPageHeading: true,
+      classes: ''
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--xl",
+      classes: 'govuk-label--xl '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--l",
+      classes: 'govuk-label--l '
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--m",
+      classes: 'govuk-label--m'
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--s",
+      classes: 'govuk-label--s'
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> No class",
+      classes: ''
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+  <h2 class="govuk-heading-l">Text input (with hint)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--xl",
+      isPageHeading: true,
+      classes: 'govuk-label--xl '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--l",
+      isPageHeading: true,
+      classes: 'govuk-label--l '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--m",
+      isPageHeading: true,
+      classes: 'govuk-label--m '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--s",
+      isPageHeading: true,
+      classes: 'govuk-label--s '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> No class",
+      isPageHeading: true,
+      classes: ''
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--xl",
+      classes: 'govuk-label--xl '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--l",
+      classes: 'govuk-label--l '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--m",
+      classes: 'govuk-label--m'
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--s",
+      classes: 'govuk-label--s'
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> No class",
+      classes: ''
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "",
+    "name": "test-name-1"
+  }) }}
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+  <h2 class="govuk-heading-l">Text input (with hint and error)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--xl",
+      isPageHeading: true,
+      classes: 'govuk-label--xl '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--l",
+      isPageHeading: true,
+      classes: 'govuk-label--l '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--m",
+      isPageHeading: true,
+      classes: 'govuk-label--m '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> govuk-label--s",
+      isPageHeading: true,
+      classes: 'govuk-label--s '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<h1> No class",
+      isPageHeading: true,
+      classes: ''
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--xl",
+      classes: 'govuk-label--xl '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--l",
+      classes: 'govuk-label--l '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--m",
+      classes: 'govuk-label--m '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> govuk-label--s",
+      classes: 'govuk-label--s '
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+  {{ govukInput({
+    "label": {
+      "text": "<label> No class",
+      classes: ''
+    },
+    "hint": {
+      "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
+    },
+    "id": "input-with-error-message",
+    "name": "test-name-1",
+    "errorMessage": {
+      "text": "Error message goes here"
+    }
+  }) }}
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+  <h2 class="govuk-heading-l">Checkboxes</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+
+
+
+
+  <h2 class="govuk-heading-l">Checkboxes (with hint)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+
+  <h2 class="govuk-heading-l">Checkboxes (with hint and error)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+  {{ govukCheckboxes({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "If you have dual nationality, select all options that are relevant to you."
+    },
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "items": [
+      {
+        "value": "british",
+        "text": "British"
+      },
+      {
+        "value": "irish",
+        "text": "Irish"
+      },
+      {
+        "value": "other",
+        "text": "Citizen of another country"
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+  <h2 class="govuk-heading-l">Radios</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+
+  <h2 class="govuk-heading-l">Radios (with hint)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+
+
+  <h2 class="govuk-heading-l">Radios (with hint and error)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+  {{ govukRadios({
+    "idPrefix": "example",
+    "name": "example",
+    "errorMessage": {
+      "text": "Please select an option"
+    },
+    "fieldset": {
+      "classes": "app-fieldset--custom-modifier",
+      "attributes": {
+        "data-attribute": "value",
+        "data-second-attribute": "second-value"
+      },
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    "hint": {
+      "text": "This includes changing your last name or spelling your name differently."
+    },
+    "items": [
+      {
+        "value": "yes",
+        "text": "Yes"
+      },
+      {
+        "value": "no",
+        "text": "No",
+        "checked": true
+      }
+    ]
+  }) }}
+
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+  <h2 class="govuk-heading-l">Date Input</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+  <h2 class="govuk-heading-l">Date Input (with hint)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  <form action="/" method="post">
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
+
+
+
+  <h2 class="govuk-heading-l">Date Input (with hint and error)</h2>
+
+  <h3 class="govuk-heading-s">isPageHeading: true</h3>
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--xl',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--l',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--m',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> govuk-fieldset__legend--s',
+        isPageHeading: true,
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<h1> No class',
+        isPageHeading: true,
+        classes: ''
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+
+  <h3 class="govuk-heading-s">isPageHeading: false</h3>
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--xl',
+        classes: 'govuk-fieldset__legend--xl'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--l',
+        classes: 'govuk-fieldset__legend--l'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--m',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> govuk-fieldset__legend--s',
+        classes: 'govuk-fieldset__legend--s'
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+  {{ govukDateInput({
+    id: 'dob',
+    name: 'dob',
+    fieldset: {
+      legend: {
+        text: '<legend> No class',
+        classes: ''
+      }
+    },
+    hint: {
+      text: 'For example 5 12 1987'
+    },
+    errorMessage: {
+      text: "You must provide your date of birth"
+    },
+    items:[
+      {
+        name: 'day'
+      },
+      {
+        name: 'month'
+      },
+      {
+        name: 'year'
+      }
+    ]
+    })
+  }}
+
+</main>
+
+{% endblock %}

--- a/src/checkboxes/README.md
+++ b/src/checkboxes/README.md
@@ -64,7 +64,9 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
       "idPrefix": "nationality",
       "name": "nationality",
       "fieldset": {
-        "legendText": "What is your nationality?"
+        "legend": {
+          "text": "What is your nationality?"
+        }
       },
       "hint": {
         "text": "If you have dual nationality, select all options that are relevant to you."
@@ -196,7 +198,9 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
     {{ govukCheckboxes({
       "name": "waste",
       "fieldset": {
-        "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+        "legend": {
+          "html": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+        }
       },
       "hint": {
         "text": "Select all that apply"
@@ -337,7 +341,9 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
           "data-attribute": "value",
           "data-second-attribute": "second-value"
         },
-        "legendText": "What is your nationality?"
+        "legend": {
+          "text": "What is your nationality?"
+        }
       },
       "hint": {
         "text": "If you have dual nationality, select all options that are relevant to you."
@@ -417,7 +423,9 @@ Find out when to use the Checkboxes component in your service in the [GOV.UK Des
         "text": "Please select an option"
       },
       "fieldset": {
-        "legendHtml": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+        "legend": {
+          "html": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+        }
       },
       "items": [
         {
@@ -491,7 +499,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText). See fieldset component.</td>
+<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See fieldset component.</td>
 
 </tr>
 

--- a/src/checkboxes/checkboxes.yaml
+++ b/src/checkboxes/checkboxes.yaml
@@ -14,7 +14,8 @@ examples:
     idPrefix: 'nationality'
     name: 'nationality'
     fieldset:
-      legendText: What is your nationality?
+      legend:
+        text: What is your nationality?
     hint:
       text: If you have dual nationality, select all options that are relevant to you.
     items:
@@ -41,8 +42,8 @@ examples:
   data:
     name: waste
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
     hint:
       text: Select all that apply
     items:
@@ -73,7 +74,8 @@ examples:
       attributes:
         'data-attribute': 'value'
         'data-second-attribute': 'second-value'
-      legendText: What is your nationality?
+      legend:
+        text: What is your nationality?
     hint:
       text: If you have dual nationality, select all options that are relevant to you.
     errorMessage:
@@ -92,8 +94,8 @@ examples:
     errorMessage:
       text: 'Please select an option'
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
     items:
       - value: animal
         text: Waste from animal carcasses
@@ -107,8 +109,8 @@ examples:
   data:
     idPrefix: 'how-contacted'
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
     items:
       - value: email
         text: Email
@@ -134,8 +136,8 @@ examples:
   data:
     idPrefix: 'how-contacted-checked'
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
     items:
     - value: email
       text: Email

--- a/src/checkboxes/index.njk
+++ b/src/checkboxes/index.njk
@@ -48,7 +48,7 @@
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText). See fieldset component.'
+        text: 'Arguments for the fieldset component (e.g. legend). See fieldset component.'
       }
     ],
     [

--- a/src/checkboxes/template.njk
+++ b/src/checkboxes/template.njk
@@ -75,8 +75,7 @@
     describedBy: describedBy,
     classes: params.fieldset.classes,
     attributes: params.fieldset.attributes,
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml
+    legend: params.fieldset.legend
   }) %}
   {{ innerHtml | trim | safe }}
   {% endcall %}

--- a/src/checkboxes/template.test.js
+++ b/src/checkboxes/template.test.js
@@ -381,7 +381,9 @@ describe('Checkboxes', () => {
           }
         ],
         fieldset: {
-          legendHtml: 'What is your <b>nationality</b>?'
+          legend: {
+            html: 'What is your <b>nationality</b>?'
+          }
         }
       })
 

--- a/src/date-input/README.md
+++ b/src/date-input/README.md
@@ -72,7 +72,9 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob",
       "name": "dob",
       "fieldset": {
-        "legendText": "What is your date of birth?"
+        "legend": {
+          "text": "What is your date of birth?"
+        }
       },
       "hint": {
         "text": "For example, 31 3 1980"
@@ -155,7 +157,9 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
     {{ govukDateInput({
       "id": "dob-errors",
       "fieldset": {
-        "legendText": "What is your date of birth?"
+        "legend": {
+          "text": "What is your date of birth?"
+        }
       },
       "hint": {
         "text": "For example, 31 3 1980"
@@ -245,7 +249,9 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-day-error",
       "name": "dob-day-error",
       "fieldset": {
-        "legendText": "What is your date of birth?"
+        "legend": {
+          "text": "What is your date of birth?"
+        }
       },
       "hint": {
         "text": "For example, 31 3 1980"
@@ -333,7 +339,9 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-month-error",
       "name": "dob-month-error",
       "fieldset": {
-        "legendText": "What is your date of birth?"
+        "legend": {
+          "text": "What is your date of birth?"
+        }
       },
       "hint": {
         "text": "For example, 31 3 1980"
@@ -421,7 +429,9 @@ Find out when to use the Date input component in your service in the [GOV.UK Des
       "id": "dob-year-error",
       "name": "dob-year-error",
       "fieldset": {
-        "legendText": "What is your date of birth?"
+        "legend": {
+          "text": "What is your date of birth?"
+        }
       },
       "hint": {
         "text": "For example, 31 3 1980"
@@ -571,7 +581,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.</td>
+<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See fieldset component.</td>
 
 </tr>
 

--- a/src/date-input/date-input.njk
+++ b/src/date-input/date-input.njk
@@ -2,8 +2,9 @@
 
 {{- govukDateInput({
   fieldset: {
-    legendText: 'What is your date of birth?',
-    legendHintText: 'For example, 31 3 1980'
+    legend: {
+      text: 'What is your date of birth?'
+    }
   },
   id: 'dob',
   name: 'dob',

--- a/src/date-input/date-input.yaml
+++ b/src/date-input/date-input.yaml
@@ -4,7 +4,8 @@ examples:
     id: 'dob'
     name: 'dob'
     fieldset:
-      legendText: 'What is your date of birth?'
+      legend:
+        text: 'What is your date of birth?'
     hint:
       text: 'For example, 31 3 1980'
     items:
@@ -18,7 +19,8 @@ examples:
   data:
     id: 'dob-errors'
     fieldset:
-      legendText: 'What is your date of birth?'
+      legend:
+        text: 'What is your date of birth?'
     hint:
       text: 'For example, 31 3 1980'
     errorMessage:
@@ -38,7 +40,8 @@ examples:
     id: 'dob-day-error'
     name: 'dob-day-error'
     fieldset:
-      legendText: 'What is your date of birth?'
+      legend:
+        text: 'What is your date of birth?'
     hint:
       text: 'For example, 31 3 1980'
     errorMessage:
@@ -56,7 +59,8 @@ examples:
     id: 'dob-month-error'
     name: 'dob-month-error'
     fieldset:
-      legendText: 'What is your date of birth?'
+      legend:
+        text: 'What is your date of birth?'
     hint:
       text: 'For example, 31 3 1980'
     errorMessage:
@@ -74,7 +78,8 @@ examples:
     id: 'dob-year-error'
     name: 'dob-year-error'
     fieldset:
-      legendText: 'What is your date of birth?'
+      legend:
+        text: 'What is your date of birth?'
     hint:
       text: 'For example, 31 3 1980'
     errorMessage:

--- a/src/date-input/index.njk
+++ b/src/date-input/index.njk
@@ -131,7 +131,7 @@
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText, legendHintText, errorMessage). See fieldset component.'
+        text: 'Arguments for the fieldset component (e.g. legend). See fieldset component.'
       }
     ]
   ]

--- a/src/date-input/template.njk
+++ b/src/date-input/template.njk
@@ -66,8 +66,7 @@
     attributes: {
       role: 'group'
     },
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml
+    legend: params.fieldset.legend
   }) %}
   {{ innerHtml | trim | safe }}
   {% endcall %}

--- a/src/date-input/template.test.js
+++ b/src/date-input/template.test.js
@@ -291,8 +291,9 @@ describe('Date input', () => {
       id: 'dob',
       name: 'dob',
       fieldset: {
-        legendHtml: 'What is your <b>date of birth</b>?',
-        legendHintHtml: 'For example, <b>31 3 1980</b>'
+        legend: {
+          html: 'What is your <b>date of birth</b>?'
+        }
       },
       errorMessage: {
         text: 'Error message goes here'

--- a/src/error-message/_error-message.scss
+++ b/src/error-message/_error-message.scss
@@ -15,11 +15,9 @@
   .govuk-error-message {
     @include govuk-font-bold-19;
 
-    display: block;
+    margin-bottom: $govuk-spacing-scale-3;
 
-    margin: 0;
-    // TODO: use a var for padding
-    padding: 2px 0;
+    display: block;
 
     clear: both;
 

--- a/src/error-message/_error-message.scss
+++ b/src/error-message/_error-message.scss
@@ -15,10 +15,8 @@
   .govuk-error-message {
     @include govuk-font-bold-19;
 
-    margin-bottom: $govuk-spacing-scale-3;
-
     display: block;
-
+    margin-bottom: $govuk-spacing-scale-3;
     clear: both;
 
     color: $govuk-error-colour;

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -29,7 +29,9 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
     {% from 'fieldset/macro.njk' import govukFieldset %}
 
     {{ govukFieldset({
-      "legendText": "What is your address?"
+      "legend": {
+        "text": "What is your address?"
+      }
     }) }}
 
 ### Fieldset--as page heading
@@ -53,8 +55,10 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
     {% from 'fieldset/macro.njk' import govukFieldset %}
 
     {{ govukFieldset({
-      "legendText": "What is your address?",
-      "legendIsPageHeading": true
+      "legend": {
+        "text": "What is your address?",
+        "isPageHeading": true
+      }
     }) }}
 
 ## Dependencies
@@ -119,7 +123,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legendText</th>
+<th class="govuk-table__header" scope="row">legend</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Arguments for the legend</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">legend.text</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -131,7 +147,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legendHtml</th>
+<th class="govuk-table__header" scope="row">legend.html</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -143,7 +159,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legendIsPageHeading</th>
+<th class="govuk-table__header" scope="row">legend.isPageHeading</th>
 
 <td class="govuk-table__cell ">boolean</td>
 

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -42,7 +42,7 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
 
     <fieldset class="govuk-fieldset">
 
-      <legend class="govuk-fieldset__legend">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
         <h1 class="govuk-fieldset__heading">
           What is your address?
         </h1>
@@ -57,6 +57,7 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
     {{ govukFieldset({
       "legend": {
         "text": "What is your address?",
+        "classes": "govuk-fieldset__legend--xl",
         "isPageHeading": true
       }
     }) }}

--- a/src/fieldset/README.md
+++ b/src/fieldset/README.md
@@ -32,6 +32,31 @@ Find out when to use the Fieldset component in your service in the [GOV.UK Desig
       "legendText": "What is your address?"
     }) }}
 
+### Fieldset--as page heading
+
+[Preview the fieldset--as page heading example](http://govuk-frontend-review.herokuapp.com/components/fieldset/as page heading/preview)
+
+#### Markup
+
+    <fieldset class="govuk-fieldset">
+
+      <legend class="govuk-fieldset__legend">
+        <h1 class="govuk-fieldset__heading">
+          What is your address?
+        </h1>
+      </legend>
+
+    </fieldset>
+
+#### Macro
+
+    {% from 'fieldset/macro.njk' import govukFieldset %}
+
+    {{ govukFieldset({
+      "legendText": "What is your address?",
+      "legendIsPageHeading": true
+    }) }}
+
 ## Dependencies
 
 To consume the fieldset component you must be running npm version 5 or above.
@@ -113,6 +138,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Legend text</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">legendIsPageHeading</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Whether the legend also acts as the heading for the page.</td>
 
 </tr>
 

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -41,19 +41,27 @@
     overflow: hidden;
 
     white-space: normal;    // 1
+  }
 
-    .govuk-heading-s {
-      margin-bottom: 0;
-    }
+  // Modifiers that make legends look more like their equivalent headings
 
-    .govuk-heading-m {
-      margin-bottom: $govuk-spacing-scale-1;
-    }
+  .govuk-fieldset__legend--xl {
+    @include govuk-font-bold-48;
+    margin-bottom: $govuk-spacing-scale-3;
+  }
 
-    .govuk-heading-l,
-    .govuk-heading-xl {
-      margin-bottom: $govuk-spacing-scale-3;
-    }
+  .govuk-fieldset__legend--l {
+    @include govuk-font-bold-36;
+    margin-bottom: $govuk-spacing-scale-3;
+  }
+
+  .govuk-fieldset__legend--m {
+    @include govuk-font-bold-24;
+    margin-bottom: $govuk-spacing-scale-1;
+  }
+
+  .govuk-fieldset__legend--s {
+    @include govuk-font-bold-19;
   }
 
   // When the legend contains an H1, we want the H1 to inherit all styles from
@@ -63,9 +71,5 @@
     margin: 0;
     font-size: inherit;
     font-weight: inherit;
-  }
-
-  .govuk-fieldset__legend--bold {
-    @include govuk-typography-weight-bold;
   }
 }

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -35,7 +35,7 @@
     box-sizing: border-box; // 1
     display: table;         // 2
     max-width: 100%;        // 1
-    margin-bottom: $govuk-spacing-scale-4;
+    margin-bottom: $govuk-spacing-scale-3;
     padding: 0;
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;
@@ -47,17 +47,14 @@
 
   .govuk-fieldset__legend--xl {
     @include govuk-font-bold-48;
-    margin-bottom: $govuk-spacing-scale-3;
   }
 
   .govuk-fieldset__legend--l {
     @include govuk-font-bold-36;
-    margin-bottom: $govuk-spacing-scale-3;
   }
 
   .govuk-fieldset__legend--m {
     @include govuk-font-bold-24;
-    margin-bottom: $govuk-spacing-scale-1;
   }
 
   .govuk-fieldset__legend--s {

--- a/src/fieldset/_fieldset.scss
+++ b/src/fieldset/_fieldset.scss
@@ -56,6 +56,15 @@
     }
   }
 
+  // When the legend contains an H1, we want the H1 to inherit all styles from
+  // the legend. Effectively we want to be able to treat the heading as if it is
+  // not there.
+  .govuk-fieldset__heading {
+    margin: 0;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
   .govuk-fieldset__legend--bold {
     @include govuk-typography-weight-bold;
   }

--- a/src/fieldset/fieldset.njk
+++ b/src/fieldset/fieldset.njk
@@ -1,8 +1,12 @@
 {% from "fieldset/macro.njk" import govukFieldset %}
 
 {{ govukFieldset({
-  "legendText": "Legend text goes here",
-  "legendHintText": "Legend hint text goes here",
+  "legend": {
+    "text": "Legend text goes here"
+  },
+  "hint": {
+    "text": "Legend hint text goes here"
+  },
   "errorMessage": {
     "text": "Error message goes here"
   }

--- a/src/fieldset/fieldset.yaml
+++ b/src/fieldset/fieldset.yaml
@@ -7,4 +7,5 @@ examples:
   data:
     legend:
       text: What is your address?
+      classes: govuk-fieldset__legend--xl
       isPageHeading: true

--- a/src/fieldset/fieldset.yaml
+++ b/src/fieldset/fieldset.yaml
@@ -1,8 +1,10 @@
 examples:
 - name: default
   data:
-    legendText: What is your address?
+    legend:
+      text: What is your address?
 - name: as page heading
   data:
-    legendText: What is your address?
-    legendIsPageHeading: true
+    legend:
+      text: What is your address?
+      isPageHeading: true

--- a/src/fieldset/fieldset.yaml
+++ b/src/fieldset/fieldset.yaml
@@ -2,3 +2,7 @@ examples:
 - name: default
   data:
     legendText: What is your address?
+- name: as page heading
+  data:
+    legendText: What is your address?
+    legendIsPageHeading: true

--- a/src/fieldset/index.njk
+++ b/src/fieldset/index.njk
@@ -81,6 +81,20 @@
     ],
     [
       {
+        text: 'legendIsPageHeading'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Whether the legend also acts as the heading for the page.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {

--- a/src/fieldset/index.njk
+++ b/src/fieldset/index.njk
@@ -53,7 +53,21 @@
     ],
     [
       {
-        text: 'legendText'
+        text: 'legend'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Arguments for the legend'
+      }
+    ],
+    [
+      {
+        text: 'legend.text'
       },
       {
         text: 'string'
@@ -67,7 +81,7 @@
     ],
     [
       {
-        text: 'legendHtml'
+        text: 'legend.html'
       },
       {
         text: 'string'
@@ -81,7 +95,7 @@
     ],
     [
       {
-        text: 'legendIsPageHeading'
+        text: 'legend.isPageHeading'
       },
       {
         text: 'boolean'

--- a/src/fieldset/template.njk
+++ b/src/fieldset/template.njk
@@ -2,14 +2,14 @@
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
-  {% if params.legendHtml or params.legendText %}
+  {% if params.legend.html or params.legend.text %}
   <legend class="govuk-fieldset__legend">
-  {%- if params.legendIsPageHeading %}
+  {%- if params.legend.isPageHeading %}
     <h1 class="govuk-fieldset__heading">
-      {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+      {{ params.legend.html | safe if params.legend.html else params.legend.text }}
     </h1>
   {% else %}
-    {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+    {{ params.legend.html | safe if params.legend.html else params.legend.text }}
   {% endif -%}
   </legend>
   {% endif %}

--- a/src/fieldset/template.njk
+++ b/src/fieldset/template.njk
@@ -4,7 +4,13 @@
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.legendHtml or params.legendText %}
   <legend class="govuk-fieldset__legend">
+  {%- if params.legendIsPageHeading %}
+    <h1 class="govuk-fieldset__heading">
+      {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+    </h1>
+  {% else %}
     {{ params.legendHtml | safe if params.legendHtml else params.legendText }}
+  {% endif -%}
   </legend>
   {% endif %}
 {{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}

--- a/src/fieldset/template.njk
+++ b/src/fieldset/template.njk
@@ -3,7 +3,7 @@
   {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.legend.html or params.legend.text %}
-  <legend class="govuk-fieldset__legend">
+  <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}">
   {%- if params.legend.isPageHeading %}
     <h1 class="govuk-fieldset__heading">
       {{ params.legend.html | safe if params.legend.html else params.legend.text }}

--- a/src/fieldset/template.test.js
+++ b/src/fieldset/template.test.js
@@ -64,6 +64,16 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is <b>your</b> address?')
   })
 
+  it('can nest the contents of the legend in an H1 if using legendIsPageHeading', () => {
+    const $ = render('fieldset', {
+      legendText: 'What is your address?',
+      legendIsPageHeading: true
+    })
+
+    const $headingInsideLegend = $('.govuk-fieldset__legend > h1')
+    expect($headingInsideLegend.text().trim()).toBe('What is your address?')
+  })
+
   it('renders attributes', () => {
     const $ = render('fieldset', {
       attributes: {

--- a/src/fieldset/template.test.js
+++ b/src/fieldset/template.test.js
@@ -72,6 +72,18 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is <b>your</b> address?')
   })
 
+  it('allows for additional classes on the legend', () => {
+    const $ = render('fieldset', {
+      legend: {
+        text: 'What is your address?',
+        classes: 'my-custom-class'
+      }
+    })
+
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.hasClass('my-custom-class')).toBeTruthy()
+  })
+
   it('can nest the contents of the legend in an H1 if using legend.isPageHeading', () => {
     const $ = render('fieldset', {
       legend: {

--- a/src/fieldset/template.test.js
+++ b/src/fieldset/template.test.js
@@ -16,7 +16,9 @@ describe('fieldset', () => {
 
   it('renders a legend element inside a fieldset element for accessibility reasons', () => {
     const $ = render('fieldset', {
-      legendText: 'What is your address?'
+      legend: {
+        text: 'What is your address?'
+      }
     })
 
     const $component = $('fieldset.govuk-fieldset')
@@ -34,9 +36,11 @@ describe('fieldset', () => {
     expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
   })
 
-  it('renders legendText using markup that is semantic', () => {
+  it('renders legend text using markup that is semantic', () => {
     const $ = render('fieldset', {
-      legendText: 'What is your address?'
+      legend: {
+        text: 'What is your address?'
+      }
     })
 
     const $component = $('fieldset.govuk-fieldset')
@@ -44,9 +48,11 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is your address?')
   })
 
-  it('renders escaped legendText when passing html', () => {
+  it('renders escaped legend text when passing html', () => {
     const $ = render('fieldset', {
-      legendText: 'What is <b>your</b> address?'
+      legend: {
+        text: 'What is <b>your</b> address?'
+      }
     })
 
     const $component = $('.govuk-fieldset')
@@ -54,9 +60,11 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is &lt;b&gt;your&lt;/b&gt; address?')
   })
 
-  it('renders legendHtml', () => {
+  it('renders legend HTML', () => {
     const $ = render('fieldset', {
-      legendHtml: 'What is <b>your</b> address?'
+      legend: {
+        html: 'What is <b>your</b> address?'
+      }
     })
 
     const $component = $('.govuk-fieldset')
@@ -64,10 +72,12 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('What is <b>your</b> address?')
   })
 
-  it('can nest the contents of the legend in an H1 if using legendIsPageHeading', () => {
+  it('can nest the contents of the legend in an H1 if using legend.isPageHeading', () => {
     const $ = render('fieldset', {
-      legendText: 'What is your address?',
-      legendIsPageHeading: true
+      legend: {
+        text: 'What is your address?',
+        isPageHeading: true
+      }
     })
 
     const $headingInsideLegend = $('.govuk-fieldset__legend > h1')

--- a/src/file-upload/README.md
+++ b/src/file-upload/README.md
@@ -139,6 +139,36 @@ Find out when to use the File upload component in your service in the [GOV.UK De
       }
     }) }}
 
+### File-upload--with-label-as-page-heading
+
+[Preview the file-upload--with-label-as-page-heading example](http://govuk-frontend-review.herokuapp.com/components/file-upload/with-label-as-page-heading/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="file-upload-1">
+          Upload a file
+        </label>
+
+      </h1>
+
+      <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
+    </div>
+
+#### Macro
+
+    {% from 'file-upload/macro.njk' import govukFileUpload %}
+
+    {{ govukFileUpload({
+      "id": "file-upload-1",
+      "name": "file-upload-1",
+      "label": {
+        "text": "Upload a file",
+        "isPageHeading": true
+      }
+    }) }}
+
 ## Dependencies
 
 To consume the file-upload component you must be running npm version 5 or above.

--- a/src/file-upload/file-upload.yaml
+++ b/src/file-upload/file-upload.yaml
@@ -32,3 +32,10 @@ examples:
       text: Upload a photo
     attributes:
       accept: .jpg, .jpeg, .png
+- name: with-label-as-page-heading
+  data:
+    id: file-upload-1
+    name: file-upload-1
+    label:
+      text: Upload a file
+      isPageHeading: true

--- a/src/file-upload/template.njk
+++ b/src/file-upload/template.njk
@@ -10,6 +10,7 @@
     html: params.label.html,
     text: params.label.text,
     classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
   }) | indent(2) | trim }}

--- a/src/hint/_hint.scss
+++ b/src/hint/_hint.scss
@@ -14,6 +14,9 @@
     @include govuk-font-regular-19;
 
     display: block;
+
+    margin-bottom: $govuk-spacing-scale-3;
+
     color: $govuk-secondary-text-colour;
   }
 }

--- a/src/input/README.md
+++ b/src/input/README.md
@@ -17,11 +17,11 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="input-1">
+      <label class="govuk-label" for="input-example">
         National Insurance number
       </label>
 
-      <input class="govuk-input" id="input-1" name="test-name" type="text">
+      <input class="govuk-input" id="input-example" name="test-name" type="text">
     </div>
 
 #### Macro
@@ -32,7 +32,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "label": {
         "text": "National Insurance number"
       },
-      "id": "input-1",
+      "id": "input-example",
       "name": "test-name"
     }) }}
 
@@ -43,15 +43,15 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="input-2">
+      <label class="govuk-label" for="input-with-hint-text">
         National insurance number
       </label>
 
-      <span id="input-2-hint" class="govuk-hint">
+      <span id="input-with-hint-text-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input" id="input-2" name="test-name-2" type="text" aria-describedby="input-2-hint">
+      <input class="govuk-input" id="input-with-hint-text" name="test-name-2" type="text" aria-describedby="input-with-hint-text-hint">
     </div>
 
 #### Macro
@@ -65,7 +65,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "hint": {
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
-      "id": "input-2",
+      "id": "input-with-hint-text",
       "name": "test-name-2"
     }) }}
 
@@ -76,19 +76,19 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group govuk-form-group--error">
-      <label class="govuk-label" for="input-3">
+      <label class="govuk-label" for="input-with-error-message">
         National Insurance number
       </label>
 
-      <span id="input-3-hint" class="govuk-hint">
+      <span id="input-with-error-message-hint" class="govuk-hint">
         It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <span id="input-3-error" class="govuk-error-message">
+      <span id="input-with-error-message-error" class="govuk-error-message">
         Error message goes here
       </span>
 
-      <input class="govuk-input govuk-input--error" id="input-3" name="test-name-3" type="text" aria-describedby="input-3-hint input-3-error">
+      <input class="govuk-input govuk-input--error" id="input-with-error-message" name="test-name-3" type="text" aria-describedby="input-with-error-message-hint input-with-error-message-error">
     </div>
 
 #### Macro
@@ -102,7 +102,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "hint": {
         "html": "It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
-      "id": "input-3",
+      "id": "input-with-error-message",
       "name": "test-name-3",
       "errorMessage": {
         "text": "Error message goes here"
@@ -116,15 +116,15 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="input-2">
+      <label class="govuk-label" for="input-width-10">
         National insurance number
       </label>
 
-      <span id="input-2-hint" class="govuk-hint">
+      <span id="input-width-10-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-10" id="input-2" name="test-name-4" type="text" aria-describedby="input-2-hint">
+      <input class="govuk-input govuk-input--width-10" id="input-width-10" name="test-name-4" type="text" aria-describedby="input-width-10-hint">
     </div>
 
 #### Macro
@@ -138,7 +138,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "hint": {
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
-      "id": "input-2",
+      "id": "input-width-10",
       "name": "test-name-4",
       "classes": "govuk-input--width-10"
     }) }}
@@ -150,15 +150,15 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="input-2">
+      <label class="govuk-label" for="input-width-20">
         National insurance number
       </label>
 
-      <span id="input-2-hint" class="govuk-hint">
+      <span id="input-width-20-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-20" id="input-2" name="test-name-5" type="text" aria-describedby="input-2-hint">
+      <input class="govuk-input govuk-input--width-20" id="input-width-20" name="test-name-5" type="text" aria-describedby="input-width-20-hint">
     </div>
 
 #### Macro
@@ -172,7 +172,7 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "hint": {
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
-      "id": "input-2",
+      "id": "input-width-20",
       "name": "test-name-5",
       "classes": "govuk-input--width-20"
     }) }}
@@ -184,15 +184,15 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="input-2">
+      <label class="govuk-label" for="input-width-30">
         National insurance number
       </label>
 
-      <span id="input-2-hint" class="govuk-hint">
+      <span id="input-width-30-hint" class="govuk-hint">
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-30" id="input-2" name="test-name-6" type="text" aria-describedby="input-2-hint">
+      <input class="govuk-input govuk-input--width-30" id="input-width-30" name="test-name-6" type="text" aria-describedby="input-width-30-hint">
     </div>
 
 #### Macro
@@ -206,9 +206,39 @@ Find out when to use the Input component in your service in the [GOV.UK Design S
       "hint": {
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
-      "id": "input-2",
+      "id": "input-width-30",
       "name": "test-name-6",
       "classes": "govuk-input--width-30"
+    }) }}
+
+### Input--with-label-as-page-heading
+
+[Preview the input--with-label-as-page-heading example](http://govuk-frontend-review.herokuapp.com/components/input/with-label-as-page-heading/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="input-with-page-heading">
+          National Insurance number
+        </label>
+
+      </h1>
+
+      <input class="govuk-input" id="input-with-page-heading" name="test-name" type="text">
+    </div>
+
+#### Macro
+
+    {% from 'input/macro.njk' import govukInput %}
+
+    {{ govukInput({
+      "label": {
+        "text": "National Insurance number",
+        "isPageHeading": true
+      },
+      "id": "input-with-page-heading",
+      "name": "test-name"
     }) }}
 
 ## Dependencies

--- a/src/input/input.yaml
+++ b/src/input/input.yaml
@@ -3,7 +3,7 @@ examples:
     data:
       label:
         text: National Insurance number
-      id: input-1
+      id: input-example
       name: test-name
   - name: with-hint-text
     data:
@@ -11,7 +11,7 @@ examples:
         text: National insurance number
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-      id: input-2
+      id: input-with-hint-text
       name: test-name-2
   - name: with-error-message
     data:
@@ -19,7 +19,7 @@ examples:
         text: National Insurance number
       hint:
         html: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-      id: input-3
+      id: input-with-error-message
       name: test-name-3
       errorMessage:
         text: Error message goes here
@@ -29,7 +29,7 @@ examples:
         text: National insurance number
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-      id: input-2
+      id: input-width-10
       name: test-name-4
       classes: govuk-input--width-10
   - name: width-20
@@ -38,7 +38,7 @@ examples:
         text: National insurance number
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-      id: input-2
+      id: input-width-20
       name: test-name-5
       classes: govuk-input--width-20
   - name: width-30
@@ -47,6 +47,13 @@ examples:
         text: National insurance number
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
-      id: input-2
+      id: input-width-30
       name: test-name-6
       classes: govuk-input--width-30
+  - name: with-label-as-page-heading
+    data:
+      label:
+        text: National Insurance number
+        isPageHeading: true
+      id: input-with-page-heading
+      name: test-name

--- a/src/input/template.njk
+++ b/src/input/template.njk
@@ -10,6 +10,7 @@
     html: params.label.html,
     text: params.label.text,
     classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
   }) | indent(2) | trim }}

--- a/src/label/README.md
+++ b/src/label/README.md
@@ -50,7 +50,7 @@ Use labels for all form fields.
 #### Markup
 
     <h1 class="govuk-label-wrapper">
-      <label class="govuk-label">
+      <label class="govuk-label govuk-label--xl">
         National Insurance number
       </label>
 
@@ -62,6 +62,7 @@ Use labels for all form fields.
 
     {{ govukLabel({
       "text": "National Insurance number",
+      "classes": "govuk-label--xl",
       "isPageHeading": true
     }) }}
 

--- a/src/label/README.md
+++ b/src/label/README.md
@@ -43,6 +43,28 @@ Use labels for all form fields.
       "text": "National Insurance number"
     }) }}
 
+### Label--as page heading
+
+[Preview the label--as page heading example](http://govuk-frontend-review.herokuapp.com/components/label/as page heading/preview)
+
+#### Markup
+
+    <h1 class="govuk-label-wrapper">
+      <label class="govuk-label">
+        National Insurance number
+      </label>
+
+    </h1>
+
+#### Macro
+
+    {% from 'label/macro.njk' import govukLabel %}
+
+    {{ govukLabel({
+      "text": "National Insurance number",
+      "isPageHeading": true
+    }) }}
+
 ## Dependencies
 
 To consume the label component you must be running npm version 5 or above.
@@ -136,6 +158,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">The value of the for attribute, the id of the input the label is associated with</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">isPageHeading</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Whether the label also acts as the heading for the page.</td>
 
 </tr>
 

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -17,8 +17,25 @@
     display: block;
   }
 
-  .govuk-label--bold {
-    @include govuk-typography-weight-bold;
+  // Modifiers that make labels look more like their equivalent headings
+
+  .govuk-label--xl {
+    @include govuk-font-bold-48;
+    margin-bottom: $govuk-spacing-scale-3;
+  }
+
+  .govuk-label--l {
+    @include govuk-font-bold-36;
+    margin-bottom: $govuk-spacing-scale-3;
+  }
+
+  .govuk-label--m {
+    @include govuk-font-bold-24;
+    margin-bottom: $govuk-spacing-scale-1;
+  }
+
+  .govuk-label--s {
+    @include govuk-font-bold-19;
   }
 
   // When the label is nested inside a heading, override the heading so that it

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -20,4 +20,14 @@
   .govuk-label--bold {
     @include govuk-typography-weight-bold;
   }
+
+  // When the label is nested inside a heading, override the heading so that it
+  // does not have a margin. Effectively we want to be able to treat the heading
+  // as if it is not there.
+  //
+  // This breaks BEM conventions because it exists as a parent of the 'block',
+  // so we can't really consider an element.
+  .govuk-label-wrapper {
+    margin: 0;
+  }
 }

--- a/src/label/_label.scss
+++ b/src/label/_label.scss
@@ -15,6 +15,8 @@
     @include govuk-text-colour;
 
     display: block;
+
+    margin-bottom: $govuk-spacing-scale-1;
   }
 
   // Modifiers that make labels look more like their equivalent headings
@@ -31,7 +33,7 @@
 
   .govuk-label--m {
     @include govuk-font-bold-24;
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: $govuk-spacing-scale-2;
   }
 
   .govuk-label--s {

--- a/src/label/index.njk
+++ b/src/label/index.njk
@@ -95,6 +95,20 @@
     ],
     [
       {
+        text: 'isPageHeading'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Whether the label also acts as the heading for the page.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {

--- a/src/label/label.yaml
+++ b/src/label/label.yaml
@@ -6,3 +6,7 @@ examples:
     data:
       classes: govuk-label--bold
       text: National Insurance number
+  - name: as page heading
+    data:
+      text: National Insurance number
+      isPageHeading: true

--- a/src/label/label.yaml
+++ b/src/label/label.yaml
@@ -9,4 +9,5 @@ examples:
   - name: as page heading
     data:
       text: National Insurance number
+      classes: govuk-label--xl
       isPageHeading: true

--- a/src/label/template.njk
+++ b/src/label/template.njk
@@ -1,5 +1,13 @@
+{% set labelHtml %}
 <label class="govuk-label{%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
   {%- if params.for %} for="{{ params.for }}"{% endif %}>
   {{ params.html | safe if params.html else params.text }}
 </label>
+{% endset %}
+
+{% if params.isPageHeading %}
+<h1 class="govuk-label-wrapper">{{ labelHtml | safe | indent(2) }}</h1>
+{% else %}
+{{ labelHtml | safe }}
+{% endif %}

--- a/src/label/template.test.js
+++ b/src/label/template.test.js
@@ -67,6 +67,16 @@ describe('Label', () => {
       expect(labelForAttr).toEqual('#dummy-input')
     })
 
+    it('can be nested inside an H1 using isPageHeading', () => {
+      const $ = render('label', {
+        text: 'National Insurance number',
+        isPageHeading: true
+      })
+
+      const $selector = $('h1 > .govuk-label')
+      expect($selector.length).toBeTruthy()
+    })
+
     it('allows additional attributes to be added to the component', () => {
       const $ = render('label', {
         attributes: {

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -57,7 +57,9 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "example",
       "name": "example",
       "fieldset": {
-        "legendText": "Have you changed your name?"
+        "legend": {
+          "text": "Have you changed your name?"
+        }
       },
       "hint": {
         "text": "This includes changing your last name or spelling your name differently."
@@ -123,7 +125,9 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "classes": "govuk-radios--inline",
       "name": "example",
       "fieldset": {
-        "legendText": "Have you changed your name?"
+        "legend": {
+          "text": "Have you changed your name?"
+        }
       },
       "hint": {
         "text": "This includes changing your last name or spelling your name differently."
@@ -188,7 +192,9 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "example-disabled",
       "name": "example-disabled",
       "fieldset": {
-        "legendText": "Have you changed your name?"
+        "legend": {
+          "text": "Have you changed your name?"
+        }
       },
       "hint": {
         "text": "This includes changing your last name or spelling your name differently."
@@ -254,7 +260,9 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "idPrefix": "housing-act",
       "name": "housing-act",
       "fieldset": {
-        "legendHtml": "<h1 class=\"govuk-heading-l\">Which part of the Housing Act was your licence issued under?</h1>"
+        "legend": {
+          "html": "<h1 class=\"govuk-heading-l\">Which part of the Housing Act was your licence issued under?</h1>"
+        }
       },
       "hint": {
         "text": "Select one of the options below."
@@ -387,7 +395,9 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
           "data-attribute": "value",
           "data-second-attribute": "second-value"
         },
-        "legendText": "Have you changed your name?"
+        "legend": {
+          "text": "Have you changed your name?"
+        }
       },
       "hint": {
         "text": "This includes changing your last name or spelling your name differently."
@@ -463,7 +473,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legendText). See fieldset component.</td>
+<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See fieldset component.</td>
 
 </tr>
 

--- a/src/radios/index.njk
+++ b/src/radios/index.njk
@@ -51,7 +51,7 @@ Please note, this component depends on @govuk-frontend/globals, which will autom
         text: 'No'
       },
       {
-        text: 'Arguments for the fieldset component (e.g. legendText). See fieldset component.'
+        text: 'Arguments for the fieldset component (e.g. legend). See fieldset component.'
       }
     ],
     [

--- a/src/radios/radios.yaml
+++ b/src/radios/radios.yaml
@@ -14,7 +14,8 @@ examples:
     idPrefix: 'example'
     name: 'example'
     fieldset:
-      legendText: Have you changed your name?
+      legend:
+        text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
@@ -30,7 +31,8 @@ examples:
     classes: 'govuk-radios--inline'
     name: 'example'
     fieldset:
-      legendText: Have you changed your name?
+      legend:
+        text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
@@ -45,7 +47,8 @@ examples:
     idPrefix: 'example-disabled'
     name: 'example-disabled'
     fieldset:
-      legendText: Have you changed your name?
+      legend:
+        text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
@@ -61,7 +64,8 @@ examples:
     idPrefix: 'housing-act'
     name: 'housing-act'
     fieldset:
-      legendHtml: <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+      legend:
+        html: <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
     hint:
       text: Select one of the options below.
     items:
@@ -96,7 +100,8 @@ examples:
       attributes:
         'data-attribute': 'value'
         'data-second-attribute': 'second-value'
-      legendText: Have you changed your name?
+      legend:
+        text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
@@ -112,8 +117,8 @@ examples:
     idPrefix: 'how-contacted'
     name: 'how-contacted'
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
     items:
       - value: email
         text: Email
@@ -140,8 +145,8 @@ examples:
     idPrefix: 'how-contacted-checked'
     name: 'how-contacted-checked'
     fieldset:
-      legendHtml:
-        <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+      legend:
+        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
     items:
     - value: email
       text: Email

--- a/src/radios/template.njk
+++ b/src/radios/template.njk
@@ -75,8 +75,7 @@
     describedBy: describedBy,
     classes: params.fieldset.classes,
     attributes: params.fieldset.attributes,
-    legendText: params.fieldset.legendText,
-    legendHtml: params.fieldset.legendHtml
+    legend: params.fieldset.legend
   }) %}
   {{ innerHtml | trim | safe }}
   {% endcall %}

--- a/src/radios/template.test.js
+++ b/src/radios/template.test.js
@@ -377,7 +377,9 @@ describe('Radios', () => {
           }
         ],
         fieldset: {
-          legendHtml: 'Have <b>you</b> changed your name?'
+          legend: {
+            html: 'Have <b>you</b> changed your name?'
+          }
         }
       })
 

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -122,6 +122,60 @@ Find out when to use the Select component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Select--with-label-as-page-heading
+
+[Preview the select--with-label-as-page-heading example](http://govuk-frontend-review.herokuapp.com/components/select/with-label-as-page-heading/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="select-3">
+          Label text goes here
+        </label>
+
+      </h1>
+
+      <select class="govuk-select" id="select-3" name="select-3">
+
+        <option value="1">GOV.UK frontend option 1</option>
+
+        <option value="2" selected>GOV.UK frontend option 2</option>
+
+        <option value="3" disabled>GOV.UK frontend option 3</option>
+
+      </select>
+    </div>
+
+#### Macro
+
+    {% from 'select/macro.njk' import govukSelect %}
+
+    {{ govukSelect({
+      "id": "select-3",
+      "name": "select-3",
+      "label": {
+        "html": "Label text goes here",
+        "isPageHeading": true
+      },
+      "items": [
+        {
+          "value": 1,
+          "text": "GOV.UK frontend option 1"
+        },
+        {
+          "value": 2,
+          "text": "GOV.UK frontend option 2",
+          "selected": true
+        },
+        {
+          "value": 3,
+          "text": "GOV.UK frontend option 3",
+          "disabled": true
+        }
+      ]
+    }) }}
+
 ## Dependencies
 
 To consume the select component you must be running npm version 5 or above.

--- a/src/select/select.yaml
+++ b/src/select/select.yaml
@@ -37,3 +37,22 @@ examples:
       -
         value: 3
         text: GOV.UK frontend option 3
+- name: with-label-as-page-heading
+  data:
+    id: select-3
+    name: select-3
+    label:
+      html: Label text goes here
+      isPageHeading: true
+    items:
+      -
+        value: 1
+        text: GOV.UK frontend option 1
+      -
+        value: 2
+        text: GOV.UK frontend option 2
+        selected: true
+      -
+        value: 3
+        text: GOV.UK frontend option 3
+        disabled: true

--- a/src/select/template.njk
+++ b/src/select/template.njk
@@ -10,6 +10,7 @@
     html: params.label.html,
     text: params.label.text,
     classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
   }) | indent(2) | trim }}

--- a/src/textarea/README.md
+++ b/src/textarea/README.md
@@ -133,6 +133,36 @@ Find out when to use the Textarea component in your service in the [GOV.UK Desig
       "rows": 8
     }) }}
 
+### Textarea--with label as page heading
+
+[Preview the textarea--with label as page heading example](http://govuk-frontend-review.herokuapp.com/components/textarea/with label as page heading/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="textarea-with-page-heading">
+          Full address
+        </label>
+
+      </h1>
+
+      <textarea class="govuk-textarea" id="textarea-with-page-heading" name="address" rows="5"></textarea>
+    </div>
+
+#### Macro
+
+    {% from 'textarea/macro.njk' import govukTextarea %}
+
+    {{ govukTextarea({
+      "id": "textarea-with-page-heading",
+      "name": "address",
+      "label": {
+        "text": "Full address",
+        "isPageHeading": true
+      }
+    }) }}
+
 ## Dependencies
 
 To consume the textarea component you must be running npm version 5 or above.

--- a/src/textarea/template.njk
+++ b/src/textarea/template.njk
@@ -10,6 +10,7 @@
     html: params.label.html,
     text: params.label.text,
     classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
     attributes: params.label.attributes,
     for: params.id
   }) | indent(2) | trim }}

--- a/src/textarea/textarea.yaml
+++ b/src/textarea/textarea.yaml
@@ -36,3 +36,11 @@ examples:
       label:
         text: Full address
       rows: 8
+
+  - name: with label as page heading
+    data:
+      id: textarea-with-page-heading
+      name: address
+      label:
+        text: Full address
+        isPageHeading: true


### PR DESCRIPTION
This decouples the markup of the label as the page heading from the styling, by removing any styling from the heading and delegating all styling responsibilities to the label.

This: 

- introduces new 'variants' for legends and labels (e.g. `govuk-label--xl`, `govuk-fieldset__legend--xl`) that make the legend or label the same size and weight as the equivalent heading
- introduces a new parameter `legend.isPageHeading` for fieldsets, which defines whether the legend text should be wrapped in an `h1` – `<legend><h1>Have you changed your name?</h1></legend>`
- introduces a new parameter `isPageHeading` for the label component, which defines whether the label _itself_ should be wrapped in an `h1` – `<h1><label>What is your National Insurance number?</label></h1>`
- adds styling for `h1`s in both contexts which effectively 'reset' the h1 such that it has no effect – i.e. the `isPageHeading` flag should have no effect on the styling of the question.
- updates components that call the label or fieldset component to pass these parameters.

![screen shot 2018-05-10 at 11 04 09-fullpage](https://user-images.githubusercontent.com/121939/39864602-0f8e7404-5442-11e8-86db-8b7831dcabbf.png)


You can see all combinations of [here](https://govuk-frontend-review-pr-684.herokuapp.com/examples/labels-legends-and-headings).