### PR TITLE
Include gulp-cli to avoid required global packages.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -208,6 +208,15 @@
         }
       }
     },
+    "ansi-colors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+      "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-cyan": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
@@ -461,6 +470,25 @@
       "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-1.1.0.tgz",
       "integrity": "sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==",
       "dev": true
+    },
+    "array-sort": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-sort/-/array-sort-1.0.0.tgz",
+      "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
+      "dev": true,
+      "requires": {
+        "default-compare": "1.0.0",
+        "get-value": "2.0.6",
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -1974,6 +2002,16 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-props": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/copy-props/-/copy-props-2.0.3.tgz",
+      "integrity": "sha512-Q5jXiqCOvlQc1Nvy2txrVg9ZexZ0UAw9NBQ7/s3cZ7SCAm0WD7NNsLwwcy+xvNwuVBbfkF2+4SBcz1L1AWbtmw==",
+      "dev": true,
+      "requires": {
+        "each-props": "1.3.1",
+        "is-plain-object": "2.0.4"
+      }
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -2335,6 +2373,23 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "default-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-compare/-/default-compare-1.0.0.tgz",
+      "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
+      "dev": true,
+      "requires": {
+        "kind-of": "5.1.0"
+      },
+      "dependencies": {
+        "kind-of": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "dev": true
+        }
+      }
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -2643,6 +2698,16 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "stream-shift": "1.0.0"
+      }
+    },
+    "each-props": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/each-props/-/each-props-1.3.1.tgz",
+      "integrity": "sha1-/BOPUeOid0KG1IWOAtbn3kYt4Vg=",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "2.0.4",
+        "object.defaults": "1.1.0"
       }
     },
     "ecc-jsbn": {
@@ -5329,6 +5394,70 @@
           "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
           "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
           "dev": true
+        }
+      }
+    },
+    "gulp-cli": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
+      "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "1.1.0",
+        "archy": "1.0.0",
+        "array-sort": "1.0.0",
+        "color-support": "1.1.3",
+        "concat-stream": "1.6.0",
+        "copy-props": "2.0.3",
+        "fancy-log": "1.3.2",
+        "gulplog": "1.0.0",
+        "interpret": "1.1.0",
+        "isobject": "3.0.1",
+        "liftoff": "2.5.0",
+        "matchdep": "2.0.0",
+        "mute-stdout": "1.0.0",
+        "pretty-hrtime": "1.0.3",
+        "replace-homedir": "1.0.0",
+        "semver-greatest-satisfied-range": "1.1.0",
+        "v8flags": "3.0.2",
+        "yargs": "7.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "v8flags": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
+          "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "1.0.1"
+          }
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "5.0.0"
+          }
         }
       }
     },
@@ -9066,6 +9195,18 @@
         "object-visit": "1.0.1"
       }
     },
+    "matchdep": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",
+      "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
+      "dev": true,
+      "requires": {
+        "findup-sync": "2.0.0",
+        "micromatch": "3.1.5",
+        "resolve": "1.5.0",
+        "stack-trace": "0.0.10"
+      }
+    },
     "math-expression-evaluator": {
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
@@ -9269,6 +9410,12 @@
       "requires": {
         "duplexer2": "0.0.2"
       }
+    },
+    "mute-stdout": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.0.tgz",
+      "integrity": "sha1-WzLqB+tDyd7WEwQ0z5JvRrKn/U0=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.5",
@@ -13696,6 +13843,17 @@
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
       "dev": true
     },
+    "replace-homedir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-homedir/-/replace-homedir-1.0.0.tgz",
+      "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
+      "dev": true,
+      "requires": {
+        "homedir-polyfill": "1.0.1",
+        "is-absolute": "1.0.0",
+        "remove-trailing-separator": "1.1.0"
+      }
+    },
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
@@ -14144,6 +14302,15 @@
         }
       }
     },
+    "semver-greatest-satisfied-range": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
+      "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
+      "dev": true,
+      "requires": {
+        "sver-compat": "1.5.0"
+      }
+    },
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
@@ -14541,6 +14708,12 @@
         "jsbn": "0.1.1",
         "tweetnacl": "0.14.5"
       }
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
     },
     "stack-utils": {
       "version": "1.0.1",
@@ -14990,6 +15163,16 @@
       "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
       "requires": {
         "has-flag": "2.0.0"
+      }
+    },
+    "sver-compat": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sver-compat/-/sver-compat-1.5.0.tgz",
+      "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
       }
     },
     "svgo": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "gulp": "^3.9.1",
     "gulp-better-rollup": "^3.1.0",
     "gulp-changed": "^3.1.0",
+    "gulp-cli": "^2.0.1",
     "gulp-data": "^1.2.1",
     "gulp-debug": "^3.1.0",
     "gulp-eol": "^0.1.2",


### PR DESCRIPTION
## The Problem

Currently to follow the steps in the readme the user needs to have already run `npm install -g gulp-cli`.  This means that the `gulp-cli` version will vary between users and some users would rather not install anything globally.

## The Solution

This change is the result of running `npm install --save-dev gulp-cli`, any scripts defined in `package.json` can refer to local dependancies therefore with this change any user can clone, `npm install` and `npm start` without global dependencies.  This also means that the version of `gulp-cli` is defined in `package.json` and `package-lock.json` which gives a more consistent outcome of the `npm start` and any `npm run XX` commands by different users/boxes.