### PR TITLE
RFC: Remove `r` in spacing overrides

### DIFF
--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -37,7 +37,7 @@
 
   {{ govukInput({
     label: {
-      "html": '<h3 class="govuk-heading-m govuk-!-mb-r1">Passport number</h3>',
+      "html": '<h3 class="govuk-heading-m govuk-!-mb-1">Passport number</h3>',
       "hintText": "For example, 502135326"
     },
     id: "passport-number",

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -38,7 +38,7 @@
 
     {% for variant_description, variant_class in variants %}
 
-      <section class="govuk-!-mt-r8">
+      <section class="govuk-!-mt-8">
         <h2 class="govuk-heading-l">{{ variant_description }}</h2>
 
       {% for state_description, state_class in states %}

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -24,7 +24,7 @@
 
       <section>
         <div>
-          <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Headings</h2>
+          <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings</h2>
         </div>
         <div>
         <h1 class="govuk-heading-xl">govuk-heading-xl</h1>
@@ -42,8 +42,8 @@
 
       <!-- Headings with captions -->
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Headings with captions</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Headings with captions</h2>
         <div>
           <h1 class="govuk-heading-xl">
             <span class="govuk-caption-xl">govuk-caption-xl</span>
@@ -66,8 +66,8 @@
 
       <!-- Body text -->
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Body text</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Body text</h2>
         <div>
           <p class="govuk-body-l">govuk-body-l</p>
         </div>
@@ -84,35 +84,35 @@
 
       <!-- Overrides -->
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Overrides</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Overrides</h2>
 
         <h3 class="govuk-heading-m">Override font-size and line-height</h3>
 
         <!-- We have to add govuk-body to get new transport, but then we get
           margins, so we have to remove them -->
 
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-80">govuk-!-f-80</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-48">govuk-!-f-48</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-36">govuk-!-f-36</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-27">govuk-!-f-27</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-24">govuk-!-f-24</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-19">govuk-!-f-19</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-16">govuk-!-f-16</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-14">govuk-!-f-14</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-80">govuk-!-f-80</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-48">govuk-!-f-48</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-36">govuk-!-f-36</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-27">govuk-!-f-27</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-24">govuk-!-f-24</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-19">govuk-!-f-19</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-16">govuk-!-f-16</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-14">govuk-!-f-14</p>
 
 
-        <h3 class="govuk-heading-m govuk-!-mt-r9">Override font weight.</h3>
+        <h3 class="govuk-heading-m govuk-!-mt-9">Override font weight.</h3>
 
-        <p class="govuk-body govuk-!-m-r0 govuk-!-w-regular">govuk-!-w-regular</p>
-        <p class="govuk-body govuk-!-m-r0 govuk-!-w-bold">govuk-!-w-bold</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-w-regular">govuk-!-w-regular</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-w-bold">govuk-!-w-bold</p>
 
 
-        <h3 class="govuk-heading-m govuk-!-mt-r9">Override both by combining classes</h3>
+        <h3 class="govuk-heading-m govuk-!-mt-9">Override both by combining classes</h3>
 
-        <p class="govuk-body govuk-!-m-r0 govuk-!-f-48 govuk-!-w-bold">govuk-!-f-48 + govuk-!-w-bold</p>
+        <p class="govuk-body govuk-!-m-0 govuk-!-f-48 govuk-!-w-bold">govuk-!-f-48 + govuk-!-w-bold</p>
 
-        <h3 class="govuk-heading-m govuk-!-mt-r9">Override typography classes</h3>
+        <h3 class="govuk-heading-m govuk-!-mt-9">Override typography classes</h3>
 
         <h1 class="govuk-heading-xl govuk-!-f-80">govuk-heading-xl + govuk-!-f-80</h1>
 
@@ -121,8 +121,8 @@
         <p class="govuk-body-l govuk-!-w-bold">govuk-body-l + govuk-!-w-bold</p>
 
       </section>
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Lists</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Lists</h2>
         <h3 class="govuk-heading-m">govuk-list</h3>
         <ul class="govuk-list govuk">
           <li>
@@ -192,8 +192,8 @@
 
       <!-- Body text -->
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Links</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Links</h2>
         <div>
           <p class="govuk-body">
             <a href="#" class="govuk-link">govuk-link</a>
@@ -206,8 +206,8 @@
         </div>
       </section>
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Example content 1</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Example content 1</h2>
 
         <h1 class="govuk-heading-xl">Request information about a vehicle or its registered keeper from DVLA</h1>
 
@@ -305,8 +305,8 @@
         <p class="govuk-body-m">Don’t use these details for general enquiries - contact DVLA instead.</p>
       </section>
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Example content 2</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Example content 2</h2>
 
         <h1 class="govuk-heading-xl">Apply for a Women’s Land Army or Women’s Timber Corps veterans badge</h1>
 
@@ -350,8 +350,8 @@
         <p class="govuk-body-m">You’ll receive your badge within 4 weeks or you’ll be contacted if you need to provide more information.</p>
       </section>
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Adjacent siblings</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Adjacent siblings</h2>
 
         <p class="govuk-body-l">govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body govuk-body </p>
 
@@ -426,8 +426,8 @@
 
       </section>
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Section breaks - Not-visible</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Section breaks - Not-visible</h2>
 
         <h2 class="govuk-heading-l">Topic A1</h2>
 
@@ -467,8 +467,8 @@
 
       </section>
 
-      <section class="govuk-!-mt-r8">
-        <h2 class="govuk-heading-l govuk-!-pb-r2" style="border-bottom: 4px solid;">Section breaks - Visible</h2>
+      <section class="govuk-!-mt-8">
+        <h2 class="govuk-heading-l govuk-!-pb-2" style="border-bottom: 4px solid;">Section breaks - Visible</h2>
 
         <h2 class="govuk-heading-l">Topic A1</h2>
 

--- a/app/views/partials/code.njk
+++ b/app/views/partials/code.njk
@@ -3,7 +3,7 @@
 <pre><code class="govuk-!-f-16">{{- componentHtml | e -}}</code></pre>
 
 <h4 class="govuk-heading-s">Macro</h4>
-<pre class="govuk-!-mb-r0 govuk-!-f-16"><code>{% raw %}{%{% endraw %} from '{{ componentName }}/macro.njk' import {{ componentName | componentNameToMacroName }} {% raw %}%}{% endraw %}
+<pre class="govuk-!-mb-0 govuk-!-f-16"><code>{% raw %}{%{% endraw %} from '{{ componentName }}/macro.njk' import {{ componentName | componentNameToMacroName }} {% raw %}%}{% endraw %}
 
 {% raw %}{{ {% endraw %}{{ componentName | componentNameToMacroName }}(
   {{- item.data | dump(2) -}}

--- a/app/views/partials/showExamples.njk
+++ b/app/views/partials/showExamples.njk
@@ -23,11 +23,11 @@
       <a href="http://govuk-frontend-review.herokuapp.com{{ previewLink }}">{{ previewText }}</a>
       {% include "code.njk" %}
     {% else %}
-      <section aria-labelledby="heading-{{ itemName}}" class="govuk-!-mb-r9">
+      <section aria-labelledby="heading-{{ itemName}}" class="govuk-!-mb-9">
         <div class="govuk-width-container">
           <div class="govuk-heading-m">
             <h3 id="heading-{{ itemName}}" class="app-!-di">{{ itemName  | capitalize }}</h3>
-            <a href="{{ previewLink }}" class="govuk-link govuk-!-ml-r1 govuk-!-f-16">
+            <a href="{{ previewLink }}" class="govuk-link govuk-!-ml-1 govuk-!-f-16">
               (open in a new window)
             </a>
           </div>

--- a/docs/coding-standards/css.md
+++ b/docs/coding-standards/css.md
@@ -68,7 +68,7 @@ Classes that override all other layers - for example to override the spacing or
 font size / line height on an element.
 
 - forms part of the @govuk-frontend/global package.
-- uses the prefix `govuk-!-` for its classes, eg. `govuk-!-mt-r8`; `r` indicates the class is responsive and `8` is the scale point; these are set in settings/spacing
+- uses the prefix `govuk-!-` for its classes, eg. `govuk-!-mt-8`; `mt` is margin-top, `8` is the scale point; these are set in settings/spacing
 
 
 # Class naming convention

--- a/src/globals/overrides/_spacing.scss
+++ b/src/globals/overrides/_spacing.scss
@@ -14,13 +14,13 @@ $spacing-directions: (
 //
 // Example output:
 //
-// .govuk-\!-m-r0 {
+// .govuk-\!-m-0 {
 //   margin: 0;
 // }
 //
 // [..]
 //
-// .govuk-\!-mt-r1 {
+// .govuk-\!-mt-1 {
 //   margin-top: [whatever spacing point 1 is...]
 // }
 
@@ -29,7 +29,7 @@ $spacing-directions: (
   // override that affects all directions...
   @each $scale-point, $scale-map in $govuk-spacing-responsive-scale {
 
-    .govuk-\!-#{$property-shorthand}-r#{$scale-point} {
+    .govuk-\!-#{$property-shorthand}-#{$scale-point} {
 
       @include govuk-responsive-spacing($scale-map, $property, "all", true);
     }
@@ -37,7 +37,7 @@ $spacing-directions: (
     // ... and then an override for each individual direction
     @each $direction-name, $direction-shorthand in $spacing-directions {
 
-      .govuk-\!-#{$property-shorthand}#{$direction-shorthand}-r#{$scale-point} {
+      .govuk-\!-#{$property-shorthand}#{$direction-shorthand}-#{$scale-point} {
         @include govuk-responsive-spacing($scale-map, $property, $direction-name, true);
       }
     }

--- a/src/radios/README.md
+++ b/src/radios/README.md
@@ -230,14 +230,14 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
           <label class="govuk-label govuk-radios__label" for="housing-act-1">
-            <span class="govuk-heading-s govuk-!-mb-r1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
+            <span class="govuk-heading-s govuk-!-mb-1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
           </label>
         </div>
 
         <div class="govuk-radios__item">
           <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
           <label class="govuk-label govuk-radios__label" for="housing-act-2">
-            <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+            <span class="govuk-heading-s govuk-!-mb-1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
           </label>
         </div>
 
@@ -262,11 +262,11 @@ Find out when to use the Radios component in your service in the [GOV.UK Design 
       "items": [
         {
           "value": "part-2",
-          "html": "<span class=\"govuk-heading-s govuk-!-mb-r1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
+          "html": "<span class=\"govuk-heading-s govuk-!-mb-1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
         },
         {
           "value": "part-3",
-          "html": "<span class=\"govuk-heading-s govuk-!-mb-r1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
+          "html": "<span class=\"govuk-heading-s govuk-!-mb-1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
         }
       ]
     }) }}

--- a/src/radios/radios.yaml
+++ b/src/radios/radios.yaml
@@ -67,11 +67,11 @@ examples:
     items:
       - value: 'part-2'
         html:
-          <span class="govuk-heading-s govuk-!-mb-r1">Part 2 of the Housing Act 2004</span>
+          <span class="govuk-heading-s govuk-!-mb-1">Part 2 of the Housing Act 2004</span>
           For properties that are 3 or more stories high and occupied by 5 or more people
       - value: 'part-3'
         html:
-          <span class="govuk-heading-s govuk-!-mb-r1">Part 3 of the Housing Act 2004</span>
+          <span class="govuk-heading-s govuk-!-mb-1">Part 3 of the Housing Act 2004</span>
           For properties that are within a geographical area defined by a local council
 
 - name: without-fieldset


### PR DESCRIPTION
As part of the "Make prototyping easier" work I think another easy fix would be to remove `r` from the spacing override classes.

The `r` stands for "responsive". With the way we have defined spacing for components and typographic elements I am not convinced we will need static spacing classes in the future as it makes sense for all spacing to follow the same rules.

We have also heard through research that the `r` can be confused with "right".

For example the expectation of adding `govuk-!-m-r9` would be applying `margin-right: 60px` not the actual output `margin: 60px`.

**Before:**
`govuk-!-mr-r9`
`govuk-!-p-r9`
etc

**After:**
`govuk-!-mr-9`
`govuk-!-p-9`
etc