### PR TITLE
Remove unused travis.yml unused before_install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: node_js
 notifications:
   email: false
 sudo: false
-before_install:
-  - if [[ `npm -v | cut -d. -f1` -lt 5 ]]; then npm i -g npm@latest; fi
-  - npm --version
 install:
   - npm install --no-optional
 before_deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,8 @@ New features:
 
 Internal:
 
+- Remove unused step in travis.yml file
+  (PR [#690](https://github.com/alphagov/govuk-frontend/pull/690))
 - Update publishing docs (PR [#651](https://github.com/alphagov/govuk-frontend/pull/651))
 - Wrap `app.css` in conditional comments in review app layout (PR [#653](https://github.com/alphagov/govuk-frontend/pull/653))
 - Fix missing code highlight and remove duplicate layout


### PR DESCRIPTION
We pin Node LTS version which contains npm version greater than 5 so the check never runs anyway.

Fixes: https://github.com/alphagov/govuk-frontend/issues/535