### PR TITLE
Remove `-webkit-tap-highlight-color` from links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@ Fixes:
 - Fix section break styles when used with GOV.UK Elements
   ([PR #682](https://github.com/alphagov/govuk-frontend/pull/682))
 
+- Remove `-webkit-tap-highlight-color` from links (PR [#692](https://github.com/alphagov/govuk-frontend/pull/692))
+
 New features:
 
 - We're now using ES6 Modules and [rollup](https://rollupjs.org/guide/en) to distribute our JavaScript. (PR [#652](https://github.com/alphagov/govuk-frontend/pull/652))

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -4,11 +4,6 @@
 @mixin govuk-link-common {
   @include govuk-typography-common;
   @include govuk-focusable-fill;
-
-  // Override the tap highlight colour (the color of the highlight that
-  // appears when a link is tapped on some mobile devices). This is
-  // ever-so-slightly darker than the default.
-  -webkit-tap-highlight-color: rgba($govuk-black, .3);
 }
 
 /// Default link style mixin


### PR DESCRIPTION
This line appears to have been copied from [GOV.UK Template link styles](https://github.com/alphagov/govuk_template/blob/8f18dc2bea0ffe7d2a3d9609a71ede43cc61d93e/source/assets/stylesheets/_accessibility.scss#L52) to set `-webkit-tap-highlight-color` to grey after [removing it globally](https://github.com/alphagov/govuk_template/blob/8f18dc2bea0ffe7d2a3d9609a71ede43cc61d93e/source/assets/stylesheets/_basic.scss#L112). However we are not removing it in `html` in GOV.UK Frontend so setting the colour here is not necessary.

If we DID want to remove `-webkit-tap-highlight-color` in FE in the future I think we'd need more evidence that removing it in is a good idea: it improves accessibility as the user gets instant feedback. [GOV.UK Template](https://github.com/alphagov/govuk_template/blob/8f18dc2bea0ffe7d2a3d9609a71ede43cc61d93e/source/assets/stylesheets/_basic.scss#L105) links to [this article from 2010](https://yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/) as the reason for removing it. However we haven't come across the problem described in the article when testing GOV.UK Frontend on iOS and the article doesn't give practical examples we could test against.

I also checked the difference between the native iOS `-webkit-tap-highlight-color` and using`rgba($govuk-black, .3)` to see if some benefit could be gained from resetting the colour in links. However as the comment for it says the colour "ever-so-slightly darker than the default" so the difference is minimal.

Trello: https://trello.com/c/UeF2Dex3/572-revisit-tap-highlighting-overrides-in-govuk-frontend