### PR TITLE
Add display overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ Fixes:
 
 - Update component readme files content
   ([PR #704](https://github.com/alphagov/govuk-frontend/pull/704))
-  
+
 New features:
+
+- Add override classes to set `display` property to `block`, `inline` and `inline-block` (PR [#694](https://github.com/alphagov/govuk-frontend/pull/654))
 
 - Add option to set CSS display property for govuk-shape-arrow mixin
   ([PR #701](https://github.com/alphagov/govuk-frontend/pull/701))

--- a/app/views/examples/form-alignment/index.njk
+++ b/app/views/examples/form-alignment/index.njk
@@ -1,6 +1,7 @@
 {% extends "layout.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
+{% from "panel/macro.njk" import govukPanel %}
 
 {% block styles %}
 <style>
@@ -275,6 +276,45 @@
       }
     }) }}
   {%- endcall %}
+
+  <h2 class="govuk-heading-m">Display with govuk-!-display</h2>
+
+  <h3 class="govuk-heading-s govuk-!-w-regular">govuk-!-display-block</h2>
+
+  {{ govukButton({
+    classes: 'govuk-!-display-block',
+    text:'Save and continue',
+    element: 'input',
+    href: '/'
+  }) }}
+
+  {{ govukButton({
+    classes: 'govuk-!-display-block',
+    text:'Save and continue',
+    element: 'input',
+    href: '/'
+  }) }}
+
+  <h3 class="govuk-heading-s govuk-!-w-regular">govuk-!-display-inline-block</h2>
+
+    {{ govukPanel({
+      classes: 'govuk-!-display-inline-block',
+      titleText: 'Application complete',
+      html: 'Your reference number<br><strong>HDJ2123F</strong>'
+    }) }}
+
+
+    {{ govukButton({
+      classes: 'govuk-!-display-inline-block',
+      text:'Save and continue',
+      element: 'input',
+      href: '/' })
+    }}
+
+  <h3 class="govuk-heading-s govuk-!-w-regular">govuk-!-display-inline</h2>
+
+  <a class="govuk-!-display-inline govuk-link" href="#">Apples</a>
+  <a class="govuk-!-display-inline govuk-link" href="#">Oranges</a>
 
 </main>
 

--- a/src/overrides/_all.scss
+++ b/src/overrides/_all.scss
@@ -1,3 +1,4 @@
+@import "display";
 @import "spacing";
 @import "typography";
 @import "width";

--- a/src/overrides/_display.scss
+++ b/src/overrides/_display.scss
@@ -1,0 +1,14 @@
+@include govuk-exports("display-overrides") {
+
+  .govuk-\!-display-inline {
+    display: inline !important;
+  }
+
+  .govuk-\!-display-inline-block {
+    display: inline-block !important;
+  }
+
+  .govuk-\!-display-block {
+    display: block !important;
+  }
+}


### PR DESCRIPTION
This PR:

- Adds override classes that allow the CSS `display` property to be set to `block`, `inline` or `inline-block`.
- Adds examples to the review app 

There are possibly more appropriate components to demonstrate how the classes should be used than the ones I picked - shout if you've got a suggestion.

Trello card: https://trello.com/c/haIqNCRH/664-fix-buttons-not-being-block-level-elements
Review app page: https://govuk-frontend-review-pr-694.herokuapp.com/examples/form-alignment