### PR TITLE
Remove normalize from /dist builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Breaking changes:
   - creating a new package.json
   - updating documentation
   - update any tests and build pipelines to support this
-  
+
   The single package will be published under a new name.
 
 - The structure of the src directory (and thus the package directory, once
@@ -127,7 +127,7 @@ Breaking changes:
   }) }}
   ```
 
-  The `legend` object can also accept new `classes` and `arguments` 
+  The `legend` object can also accept new `classes` and `arguments`
 
   Components that use the fieldset component have been updated to reflect these
   changes.
@@ -189,6 +189,9 @@ Fixes:
   ([PR #682](https://github.com/alphagov/govuk-frontend/pull/682))
 
 - Remove `-webkit-tap-highlight-color` from links (PR [#692](https://github.com/alphagov/govuk-frontend/pull/692))
+
+- Remove normalize from /dist builds
+(PR [#699](https://github.com/alphagov/govuk-frontend/pull/699))
 
 New features:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11114,16 +11114,6 @@
         }
       }
     },
-    "postcss-normalize": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-normalize/-/postcss-normalize-3.0.0.tgz",
-      "integrity": "sha1-8hfrLQhn2585NFio7nqgetvtqlU=",
-      "dev": true,
-      "requires": {
-        "browserslist": "2.11.3",
-        "postcss": "6.0.17"
-      }
-    },
     "postcss-normalize-charset": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "node-sass": "^4.7.2",
     "nodemon": "^1.12.1",
     "oldie": "^1.3.0",
-    "postcss-normalize": "^3.0.0",
     "postcss-pseudo-classes": "^0.2.0",
     "puppeteer": "^1.1.1",
     "recursive-readdir": "^2.2.2",

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -14,7 +14,6 @@ const uglify = require('gulp-uglify')
 const eol = require('gulp-eol')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
-const postcssnormalize = require('postcss-normalize')
 const postcsspseudoclasses = require('postcss-pseudo-classes')
 
 // Compile CSS and JS task --------------
@@ -42,8 +41,7 @@ gulp.task('scss:compile', () => {
     // minify css add vendor prefixes and normalize to compiled css
     .pipe(gulpif(isDist, postcss([
       autoprefixer,
-      cssnano,
-      postcssnormalize
+      cssnano
     ])))
     .pipe(gulpif(!isDist, postcss([
       autoprefixer,
@@ -66,7 +64,6 @@ gulp.task('scss:compile', () => {
     .pipe(gulpif(isDist, postcss([
       autoprefixer,
       cssnano,
-      postcssnormalize,
       // transpile css for ie https://github.com/jonathantneal/oldie
       require('oldie')({
         rgba: {filter: true},


### PR DESCRIPTION
Normalize adds globals that we are not testing for.

Keep the /dist builds consistent with what is in npm by removing this layer.

Fixes #679