### PR TITLE
Ensure 'after' tests are not ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Internal:
 - Fix CI timeouts: run Jest single thread in TravisCI
   ([PR #712](https://github.com/alphagov/govuk-frontend/pull/712))
 
+- Ensure 'after' tests are not ignored
+  ([PR #720](https://github.com/alphagov/govuk-frontend/pull/720))
+
 ## 0.0.29-alpha (Breaking release)
 
 Breaking changes:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "node bin/check-nvmrc.js && ./bin/release.sh",
     "build:package": "node bin/check-nvmrc.js && gulp build:package --destination 'package' && npm run test:build:package",
     "build:dist": "node bin/check-nvmrc.js && gulp build:dist --destination 'dist' && npm run test:build:dist",
-    "test": "standard && gulp test && gulp copy-assets && jest",
+    "test": "standard && gulp test && gulp copy-assets && jest --testPathIgnorePatterns='after-*'",
     "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
     "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js"
   },
@@ -85,10 +85,6 @@
     ]
   },
   "jest": {
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "after-*"
-    ],
     "setupTestFrameworkScriptFile": "./config/jest-setup.js",
     "snapshotSerializers": [
       "jest-serializer-html"


### PR DESCRIPTION
Unblocks releases, `after` tests are only used to test the result of other tasks, for example
building the `dist/` folder.