### PR TITLE
Omit empty labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Note: We're not following semantic versioning yet, we are going to talk about this soon.
 
+## Unreleased
+
+🔧 Fixes:
+
+- The `<label>` element will now be omitted for form controls where no label
+  text or html is provided. If you call the label component directly whilst
+  passing neither text nor html, no HTML will be outputted.
+  ([PR #740])(https://github.com/alphagov/govuk-frontend/pull/740)
+
 ## 0.0.31-alpha (Breaking release)
 
 💥 Breaking changes:

--- a/src/components/label/template.njk
+++ b/src/components/label/template.njk
@@ -1,3 +1,4 @@
+{% if params.html or params.text %}
 {% set labelHtml %}
 <label class="govuk-label{%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
@@ -10,4 +11,5 @@
 <h1 class="govuk-label-wrapper">{{ labelHtml | safe | indent(2) }}</h1>
 {% else %}
 {{ labelHtml | safe }}
+{% endif %}
 {% endif %}

--- a/src/components/label/template.test.js
+++ b/src/components/label/template.test.js
@@ -22,8 +22,17 @@ describe('Label', () => {
       expect($component.get(0).tagName).toEqual('label')
     })
 
+    it('does not output anything if no html or text is provided', () => {
+      const $ = render('label', {})
+
+      const $component = $('.govuk-label')
+
+      expect($component.length).toEqual(0)
+    })
+
     it('allows additional classes to be added to the component', () => {
       const $ = render('label', {
+        text: 'National Insurance number',
         classes: 'extra-class one-more-class'
       })
 
@@ -60,6 +69,7 @@ describe('Label', () => {
 
     it('renders for attribute if specified', () => {
       const $ = render('label', {
+        text: 'National Insurance number',
         for: '#dummy-input'
       })
 
@@ -79,6 +89,7 @@ describe('Label', () => {
 
     it('allows additional attributes to be added to the component', () => {
       const $ = render('label', {
+        text: 'National Insurance number',
         attributes: {
           'first-attribute': 'true',
           'second-attribute': 'false'


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/714

This ensures that the label element is not outputted if no text or HTML are provided. This allows for other form control components to be used with a separate label, e.g. if a user wants to have an input and a button on one line with a separate label above.

An example of where this is problematic is on the form-alignment page, where an empty label is included above each input:

## Before
```html
<fieldset class="govuk-fieldset">
    <label class="govuk-label" for="govuk-input-a">
        National Insurance number
    </label>

    <div class="app-u-w-half">
        <div class="govuk-form-group">
            <label class="govuk-label" for="govuk-input-a">

            </label>
            <input class="govuk-input" id="govuk-input-a" name="national-insurance-number" type="text">
        </div>

    </div>
    <div class="app-u-w-half">
        <button type="submit" class="govuk-button">
            Save and continue
        </button>
    </div>
</fieldset>
```
<img width="1392" alt="screen shot 2018-05-31 at 13 45 45bst" src="https://user-images.githubusercontent.com/121939/40782997-00356de4-64d9-11e8-8ec4-30e2fdea4750.png">

## After
```html
<fieldset class="govuk-fieldset">
    <label class="govuk-label" for="govuk-input-a">
        National Insurance number
    </label>

    <div class="app-u-w-half">
        <div class="govuk-form-group">
            <input class="govuk-input" id="govuk-input-a" name="national-insurance-number" type="text">
        </div>

    </div>
    <div class="app-u-w-half">
        <button type="submit" class="govuk-button">
            Save and continue
        </button>
    </div>
</fieldset>
```
<img width="1392" alt="screen shot 2018-05-31 at 13 45 48bst" src="https://user-images.githubusercontent.com/121939/40783001-045d2fba-64d9-11e8-884f-9dd57fccec39.png">