### PR TITLE
Fix issues with canvas colour bleeding into main review page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 - Reintroduce mistakenly deleted HTML5Shiv required for IE8
   ([PR #749](https://github.com/alphagov/govuk-frontend/pull/749))
 
+- Fix issues with canvas colour bleeding into main review page
+  ([PR #741](https://github.com/alphagov/govuk-frontend/pull/741))
+
 ## 0.0.31-alpha (Breaking release)
 
 💥 Breaking changes:

--- a/app/assets/scss/partials/_app.scss
+++ b/app/assets/scss/partials/_app.scss
@@ -1,3 +1,7 @@
+.app-no-canvas-background {
+  background-color: $govuk-body-background-colour;
+}
+
 .app-iframe-in-component-preview {
   margin: 15px 0;
 }

--- a/app/views/examples/template-block-areas/index.njk
+++ b/app/views/examples/template-block-areas/index.njk
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
 
+{% set htmlClasses = "app-no-canvas-background" %}
+
 {% block head -%}
   <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="/public/app.css">

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -1,5 +1,7 @@
 {% extends "template.njk" %}
 
+{% set htmlClasses = "app-no-canvas-background" %}
+
 {% block pageTitle %}GOV.UK Frontend{% endblock %}
 
 {% block head %}


### PR DESCRIPTION
Sets the canvas colour to the body colour on review app pages, doesnt impact the template examples which do not inherit the _generic template.