### PR TITLE
Template updates: beforeContent, mainClasses, review application updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ Note: We're not following semantic versioning yet, we are going to talk about th
   passing neither text nor html, no HTML will be outputted.
   ([PR #740])(https://github.com/alphagov/govuk-frontend/pull/740)
 
+- Add `govuk-main-wrapper` to `<main>` element by default.
+  ([PR #740])(https://github.com/alphagov/govuk-frontend/pull/740)
+
+🆕 New features:
+
+- Add `beforeContent` block to the template, for content that does not belong inside `<main>` element.
+  For example: Back links.
+  ([PR #740])(https://github.com/alphagov/govuk-frontend/pull/740)
+
+🏠 Internal:
+
+- Fix review application templates to give them the correct HTML structure.
+  ([PR #740])(https://github.com/alphagov/govuk-frontend/pull/740)
+
 ## 0.0.31-alpha (Breaking release)
 
 💥 Breaking changes:

--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -278,6 +278,27 @@ describe('frontend app', () => {
           done(err)
         })
       })
+      it('should have `content` within the main section of the page', done => {
+        request.get(requestParamsExampleTemplateCustom, (err, res) => {
+          let $ = cheerio.load(res.body)
+          const $main = $('main')
+
+          expect($main.html()).toContain('<!-- block:content -->')
+          done(err)
+        })
+      })
+      it('should have `beforeContent` outside the main section of the page', done => {
+        request.get(requestParamsExampleTemplateCustom, (err, res) => {
+          let $ = cheerio.load(res.body)
+          const $container = $('.govuk-width-container')
+          const $phaseBanner = $container.find('> .govuk-phase-banner')
+          const $backLink = $container.find('> .govuk-back-link')
+
+          expect($phaseBanner.length).toBe(1)
+          expect($backLink.length).toBe(1)
+          done(err)
+        })
+      })
     })
   })
 

--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -299,6 +299,15 @@ describe('frontend app', () => {
           done(err)
         })
       })
+      it('should have set `mainClasses`', done => {
+        request.get(requestParamsExampleTemplateCustom, (err, res) => {
+          let $ = cheerio.load(res.body)
+          const $main = $('main')
+
+          expect($main.attr('class')).toBe('govuk-main-wrapper app-main-class')
+          done(err)
+        })
+      })
     })
   })
 

--- a/app/views/examples/all-components/index.njk
+++ b/app/views/examples/all-components/index.njk
@@ -1,34 +1,37 @@
 {% extends "layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
+{% block beforeContent %}
+  {% from "back-link/macro.njk" import govukBackLink %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
 
 {% block content %}
-  {{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-  <main class="govuk-main-wrapper">
-    {% include "back-link/back-link.njk" %}
-    {% include "breadcrumbs/breadcrumbs.njk" %}
-    {% include "button/button.njk" %}
-    {% include "checkboxes/checkboxes.njk" %}
-    {% include "date-input/date-input.njk" %}
-    {% include "details/details.njk" %}
-    {% include "error-message/error-message.njk" %}
-    {% include "error-summary/error-summary.njk" %}
-    {% include "fieldset/fieldset.njk" %}
-    {% include "file-upload/file-upload.njk" %}
-    {% include "input/input.njk" %}
-    {% include "label/label.njk" %}
-    {% include "panel/panel.njk" %}
-    {% include "phase-banner/phase-banner.njk" %}
-    {% include "radios/radios.njk" %}
-    {% include "select/select.njk" %}
-    {% include "skip-link/skip-link.njk" %}
-    {% include "table/table.njk" %}
-    {% include "tag/tag.njk" %}
-    {% include "textarea/textarea.njk" %}
-    {% include "warning-text/warning-text.njk" %}
-  </main>
+  {% include "back-link/back-link.njk" %}
+  {% include "breadcrumbs/breadcrumbs.njk" %}
+  {% include "button/button.njk" %}
+  {% include "checkboxes/checkboxes.njk" %}
+  {% include "date-input/date-input.njk" %}
+  {% include "details/details.njk" %}
+  {% include "error-message/error-message.njk" %}
+  {% include "error-summary/error-summary.njk" %}
+  {% include "fieldset/fieldset.njk" %}
+  {% include "file-upload/file-upload.njk" %}
+  {% include "footer/footer.njk" %}
+  {% include "header/header.njk" %}
+  {% include "hint/hint.njk" %}
+  {% include "input/input.njk" %}
+  {% include "inset-text/inset-text.njk" %}
+  {% include "label/label.njk" %}
+  {% include "panel/panel.njk" %}
+  {% include "phase-banner/phase-banner.njk" %}
+  {% include "radios/radios.njk" %}
+  {% include "select/select.njk" %}
+  {% include "skip-link/skip-link.njk" %}
+  {% include "table/table.njk" %}
+  {% include "tag/tag.njk" %}
+  {% include "textarea/textarea.njk" %}
+  {% include "warning-text/warning-text.njk" %}
 {% endblock %}

--- a/app/views/examples/error-messages/index.njk
+++ b/app/views/examples/error-messages/index.njk
@@ -1,6 +1,15 @@
-{% extends "layout.njk" %}
-
 {% from "back-link/macro.njk" import govukBackLink %}
+{% from "fieldset/macro.njk" import govukFieldset %}
+{% from "label/macro.njk" import govukLabel %}
+{% from "input/macro.njk" import govukInput %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "select/macro.njk" import govukSelect %}
+{% from 'checkboxes/macro.njk' import govukCheckboxes %}
+{% from 'radios/macro.njk' import govukRadios %}
+{% from 'textarea/macro.njk' import govukTextarea %}
+
+{% extends "layout.njk" %}
 
 {% block styles %}
 <style>
@@ -30,25 +39,14 @@
 </style>
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "label/macro.njk" import govukLabel %}
-{% from "input/macro.njk" import govukInput %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "button/macro.njk" import govukButton %}
-{% from "select/macro.njk" import govukSelect %}
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
-{% from 'radios/macro.njk' import govukRadios %}
-{% from 'textarea/macro.njk' import govukTextarea %}
-
   <h1 class="govuk-heading-xl">Error messages</h1>
 
 
@@ -253,5 +251,4 @@
     }}
 
   </form>
-</main>
 {% endblock %}

--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -6,15 +6,14 @@
 
 {% extends "layout.njk" %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
 <form action="/" method="post">
 
   {{ govukErrorSummary({
@@ -73,7 +72,4 @@
   }) }}
 
 </form>
-
-</main>
-
 {% endblock %}

--- a/app/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/app/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -5,15 +5,14 @@
 
 {% extends "layout.njk" %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
 <form action="/" method="post">
 
   {{ govukErrorSummary({
@@ -67,7 +66,4 @@
   }) }}
 
 </form>
-
-</main>
-
 {% endblock %}

--- a/app/views/examples/form-alignment/index.njk
+++ b/app/views/examples/form-alignment/index.njk
@@ -1,7 +1,14 @@
-{% extends "layout.njk" %}
-
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "panel/macro.njk" import govukPanel %}
+{% from "fieldset/macro.njk" import govukFieldset %}
+{% from "label/macro.njk" import govukLabel %}
+{% from "input/macro.njk" import govukInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "radios/macro.njk" import govukRadios %}
+
+{% extends "layout.njk" %}
 
 {% block styles %}
 <style>
@@ -31,24 +38,14 @@
 </style>
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
-  {% from "fieldset/macro.njk" import govukFieldset %}
-  {% from "label/macro.njk" import govukLabel %}
-  {% from "input/macro.njk" import govukInput %}
-  {% from "button/macro.njk" import govukButton %}
-  {% from "select/macro.njk" import govukSelect %}
-  {% from 'checkboxes/macro.njk' import govukCheckboxes %}
-  {% from 'radios/macro.njk' import govukRadios %}
-
   <h1 class="govuk-heading-xl">Form elements alignment</h1>
   <h2 class="govuk-heading-m">Input and button</h2>
 
@@ -315,7 +312,4 @@
 
   <a class="govuk-!-display-inline govuk-link" href="#">Apples</a>
   <a class="govuk-!-display-inline govuk-link" href="#">Oranges</a>
-
-</main>
-
 {% endblock %}

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -1,25 +1,23 @@
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "fieldset/macro.njk" import govukFieldset %}
+{% from "input/macro.njk" import govukInput %}
+{% from "button/macro.njk" import govukButton %}
+{% from "radios/macro.njk" import govukRadios %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "file-upload/macro.njk" import govukFileUpload %}
+
 {% extends "layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
 
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
-  {% from "fieldset/macro.njk" import govukFieldset %}
-  {% from "input/macro.njk" import govukInput %}
-  {% from "button/macro.njk" import govukButton %}
-  {% from 'radios/macro.njk' import govukRadios %}
-  {% from 'checkboxes/macro.njk' import govukCheckboxes %}
-  {% from "date-input/macro.njk" import govukDateInput %}
-  {% from "select/macro.njk" import govukSelect %}
-  {% from "file-upload/macro.njk" import govukFileUpload %}
-
   <h1 class="govuk-heading-xl">Form elements</h1>
 
   <ul class="govuk-list govuk-list--bullet">
@@ -181,5 +179,4 @@
     {% endcall %}
 
   </form>
-</main>
 {% endblock %}

--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -1,15 +1,15 @@
-{% extends "layout.njk" %}
-
 {% from "back-link/macro.njk" import govukBackLink %}
 
+{% extends "layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main id="content" role="main" class="govuk-main-wrapper">
   <h1 class="govuk-heading-l">Example: Grid layout</h1>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -99,6 +99,4 @@
       </p>
     </div>
   </div>
-</main>
-
 {% endblock %}

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -8,15 +8,14 @@
 
 {% extends "layout.njk" %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
-
   <h1 class="govuk-heading-xl">Labels, legends and headings</h1>
 
   <h2 class="govuk-heading-l">Text input</h2>
@@ -3262,7 +3261,4 @@
     ]
     })
   }}
-
-</main>
-
 {% endblock %}

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -1,13 +1,15 @@
-{% extends "layout.njk" %}
-
 {% from "back-link/macro.njk" import govukBackLink %}
 
-{% block content %}
+{% extends "layout.njk" %}
 
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
 
 {% set variants = {
   'Link': '',
@@ -26,8 +28,6 @@
   'Focussed hovered link': ':focus :hover',
   'Focussed active link': ':focus :active'
 } %}
-
-<main class="govuk-main-wrapper">
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
@@ -53,7 +53,4 @@
 
     </div>
   </div>
-
-</main>
-
 {% endblock %}

--- a/app/views/examples/prose-scope/index.njk
+++ b/app/views/examples/prose-scope/index.njk
@@ -1,15 +1,15 @@
-{% extends "layout.njk" %}
-
 {% from "back-link/macro.njk" import govukBackLink %}
 
+{% extends "layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
+
 {% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
-<main class="govuk-main-wrapper">
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/app/views/examples/template-block-areas/index.njk
+++ b/app/views/examples/template-block-areas/index.njk
@@ -105,9 +105,26 @@
 {% block main -%}
   <div data-block="main">
     <p class="govuk-body">
-      Set this block to override the default <code>&lt;main&gt;</code> element.
+      Set this block to override the default <code>&lt;main&gt;</code> section.
     </p>
     {{- super() -}}
+  </div>
+{%- endblock %}
+
+{% block beforeContent -%}
+  <div data-block="beforeContent">
+    {{- super() -}}
+    <p class="govuk-body">
+      Set this block to add content before to appear outside <code>&lt;main&gt;</code> element.
+      <br>
+      For example: The Back link component, Phase banner component.
+    </p>
+    {% from 'back-link/macro.njk' import govukBackLink %}
+
+    {{ govukBackLink({
+      "href": "/",
+      "text": "Back"
+    }) }}
   </div>
 {%- endblock %}
 

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -1,5 +1,6 @@
 {# Example that changes every setting in the template #}
 
+{% from "back-link/macro.njk" import govukBackLink %}
 {% from "skip-link/macro.njk" import govukSkipLink %}
 {% from "header/macro.njk" import govukHeader %}
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
@@ -77,15 +78,23 @@
 
 {% block main %}
   <!-- block:main -->
+  {{ super() }}
+  <!-- endblock:main -->
+{% endblock %}
+
+{% block beforeContent %}
+  <!-- block:beforeContent -->
   {{ govukPhaseBanner({
-    classes: "govuk-width-container",
     tag: {
       text: "alpha"
     },
     html: 'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
   }) }}
-  {{ super() }}
-  <!-- endblock:main -->
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+  <!-- endblock:beforeContent -->
 {% endblock %}
 
 {% block content %}

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -76,6 +76,8 @@
   <!-- endblock:header -->
 {% endblock %}
 
+{% set mainClasses = 'app-main-class' %}
+
 {% block main %}
   <!-- block:main -->
   {{ super() }}

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -1,18 +1,16 @@
 {% extends "layout.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
-
-{% block content %}
-
-{{ govukBackLink({
-  "href": "/",
-  "text": "Back"
-}) }}
-
 {% from 'table/macro.njk' import govukTable %}
 
-<main class="govuk-main-wrapper">
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/",
+    "text": "Back"
+  }) }}
+{% endblock %}
 
+{% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
@@ -511,7 +509,4 @@
 
     </div>
   </div>
-
-</main>
-
 {% endblock %}

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -1,9 +1,11 @@
-{% set componentName = componentPath %}
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "showExamples.njk" import showExamples %}
+
 {% extends "full-width.njk" %}
-{% block bodyClasses %}
-language-markup
-{% endblock %}
-{% block content %}
+
+{% set bodyClasses %}
+  language-markup
+{% endset %}
 
 {% set componentName = componentPath %}
 {% set componentNameHuman = componentName | replace("-", " ") | capitalize %}
@@ -12,29 +14,25 @@ language-markup
   {% include componentName +"/"+ componentName +".njk" ignore missing %}
 {% endset %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-<div class="govuk-width-container">
-{{ govukBreadcrumbs({
-  "items": [
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    "items": [
     { text: 'GOV.UK Frontend', href: '/' },
     { text: componentNameHuman }
-  ]
-}) }}
-</div>
+    ]
+  }) }}
+{% endblock %}
 
-<div class="govuk-main-wrapper">
+{% block content %}
   <div class="govuk-width-container">
     <h1 class="govuk-heading-xl">
-    {% block componentName %}
-    {{ componentNameHuman }}
-    {% endblock %}
+      {% block componentName %}
+        {{ componentNameHuman }}
+      {% endblock %}
     </h1>
   </div>
-</div>
 
-  {% from "showExamples.njk" import showExamples %}
   {% block examples %}
-  {{ showExamples(componentName, componentData) }}
+    {{ showExamples(componentName, componentData) }}
   {% endblock %}
-
 {% endblock %}

--- a/app/views/layouts/full-width.njk
+++ b/app/views/layouts/full-width.njk
@@ -1,5 +1,10 @@
 {% extends "_generic.njk" %}
 
 {% block main %}
-  {% block content %}{% endblock %}
+  <div class="govuk-width-container">
+    {% block beforeContent %}{% endblock %}
+  </div>
+  <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
+    {% block content %}{% endblock %}
+  </main>
 {% endblock %}

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -1,32 +1,30 @@
 {% extends "layout.njk" %}
 
 {% block content %}
-  <div class="govuk-main-wrapper">
-    <h1 class="govuk-heading-xl">
-      GOV.UK Frontend
-    </h1>
+  <h1 class="govuk-heading-xl">
+    GOV.UK Frontend
+  </h1>
 
-    <div class="govuk-grid-row">
+  <div class="govuk-grid-row">
 
-      <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m">Components</h2>
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m">Components</h2>
 
-        <ul class="govuk-list">
-        {% for componentName in componentsDirectory | sort %}
-          <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
-        {% endfor %}
-        </ul>
-      </div>
+      <ul class="govuk-list">
+      {% for componentName in componentsDirectory | sort %}
+        <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+      {% endfor %}
+      </ul>
+    </div>
 
-      <div class="govuk-grid-column-one-half">
-        <h2 class="govuk-heading-m">Examples</h2>
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m">Examples</h2>
 
-        <ul class="govuk-list">
-        {% for exampleName in examplesDirectory | sort %}
-          <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
-        {% endfor %}
-        </ul>
-      </div>
+      <ul class="govuk-list">
+      {% for exampleName in examplesDirectory | sort %}
+        <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+      {% endfor %}
+      </ul>
     </div>
   </div>
 {% endblock %}

--- a/src/template.njk
+++ b/src/template.njk
@@ -43,11 +43,12 @@
     {% endblock %}
 
     {% block main %}
-      <main id="main-content" role="main">
-        <div class="govuk-width-container">
+      <div class="govuk-width-container">
+        {% block beforeContent %}{% endblock %}
+        <main id="main-content" role="main">
           {% block content %}{% endblock %}
-        </div>
-      </main>
+        </main>
+      </div>
     {% endblock %}
 
     {% block footer %}

--- a/src/template.njk
+++ b/src/template.njk
@@ -45,7 +45,7 @@
     {% block main %}
       <div class="govuk-width-container">
         {% block beforeContent %}{% endblock %}
-        <main id="main-content" role="main">
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
           {% block content %}{% endblock %}
         </main>
       </div>


### PR DESCRIPTION
- Adds a beforeContent feature, for content that does not belong in the 'main' element.
- Adds mainClasses, this is something that was missed in the original version, the main classes add padding to pages.

I made an oversight on how the review application templates work so this PR includes some clean up for that.

See individual commits.
