### PR TITLE
Use relative imports in components

### DIFF
--- a/src/components/all.test.js
+++ b/src/components/all.test.js
@@ -1,0 +1,27 @@
+/* eslint-env jest */
+
+const { allComponents } = require('../../lib/file-helper')
+
+const configPaths = require('../../config/paths.json')
+
+// We can't use the render function from jest-helpers, because we need control
+// over the nunjucks environment.
+const nunjucks = require('nunjucks')
+
+describe('When nunjucks is configured with a different base path', () => {
+  beforeAll(() => {
+    // Create a new Nunjucks environment that uses the src directory as its
+    // base path, rather than the components folder itself
+    nunjucks.configure(configPaths.src)
+  })
+
+  allComponents.forEach((component) => {
+    describe(`the ${component} component`, () => {
+      it('can be rendered without erroring', () => {
+        expect(() => {
+          nunjucks.render(`components/${component}/template.njk`, {})
+        }).not.toThrow()
+      })
+    })
+  })
+})

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -1,7 +1,7 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -1,7 +1,7 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "hint/macro.njk" import govukHint %}
-{% from "input/macro.njk" import govukInput %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../input/macro.njk" import govukInput %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,6 +1,6 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,6 +1,6 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}

--- a/src/components/phase-banner/template.njk
+++ b/src/components/phase-banner/template.njk
@@ -1,4 +1,4 @@
-{% from "tag/macro.njk" import govukTag -%}
+{% from "../tag/macro.njk" import govukTag -%}
 
 <div class="govuk-phase-banner
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -1,7 +1,7 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -1,6 +1,6 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,6 +1,6 @@
-{% from "error-message/macro.njk" import govukErrorMessage -%}
-{% from "hint/macro.njk" import govukHint %}
-{% from "label/macro.njk" import govukLabel %}
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}

--- a/src/components/warning-text/template.njk
+++ b/src/components/warning-text/template.njk
@@ -1,5 +1,3 @@
-{% from "warning-text/macro.njk" import govukWarningText -%}
-
 <div class="govuk-warning-text {{- ' ' + params.classes if params.classes}}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor -%}
   >


### PR DESCRIPTION
Also introduces a test (failing in 420f674) to ensure that every component can be rendered even when using a different base path for the Nunjucks environment.

Fixes #722 

https://trello.com/c/WVfR5Sna/1022-relative-paths-for-nunjucks-imports