### PR TITLE
Update JavaScript global namespace from 'all' to 'GOVUKFrontend'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Note: We're not following semantic versioning yet, we are going to talk about th
   nunjucks paths.
   ([PR #743](https://github.com/alphagov/govuk-frontend/pull/743))
 
+- Update JavaScript global namespace from 'all' to 'GOVUKFrontend',
+  we intend to allow users to initialize components from this namespace.
+  ([PR #747](https://github.com/alphagov/govuk-frontend/pull/747))
+
+
 🆕 New features:
 
 - Add `beforeContent` block to the template, for content that does not belong inside `<main>` element.

--- a/src/all.test.js
+++ b/src/all.test.js
@@ -1,8 +1,12 @@
+/**
+ * @jest-environment ./lib/puppeteer/environment.js
+ */
 /* eslint-env jest */
 
 const util = require('util')
 
 const configPaths = require('../config/paths.json')
+const PORT = configPaths.ports.test
 
 const sass = require('node-sass')
 const sassRender = util.promisify(sass.render)
@@ -11,7 +15,31 @@ const sassConfig = {
   includePaths: [ configPaths.src ]
 }
 
+let browser
+let page
+let baseUrl = 'http://localhost:' + PORT
+
+beforeAll(async (done) => {
+  browser = global.__BROWSER__
+  page = await browser.newPage()
+  done()
+})
+
+afterAll(async (done) => {
+  await page.close()
+  done()
+})
+
 describe('GOV.UK Frontend', () => {
+  describe('javascript', async() => {
+    it('can be accessed via `GOVUKFrontend`', async () => {
+      await page.goto(baseUrl + '/', { waitUntil: 'load' })
+
+      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
+
+      expect(typeof GOVUKFrontendGlobal).toBe('object')
+    })
+  })
   describe('global styles', async() => {
     it('are disabled by default', async () => {
       const sass = `

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -104,6 +104,8 @@ gulp.task('js:compile', () => {
     srcFiles
   ])
     .pipe(rollup({
+      // Used to set the `window` global and UMD/AMD export name.
+      name: 'GOVUKFrontend',
       // Legacy mode is required for IE8 support
       legacy: true,
       // UMD allows the published bundle to work in CommonJS and in the browser.


### PR DESCRIPTION
This allows JavaScript to be accessed when not using a bundler.

The pre-existing convention for JavaScript on GOV.UK uses
`window.GOVUK`, to avoid conflicting with this we are using a different namespace.

Fixes #659