### PR TITLE
Remove pageStart block from template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
   ([PR #748](https://github.com/alphagov/govuk-frontend/pull/748))
 
+- Remove `pageStart` block from template, as could result in rendering issues in older IE.
+  ([PR #765](https://github.com/alphagov/govuk-frontend/pull/765))
 
 🔧 Fixes:
 

--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -174,7 +174,6 @@ describe('frontend app', () => {
         })
       })
       ;[
-        'pageStart',
         'headIcons',
         'bodyStart',
         'main',

--- a/app/views/examples/template-block-areas/index.njk
+++ b/app/views/examples/template-block-areas/index.njk
@@ -53,13 +53,6 @@
 
 {% block bodyStart -%}
   {# Since we can't show the blocks in the `<head>`, we pretend by creating a section in `bodyStart` #}
-  <div data-block="pageTop">
-    <p class="govuk-body">
-      Set this block for comments above the <code>&lt;!DOCTYPE html&gt;</code>, useful if you want to set a comment.
-      <br>
-      For example: <code>&lt;!-- Hello, World. --&gt;</code>
-    </p>
-  </div>
   <div data-block="headIcons">
     <p class="govuk-body">
       Set this block to override the default icons used for GOV.UK branded pages.

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -8,10 +8,6 @@
 
 {% extends "template.njk" %}
 
-{% block pageStart %}
-  <!-- block:pageStart -->
-{% endblock %}
-
 {% set htmlClasses = 'app-html-class' %}
 {% set htmlLang = 'fr' %}
 {% set assetPath = '' %}

--- a/package/template.njk
+++ b/package/template.njk
@@ -1,8 +1,6 @@
 {% from "./components/skip-link/macro.njk" import govukSkipLink %}
 {% from "./components/header/macro.njk" import govukHeader %}
 {% from "./components/footer/macro.njk" import govukFooter %}
-
-{% block pageStart %}{% endblock %}
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>

--- a/src/template.njk
+++ b/src/template.njk
@@ -1,8 +1,6 @@
 {% from "./components/skip-link/macro.njk" import govukSkipLink %}
 {% from "./components/header/macro.njk" import govukHeader %}
 {% from "./components/footer/macro.njk" import govukFooter %}
-
-{% block pageStart %}{% endblock %}
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/751

This feature can result in failures in older IE8, so it doesnt seem worth having in the public API.

# IE8

## Before

<img width="1440" alt="screen shot 2018-06-05 at 15 42 20" src="https://user-images.githubusercontent.com/2445413/40983260-1f74e19c-68d7-11e8-8e6d-a0c448733c3d.png">

## After

<img width="1440" alt="screen shot 2018-06-05 at 15 39 34" src="https://user-images.githubusercontent.com/2445413/40983086-bd27281a-68d6-11e8-970d-6aeb0f52da2b.png">

