### PR TITLE
Fix govuk-equilateral-height function usage in shape-arrow helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 🔧 Fixes:
 
+- Fix govuk-equilateral-height function usage in shape-arrow helper
+  ([PR ##766](https://github.com/alphagov/govuk-frontend/pull/766))
+
 - The `<label>` element will now be omitted for form controls where no label
   text or html is provided. If you call the label component directly whilst
   passing neither text nor html, no HTML will be outputted.

--- a/src/helpers/_shape-arrow.scss
+++ b/src/helpers/_shape-arrow.scss
@@ -47,7 +47,7 @@
   $perpendicular: $base / 2;
 
   @if ($height == null) {
-    $height: govuk-equilateral-height($base);
+    $height: _govuk-equilateral-height($base);
   }
 
   @if $direction == "up" {


### PR DESCRIPTION
In #762 we changed the name of the `govuk-equilateral-height` function to `_govuk-equilateral-height` to signify that is is a private function.

Unfortunately we forgot to update the name where it was used to create the open/closed indicator for the details component.

This PR fixes this.

Before:
![screen shot 2018-06-05 at 19 39 00](https://user-images.githubusercontent.com/3758555/40995895-576e7b28-68f8-11e8-81b9-b67078b76866.jpg)


After: 
![screen shot 2018-06-05 at 19 39 41](https://user-images.githubusercontent.com/3758555/40995867-48baff02-68f8-11e8-8b03-1cdf0cb34527.jpg)

