### PR TITLE
Update components' tables of arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,9 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 - Use the correct class name in bold label example 
   (govuk-label--s rather than govuk-label--bold)
   ([PR #784](https://github.com/alphagov/govuk-frontend/pull/784))
+  
+- Update table of arguments for each component to ensure they're accurate.
+  ([PR #769](https://github.com/alphagov/govuk-frontend/pull/769))
 
 
 🆕 New features:

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -69,37 +69,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes for the back-link component.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text to use within the back link component.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the back link. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Text or HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -112,6 +88,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">The value of the link href attribute</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the anchor tag.</td>
 
 </tr>
 

--- a/src/components/back-link/index.njk
+++ b/src/components/back-link/index.njk
@@ -39,44 +39,16 @@ Link back component, to go back a page.
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text:'No'
+        text:'Yes'
       },
       {
-        text: 'Optional additional classes for the back-link component.'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text:'No'
-      },
-      {
-        text: 'Text to use within the back link component.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text:'No'
-      },
-      {
-        text: 'HTML to use within the back link. If this is provided, the text argument will be ignored.'
+        text: 'Text or HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -91,6 +63,20 @@ Link back component, to go back a page.
       },
       {
         text: 'The value of the link href attribute'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'No'
+      },
+      {
+        text: 'Optional additional classes to add to the anchor tag.'
       }
     ],
     [

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -250,61 +250,49 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">items</th>
 
 <td class="govuk-table__cell ">array</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Array of breadcrumbs items</td>
+<td class="govuk-table__cell ">Array of breadcrumbs item objects.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Text to use within the breadcrumbs item</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the breadcrumbs item. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Text or HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">href</th>
+<th class="govuk-table__header" scope="row">items.{}.href</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">no</td>
 
 <td class="govuk-table__cell ">Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the breadcrumbs container.</td>
 
 </tr>
 

--- a/src/components/breadcrumbs/index.njk
+++ b/src/components/breadcrumbs/index.njk
@@ -37,20 +37,6 @@ The Breadcrumbs component helps users to understand where they are within a webs
   'rows': [
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
         text: 'items'
       },
       {
@@ -60,40 +46,26 @@ The Breadcrumbs component helps users to understand where they are within a webs
         text: 'Yes'
       },
       {
-        text: 'Array of breadcrumbs items'
+        text: 'Array of breadcrumbs item objects.'
       }
     ],
     [
       {
-        text: 'text'
+        text: 'items.{}.text (or) items.{}.html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text:'Yes'
       },
       {
-        text: 'Text to use within the breadcrumbs item'
+        text: 'Text or HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
       {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the breadcrumbs item. If this is provided, the text argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'href'
+        text: 'items.{}.href'
       },
       {
         text: 'string'
@@ -103,6 +75,20 @@ The Breadcrumbs component helps users to understand where they are within a webs
       },
       {
         text: 'Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the breadcrumbs container.'
       }
     ],
     [

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -190,7 +190,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.</td>
 
@@ -198,25 +198,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Text for the button</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">HTML for the button or link. If this is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.</td>
+<td class="govuk-table__cell ">Text or HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.</td>
 
 </tr>
 
@@ -300,7 +288,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error message span tag</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the button component.</td>
 
 </tr>
 

--- a/src/components/button/index.njk
+++ b/src/components/button/index.njk
@@ -51,7 +51,7 @@ Buttons are configured to perform an action and they can have a different look. 
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
         text: 'Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.'
@@ -59,30 +59,16 @@ Buttons are configured to perform an action and they can have a different look. 
     ],
     [
       {
-        text: 'text'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'Yes'
+        text:'Yes'
       },
       {
-        text: 'Text for the button'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'HTML for the button or link. If this is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.'
+        text: 'Text or HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.'
       }
     ],
     [
@@ -180,7 +166,7 @@ Buttons are configured to perform an action and they can have a different look. 
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the error message span tag'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the button component.'
       }
     ]
   ]

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -589,25 +589,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">idPrefix</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">String to prefix id for each checkbox item if no id is specified on each item.</td>
+<td class="govuk-table__cell ">String to prefix id for each checkbox item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
 
 </tr>
 
@@ -631,67 +619,127 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Array of checkbox items.</td>
+<td class="govuk-table__cell ">Array of checkbox items objects.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Text or HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.id</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text to use within each checkbox item label.</td>
+<td class="govuk-table__cell ">Specific id attribute for the checkbox item. If ommited, then `idPrefix` string will be applied.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">html</th>
+<th class="govuk-table__header" scope="row">items.{}.name</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">HTML to use within each checkbox item label. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Specific name for the checkbox item. If ommited, then component global `name` string will be applied.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">label</th>
+<th class="govuk-table__header" scope="row">items.{}.value</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Value for the checkbox input.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.label</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Provide additional attributes to each checkbox item label.</td>
+<td class="govuk-table__cell ">Provide additional attributes to each checkbox item label. See `label` component for more details.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">checked</th>
+<th class="govuk-table__header" scope="row">items.{}.checked</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">If true, checkbox will be checked</td>
+<td class="govuk-table__cell ">If true, checkbox will be checked.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">disabled</th>
+<th class="govuk-table__header" scope="row">items.{}.conditional</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">If true, checkbox will be disabled</td>
+<td class="govuk-table__cell ">If true, content provided will be revealed when the item is checked.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.conditional.html</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Provide content for the conditional reveal.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.disabled</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">If true, checkbox will be disabled.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the checkboxes container.</td>
 
 </tr>
 

--- a/src/components/checkboxes/index.njk
+++ b/src/components/checkboxes/index.njk
@@ -81,20 +81,6 @@
     ],
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
         text: 'idPrefix'
       },
       {
@@ -104,7 +90,7 @@
         text: 'No'
       },
       {
-        text: 'String to prefix id for each checkbox item if no id is specified on each item.'
+        text: 'String to prefix id for each checkbox item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.'
       }
     ],
     [
@@ -132,12 +118,26 @@
         text: 'Yes'
       },
       {
-        text: 'Array of checkbox items.'
+        text: 'Array of checkbox items objects.'
       }
     ],
     [
       {
-        text: 'text'
+        text: 'items.{}.text (or) items.{}.html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Text or HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.id'
       },
       {
         text: 'string'
@@ -146,26 +146,40 @@
         text: 'No'
       },
       {
-        text: 'Text to use within each checkbox item label.'
+        text: 'Specific id attribute for the checkbox item. If ommited, then `idPrefix` string will be applied.'
       }
     ],
     [
       {
-        text: 'html'
+        text: 'items.{}.name'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'HTML to use within each checkbox item label. If this is provided, the text argument will be ignored.'
+        text: 'Specific name for the checkbox item. If ommited, then component global `name` string will be applied.'
       }
     ],
     [
       {
-        text: 'label'
+        text: 'items.{}.value'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Value for the checkbox input.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.label'
       },
       {
         text: 'object'
@@ -174,12 +188,12 @@
         text: 'No'
       },
       {
-        text: 'Provide additional attributes to each checkbox item label.'
+        html: 'Provide additional attributes to each checkbox item label. See `label` component for more details.'
       }
     ],
     [
       {
-        text: 'checked'
+        text: 'items.{}.checked'
       },
       {
         text: 'boolean'
@@ -188,12 +202,12 @@
         text: 'No'
       },
       {
-        text: 'If true, checkbox will be checked'
+        text: 'If true, checkbox will be checked.'
       }
     ],
     [
       {
-        text: 'disabled'
+        text: 'items.{}.conditional'
       },
       {
         text: 'boolean'
@@ -202,7 +216,49 @@
         text: 'No'
       },
       {
-        text: 'If true, checkbox will be disabled'
+        text: 'If true, content provided will be revealed when the item is checked.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.conditional.html'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Provide content for the conditional reveal.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.disabled'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'If true, checkbox will be disabled.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the checkboxes container.'
       }
     ],
     [

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -495,25 +495,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">id</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional id. This is used for the main component and to compose the items' ids.</td>
+<td class="govuk-table__cell ">Optional id. This is used for the main component and to compose id attribute for each item.</td>
 
 </tr>
 
@@ -525,19 +513,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional name. This is used to compose the items' names.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">attributes</th>
-
-<td class="govuk-table__cell ">object</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the date div tag.</td>
+<td class="govuk-table__cell ">Optional name. This is used to compose the name attribute for each item.</td>
 
 </tr>
 
@@ -550,6 +526,42 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">An array of input objects with name, value and optional classes</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.id</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.name</th>
+
+<td class="govuk-table__cell ">array</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Optional item-specific name attribute. If provided, it will be used instead of the generated name.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional hint. See hint component.</td>
 
 </tr>
 
@@ -574,6 +586,30 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See fieldset component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the date-input container.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the date-input container.</td>
 
 </tr>
 

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -38,20 +38,6 @@
   'rows': [
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
         text: 'id'
       },
       {
@@ -61,7 +47,7 @@
         text: 'No'
       },
       {
-        text: 'Optional id. This is used for the main component and to compose the items\' ids.'
+        text: 'Optional id. This is used for the main component and to compose id attribute for each item.'
       }
     ],
     [
@@ -75,21 +61,7 @@
         text: 'No'
       },
       {
-        text: 'Optional name. This is used to compose the items\' names.'
-      }
-    ],
-    [
-      {
-        text: 'attributes'
-      },
-      {
-        text: 'object'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the date div tag.'
+        text: 'Optional name. This is used to compose the name attribute for each item.'
       }
     ],
     [
@@ -104,6 +76,48 @@
       },
       {
         text: 'An array of input objects with name, value and optional classes'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.id'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional item-specific id. If provided, it will be used instead of the generated.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.name'
+      },
+      {
+        text: 'array'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Optional item-specific name attribute. If provided, it will be used instead of the generated name.'
+      }
+    ],
+    [
+      {
+        text: 'hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional hint. See hint component.'
       }
     ],
     [
@@ -132,6 +146,34 @@
       },
       {
         text: 'Arguments for the fieldset component (e.g. legend). See fieldset component.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the date-input container.'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the date-input container.'
       }
     ]
   ]

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -140,49 +140,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">summaryText</th>
+<th class="govuk-table__header" scope="row">summaryText (or) summaryHtml</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Text to use within the summary element (the visible part of the details element)</td>
+<td class="govuk-table__cell ">Text or HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">summaryHtml</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">HTML to use within the summary element (the visible part of the details element). If this is provided, the summaryText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">Text to use within the disclosed part of the details element.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">HTML to use within the disclosed part of the details element. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Text or HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -194,19 +170,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional id</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Optional id to add to the details element.</td>
 
 </tr>
 
@@ -218,7 +182,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">If true, details will be expanded.</td>
+<td class="govuk-table__cell ">If true, details element will be expanded.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the details element.</td>
 
 </tr>
 
@@ -230,7 +206,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the details element</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the details element.</td>
 
 </tr>
 

--- a/src/components/details/index.njk
+++ b/src/components/details/index.njk
@@ -39,7 +39,7 @@
   'rows' : [
     [
       {
-        text: 'summaryText'
+        text: 'summaryText (or) summaryHtml'
       },
       {
         text: 'string'
@@ -48,12 +48,12 @@
         text: 'Yes'
       },
       {
-        text: 'Text to use within the summary element (the visible part of the details element)'
+        text: 'Text or HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.'
       }
     ],
     [
       {
-        text: 'summaryHtml'
+        text: 'text (or) html'
       },
       {
         text: 'string'
@@ -62,35 +62,7 @@
         text: 'Yes'
       },
       {
-        text: 'HTML to use within the summary element (the visible part of the details element). If this is provided, the summaryText argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'Text to use within the disclosed part of the details element.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'HTML to use within the disclosed part of the details element. If this is provided, the text argument will be ignored.'
+        text: 'Text or HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -104,21 +76,7 @@
         text: 'No'
       },
       {
-        text: 'Optional id'
-      }
-    ],
-    [
-      {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
+        text: 'Optional id to add to the details element.'
       }
     ],
     [
@@ -132,7 +90,21 @@
         text: 'No'
       },
       {
-        text: 'If true, details will be expanded.'
+        text: 'If true, details element will be expanded.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the details element.'
       }
     ],
     [
@@ -146,7 +118,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the details element'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the details element.'
       }
     ]
   ]

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -70,37 +70,37 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">text (or) html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text to use within the error message. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">id</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional id attribute to add to the error message span tag.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text to use within the error message</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the error message. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the error message span tag.</td>
 
 </tr>
 

--- a/src/components/error-message/index.njk
+++ b/src/components/error-message/index.njk
@@ -39,6 +39,34 @@
   'rows' : [
     [
       {
+        text: 'text (or) html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Text to use within the error message. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'id'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional id attribute to add to the error message span tag.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {
@@ -48,35 +76,7 @@
         text: 'No'
       },
       {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Text to use within the error message'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the error message. If this is provided, the text argument will be ignored.'
+        text: 'Optional additional classes to add to the error message span tag.'
       }
     ],
     [

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -106,61 +106,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">titleText (or) titleHtml</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Text or HTML to use for the heading of the error summary block. If `titleHtml` is provided, the `titleText` argument will be ignored.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">titleText</th>
+<th class="govuk-table__header" scope="row">descriptionText (or) descriptionHtml</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text to use for the heading of the error summary block.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">titleHtml</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use for the heading of the error summary block. If this is provided, the titleText argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">descriptionText</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional text description of the errors.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">descriptionHtml</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional HTML description of the errors. If this is provided, the descriptionText argument will be ignored.</td>
+<td class="govuk-table__cell ">Optional text or HTML description of the errors. If `descriptionhtml` is provided, the `descriptionText` argument will be ignored.</td>
 
 </tr>
 
@@ -173,6 +137,42 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">Contains an array of error link items and all their available arguments.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">errorList.{}.href</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Href attribute for the error link item. If provided item will be an anchor.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">errorList.{}.text (or) errorList.{}.html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Text or HTML for the error link item. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the error-summary container.</td>
 
 </tr>
 

--- a/src/components/error-summary/index.njk
+++ b/src/components/error-summary/index.njk
@@ -39,21 +39,21 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'titleText (or) titleHtml'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Text or HTML to use for the heading of the error summary block. If `titleHtml` is provided, the `titleText` argument will be ignored.'
       }
     ],
     [
       {
-        text: 'titleText'
+        text: 'descriptionText (or) descriptionHtml'
       },
       {
         text: 'string'
@@ -62,49 +62,7 @@
         text: 'No'
       },
       {
-        text: 'Text to use for the heading of the error summary block.'
-      }
-    ],
-    [
-      {
-        text: 'titleHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use for the heading of the error summary block. If this is provided, the titleText argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'descriptionText'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional text description of the errors.'
-      }
-    ],
-     [
-      {
-        text: 'descriptionHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional HTML description of the errors.  If this is provided, the descriptionText argument will be ignored.'
+        text: 'Optional text or HTML description of the errors.  If `descriptionhtml` is provided, the `descriptionText` argument will be ignored.'
       }
     ],
     [
@@ -119,6 +77,48 @@
       },
       {
         text: 'Contains an array of error link items and all their available arguments.'
+      }
+    ],
+    [
+      {
+        text: 'errorList.{}.href'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Href attribute for the error link item. If provided item will be an anchor.'
+      }
+    ],
+    [
+      {
+        text: 'errorList.{}.text (or) errorList.{}.html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Text or HTML for the error link item. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the error-summary container.'
       }
     ],
     [

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -104,13 +104,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">describedBy</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Text or element id to add to the `aria-describedby` attribute to provide description of the group of fields for screenreader users.</td>
 
 </tr>
 
@@ -128,37 +128,49 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legend.text</th>
+<th class="govuk-table__header" scope="row">legend.{}.text (or) legend.{}.html</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Legend text</td>
+<td class="govuk-table__cell ">Legend text or HTML. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legend.html</th>
+<th class="govuk-table__header" scope="row">legend.{}.classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Legend text</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the legend container.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">legend.isPageHeading</th>
+<th class="govuk-table__header" scope="row">legend.{}.isPageHeading</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Whether the legend also acts as the heading for the page.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the fieldset container.</td>
 
 </tr>
 

--- a/src/components/fieldset/index.njk
+++ b/src/components/fieldset/index.njk
@@ -39,7 +39,7 @@
   'rows': [
     [
       {
-        text: 'classes'
+        text: 'describedBy'
       },
       {
         text: 'string'
@@ -48,7 +48,7 @@
         text: 'No'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Text or element id to add to the `aria-describedby` attribute to provide description of the group of fields for screenreader users.'
       }
     ],
     [
@@ -67,7 +67,7 @@
     ],
     [
       {
-        text: 'legend.text'
+        text: 'legend.{}.text (or) legend.{}.html'
       },
       {
         text: 'string'
@@ -76,12 +76,12 @@
         text: 'No'
       },
       {
-        text: 'Legend text'
+        text: 'Legend text or HTML. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
       {
-        text: 'legend.html'
+        text: 'legend.{}.classes'
       },
       {
         text: 'string'
@@ -90,12 +90,12 @@
         text: 'No'
       },
       {
-        text: 'Legend text'
+        text: 'Optional additional classes to add to the legend container.'
       }
     ],
     [
       {
-        text: 'legend.isPageHeading'
+        text: 'legend.{}.isPageHeading'
       },
       {
         text: 'boolean'
@@ -105,6 +105,20 @@
       },
       {
         text: 'Whether the legend also acts as the heading for the page.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the fieldset container.'
       }
     ],
     [

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -211,6 +211,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">name</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">The name of the input, which is submitted with the form data.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">id</th>
 
 <td class="govuk-table__cell ">string</td>
@@ -218,18 +230,6 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">The id of the input</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">name</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">The name of the input, which is submitted with the form data</td>
 
 </tr>
 
@@ -253,7 +253,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Arguments for the label component</td>
+<td class="govuk-table__cell ">Arguments for the label component. See label component.</td>
 
 </tr>
 
@@ -289,7 +289,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the input tag.</td>
 
 </tr>
 
@@ -301,7 +301,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example accept or data attributes) to add to the input tag</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example accept or data attributes) to add to the input tag.</td>
 
 </tr>
 

--- a/src/components/file-upload/index.njk
+++ b/src/components/file-upload/index.njk
@@ -38,6 +38,20 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
   'rows' : [
     [
       {
+        text: 'name'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'The name of the input, which is submitted with the form data.'
+      }
+    ],
+    [
+      {
         text: 'id'
       },
       {
@@ -48,20 +62,6 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
       },
       {
         text: 'The id of the input'
-      }
-    ],
-    [
-      {
-        text: 'name'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'The name of the input, which is submitted with the form data'
       }
     ],
     [
@@ -89,7 +89,7 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
         text: 'Yes'
       },
       {
-        text: 'Arguments for the label component'
+        text: 'Arguments for the label component. See label component.'
       }
     ],
     [
@@ -131,7 +131,7 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
         text: 'No'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Optional additional classes to add to the input tag.'
       }
     ],
     [
@@ -145,7 +145,7 @@ The HTML <code>&lt;input&gt;</code> element with type="file" lets a user pick on
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example accept or data attributes) to add to the input tag'
+        text: 'Any extra HTML attributes (for example accept or data attributes) to add to the input tag.'
       }
     ]
   ]

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -109,19 +109,43 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Object containing parameters for the meta navigation</td>
+<td class="govuk-table__cell ">Object containing parameters for the meta navigation.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">meta.items[]</th>
+<th class="govuk-table__header" scope="row">meta.items</th>
 
 <td class="govuk-table__cell ">array</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Array of items for use in the meta section of the footer</td>
+<td class="govuk-table__cell ">Array of items for use in the meta section of the footer.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">meta.items.{}.text</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">List item text in the meta section of the footer.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">meta.items.{}.href</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">List item href attribute in the meta section of the footer.</td>
 
 </tr>
 
@@ -133,13 +157,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Array of items for use in the navigation section of the footer</td>
+<td class="govuk-table__cell ">Array of items for use in the navigation section of the footer.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">navigation[].title</th>
+<th class="govuk-table__header" scope="row">navigation.{}.title</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -151,49 +175,49 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">navigation[].columns</th>
+<th class="govuk-table__header" scope="row">navigation.{}.columns</th>
 
 <td class="govuk-table__cell ">integer</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Amount of columns to display items in</td>
+<td class="govuk-table__cell ">Amount of columns to display items in navigation section of the footer.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">navigation[].items</th>
+<th class="govuk-table__header" scope="row">navigation.items</th>
 
 <td class="govuk-table__cell ">array</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Array of items to display in the list</td>
+<td class="govuk-table__cell ">Array of items to display in the list in navigation section of the footer.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">attributes</th>
-
-<td class="govuk-table__cell ">object</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Will add attributes to the footer component root</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">navigation.items.{}.text</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Will add classes to the footer component root</td>
+<td class="govuk-table__cell ">List item text in the navigation section of the footer.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">navigation.items.{}.href</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.</td>
 
 </tr>
 
@@ -205,7 +229,31 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Classes that can be added to the container, useful if you want to make the footer full width.</td>
+<td class="govuk-table__cell ">Classes that can be added to the inner container, useful if you want to make the footer full width.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the footer component container.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the footer component container.</td>
 
 </tr>
 

--- a/src/components/footer/index.njk
+++ b/src/components/footer/index.njk
@@ -47,12 +47,12 @@
         text: 'No'
       },
       {
-        text: 'Object containing parameters for the meta navigation'
+        text: 'Object containing parameters for the meta navigation.'
       }
     ],
     [
       {
-        text: 'meta.items[]'
+        text: 'meta.items'
       },
       {
         text: 'array'
@@ -61,7 +61,35 @@
         text: 'No'
       },
       {
-        text: 'Array of items for use in the meta section of the footer'
+        text: 'Array of items for use in the meta section of the footer.'
+      }
+    ],
+    [
+      {
+        text: 'meta.items.{}.text'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'List item text in the meta section of the footer.'
+      }
+    ],
+    [
+      {
+        text: 'meta.items.{}.href'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'List item href attribute in the meta section of the footer.'
       }
     ],
     [
@@ -75,12 +103,12 @@
         text: 'No'
       },
       {
-        text: 'Array of items for use in the navigation section of the footer'
+        text: 'Array of items for use in the navigation section of the footer.'
       }
     ],
     [
       {
-        text: 'navigation[].title'
+        text: 'navigation.{}.title'
       },
       {
         text: 'string'
@@ -94,7 +122,7 @@
     ],
     [
       {
-        text: 'navigation[].columns'
+        text: 'navigation.{}.columns'
       },
       {
         text: 'integer'
@@ -103,12 +131,12 @@
         text: 'No'
       },
       {
-        text: 'Amount of columns to display items in'
+        text: 'Amount of columns to display items in navigation section of the footer.'
       }
     ],
     [
       {
-        text: 'navigation[].items'
+        text: 'navigation.items'
       },
       {
         text: 'array'
@@ -117,26 +145,12 @@
         text: 'No'
       },
       {
-        text: 'Array of items to display in the list'
+        text: 'Array of items to display in the list in navigation section of the footer.'
       }
     ],
     [
       {
-        text: 'attributes'
-      },
-      {
-        text: 'object'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Will add attributes to the footer component root'
-      }
-    ],
-    [
-      {
-        text: 'classes'
+        text: 'navigation.items.{}.text'
       },
       {
         text: 'string'
@@ -145,7 +159,21 @@
         text: 'No'
       },
       {
-        text: 'Will add classes to the footer component root'
+        text: 'List item text in the navigation section of the footer.'
+      }
+    ],
+    [
+      {
+        text: 'navigation.items.{}.href'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.'
       }
     ],
     [
@@ -159,7 +187,35 @@
         text: 'No'
       },
       {
-        text: 'Classes that can be added to the container, useful if you want to make the footer full width.'
+        text: 'Classes that can be added to the inner container, useful if you want to make the footer full width.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the footer component container.'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the footer component container.'
       }
     ]
   ]

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -364,49 +364,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Will add classes to the header component root</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">containerClasses</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Classes that can be added to the container, useful if you want to make the header fixed width.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">attributes</th>
-
-<td class="govuk-table__cell ">object</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Will add attributes to the footer component root</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">homepageUrl</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">The url of the hompeage. Defaults to /</td>
+<td class="govuk-table__cell ">The url of the homepage. Defaults to /</td>
 
 </tr>
 
@@ -416,7 +380,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">The public path for the assets folder. If not provided it defaults to /assets/images</td>
 
@@ -424,7 +388,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">title</th>
+<th class="govuk-table__header" scope="row">productName</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -448,13 +412,49 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">serviceUrl</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Url for the service name anchor.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">navigation</th>
 
 <td class="govuk-table__cell ">array</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Navigation items</td>
+<td class="govuk-table__cell ">An array of navigation item objects.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">navigation.{}.text</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text of the navigation item.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">navigation.{}.href</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.</td>
 
 </tr>
 
@@ -466,7 +466,43 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Classes that can be added to the navigation.</td>
+<td class="govuk-table__cell ">Optional classes that can be added to the navigation section of the header.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">containerClasses</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional classes that can be added to the container, useful if you want to make the header fixed width.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the header container.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the header container.</td>
 
 </tr>
 

--- a/src/components/header/index.njk
+++ b/src/components/header/index.njk
@@ -38,58 +38,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Will add classes to the header component root'
-      }
-    ],
-    [
-      {
-        text: 'containerClasses'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Classes that can be added to the container, useful if you want to make the header fixed width.'
-      }
-    ],
-    [
-      {
-        text: 'attributes'
-      },
-      {
-        text: 'object'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Will add attributes to the footer component root'
-      }
-    ],
-    [
-      {
         text: 'homepageUrl'
       },
       {
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
-        text: 'The url of the hompeage. Defaults to /'
+        text: 'The url of the homepage. Defaults to /'
       }
     ],
     [
@@ -100,7 +58,7 @@
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
         text: 'The public path for the assets folder. If not provided it defaults to /assets/images'
@@ -108,7 +66,7 @@
     ],
     [
       {
-        text: 'title'
+        text: 'productName'
       },
       {
         text: 'string'
@@ -136,6 +94,20 @@
     ],
     [
       {
+        text: 'serviceUrl'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Url for the service name anchor.'
+      }
+    ],
+    [
+      {
         text: 'navigation'
       },
       {
@@ -145,7 +117,35 @@
         text: 'No'
       },
       {
-        text: 'Navigation items'
+        text: 'An array of navigation item objects.'
+      }
+    ],
+    [
+      {
+        text: 'navigation.{}.text'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Text of the navigation item.'
+      }
+    ],
+    [
+      {
+        text: 'navigation.{}.href'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.'
       }
     ],
     [
@@ -159,7 +159,49 @@
         text: 'No'
       },
       {
-        text: 'Classes that can be added to the navigation.'
+        text: 'Optional classes that can be added to the navigation section of the header.'
+      }
+    ],
+    [
+      {
+        text: 'containerClasses'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional classes that can be added to the container, useful if you want to make the header fixed width.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the header container.'
+      }
+    ],
+    [
+      {
+        text: 'attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the header container.'
       }
     ]
   ]

--- a/src/components/hint/README.md
+++ b/src/components/hint/README.md
@@ -84,13 +84,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text or (html) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Text or HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -102,31 +102,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">The id of the hint</td>
+<td class="govuk-table__cell ">Optional id attribute o add to the hint span tag.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text to use within the hint</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the hint. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the hint span tag.</td>
 
 </tr>
 

--- a/src/components/hint/index.njk
+++ b/src/components/hint/index.njk
@@ -39,16 +39,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text or (html) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Text or HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -62,12 +62,12 @@
         text: 'Yes'
       },
       {
-        text: 'The id of the hint'
+        text: 'Optional id attribute o add to the hint span tag.'
       }
     ],
     [
       {
-        text: 'text'
+        text: 'classes'
       },
       {
         text: 'string'
@@ -76,21 +76,7 @@
         text: 'No'
       },
       {
-        text: 'Text to use within the hint'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the hint. If this is provided, the text argument will be ignored.'
+        text: 'Optional additional classes to add to the hint span tag.'
       }
     ],
     [

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -283,25 +283,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">id</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">The id of the input</td>
+<td class="govuk-table__cell ">The id of the input.</td>
 
 </tr>
 
@@ -313,7 +301,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">The name of the input, which is submitted with the form data</td>
+<td class="govuk-table__cell ">The name of the input, which is submitted with the form data.</td>
 
 </tr>
 
@@ -325,7 +313,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Type of input control to render. Defaults to "text"</td>
+<td class="govuk-table__cell ">Type of input control to render. Defaults to "text".</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">value</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional initial value of the input.</td>
 
 </tr>
 
@@ -367,6 +367,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes add to the input component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">attributes</th>
 
 <td class="govuk-table__cell ">object</td>
@@ -374,18 +386,6 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the input component.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">value</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional initial value of the input</td>
 
 </tr>
 

--- a/src/components/input/index.njk
+++ b/src/components/input/index.njk
@@ -39,20 +39,6 @@
   'rows' : [
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
         text: 'id'
       },
       {
@@ -62,7 +48,7 @@
         text: 'Yes'
       },
       {
-        text: 'The id of the input'
+        text: 'The id of the input.'
       }
     ],
     [
@@ -76,7 +62,7 @@
         text: 'Yes'
       },
       {
-        text: 'The name of the input, which is submitted with the form data'
+        text: 'The name of the input, which is submitted with the form data.'
       }
     ],
     [
@@ -90,7 +76,21 @@
         text: 'No'
       },
       {
-        text: 'Type of input control to render. Defaults to "text"'
+        text: 'Type of input control to render. Defaults to "text".'
+      }
+    ],
+    [
+      {
+        text: 'value'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional initial value of the input.'
       }
     ],
     [
@@ -137,6 +137,20 @@
     ],
     [
       {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes add to the input component.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {
@@ -147,20 +161,6 @@
       },
       {
         text: 'Any extra HTML attributes (for example data attributes) to add to the input component.'
-      }
-    ],
-    [
-      {
-        text: 'value'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional initial value of the input'
       }
     ]
   ]

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -84,13 +84,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Text or HTML to use within the inset text. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -100,33 +100,21 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">The id of the inset text</td>
+<td class="govuk-table__cell ">Optional id attribute to add to the inset text container.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text to use within the inset text</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the inset text. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the inset text container.</td>
 
 </tr>
 
@@ -138,7 +126,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the inset text div tag.</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the inset text container.</td>
 
 </tr>
 

--- a/src/components/inset-text/index.njk
+++ b/src/components/inset-text/index.njk
@@ -39,16 +39,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Text or HTML to use within the inset text. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -59,15 +59,15 @@
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
-        text: 'The id of the inset text'
+        text: 'Optional id attribute to add to the inset text container.'
       }
     ],
     [
       {
-        text: 'text'
+        text: 'classes'
       },
       {
         text: 'string'
@@ -76,21 +76,7 @@
         text: 'No'
       },
       {
-        text: 'Text to use within the inset text'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the inset text. If this is provided, the text argument will be ignored.'
+        text: 'Optional additional classes to add to the inset text container.'
       }
     ],
     [
@@ -104,7 +90,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the inset text div tag.'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the inset text container.'
       }
     ]
   ]

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -108,37 +108,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text to use within the label</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the label. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Text or HTML to use within the label. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -150,7 +126,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">The value of the for attribute, the id of the input the label is associated with</td>
+<td class="govuk-table__cell ">The value of the for attribute, the id of the input the label is associated with.</td>
 
 </tr>
 
@@ -168,13 +144,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the label tag.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">attributes</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error message span tag.</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the label tag.</td>
 
 </tr>
 

--- a/src/components/label/index.njk
+++ b/src/components/label/index.njk
@@ -39,44 +39,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Text to use within the label'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within the label. If this is provided, the text argument will be ignored.'
+        text: 'Text or HTML to use within the label. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -90,7 +62,7 @@
         text: 'Yes'
       },
       {
-        text: 'The value of the for attribute, the id of the input the label is associated with'
+        text: 'The value of the for attribute, the id of the input the label is associated with.'
       }
     ],
     [
@@ -109,6 +81,20 @@
     ],
     [
       {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the label tag.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {
@@ -118,7 +104,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the error message span tag.'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the label tag.'
       }
     ]
   ]

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -78,49 +78,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">titleText</th>
+<th class="govuk-table__header" scope="row">titleText (or) titleHtml</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Text for the panel title</td>
+<td class="govuk-table__cell ">Text or HTML for the panel title. If `titleHtml` is provided, the `titleText` argument is ignored.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">titleHtml</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">HTML for the panel title. If this is provided, the titleText argument is ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text for the panel content</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML for the panel content. If this is provided, the text argument is ignored.</td>
+<td class="govuk-table__cell ">Text or HTML for the panel content. If `html` is provided, the `text` argument is ignored.</td>
 
 </tr>
 
@@ -132,7 +108,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the panel container.</td>
 
 </tr>
 
@@ -144,7 +120,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the panel container</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the panel container.</td>
 
 </tr>
 

--- a/src/components/panel/index.njk
+++ b/src/components/panel/index.njk
@@ -38,7 +38,7 @@
   'rows' : [
     [
       {
-        text: 'titleText'
+        text: 'titleText (or) titleHtml'
       },
       {
         text: 'string'
@@ -47,26 +47,12 @@
         text: 'Yes'
       },
       {
-        text: 'Text for the panel title'
+        text: 'Text or HTML for the panel title. If `titleHtml` is provided, the `titleText` argument is ignored.'
       }
     ],
     [
       {
-        text: 'titleHtml'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'HTML for the panel title. If this is provided, the titleText argument is ignored.'
-      }
-    ],
-    [
-      {
-        text: 'text'
+        text: 'text (or) html'
       },
       {
         text: 'string'
@@ -75,21 +61,7 @@
         text: 'No'
       },
       {
-        text: 'Text for the panel content'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML for the panel content. If this is provided, the text argument is ignored.'
+        text: 'Text or HTML for the panel content. If `html` is provided, the `text` argument is ignored.'
       }
     ],
     [
@@ -103,7 +75,7 @@
         text: 'No'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Optional additional classes to add to the panel container.'
       }
     ],
     [
@@ -117,7 +89,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the panel container'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the panel container.'
       }
     ]
   ]

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -79,37 +79,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text for teh phase-banner message.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use for the phase-banner message. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">HTML to use for the phase-banner message. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -121,7 +97,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Arguments for the tag object. Can contain text or html.</td>
+<td class="govuk-table__cell ">Arguments for the tag object. See tag component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the phase banner container.</td>
 
 </tr>
 

--- a/src/components/phase-banner/index.njk
+++ b/src/components/phase-banner/index.njk
@@ -39,44 +39,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Text for teh phase-banner message.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use for the phase-banner message. If this is provided, the text argument will be ignored.'
+        text: 'HTML to use for the phase-banner message. If `html` is provided, the `text` argument will be ignored.'
       }
     ],
     [
@@ -90,7 +62,21 @@
         text: 'No'
       },
       {
-        text: 'Arguments for the tag object. Can contain text or html.'
+        text: 'Arguments for the tag object. See tag component.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the phase banner container.'
       }
     ],
     [

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -493,25 +493,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">idPrefix</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">String to prefix id for each radio item if no id is specified on each item.</td>
+<td class="govuk-table__cell ">String to prefix id for each radio item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
 
 </tr>
 
@@ -535,49 +523,73 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Array of radio items.</td>
+<td class="govuk-table__cell ">Array of checkbox items objects.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Text or HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.id</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text to use within the radio label.</td>
+<td class="govuk-table__cell ">Specific id attribute for the radio item. If ommited, then `idPrefix` string will be applied.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">html</th>
+<th class="govuk-table__header" scope="row">items.{}.name</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">HTML to use within the radio label. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Specific name for the radio item. If ommited, then component global `name` string will be applied.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">label</th>
+<th class="govuk-table__header" scope="row">items.{}.value</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Value for the radio input.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.label</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Provide additional attributes to the radio label.</td>
+<td class="govuk-table__cell ">Provide additional attributes to each radio item label. See `label` component for more details.</td>
 
 </tr>
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">checked</th>
+<th class="govuk-table__header" scope="row">items.{}.checked</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
@@ -589,7 +601,31 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">disabled</th>
+<th class="govuk-table__header" scope="row">items.{}.conditional</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">If true, content provided will be revealed when the item is checked.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.conditional.html</th>
+
+<td class="govuk-table__cell ">boolean</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Provide content for the conditional reveal.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.disabled</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
@@ -601,13 +637,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the radios container.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">attributes</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the radio container.</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the radios container.</td>
 
 </tr>
 

--- a/src/components/radios/index.njk
+++ b/src/components/radios/index.njk
@@ -80,20 +80,6 @@ Let users select a single option from a list.
     ],
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
         text: 'idPrefix'
       },
       {
@@ -103,7 +89,7 @@ Let users select a single option from a list.
         text: 'No'
       },
       {
-        text: 'String to prefix id for each radio item if no id is specified on each item.'
+        text: 'String to prefix id for each radio item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.'
       }
     ],
     [
@@ -131,12 +117,26 @@ Let users select a single option from a list.
         text: 'Yes'
       },
       {
-        text: 'Array of radio items.'
+        text: 'Array of checkbox items objects.'
       }
     ],
     [
       {
-        text: 'text'
+        text: 'items.{}.text (or) items.{}.html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Text or HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.id'
       },
       {
         text: 'string'
@@ -145,26 +145,40 @@ Let users select a single option from a list.
         text: 'No'
       },
       {
-        text: 'Text to use within the radio label.'
+        text: 'Specific id attribute for the radio item. If ommited, then `idPrefix` string will be applied.'
       }
     ],
     [
       {
-        text: 'html'
+        text: 'items.{}.name'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'HTML to use within the radio label. If this is provided, the text argument will be ignored.'
+        text: 'Specific name for the radio item. If ommited, then component global `name` string will be applied.'
       }
     ],
     [
       {
-        text: 'label'
+        text: 'items.{}.value'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Value for the radio input.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.label'
       },
       {
         text: 'object'
@@ -173,12 +187,12 @@ Let users select a single option from a list.
         text: 'No'
       },
       {
-        text: 'Provide additional attributes to the radio label.'
+        html: 'Provide additional attributes to each radio item label. See `label` component for more details.'
       }
     ],
     [
       {
-        text: 'checked'
+        text: 'items.{}.checked'
       },
       {
         text: 'boolean'
@@ -192,7 +206,35 @@ Let users select a single option from a list.
     ],
     [
       {
-        text: 'disabled'
+        text: 'items.{}.conditional'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'If true, content provided will be revealed when the item is checked.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.conditional.html'
+      },
+      {
+        text: 'boolean'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Provide content for the conditional reveal.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.disabled'
       },
       {
         text: 'boolean'
@@ -206,6 +248,20 @@ Let users select a single option from a list.
     ],
     [
       {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the radios container.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {
@@ -215,7 +271,7 @@ Let users select a single option from a list.
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the radio container.'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the radios container.'
       }
     ]
   ]

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -218,18 +218,6 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">id</th>
 
 <td class="govuk-table__cell ">string</td>
@@ -266,7 +254,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">value</th>
+<th class="govuk-table__header" scope="row">item.value</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -278,7 +266,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">item.text</th>
 
 <td class="govuk-table__cell ">string</td>
 
@@ -290,7 +278,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">selected</th>
+<th class="govuk-table__header" scope="row">item.selected</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
@@ -302,7 +290,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">disabled</th>
+<th class="govuk-table__header" scope="row">item.disabled</th>
 
 <td class="govuk-table__cell ">boolean</td>
 
@@ -345,6 +333,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the select component.</td>
 
 </tr>
 

--- a/src/components/select/index.njk
+++ b/src/components/select/index.njk
@@ -38,20 +38,6 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
   'rows' : [
     [
       {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes.'
-      }
-    ],
-    [
-      {
         text: 'id'
       },
       {
@@ -94,7 +80,7 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'value'
+        text: 'item.value'
       },
       {
         text: 'string'
@@ -108,7 +94,7 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'text'
+        text: 'item.text'
       },
       {
         text: 'string'
@@ -122,7 +108,7 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'selected'
+        text: 'item.selected'
       },
       {
         text: 'boolean'
@@ -136,7 +122,7 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
     ],
     [
       {
-        text: 'disabled'
+        text: 'item.disabled'
       },
       {
         text: 'boolean'
@@ -188,6 +174,20 @@ The HTML <code>&lt;select&gt;</code> element represents a control that provides 
       },
       {
         text: 'Arguments for the errorMessage component (e.g. text). See errorMessage component.'
+      }
+    ],
+    [
+      {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the select component.'
       }
     ],
     [

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -69,6 +69,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">text (or) html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text or HTML to use within the skip link. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">href</th>
 
 <td class="govuk-table__cell ">string</td>
@@ -81,37 +93,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text to use within the skip link.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within the skip link. If this is provided, the text argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes for the skip link.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the skip link.</td>
 
 </tr>
 

--- a/src/components/skip-link/index.njk
+++ b/src/components/skip-link/index.njk
@@ -40,6 +40,20 @@ You'll need to add correct id to your main content area, to ensure the skip link
   'rows' : [
     [
       {
+        text: 'text (or) html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text:'No'
+      },
+      {
+        text: 'Text or HTML to use within the skip link. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
         text: 'href'
       },
       {
@@ -54,34 +68,6 @@ You'll need to add correct id to your main content area, to ensure the skip link
     ],
     [
       {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text:'No'
-      },
-      {
-        text: 'Text to use within the skip link.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text:'No'
-      },
-      {
-        text: 'HTML to use within the skip link. If this is provided, the text argument will be ignored.'
-      }
-    ],
-    [
-      {
         text: 'classes'
       },
       {
@@ -91,7 +77,7 @@ You'll need to add correct id to your main content area, to ensure the skip link
         text:'No'
       },
       {
-        text: 'Optional additional classes for the skip link.'
+        text: 'Optional additional classes to add to the skip link.'
       }
     ],
     [

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -380,13 +380,121 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">rows</th>
+
+<td class="govuk-table__cell ">array</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Array of table rows and cells.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">rows.[].text (or) rows.[].html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">Yes</td>
+
+<td class="govuk-table__cell ">Text or HTML for cells in table rows. If `html` is specified, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">rows.[].format</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes.</td>
+<td class="govuk-table__cell ">Specify format of a cell. Currently we only use "numeric".</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">rows.[].colspan</th>
+
+<td class="govuk-table__cell ">number</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Specify how many columns a cell extends.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">rows.[].rowspan</th>
+
+<td class="govuk-table__cell ">number</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Specify how many rows a cell extends.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head</th>
+
+<td class="govuk-table__cell ">array</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional array of table head cells.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head.[].text or head.[].html</th>
+
+<td class="govuk-table__cell ">array</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional array of table head cells. If `html` is specified, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head.[].colspan</th>
+
+<td class="govuk-table__cell ">number</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Specify how many columns a cell extends.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head.[].rowspan</th>
+
+<td class="govuk-table__cell ">number</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Specify how many rows a cell extends.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head.[].format</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Specify format of a cell. Currently we only use "numeric".</td>
 
 </tr>
 
@@ -428,85 +536,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">head</th>
-
-<td class="govuk-table__cell ">array</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional array of table head cells</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">rows</th>
-
-<td class="govuk-table__cell ">array</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">Array of table rows and cells.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Text for cells in table head and rows.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML for cells in table head and rows. If this is specified, the text argument will be ignored.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">format</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Specify format of any cell. Currently we only use "numeric".</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">colspan</th>
-
-<td class="govuk-table__cell ">number</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Specify how many columns the cell extends.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">rowspan</th>
-
-<td class="govuk-table__cell ">number</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Specify how many rows the cell extends.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the table container.</td>
 
 </tr>
 

--- a/src/components/table/index.njk
+++ b/src/components/table/index.njk
@@ -39,7 +39,35 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'rows'
+      },
+      {
+        text: 'array'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Array of table rows and cells.'
+      }
+    ],
+    [
+      {
+        text: 'rows.[].text (or) rows.[].html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'Yes'
+      },
+      {
+        text: 'Text or HTML for cells in table rows. If `html` is specified, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'rows.[].format'
       },
       {
         text: 'string'
@@ -48,7 +76,105 @@
         text: 'No'
       },
       {
-        text: 'Optional additional classes.'
+        text: 'Specify format of a cell. Currently we only use "numeric".'
+      }
+    ],
+    [
+      {
+        text: 'rows.[].colspan'
+      },
+      {
+        text: 'number'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Specify how many columns a cell extends.'
+      }
+    ],
+    [
+      {
+        text: 'rows.[].rowspan'
+      },
+      {
+        text: 'number'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Specify how many rows a cell extends.'
+      }
+    ],
+    [
+      {
+        text: 'head'
+      },
+      {
+        text: 'array'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional array of table head cells.'
+      }
+    ],
+    [
+      {
+        text: 'head.[].text or head.[].html'
+      },
+      {
+        text: 'array'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional array of table head cells. If `html` is specified, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'head.[].colspan'
+      },
+      {
+        text: 'number'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Specify how many columns a cell extends.'
+      }
+    ],
+    [
+      {
+        text: 'head.[].rowspan'
+      },
+      {
+        text: 'number'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Specify how many rows a cell extends.'
+      }
+    ],
+    [
+      {
+        text: 'head.[].format'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Specify format of a cell. Currently we only use "numeric".'
       }
     ],
     [
@@ -95,35 +221,7 @@
     ],
     [
       {
-        text: 'head'
-      },
-      {
-        text: 'array'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional array of table head cells'
-      }
-    ],
-    [
-      {
-        text: 'rows'
-      },
-      {
-        text: 'array'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'Array of table rows and cells.'
-      }
-    ],
-    [
-      {
-        text: 'text'
+        text: 'classes'
       },
       {
         text: 'string'
@@ -132,63 +230,7 @@
         text: 'No'
       },
       {
-        text: 'Text for cells in table head and rows.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML for cells in table head and rows. If this is specified, the text argument will be ignored.'
-      }
-    ],
-    [
-      {
-        text: 'format'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Specify format of any cell. Currently we only use "numeric".'
-      }
-    ],
-    [
-      {
-        text: 'colspan'
-      },
-      {
-        text: 'number'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Specify how many columns the cell extends.'
-      }
-    ],
-    [
-      {
-        text: 'rowspan'
-      },
-      {
-        text: 'number'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Specify how many rows the cell extends.'
+        text: 'Optional additional classes to add to the table container.'
       }
     ],
     [

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -89,37 +89,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">text (or) html</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text or HTML to use within for the tag component. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">text</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Text for the tag component.</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">HTML to use within for the tag component. If this is provided, the text argument will be ignored.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the tag container.</td>
 
 </tr>
 

--- a/src/components/tag/index.njk
+++ b/src/components/tag/index.njk
@@ -37,6 +37,20 @@
   'rows' : [
     [
       {
+        text: 'text (or) html'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Text or HTML to use within for the tag component. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {
@@ -46,35 +60,7 @@
         text: 'No'
       },
       {
-        text: 'Optional additional classes'
-      }
-    ],
-    [
-      {
-        text: 'text'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Text for the tag component.'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'HTML to use within for the tag component. If this is provided, the text argument will be ignored.'
+        text: 'Optional additional classes to add to the tag container.'
       }
     ],
     [

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -205,18 +205,6 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">No</td>
-
-<td class="govuk-table__cell ">Optional additional classes</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
 <th class="govuk-table__header" scope="row">id</th>
 
 <td class="govuk-table__cell ">string</td>
@@ -229,13 +217,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">describedBy</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">name</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">The name of the textarea, which is submitted with the form data</td>
+<td class="govuk-table__cell ">The name of the textarea, which is submitted with the form data.</td>
 
 </tr>
 
@@ -247,7 +247,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional number of textarea rows (default is 5 rows)</td>
+<td class="govuk-table__cell ">Optional number of textarea rows (default is 5 rows).</td>
 
 </tr>
 
@@ -259,7 +259,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional initial value of the textarea</td>
+<td class="govuk-table__cell ">Optional initial value of the textarea.</td>
 
 </tr>
 
@@ -271,7 +271,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Arguments for the label component</td>
+<td class="govuk-table__cell ">Arguments for the label component. See label component.</td>
 
 </tr>
 
@@ -301,13 +301,25 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">classes</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional additional classes to add to the textarea tag.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">attributes</th>
 
 <td class="govuk-table__cell ">object</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the textarea tag</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the textarea tag.</td>
 
 </tr>
 

--- a/src/components/textarea/index.njk
+++ b/src/components/textarea/index.njk
@@ -36,20 +36,7 @@
     }
   ],
   'rows' : [
-    [
-      {
-        text: 'classes'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'No'
-      },
-      {
-        text: 'Optional additional classes'
-      }
-    ],
+    
     [
       {
         text: 'id'
@@ -66,6 +53,20 @@
     ],
     [
       {
+        text: 'describedBy'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.'
+      }
+    ],
+    [
+      {
         text: 'name'
       },
       {
@@ -75,7 +76,7 @@
         text: 'Yes'
       },
       {
-        text: 'The name of the textarea, which is submitted with the form data'
+        text: 'The name of the textarea, which is submitted with the form data.'
       }
     ],
     [
@@ -89,7 +90,7 @@
         text: 'No'
       },
       {
-        text: 'Optional number of textarea rows (default is 5 rows)'
+        text: 'Optional number of textarea rows (default is 5 rows).'
       }
     ],
     [
@@ -103,7 +104,7 @@
         text: 'No'
       },
       {
-        text: 'Optional initial value of the textarea'
+        text: 'Optional initial value of the textarea.'
       }
     ],
     [
@@ -117,7 +118,7 @@
         text: 'Yes'
       },
       {
-        text: 'Arguments for the label component'
+        text: 'Arguments for the label component. See label component.'
       }
     ],
     [
@@ -150,6 +151,20 @@
     ],
     [
       {
+        text: 'classes'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional additional classes to add to the textarea tag.'
+      }
+    ],
+    [
+      {
         text: 'attributes'
       },
       {
@@ -159,7 +174,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the textarea tag'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the textarea tag.'
       }
     ]
   ]

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -75,13 +75,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">classes</th>
+<th class="govuk-table__header" scope="row">text (or) html</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell ">Text or HTML for the warning text content. If `html` is provided, the `text` argument is ignored.</td>
 
 </tr>
 
@@ -99,25 +99,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">text</th>
+<th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">The text next to the icon</td>
-
-</tr>
-
-<tr class="govuk-table__row">
-
-<th class="govuk-table__header" scope="row">html</th>
-
-<td class="govuk-table__cell ">string</td>
-
-<td class="govuk-table__cell ">Yes</td>
-
-<td class="govuk-table__cell ">HTML for the warning text content. If this is provided, the text argument is ignored.</td>
+<td class="govuk-table__cell ">Optional additional classes to add to the warning-text container.</td>
 
 </tr>
 
@@ -129,7 +117,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the textarea tag</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the warning-text container.</td>
 
 </tr>
 

--- a/src/components/warning-text/index.njk
+++ b/src/components/warning-text/index.njk
@@ -37,16 +37,16 @@
   'rows' : [
     [
       {
-        text: 'classes'
+        text: 'text (or) html'
       },
       {
         text: 'string'
       },
       {
-        text: 'No'
+        text: 'Yes'
       },
       {
-        text: 'Optional additional classes'
+        text: 'Text or HTML for the warning text content. If `html` is provided, the `text` argument is ignored.'
       }
     ],
     [
@@ -65,30 +65,16 @@
     ],
     [
       {
-        text: 'text'
+        text: 'classes'
       },
       {
         text: 'string'
       },
       {
-        text: 'Yes'
+        text: 'No'
       },
       {
-        text: 'The text next to the icon'
-      }
-    ],
-    [
-      {
-        text: 'html'
-      },
-      {
-        text: 'string'
-      },
-      {
-        text: 'Yes'
-      },
-      {
-        text: 'HTML for the warning text content. If this is provided, the text argument is ignored.'
+        text: 'Optional additional classes to add to the warning-text container.'
       }
     ],
     [
@@ -102,7 +88,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the textarea tag'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the warning-text container.'
       }
     ]
   ]


### PR DESCRIPTION
Ensuring table of arguments for each components is accurate.

Updates to  `index.njk` and `README.md` files for each component.

Trello ticket: https://trello.com/c/rRQl78KY/1038-make-sure-all-component-argument-tables-are-accurate

For reviewers: Might be easiest to go through each component page on Github in the [branch](https://github.com/alphagov/govuk-frontend/tree/update-tables-of-arguments) to check the rendered README file.
