### PR TITLE
Refactor organisation colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,19 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
   ([PR #772](https://github.com/alphagov/govuk-frontend/pull/772))
 
+- All organisation variables (e.g. `$govuk-cabinet-office`) have been moved into
+  a single `$govuk-colours-organisations` map. If you need to use an
+  organisation colour in your own code, you should use the new
+  `govuk-organisation-colour` function:
+
+  ```scss
+  .element {
+    color: govuk-organisation-colour(cabinet-office);
+  }
+  ```
+
+  Note that this function will return 'web-safe' colours by default. You can
+  pass $websafe: false to get the non-websafe colour.
 
 🔧 Fixes:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "accepts": {
       "version": "1.3.4",
@@ -178,7 +178,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -235,7 +235,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
       "requires": {
         "color-convert": "1.9.1"
       }
@@ -249,7 +249,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -368,7 +368,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo=",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
       "dev": true
     },
     "archy": {
@@ -404,7 +404,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -976,7 +976,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -1924,13 +1924,13 @@
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
@@ -2295,7 +2295,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "convert-source-map": {
@@ -2334,7 +2334,7 @@
     "cosmiconfig": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-      "integrity": "sha1-YXPOvVb6wELB9DkO33r2wHx8uJI=",
+      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -2528,7 +2528,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -2676,7 +2676,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -2789,7 +2789,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -3206,7 +3206,7 @@
     "escodegen": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha1-mBGi8mXcHNOJRCDuNxcGS2MriFI=",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
@@ -3306,7 +3306,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -3343,7 +3343,7 @@
     "eslint-config-standard-jsx": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz",
-      "integrity": "sha1-AJ5TxN2x6e5wtGUP/mOn85+INuE=",
+      "integrity": "sha512-F8fRh2WFnTek7dZH9ZaE0PCBwdVGkwVWZmizla/DDNOmg7Tx6B/IlK5+oYpiX29jpu73LszeJj5i1axEZv6VMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -3360,7 +3360,7 @@
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
-      "integrity": "sha1-q67IJBd2E7ipWymWOeG2+s9HNEk=",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -3388,7 +3388,7 @@
     "eslint-plugin-node": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz",
-      "integrity": "sha1-wEOQq428u2iHF0Aj1vOnJ2nmO5c=",
+      "integrity": "sha512-vIUQPuwbVYdz/CYnlTLsJrRy7iXHQjdEe5wz0XhhdTym3IInM/zZLlPf9nZ2mThsH0QcsieCOWs2vOeCy/22LQ==",
       "dev": true,
       "requires": {
         "ignore": "3.3.7",
@@ -3545,7 +3545,7 @@
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-          "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+          "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -4005,7 +4005,7 @@
     "find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-      "integrity": "sha1-q8/Iunb3CMQql7PWhbfpRQv7nOQ=",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
       "dev": true
     },
     "find-up": {
@@ -4730,7 +4730,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
@@ -4782,7 +4782,7 @@
     "get-own-enumerable-property-symbols": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
-      "integrity": "sha1-XErYfyg0xLm06EVJ3B4GUPs4wks=",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -4991,7 +4991,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -5011,7 +5011,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -5637,7 +5637,7 @@
     "gulp-sass-lint": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/gulp-sass-lint/-/gulp-sass-lint-1.3.4.tgz",
-      "integrity": "sha1-qZUMLdBQ/QD78uvAYwFkNKIhAOI=",
+      "integrity": "sha512-HjRwdVueJOQKV0+wVT3Ld5HFRk9fELXIHllQPS4cU9C2SC9RKIfExT7/RLDegZ2cQXeFRkVii4GFw4WnzV+epQ==",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
@@ -6059,7 +6059,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-comment-regex": {
@@ -6179,7 +6179,7 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs=",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
     "ignore": {
@@ -6610,7 +6610,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
         "isobject": "3.0.1"
@@ -8160,7 +8160,7 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
         }
       }
     },
@@ -8308,7 +8308,7 @@
     "known-css-properties": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.3.0.tgz",
-      "integrity": "sha1-o9E1u/xg7oxurPL35+by1HVeSaQ=",
+      "integrity": "sha512-QMQcnKAiQccfQTqtBh/qwquGZ2XK/DXND1jrcN9M8gMMy99Gwla7GQjndVUsEqIaRyP6bsFRuhwRj5poafBGJQ==",
       "dev": true
     },
     "latest-version": {
@@ -9189,7 +9189,7 @@
     "mime": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
       "dev": true
     },
     "mime-db": {
@@ -9216,7 +9216,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.9"
       }
@@ -9401,7 +9401,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -10355,7 +10355,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
@@ -10401,7 +10401,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
         "are-we-there-yet": "1.1.4",
@@ -10462,7 +10462,7 @@
     "nwmatcher": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha1-ZDSOOz2A8DW0CsEVY9J4+LctuJw=",
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
       "dev": true
     },
     "oauth-sign": {
@@ -10694,7 +10694,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11148,7 +11148,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11400,7 +11400,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11473,7 +11473,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11545,7 +11545,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11616,7 +11616,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11687,7 +11687,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11758,7 +11758,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11829,7 +11829,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -11901,7 +11901,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12077,7 +12077,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12148,7 +12148,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12233,7 +12233,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12312,7 +12312,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12384,7 +12384,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12458,7 +12458,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12532,7 +12532,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12603,7 +12603,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12677,7 +12677,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12749,7 +12749,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12820,7 +12820,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12891,7 +12891,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -12963,7 +12963,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13034,7 +13034,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13107,7 +13107,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13200,7 +13200,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13273,7 +13273,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13345,7 +13345,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13417,7 +13417,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13500,7 +13500,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13582,7 +13582,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13654,7 +13654,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13726,7 +13726,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13816,7 +13816,7 @@
         "postcss": {
           "version": "5.2.18",
           "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-          "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
@@ -13987,7 +13987,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg=",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
       "dev": true
     },
     "query-string": {
@@ -14188,7 +14188,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
         "is-equal-shallow": "0.1.3"
       }
@@ -14406,7 +14406,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       },
@@ -14414,7 +14414,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -14494,7 +14494,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -15152,6 +15152,12 @@
         }
       }
     },
+    "sass-color-helpers": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/sass-color-helpers/-/sass-color-helpers-2.1.1.tgz",
+      "integrity": "sha1-imeeIibmQRKiqzYIHPLAELbxHNY=",
+      "dev": true
+    },
     "sass-convert": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/sass-convert/-/sass-convert-0.5.2.tgz",
@@ -15208,7 +15214,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -15278,7 +15284,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -15682,7 +15688,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scss-comment-parser": {
@@ -15743,7 +15749,7 @@
     "send": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
-      "integrity": "sha1-pw4coh0TgsEdDZ9iMd6ygQgNerM=",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -15770,7 +15776,7 @@
     "serve-static": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha1-TFfVNASnYdjy58HooYpH2/J4pxk=",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.2",
@@ -15815,7 +15821,7 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
     },
     "shebang-command": {
@@ -16008,7 +16014,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
     "source-map-resolve": {
       "version": "0.5.1",
@@ -16135,7 +16141,7 @@
     "standard": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/standard/-/standard-10.0.3.tgz",
-      "integrity": "sha1-eGm8v0Ir3uqraJof+x/qlnfdUOo=",
+      "integrity": "sha512-JURZ+85ExKLQULckDFijdX5WHzN6RC7fgiZNSV4jFQVo+3tPoQGHyBrGekye/yf0aOfb4210EM5qPNlc2cRh4w==",
       "dev": true,
       "requires": {
         "eslint": "3.19.0",
@@ -16233,7 +16239,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -16731,7 +16737,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -17146,7 +17152,7 @@
     "touch": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.0.tgz",
-      "integrity": "sha1-/jZfX3XsntTlaCXgu3bSSrdK+Ds=",
+      "integrity": "sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==",
       "dev": true,
       "requires": {
         "nopt": "1.0.10"
@@ -17854,7 +17860,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -17868,7 +17874,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
+      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
         "string-width": "1.0.2"
@@ -17950,7 +17956,7 @@
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -18070,7 +18076,7 @@
         "os-locale": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-          "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
             "execa": "0.7.0",
@@ -18111,7 +18117,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "recursive-readdir": "^2.2.2",
     "request": "^2.87.0",
     "run-sequence": "^2.2.0",
+    "sass-color-helpers": "^2.1.1",
     "standard": "^10.0.2",
     "vinyl-paths": "^2.1.0",
     "yargs": "^8.0.2"

--- a/src/helpers/_all.scss
+++ b/src/helpers/_all.scss
@@ -1,4 +1,5 @@
 @import "clearfix";
+@import "colour";
 @import "device-pixels";
 @import "focusable";
 @import "font-faces";

--- a/src/helpers/_colour.scss
+++ b/src/helpers/_colour.scss
@@ -1,0 +1,25 @@
+////
+/// @group helpers/colour
+////
+
+/// Get the colour for a government organisation
+///
+/// @param {String} $organisation - Organisation name, lowercase, hyphenated
+/// @param {Boolean} $websafe - Set this to true if the colour will be used for
+///   text, to ensure that the colour returned will meet contrast requirements.
+///
+/// @access public
+
+@function govuk-organisation-colour($organisation, $websafe: false) {
+  @if not map-has-key($govuk-colours-organisations, $organisation) {
+    @error "Unknown organisation `#{$organisation}`";
+  }
+
+  $org-colour: map-get($govuk-colours-organisations, $organisation);
+
+  @if ($websafe and map-has-key($org-colour, colour-websafe)) {
+    @return map-get($org-colour, colour-websafe);
+  } @else {
+    @return map-get($org-colour, colour);
+  }
+}

--- a/src/helpers/_colour.scss
+++ b/src/helpers/_colour.scss
@@ -5,12 +5,15 @@
 /// Get the colour for a government organisation
 ///
 /// @param {String} $organisation - Organisation name, lowercase, hyphenated
-/// @param {Boolean} $websafe - Set this to true if the colour will be used for
-///   text, to ensure that the colour returned will meet contrast requirements.
+/// @param {Boolean} $websafe [true] - By default a 'websafe' version of the
+///   colour will be returned which meets contrast requirements . If you want to
+///   use the non-websafe version you can set this to `false` but your should
+///   ensure that you still meets contrast requirements for accessibility - for
+///   example, don't use the non-websafe version for text.
 ///
 /// @access public
 
-@function govuk-organisation-colour($organisation, $websafe: false) {
+@function govuk-organisation-colour($organisation, $websafe: true) {
   @if not map-has-key($govuk-colours-organisations, $organisation) {
     @error "Unknown organisation `#{$organisation}`";
   }

--- a/src/helpers/colour.test.js
+++ b/src/helpers/colour.test.js
@@ -1,0 +1,83 @@
+/* eslint-env jest */
+
+const util = require('util')
+
+const configPaths = require('../../config/paths.json')
+
+const sass = require('node-sass')
+const sassRender = util.promisify(sass.render)
+
+const sassConfig = {
+  includePaths: [ configPaths.src ],
+  outputStyle: 'compact'
+}
+
+const sassBootstrap = `
+  $govuk-colours-organisations: (
+    'floo-network-authority': (
+      colour: #EC22FF,
+      colour-websafe: #9A00A8
+    ),
+    'broom-regulatory-control': (
+      colour: #A81223
+    )
+  );
+
+  @import "helpers/colour";
+`
+
+describe('@function govuk-organisation-colour', () => {
+  it('returns the colour for a given organisation', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        background: govuk-organisation-colour('floo-network-authority');
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe('.foo { background: #EC22FF; }')
+  })
+
+  it('returns the websafe colour for a given organisation if requested', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-organisation-colour('floo-network-authority', $websafe: true);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe('.foo { color: #9A00A8; }')
+  })
+
+  it('falls back to the default colour if websafe is requested but not defined for that organisation', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-organisation-colour('broom-regulatory-control', $websafe: true);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe('.foo { color: #A81223; }')
+  })
+
+  it('throws an error if a non-existent organisation is requested', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        color: govuk-organisation-colour('muggle-born-registration-commission');
+      }`
+
+    await expect(sassRender({ data: sass, ...sassConfig }))
+      .rejects
+      .toThrow(
+        'Unknown organisation `muggle-born-registration-commission`'
+      )
+  })
+})

--- a/src/helpers/colour.test.js
+++ b/src/helpers/colour.test.js
@@ -27,25 +27,12 @@ const sassBootstrap = `
 `
 
 describe('@function govuk-organisation-colour', () => {
-  it('returns the colour for a given organisation', async () => {
+  it('returns the websafe colour for a given organisation by default', async () => {
     const sass = `
       ${sassBootstrap}
 
       .foo {
-        background: govuk-organisation-colour('floo-network-authority');
-      }`
-
-    const results = await sassRender({ data: sass, ...sassConfig })
-
-    expect(results.css.toString().trim()).toBe('.foo { background: #EC22FF; }')
-  })
-
-  it('returns the websafe colour for a given organisation if requested', async () => {
-    const sass = `
-      ${sassBootstrap}
-
-      .foo {
-        color: govuk-organisation-colour('floo-network-authority', $websafe: true);
+        color: govuk-organisation-colour('floo-network-authority');
       }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
@@ -53,17 +40,30 @@ describe('@function govuk-organisation-colour', () => {
     expect(results.css.toString().trim()).toBe('.foo { color: #9A00A8; }')
   })
 
-  it('falls back to the default colour if websafe is requested but not defined for that organisation', async () => {
+  it('falls back to the default colour if a websafe colour is not explicitly defined', async () => {
     const sass = `
       ${sassBootstrap}
 
       .foo {
-        color: govuk-organisation-colour('broom-regulatory-control', $websafe: true);
+        color: govuk-organisation-colour('broom-regulatory-control');
       }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
 
     expect(results.css.toString().trim()).toBe('.foo { color: #A81223; }')
+  })
+
+  it('can be overridden to return the non-websafe colour', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        border-color: govuk-organisation-colour('floo-network-authority', $websafe: false);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe('.foo { border-color: #EC22FF; }')
   })
 
   it('throws an error if a non-existent organisation is requested', async () => {

--- a/src/settings/_colours-organisations.scss
+++ b/src/settings/_colours-organisations.scss
@@ -1,103 +1,136 @@
-// https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_organisation.scss
+////
+/// @group settings/colours
+////
 
-// We use `websafe` to mean strong enough contrast against white to
-// be used for copy and meet the AAA (large text) and AA (smaller
-// copy) WCAG guidelines.
+/// Organisation colours
+///
+/// @type Map
+///
+/// @prop $organisation.colour - Colour for the given `$organisation`
+/// @prop $organisation.colour-websafe - Websafe colour for the given
+///   `$organisation`. We use `websafe` to mean strong enough contrast against
+///   white to be used for copy and meet the AAA (large text) and AA (smaller
+///   copy) WCAG guidelines.
+///
+/// @access public
 
-$govuk-attorney-generals-office: #9f1888;
-$govuk-attorney-generals-office-websafe: #a03a88;
-$govuk-cabinet-office: #005abb;
-$govuk-cabinet-office-websafe: #347da4;
-$govuk-civil-service: #af292e;
-$govuk-department-for-business-innovation-skills: #003479;
-$govuk-department-for-business-innovation-skills-websafe: #347da4;
-$govuk-department-for-communities-and-local-government: #00857e;
-$govuk-department-for-communities-and-local-government-websafe: #37836e;
-$govuk-department-for-culture-media-sport: #d40072;
-$govuk-department-for-culture-media-sport-websafe: #a03155;
-$govuk-department-for-education: #003a69;
-$govuk-department-for-education-websafe: #347ca9;
-$govuk-department-for-environment-food-rural-affairs: #00a33b;
-$govuk-department-for-international-development: #002878;
-$govuk-department-for-international-development-websafe: #405e9a;
-$govuk-department-for-transport: #006c56;
-$govuk-department-for-transport-websafe: #398373;
-$govuk-department-for-work-pensions: #00beb7;
-$govuk-department-for-work-pensions-websafe: #37807b;
-$govuk-department-of-energy-climate-change: #009ddb;
-$govuk-department-of-energy-climate-change-websafe: #2b7cac;
-$govuk-department-of-health: #00ad93;
-$govuk-department-of-health-websafe: #39836e;
-$govuk-foreign-commonwealth-office: #003e74;
-$govuk-foreign-commonwealth-office-websafe: #406e97;
-$govuk-government-equalities-office: #9325b2;
-$govuk-hm-government: #0076c0;
-$govuk-hm-government-websafe: #347da4;
-$govuk-hm-revenue-customs: #009390;
-$govuk-hm-revenue-customs-websafe: #008770;
-$govuk-hm-treasury: #af292e;
-$govuk-hm-treasury-websafe: #832322;
-$govuk-home-office: #9325b2;
-$govuk-home-office-websafe: #9440b2;
-$govuk-ministry-of-defence: #4d2942;
-$govuk-ministry-of-defence-websafe: #5a5c92;
-$govuk-ministry-of-justice: #231f20;
-$govuk-ministry-of-justice-websafe: #5a5c92;
-$govuk-northern-ireland-office: #002663;
-$govuk-northern-ireland-office-websafe: #3e598c;
-$govuk-office-of-the-advocate-general-for-scotland: #002663;
-$govuk-office-of-the-advocate-general-for-scotland-websafe: $govuk-blue;
-$govuk-office-of-the-leader-of-the-house-of-lords: #9c132e;
-$govuk-office-of-the-leader-of-the-house-of-lords-websafe: #c2395d;
-$govuk-scotland-office: #002663;
-$govuk-scotland-office-websafe: #405c8a;
-// Note: the "the" part here will get dropped
-$govuk-the-office-of-the-leader-of-the-house-of-commons: #317023;
-$govuk-the-office-of-the-leader-of-the-house-of-commons-websafe: #005f8f;
-$govuk-uk-export-finance: #005747;
-$govuk-uk-export-finance-websafe: $govuk-blue;
-$govuk-uk-trade-investment: #c80651;
-$govuk-uk-trade-investment-websafe: $govuk-blue;
-$govuk-wales-office: #a33038;
-$govuk-wales-office-websafe: #7a242a;
-
-// All organisation colours in a list
-// (class_name, brand colour, WCAG acceptible text colour)
-//
-// example usage:
-// @each $govuk-organisation in $govuk-all-organisation-brand-colours {
-//    .#{nth($govuk-organisation, 1)} {
-//      border-color: nth($govuk-organisation, 2);
-//    }
-// }
-
-$govuk-all-organisation-brand-colours: (
-  "govuk-attorney-generals-office": $govuk-attorney-generals-office $govuk-attorney-generals-office-websafe,
-  "govuk-cabinet-office": $govuk-cabinet-office $govuk-cabinet-office-websafe,
-  "govuk-civil-service": $govuk-civil-service $govuk-civil-service,
-  "govuk-department-for-business-innovation-skills": $govuk-department-for-business-innovation-skills $govuk-department-for-business-innovation-skills-websafe,
-  "govuk-department-for-communities-and-local-government": $govuk-department-for-communities-and-local-government $govuk-department-for-communities-and-local-government-websafe,
-  "govuk-department-for-culture-media-sport": $govuk-department-for-culture-media-sport $govuk-department-for-culture-media-sport-websafe,
-  "govuk-department-for-education": $govuk-department-for-education $govuk-department-for-education-websafe,
-  "govuk-department-for-environment-food-rural-affairs": $govuk-department-for-environment-food-rural-affairs $govuk-department-for-environment-food-rural-affairs,
-  "govuk-department-for-international-development": $govuk-department-for-international-development $govuk-department-for-international-development-websafe,
-  "govuk-department-for-transport": $govuk-department-for-transport $govuk-department-for-transport-websafe,
-  "govuk-department-for-work-pensions": $govuk-department-for-work-pensions $govuk-department-for-work-pensions-websafe,
-  "govuk-department-of-energy-climate-change": $govuk-department-of-energy-climate-change $govuk-department-of-energy-climate-change-websafe,
-  "govuk-department-of-health": $govuk-department-of-health $govuk-department-of-health-websafe,
-  "govuk-foreign-commonwealth-office": $govuk-foreign-commonwealth-office $govuk-foreign-commonwealth-office-websafe,
-  "govuk-hm-government": $govuk-hm-government $govuk-hm-government-websafe,
-  "govuk-hm-revenue-customs": $govuk-hm-revenue-customs $govuk-hm-revenue-customs-websafe,
-  "govuk-hm-treasury": $govuk-hm-treasury $govuk-hm-treasury-websafe,
-  "govuk-home-office": $govuk-home-office $govuk-home-office-websafe,
-  "govuk-ministry-of-defence": $govuk-ministry-of-defence $govuk-ministry-of-defence-websafe,
-  "govuk-ministry-of-justice": $govuk-ministry-of-justice $govuk-ministry-of-justice-websafe,
-  "govuk-northern-ireland-office": $govuk-northern-ireland-office $govuk-northern-ireland-office-websafe,
-  "govuk-office-of-the-advocate-general-for-scotland": $govuk-office-of-the-advocate-general-for-scotland $govuk-office-of-the-advocate-general-for-scotland-websafe,
-  "govuk-office-of-the-leader-of-the-house-of-lords": $govuk-office-of-the-leader-of-the-house-of-lords $govuk-office-of-the-leader-of-the-house-of-lords-websafe,
-  "govuk-scotland-office": $govuk-scotland-office $govuk-scotland-office-websafe,
-  "govuk-the-office-of-the-leader-of-the-house-of-commons": $govuk-the-office-of-the-leader-of-the-house-of-commons $govuk-the-office-of-the-leader-of-the-house-of-commons-websafe,
-  "govuk-uk-export-finance": $govuk-uk-export-finance $govuk-uk-export-finance-websafe,
-  "govuk-uk-trade-investment": $govuk-uk-trade-investment $govuk-uk-trade-investment-websafe,
-  "govuk-wales-office": $govuk-wales-office $govuk-wales-office-websafe
-);
+$govuk-colours-organisations: (
+  "attorney-generals-office": (
+    colour: #9f1888,
+    colour-websafe: #a03a88
+  ),
+  "cabinet-office": (
+    colour: #005abb,
+    colour-websafe: #347da4
+  ),
+  "civil-service": (
+    colour: #af292e
+  ),
+  "department-for-business-innovation-skills": (
+    colour: #003479,
+    colour-websafe: #347da4
+  ),
+  "department-for-communities-and-local-government": (
+    colour: #00857e,
+    colour-websafe: #37836e
+  ),
+  "department-for-culture-media-sport": (
+    colour: #d40072,
+    colour-websafe: #a03155
+  ),
+  "department-for-education": (
+    colour: #003a69,
+    colour-websafe: #347ca9
+  ),
+  "department-for-environment-food-rural-affairs": (
+    colour: #00a33b,
+    colour-websafe: #008938
+  ),
+  "department-for-international-development": (
+    colour: #002878,
+    colour-websafe: #405e9a
+  ),
+  "department-for-international-trade": (
+    colour: #cf102d,
+    colour-websafe: #005ea5
+  ),
+  "department-for-transport": (
+    colour: #006c56,
+    colour-websafe: #398373
+  ),
+  "department-for-work-pensions": (
+    colour: #00beb7,
+    colour-websafe: #37807b
+  ),
+  "department-of-energy-climate-change": (
+    colour: #009ddb,
+    colour-websafe: #2b7cac
+  ),
+  "department-of-health": (
+    colour: #00ad93,
+    colour-websafe: #39836e
+  ),
+  "foreign-commonwealth-office": (
+    colour: #003e74,
+    colour-websafe: #406e97
+  ),
+  "government-equalities-office": (
+    colour:  #9325b2
+  ),
+  "hm-government": (
+    colour: #0076c0,
+    colour-websafe: #347da4
+  ),
+  "hm-revenue-customs": (
+    colour: #009390,
+    colour-websafe: #008670
+  ),
+  "hm-treasury": (
+    colour: #af292e,
+    colour-websafe: #832322
+  ),
+  "home-office": (
+    colour: #9325b2,
+    colour-websafe: #9440b2
+  ),
+  "ministry-of-defence": (
+    colour: #4d2942,
+    colour-websafe: #5a5c92
+  ),
+  "ministry-of-justice": (
+    colour: #231f20,
+    colour-websafe: #5a5c92
+  ),
+  "northern-ireland-office": (
+    colour: #002663,
+    colour-websafe: #3e598c
+  ),
+  "office-of-the-advocate-general-for-scotland": (
+    colour: #002663,
+    colour-websafe: #005ea5
+  ),
+  "office-of-the-leader-of-the-house-of-commons": (
+    colour: #317023,
+    colour-websafe: #005f8f
+  ),
+  "office-of-the-leader-of-the-house-of-lords": (
+    colour: #9c132e,
+    colour-websafe: #c2395d
+  ),
+  "scotland-office": (
+    colour: #002663,
+    colour-websafe: #405c8a
+  ),
+  "uk-export-finance": (
+    colour: #005747,
+    colour-websafe: #005ea5
+  ),
+  "uk-trade-investment": (
+    colour: #c80651,
+    colour-websafe: #005ea5
+  ),
+  "wales-office": (
+    colour: #a33038,
+    colour-websafe: #7a242a
+  )
+) !default;

--- a/src/settings/colours.test.js
+++ b/src/settings/colours.test.js
@@ -1,0 +1,41 @@
+/* eslint-env jest */
+
+const util = require('util')
+
+const sass = require('node-sass')
+const sassRender = util.promisify(sass.render)
+
+const configPaths = require('../../config/paths.json')
+
+const sassConfig = {
+  includePaths: [ configPaths.src, 'node_modules/' ],
+  outputStyle: 'compressed'
+}
+
+describe('Organisation colours', () => {
+  it('should have websafe colours that meet contrast requirements', async () => {
+    const sass = `
+      @import "settings/colours-palette";
+      @import "settings/colours-organisations";
+      @import "settings/colours-applied";
+      @import "helpers/colour";
+
+      @import "sass-color-helpers/stylesheets/color-helpers";
+
+      $minimum-contrast: 4.5;
+
+      @each $organisation in map-keys($govuk-colours-organisations) {
+
+        $colour: govuk-organisation-colour($organisation, $websafe: true);
+        $contrast: ch-color-contrast($govuk-body-background-colour, $colour);
+
+        @if ($contrast < $minimum-contrast) {
+          @error "Contrast ratio for #{$organisation} too low."
+          + " #{$colour} on #{$govuk-body-background-colour} has a contrast of: #{$contrast}."
+          + " Must be higher than #{$minimum-contrast} for WCAG AA support.";
+        }
+      }`
+
+    await sassRender({ data: sass, ...sassConfig })
+  })
+})

--- a/src/settings/colours.test.js
+++ b/src/settings/colours.test.js
@@ -13,7 +13,7 @@ const sassConfig = {
 }
 
 describe('Organisation colours', () => {
-  it('should have websafe colours that meet contrast requirements', async () => {
+  it('should define websafe colours that meet contrast requirements', async () => {
     const sass = `
       @import "settings/colours-palette";
       @import "settings/colours-organisations";
@@ -26,7 +26,7 @@ describe('Organisation colours', () => {
 
       @each $organisation in map-keys($govuk-colours-organisations) {
 
-        $colour: govuk-organisation-colour($organisation, $websafe: true);
+        $colour: govuk-organisation-colour($organisation);
         $contrast: ch-color-contrast($govuk-body-background-colour, $colour);
 
         @if ($contrast < $minimum-contrast) {


### PR DESCRIPTION
- Define organisation colours in a map, rather than as multiple variables, allowing them to be overridden by consumers
- Add tests to ensure that all organisation colours meet colour contrast, based on the tests from Frontend Toolkit (https://github.com/alphagov/govuk_frontend_toolkit/blob/bf34b09a5e0433ef50781c68a0d3180a267d51d9/spec/stylesheets/_colour_contrast_spec.scss)
- Update DEFRA and HMRC organisation colours to match the latest colours in Frontend Toolkit (see https://github.com/alphagov/govuk_frontend_toolkit/pull/368)
- Add a new function govuk-organisation-colour to allow you to easily get an organisation colour