### PR TITLE
Prevent inline SVGs from being focusable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@ Note: We're not following semantic versioning yet, we are going to talk about th
   setting rather than being hardcoded to use NTA tabular.
   ([PR #748](https://github.com/alphagov/govuk-frontend/pull/748))
 
+- Prevents focus from being lost to the inline SVGs in the header (the crown)
+  and footer (the OGL logo) by marking them as non-focusable elements
+  ([PR #774](https://github.com/alphagov/govuk-frontend/pull/774))
+
 
 🆕 New features:
 

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -24,6 +24,7 @@ Find out when to use the Footer component in your service in the [GOV.UK Design 
 
             <svg
               role="presentation"
+              focusable="false"
               class="govuk-footer__licence-logo"
               xmlns="http://www.w3.org/2000/svg"
               viewbox="0 0 483.2 195.7"

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -43,8 +43,12 @@
             {% endfor %}
           </ul>
         {% endif %}
+        {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+        treat it as an interactive element - without this it will be
+        'focusable' when using the keyboard to navigate. #}
         <svg
           role="presentation"
+          focusable="false"
           class="govuk-footer__licence-logo"
           xmlns="http://www.w3.org/2000/svg"
           viewbox="0 0 483.2 195.7"

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -25,6 +25,7 @@ Find out when to use the Header component in your service in the [GOV.UK Design 
 
               <svg
                 role="presentation"
+                focusable="false"
                 class="govuk-header__logotype-crown"
                 xmlns="http://www.w3.org/2000/svg"
                 viewbox="0 0 132 97"
@@ -74,6 +75,7 @@ Find out when to use the Header component in your service in the [GOV.UK Design 
 
               <svg
                 role="presentation"
+                focusable="false"
                 class="govuk-header__logotype-crown"
                 xmlns="http://www.w3.org/2000/svg"
                 viewbox="0 0 132 97"
@@ -129,6 +131,7 @@ Find out when to use the Header component in your service in the [GOV.UK Design 
 
               <svg
                 role="presentation"
+                focusable="false"
                 class="govuk-header__logotype-crown"
                 xmlns="http://www.w3.org/2000/svg"
                 viewbox="0 0 132 97"

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -12,9 +12,14 @@
 
           We use currentColour so that we can easily invert it when printing and
           when the focus state is applied. This also benefits users who override
-          colours in their browser as they will still see the crown. #}
+          colours in their browser as they will still see the crown.
+
+          The SVG needs `focusable="false"` so that Internet Explorer does not
+          treat it as an interactive element - without this it will be
+          'focusable' when using the keyboard to navigate. #}
           <svg
             role="presentation"
+            focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"
             viewbox="0 0 132 97"


### PR DESCRIPTION
Remove the inline SVGs from the header and header from the tab order in Internet Explorer so that focus order is logical when using a keyboard to navigate through the page.

https://trello.com/c/M5zdFlPS/1100-dac-audit-navigation-interactive-elements

## Header

### Before

![header-before](https://user-images.githubusercontent.com/121939/41108013-6963e36c-6a6b-11e8-96d4-24881a456c20.gif)

### After

![header-after](https://user-images.githubusercontent.com/121939/41108021-6d7cc1d0-6a6b-11e8-834b-9a8525864c18.gif)

## Footer

### Before

![footer-before](https://user-images.githubusercontent.com/121939/41108035-74716252-6a6b-11e8-9bd7-7f01390ef0bf.gif)

### After

![footer-after](https://user-images.githubusercontent.com/121939/41108038-77b5f7fc-6a6b-11e8-9f79-4c96b1c25af8.gif)


See http://simplyaccessible.com/article/7-solutions-svgs/#acc-heading-4 for more details