### PR TITLE
Refactor spacing API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,36 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
   ([PR #748](https://github.com/alphagov/govuk-frontend/pull/748))
 
+- Spacing has been refactored. You will need to update Sass that currently uses GOV.UK Frontend spacing:
+
+  - Instead of
+  ``` css
+  $govuk-spacing-scale-*
+  ```
+  use
+  ``` css
+  govuk-spacing(*)
+  ```
+  where `*` is the number on the spacing scale. The scale itself has remained the same so that `$govuk-spacing-scale-3` corresponds to `govuk-spacing(3)`. This change allows us to control the error messaging when incorrect values are used and to deprecate variables. The values of spacing variables can also be overridden by consumers.
+
+  - Instead of:
+  ``` css
+  @include govuk-responsive-margin($govuk-spacing-responsive-2, "bottom");
+  @include govuk-responsive-padding($govuk-spacing-responsive-2, "bottom");
+  ```
+  use
+  ``` css
+  @include govuk-responsive-margin(2, "bottom");
+  @include govuk-responsive-padding(2, "bottom");
+  ```
+  This change, again, allows us to control the error messaging since spacing variables are not exposed directly. Also, the spacing scale itself has not changed so that `$govuk-spacing-responsive-2` corresponds to `2` when passed to the padding and margin mixins.
+
+  This PR also updates tests and sass-docs of spacing variables and helpers.
+
+  Additionally, this PR hardcodes the value of `$govuk-gutter`, see PR for more details.
+
+  ([PR #779](https://github.com/alphagov/govuk-frontend/pull/779))
+
 - Remove `pageStart` block from template, as could result in rendering issues in older IE.
   ([PR #765](https://github.com/alphagov/govuk-frontend/pull/765))
 

--- a/src/components/back-link/_back-link.scss
+++ b/src/components/back-link/_back-link.scss
@@ -12,8 +12,8 @@
     display: inline-block;
     position: relative;
 
-    margin-top: $govuk-spacing-scale-3;
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-top: govuk-spacing(3);
+    margin-bottom: govuk-spacing(3);
 
     // Allow space for the arrow
     padding-left: 14px;

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -23,8 +23,8 @@
     @include govuk-font($size: 16);
     @include govuk-text-colour;
 
-    margin-top: $govuk-spacing-scale-3;
-    margin-bottom: $govuk-spacing-scale-2;
+    margin-top: govuk-spacing(3);
+    margin-bottom: govuk-spacing(2);
   }
 
   .govuk-breadcrumbs__list {
@@ -40,12 +40,12 @@
     display: inline-block;
     position: relative;
 
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: govuk-spacing(1);
 
     // Add both margin and padding such that the chevron appears centrally
     // between each breadcrumb item
-    margin-left: $govuk-spacing-scale-2;
-    padding-left: $govuk-spacing-scale-2 + $chevron-altitude-calculated;
+    margin-left: govuk-spacing(2);
+    padding-left: govuk-spacing(2) + $chevron-altitude-calculated;
 
     float: left;
 

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -24,7 +24,7 @@
     width: 100%;
     margin-top: 0;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom", $adjustment: $button-shadow-size); // s2
-    padding: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2)) $govuk-spacing-scale-2; // s1
+    padding: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2)) govuk-spacing(2); // s1
     border: $govuk-border-width-form-element solid transparent;
     border-radius: 0;
     color: $govuk-button-text-colour;
@@ -146,10 +146,10 @@
     @include govuk-typography-responsive($size: 24, $override-line-height: 1);
 
     min-height: auto;
-    padding-top: $govuk-spacing-scale-2 - $govuk-border-width-form-element;
-    padding-right: $govuk-spacing-scale-7;
-    padding-bottom: $govuk-spacing-scale-2 - $govuk-border-width-form-element;
-    padding-left: $govuk-spacing-scale-3;
+    padding-top: govuk-spacing(2) - $govuk-border-width-form-element;
+    padding-right: govuk-spacing(7);
+    padding-bottom: govuk-spacing(2) - $govuk-border-width-form-element;
+    padding-left: govuk-spacing(3);
 
     background-image: govuk-image-url("icon-pointer.png");
     background-repeat: no-repeat;
@@ -168,13 +168,13 @@
   $offset: 2;
 
   .govuk-button {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
+    padding-top: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
+    padding-bottom: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
   }
 
   .govuk-button--start {
-    padding-top: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
-    padding-bottom: ($govuk-spacing-scale-2 - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
+    padding-top: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2) + $offset); // s1
+    padding-bottom: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2) - $offset + 1); // s1
   }
 
 }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -23,7 +23,7 @@
     position: relative;
     width: 100%;
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom", $adjustment: $button-shadow-size); // s2
+    @include govuk-responsive-margin(6, "bottom", $adjustment: $button-shadow-size); // s2
     padding: (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2)) govuk-spacing(2); // s1
     border: $govuk-border-width-form-element solid transparent;
     border-radius: 0;

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -8,8 +8,8 @@
 @import "../label/label";
 
 @include govuk-exports("govuk/component/checkboxes") {
-  $govuk-checkboxes-size: $govuk-spacing-scale-7;
-  $govuk-checkboxes-label-padding-left-right: $govuk-spacing-scale-3;
+  $govuk-checkboxes-size: govuk-spacing(7);
+  $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 
   .govuk-checkboxes__item {
     @include govuk-font($size: 19);
@@ -19,7 +19,7 @@
 
     min-height: $govuk-checkboxes-size;
 
-    margin-bottom: $govuk-spacing-scale-2;
+    margin-bottom: govuk-spacing(2);
     padding: 0 0 0 $govuk-checkboxes-size;
 
     clear: left;
@@ -58,7 +58,7 @@
 
   .govuk-checkboxes__label {
     display: block;
-    padding: 8px $govuk-checkboxes-label-padding-left-right $govuk-spacing-scale-1;
+    padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -129,7 +129,7 @@
   $conditional-padding-left: $conditional-border-padding + $govuk-checkboxes-label-padding-left-right;
 
   .govuk-checkboxes__conditional {
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
     margin-left: $conditional-margin-left;
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;

--- a/src/components/date-input/_date-input.scss
+++ b/src/components/date-input/_date-input.scss
@@ -14,7 +14,7 @@
 
   .govuk-date-input__item {
     width: 50px;
-    margin-right: $govuk-spacing-scale-4;
+    margin-right: govuk-spacing(4);
     margin-bottom: 0;
     float: left;
     clear: none;

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -19,10 +19,10 @@
     // Absolutely position the marker against this element
     position: relative;
 
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: govuk-spacing(1);
 
     // Allow for absolutely positioned marker and align with disclosed text
-    padding-left: $govuk-spacing-scale-4 + $govuk-border-width;
+    padding-left: govuk-spacing(4) + $govuk-border-width;
 
     // Style the summary to look like a link...
     color: $govuk-link-colour;
@@ -70,14 +70,14 @@
   }
 
   .govuk-details__text {
-    padding: $govuk-spacing-scale-3;
-    padding-left: $govuk-spacing-scale-4;
+    padding: govuk-spacing(3);
+    padding-left: govuk-spacing(4);
     border-left: $govuk-border-width solid $govuk-border-colour;
   }
 
   .govuk-details__text p {
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-4;
+    margin-bottom: govuk-spacing(4);
   }
 
   .govuk-details__text p:last-child {

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -7,7 +7,7 @@
   .govuk-details {
     @include govuk-font($size: 19);
     @include govuk-text-colour;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
 
     display: block;
   }

--- a/src/components/error-message/_error-message.scss
+++ b/src/components/error-message/_error-message.scss
@@ -7,7 +7,7 @@
     @include govuk-font($size: 19, $weight: bold);
 
     display: block;
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
     clear: both;
 
     color: $govuk-error-colour;

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -8,8 +8,8 @@
 
   .govuk-error-summary {
     @include govuk-text-colour;
-    @include govuk-responsive-padding($govuk-spacing-responsive-4);
-    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
+    @include govuk-responsive-padding(4);
+    @include govuk-responsive-margin(8, "bottom");
     @include govuk-focusable;
 
     border: $govuk-border-width-mobile solid $govuk-error-colour;
@@ -23,7 +23,7 @@
     @include govuk-font($size: 24, $weight: bold);
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-error-summary__body {
@@ -31,7 +31,7 @@
 
     p {
       margin-top: 0;
-      @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+      @include govuk-responsive-margin(4, "bottom");
     }
   }
 

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -20,7 +20,7 @@
     box-sizing: border-box; // 1
     display: table;         // 2
     max-width: 100%;        // 1
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
     padding: 0;
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -76,7 +76,7 @@
 
   .govuk-footer__meta-item {
     margin-right: $govuk-gutter-half;
-    margin-bottom: $govuk-spacing-scale-5;
+    margin-bottom: govuk-spacing(5);
     margin-left: $govuk-gutter-half;
   }
 
@@ -89,9 +89,9 @@
 
   .govuk-footer__licence-logo {
     display: inline-block;
-    margin-right: $govuk-spacing-scale-2;
+    margin-right: govuk-spacing(2);
     @include mq ($until: desktop) {
-      margin-bottom: $govuk-spacing-scale-3;
+      margin-bottom: govuk-spacing(3);
     }
     vertical-align: top;
   }
@@ -103,7 +103,7 @@
   .govuk-footer__copyright-logo {
     display: inline-block;
     min-width: $govuk-footer-crest-image-width;
-    padding-top: ($govuk-footer-crest-image-height + $govuk-spacing-scale-2);
+    padding-top: ($govuk-footer-crest-image-height + govuk-spacing(2));
     background-image: govuk-image-url("govuk-crest.png");
     @include govuk-device-pixel-ratio {
       background-image: govuk-image-url("govuk-crest-2x.png");
@@ -118,21 +118,21 @@
 
   .govuk-footer__inline-list {
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
     padding: 0;
   }
 
   .govuk-footer__inline-list-item {
     display: inline-block;
-    margin-right: $govuk-spacing-scale-3;
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-right: govuk-spacing(3);
+    margin-bottom: govuk-spacing(1);
   }
 
   .govuk-footer__heading {
     @include govuk-responsive-margin($govuk-spacing-responsive-7, "bottom");
-    padding-bottom: $govuk-spacing-scale-4;
+    padding-bottom: govuk-spacing(4);
     @include mq ($until: tablet) {
-      padding-bottom: $govuk-spacing-scale-2;
+      padding-bottom: govuk-spacing(2);
     }
     border-bottom: 1px solid $govuk-footer-border;
   }

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -22,8 +22,8 @@
 
   .govuk-footer {
     @include govuk-font($size: 16);
-    @include govuk-responsive-padding($govuk-spacing-responsive-7, "top");
-    @include govuk-responsive-padding($govuk-spacing-responsive-5, "bottom");
+    @include govuk-responsive-padding(7, "top");
+    @include govuk-responsive-padding(5, "bottom");
 
     border-top: 1px solid $govuk-footer-border-top;
     color: $govuk-footer-text;
@@ -60,7 +60,7 @@
 
   .govuk-footer__section-break {
     margin: 0; // Reset `<hr>` default margins
-    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
+    @include govuk-responsive-margin(8, "bottom");
     border: 0; // Reset `<hr>` default borders
     border-bottom: 1px solid $govuk-footer-border;
   }
@@ -129,7 +129,7 @@
   }
 
   .govuk-footer__heading {
-    @include govuk-responsive-margin($govuk-spacing-responsive-7, "bottom");
+    @include govuk-responsive-margin(7, "bottom");
     padding-bottom: govuk-spacing(4);
     @include mq ($until: tablet) {
       padding-bottom: govuk-spacing(2);
@@ -185,7 +185,7 @@
   }
 
   .govuk-footer__list-item {
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-footer__list-item:last-child {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -8,7 +8,7 @@
 
   $govuk-header-background: govuk-colour("black");
   $govuk-header-border-color: $govuk-brand-colour;
-  $govuk-header-border-width: $govuk-spacing-scale-2;
+  $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-text: govuk-colour("white");
   $govuk-header-link: govuk-colour("white");
   $govuk-header-link-hover: govuk-colour("white");
@@ -18,26 +18,26 @@
   .govuk-header {
     @include govuk-font($size: 16);
 
-    border-bottom: $govuk-spacing-scale-2 solid govuk-colour("white");
+    border-bottom: govuk-spacing(2) solid govuk-colour("white");
     color: $govuk-header-text;
     background: $govuk-header-background;
 
   }
 
   .govuk-header--full-width {
-    padding: 0 $govuk-spacing-scale-3;
+    padding: 0 govuk-spacing(3);
     border-color: $govuk-header-border-color;
   }
 
   .govuk-header__container {
     position: relative;
     margin-bottom: -$govuk-header-border-width;
-    padding-top: $govuk-spacing-scale-2;
+    padding-top: govuk-spacing(2);
     border-bottom: $govuk-header-border-width solid $govuk-header-border-color;
   }
 
   .govuk-header__logotype {
-    margin-right: $govuk-spacing-scale-1;
+    margin-right: govuk-spacing(1);
   }
 
   .govuk-header__logotype-crown {
@@ -109,13 +109,13 @@
 
   .govuk-header__link--service-name {
     display: inline-block;
-    margin-bottom: $govuk-spacing-scale-2;
+    margin-bottom: govuk-spacing(2);
     @include govuk-font($size: 24, $weight: bold);
   }
 
   .govuk-header__logo {
-    @include govuk-responsive-margin($govuk-spacing-responsive-2, "bottom");
-    padding-right: $govuk-spacing-scale-8;
+    @include govuk-responsive-new-margin(2, "bottom");
+    padding-right: govuk-spacing(8);
 
     @include mq ($from: desktop) {
       display: inline-block;
@@ -136,7 +136,7 @@
     @include govuk-font($size: 16);
     display: none;
     position: absolute;
-    top: $govuk-spacing-scale-4;
+    top: govuk-spacing(4);
     right: 0;
     margin: 0;
     padding: 0;
@@ -151,13 +151,13 @@
     &::after {
       @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
       content: "";
-      margin-left: $govuk-spacing-scale-1;
+      margin-left: govuk-spacing(1);
     }
 
     @include govuk-focusable;
 
     @include mq ($from: tablet) {
-      top: $govuk-spacing-scale-3;
+      top: govuk-spacing(3);
     }
   }
 
@@ -196,23 +196,23 @@
   .govuk-header__navigation--end {
     @include mq ($from: desktop) {
       margin: 0;
-      padding: $govuk-spacing-scale-1 0;
+      padding: govuk-spacing(1) 0;
       text-align: right;
     }
   }
 
   .govuk-header__navigation--no-service-name {
-    padding-top: $govuk-spacing-scale-7;
+    padding-top: govuk-spacing(7);
   }
 
   .govuk-header__navigation-item {
-    padding: $govuk-spacing-scale-2 0;
+    padding: govuk-spacing(2) 0;
     border-bottom: 1px solid $govuk-header-nav-item-border-color;
 
     @include mq ($from: desktop) {
       display: inline-block;
-      margin-right: $govuk-spacing-scale-3;
-      padding: $govuk-spacing-scale-1 0;
+      margin-right: govuk-spacing(3);
+      padding: govuk-spacing(1) 0;
       border: 0;
     }
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -114,7 +114,7 @@
   }
 
   .govuk-header__logo {
-    @include govuk-responsive-new-margin(2, "bottom");
+    @include govuk-responsive-margin(2, "bottom");
     padding-right: govuk-spacing(8);
 
     @include mq ($from: desktop) {
@@ -168,7 +168,7 @@
   }
 
   .govuk-header__navigation {
-    @include govuk-responsive-margin($govuk-spacing-responsive-2, "bottom");
+    @include govuk-responsive-margin(2, "bottom");
     display: block;
     margin: 0;
     padding: 0;

--- a/src/components/hint/_hint.scss
+++ b/src/components/hint/_hint.scss
@@ -8,7 +8,7 @@
 
     display: block;
 
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
 
     color: $govuk-secondary-text-colour;
   }

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -16,7 +16,7 @@
     height: 40px;
     margin-top: 0;
 
-    padding: $govuk-spacing-scale-1;
+    padding: govuk-spacing(1);
     // setting any background-color makes text invisible when changing colours to dark backgrounds in Firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1335476)
     // as background-color and color need to always be set together, color should not be set either
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -6,7 +6,7 @@
   .govuk-inset-text {
     @include govuk-font($size: 19);
     @include govuk-text-colour;
-    padding: $govuk-spacing-scale-3;
+    padding: govuk-spacing(3);
     // Margin top intended to collapse
     // This adds an additional 10px to the paragraph above
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -9,8 +9,8 @@
     padding: govuk-spacing(3);
     // Margin top intended to collapse
     // This adds an additional 10px to the paragraph above
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "top");
+    @include govuk-responsive-margin(6, "bottom");
 
     clear: both;
 

--- a/src/components/label/_label.scss
+++ b/src/components/label/_label.scss
@@ -9,24 +9,24 @@
 
     display: block;
 
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: govuk-spacing(1);
   }
 
   // Modifiers that make labels look more like their equivalent headings
 
   .govuk-label--xl {
     @include govuk-font($size: 48, $weight: bold);
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
   }
 
   .govuk-label--l {
     @include govuk-font($size: 36, $weight: bold);
-    margin-bottom: $govuk-spacing-scale-3;
+    margin-bottom: govuk-spacing(3);
   }
 
   .govuk-label--m {
     @include govuk-font($size: 24, $weight: bold);
-    margin-bottom: $govuk-spacing-scale-2;
+    margin-bottom: govuk-spacing(2);
   }
 
   .govuk-label--s {

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -9,15 +9,15 @@
 
     box-sizing: border-box;
 
-    margin-bottom: $govuk-spacing-scale-3;
-    padding: $govuk-spacing-scale-7 - $govuk-border-width;
+    margin-bottom: govuk-spacing(3);
+    padding: govuk-spacing(7) - $govuk-border-width;
 
     border: $govuk-border-width solid transparent;
 
     text-align: center;
 
     @include govuk-media-query($until: tablet) {
-      padding: $govuk-spacing-scale-6 - $govuk-border-width;
+      padding: govuk-spacing(6) - $govuk-border-width;
     }
   }
 
@@ -28,7 +28,7 @@
 
   .govuk-panel__title {
     margin-top: 0;
-    margin-bottom: $govuk-spacing-scale-6;
+    margin-bottom: govuk-spacing(6);
 
     @include govuk-font($size: 48, $weight: bold);
   }

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -9,8 +9,8 @@
     @include govuk-font($size: 16);
     @include govuk-text-colour;
 
-    padding-top: $govuk-spacing-scale-2;
-    padding-bottom: $govuk-spacing-scale-2;
+    padding-top: govuk-spacing(2);
+    padding-bottom: govuk-spacing(2);
 
     border-bottom: 1px solid $govuk-border-colour;
   }
@@ -21,7 +21,7 @@
   }
 
   .govuk-phase-banner__content__tag {
-    margin-right: $govuk-spacing-scale-2;
+    margin-right: govuk-spacing(2);
   }
 
   .govuk-phase-banner__text {

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -8,8 +8,8 @@
 @import "../label/label";
 
 @include govuk-exports("govuk/component/radios") {
-  $govuk-radios-size: $govuk-spacing-scale-7;
-  $govuk-radios-label-padding-left-right: $govuk-spacing-scale-3;
+  $govuk-radios-size: govuk-spacing(7);
+  $govuk-radios-label-padding-left-right: govuk-spacing(3);
 
   .govuk-radios__item {
     @include govuk-font($size: 19);
@@ -20,7 +20,7 @@
 
     min-height: $govuk-radios-size;
 
-    margin-bottom: $govuk-spacing-scale-2;
+    margin-bottom: govuk-spacing(2);
     padding: 0 0 0 $govuk-radios-size;
 
     clear: left;
@@ -59,7 +59,7 @@
 
   .govuk-radios__label {
     display: block;
-    padding: 8px $govuk-radios-label-padding-left-right $govuk-spacing-scale-1;
+    padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile
     -ms-touch-action: manipulation;
@@ -85,13 +85,13 @@
     content: "";
 
     position: absolute;
-    top: $govuk-spacing-scale-2;
-    left: $govuk-spacing-scale-2;
+    top: govuk-spacing(2);
+    left: govuk-spacing(2);
 
     width: 0;
     height: 0;
 
-    border: $govuk-spacing-scale-2 solid currentColor;
+    border: govuk-spacing(2) solid currentColor;
     border-radius: 50%;
     opacity: 0;
     background: currentColor;
@@ -123,7 +123,7 @@
       @include govuk-clearfix;
 
       .govuk-radios__item {
-        margin-right: $govuk-spacing-scale-4;
+        margin-right: govuk-spacing(4);
         float: left;
         clear: none;
       }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -139,7 +139,7 @@
   $conditional-padding-left: $conditional-border-padding + $govuk-radios-label-padding-left-right;
 
   .govuk-radios__conditional {
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
     margin-left: $conditional-margin-left;
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -15,7 +15,7 @@
     width: 100%;
     height: 40px;
 
-    padding: $govuk-spacing-scale-1; // was 5px 4px 4px - size of it should be adjusted to match other form elements
+    padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   }
 

--- a/src/components/skip-link/_skip-link.scss
+++ b/src/components/skip-link/_skip-link.scss
@@ -10,6 +10,6 @@
     @include govuk-typography-responsive($size: 16);
 
     display: block;
-    padding: $govuk-spacing-scale-2 $govuk-spacing-scale-3;
+    padding: govuk-spacing(2) govuk-spacing(3);
   }
 }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -16,13 +16,13 @@
   .govuk-table__header {
     @include govuk-typography-weight-bold;
 
-    padding: govuk-em($govuk-spacing-scale-2, 19px) govuk-em($govuk-spacing-scale-4, 19px) govuk-em($govuk-spacing-scale-2, 19px) 0;
+    padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px) govuk-em(govuk-spacing(2), 19px) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
   }
 
   .govuk-table__cell {
-    padding: govuk-em($govuk-spacing-scale-2, 19px) govuk-em($govuk-spacing-scale-4, 19px) govuk-em($govuk-spacing-scale-2, 19px) 0;
+    padding: govuk-em(govuk-spacing(2), 19px) govuk-em(govuk-spacing(4), 19px) govuk-em(govuk-spacing(2), 19px) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
   }

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -7,7 +7,7 @@
     @include govuk-font($size: 19);
     @include govuk-text-colour;
     width: 100%;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
 
     border-spacing: 0;
     border-collapse: collapse;

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -7,7 +7,7 @@
     @include govuk-font($size: 16, $weight: bold, $line-height: 1.25);
 
     display: inline-block;
-    padding: $govuk-spacing-scale-1 8px 0;
+    padding: govuk-spacing(1) 8px 0;
 
     color: govuk-colour("white");
     background-color: govuk-colour("blue");

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -14,7 +14,7 @@
     box-sizing: border-box; // should this be global?
     display: block;
     width: 100%;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(1);
 
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -15,7 +15,7 @@
     display: block;
     width: 100%;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-    padding: $govuk-spacing-scale-1;
+    padding: govuk-spacing(1);
 
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
     border-radius: 0;

--- a/src/components/warning-text/_warning-text.scss
+++ b/src/components/warning-text/_warning-text.scss
@@ -12,7 +12,7 @@
 
     position: relative;
     @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
-    padding: $govuk-spacing-scale-2 0;
+    padding: govuk-spacing(2) 0;
   }
 
   .govuk-warning-text__assistive {

--- a/src/components/warning-text/_warning-text.scss
+++ b/src/components/warning-text/_warning-text.scss
@@ -11,7 +11,7 @@
     @include govuk-text-colour;
 
     position: relative;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(2) 0;
   }
 

--- a/src/core/_lists.scss
+++ b/src/core/_lists.scss
@@ -8,7 +8,7 @@
     @include govuk-font($size: 19);
     @include govuk-text-colour;
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
     padding-left: 0;
     list-style-type: none;
 

--- a/src/core/_lists.scss
+++ b/src/core/_lists.scss
@@ -14,13 +14,13 @@
 
     // Add a top margin for nested lists
     %govuk-list {
-      margin-top: $govuk-spacing-scale-2;
+      margin-top: govuk-spacing(2);
     }
   }
 
   %govuk-list > li {
     @include govuk-media-query($from: tablet) {
-      margin-bottom: $govuk-spacing-scale-1;
+      margin-bottom: govuk-spacing(1);
     }
   }
 
@@ -47,7 +47,7 @@
   }
 
   %govuk-list--bullet {
-    padding-left: $govuk-spacing-scale-4;
+    padding-left: govuk-spacing(4);
 
     list-style-type: disc;
   }
@@ -57,7 +57,7 @@
   }
 
   %govuk-list--number {
-    padding-left: $govuk-spacing-scale-4;
+    padding-left: govuk-spacing(4);
     list-style-type: decimal;
   }
 

--- a/src/core/_section-break.scss
+++ b/src/core/_section-break.scss
@@ -20,8 +20,8 @@
   // Sizes
 
   %govuk-section-break--xl {
-    @include govuk-responsive-margin($govuk-spacing-responsive-8, "top");
-    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
+    @include govuk-responsive-margin(8, "top");
+    @include govuk-responsive-margin(8, "bottom");
   }
 
   .govuk-section-break--xl {
@@ -29,8 +29,8 @@
   }
 
   %govuk-section-break--l {
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "top");
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "top");
+    @include govuk-responsive-margin(6, "bottom");
   }
 
   .govuk-section-break--l {
@@ -38,8 +38,8 @@
   }
 
   %govuk-section-break--m {
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "top");
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "top");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-section-break--m {

--- a/src/core/_typography.scss
+++ b/src/core/_typography.scss
@@ -72,7 +72,7 @@
 
     display: block;
 
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: govuk-spacing(1);
 
     color: $govuk-secondary-text-colour;
   }
@@ -82,7 +82,7 @@
 
     display: block;
 
-    margin-bottom: $govuk-spacing-scale-1;
+    margin-bottom: govuk-spacing(1);
     color: $govuk-secondary-text-colour;
 
     @include govuk-media-query($from: tablet) {
@@ -169,10 +169,10 @@
   // Add top padding to headings that appear directly after paragraphs.
 
   %govuk-body-l  + %govuk-heading-l {
-    padding-top: $govuk-spacing-scale-1;
+    padding-top: govuk-spacing(1);
 
     @include govuk-media-query($from: tablet) {
-      padding-top: $govuk-spacing-scale-2;
+      padding-top: govuk-spacing(2);
     }
   }
 
@@ -188,10 +188,10 @@
   %govuk-body-m + %govuk-heading-s,
   %govuk-body-s + %govuk-heading-s,
   %govuk-list + %govuk-heading-s {
-    padding-top: $govuk-spacing-scale-1;
+    padding-top: govuk-spacing(1);
 
     @include govuk-media-query($from: tablet) {
-      padding-top: $govuk-spacing-scale-2;
+      padding-top: govuk-spacing(2);
     }
   }
 }

--- a/src/core/_typography.scss
+++ b/src/core/_typography.scss
@@ -13,7 +13,7 @@
     display: block;
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-8, "bottom");
+    @include govuk-responsive-margin(8, "bottom");
   }
 
   .govuk-heading-xl {
@@ -27,7 +27,7 @@
     display: block;
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
   }
 
   .govuk-heading-l {
@@ -41,7 +41,7 @@
     display: block;
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-heading-m {
@@ -55,7 +55,7 @@
     display: block;
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-heading-s {
@@ -105,7 +105,7 @@
     @include govuk-font($size: 24);
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
   }
 
   .govuk-body-l {
@@ -117,7 +117,7 @@
     @include govuk-font($size: 19);
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-body-m {
@@ -129,7 +129,7 @@
     @include govuk-font($size: 16);
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-body-s {
@@ -141,7 +141,7 @@
     @include govuk-font($size: 14);
 
     margin-top: 0;
-    @include govuk-responsive-margin($govuk-spacing-responsive-4, "bottom");
+    @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-body-xs {
@@ -179,7 +179,7 @@
   %govuk-body-m  + %govuk-heading-l,
   %govuk-body-s  + %govuk-heading-l,
   %govuk-list + %govuk-heading-l {
-    @include govuk-responsive-padding($govuk-spacing-responsive-4, "top");
+    @include govuk-responsive-padding(4, "top");
   }
 
   %govuk-body-m + %govuk-heading-m,

--- a/src/helpers/_spacing.scss
+++ b/src/helpers/_spacing.scss
@@ -2,34 +2,76 @@
 /// @group helpers
 ////
 
+/// Single point spacing
+///
+/// Returns measurement corresponding to the spacing point requested.
+///
+/// @param {Number} $spacing-point - Point on the spacing scale (set in `settings/_spacing.sccs`)
+///
+/// @returns {String} Spacing Measurement eg. 10px
+///
+/// @example scss
+///   .element {
+///     padding: govuk-spacing(5);
+///     top: govuk-spacing(2) !important; // if `!important` is required
+///   }
+/// @access public
+
+@function govuk-spacing($spacing-point) {
+
+  $actual-input-type: type-of($spacing-point);
+  @if $actual-input-type != "number" {
+    @error "Expected a number (integer), but got a "
+    + "#{$actual-input-type}.";
+  }
+
+  @if not map-has-key($govuk-spacing-points, $spacing-point) {
+    @error "Unknown spacing variable `#{$spacing-point}`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.";
+  }
+
+  @return map-get($govuk-spacing-points, $spacing-point);
+}
+
 /// Responsive spacing
 ///
 /// Adds responsive spacing (either padding or margin, depending on `$property`)
-/// using a 'spacing map', which defines different spacing values at different
-/// breakpoints.
+/// by fetching a 'spacing map' from the responsive spacing scale, which defines
+/// different spacing values at different breakpoints.
 ///
-/// @param {Map} $scale-map - Map of breakpoints and spacing values
+/// To generate responsive spacing, use 'govuk-responsive-margin' or
+/// 'govuk-responsive-padding' mixins
+///
+/// @param {Number} $responsive-spacing-point - Point on the responsive spacing
+///   scale, corresponds to a map of breakpoints and spacing values
 /// @param {String} $property - Property to add spacing to (e.g. 'margin')
 /// @param {String} $direction [all] - Direction to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [false] - Offset to adjust spacing by
 ///
-/// @access public
+/// @access private
 
-@mixin govuk-responsive-spacing($scale-map, $property, $direction: "all", $important: false, $adjustment: false) {
+@mixin _govuk-responsive-spacing($responsive-spacing-point, $property, $direction: "all", $important: false, $adjustment: false) {
 
-  // Ensure that $scale-map is actually a map - it's really easy to accidentally
-  // pass in a point from the non-responsive scale, in which case this mixin
-  // would otherwise no-op silently.
-  $actual-input-type: type-of($scale-map);
-  @if $actual-input-type != "map" {
-    @error "Expected a map of breakpoints from the responsive scale, but got a "
-    + "#{$actual-input-type}. Make sure you are using a point from the "
-    + "responsive spacing scale.";
+  $actual-input-type: type-of($responsive-spacing-point);
+  @if $actual-input-type != "number" {
+    @error "Expected a number (integer), but got a " + "#{$actual-input-type}.";
   }
 
-  // Loop through each breakpoint
+  @if not map-has-key($govuk-spacing-responsive-scale, $responsive-spacing-point) {
+    @error "Unknown spacing point `#{$responsive-spacing-point}`. Make sure you are using a point from the "
+    + "responsive spacing scale in `_settings/spacing.scss`.";
+  }
+
+  // Make sure that the return value from `_settings/spacing.scss` is a map.
+  $scale-map: map-get($govuk-spacing-responsive-scale, $responsive-spacing-point);
+  $actual-map-type: type-of($scale-map);
+  @if $actual-map-type != "map" {
+    @error "Expected a number (integer), but got a "
+    + "#{$actual-map-type}. Make sure you are using a map to set the responsive spacing in `_settings/spacing.scss`)";
+  }
+
+  // Loop through each breakpoint in the map
   @each $breakpoint, $breakpoint-value in $scale-map {
 
     @if ($adjustment) {
@@ -58,40 +100,53 @@
 
 /// Responsive margin
 ///
-/// Adds responsive margin using a 'spacing map', which defines different
-/// spacing values at different breakpoints. Wrapper for the
-/// `govuk-responsive-spacing` mixin.
+/// Adds responsive margin by fetching a 'spacing map' from the responsive
+/// spacing scale, which defines different spacing values at different
+/// breakpoints. Wrapper for the `_govuk-responsive-spacing` mixin.
 ///
-/// @see {mixin} govuk-responsive-spacing
+/// @see {mixin} _govuk-responsive-spacing
 ///
-/// @param {Map} $scale-map - Map of breakpoints and spacing values
+/// @param {Number} $responsive-spacing-point - Point on the responsive spacing
+/// scale, corresponds to a map of breakpoints and spacing values
 /// @param {String} $direction [all] - Direction to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
 /// @param {Number} $adjustment [false] - Offset to adjust spacing by
 ///
+/// @example scss
+///   .element {
+///      @include govuk-responsive-margin(6, "left", $adjustment: 1px);
+///   }
+///
 /// @access public
 
-@mixin govuk-responsive-margin($scale-map, $direction: "all", $important: false, $adjustment: false) {
-  @include govuk-responsive-spacing($scale-map, "margin", $direction, $important, $adjustment);
+@mixin govuk-responsive-margin($responsive-spacing-point, $direction: "all", $important: false, $adjustment: false) {
+  @include _govuk-responsive-spacing($responsive-spacing-point, "margin", $direction, $important, $adjustment);
 }
 
 /// Responsive padding
 ///
-/// Adds responsive padding using a 'spacing map', which defines different
-/// spacing values at different breakpoints. Wrapper for the
-/// `govuk-responsive-spacing` mixin.
+/// Adds responsive padding by fetching a 'spacing map' from the responsive
+/// spacing scale, which defines different spacing values at different
+/// breakpoints. Wrapper for the `_govuk-responsive-spacing` mixin.
 ///
-/// @see {mixin} govuk-responsive-spacing
+/// @see {mixin} _govuk-responsive-spacing
 ///
-/// @param {Map} $scale-map - Map of breakpoints and spacing values
+/// @param {Number} $responsive-spacing-point - Point on the responsive spacing
+///   scale, corresponds to a map of breakpoints and spacing values
 /// @param {String} $direction [all] - Direction to add spacing to
 ///   (`top`, `right`, `bottom`, `left`, `all`)
 /// @param {Boolean} $important [false] - Whether to mark as `!important`
-/// @param {Number} $adjustment [false] - Offset to adjust spacing by
+/// @param {Number} $adjustment [false] - Offset to adjust spacing
+///
+/// @example scss
+///   .element {
+///      @include govuk-responsive-padding(6, "left", $adjustment: 1px);
+///   }
 ///
 /// @access public
 
-@mixin govuk-responsive-padding($scale-map, $direction: "all", $important: false, $adjustment: false) {
-  @include govuk-responsive-spacing($scale-map, "padding", $direction, $important, $adjustment);
+
+@mixin govuk-responsive-padding($responsive-spacing-point, $direction: "all", $important: false, $adjustment: false) {
+  @include _govuk-responsive-spacing($responsive-spacing-point, "padding", $direction, $important, $adjustment);
 }

--- a/src/helpers/spacing.test.js
+++ b/src/helpers/spacing.test.js
@@ -17,26 +17,69 @@ const sassBootstrap = `
   @import "settings/media-queries";
   @import "settings/ie8";
 
+  $spacing-point: 2;
+
+  // Emulates data from _settings/media-queries.scss
   $govuk-breakpoints: (
     my_breakpoint: 30em
   );
 
-  $spacing-map: (
-    null: 15px,
-    my_breakpoint: 25px
+  // Emulates data from _settings/spacing.scss
+  $govuk-spacing-points: (
+    2: 15px
+  );
+
+  // Emulates data from _settings/spacing.scss
+  $govuk-spacing-responsive-scale: (
+    2: (
+      null: 15px,
+      my_breakpoint: 25px
+    )
   );
 
   @import "helpers/media-queries";
   @import "tools/iff";
   @import "helpers/spacing";`
 
-describe('@mixin govuk-responsive-spacing', () => {
+describe('@function govuk-spacing', () => {
+  it('returns CSS for a property based on the given spacing point', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        top: govuk-spacing($spacing-point)
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe(outdent`
+      .foo {
+        top: 15px; }`)
+  })
+
+  it('throws an exception when passed anything other than a number', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        top: govuk-spacing('margin')
+      }`
+
+    await expect(sassRender({ data: sass, ...sassConfig }))
+      .rejects
+      .toThrow(
+        'Expected a number (integer), but got a string.'
+      )
+  })
+})
+
+describe('@mixin _govuk-responsive-spacing', () => {
   it('outputs CSS for a property based on the given spacing map', async () => {
     const sass = `
       ${sassBootstrap}
 
       .foo {
-        @include govuk-responsive-spacing($spacing-map, 'margin')
+        @include _govuk-responsive-spacing($spacing-point, 'margin')
       }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
@@ -54,7 +97,7 @@ describe('@mixin govuk-responsive-spacing', () => {
       ${sassBootstrap}
 
       .foo {
-        @include govuk-responsive-spacing($spacing-map, 'padding', 'top');
+        @include _govuk-responsive-spacing($spacing-point, 'padding', 'top');
       }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
@@ -67,20 +110,18 @@ describe('@mixin govuk-responsive-spacing', () => {
             padding-top: 25px; } }`)
   })
 
-  it('throws an exception when passed anything other than a map', async () => {
+  it('throws an exception when passed a non-existent point', async () => {
     const sass = `
       ${sassBootstrap}
 
       .foo {
-        @include govuk-responsive-spacing(14px, 'margin')
+        @include _govuk-responsive-spacing(14px, 'margin')
       }`
 
     await expect(sassRender({ data: sass, ...sassConfig }))
       .rejects
       .toThrow(
-        'Expected a map of breakpoints from the responsive scale, but got a ' +
-        'number. Make sure you are using a point from the responsive spacing ' +
-        'scale.'
+        'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
       )
   })
 
@@ -90,8 +131,8 @@ describe('@mixin govuk-responsive-spacing', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-spacing(
-            $spacing-map,
+          @include _govuk-responsive-spacing(
+            $spacing-point,
             'margin',
             $important: true
           )
@@ -112,8 +153,8 @@ describe('@mixin govuk-responsive-spacing', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-spacing(
-            $spacing-map,
+          @include _govuk-responsive-spacing(
+            $spacing-point,
             'margin',
             'top',
             $important: true
@@ -137,8 +178,8 @@ describe('@mixin govuk-responsive-spacing', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-spacing(
-            $spacing-map,
+          @include _govuk-responsive-spacing(
+            $spacing-point,
             'margin',
             $adjustment: 2px
           )
@@ -159,8 +200,8 @@ describe('@mixin govuk-responsive-spacing', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-spacing(
-            $spacing-map,
+          @include _govuk-responsive-spacing(
+            $spacing-point,
             'margin',
             'top',
             $adjustment: 2px
@@ -185,7 +226,7 @@ describe('@mixin govuk-responsive-margin', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-margin($spacing-map)
+          @include govuk-responsive-margin($spacing-point)
         }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
@@ -204,7 +245,7 @@ describe('@mixin govuk-responsive-margin', () => {
 
         .foo {
           @include govuk-responsive-margin(
-            $spacing-map,
+            $spacing-point,
             'top',
             $important: true,
             $adjustment: 2px
@@ -228,7 +269,7 @@ describe('@mixin govuk-responsive-padding', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-responsive-padding($spacing-map)
+          @include govuk-responsive-padding($spacing-point)
         }`
 
     const results = await sassRender({ data: sass, ...sassConfig })
@@ -247,7 +288,7 @@ describe('@mixin govuk-responsive-padding', () => {
 
         .foo {
           @include govuk-responsive-padding(
-            $spacing-map,
+            $spacing-point,
             'top',
             $important: true,
             $adjustment: 2px

--- a/src/objects/_form-group.scss
+++ b/src/objects/_form-group.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("govuk/objects/form-group") {
 
   .govuk-form-group {
-    @include govuk-responsive-margin($govuk-spacing-responsive-6, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
 
     .govuk-form-group:last-of-type {
       margin-bottom: 0; // Remove margin from last item in nested groups

--- a/src/objects/_form-group.scss
+++ b/src/objects/_form-group.scss
@@ -9,7 +9,7 @@
   }
 
   .govuk-form-group--error {
-    padding-left: $govuk-spacing-scale-3;
+    padding-left: govuk-spacing(3);
     border-left: $govuk-border-width-form-group-error solid $govuk-error-colour;
 
     .govuk-form-group {

--- a/src/objects/_main-wrapper.scss
+++ b/src/objects/_main-wrapper.scss
@@ -17,13 +17,13 @@
 
 
 @mixin govuk-main-wrapper {
-  @include govuk-responsive-padding($govuk-spacing-responsive-6, "top");
-  @include govuk-responsive-padding($govuk-spacing-responsive-6, "bottom");
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(6, "bottom");
 }
 
 // Use govuk-main-wrapper--l when you page does not have Breadcrumbs, phase banners or back links
 @mixin govuk-main-wrapper--l {
-  @include govuk-responsive-padding($govuk-spacing-responsive-8, "top");
+  @include govuk-responsive-padding(8, "top");
 }
 
 @include govuk-exports("govuk/objects/main-wrapper") {

--- a/src/overrides/_spacing.scss
+++ b/src/overrides/_spacing.scss
@@ -1,50 +1,62 @@
-// Spacing directions
-$spacing-directions: (
+////
+/// @group overrides
+////
+
+/// Directions for spacing
+///
+/// @type Map
+/// @access private
+
+$_spacing-directions: (
   "top": "t",
   "right": "r",
   "bottom": "b",
   "left": "l"
 ) !default;
 
-// Generate spacing override classes for the given property (e.g. margin)
-// for each point in the spacing scale.
+/// Spacing override classes
+///
+/// Generate spacing override classes for the given property (e.g. margin)
+/// for each point in the spacing scale.
+///
+/// These override classes are responsive - the 'r' before the scale point
+/// indicates that. We might want to add non-responsive ones later.
+///
+/// @param {String} $property - Property to add spacing to (e.g. 'margin')
+/// @param {String} $property-shorthand - Shorthand representation of property, eg. "m" for "margin"
+///
+/// @example scss
+///   .govuk-\!-m-r0 {
+///      margin: 0;
+///   }
+///
+///  .govuk-\!-mt-r1 {
+///     margin-top: [whatever spacing point 1 is...]
+///   }
+///
+/// @access private
 
-// These override classes are responsive - the 'r' before the scale point
-// indicates that. We might want to add non-responsive ones later.
-//
-// Example output:
-//
-// .govuk-\!-m-r0 {
-//   margin: 0;
-// }
-//
-// [..]
-//
-// .govuk-\!-mt-r1 {
-//   margin-top: [whatever spacing point 1 is...]
-// }
-
-@mixin generate-spacing-overrides($property, $property-shorthand) {
+@mixin _govuk-generate-spacing-overrides($property, $property-shorthand) {
   // For each point in the spacing scale (defined in settings), create an
   // override that affects all directions...
   @each $scale-point, $scale-map in $govuk-spacing-responsive-scale {
 
     .govuk-\!-#{$property-shorthand}-r#{$scale-point} {
 
-      @include govuk-responsive-spacing($scale-map, $property, "all", true);
+      @include _govuk-responsive-spacing($scale-point, $property, "all", true);
     }
 
     // ... and then an override for each individual direction
-    @each $direction-name, $direction-shorthand in $spacing-directions {
+    @each $direction-name, $direction-shorthand in $_spacing-directions {
 
       .govuk-\!-#{$property-shorthand}#{$direction-shorthand}-r#{$scale-point} {
-        @include govuk-responsive-spacing($scale-map, $property, $direction-name, true);
+        @include _govuk-responsive-spacing($scale-point, $property, $direction-name, true);
       }
     }
   }
 }
 
 @include govuk-exports("govuk/overrides/spacing") {
-  @include generate-spacing-overrides("margin", "m");
-  @include generate-spacing-overrides("padding", "p");
+  @include _govuk-generate-spacing-overrides("margin", "m");
+  @include _govuk-generate-spacing-overrides("padding", "p");
 }

--- a/src/settings/_measurements.scss
+++ b/src/settings/_measurements.scss
@@ -20,7 +20,7 @@ $govuk-page-width: 960px !default;
 /// @type Number
 /// @access public
 
-$govuk-gutter: $govuk-spacing-scale-6 !default;
+$govuk-gutter: 30px !default;
 
 /// Width of half the gutter between grid columns
 ///

--- a/src/settings/_spacing.scss
+++ b/src/settings/_spacing.scss
@@ -1,88 +1,80 @@
-// Single points on spacing scale
-$govuk-spacing-scale-1: 5px;
-$govuk-spacing-scale-2: 10px;
-$govuk-spacing-scale-3: 15px;
-$govuk-spacing-scale-4: 20px;
-$govuk-spacing-scale-5: 25px;
-$govuk-spacing-scale-6: 30px;
-$govuk-spacing-scale-7: 40px;
-$govuk-spacing-scale-8: 50px;
-$govuk-spacing-scale-9: 60px;
+////
+/// @group settings/spacing
+////
 
-// Responsive spacing maps
-//
-// These definitions are used to generate responsive spacing that adapts
-// according to the breakpoints (see 'helpers/spacing'). These maps should be
-// used wherever possible to standardise responsive spacing.
+/// Single point spacing variables. Access using `govuk-spacing()`
+/// (see `helpers/spacing`).
+///
+/// @type Map
+/// @access private
 
-// You can define different behaviour on tablet and desktop. The 'null'
-// breakpoint is for mobile.
+$govuk-spacing-points: (
+  0: 0,
+  1: 5px,
+  2: 10px,
+  3: 15px,
+  4: 20px,
+  5: 25px,
+  6: 30px,
+  7: 40px,
+  8: 50px,
+  9: 60px
+) !default;
 
-// To use the responsive spacing maps, combine them with
-// 'govuk-responsive-margin' or 'govuk-responsive-padding' mixins
-// (see 'helpers/spacing').
+/// Responsive spacing maps
+///
+/// These definitions are used to generate responsive spacing that adapts
+/// according to the breakpoints (see 'helpers/spacing'). These maps should be
+/// used wherever possible to standardise responsive spacing.
+///
+/// You can define different behaviour on tablet and desktop. The 'null'
+/// breakpoint is for mobile.
+///
+/// Access responsive spacing with `govuk-responsive-margin` or
+/// `govuk-responsive-padding` mixins (see `helpers/spacing`).
+///
+/// @type Map
+/// @access private
 
-
-$govuk-spacing-responsive-0: (
-  null: 0,
-  tablet: 0
-);
-
-$govuk-spacing-responsive-1: (
-  null: 5px,
-  tablet: 5px
-);
-
-$govuk-spacing-responsive-2: (
-  null: 10px,
-  tablet: 10px
-);
-
-$govuk-spacing-responsive-3: (
-  null: 15px,
-  tablet: 15px
-);
-
-$govuk-spacing-responsive-4: (
-  null: 15px,
-  tablet: 20px
-);
-
-$govuk-spacing-responsive-5: (
-  null: 15px,
-  tablet: 25px
-);
-
-$govuk-spacing-responsive-6: (
-  null: 20px,
-  tablet: 30px
-);
-
-$govuk-spacing-responsive-7: (
-  null: 25px,
-  tablet: 40px
-);
-
-$govuk-spacing-responsive-8: (
-  null: 30px,
-  tablet: 50px
-);
-
-$govuk-spacing-responsive-9: (
-  null: 40px,
-  tablet: 60px
-);
-
-// Create a list of all spacing points we can iterate over elsewhere
 $govuk-spacing-responsive-scale: (
-  0: $govuk-spacing-responsive-0,
-  1: $govuk-spacing-responsive-1,
-  2: $govuk-spacing-responsive-2,
-  3: $govuk-spacing-responsive-3,
-  4: $govuk-spacing-responsive-4,
-  5: $govuk-spacing-responsive-5,
-  6: $govuk-spacing-responsive-6,
-  7: $govuk-spacing-responsive-7,
-  8: $govuk-spacing-responsive-8,
-  9: $govuk-spacing-responsive-9
-);
+  0: (
+    null: 0,
+    tablet: 0
+  ),
+  1: (
+    null: 5px,
+    tablet: 5px
+  ),
+  2: (
+    null: 10px,
+    tablet: 10px
+  ),
+  3: (
+    null: 15px,
+    tablet: 15px
+  ),
+  4: (
+    null: 15px,
+    tablet: 20px
+  ),
+  5: (
+    null: 15px,
+    tablet: 25px
+  ),
+  6: (
+    null: 20px,
+    tablet: 30px
+  ),
+  7: (
+    null: 25px,
+    tablet: 40px
+  ),
+  8: (
+    null: 30px,
+    tablet: 50px
+  ),
+  9: (
+    null: 40px,
+    tablet: 60px
+  )
+) !default;


### PR DESCRIPTION
This PR:

- Defines the spacing variables in a map, rather than as multiple variables, allowing control over error messaging when an incorrect variable is used and allows them to be overridden by consumers.

In detail, it:
- Adds a new helper `govuk-spacing` to fetching single point spacing.
- Moves single point spacing variables inside a map.
- Moves responsive spacing maps inside a collective map `$govuk-spacing-responsive-scale` and updates the helper.
- Removes the old `$govuk-spacing-responsive-scale` map we created for generating overrides as the overrides can now use the new scale map 🎉 
- Possibly controversial: makes `govuk-responsive-spacing()` a **private** mixin as it should only be used via `govuk-responsive-margin` and `govuk-responsive-padding`.
- Updates other layers to use the `govuk-spacing` function and the new responsive spacing map.
- Updates tests accordingly and adds new tests for `govuk-spacing()`
- Updates comments for sass-docs.

Other:
- `$govuk-gutter` is now hardcoded as `govuk-spacing` cannot be accessed from inside the settings layer. However if we think it should be coupled more tightly with the spacing scale, we could maybe use `map-get` to fetch a specific spacing point in settings... I’ve created an [issue](https://github.com/alphagov/govuk-frontend/issues/780) to review this.

Note: the PR is easiest to review commit-by-commit.

https://trello.com/c/0IDTgRtF/1112-provide-a-defined-public-api-for-govuk-frontend-spacing