### PR TITLE
Use the correct class name in bold label example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@ Note: We're not following semantic versioning yet, we are going to talk about th
   and footer (the OGL logo) by marking them as non-focusable elements
   ([PR #774](https://github.com/alphagov/govuk-frontend/pull/774))
 
+- Use the correct class name in bold label example 
+  (govuk-label--s rather than govuk-label--bold)
+  ([PR #784](https://github.com/alphagov/govuk-frontend/pull/784))
+
 
 🆕 New features:
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -30,7 +30,7 @@ Use labels for all form fields.
 
 #### Markup
 
-    <label class="govuk-label govuk-label--bold">
+    <label class="govuk-label govuk-label--s">
       National Insurance number
     </label>
 
@@ -39,7 +39,7 @@ Use labels for all form fields.
     {% from 'label/macro.njk' import govukLabel %}
 
     {{ govukLabel({
-      "classes": "govuk-label--bold",
+      "classes": "govuk-label--s",
       "text": "National Insurance number"
     }) }}
 

--- a/src/components/label/label.yaml
+++ b/src/components/label/label.yaml
@@ -4,7 +4,7 @@ examples:
       text: National Insurance number
   - name: with bold text
     data:
-      classes: govuk-label--bold
+      classes: govuk-label--s
       text: National Insurance number
   - name: as page heading
     data:


### PR DESCRIPTION
Currently we talk about a bold label modifier class
https://govuk-frontend-review.herokuapp.com/components/label
which doesn't exist.

It's been replaced by `.govuk-label--s` class.

Updated to add the correct modifier class to the yaml file and README
https://govuk-frontend-review-pr-784.herokuapp.com/components/label

Fixes #783 