### PR TITLE
Add notice about the use of `html` arguments in Nunjucks macros for production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 - Update docs about installing fonts ([PR #802](https://github.com/alphagov/govuk-frontend/pull/802))
 
+- Add notice about the use of `html` arguments in Nunjucks macros for production
+  ([PR #785](https://github.com/alphagov/govuk-frontend/pull/785))
+
+
 ## 0.0.32 (Breaking release)
 
 **This release changes the name of package.** It's now published as `govuk-frontend` on `npm`.
@@ -261,6 +265,7 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 - Add explicit dependency on colour maps
   ([PR #790](https://github.com/alphagov/govuk-frontend/pull/790))
+
 
 🆕 New features:
 

--- a/app/views/layouts/readme.njk
+++ b/app/views/layouts/readme.njk
@@ -1,3 +1,4 @@
+{% set nunjucksHtmlUsageMessage = '**If you’re using Nunjucks macros in production be aware that using  `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**' %}
 {% set componentName = componentPath %}
 {% set componentNameHuman = componentName | replace("-", " ") | capitalize %}
 {% set componentGuidanceLink = componentGuidanceLink | default('https://govuk-design-system-production.cloudapps.digital/components/' + componentName)%}
@@ -48,8 +49,11 @@ app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-fron
 <p>If you are using Nunjucks,then macros take the following arguments</p>
 
 {% from "table/macro.njk" import govukTable %}
+
+{{ nunjucksHtmlUsageMessage }}
 {% block componentArguments %}
 {% endblock %}
+{{ nunjucksHtmlUsageMessage }}
 
 <h3>Setting up Nunjucks views and paths</h3>
 <p>Below is an example setup using express configure views:</p>

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -47,6 +47,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -118,6 +120,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -228,6 +228,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -311,6 +313,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -164,6 +164,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -295,6 +297,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -531,6 +531,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -758,6 +760,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -473,6 +473,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -616,6 +618,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -118,6 +118,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -213,6 +215,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -48,6 +48,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -119,6 +121,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -84,6 +84,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -191,6 +193,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -82,6 +82,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -189,6 +191,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -189,6 +189,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -308,6 +310,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -81,6 +81,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -260,6 +262,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -342,6 +342,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -509,6 +511,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/hint/README.md
+++ b/src/components/hint/README.md
@@ -62,6 +62,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -133,6 +135,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -261,6 +261,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -392,6 +394,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -62,6 +62,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -133,6 +135,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -86,6 +86,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -169,6 +171,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -56,6 +56,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -127,6 +129,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -57,6 +57,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -128,6 +130,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -435,6 +435,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -662,6 +664,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -196,6 +196,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -363,6 +365,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -47,6 +47,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -118,6 +120,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -358,6 +358,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -561,6 +563,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -67,6 +67,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -126,6 +128,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -183,6 +183,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -326,6 +328,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -53,6 +53,8 @@ In order to include the images used in the components, you need to configure you
 
 If you are using Nunjucks,then macros take the following arguments
 
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
+
 <table class="govuk-table">
 
 <thead class="govuk-table__head">
@@ -124,6 +126,8 @@ If you are using Nunjucks,then macros take the following arguments
 </tbody>
 
 </table>
+
+**If you’re using Nunjucks macros in production be aware that using `html` arguments, or ones ending with `Html` can be a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting). More about it in the [Nunjucks documentation](https://mozilla.github.io/nunjucks/api.html#user-defined-templates-warning).**
 
 ### Setting up Nunjucks views and paths
 


### PR DESCRIPTION
We need to make developers aware that if they decide to use Nunjucks macros in production and use `html` arguments or ones ending in `Html` that render unescaped html, making it a [security risk](https://en.wikipedia.org/wiki/Cross-site_scripting)

This adds notice text before and after the table of arguments in the README file for each component.
Text is set as a variable, so it can be updated in a single place if required.

Part of this Trello ticket: 
https://trello.com/c/SruPShLz/1049-add-clearer-documentation-around-text-vs-html-in-nunjucks-macros

Adresses: #514


