### PR TITLE
Add explicit dependency on colour maps

### DIFF
--- a/src/helpers/_colour.scss
+++ b/src/helpers/_colour.scss
@@ -1,3 +1,6 @@
+@import "../settings/colours-palette";
+@import "../settings/colours-organisations";
+
 ////
 /// @group helpers/colour
 ////


### PR DESCRIPTION
When trying to build these files on their own (for demonstration in the Design System),
they fail since the variables referenced in the helper functions are not defined.