### PR TITLE
Use the main README when deploying to npm

### DIFF
--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -76,7 +76,7 @@ describe('package/', () => {
       return readFile(path.join(configPaths.package, 'README.md'), 'utf8')
         .then(contents => {
           // Look for H1 matching 'GOV.UK Frontend' from existing README
-          expect(contents).toMatch(/^# GOV.UK Frontend/)
+          expect(contents).toMatch(/^GOV.UK Frontend/)
         }).catch(error => {
           throw error
         })

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -11,6 +11,7 @@ let scssFiles = filter([configPaths.src + '**/*.scss'], {restore: true})
 
 gulp.task('copy-files', () => {
   return gulp.src([
+    './README.md', // Publish the main README to npm.
     configPaths.src + '**/*',
     '!**/.DS_Store',
     '!**/*.test.js',


### PR DESCRIPTION
When running the `npm run build:package` command now the main project README will be copied into the `package/` directory, bringing the two in sync for when it is published to npm.