### PR TITLE
Document assistive tech support in FE Readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 - Remove instructions to login with npm, which is no longer required
   ([PR #795](https://github.com/alphagov/govuk-frontend/pull/795))
 
+- Update docs with the assistive technology we support ([PR #800](https://github.com/alphagov/govuk-frontend/pull/800))
+
 ## 0.0.32 (Breaking release)
 
 **This release changes the name of package.** It's now published as `govuk-frontend` on `npm`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,10 @@ See our [coding standards for components](/docs/contributing/coding-standards/co
 See [testing and linting](/docs/contributing/testing-and-linting.md).
 
 ## Supported browsers
-Your contribution needs to work with certain browsers as set out in [README](README.md). See also [supporting Internet Explorer 8](/docs/installation/supporting-internet-explorer-8.md).
+Your contribution needs to work with certain browsers as set out in [README](README.md#browser-support). See also [supporting Internet Explorer 8](/docs/installation/supporting-internet-explorer-8.md).
+
+## Supported assistive technology
+Your contribution needs to work with certain assistive technology as set out in [README](README.md#assistive-technology-support).
 
 ## Commit hygiene
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,37 @@ include a separate stylesheet in order to support Internet Explorer
 
 [service-manual-browsers]: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in
 
+## Assistive technology support
+
+GOV.UK Frontend will allow you to build services that comply with the [guidance
+in the Service Manual][service-manual-assistive-technologies].
+
+Currently, GOV.UK Frontend officially supports the following assistive technologies:
+
+| Software                 | Version        | Type               | Browser                   |
+|--------------------------|----------------|--------------------|---------------------------|
+| JAWS                     | 15 or later    | screen reader      | Internet Explorer 11      |
+| ZoomText                 | 10.11 or later | screen magnifier   | Internet Explorer 11      |
+| Dragon NaturallySpeaking | 11 or later    | speech recognition | Internet Explorer 11      |
+| NVDA                     | 2016 or later  | screen reader      | Firefox (latest versions) |
+| VoiceOver                | 7.0 or later   | screen reader      | Safari on iOS10 and OS X  |
+
+In addition, we test that all content is accessible with keyboard only.
+
+We aim to support [users who adjust or override the colours of websites they visit][how-users-change-colours-on-websites]. We test this by [changing colours in Firefox][changing-colours-in-firefox], by [enabling 'High Contrast' mode in Windows][enabling-high-contrast-mode-in-windows] and by using the [High Contrast plugin for Chrome][high-contrast-plugin-for-chrome].
+
+[service-manual-assistive-technologies]: https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test
+
+[changing-colours-in-firefox]:
+https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use
+
+[enabling-high-contrast-mode-in-windows]:
+https://support.microsoft.com/en-gb/help/13862/windows-use-high-contrast-mode
+
+[high-contrast-plugin-for-chrome]: https://chrome.google.com/webstore/detail/high-contrast/djcfdncoelnlbldjfhinnjlhdjlikmph?hl=en-US
+
+[how-users-change-colours-on-websites]:
+https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
 
 ## Licence
 

--- a/docs/contributing/coding-standards/README.md
+++ b/docs/contributing/coding-standards/README.md
@@ -5,4 +5,4 @@
 - [CSS](css.md)
 - [JavaScript](js.md)
 
-See also [browser support](../../README.md#browser-support) and [supporting Internet Explorer 8](../../installation/supporting-internet-explorer-8.md).
+See also [browser support](../../../README.md#browser-support), [support for assistive technology](../../../README.md#assistive-technology-support) and [supporting Internet Explorer 8](../../installation/supporting-internet-explorer-8.md).


### PR DESCRIPTION
This sets out the assistive technology that GOV.UK Frontend supports. 

In the future, we would like to add guidance about [writing accessibility acceptance criteria](https://github.com/alphagov/govuk-frontend/issues/799).

https://trello.com/c/hZD483RS/1030-document-assistive-tech-support-in-fe-readme