### PR TITLE
Update browser support matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ Note: We're not following semantic versioning yet, we are going to talk about th
 
 - Update docs with the assistive technology we support ([PR #800](https://github.com/alphagov/govuk-frontend/pull/800))
 
-- Update docs about installing fonts ([PR #802](https://github.com/alphagov/govuk-frontend/pull/802))
+- Update docs about installing fonts ([PR #802]     (https://github.com/alphagov/govuk-frontend/pull/802))
+
+- Update browser support matrix
+  Remove Windows Phone
+  Update IE 8-10 to functional and IE 11 to compliant
+  ([PR #803](https://github.com/alphagov/govuk-frontend/pull/803)
 
 ## 0.0.32 (Breaking release)
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Currently, GOV.UK Frontend officially supports the following browsers:
 
 | Operating system | Browser                                | Support     |
 |----------------- |----------------------------------------|-------------|
-| Windows          | Internet Explorer 8                    | functional  |
-| Windows          | Internet Explorer 9-11                 | compliant   |
+| Windows          | Internet Explorer 8-10                 | functional  |
+| Windows          | Internet Explorer 11                   | compliant   |
 | Windows          | Edge (latest 2 versions)               | compliant   |
 | Windows          | Google Chrome (latest 2 versions)      | compliant   |
 | Windows          | Mozilla Firefox (latest 2 versions)    | compliant   |
@@ -62,7 +62,6 @@ Currently, GOV.UK Frontend officially supports the following browsers:
 | iOS              | Google Chrome (latest 2 versions)      | compliant   |
 | Android          | Google Chrome (latest 2 versions)      | compliant   |
 | Android          | Samsung Internet (latest 2 versions)   | compliant   |
-| Windows Phone    | Internet Explorer (latest 2 versions)  | compliant   |
 
 ‘Compliant’ means that the components must look as good and function as well as
 they do in other modern browsers.


### PR DESCRIPTION
- Remove Windows Phone
- Update IE 8-10 to functional and IE 11 to compliant

Aligns with the [Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in)