### PR TITLE
Reduce margin-bottom on the hint when following a default or small label

### DIFF
--- a/src/components/hint/_hint.scss
+++ b/src/components/hint/_hint.scss
@@ -12,4 +12,18 @@
 
     color: $govuk-secondary-text-colour;
   }
+
+  // Reduces margin-bottom of hint when used after the default label (no class)
+  // or govuk-label--s for better vertical alignment.
+
+  // This adjustment will not work when the label is inside the <h1>, however
+  // it is unlikely that the default or govuk-label--s class would be used in
+  // this case.
+
+  // This adjustment will not work in browsers that do not support :not()
+  // Users with these browsers will see the default size margin (5px larger)
+
+  .govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
+    margin-bottom: govuk-spacing(2);
+  }
 }


### PR DESCRIPTION
The `margin-bottom` of the hint component is the same for all label sizes.

For the default (no class) or `govuk-label--s` class this looks unbalanced.

<img width="1012" alt="screen shot 2018-06-20 at 09 46 35" src="https://user-images.githubusercontent.com/23356842/41647766-123222c6-746f-11e8-81ed-c1c8b812ec8b.png">

This PR reduces the margin-bottom of the hint by 5px after a default `<label>` or `<label class="govuk-label--s">`.

**Before**
<img width="1003" alt="screen shot 2018-06-20 at 09 45 05" src="https://user-images.githubusercontent.com/23356842/41647841-4e26eb40-746f-11e8-96b6-726b782d48c6.png">

**After**
<img width="1000" alt="screen shot 2018-06-20 at 09 45 34" src="https://user-images.githubusercontent.com/23356842/41647854-579d3bfc-746f-11e8-89b1-97c3f524a962.png">

This does not affect the hint when used with a legend (original spacing is fine) or when the `<label>` is inside an `<h1>` (isPageHeading: True) - however I'm ok with this because the default / `govuk-label--s` will never be used in this scenario.
