### PR TITLE
Update back-link example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Fix Design System url in package READMEs and review app
   ([PR #812](https://github.com/alphagov/govuk-frontend/pull/812))
 
+- Update back-link example to show default usage doesn't need
+  `text` parameter
+  ([PR #819](https://github.com/alphagov/govuk-frontend/pull/819))
+
 ## 1.0.0 (Major release)
 
 🆕 New features:

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -16,15 +16,31 @@ Find out when to use the Back link component in your service in the [GOV.UK Desi
 
 #### Markup
 
-    <a href="https://gov.uk" class="govuk-back-link">Back</a>
+    <a href="#" class="govuk-back-link">Back</a>
 
 #### Macro
 
     {% from 'back-link/macro.njk' import govukBackLink %}
 
     {{ govukBackLink({
-      "href": "https://gov.uk",
-      "text": "Back"
+      "href": "#"
+    }) }}
+
+### Back-link--with custom text
+
+[Preview the back-link--with custom text example](http://govuk-frontend-review.herokuapp.com/components/back-link/with custom text/preview)
+
+#### Markup
+
+    <a href="#" class="govuk-back-link">Back to home</a>
+
+#### Macro
+
+    {% from 'back-link/macro.njk' import govukBackLink %}
+
+    {{ govukBackLink({
+      "href": "#",
+      "text": "Back to home"
     }) }}
 
 ## Requirements

--- a/src/components/back-link/back-link.yaml
+++ b/src/components/back-link/back-link.yaml
@@ -1,5 +1,8 @@
 examples:
 - name: default
   data:
-    href: 'https://gov.uk'
-    text: Back
+    href: '#'
+- name: with custom text
+  data:
+    href: '#'
+    text: Back to home

--- a/src/components/back-link/template.test.js
+++ b/src/components/back-link/template.test.js
@@ -29,7 +29,7 @@ describe('back-link component', () => {
 
     const $component = $('.govuk-back-link')
     expect($component.get(0).tagName).toEqual('a')
-    expect($component.attr('href')).toEqual('https://gov.uk')
+    expect($component.attr('href')).toEqual('#')
     expect($component.text()).toEqual('Back')
   })
 


### PR DESCRIPTION
Follow on from #793 where default text of 'Back' is set by default.
This updates the example in the review app in generated readme