### PR TITLE
Update link to Crown copyright

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,12 @@
 
 🔧 Fixes:
 
-- Pull Request Title goes here
+- Update Crown copyright link
 
-  Description goes here (optional)
+  Update the Crown copyright link on the National Archives so
+  we don't send users on an unnecessary redirect.
 
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR 824](https://github.com/alphagov/govuk-frontend/pull/824))
 
 🏠 Internal:
 

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -48,7 +48,7 @@ Find out when to use the Footer component in your service in the [GOV.UK Design 
           <div class="govuk-footer__meta-item">
             <a
               class="govuk-footer__link govuk-footer__copyright-logo"
-              href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"
+              href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
             >© Crown copyright</a>
           </div>
         </div>

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -72,7 +72,7 @@
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
-          href="http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright-and-re-use/crown-copyright/"
+          href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
         >© Crown copyright</a>
       </div>
     </div>


### PR DESCRIPTION
Update the link to the Crown copyright so we don't send users on an
unnecessary redirect.