### PR TITLE
Add support for customising item inputs’ field names in date-input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,7 @@
 
 🆕 New features:
 
-- Pull Request Title goes here
-
-  Description goes here (optional)
-
+- Add support for specific input field names to date-input component
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
 🔧 Fixes:
@@ -53,7 +50,7 @@
 🔧 Fixes:
 
 - Reduce margin-bottom on the hint when following a default or small labe
-  This reduces the margin-bottom of the hint by 5px after a default 
+  This reduces the margin-bottom of the hint by 5px after a default
   `<label>` or `<label class="govuk-label--s">`.
   ([PR #806](https://github.com/alphagov/govuk-frontend/pull/806))
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -539,7 +539,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated.</td>
+<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated id.</td>
 
 </tr>
 
@@ -551,7 +551,19 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional item-specific name attribute. If provided, it will be used instead of the generated name.</td>
+<td class="govuk-table__cell ">Item-specific name attribute.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.fieldName</th>
+
+<td class="govuk-table__cell ">array</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional item-specific field name attribute. If provided, it will be used instead of the generated name.</td>
 
 </tr>
 

--- a/src/components/date-input/index.njk
+++ b/src/components/date-input/index.njk
@@ -89,7 +89,7 @@
         text: 'No'
       },
       {
-        text: 'Optional item-specific id. If provided, it will be used instead of the generated.'
+        text: 'Optional item-specific id. If provided, it will be used instead of the generated id.'
       }
     ],
     [
@@ -103,7 +103,20 @@
         text: 'Yes'
       },
       {
-        text: 'Optional item-specific name attribute. If provided, it will be used instead of the generated name.'
+        text: 'Item-specific name attribute.'
+      }
+    ],[
+      {
+        text: 'items.{}.fieldName'
+      },
+      {
+        text: 'array'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional item-specific field name attribute. If provided, it will be used instead of the generated name.'
       }
     ],
     [

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -42,7 +42,7 @@
         },
         "id": params.id + "-" + item.name,
         "classes": "govuk-date-input__input" + (" " + item.classes if item.classes),
-        "name": params.name + "-" + item.name,
+        "name": item.fieldName or (params.name + "-" + item.name),
         "value": item.value,
         "type": "number",
         "attributes": {

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -265,6 +265,23 @@ describe('Date input', () => {
     })
   })
 
+  describe('when items include a fieldName attribute', () => {
+    it('renders item with specific field name', () => {
+      const $ = render('date-input', {
+        name: 'my-date-input',
+        items: [
+          {
+            'name': 'day',
+            'fieldName': 'my-date[dd]'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('my-date[dd]')
+    })
+  })
+
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
       const $ = render('date-input', examples['default'])


### PR DESCRIPTION
Add support for a new `item.{}.fieldName` parameter on the `date-input`
macro. This allows the author to explicitly set the field name on each
item input rather than rely on the `<param.name>-<item.name>` default
convention, which is not always convenient and couples the field name to
the displayed label too tightly.

Also fix a few minor missing/incorrect parts in the date-input README.