### PR TITLE
Update installing-with-npm.md

### DIFF
--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -100,7 +100,7 @@ These [global styles](src/core/_global-styles.scss) are are not included by defa
 
 $govuk-global-styles: true;
 
-@import "govuk-frontend/frontend/all";
+@import "govuk-frontend/all";
 ```
 
 ## Using JavaScript


### PR DESCRIPTION
Possible mistake in this path name.
all.scss is directly in the root, not in a subdirectory.

Assuming this example refers to importing via node_modules not copying it into the project locally that is.