### PR TITLE
Fix failing Heroku review app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 - Tidy up some package.json fields to help contributors and users
   ([PR #827](https://github.com/alphagov/govuk-frontend/pull/827))
 
+- Fix failing Heroku app with Node 10.5.0
+  Revert to pinning node version in package json
+  ([PR #833](https://github.com/alphagov/govuk-frontend/pull/833))
+
 ## 1.0.0 (Major release)
 
 🆕 New features:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "govuk-frontend-repository",
   "description": "Used only for the development of GOV.UK Frontend, see `package/package.json` for the published `package.json`",
   "engines": {
-    "node": ">= 8.9.4"
+    "node": "8.9.4"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
In #827 we removed pinning the node version, instead specifying the minimum version.

This resulted in Heroku failing as there is an error in the gulp taks in node 10.5.0 Heroku installs.

Until we decide to upgrade to Gulp 4 we need to pin the version in package.json.

Alternative option is to remove version entirely, although we want to set that for anyone wanting to contribute using `yarn` instead of `npm`.

Heroku used Node 10.5, built and deployed correctly
```
Installing binaries
engines.node (package.json):  >= 8.9.4
engines.npm (package.json):   unspecified (use default)
       
Resolving node version >= 8.9.4...
Downloading and installing node 10.5.0...
Using default npm version: 6.1.0

Caching build
       Clearing previous node cache
       Skipping cache save (disabled by config)
-----> Pruning devDependencies
       Skipping because NPM_CONFIG_PRODUCTION is 'false'
-----> Build succeeded!
-----> Discovering process types
       Procfile declares types -> web
-----> Compressing...
       Done: 144.1M
-----> Launching...
       Released v517
       https://govuk-frontend-review.herokuapp.com/ deployed to Heroku
```

When requesting the site it threw a 503 error

```
2018-06-25T15:15:57.649864+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=govuk-frontend-review.herokuapp.com request_id=180da83d-7c96-4c99-9a4e-52830e670538 fwd="195.89.171.5" dyno= connect= service= status=503 bytes= protocol=http
```

Firstly we tried removing the space between number and greaterOrEqual sign, but that didn't work.