### PR TITLE
Proposal: Remove internal changelog entry requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,14 +71,15 @@ which describes how we prefer git history and commit messages to read.
 
 If you open a GitHub pull request on this repo, please update `CHANGELOG` to reflect your contribution.
 
-Add your entry under `Unreleased` as `Breaking changes`, `New features`, `Fixes` or `Internal`.
+Add your entry under `Unreleased` as `Breaking changes`, `New features`, `Fixes`.
+
+Internal changes to the project that are not part of the public API do not need changelog entries, for example fixing the CI build server.
 
 These sections follow [semantic versioning](https://semver.org/), where:
 
 - `Breaking changes` corresponds to a `major` (1.X.X) change.
 - `New features` corresponds to a `minor` (X.1.X) change.
 - `Fixes` corresponds to a `patch` (X.X.1) change.
-- `Internal` corresponds to changes to the project that are not part of the public API, for example fixing the CI build server.
 
 See the [`CHANGELOG_TEMPLATE.md`](/docs/contribution/CHANGELOG_TEMPLATE.md) for an example for how this looks.
 

--- a/docs/contributing/CHANGELOG_TEMPLATE.md
+++ b/docs/contributing/CHANGELOG_TEMPLATE.md
@@ -27,11 +27,3 @@
   Description goes here (optional)
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
-
-🏠 Internal:
-
-- Pull Request Title goes here
-
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))


### PR DESCRIPTION
The primary use case for the CHANGELOG is to make sure users can react to any new release.

For example if there are breaking changes, they need to be able to action those.

Internal changes do not impact the running of GOV.UK Frontend in our users applications.

This commit removes this requirement to document changes, so we do not have to require,
contributors to update the CHANGELOG for a trivial change.