### PR TITLE
RFC - Use rem with px fallback

### DIFF
--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -99,6 +99,7 @@
 
   @each $breakpoint, $breakpoint-map in $font-map {
     $font-size: map-get($breakpoint-map, "font-size") iff($important, !important);
+    $font-size-rem: map-get($breakpoint-map, "font-size-rem") iff($important, !important);
     $line-height: map-get($breakpoint-map, "line-height") iff($important, !important);
 
     // Sometimes we need to use a custom non-responsive line height for
@@ -109,6 +110,8 @@
 
     @if $breakpoint == null {
       font-size: $font-size;
+      // sass-lint:disable no-duplicate-properties
+      font-size: $font-size-rem;
       line-height: $line-height;
     } @elseif $breakpoint == "print" {
       @include govuk-media-query($media-type: print) {
@@ -118,6 +121,8 @@
     } @else {
       @include govuk-media-query($from: $breakpoint) {
         font-size: $font-size;
+        // sass-lint:disable no-duplicate-properties
+        font-size: $font-size-rem;
         line-height: $line-height;
       }
     }

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -26,10 +26,12 @@ $govuk-typography-scale: (
   80: (
     null: (
       font-size: 53px,
+      font-size-rem: 3.3125rem, // 53/16
       line-height: 1.0377358491 // 55px
     ),
     tablet: (
       font-size: 80px,
+      font-size-rem: 5rem, // 80/16
       line-height: 1 // 80px
     ),
     print: (
@@ -40,10 +42,12 @@ $govuk-typography-scale: (
   48: (
     null: (
       font-size: 32px,
+      font-size-rem: 2rem, // 32/16
       line-height: 1.09375 // 35px
     ),
     tablet: (
       font-size: 48px,
+      font-size-rem: 3rem, // 48/16
       line-height: 1.0416666667 // 50px
     ),
     print: (
@@ -54,10 +58,12 @@ $govuk-typography-scale: (
   36: (
     null: (
       font-size: 24px,
+      font-size-rem: 1.5rem, // 24/16
       line-height: 1.0416666667 // 25px
     ),
     tablet: (
       font-size: 36px,
+      font-size-rem: 2.25rem, // 36/16
       line-height: 1.1111111111 // 40px
     ),
     print: (
@@ -68,10 +74,12 @@ $govuk-typography-scale: (
   27: (
     null: (
       font-size: 18px,
+      font-size-rem: 1.125rem, // 18/16
       line-height: 1.1111111111 // 20px
     ),
     tablet: (
       font-size: 27px,
+      font-size-rem: 1.6875rem, // 27/16
       line-height: 1.1111111111 // 30px
     ),
     print: (
@@ -82,10 +90,12 @@ $govuk-typography-scale: (
   24: (
     null: (
       font-size: 18px,
+      font-size-rem: 1.125rem, // 18/16
       line-height: 1.1111111111 // 20px
     ),
     tablet: (
       font-size: 24px,
+      font-size-rem: 1.5rem, // 24/16
       line-height: 1.25 // 30px
     ),
     print: (
@@ -96,10 +106,12 @@ $govuk-typography-scale: (
   19: (
     null: (
       font-size: 16px,
+      font-size-rem: 1rem, // 16/16
       line-height: 1.3333333333 // 20px
     ),
     tablet: (
       font-size: 19px,
+      font-size-rem: 1.1875rem, // 19/16
       line-height: 1.3157894737 // 25px
     ),
     print: (
@@ -110,10 +122,12 @@ $govuk-typography-scale: (
   16: (
     null: (
       font-size: 14px,
+      font-size-rem: .875rem, // 14/16
       line-height: 1.1428571429 // 16px
     ),
     tablet: (
       font-size: 16px,
+      font-size-rem: 1rem, // 16/16
       line-height: 1.3333333333 // 20px
     ),
     print: (
@@ -124,10 +138,12 @@ $govuk-typography-scale: (
   14: (
     null: (
       font-size: 12px,
+      font-size-rem: .75rem, // 12/16
       line-height: 1.25 // 15px
     ),
     tablet: (
       font-size: 14px,
+      font-size-rem: .875rem, // 14/16
       line-height: 1.4285714286 // 20px
     ),
     print: (

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -107,7 +107,7 @@ $govuk-typography-scale: (
     null: (
       font-size: 16px,
       font-size-rem: 1rem, // 16/16
-      line-height: 1.3333333333 // 20px
+      line-height: 1.25 // 20px
     ),
     tablet: (
       font-size: 19px,
@@ -128,7 +128,7 @@ $govuk-typography-scale: (
     tablet: (
       font-size: 16px,
       font-size-rem: 1rem, // 16/16
-      line-height: 1.3333333333 // 20px
+      line-height: 1.25 // 20px
     ),
     print: (
       font-size: 14pt,

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -26,11 +26,11 @@ $govuk-typography-scale: (
   80: (
     null: (
       font-size: 53px,
-      line-height: 55px
+      line-height: 1.0377358491 // 55px
     ),
     tablet: (
       font-size: 80px,
-      line-height: 80px
+      line-height: 1 // 80px
     ),
     print: (
       font-size: 53pt,
@@ -40,11 +40,11 @@ $govuk-typography-scale: (
   48: (
     null: (
       font-size: 32px,
-      line-height: 35px
+      line-height: 1.09375 // 35px
     ),
     tablet: (
       font-size: 48px,
-      line-height: 50px
+      line-height: 1.0416666667 // 50px
     ),
     print: (
       font-size: 32pt,
@@ -54,11 +54,11 @@ $govuk-typography-scale: (
   36: (
     null: (
       font-size: 24px,
-      line-height: 25px
+      line-height: 1.0416666667 // 25px
     ),
     tablet: (
       font-size: 36px,
-      line-height: 40px
+      line-height: 1.1111111111 // 40px
     ),
     print: (
       font-size: 24pt,
@@ -68,11 +68,11 @@ $govuk-typography-scale: (
   27: (
     null: (
       font-size: 18px,
-      line-height: 20px
+      line-height: 1.1111111111 // 20px
     ),
     tablet: (
       font-size: 27px,
-      line-height: 30px
+      line-height: 1.1111111111 // 30px
     ),
     print: (
       font-size: 18pt,
@@ -82,11 +82,11 @@ $govuk-typography-scale: (
   24: (
     null: (
       font-size: 18px,
-      line-height: 20px
+      line-height: 1.1111111111 // 20px
     ),
     tablet: (
       font-size: 24px,
-      line-height: 30px
+      line-height: 1.25 // 30px
     ),
     print: (
       font-size: 18pt,
@@ -96,11 +96,11 @@ $govuk-typography-scale: (
   19: (
     null: (
       font-size: 16px,
-      line-height: 20px
+      line-height: 1.3333333333 // 20px
     ),
     tablet: (
       font-size: 19px,
-      line-height: 25px
+      line-height: 1.3157894737 // 25px
     ),
     print: (
       font-size: 14pt,
@@ -110,11 +110,11 @@ $govuk-typography-scale: (
   16: (
     null: (
       font-size: 14px,
-      line-height: 16px
+      line-height: 1.1428571429 // 16px
     ),
     tablet: (
       font-size: 16px,
-      line-height: 20px
+      line-height: 1.3333333333 // 20px
     ),
     print: (
       font-size: 14pt,
@@ -124,11 +124,11 @@ $govuk-typography-scale: (
   14: (
     null: (
       font-size: 12px,
-      line-height: 15px
+      line-height: 1.25 // 15px
     ),
     tablet: (
       font-size: 14px,
-      line-height: 20px
+      line-height: 1.4285714286 // 20px
     ),
     print: (
       font-size: 12pt,


### PR DESCRIPTION
## Changes

- Converts font-size from px to rem with px fallback

## Rems
Due to defining font-size in px a users choice to change their default font size (not zooming) on a OS or browser level is not respected. This is acceptable as we do not disable zooming, however it would be good to know if we can do more.

I've intentionally **not** used the "62.5%" trick on the `<html>`, we don't need an easy way to remember 24px = 2.4rem as the users will never interact with the rem font size directly, only the mixins and classes. GOV.UK Frontend also steers away from setting global styles.

### Rem concerns
As we are aware using relative font sizes in frontend will have issues with users app's with a base font size that is **not** 100% / 16px / default. This means including frontend in an existing app with a different base font size would leak / affect their apps existing styles. We have seen governments services using a variety of units and measurements on their root, 62.5%, 160%, 19px and 16px.

For example:

#### Default HTML (works as intended with a 16px base)
![screen shot 2018-06-27 at 11 51 43](https://user-images.githubusercontent.com/23356842/41969967-08685d36-7a01-11e8-955a-ae2640256b0b.png)

#### `html { font-size: 62.5% }` `body { font-size: 160% }` (as on GOV.UK)
![screen shot 2018-06-27 at 11 53 20](https://user-images.githubusercontent.com/23356842/41970006-2a12ada6-7a01-11e8-83ee-5c404a57b239.png)

#### `html { font-size: 19px }` `body { font-size: 100% }`
![screen shot 2018-06-27 at 11 54 59](https://user-images.githubusercontent.com/23356842/41970027-3afaaede-7a01-11e8-9812-3849e30bf71c.png)

We could potentially allow the user to not include the `$font-size-rem` on output, however there are some concerns that this may feel like an "accessible or not" switch.

(p.s. I have left the commit to convert line-height to a relative unit-less unit in the PR to show the end state of this change)