### PR TITLE
Add bottom margin to tabs component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,14 @@
 
 🔧 Fixes:
 
-- Use relative line-height  
-  Update typography styles to use relative, unitless line-height  
+- Use relative line-height
+  Update typography styles to use relative, unitless line-height
   ([PR #837](https://github.com/alphagov/govuk-frontend/pull/837))
+
+- Add bottom margin to Tabs component
+  All components (or outer layer components) have a bottom margin
+  applied to them so spacing feels automatic.
+  ([PR #841](https://github.com/alphagov/govuk-frontend/pull/841))
 
 - Update Crown copyright link
   Update the Crown copyright link on the National Archives so

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -8,6 +8,7 @@
     @include govuk-font($size: 19);
     @include govuk-text-colour;
     @include govuk-responsive-margin(1, "top");
+    @include govuk-responsive-margin(6, "bottom");
   }
 
   .govuk-tabs__title {


### PR DESCRIPTION
All components (or outer layer components) have `@include govuk-responsive-margin(6, "bottom");`
applied to them so spacing feels automatic.

Tabs had no margin, so this fixes: #820 