### PR TITLE
Allow an optional hint for each radio and checkbox item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
   colours in their browser, rather than it appearing underlined all the time
   ([PR #926](https://github.com/alphagov/govuk-frontend/pull/926))
 
+- Allow for optional hint for each radio and checkbox item
+
+  You can now pass a hint object (or add in html) to each radio
+  and checkbox item to display the hint
+  ([PR #846](https://github.com/alphagov/govuk-frontend/pull/846))
+
 🔧 Fixes:
 
 - Replace conflicting `js-hidden` class used within the tabs component with a new modifier class.

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -155,6 +155,82 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
       ]
     }) }}
 
+### Checkboxes with hints on items
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-hints-on-items/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+
+      <fieldset class="govuk-fieldset">
+
+      <legend class="govuk-fieldset__legend">
+        <h1 class="govuk-fieldset__heading">
+          How do you want to sign in?
+        </h1>
+      </legend>
+
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="government-gateway" name="gateway" type="checkbox" value="gov-gateway" aria-describedby="government-gateway-item-hint">
+          <label class="govuk-label govuk-checkboxes__label" for="government-gateway">
+            Sign in with Government Gateway
+          </label>
+          <span id="government-gateway-item-hint" class="govuk-hint govuk-checkboxes__hint">
+            You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+          </span>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="govuk-verify" name="verify" type="checkbox" value="gov-verify" aria-describedby="govuk-verify-item-hint">
+          <label class="govuk-label govuk-checkboxes__label" for="govuk-verify">
+            Sign in with GOV.UK Verify
+          </label>
+          <span id="govuk-verify-item-hint" class="govuk-hint govuk-checkboxes__hint">
+            You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+          </span>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+    {{ govukCheckboxes({
+      "fieldset": {
+        "legend": {
+          "text": "How do you want to sign in?",
+          "isPageHeading": true
+        }
+      },
+      "items": [
+        {
+          "name": "gateway",
+          "id": "government-gateway",
+          "value": "gov-gateway",
+          "text": "Sign in with Government Gateway",
+          "hint": {
+            "text": "You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before."
+          }
+        },
+        {
+          "name": "verify",
+          "id": "govuk-verify",
+          "value": "gov-verify",
+          "text": "Sign in with GOV.UK Verify",
+          "hint": {
+            "text": "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+          }
+        }
+      ]
+    }) }}
+
 ### Checkboxes with disabled item
 
 [Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-disabled-item/preview)
@@ -770,6 +846,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Provide additional attributes to each checkbox item label. See [label](../label/README.md#component-arguments) component for more details.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Provide optional hint to each checkbox item. See `hint` component for more details.</td>
 
 </tr>
 

--- a/src/components/checkboxes/README.njk
+++ b/src/components/checkboxes/README.njk
@@ -187,6 +187,20 @@
     ],
     [
       {
+        text: 'items.{}.hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        html: 'Provide optional hint to each checkbox item. See `hint` component for more details.'
+      }
+    ],
+    [
+      {
         text: 'items.{}.checked'
       },
       {

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -66,6 +66,12 @@
     touch-action: manipulation;
   }
 
+  .govuk-checkboxes__hint {
+    display: block;
+    padding-right: $govuk-checkboxes-label-padding-left-right;
+    padding-left: $govuk-checkboxes-label-padding-left-right;
+  }
+
   .govuk-checkboxes__input + .govuk-checkboxes__label::before {
     content: "";
     box-sizing: border-box;

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -43,6 +43,26 @@ examples:
         value: irish
         text: Irish
 
+- name: with hints on items
+  data:
+    fieldset:
+      legend:
+        text: How do you want to sign in?
+        isPageHeading: true
+    items:
+      - name: gateway
+        id: government-gateway
+        value: gov-gateway
+        text: Sign in with Government Gateway
+        hint:
+          text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+      - name: verify
+        id: govuk-verify
+        value: gov-verify
+        text: Sign in with GOV.UK Verify
+        hint:
+          text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+
 - name: with disabled item
   data:
     name: colours

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -48,11 +48,14 @@
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
     {% set name = item.name if item.name else params.name %}
     {% set conditionalId = "conditional-" + id %}
+    {% set hasHint = true if item.hint.text or item.hint.html %}
+    {% set itemHintId = id + '-item-hint' %}
     <div class="govuk-checkboxes__item">
       <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
       {{-" checked" if item.checked }}
       {{-" disabled" if item.disabled }}
-      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}>
+      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}>
       {{ govukLabel({
         html: item.html,
         text: item.text,
@@ -60,6 +63,15 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
+      {%- if hasHint %}
+      {{ govukHint({
+        id: itemHintId,
+        classes: 'govuk-checkboxes__hint',
+        attributes: item.hint.attributes,
+        html: item.hint.html,
+        text: item.hint.text
+      }) | indent(6) | trim }}
+      {%- endif %}
     </div>
     {% if item.conditional %}
       <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -255,6 +255,60 @@ describe('Checkboxes', () => {
     })
   })
 
+  describe('when they include a hint', () => {
+    it('it renders the hint text', () => {
+      const $ = render('checkboxes', {
+        name: 'gov',
+        items: [
+          {
+            value: 'value',
+            text: 'This is text',
+            hint: {
+              text: 'This is a hint'
+            }
+          }
+        ]
+      })
+      expect($('.govuk-checkboxes__hint').text()).toContain('This is a hint')
+    })
+
+    it('it renders the correct id attribute for the hint', () => {
+      const $ = render('checkboxes', {
+        name: 'gov',
+        items: [
+          {
+            value: 'value',
+            text: 'This is text',
+            id: 'item-id',
+            hint: {
+              text: 'This is a hint'
+            }
+          }
+        ]
+      })
+
+      expect($('.govuk-checkboxes__hint').attr('id')).toBe('item-id-item-hint')
+    })
+
+    it('the input describedBy attribute matches the item hint id', () => {
+      const $ = render('checkboxes', {
+        name: 'gov',
+        items: [
+          {
+            value: 'value',
+            text: 'This is text',
+            id: 'item-id',
+            hint: {
+              text: 'This is a hint'
+            }
+          }
+        ]
+      })
+
+      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe('item-id-item-hint')
+    })
+  })
+
   describe('render conditionals', () => {
     it('hidden by default when not checked', () => {
       const $ = render('checkboxes', {

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -425,6 +425,80 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Radios with hints on items
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/radios/with-hints-on-items/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+
+      <fieldset class="govuk-fieldset">
+
+      <legend class="govuk-fieldset__legend">
+        <h1 class="govuk-fieldset__heading">
+          How do you want to sign in?
+        </h1>
+      </legend>
+
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="gov-1" name="gov" type="radio" value="gateway" aria-describedby="gov-1-item-hint">
+          <label class="govuk-label govuk-radios__label" for="gov-1">
+            Sign in with Government Gateway
+          </label>
+          <span id="gov-1-item-hint" class="govuk-hint govuk-radios__hint">
+            You&#39;ll have a user ID if you&#39;ve registered for Self Assessment or filed a tax return online before.
+          </span>
+        </div>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="gov-2" name="gov" type="radio" value="verify" aria-describedby="gov-2-item-hint">
+          <label class="govuk-label govuk-radios__label" for="gov-2">
+            Sign in with GOV.UK Verify
+          </label>
+          <span id="gov-2-item-hint" class="govuk-hint govuk-radios__hint">
+            You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+          </span>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "radios/macro.njk" import govukRadios %}
+
+    {{ govukRadios({
+      "idPrefix": "gov",
+      "name": "gov",
+      "fieldset": {
+        "legend": {
+          "text": "How do you want to sign in?",
+          "isPageHeading": true
+        }
+      },
+      "items": [
+        {
+          "value": "gateway",
+          "text": "Sign in with Government Gateway",
+          "hint": {
+            "text": "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+          }
+        },
+        {
+          "value": "verify",
+          "text": "Sign in with GOV.UK Verify",
+          "hint": {
+            "text": "You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity."
+          }
+        }
+      ]
+    }) }}
+
 ### Radios without fieldset
 
 [Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/radios/without-fieldset/preview)
@@ -732,6 +806,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Provide additional attributes to each radio item label. See [label](../label/README.md#component-arguments) component for more details.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.hint</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Provide optional hint to each radio item. See `hint` component for more details.</td>
 
 </tr>
 

--- a/src/components/radios/README.njk
+++ b/src/components/radios/README.njk
@@ -186,6 +186,20 @@ Let users select a single option from a list.
     ],
     [
       {
+        text: 'items.{}.hint'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Provide optional hint to each radio item. See `hint` component for more details.'
+      }
+    ],
+    [
+      {
         text: 'items.{}.divider'
       },
       {

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -70,6 +70,12 @@
     touch-action: manipulation;
   }
 
+  .govuk-radios__hint {
+    display: block;
+    padding-right: $govuk-radios-label-padding-left-right;
+    padding-left: $govuk-radios-label-padding-left-right;
+  }
+
   .govuk-radios__input + .govuk-radios__label::before {
     content: "";
     box-sizing: border-box;

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -116,6 +116,24 @@ examples:
       - value: create-account
         text: Create an account
 
+- name: with hints on items
+  data:
+    idPrefix: gov
+    name: gov
+    fieldset:
+      legend:
+        text: How do you want to sign in?
+        isPageHeading: true
+    items:
+      - value: gateway
+        text: Sign in with Government Gateway
+        hint:
+          text: You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.
+      - value: verify
+        text: Sign in with GOV.UK Verify
+        hint:
+          text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+
 - name: without fieldset
   data:
     name: colours

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -50,11 +50,14 @@
     {%- if item.divider %}
     <div class="govuk-radios__divider">{{ item.divider }}</div>
     {%- else %}
+    {% set hasHint = true if item.hint.text or item.hint.html %}
+    {% set itemHintId = id + '-item-hint' %}
     <div class="govuk-radios__item">
       <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
       {{-" checked" if item.checked }}
       {{-" disabled" if item.disabled }}
-      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}>
+      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}>
       {{ govukLabel({
         html: item.html,
         text: item.text,
@@ -62,6 +65,15 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
+      {%- if hasHint %}
+      {{ govukHint({
+        id: itemHintId,
+        classes: 'govuk-radios__hint',
+        attributes: item.hint.attributes,
+        html: item.hint.html,
+        text: item.hint.text
+      }) | indent(6) | trim }}
+      {%- endif %}
     </div>
     {% if item.conditional %}
       <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -198,6 +198,57 @@ describe('Radios', () => {
       expect($lastInput.attr('checked')).toEqual('checked')
     })
 
+    describe('when they include a hint', () => {
+      it('it renders the hint text', () => {
+        const $ = render('radios', {
+          items: [
+            {
+              value: 'value',
+              text: 'This is text',
+              hint: {
+                text: 'This is a hint'
+              }
+            }
+          ]
+        })
+        expect($('.govuk-radios__hint').text()).toContain('This is a hint')
+      })
+
+      it('it renders the correct id attribute for the hint', () => {
+        const $ = render('radios', {
+          items: [
+            {
+              value: 'value',
+              text: 'This is text',
+              id: 'item-id',
+              hint: {
+                text: 'This is a hint'
+              }
+            }
+          ]
+        })
+
+        expect($('.govuk-radios__hint').attr('id')).toBe('item-id-item-hint')
+      })
+
+      it('the input describedBy attribute matches the item hint id', () => {
+        const $ = render('radios', {
+          items: [
+            {
+              value: 'value',
+              text: 'This is text',
+              id: 'item-id',
+              hint: {
+                text: 'This is a hint'
+              }
+            }
+          ]
+        })
+
+        expect($('.govuk-radios__input').attr('aria-describedby')).toBe('item-id-item-hint')
+      })
+    })
+
     describe('render conditionals', () => {
       it('hidden by default when not checked', () => {
         const $ = render('radios', {


### PR DESCRIPTION
It's currently it is not possible to use hints in items as seen in https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity in Nunjucks macros

This work allows for optional hint object to be passed to each item that outputs a hint component. Id of that hint component is set as `aria-describedby` on radio/checkbox into so that it's read by AT.

- Update template to allow for hint component to be passed
- Add example to yaml
- Add test to check that hint is present
- Update table of arguments with the new option
- Regenerate README

Direct urls:
https://govuk-frontend-review-pr-846.herokuapp.com/components/checkboxes/with-hints-on-items/preview
https://govuk-frontend-review-pr-846.herokuapp.com/components/radios/with-hints-on-items/preview

**Browser tests:**
<details>
<summary>Chrome 67 and  Safari 11.1.1 ✅</summary>
<img width="968" alt="safari" src="https://user-images.githubusercontent.com/3758555/42079649-23e808ae-7b78-11e8-9a6d-fc850102db9f.png">
<img width="791" alt="chrome" src="https://user-images.githubusercontent.com/3758555/42079549-eae1739c-7b77-11e8-8499-bf891baca552.png">
</details>
<details>
<summary>IE8 ✅</summary>
<img width="1875" alt="ie8" src="https://user-images.githubusercontent.com/3758555/42079913-f21ac3e2-7b78-11e8-9193-4f5f80f03902.png">
</details>
<details>
<summary>IE11 ✅</summary>
<img width="847" alt="ie11" src="https://user-images.githubusercontent.com/3758555/42080139-89b63092-7b79-11e8-98fd-ac685ec04e0b.png">
</details>
<details>
<summary>Safari 9.3  iOS and Samsung Internet browser ✅</summary>
<img width="339" alt="safari9-3" src="https://user-images.githubusercontent.com/3758555/42080246-f322b8e8-7b79-11e8-95ed-64af97f5be18.png">
<img width="358" alt="samsung-internet" src="https://user-images.githubusercontent.com/3758555/42080347-480e720c-7b7a-11e8-9187-b1e192ce53bd.png">
</details>
<hr/>
<details>
<summary>AT tests:</summary>
VoiceOver on maOS
<img width="1010" alt="voiceover" src="https://user-images.githubusercontent.com/3758555/42078499-a91fe3a6-7b74-11e8-8a97-4feddffd8464.jpg">

JAWS 16, 17, 18 in IE11: Hint read
NVDA: Hint read
Talkback on Android: Hint read
Voiceover on iOS: Hint read
</details>


This fixes: #768 
