### PR TITLE
Allow og:image meta tag to be customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
   You can now provide a divider item (e.g "or") to separate items
   ([PR #849](https://github.com/alphagov/govuk-frontend/pull/849))
 
+- Allow og:image meta tag url to be set independantly
+  Image url for the opengraph image needs to be absolute and
+  can now be overwritten by setting the `assetUrl` variable.
+  ([PR #847](https://github.com/alphagov/govuk-frontend/pull/847))
+
 🔧 Fixes:
 
 - Replace conflicting `js-hidden` class used within the tabs component with a new modifier class.
@@ -75,7 +80,7 @@
   `headingLevel: <number>` parameter. Default is `2`.
   ([PR #853](https://github.com/alphagov/govuk-frontend/pull/853))
 
-- Update date input component  
+- Update date input component
 
   Allow the `name` and `id` attributes to be passed individually for each input item.
 

--- a/src/template.njk
+++ b/src/template.njk
@@ -1,6 +1,8 @@
 {% from "./components/skip-link/macro.njk" import govukSkipLink %}
 {% from "./components/header/macro.njk" import govukHeader %}
 {% from "./components/footer/macro.njk" import govukFooter %}
+{# specify absolute url for the static assets folder e.g. http://wwww.domain.com/assets #}
+{% set assetUrl = assetUrl | default(assetPath) %}
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>
@@ -19,9 +21,9 @@
     {% endblock %}
 
     {% block head %}{% endblock %}
-
     {# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
-    <meta property="og:image" content="{{ assetPath | default('/assets') }}/images/govuk-opengraph-image.png">
+    {# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
+    <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>


### PR DESCRIPTION
Moving the meta tag into the `head` block so that it can be overwritten, as the image path for it needs to be an absolute path.

Fixes: #813 