### PR TITLE
Convert line-height from pixel values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@
 
 🔧 Fixes:
 
-- Use relative line-height
-  Update typography styles to use relative, unitless line-height
-  ([PR #837](https://github.com/alphagov/govuk-frontend/pull/837))
+- Line-heights are now converted from pixels to relative 'unit-less' values
+  in order to prevent issues when resizing text in the browser.
+  ([PR #837](https://github.com/alphagov/govuk-frontend/pull/837) and
+   [PR #848](https://github.com/alphagov/govuk-frontend/pull/848))
 
 - Add bottom margin to Tabs component
   All components (or outer layer components) have a bottom margin

--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -103,7 +103,8 @@
 
     // Convert line-heights specified in pixels into a relative value, unless
     // they are already unit-less (and thus already treated as relative values)
-    @if not unitless($line-height) {
+    // or the units do not match the units used for the font size.
+    @if not unitless($line-height) and unit($line-height) == unit($font-size) {
       $line-height: $line-height / $font-size;
     }
 

--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -98,14 +98,26 @@
   $font-map: map-get($govuk-typography-scale, $size);
 
   @each $breakpoint, $breakpoint-map in $font-map {
-    $font-size: map-get($breakpoint-map, "font-size") iff($important, !important);
-    $line-height: map-get($breakpoint-map, "line-height") iff($important, !important);
+    $font-size: map-get($breakpoint-map, "font-size");
+    $line-height: map-get($breakpoint-map, "line-height");
+
+    // Convert line-heights specified in pixels into a relative value, unless
+    // they are already unit-less (and thus already treated as relative values)
+    @if not unitless($line-height) {
+      $line-height: $line-height / $font-size;
+    }
 
     // Sometimes we need to use a custom non-responsive line height for
     // a component.
     @if $override-line-height {
       $line-height: $override-line-height iff($important, !important);
     }
+
+    // Mark rules as !important if $important is true - this will result in
+    // these variables becoming strings, so this needs to happen *after* they
+    // are used in calculations
+    $font-size: $font-size iff($important, !important);
+    $line-height: $line-height iff($important, !important);
 
     @if $breakpoint == null {
       font-size: $font-size;

--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -59,6 +59,23 @@
   font-weight: $govuk-font-weight-bold iff($important, !important);
 }
 
+/// Convert line-heights specified in pixels into a relative value, unless
+/// they are already unit-less (and thus already treated as relative values)
+/// or the units do not match the units used for the font size.
+///
+/// @param {Number} $line-height Line height
+/// @param {Number} $font-size Font size
+/// @return {Number} The line height as either a relative value or unmodified
+///
+/// @access private
+@function _govuk-line-height($line-height, $font-size) {
+  @if not unitless($line-height) and unit($line-height) == unit($font-size) {
+    $line-height: $line-height / $font-size;
+  }
+
+  @return $line-height;
+}
+
 /// Responsive typography helper
 ///
 /// Takes a 'font map' as an argument and uses it to create font-size and
@@ -99,20 +116,13 @@
 
   @each $breakpoint, $breakpoint-map in $font-map {
     $font-size: map-get($breakpoint-map, "font-size");
-    $line-height: map-get($breakpoint-map, "line-height");
-
-    // Convert line-heights specified in pixels into a relative value, unless
-    // they are already unit-less (and thus already treated as relative values)
-    // or the units do not match the units used for the font size.
-    @if not unitless($line-height) and unit($line-height) == unit($font-size) {
-      $line-height: $line-height / $font-size;
-    }
-
-    // Sometimes we need to use a custom non-responsive line height for
-    // a component.
-    @if $override-line-height {
-      $line-height: $override-line-height iff($important, !important);
-    }
+    $line-height: _govuk-line-height(
+      $line-height: if($override-line-height,
+        $override-line-height,
+        map-get($breakpoint-map, "line-height")
+      ),
+      $font-size: $font-size
+    );
 
     // Mark rules as !important if $important is true - this will result in
     // these variables becoming strings, so this needs to happen *after* they

--- a/src/helpers/typography.test.js
+++ b/src/helpers/typography.test.js
@@ -29,7 +29,7 @@ const sassBootstrap = `
       ),
       print: (
         font-size: 14pt,
-        line-height: 20pt
+        line-height: 1.5
       )
     ),
     14: (
@@ -62,11 +62,11 @@ describe('@mixin govuk-typography-responsive', () => {
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
         font-size: 12px;
-        line-height: 15px; }
+        line-height: 1.25; }
         @media (min-width: 30em) {
           .foo {
             font-size: 14px;
-            line-height: 20px; } }`)
+            line-height: 1.42857; } }`)
   })
 
   it('outputs CSS with suitable media queries for print', async () => {
@@ -82,11 +82,11 @@ describe('@mixin govuk-typography-responsive', () => {
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
         font-size: 12px;
-        line-height: 15px; }
+        line-height: 1.25; }
         @media print {
           .foo {
             font-size: 14pt;
-            line-height: 20pt; } }`)
+            line-height: 1.5; } }`)
   })
 
   it('throws an exception when passed a size that is not in the scale', async () => {
@@ -118,11 +118,11 @@ describe('@mixin govuk-typography-responsive', () => {
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
           font-size: 12px !important;
-          line-height: 15px !important; }
+          line-height: 1.25 !important; }
           @media (min-width: 30em) {
             .foo {
               font-size: 14px !important;
-              line-height: 20px !important; } }`)
+              line-height: 1.42857 !important; } }`)
     })
 
     it('marks font-size and line-height as important for print media', async () => {
@@ -138,11 +138,11 @@ describe('@mixin govuk-typography-responsive', () => {
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
           font-size: 12px !important;
-          line-height: 15px !important; }
+          line-height: 1.25 !important; }
           @media print {
             .foo {
               font-size: 14pt !important;
-              line-height: 20pt !important; } }`)
+              line-height: 1.5 !important; } }`)
     })
   })
 

--- a/src/helpers/typography.test.js
+++ b/src/helpers/typography.test.js
@@ -48,6 +48,53 @@ const sassBootstrap = `
   @import "tools/iff";
   @import "helpers/typography";`
 
+describe('@function _govuk-line-height', () => {
+  it('preserves line-height if already unitless', async () => {
+    const sass = `
+      @import "helpers/typography";
+
+      .foo {
+        line-height: _govuk-line-height($line-height: 3.141, $font-size: 20px);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe(outdent`
+      .foo {
+        line-height: 3.141; }`)
+  })
+
+  it('preserves line-height if using different units', async () => {
+    const sass = `
+      @import "helpers/typography";
+
+      .foo {
+        line-height: _govuk-line-height($line-height: 2em, $font-size: 20px);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe(outdent`
+      .foo {
+        line-height: 2em; }`)
+  })
+
+  it('converts line-height to a relative number', async () => {
+    const sass = `
+      @import "helpers/typography";
+
+      .foo {
+        line-height: _govuk-line-height($line-height: 30px, $font-size: 20px);
+      }`
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+
+    expect(results.css.toString().trim()).toBe(outdent`
+      .foo {
+        line-height: 1.5; }`)
+  })
+})
+
 describe('@mixin govuk-typography-responsive', () => {
   it('outputs CSS with suitable media queries', async () => {
     const sass = `
@@ -152,7 +199,7 @@ describe('@mixin govuk-typography-responsive', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-typography-responsive($size: 14, $override-line-height: 30px);
+          @include govuk-typography-responsive($size: 14, $override-line-height: 21px);
         }`
 
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -160,11 +207,11 @@ describe('@mixin govuk-typography-responsive', () => {
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
           font-size: 12px;
-          line-height: 30px; }
+          line-height: 1.75; }
           @media (min-width: 30em) {
             .foo {
               font-size: 14px;
-              line-height: 30px; } }`)
+              line-height: 1.5; } }`)
     })
   })
 })

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -11,6 +11,10 @@
 /// different behaviour on tablet and desktop. The 'null' breakpoint is for
 /// mobile.
 ///
+/// Line-heights will automatically be converted from pixel measurements into
+/// relative values. For example, with a font-size of 16px and a line-height of
+/// 24px, the line-height will be converted to 1.5 before output.
+///
 /// You can also specify a separate font size and line height for print media.
 ///
 /// @type Map
@@ -26,11 +30,11 @@ $govuk-typography-scale: (
   80: (
     null: (
       font-size: 53px,
-      line-height: 1.0377358491 // 55px
+      line-height: 55px
     ),
     tablet: (
       font-size: 80px,
-      line-height: 1 // 80px
+      line-height: 80px
     ),
     print: (
       font-size: 53pt,
@@ -40,11 +44,11 @@ $govuk-typography-scale: (
   48: (
     null: (
       font-size: 32px,
-      line-height: 1.09375 // 35px
+      line-height: 35px
     ),
     tablet: (
       font-size: 48px,
-      line-height: 1.0416666667 // 50px
+      line-height: 50px
     ),
     print: (
       font-size: 32pt,
@@ -54,11 +58,11 @@ $govuk-typography-scale: (
   36: (
     null: (
       font-size: 24px,
-      line-height: 1.0416666667 // 25px
+      line-height: 25px
     ),
     tablet: (
       font-size: 36px,
-      line-height: 1.1111111111 // 40px
+      line-height: 40px
     ),
     print: (
       font-size: 24pt,
@@ -68,11 +72,11 @@ $govuk-typography-scale: (
   27: (
     null: (
       font-size: 18px,
-      line-height: 1.1111111111 // 20px
+      line-height: 20px
     ),
     tablet: (
       font-size: 27px,
-      line-height: 1.1111111111 // 30px
+      line-height: 30px
     ),
     print: (
       font-size: 18pt,
@@ -82,11 +86,11 @@ $govuk-typography-scale: (
   24: (
     null: (
       font-size: 18px,
-      line-height: 1.1111111111 // 20px
+      line-height: 20px
     ),
     tablet: (
       font-size: 24px,
-      line-height: 1.25 // 30px
+      line-height: 30px
     ),
     print: (
       font-size: 18pt,
@@ -96,11 +100,11 @@ $govuk-typography-scale: (
   19: (
     null: (
       font-size: 16px,
-      line-height: 1.25 // 20px
+      line-height: 20px
     ),
     tablet: (
       font-size: 19px,
-      line-height: 1.3157894737 // 25px
+      line-height: 25px
     ),
     print: (
       font-size: 14pt,
@@ -110,11 +114,11 @@ $govuk-typography-scale: (
   16: (
     null: (
       font-size: 14px,
-      line-height: 1.1428571429 // 16px
+      line-height: 16px
     ),
     tablet: (
       font-size: 16px,
-      line-height: 1.25 // 20px
+      line-height: 20px
     ),
     print: (
       font-size: 14pt,
@@ -124,11 +128,11 @@ $govuk-typography-scale: (
   14: (
     null: (
       font-size: 12px,
-      line-height: 1.25 // 15px
+      line-height: 15px
     ),
     tablet: (
       font-size: 14px,
-      line-height: 1.4285714286 // 20px
+      line-height: 20px
     ),
     print: (
       font-size: 12pt,


### PR DESCRIPTION
Rather than having to declare the line-heights as relative values (such as 1.5) in the font map, allow them to be specified in pixels and convert them to relative unitless values within our typography mixin.

This provides a much clearer way to define line heights without the need for comments explaining how the values are calculated, whilst retaining the benefits of using relative unitless line-heights.