### PR TITLE
Allow for an optional divider between radio items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Allow for optional divider between radio items
+
+  You can now provide a divider item (e.g "or") to separate items
+  ([PR #849](https://github.com/alphagov/govuk-frontend/pull/849))
+
 🔧 Fixes:
 
 - Replace conflicting `js-hidden` class used within the tabs component with a new modifier class.

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -350,6 +350,81 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Radios with a divider
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/radios/with-a-divider/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+
+      <fieldset class="govuk-fieldset">
+
+      <legend class="govuk-fieldset__legend">
+        How do you want to sign in?
+      </legend>
+
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-divider-1" name="example" type="radio" value="governement-gateway">
+          <label class="govuk-label govuk-radios__label" for="example-divider-1">
+            Use Government Gateway
+          </label>
+        </div>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-divider-2" name="example" type="radio" value="govuk-verify">
+          <label class="govuk-label govuk-radios__label" for="example-divider-2">
+            Use GOV.UK Verify
+          </label>
+        </div>
+
+        <div class="govuk-radios__divider">or</div>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="example-divider-4" name="example" type="radio" value="create-account">
+          <label class="govuk-label govuk-radios__label" for="example-divider-4">
+            Create an account
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "radios/macro.njk" import govukRadios %}
+
+    {{ govukRadios({
+      "idPrefix": "example-divider",
+      "name": "example",
+      "fieldset": {
+        "legend": {
+          "text": "How do you want to sign in?"
+        }
+      },
+      "items": [
+        {
+          "value": "governement-gateway",
+          "text": "Use Government Gateway"
+        },
+        {
+          "value": "govuk-verify",
+          "text": "Use GOV.UK Verify"
+        },
+        {
+          "divider": "or"
+        },
+        {
+          "value": "create-account",
+          "text": "Create an account"
+        }
+      ]
+    }) }}
+
 ### Radios without fieldset
 
 [Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/radios/without-fieldset/preview)
@@ -657,6 +732,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Provide additional attributes to each radio item label. See `label` component for more details.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.divider</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional divider text to separate radio items, for example the text "or".</td>
 
 </tr>
 

--- a/src/components/radios/README.njk
+++ b/src/components/radios/README.njk
@@ -186,6 +186,20 @@ Let users select a single option from a list.
     ],
     [
       {
+        text: 'items.{}.divider'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional divider text to separate radio items, for example the text "or".'
+      }
+    ],
+    [
+      {
         text: 'items.{}.checked'
       },
       {

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -139,6 +139,14 @@
     }
   }
 
+  .govuk-radios__divider {
+    $govuk-divider-size: $govuk-radios-size !default;
+    @include govuk-font($size: 19);
+    width: $govuk-divider-size;
+    margin-bottom: govuk-spacing(2);
+    text-align: center;
+  }
+
   $conditional-border-width: $govuk-border-width-mobile;
   // Calculate the amount of padding needed to keep the border centered against the radios.
   $conditional-border-padding: ($govuk-radios-size / 2) - ($conditional-border-width / 2);

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -100,6 +100,22 @@ examples:
           <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span>
           For properties that are within a geographical area defined by a local council
 
+- name: with a divider
+  data:
+    idPrefix: example-divider
+    name: example
+    fieldset:
+      legend:
+        text: How do you want to sign in?
+    items:
+      - value: governement-gateway
+        text: Use Government Gateway
+      - value: govuk-verify
+        text: Use GOV.UK Verify
+      - divider: or
+      - value: create-account
+        text: Create an account
+
 - name: without fieldset
   data:
     name: colours

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -47,6 +47,9 @@
     {% for item in params.items %}
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
     {% set conditionalId = "conditional-" + id %}
+    {%- if item.divider %}
+    <div class="govuk-radios__divider">{{ item.divider }}</div>
+    {%- else %}
     <div class="govuk-radios__item">
       <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
       {{-" checked" if item.checked }}
@@ -64,6 +67,7 @@
       <div class="govuk-radios__conditional" id="{{ conditionalId }}">
         {{ item.conditional.html | safe }}
       </div>
+    {% endif %}
     {% endif %}
     {% endfor %}
   </div>

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -224,6 +224,33 @@ describe('Radios', () => {
       expect($lastConditional.attr('id')).toBe('conditional-example-conditional-2')
       expect($lastConditional.html()).toContain('Conditional content')
     })
+
+    it('render divider', () => {
+      const $ = render('radios', {
+        name: 'example-divider',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes'
+          },
+          {
+            value: 'no',
+            text: 'No'
+          },
+          {
+            divider: 'or'
+          },
+          {
+            value: 'maybe',
+            text: 'Maybe'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-radios')
+      const $divider = $component.find('.govuk-radios__divider')
+      expect($divider.text()).toBe('or')
+    })
   })
 
   describe('when they include a hint', () => {


### PR DESCRIPTION
It used to be a feature in [GOV.UK Elements](https://govuk-elements.herokuapp.com/form-elements/#form-radio-buttons) and it's not currently available in our macros.

Direct url: https://govuk-frontend-review-pr-849.herokuapp.com/components/radios/with-a-divider/preview

This PR:
- Adds an example
- Updates the component template
- Adds a test to check the divider item gets output
- Updates README

Fixes: #729 

Works fine with conditional reveal as well.

<details>
<summary>Screenshots</summary>

IE 8
<img alt="" src="https://user-images.githubusercontent.com/3758555/42133812-abe701a0-7d27-11e8-9de2-77ed11301922.jpg">

IE 9
<img alt="" src="https://user-images.githubusercontent.com/3758555/42133811-abd1f5e4-7d27-11e8-8513-1a5996c53db2.jpg">

IE 11
<img alt="" src="https://user-images.githubusercontent.com/3758555/42133814-ac1484ea-7d27-11e8-9bea-7f657ebf0494.jpg">

Firefox 60
<img alt="" src="https://user-images.githubusercontent.com/3758555/42133813-ac0029d2-7d27-11e8-9249-a9d0a23dbbae.jpg">

Safari 9.3
<img alt="" src="https://user-images.githubusercontent.com/3758555/42133810-abbc8bfa-7d27-11e8-8809-6fd75a93059c.jpg">

</details>
