### PR TITLE
Add border to warning text circle for overriden colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   of text
   ([PR #856](https://github.com/alphagov/govuk-frontend/pull/856))
 
+- Add customised colours handling for warning text
+
+  By adding a border to this component, when a user customises their colour settings
+  they will still see a circle even if the background is removed.
+  ([PR #852](https://github.com/alphagov/govuk-frontend/pull/852))
 
 🏠 Internal:
 

--- a/src/components/warning-text/_warning-text.scss
+++ b/src/components/warning-text/_warning-text.scss
@@ -26,18 +26,21 @@
     top: 50%;
     left: 0;
 
-    min-width: 38px;
-    min-height: 35px;
-    margin-top: -20px; // Half the height of the 38px circle (adjusted for NTA)
+    min-width: 32px;
+    min-height: 29px;
+    margin-top: -20px; // Half the height of the circle (adjusted for NTA)
     padding-top: 3px;
 
+    // When a user customises their colours the background colour will often be removed.
+    // Adding a border to the component keeps it's shape as a circle.
+    border: 3px solid govuk-colour("black");
     border-radius: 50%;
 
     color: govuk-colour("white");
     background: govuk-colour("black");
 
     font-size: 1.6em;
-    line-height: 35px;
+    line-height: 29px;
 
     text-align: center;
 


### PR DESCRIPTION
While writing a blog post on overriding classes I noticed this opportunity:

## Before overriden colours
<img width="722" alt="screen shot 2018-07-02 at 12 19 16" src="https://user-images.githubusercontent.com/2445413/42161289-40d7a98e-7df2-11e8-9bcc-625aa774303d.png">

## After overriden colours
<img width="722" alt="screen shot 2018-07-02 at 12 19 22" src="https://user-images.githubusercontent.com/2445413/42161286-408be134-7df2-11e8-854b-0b1803c1672b.png">

## Before regular colours
<img width="722" alt="screen shot 2018-07-02 at 12 19 41" src="https://user-images.githubusercontent.com/2445413/42161287-40a4bae2-7df2-11e8-9d74-a7c196878f40.png">

## After regular colours
<img width="722" alt="screen shot 2018-07-02 at 12 19 52" src="https://user-images.githubusercontent.com/2445413/42161288-40bb9f50-7df2-11e8-897f-e1bcaca742fa.png">

