### PR TITLE
Allow the panel component title heading level to be customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,11 @@
 
   ([PR #859](https://github.com/alphagov/govuk-frontend/pull/859))
 
-- Pull Request Title goes here
+- Allow panel component title heading to be customisable.
 
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  You can now specify a heading level by providing
+  `headingLevel: <number>` parameter. Default is `2`.
+  ([PR #853](https://github.com/alphagov/govuk-frontend/pull/853))
 
 
 🔧 Fixes:

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -32,7 +32,34 @@ Find out when to use the panel component in your service in the [GOV.UK Design S
     {% from "panel/macro.njk" import govukPanel %}
 
     {{ govukPanel({
+      "titleHtml": "Application complete",
+      "text": "Your reference number: HDJ2123F"
+    }) }}
+
+### Panel custom heading level
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/panel/custom-heading-level/preview)
+
+#### Markup
+
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        Application complete
+      </h1>
+
+      <div class="govuk-panel__body">
+        Your reference number: HDJ2123F
+      </div>
+
+    </div>
+
+#### Macro
+
+    {% from "panel/macro.njk" import govukPanel %}
+
+    {{ govukPanel({
       "titleText": "Application complete",
+      "headingLevel": 1,
       "text": "Your reference number: HDJ2123F"
     }) }}
 
@@ -87,6 +114,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">Text or HTML for the panel title. If `titleHtml` is provided, the `titleText` argument is ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">headingLevel</th>
+
+<td class="govuk-table__cell ">number</td>
+
+<td class="govuk-table__cell ">no</td>
+
+<td class="govuk-table__cell ">Optional heading level, from 1 to 6\. Default is 2.</td>
 
 </tr>
 

--- a/src/components/panel/README.njk
+++ b/src/components/panel/README.njk
@@ -46,6 +46,20 @@
     ],
     [
       {
+        text: 'headingLevel'
+      },
+      {
+        text: 'number'
+      },
+      {
+        text: 'no'
+      },
+      {
+        text: 'Optional heading level, from 1 to 6. Default is 2.'
+      }
+    ],
+    [
+      {
         text: 'text (or) html'
       },
       {

--- a/src/components/panel/panel.yaml
+++ b/src/components/panel/panel.yaml
@@ -1,5 +1,10 @@
 examples:
 - name: default
   data:
+    titleHtml: Application complete
+    text: 'Your reference number: HDJ2123F'
+- name: custom heading level
+  data:
     titleText: Application complete
+    headingLevel: 1
     text: 'Your reference number: HDJ2123F'

--- a/src/components/panel/template.njk
+++ b/src/components/panel/template.njk
@@ -1,9 +1,11 @@
+{#- TODO: Change default title heading level to 1 - https://github.com/alphagov/govuk-frontend/issues/864 -#}
+{% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 <div class="govuk-panel govuk-panel--confirmation
   {%- if params.classes %} {{ params.classes }}{% endif %}"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <h2 class="govuk-panel__title">
+  <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
-  </h2>
+  </h{{ headingLevel }}>
   {% if params.html or params.text %}
   <div class="govuk-panel__body">
     {{ params.html | safe if params.html else params.text }}

--- a/src/components/panel/template.test.js
+++ b/src/components/panel/template.test.js
@@ -30,6 +30,22 @@ describe('Panel', () => {
     expect(panelTitle).toEqual('Application &lt;strong&gt;not&lt;/strong&gt; complete')
   })
 
+  it('renders title as h2 (as the default heading level)', () => {
+    const $ = render('panel', examples.default)
+    const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
+
+    expect(panelTitleHeadingLevel).toEqual('h2')
+  })
+
+  it('renders title as specified heading level', () => {
+    const $ = render('panel', {
+      headingLevel: 3
+    })
+    const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
+
+    expect(panelTitleHeadingLevel).toEqual('h3')
+  })
+
   it('allows title HTML to be passed un-escaped', () => {
     const $ = render('panel', {
       titleHtml: 'Application <strong>not</strong> complete'


### PR DESCRIPTION
This modification allows it panel component title to be any heading level by specifying `headingLevel` parameter
Default is `2`.

This PR
- Adds test
- Adds an example
- Updates component table of arguments
- Generates an updated README

Adresses: https://github.com/alphagov/govuk-design-system/issues/413 