### PR TITLE
Show focus outlines when customising colours settings on Radios and Checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,13 @@
 
 - Fixes a bug where the phase banner incorrectly uses a font-size of 19px when
   global styles are enabled
-  ([PR #877}])https://github.com/alphagov/govuk-frontend/pull/877
+  ([PR #877](https://github.com/alphagov/govuk-frontend/pull/877))
+
+- Add outlines to Radios and Checkboxes for customised colour users
+
+  Now when a [user customises their colours](https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/),
+  they should see a focus state on both Radios and Checkboxes.
+  ([PR #854](https://github.com/alphagov/govuk-frontend/pull/854))
 
 🏠 Internal:
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -102,6 +102,11 @@
 
   // Focused state
   .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+    // Since box-shadows are removed when users customise their colours
+    // We set a transparent outline that is shown instead.
+    // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+    outline: $govuk-focus-width solid transparent;
+    outline-offset: $govuk-focus-width;
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -10,6 +10,9 @@
 @include govuk-exports("govuk/component/radios") {
   $govuk-radios-size: govuk-spacing(7);
   $govuk-radios-label-padding-left-right: govuk-spacing(3);
+  // When the default focus width is used on a curved edge it looks visually smaller.
+  // So for the circular radios we bump the default to make it look visually consistent.
+  $govuk-radios-focus-width: $govuk-focus-width + 1px;
 
   .govuk-radios__item {
     @include govuk-font($size: 19);
@@ -99,7 +102,12 @@
 
   // Focused state
   .govuk-radios__input:focus + .govuk-radios__label::before {
-    box-shadow: 0 0 0 4px $govuk-focus-colour;
+    // Since box-shadows are removed when users customise their colours
+    // We set a transparent outline that is shown instead.
+    // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+    outline: $govuk-focus-width solid transparent;
+    outline-offset: $govuk-focus-width;
+    box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
   }
 
   // Selected state


### PR DESCRIPTION
Adds invisible outlines that will be shown when colours are overridden.

## Checkboxes
## Before overriden colours
![before-checkboxes](https://user-images.githubusercontent.com/2445413/42286013-529e2b8a-7fa9-11e8-8da0-dab622323afa.gif)

## After overridden colours
![after-checkboxes](https://user-images.githubusercontent.com/2445413/42285990-3fb32d9a-7fa9-11e8-9c83-d8a501baabc0.gif)


## Radios
## Before overridden colours
![before-radios](https://user-images.githubusercontent.com/2445413/42286017-5594cd26-7fa9-11e8-9272-047ce41d3efd.gif)

## After overridden colours
![after-radios](https://user-images.githubusercontent.com/2445413/42286008-4c4547fa-7fa9-11e8-83f5-96873bcbf38b.gif)


<details>
<summary>Cross browser testing</summary>

## Internet Explorer 11
<img width="603" alt="screen shot 2018-07-09 at 10 58 20" src="https://user-images.githubusercontent.com/2445413/42444102-3359be26-8367-11e8-8f66-96606a616d00.png">
<img width="596" alt="screen shot 2018-07-09 at 10 59 07" src="https://user-images.githubusercontent.com/2445413/42444103-337467f8-8367-11e8-81b4-95a23951d92c.png">

## Internet Explorer 10
<img width="587" alt="screen shot 2018-07-09 at 11 00 57" src="https://user-images.githubusercontent.com/2445413/42444480-232ce8d8-8368-11e8-9506-59bf37769ea9.png">
<img width="604" alt="screen shot 2018-07-09 at 11 01 33" src="https://user-images.githubusercontent.com/2445413/42444482-2343221a-8368-11e8-9956-4545cc90e09c.png">

## Internet Explorer 9
<img width="587" alt="screen shot 2018-07-09 at 11 02 54" src="https://user-images.githubusercontent.com/2445413/42444495-29421824-8368-11e8-9521-cccae87dbf84.png">
<img width="600" alt="screen shot 2018-07-09 at 11 02 24" src="https://user-images.githubusercontent.com/2445413/42444496-295a225c-8368-11e8-857a-5c24527f899b.png">

## Internet Explorer 8
<img width="590" alt="screen shot 2018-07-09 at 11 05 34" src="https://user-images.githubusercontent.com/2445413/42444513-365b532c-8368-11e8-8b2d-dc5e66fe6b1a.png">
<img width="573" alt="screen shot 2018-07-09 at 11 04 38" src="https://user-images.githubusercontent.com/2445413/42444514-36726684-8368-11e8-8e0a-383c08dc3158.png">

# Firefox latest, Chrome latest, Chrome Android latest, Safari latest, Safari iOS latest
No change

</details>


