### PR TITLE
Add outline to tag for customised colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,12 @@
   they should see a focus state on both Radios and Checkboxes.
   ([PR #854](https://github.com/alphagov/govuk-frontend/pull/854))
 
+- Add outline to tag for customised colour users
+
+  Now when a [user customises their colours](https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/),
+  the tag component still keeps it's meaning.
+  ([PR #855](https://github.com/alphagov/govuk-frontend/pull/855))
+
 🏠 Internal:
 
 - Fix Design System url in package READMEs and review app

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -9,6 +9,12 @@
     display: inline-block;
     padding: govuk-spacing(1) 8px 0;
 
+    // When a user customises their colours often the background is removed,
+    // by adding a outline we ensure that the tag component still keeps it's meaning.
+    // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+    outline: 2px solid transparent;
+    outline-offset: -2px;
+
     color: govuk-colour("white");
     background-color: govuk-colour("blue");
     letter-spacing: 1px;


### PR DESCRIPTION
Adds a border to the tag element so it makes more sense when colours are overridden.

The screenshots I've included here show the tag component when used in the phase banner component.

Uses relative spacing to keep alignment when the label is on a smaller screen.

## Before overriden colours
<img width="722" alt="screen shot 2018-07-02 at 12 48 15" src="https://user-images.githubusercontent.com/2445413/42162405-7de31936-7df6-11e8-9acb-9f2fbafba15c.png">

## After overriden colours
<img width="723" alt="screen shot 2018-07-02 at 12 48 10" src="https://user-images.githubusercontent.com/2445413/42162404-7dca158a-7df6-11e8-85e2-b9b554c4e24b.png">

## Before regular colours
<img width="539" alt="screen shot 2018-07-02 at 12 47 18" src="https://user-images.githubusercontent.com/2445413/42162407-7e1582cc-7df6-11e8-8cce-0a2c3853a95a.png">

## After regular colours
<img width="519" alt="screen shot 2018-07-02 at 12 47 22" src="https://user-images.githubusercontent.com/2445413/42162406-7dfcac3e-7df6-11e8-9ca2-1e08985a9aaa.png">

## Smaller screens:
### Before overriden colours
<img width="336" alt="screen shot 2018-07-02 at 12 53 56" src="https://user-images.githubusercontent.com/2445413/42162558-01318912-7df7-11e8-83d0-a3343b9b2867.png">

### After overriden colours
<img width="337" alt="screen shot 2018-07-02 at 12 53 52" src="https://user-images.githubusercontent.com/2445413/42162561-01494232-7df7-11e8-87bc-28b41f503045.png">

### Before regular colours
<img width="424" alt="screen shot 2018-07-02 at 12 53 47" src="https://user-images.githubusercontent.com/2445413/42162562-01610d18-7df7-11e8-89c6-300e393fb6cc.png">

### After regular colours
<img width="427" alt="screen shot 2018-07-02 at 12 53 41" src="https://user-images.githubusercontent.com/2445413/42162563-017bdf94-7df7-11e8-8592-097be177cbab.png">

