### PR TITLE
Make the warning icon un-selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@
 - Fixes radio and checkbox labels extending full width of page
   ([PR #821](https://github.com/alphagov/govuk-frontend/pull/821))
 
+- Prevent the exclamation mark in the warning text component from being
+  selectable, which also excludes it when it is copied as part of a wider body
+  of text
+  ([PR #856](https://github.com/alphagov/govuk-frontend/pull/856))
+
+
 🏠 Internal:
 
 - Fix Design System url in package READMEs and review app

--- a/src/components/warning-text/_warning-text.scss
+++ b/src/components/warning-text/_warning-text.scss
@@ -40,6 +40,10 @@
     line-height: 35px;
 
     text-align: center;
+
+    // Prevent the exclamation mark from being included when the warning text
+    // is copied, for example.
+    user-select: none;
   }
 
   .govuk-warning-text__text {


### PR DESCRIPTION
This prevents the exclamation mark from being included when the warning text is copied - for example if a user is copying a page that includes it.

## Before

![before](https://user-images.githubusercontent.com/121939/42163196-865bc0ba-7df9-11e8-987e-c18529ee3172.gif)


## After

![after](https://user-images.githubusercontent.com/121939/42163200-89cd21bc-7df9-11e8-8f16-c8676c9be630.gif)
