### PR TITLE
Update date input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@
   `headingLevel: <number>` parameter. Default is `2`.
   ([PR #853](https://github.com/alphagov/govuk-frontend/pull/853))
 
+- Update date input component  
+
+  Allow the `name` and `id` attributes to be passed individually for each input item.
+
+  Rely on `classes` instead of item names to set the width of input items.
+
+  Add default (day, month, year) date input items if no items are being specified
+
+  ([PR #857](https://github.com/alphagov/govuk-frontend/pull/857))
 
 🔧 Fixes:
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -29,33 +29,33 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
       <div class="govuk-date-input" id="dob">
 
-        <div class="govuk-date-input__item govuk-date-input__item--day">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-day">
               Day
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--month">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-month">
               Month
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--year">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-year">
               Year
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
           </div>
         </div>
 
@@ -81,13 +81,16 @@ Find out when to use the date input component in your service in the [GOV.UK Des
       },
       "items": [
         {
-          "name": "day"
+          "name": "day",
+          "classes": "govuk-input--width-2"
         },
         {
-          "name": "month"
+          "name": "month",
+          "classes": "govuk-input--width-2"
         },
         {
-          "name": "year"
+          "name": "year",
+          "classes": "govuk-input--width-4"
         }
       ]
     }) }}
@@ -115,33 +118,33 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
       <div class="govuk-date-input" id="dob-errors">
 
-        <div class="govuk-date-input__item govuk-date-input__item--day">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-errors-day">
               Day
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-day" name="undefined-day" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2 govuk-input--error" id="dob-errors-day" name="day" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--month">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-errors-month">
               Month
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-month" name="undefined-month" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2 govuk-input--error" id="dob-errors-month" name="month" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--year">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-errors-year">
               Year
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-errors-year" name="undefined-year" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4 govuk-input--error" id="dob-errors-year" name="year" type="number" pattern="[0-9]*">
           </div>
         </div>
 
@@ -170,15 +173,15 @@ Find out when to use the date input component in your service in the [GOV.UK Des
       "items": [
         {
           "name": "day",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-2 govuk-input--error"
         },
         {
           "name": "month",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-2 govuk-input--error"
         },
         {
           "name": "year",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-4 govuk-input--error"
         }
       ]
     }) }}
@@ -206,33 +209,33 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
       <div class="govuk-date-input" id="dob-day-error">
 
-        <div class="govuk-date-input__item govuk-date-input__item--day">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-day-error-day">
               Day
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2 govuk-input--error" id="dob-day-error-day" name="dob-day-error-day" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--month">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-day-error-month">
               Month
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-day-error-month" name="dob-day-error-month" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--year">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-day-error-year">
               Year
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4" id="dob-day-error-year" name="dob-day-error-year" type="number" pattern="[0-9]*">
           </div>
         </div>
 
@@ -262,13 +265,15 @@ Find out when to use the date input component in your service in the [GOV.UK Des
       "items": [
         {
           "name": "day",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-2 govuk-input--error"
         },
         {
-          "name": "month"
+          "name": "month",
+          "classes": "govuk-input--width-2"
         },
         {
-          "name": "year"
+          "name": "year",
+          "classes": "govuk-input--width-4"
         }
       ]
     }) }}
@@ -296,33 +301,33 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
       <div class="govuk-date-input" id="dob-month-error">
 
-        <div class="govuk-date-input__item govuk-date-input__item--day">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-month-error-day">
               Day
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-month-error-day" name="dob-month-error-day" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--month">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-month-error-month">
               Month
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2 govuk-input--error" id="dob-month-error-month" name="dob-month-error-month" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--year">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-month-error-year">
               Year
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4" id="dob-month-error-year" name="dob-month-error-year" type="number" pattern="[0-9]*">
           </div>
         </div>
 
@@ -351,14 +356,16 @@ Find out when to use the date input component in your service in the [GOV.UK Des
       },
       "items": [
         {
-          "name": "day"
+          "name": "day",
+          "classes": "govuk-input--width-2"
         },
         {
           "name": "month",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-2 govuk-input--error"
         },
         {
-          "name": "year"
+          "name": "year",
+          "classes": "govuk-input--width-4"
         }
       ]
     }) }}
@@ -386,33 +393,33 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
       <div class="govuk-date-input" id="dob-year-error">
 
-        <div class="govuk-date-input__item govuk-date-input__item--day">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-year-error-day">
               Day
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-year-error-day" name="dob-year-error-day" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--month">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-year-error-month">
               Month
             </label>
 
-            <input class="govuk-input govuk-date-input__input" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-year-error-month" name="dob-year-error-month" type="number" pattern="[0-9]*">
           </div>
         </div>
 
-        <div class="govuk-date-input__item govuk-date-input__item--year">
+        <div class="govuk-date-input__item">
           <div class="govuk-form-group">
             <label class="govuk-label govuk-date-input__label" for="dob-year-error-year">
               Year
             </label>
 
-            <input class="govuk-input govuk-date-input__input govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4 govuk-input--error" id="dob-year-error-year" name="dob-year-error-year" type="number" pattern="[0-9]*">
           </div>
         </div>
 
@@ -441,16 +448,89 @@ Find out when to use the date input component in your service in the [GOV.UK Des
       },
       "items": [
         {
-          "name": "day"
+          "name": "day",
+          "classes": "govuk-input--width-2"
         },
         {
-          "name": "month"
+          "name": "month",
+          "classes": "govuk-input--width-2"
         },
         {
           "name": "year",
-          "classes": "govuk-input--error"
+          "classes": "govuk-input--width-4 govuk-input--error"
         }
       ]
+    }) }}
+
+### Date input with default items
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/date-input/with-default-items/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+    <fieldset class="govuk-fieldset" aria-describedby="dob-hint" role="group">
+
+      <legend class="govuk-fieldset__legend">
+        What is your date of birth?
+      </legend>
+
+      <span id="dob-hint" class="govuk-hint">
+        For example, 31 3 1980
+      </span>
+
+      <div class="govuk-date-input" id="dob">
+
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-day">
+              Day
+            </label>
+
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-day" name="dob-day" type="number" pattern="[0-9]*">
+          </div>
+        </div>
+
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-month">
+              Month
+            </label>
+
+            <input class="govuk-input govuk-date-input__input govuk-input--width-2 govuk-input--width-2" id="dob-month" name="dob-month" type="number" pattern="[0-9]*">
+          </div>
+        </div>
+
+        <div class="govuk-date-input__item">
+          <div class="govuk-form-group">
+            <label class="govuk-label govuk-date-input__label" for="dob-year">
+              Year
+            </label>
+
+            <input class="govuk-input govuk-date-input__input govuk-input--width-4 govuk-input--width-4" id="dob-year" name="dob-year" type="number" pattern="[0-9]*">
+          </div>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "date-input/macro.njk" import govukDateInput %}
+
+    {{ govukDateInput({
+      "id": "dob",
+      "name": "dob",
+      "fieldset": {
+        "legend": {
+          "text": "What is your date of birth?"
+        }
+      },
+      "hint": {
+        "text": "For example, 31 3 1980"
+      }
     }) }}
 
 ## Requirements

--- a/src/components/date-input/_date-input.scss
+++ b/src/components/date-input/_date-input.scss
@@ -13,7 +13,6 @@
   }
 
   .govuk-date-input__item {
-    width: 50px;
     margin-right: govuk-spacing(4);
     margin-bottom: 0;
     float: left;
@@ -27,9 +26,5 @@
 
   .govuk-date-input__input {
     margin-bottom: 0;
-  }
-
-  .govuk-date-input__item--year {
-    width: 70px;
   }
 }

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -101,3 +101,12 @@ examples:
       -
         name: year
         classes: govuk-input--width-4 govuk-input--error
+- name: with default items
+  data:
+    id: dob
+    name: dob
+    fieldset:
+      legend:
+        text: What is your date of birth?
+    hint:
+      text: For example, 31 3 1980

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -11,10 +11,13 @@ examples:
     items:
       -
         name: day
+        classes: govuk-input--width-2
       -
         name: month
+        classes: govuk-input--width-2
       -
         name: year
+        classes: govuk-input--width-4
 - name: with errors
   data:
     id: dob-errors
@@ -28,13 +31,13 @@ examples:
     items:
       -
         name: day
-        classes: govuk-input--error
+        classes: govuk-input--width-2 govuk-input--error
       -
         name: month
-        classes: govuk-input--error
+        classes: govuk-input--width-2 govuk-input--error
       -
         name: year
-        classes: govuk-input--error
+        classes: govuk-input--width-4 govuk-input--error
 - name: with error on day input
   data:
     id: dob-day-error
@@ -49,11 +52,13 @@ examples:
     items:
       -
         name: day
-        classes: govuk-input--error
+        classes: govuk-input--width-2 govuk-input--error
       -
         name: month
+        classes: govuk-input--width-2
       -
         name: year
+        classes: govuk-input--width-4
 - name: with error on month input
   data:
     id: dob-month-error
@@ -68,11 +73,13 @@ examples:
     items:
       -
         name: day
+        classes: govuk-input--width-2
       -
         name: month
-        classes: govuk-input--error
+        classes: govuk-input--width-2 govuk-input--error
       -
         name: year
+        classes: govuk-input--width-4
 - name: with error on year input
   data:
     id: dob-year-error
@@ -87,8 +94,10 @@ examples:
     items:
       -
         name: day
+        classes: govuk-input--width-2
       -
         name: month
+        classes: govuk-input--width-2
       -
         name: year
-        classes: govuk-input--error
+        classes: govuk-input--width-4 govuk-input--error

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -7,6 +7,25 @@
    aria-describedby – for example hints or error messages -#}
 {% set describedBy = "" %}
 
+{% if params.items %}
+  {% set dateInputItems = params.items %}
+{% else %}
+  {% set dateInputItems = [
+    {
+      name: "day",
+      classes: "govuk-input--width-2"
+    },
+    {
+      name: "month",
+      classes: "govuk-input--width-2"
+    },
+    {
+      name: "year",
+      classes: "govuk-input--width-4"
+    }
+  ] %}
+{% endif %}
+
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -33,7 +52,7 @@
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
-    {% for item in params.items %}
+    {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
       {{ govukInput({
         label: {

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -10,8 +10,8 @@
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {% set hintId = params.id + "-hint" %}
+  {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
     classes: params.hint.classes,
@@ -21,8 +21,8 @@
   }) | indent(2) | trim }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {% set errorId = params.id + "-error" %}
+  {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
     classes: params.errorMessage.classes,
@@ -34,19 +34,19 @@
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in params.items %}
-    <div class="govuk-date-input__item govuk-date-input__item--{{ item.name }}">
+    <div class="govuk-date-input__item">
       {{ govukInput({
-        "label":{
-          "text": item.name | capitalize,
-          "classes": 'govuk-date-input__label'
+        label: {
+          text: item.label if item.label else item.name | capitalize,
+          classes: "govuk-date-input__label"
         },
-        "id": params.id + "-" + item.name,
-        "classes": "govuk-date-input__input" + (" " + item.classes if item.classes),
-        "name": params.name + "-" + item.name,
-        "value": item.value,
-        "type": "number",
-        "attributes": {
-          "pattern": "[0-9]*"
+        id: item.id if item.id else (params.id + "-" + item.name),
+        classes: "govuk-date-input__input " + item.classes,
+        name: (params.name + "-" + item.name) if params.name else item.name,
+        value: item.value,
+        type: "number",
+        attributes: {
+          pattern: "[0-9]*"
         }
       }) | indent(6) | trim }}
     </div>
@@ -64,7 +64,7 @@
     describedBy: describedBy,
     classes: params.fieldset.classes,
     attributes: {
-      role: 'group'
+      role: "group"
     },
     legend: params.fieldset.legend
   }) %}

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -53,6 +53,10 @@
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in dateInputItems %}
+
+    {# @todo Remove this definition and any mentions of it on the next breaking release #}
+    {% set inputWidthClass = 'govuk-input--width-4 ' if item.name == 'year' else 'govuk-input--width-2 ' %}
+
     <div class="govuk-date-input__item">
       {{ govukInput({
         label: {
@@ -60,7 +64,7 @@
           classes: "govuk-date-input__label"
         },
         id: item.id if item.id else (params.id + "-" + item.name),
-        classes: "govuk-date-input__input " + item.classes,
+        classes: "govuk-date-input__input " + inputWidthClass + item.classes,
         name: (params.name + "-" + item.name) if params.name else item.name,
         value: item.value,
         type: "number",

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -66,6 +66,16 @@ describe('Date input', () => {
       expect($items.length).toEqual(3)
     })
 
+    it('renders with default items', () => {
+      const $ = render('date-input', {})
+
+      const $items = $('.govuk-date-input__item')
+      const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
+
+      expect($items.length).toEqual(3)
+      expect($firstItemInput.attr('name')).toEqual('day')
+    })
+
     it('renders item with capitalised label text', () => {
       const $ = render('date-input', {
         items: [
@@ -149,6 +159,25 @@ describe('Date input', () => {
       expect($firstItems.hasClass('govuk-date-input__input')).toBeTruthy()
     })
 
+    it('renders items with name', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'date[dd]'
+          },
+          {
+            'name': 'date[mm]'
+          },
+          {
+            'name': 'date[yyy]'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('date[dd]')
+    })
+
     it('renders item with suffixed name for input', () => {
       const $ = render('date-input', {
         name: 'my-date-input',
@@ -167,6 +196,25 @@ describe('Date input', () => {
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('name')).toEqual('my-date-input-day')
+    })
+
+    it('renders items with id', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'id': 'day'
+          },
+          {
+            'id': 'month'
+          },
+          {
+            'id': 'year'
+          }
+        ]
+      })
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('id')).toEqual('day')
     })
 
     it('renders item with suffixed id for input', () => {

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -109,6 +109,142 @@ Find out when to use the input component in your service in the [GOV.UK Design S
       }
     }) }}
 
+### Input with width-2 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/input/with-width-2-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-width-2">
+        National insurance number
+      </label>
+
+      <span id="input-width-2-hint" class="govuk-hint">
+        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+      </span>
+
+      <input class="govuk-input govuk-input--width-2" id="input-width-2" name="test-width-2" type="text" aria-describedby="input-width-2-hint">
+    </div>
+
+#### Macro
+
+    {% from "input/macro.njk" import govukInput %}
+
+    {{ govukInput({
+      "label": {
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      },
+      "id": "input-width-2",
+      "name": "test-width-2",
+      "classes": "govuk-input--width-2"
+    }) }}
+
+### Input with width-3 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/input/with-width-3-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-width-3">
+        National insurance number
+      </label>
+
+      <span id="input-width-3-hint" class="govuk-hint">
+        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+      </span>
+
+      <input class="govuk-input govuk-input--width-3" id="input-width-3" name="test-width-3" type="text" aria-describedby="input-width-3-hint">
+    </div>
+
+#### Macro
+
+    {% from "input/macro.njk" import govukInput %}
+
+    {{ govukInput({
+      "label": {
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      },
+      "id": "input-width-3",
+      "name": "test-width-3",
+      "classes": "govuk-input--width-3"
+    }) }}
+
+### Input with width-4 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/input/with-width-4-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-width-4">
+        National insurance number
+      </label>
+
+      <span id="input-width-4-hint" class="govuk-hint">
+        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+      </span>
+
+      <input class="govuk-input govuk-input--width-4" id="input-width-4" name="test-width-4" type="text" aria-describedby="input-width-4-hint">
+    </div>
+
+#### Macro
+
+    {% from "input/macro.njk" import govukInput %}
+
+    {{ govukInput({
+      "label": {
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      },
+      "id": "input-width-4",
+      "name": "test-width-4",
+      "classes": "govuk-input--width-4"
+    }) }}
+
+### Input with width-5 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/input/with-width-5-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="input-width-5">
+        National insurance number
+      </label>
+
+      <span id="input-width-5-hint" class="govuk-hint">
+        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+      </span>
+
+      <input class="govuk-input govuk-input--width-5" id="input-width-5" name="test-width-5" type="text" aria-describedby="input-width-5-hint">
+    </div>
+
+#### Macro
+
+    {% from "input/macro.njk" import govukInput %}
+
+    {{ govukInput({
+      "label": {
+        "text": "National insurance number"
+      },
+      "hint": {
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+      },
+      "id": "input-width-5",
+      "name": "test-width-5",
+      "classes": "govuk-input--width-5"
+    }) }}
+
 ### Input with width-10 class
 
 [Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/input/with-width-10-class/preview)
@@ -124,7 +260,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-10" id="input-width-10" name="test-name-4" type="text" aria-describedby="input-width-10-hint">
+      <input class="govuk-input govuk-input--width-10" id="input-width-10" name="test-width-10" type="text" aria-describedby="input-width-10-hint">
     </div>
 
 #### Macro
@@ -139,7 +275,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-width-10",
-      "name": "test-name-4",
+      "name": "test-width-10",
       "classes": "govuk-input--width-10"
     }) }}
 
@@ -158,7 +294,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-20" id="input-width-20" name="test-name-5" type="text" aria-describedby="input-width-20-hint">
+      <input class="govuk-input govuk-input--width-20" id="input-width-20" name="test-width-20" type="text" aria-describedby="input-width-20-hint">
     </div>
 
 #### Macro
@@ -173,7 +309,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-width-20",
-      "name": "test-name-5",
+      "name": "test-width-20",
       "classes": "govuk-input--width-20"
     }) }}
 
@@ -192,7 +328,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
-      <input class="govuk-input govuk-input--width-30" id="input-width-30" name="test-name-6" type="text" aria-describedby="input-width-30-hint">
+      <input class="govuk-input govuk-input--width-30" id="input-width-30" name="test-width-30" type="text" aria-describedby="input-width-30-hint">
     </div>
 
 #### Macro
@@ -207,7 +343,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-width-30",
-      "name": "test-name-6",
+      "name": "test-width-30",
       "classes": "govuk-input--width-30"
     }) }}
 

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -42,17 +42,34 @@
 
   // The ex measurements are based on the number of W's that can fit inside the input
   // Extra space is left on the right hand side to allow for the Safari prefill icon
+  // Linear regression estimation based on visual tests: y = 1.76 + 1.81x
 
   .govuk-input--width-30 {
-    max-width: 60ex;
+    max-width: 56ex + 3ex;
   }
 
   .govuk-input--width-20 {
-    max-width: 41ex;
+    max-width: 38ex + 3ex;
   }
 
   .govuk-input--width-10 {
-    max-width: 23ex;
+    max-width: 20ex + 3ex;
+  }
+
+  .govuk-input--width-5 {
+    max-width: 10.8ex;
+  }
+
+  .govuk-input--width-4 {
+    max-width: 9ex;
+  }
+
+  .govuk-input--width-3 {
+    max-width: 7.2ex;
+  }
+
+  .govuk-input--width-2 {
+    max-width: 5.4ex;
   }
 
 }

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -23,6 +23,42 @@ examples:
       name: test-name-3
       errorMessage:
         text: Error message goes here
+  - name: with width-2 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-2
+      name: test-width-2
+      classes: govuk-input--width-2
+  - name: with width-3 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-3
+      name: test-width-3
+      classes: govuk-input--width-3
+  - name: with width-4 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-4
+      name: test-width-4
+      classes: govuk-input--width-4
+  - name: with width-5 class
+    data:
+      label:
+        text: National insurance number
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+      id: input-width-5
+      name: test-width-5
+      classes: govuk-input--width-5
   - name: with width-10 class
     data:
       label:
@@ -30,7 +66,7 @@ examples:
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-width-10
-      name: test-name-4
+      name: test-width-10
       classes: govuk-input--width-10
   - name: with width-20 class
     data:
@@ -39,7 +75,7 @@ examples:
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-width-20
-      name: test-name-5
+      name: test-width-20
       classes: govuk-input--width-20
   - name: with width-30 class
     data:
@@ -48,7 +84,7 @@ examples:
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-width-30
-      name: test-name-6
+      name: test-width-30
       classes: govuk-input--width-30
   - name: with label as page heading
     data:


### PR DESCRIPTION
This PR:

Extends the input width classes to cover 2 to 5 characters so it can be reused for the date-input component:
   - defines a relationship between the number of characters and maximum ex width of an input
   - keeps the extra space for safari pre-fill icon on large inputs (10, 20, 30)


Updates the date-input component to:
   - decouple item name from style (fixes #836)
   - decouple the component name from the item name and item id (covers the work proposed by @lhokktyn in #826)
   - set the item width at input level in order to avoid label overlapping (see screenshot below)


Adds default date-input items if no items are being specified (fixes #468)

<img width="512" alt="input-width" src="https://user-images.githubusercontent.com/788096/42163211-93177bc8-7df9-11e8-89ea-4720943630b5.png">
<img width="513" alt="date-input-examples" src="https://user-images.githubusercontent.com/788096/42163212-9330fa9e-7df9-11e8-82dc-f3114aac5142.png">

### When users increase the font-size on labels
Before
<img width="213" alt="screen shot 2018-07-04 at 12 14 55" src="https://user-images.githubusercontent.com/788096/42274362-48c5defc-7f84-11e8-9957-ef9b911509b1.png">

After
<img width="261" alt="screen shot 2018-07-04 at 12 15 17" src="https://user-images.githubusercontent.com/788096/42274366-4bddbfba-7f84-11e8-88b5-14a004694a45.png">
