### PR TITLE
Add govuk-visually-hidden-focusable class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 🆕 New features:
 
+- Add `govuk-visually-hidden-focusable` class
+
+  Adds `.govuk-visually-hidden-focusable` and deprecates `.govuk-visually-hidden-focussable` in order to fix the typo in the class name. Please consider updating your code as the next major release will remove the deprecated class.
+
+  ([PR #859](https://github.com/alphagov/govuk-frontend/pull/859))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/utilities/_visually-hidden.scss
+++ b/src/utilities/_visually-hidden.scss
@@ -3,7 +3,13 @@
     @include govuk-visually-hidden;
   }
 
+  /// @deprecated Deprecated as of release 1.1, replaced by `.govuk-visually-hidden-focusable`
   .govuk-visually-hidden-focussable {
     @include govuk-visually-hidden-focusable;
   }
+
+  .govuk-visually-hidden-focusable {
+    @include govuk-visually-hidden-focusable;
+  }
+
 }


### PR DESCRIPTION
This PR introduces a new class `.govuk-visually-hidden-focusable` and deprecates `.govuk-visually-hidden-focussable`

[<img width="965" alt="screen shot 2018-07-04 at 11 01 13" src="https://user-images.githubusercontent.com/788096/42270789-9c5d6748-7f79-11e8-9b0c-32bb9e8d1113.png">](https://govuk-frontend-review-pr-859.herokuapp.com/docs/#undefined-css-.govuk-visually-hidden-focussable)

