### PR TITLE
Update examples

### DIFF
--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -213,9 +213,9 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
       ]
     }) }}
 
-### Checkboxes with html in legend
+### Checkboxes with legend as a page heading
 
-[Preview the Checkboxes with html in legend example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-html-in-legend/preview)
+[Preview the Checkboxes with legend as a page heading example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-legend-as-a-page-heading/preview)
 
 #### Markup
 
@@ -223,8 +223,10 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
 
       <fieldset class="govuk-fieldset" aria-describedby="waste-hint">
 
-      <legend class="govuk-fieldset__legend">
-        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          Which types of waste do you transport regularly?
+        </h1>
       </legend>
 
       <span id="waste-hint" class="govuk-hint">
@@ -267,11 +269,97 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
       "name": "waste",
       "fieldset": {
         "legend": {
-          "html": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+          "text": "Which types of waste do you transport regularly?",
+          "classes": "govuk-fieldset__legend--l",
+          "isPageHeading": true
         }
       },
       "hint": {
         "text": "Select all that apply"
+      },
+      "items": [
+        {
+          "value": "animal",
+          "text": "Waste from animal carcasses"
+        },
+        {
+          "value": "mines",
+          "text": "Waste from mines or quarries"
+        },
+        {
+          "value": "farm",
+          "text": "Farm or agricultural waste"
+        }
+      ]
+    }) }}
+
+### Checkboxes with a medium legend
+
+[Preview the Checkboxes with a medium legend example](http://govuk-frontend-review.herokuapp.com/components/checkboxes/with-a-medium-legend/preview)
+
+#### Markup
+
+    <div class="govuk-form-group govuk-form-group--error">
+
+      <fieldset class="govuk-fieldset" aria-describedby="waste-hint waste-error">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Which types of waste do you transport regularly?
+      </legend>
+
+      <span id="waste-hint" class="govuk-hint">
+        Select all that apply
+      </span>
+
+      <span id="waste-error" class="govuk-error-message">
+        Select which types of waste you transport regularly
+      </span>
+
+      <div class="govuk-checkboxes">
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-1" name="waste" type="checkbox" value="animal">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-1">
+            Waste from animal carcasses
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-2" name="waste" type="checkbox" value="mines">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-2">
+            Waste from mines or quarries
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="waste-3" name="waste" type="checkbox" value="farm">
+          <label class="govuk-label govuk-checkboxes__label" for="waste-3">
+            Farm or agricultural waste
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "checkboxes/macro.njk" import govukCheckboxes %}
+
+    {{ govukCheckboxes({
+      "name": "waste",
+      "fieldset": {
+        "legend": {
+          "text": "Which types of waste do you transport regularly?",
+          "classes": "govuk-fieldset__legend--m"
+        }
+      },
+      "hint": {
+        "text": "Select all that apply"
+      },
+      "errorMessage": {
+        "text": "Select which types of waste you transport regularly"
       },
       "items": [
         {
@@ -446,7 +534,7 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
       <fieldset class="govuk-fieldset" aria-describedby="waste-error">
 
       <legend class="govuk-fieldset__legend">
-        <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+        Which types of waste do you transport regularly?
       </legend>
 
       <span id="waste-error" class="govuk-error-message">
@@ -492,7 +580,7 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
       },
       "fieldset": {
         "legend": {
-          "html": "<h3 class=\"govuk-heading-m\">Which types of waste do you transport regularly?</h3>"
+          "text": "Which types of waste do you transport regularly?"
         }
       },
       "items": [

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -55,14 +55,35 @@ examples:
         text: Blue
         disabled: true
 
-- name: with html in legend
+- name: with legend as a page heading
   data:
     name: waste
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+        text: Which types of waste do you transport regularly?
+        classes: govuk-fieldset__legend--l
+        isPageHeading: true
     hint:
       text: Select all that apply
+    items:
+      - value: animal
+        text: Waste from animal carcasses
+      - value: mines
+        text: Waste from mines or quarries
+      - value: farm
+        text: Farm or agricultural waste
+
+- name: with a medium legend
+  data:
+    name: waste
+    fieldset:
+      legend:
+        text: Which types of waste do you transport regularly?
+        classes: govuk-fieldset__legend--m
+    hint:
+      text: Select all that apply
+    errorMessage:
+      text: Select which types of waste you transport regularly
     items:
       - value: animal
         text: Waste from animal carcasses
@@ -112,7 +133,7 @@ examples:
       text: Please select an option
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">Which types of waste do you transport regularly?</h3>
+        text: Which types of waste do you transport regularly?
     items:
       - value: animal
         text: Waste from animal carcasses
@@ -121,13 +142,52 @@ examples:
       - value: farm
         text: Farm or agricultural waste
 
+- name: with very long option text
+  readme: false
+  data:
+    name: waste
+    hint:
+      text:
+        Nullam id dolor id nibh ultricies vehicula ut id elit.
+    errorMessage:
+      text:
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    fieldset:
+      legend:
+        text:
+          Maecenas faucibus mollis interdum?
+    items:
+      - value: nullam
+        text:
+          Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
+          quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+          Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
+          at eget metus.
+      - value: aenean
+        text:
+          Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
+          nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
+          natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+          mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Cras mattis consectetur purus sit amet
+          fermentum.
+      - value: fusce
+        text:
+          Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
+          nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
+          malesuada magna mollis euismod. Praesent commodo cursus magna, vel
+          scelerisque nisl consectetur et. Etiam porta sem malesuada magna
+          mollis euismod. Etiam porta sem malesuada magna mollis euismod.
+          Donec sed odio dui. Sed posuere consectetur est at lobortis.
+
 - name: with conditional items
   readme: false
   data:
     idPrefix: how-contacted
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+        text: How do you want to be contacted?
     items:
       - value: email
         text: Email
@@ -154,7 +214,7 @@ examples:
     idPrefix: how-contacted-checked
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+        text: How do you want to be contacted?
     items:
     - value: email
       text: Email

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -58,7 +58,7 @@ Find out when to use the error summary component in your service in the [GOV.UK 
           "href": "#example-error-1"
         },
         {
-          "html": "Descriptive link to the question with an error",
+          "text": "Descriptive link to the question with an error",
           "href": "#example-error-1"
         }
       ]

--- a/src/components/error-summary/error-summary.yaml
+++ b/src/components/error-summary/error-summary.yaml
@@ -12,5 +12,5 @@ examples:
         text: Descriptive link to the question with an error
         href: '#example-error-1'
       -
-        html: Descriptive link to the question with an error
+        text: Descriptive link to the question with an error
         href: '#example-error-1'

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -81,7 +81,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
       </label>
 
       <span id="input-with-error-message-hint" class="govuk-hint">
-        It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
+        It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’.
       </span>
 
       <span id="input-with-error-message-error" class="govuk-error-message">
@@ -100,7 +100,7 @@ Find out when to use the input component in your service in the [GOV.UK Design S
         "text": "National Insurance number"
       },
       "hint": {
-        "html": "It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
+        "text": "It’s on your National Insurance card, benefit letter, payslip or P60\. For example, ‘QQ 12 34 56 C’."
       },
       "id": "input-with-error-message",
       "name": "test-name-3",

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -18,7 +18,7 @@ examples:
       label:
         text: National Insurance number
       hint:
-        html: It’s on your <i>National Insurance card</i>, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
       id: input-with-error-message
       name: test-name-3
       errorMessage:

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -213,9 +213,9 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
       ]
     }) }}
 
-### Radios with html
+### Radios with legend as page heading
 
-[Preview the Radios with html example](http://govuk-frontend-review.herokuapp.com/components/radios/with-html/preview)
+[Preview the Radios with legend as page heading example](http://govuk-frontend-review.herokuapp.com/components/radios/with-legend-as-page-heading/preview)
 
 #### Markup
 
@@ -223,8 +223,10 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
 
       <fieldset class="govuk-fieldset" aria-describedby="housing-act-hint">
 
-      <legend class="govuk-fieldset__legend">
-        <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+          Which part of the Housing Act was your licence issued under?
+        </h1>
       </legend>
 
       <span id="housing-act-hint" class="govuk-hint">
@@ -261,7 +263,76 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
       "name": "housing-act",
       "fieldset": {
         "legend": {
-          "html": "<h1 class=\"govuk-heading-l\">Which part of the Housing Act was your licence issued under?</h1>"
+          "text": "Which part of the Housing Act was your licence issued under?",
+          "classes": "govuk-fieldset__legend--l",
+          "isPageHeading": true
+        }
+      },
+      "hint": {
+        "text": "Select one of the options below."
+      },
+      "items": [
+        {
+          "value": "part-2",
+          "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people"
+        },
+        {
+          "value": "part-3",
+          "html": "<span class=\"govuk-heading-s govuk-!-margin-bottom-1\">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council"
+        }
+      ]
+    }) }}
+
+### Radios with a medium legend
+
+[Preview the Radios with a medium legend example](http://govuk-frontend-review.herokuapp.com/components/radios/with-a-medium-legend/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+
+      <fieldset class="govuk-fieldset" aria-describedby="housing-act-hint">
+
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+        Which part of the Housing Act was your licence issued under?
+      </legend>
+
+      <span id="housing-act-hint" class="govuk-hint">
+        Select one of the options below.
+      </span>
+
+      <div class="govuk-radios">
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="housing-act-1" name="housing-act" type="radio" value="part-2">
+          <label class="govuk-label govuk-radios__label" for="housing-act-1">
+            <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 2 of the Housing Act 2004</span> For properties that are 3 or more stories high and occupied by 5 or more people
+          </label>
+        </div>
+
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="housing-act-2" name="housing-act" type="radio" value="part-3">
+          <label class="govuk-label govuk-radios__label" for="housing-act-2">
+            <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span> For properties that are within a geographical area defined by a local council
+          </label>
+        </div>
+
+      </div>
+      </fieldset>
+
+    </div>
+
+#### Macro
+
+    {% from "radios/macro.njk" import govukRadios %}
+
+    {{ govukRadios({
+      "idPrefix": "housing-act",
+      "name": "housing-act",
+      "fieldset": {
+        "legend": {
+          "text": "Which part of the Housing Act was your licence issued under?",
+          "classes": "govuk-fieldset__legend--m"
         }
       },
       "hint": {

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -59,13 +59,35 @@ examples:
         text: No
         disabled: true
 
-- name: with html
+- name: with legend as page heading
   data:
     idPrefix: housing-act
     name: housing-act
     fieldset:
       legend:
-        html: <h1 class="govuk-heading-l">Which part of the Housing Act was your licence issued under?</h1>
+        text: Which part of the Housing Act was your licence issued under?
+        classes: govuk-fieldset__legend--l
+        isPageHeading: true
+    hint:
+      text: Select one of the options below.
+    items:
+      - value: part-2
+        html:
+          <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 2 of the Housing Act 2004</span>
+          For properties that are 3 or more stories high and occupied by 5 or more people
+      - value: part-3
+        html:
+          <span class="govuk-heading-s govuk-!-margin-bottom-1">Part 3 of the Housing Act 2004</span>
+          For properties that are within a geographical area defined by a local council
+
+- name: with a medium legend
+  data:
+    idPrefix: housing-act
+    name: housing-act
+    fieldset:
+      legend:
+        text: Which part of the Housing Act was your licence issued under?
+        classes: govuk-fieldset__legend--m
     hint:
       text: Select one of the options below.
     items:
@@ -111,6 +133,45 @@ examples:
         text: No
         checked: true
 
+- name: with very long option text
+  readme: false
+  data:
+    name: waste
+    hint:
+      text:
+        Nullam id dolor id nibh ultricies vehicula ut id elit.
+    errorMessage:
+      text:
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+    fieldset:
+      legend:
+        text:
+          Maecenas faucibus mollis interdum?
+    items:
+      - value: nullam
+        text:
+          Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
+          quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+          Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
+          at eget metus.
+      - value: aenean
+        text:
+          Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
+          nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
+          natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+          mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Cras mattis consectetur purus sit amet
+          fermentum.
+      - value: fusce
+        text:
+          Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
+          nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
+          malesuada magna mollis euismod. Praesent commodo cursus magna, vel
+          scelerisque nisl consectetur et. Etiam porta sem malesuada magna
+          mollis euismod. Etiam porta sem malesuada magna mollis euismod.
+          Donec sed odio dui. Sed posuere consectetur est at lobortis.
+
 - name: with conditional items
   readme: false
   data:
@@ -118,7 +179,7 @@ examples:
     name: how-contacted
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+        text: How do you want to be contacted?
     items:
       - value: email
         text: Email
@@ -146,7 +207,7 @@ examples:
     name: 'how-contacted-checked'
     fieldset:
       legend:
-        html: <h3 class="govuk-heading-m">How do you want to be contacted?</h3>
+        text: How do you want to be contacted?
     items:
     - value: email
       text: Email

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -40,7 +40,7 @@ Find out when to use the select component in your service in the [GOV.UK Design 
       "id": "select-1",
       "name": "select-1",
       "label": {
-        "html": "Label text goes here"
+        "text": "Label text goes here"
       },
       "items": [
         {
@@ -155,7 +155,7 @@ Find out when to use the select component in your service in the [GOV.UK Design 
       "id": "select-3",
       "name": "select-3",
       "label": {
-        "html": "Label text goes here",
+        "text": "Label text goes here",
         "isPageHeading": true
       },
       "items": [

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -4,7 +4,7 @@ examples:
     id: select-1
     name: select-1
     label:
-      html: Label text goes here
+      text: Label text goes here
     items:
       -
         value: 1
@@ -42,7 +42,7 @@ examples:
     id: select-3
     name: select-3
     label:
-      html: Label text goes here
+      text: Label text goes here
       isPageHeading: true
     items:
       -


### PR DESCRIPTION
- Avoid styling legends and labels as headings as that’s not how we’d like users to do it.
- Avoid using the html attribute where possible.
- Add some examples of radios and checkboxes with really long text for the options as a stress case.