### PR TITLE
Fix phase banner being affected by global styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@
   they will still see a circle even if the background is removed.
   ([PR #852](https://github.com/alphagov/govuk-frontend/pull/852))
 
+- Fixes a bug where the phase banner incorrectly uses a font-size of 19px when
+  global styles are enabled
+  ([PR #877}])https://github.com/alphagov/govuk-frontend/pull/877
+
 🏠 Internal:
 
 - Fix Design System url in package READMEs and review app

--- a/src/components/phase-banner/_phase-banner.scss
+++ b/src/components/phase-banner/_phase-banner.scss
@@ -6,9 +6,6 @@
 
 @include govuk-exports("govuk/component/phase-banner") {
   .govuk-phase-banner {
-    @include govuk-font($size: 16);
-    @include govuk-text-colour;
-
     padding-top: govuk-spacing(2);
     padding-bottom: govuk-spacing(2);
 
@@ -16,6 +13,9 @@
   }
 
   .govuk-phase-banner__content {
+    @include govuk-font($size: 16);
+    @include govuk-text-colour;
+
     display: table;
     margin: 0;
   }


### PR DESCRIPTION
When global styles are enabled, the phase banner uses the wrong font size.

This is because the font-size of 16px is currently set on the parent `.govuk-phase-banner`, but `p.govuk-phase-banner__content` doesn't have a `font-size` set, so inherits the font size from the global paragraph styling.

Moving the font-size declaration onto `.phase-banner__content` fixes this.

Fixes #876 