### PR TITLE
Remove bottom margin on checkbox and radio labels 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@
 
 🔧 Fixes:
 
+- Remove mistakenly applied 5px bottom margin from radio and checkbox
+  labels.
+  ([PR #883](https://github.com/alphagov/govuk-frontend/pull/883))
+
 - Apply `display:block` to `.govuk-main-wrapper`
 
   In IE11 `main` element is set to `display:inline` so padding

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -58,6 +58,7 @@
 
   .govuk-checkboxes__label {
     display: inline-block;
+    margin-bottom: 0;
     padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -62,6 +62,7 @@
 
   .govuk-radios__label {
     display: inline-block;
+    margin-bottom: 0;
     padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile


### PR DESCRIPTION
With the labels, legends and headings work margin-bottom: 5px was added to `govuk-label`.
This was intended for labels above text inputs but has been applied to checkbox and radios  labels too.

So `govuk-checkboxes__label` and `govuk-radios__label` need to have `margin-bottom: 0;` applied to override this.

https://trello.com/c/aplfBBBF/1197-checkbox-and-radio-labels-should-not-have-a-bottom-margin

Fixes: #881 