### PR TITLE
Fix flash of unstyled content with conditional reveals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@
   Because this class is defined and used within the JavaScript, no markup changes are required.
   ([PR #916](https://github.com/alphagov/govuk-frontend/pull/916))
 
+- Fix flash of unstyled content with conditional reveals (Radios and Checkboxes)
+
+  If the conditional reveal JavaScript is slow to execute it can result in showing the user their contents briefly which can be jarring.
+
+  ([PR #885](https://github.com/alphagov/govuk-frontend/pull/885))
 
 ## 1.1.1 (fix release)
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -140,7 +140,7 @@
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;
 
-    &[aria-hidden="true"] {
+    .js-enabled &--hidden {
       display: none;
     }
 

--- a/src/components/checkboxes/checkboxes.js
+++ b/src/components/checkboxes/checkboxes.js
@@ -40,7 +40,7 @@ Checkboxes.prototype.setAttributes = function ($input) {
   $input.setAttribute('aria-expanded', inputIsChecked)
 
   var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
-  $content.setAttribute('aria-hidden', !inputIsChecked)
+  $content.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
 }
 
 Checkboxes.prototype.handleClick = function (event) {

--- a/src/components/checkboxes/checkboxes.js
+++ b/src/components/checkboxes/checkboxes.js
@@ -1,5 +1,6 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
+import '../../vendor/polyfills/Element/prototype/classList'
 import { nodeListForEach } from '../../common'
 
 function Checkboxes ($module) {

--- a/src/components/checkboxes/checkboxes.test.js
+++ b/src/components/checkboxes/checkboxes.test.js
@@ -51,11 +51,9 @@ describe('Checkboxes with conditional reveals', () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-items')
       const $component = $('.govuk-checkboxes')
 
-      const hasAriaHidden = $component.find('.govuk-checkboxes__conditional[aria-hidden]').length
       const hasAriaExpanded = $component.find('.govuk-checkboxes__input[aria-expanded]').length
       const hasAriaControls = $component.find('.govuk-checkboxes__input[aria-controls]').length
 
-      expect(hasAriaHidden).toBeFalsy()
       expect(hasAriaExpanded).toBeFalsy()
       expect(hasAriaControls).toBeFalsy()
     })
@@ -75,7 +73,7 @@ describe('Checkboxes with conditional reveals', () => {
       const $checkedInput = $component.find('.govuk-checkboxes__input:checked')
       const inputAriaControls = $checkedInput.attr('aria-controls')
 
-      const isContentVisible = await waitForVisibleSelector(`[aria-hidden=false][id="${inputAriaControls}"]`)
+      const isContentVisible = await waitForVisibleSelector(`[id="${inputAriaControls}"]:not(.govuk-checkboxes__conditional--hidden)`)
       expect(isContentVisible).toBeTruthy()
     })
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
@@ -84,7 +82,7 @@ describe('Checkboxes with conditional reveals', () => {
       const $firstInput = $component.find('.govuk-checkboxes__item:first-child .govuk-checkboxes__input')
       const firstInputAriaControls = $firstInput.attr('aria-controls')
 
-      const isContentHidden = await waitForHiddenSelector(`[aria-hidden=true][id="${firstInputAriaControls}"]`)
+      const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"].govuk-checkboxes__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
     it('indicates when conditional content is collapsed or revealed', async () => {

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -62,7 +62,7 @@
       }) | indent(6) | trim }}
     </div>
     {% if item.conditional %}
-      <div class="govuk-checkboxes__conditional" id="{{ conditionalId }}">
+      <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
         {{ item.conditional.html | safe }}
       </div>
     {% endif %}

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -255,31 +255,82 @@ describe('Checkboxes', () => {
     })
   })
 
-  it('render conditional', () => {
-    const $ = render('checkboxes', {
-      name: 'example-conditional',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No',
-          checked: true,
-          conditional: {
-            html: 'Conditional content'
+  describe('render conditionals', () => {
+    it('hidden by default when not checked', () => {
+      const $ = render('checkboxes', {
+        name: 'example-conditional',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes',
+            conditional: {
+              html: 'Conditional content that should be hidden'
+            }
+          },
+          {
+            value: 'no',
+            text: 'No'
           }
-        }
-      ]
-    })
+        ]
+      })
 
-    const $component = $('.govuk-checkboxes')
-    const $lastInput = $component.find('.govuk-checkboxes__input').last()
-    expect($lastInput.attr('data-aria-controls')).toBe('conditional-example-conditional-2')
-    const $lastConditional = $component.find('.govuk-checkboxes__conditional').last()
-    expect($lastConditional.attr('id')).toBe('conditional-example-conditional-2')
-    expect($lastConditional.html()).toContain('Conditional content')
+      const $component = $('.govuk-checkboxes')
+
+      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      expect($firstConditional.html()).toContain('Conditional content that should be hidden')
+      expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeTruthy()
+    })
+    it('visible by default when checked', () => {
+      const $ = render('checkboxes', {
+        name: 'example-conditional',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes',
+            checked: true,
+            conditional: {
+              html: 'Conditional content that should be visible'
+            }
+          },
+          {
+            value: 'no',
+            text: 'No'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      expect($firstConditional.html()).toContain('Conditional content that should be visible')
+      expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeFalsy()
+    })
+    it('with association to the input they are controlled by', () => {
+      const $ = render('checkboxes', {
+        name: 'example-conditional',
+        items: [
+          {
+            value: 'yes',
+            text: 'Yes',
+            conditional: {
+              html: 'Conditional content that should be hidden'
+            }
+          },
+          {
+            value: 'no',
+            text: 'No'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstInput = $component.find('.govuk-checkboxes__input').first()
+      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+
+      expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional-1')
+      expect($firstConditional.attr('id')).toBe('conditional-example-conditional-1')
+    })
   })
 
   describe('when they include an error message', () => {

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -153,7 +153,7 @@
     padding-left: $conditional-padding-left;
     border-left: $conditional-border-width solid $govuk-border-colour;
 
-    &[aria-hidden="true"] {
+    .js-enabled &--hidden {
       display: none;
     }
 

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -40,7 +40,7 @@ Radios.prototype.setAttributes = function ($input) {
   $input.setAttribute('aria-expanded', inputIsChecked)
 
   var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
-  $content.setAttribute('aria-hidden', !inputIsChecked)
+  $content.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
 }
 
 Radios.prototype.handleClick = function (event) {

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -1,5 +1,6 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
+import '../../vendor/polyfills/Element/prototype/classList'
 import { nodeListForEach } from '../../common'
 
 function Radios ($module) {

--- a/src/components/radios/radios.test.js
+++ b/src/components/radios/radios.test.js
@@ -51,11 +51,9 @@ describe('Radios with conditional reveals', () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-items')
       const $component = $('.govuk-radios')
 
-      const hasAriaHidden = $component.find('.govuk-radios__conditional[aria-hidden]').length
       const hasAriaExpanded = $component.find('.govuk-radios__input[aria-expanded]').length
       const hasAriaControls = $component.find('.govuk-radios__input[aria-controls]').length
 
-      expect(hasAriaHidden).toBeFalsy()
       expect(hasAriaExpanded).toBeFalsy()
       expect(hasAriaControls).toBeFalsy()
     })
@@ -75,7 +73,7 @@ describe('Radios with conditional reveals', () => {
       const $checkedInput = $component.find('.govuk-radios__input:checked')
       const inputAriaControls = $checkedInput.attr('aria-controls')
 
-      const isContentVisible = await waitForVisibleSelector(`[id="${inputAriaControls}"]`)
+      const isContentVisible = await waitForVisibleSelector(`[id="${inputAriaControls}"]:not(.govuk-radios__conditional--hidden)`)
       expect(isContentVisible).toBeTruthy()
     })
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
@@ -84,7 +82,7 @@ describe('Radios with conditional reveals', () => {
       const $firstInput = $component.find('.govuk-radios__item:first-child .govuk-radios__input')
       const firstInputAriaControls = $firstInput.attr('aria-controls')
 
-      const isContentHidden = await waitForHiddenSelector(`[aria-hidden=true][id="${firstInputAriaControls}"]`)
+      const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"].govuk-radios__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
     it('indicates when conditional content is collapsed or revealed', async () => {

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -61,7 +61,7 @@
       }) | indent(6) | trim }}
     </div>
     {% if item.conditional %}
-      <div class="govuk-radios__conditional" id="{{ conditionalId }}">
+      <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
         {{ item.conditional.html | safe }}
       </div>
     {% endif %}

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -198,31 +198,82 @@ describe('Radios', () => {
       expect($lastInput.attr('checked')).toEqual('checked')
     })
 
-    it('render conditional', () => {
-      const $ = render('radios', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No',
-            checked: true,
-            conditional: {
-              html: 'Conditional content'
+    describe('render conditionals', () => {
+      it('hidden by default when not checked', () => {
+        const $ = render('radios', {
+          name: 'example-conditional',
+          items: [
+            {
+              value: 'yes',
+              text: 'Yes',
+              conditional: {
+                html: 'Conditional content that should be hidden'
+              }
+            },
+            {
+              value: 'no',
+              text: 'No'
             }
-          }
-        ]
-      })
+          ]
+        })
 
-      const $component = $('.govuk-radios')
-      const $lastInput = $component.find('.govuk-radios__input').last()
-      expect($lastInput.attr('data-aria-controls')).toBe('conditional-example-conditional-2')
-      const $lastConditional = $component.find('.govuk-radios__conditional').last()
-      expect($lastConditional.attr('id')).toBe('conditional-example-conditional-2')
-      expect($lastConditional.html()).toContain('Conditional content')
+        const $component = $('.govuk-radios')
+
+        const $firstConditional = $component.find('.govuk-radios__conditional').first()
+        expect($firstConditional.html()).toContain('Conditional content that should be hidden')
+        expect($firstConditional.hasClass('govuk-radios__conditional--hidden')).toBeTruthy()
+      })
+      it('visible by default when checked', () => {
+        const $ = render('radios', {
+          name: 'example-conditional',
+          items: [
+            {
+              value: 'yes',
+              text: 'Yes',
+              checked: true,
+              conditional: {
+                html: 'Conditional content that should be visible'
+              }
+            },
+            {
+              value: 'no',
+              text: 'No'
+            }
+          ]
+        })
+
+        const $component = $('.govuk-radios')
+
+        const $firstConditional = $component.find('.govuk-radios__conditional').first()
+        expect($firstConditional.html()).toContain('Conditional content that should be visible')
+        expect($firstConditional.hasClass('govuk-radios__conditional--hidden')).toBeFalsy()
+      })
+      it('with association to the input they are controlled by', () => {
+        const $ = render('radios', {
+          name: 'example-conditional',
+          items: [
+            {
+              value: 'yes',
+              text: 'Yes',
+              conditional: {
+                html: 'Conditional content that should be hidden'
+              }
+            },
+            {
+              value: 'no',
+              text: 'No'
+            }
+          ]
+        })
+
+        const $component = $('.govuk-radios')
+
+        const $firstInput = $component.find('.govuk-radios__input').first()
+        const $firstConditional = $component.find('.govuk-radios__conditional').first()
+
+        expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional-1')
+        expect($firstConditional.attr('id')).toBe('conditional-example-conditional-1')
+      })
     })
   })
 


### PR DESCRIPTION
If the conditional reveal JavaScript is slow to execute it can result in showing the user their contents briefly which can be jarring.

See the original issue for an example: https://github.com/alphagov/govuk-frontend/issues/787

Fixes https://github.com/alphagov/govuk-frontend/issues/787

Tested in:
- IE 8 ✅
- IE 9 ✅
- IE 10 ✅
- IE 11 ✅
- Edge 17 ✅
- Firefox 61 ✅
- Chrome 67 ✅
- Safari 11.1 ✅

Assistive technologies:
I've tested this in VoiceOver and since `display: none` has the same behaviour as `aria-hidden=true` (styled with `display: none`), I've decided not to do a full test of assistive technologies.

Pages to review:
- https://govuk-frontend-review-pr-885.herokuapp.com/components/radios/with-conditional-item-checked/preview
- https://govuk-frontend-review-pr-885.herokuapp.com/components/checkboxes/with-conditional-item-checked/preview

https://trello.com/c/o9krC0SR/1195-conditional-reveals-result-in-a-flash-of-unstyled-content-as-the-page-loads
