### PR TITLE
Update tabs spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@
 🔧 Fixes:
 
 - Update details behaviour to remove margin-bottom for all elements
-
   ([PR #900](https://github.com/alphagov/govuk-frontend/pull/900))
+
+- Update internal padding of tab content in the tabs component
+  ([PR #886](https://github.com/alphagov/govuk-frontend/pull/886))
 
 ## 1.1.0 (feature release)
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -115,6 +115,10 @@
         padding-left: govuk-spacing(4);
         border: 1px solid $govuk-border-colour;
         border-top: 0;
+
+        & > :last-child {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -21,7 +21,7 @@
     padding: 0;
     list-style: none;
     @include mq($until: tablet) {
-      @include govuk-responsive-margin(2, "bottom");
+      @include govuk-responsive-margin(6, "bottom");
     }
   }
 
@@ -48,6 +48,10 @@
       color: govuk-colour("black");
       text-decoration: none;
     }
+  }
+
+  .govuk-tabs__panel {
+    @include govuk-responsive-margin(8, "bottom");
   }
 
   // JavaScript enabled
@@ -104,9 +108,10 @@
       }
 
       .govuk-tabs__panel {
+        @include govuk-responsive-margin(0, "bottom");
         padding-top: govuk-spacing(6);
         padding-right: govuk-spacing(4);
-        padding-bottom: govuk-spacing(2);
+        padding-bottom: govuk-spacing(6);
         padding-left: govuk-spacing(4);
         border: 1px solid $govuk-border-colour;
         border-top: 0;


### PR DESCRIPTION
Updates internal padding of tab content in the Tabs component (backlog https://github.com/alphagov/govuk-design-system-backlog/issues/100)

**Before** 
<img width="993" alt="screen shot 2018-07-12 at 09 57 58" src="https://user-images.githubusercontent.com/23356842/42623222-3a29ab94-85ba-11e8-8924-59b91c8a1d6e.png">

**After**
<img width="1014" alt="screen shot 2018-07-12 at 14 24 56" src="https://user-images.githubusercontent.com/23356842/42635952-662f818a-85df-11e8-8434-e883565c0333.png">

This required margin to be defined on the tab container at mobile breakpoint to separate content.
I also increased the space below the contents menu.

<img width="424" alt="screen shot 2018-07-12 at 09 54 06" src="https://user-images.githubusercontent.com/23356842/42623274-5b4cee12-85ba-11e8-99be-12e8d38db6de.png">

Have also used the `:last-child` solution from conditional radios and checkboxes to remove the margin-bottom of the last item that is inside the container to avoid double margin.