### PR TITLE
Update docs to add missing value property for items in date-input

### DIFF
--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -619,7 +619,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated.</td>
+<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated id.</td>
 
 </tr>
 
@@ -632,6 +632,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">Yes</td>
 
 <td class="govuk-table__cell ">Optional item-specific name attribute. If provided, it will be used instead of the generated name.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.value</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional item-specific value attribute. If provided, it will be used as the initial value of the input.</td>
 
 </tr>
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -631,7 +631,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">Yes</td>
 
-<td class="govuk-table__cell ">Optional item-specific name attribute. If provided, it will be used instead of the generated name.</td>
+<td class="govuk-table__cell ">Item-specific name attribute.</td>
 
 </tr>
 

--- a/src/components/date-input/README.njk
+++ b/src/components/date-input/README.njk
@@ -83,7 +83,7 @@
         text: 'No'
       },
       {
-        text: 'Optional item-specific id. If provided, it will be used instead of the generated.'
+        text: 'Optional item-specific id. If provided, it will be used instead of the generated id.'
       }
     ],
     [
@@ -98,6 +98,20 @@
       },
       {
         text: 'Optional item-specific name attribute. If provided, it will be used instead of the generated name.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.value'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional item-specific value attribute. If provided, it will be used as the initial value of the input.'
       }
     ],
     [

--- a/src/components/date-input/README.njk
+++ b/src/components/date-input/README.njk
@@ -97,7 +97,7 @@
         text: 'Yes'
       },
       {
-        text: 'Optional item-specific name attribute. If provided, it will be used instead of the generated name.'
+        text: 'Item-specific name attribute.'
       }
     ],
     [


### PR DESCRIPTION
When specifying the items for the date input the docs only mentioned name and id
This adds the missing value property that you can also enter