### PR TITLE
Update details behaviour to remove margin-bottom for all elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,9 @@
 
 🔧 Fixes:
 
-- Pull Request Title goes here
+- Update details behaviour to remove margin-bottom for all elements
 
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR #900](https://github.com/alphagov/govuk-frontend/pull/900))
 
 ## 1.1.0 (feature release)
 

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -80,7 +80,7 @@
     margin-bottom: govuk-spacing(4);
   }
 
-  .govuk-details__text p:last-child {
+  .govuk-details__text > :last-child {
     margin-bottom: 0;
   }
 }


### PR DESCRIPTION
If we have a form-group it will not be caught by the logic that only targets paragraphs.

This is consistent with the tabs and conditional reveal logic.

Fixes https://github.com/alphagov/govuk-frontend/issues/899