### PR TITLE
Bind event handlers on the details `summary` only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@
 - Update internal padding of tab content in the tabs component
   ([PR #886](https://github.com/alphagov/govuk-frontend/pull/886))
 
+- Fixes an issue where clicking the revealed content in browsers that do not
+  support the native details element causes the details element to collapse.
+  ([PR #912])(https://github.com/alphagov/govuk-frontend/pull/912)
+
+- Fixes an issue where clicking the revealed content within a details element
+  toggles the aria-expanded attribute on the summary element and the aria-hidden
+  attribute on the content element, causing them to get out of sync with the
+  visible state of the component.
+  ([PR #912])(https://github.com/alphagov/govuk-frontend/pull/912)
+
+
 ## 1.1.0 (feature release)
 
 🆕 New features:

--- a/src/components/details/details.js
+++ b/src/components/details/details.js
@@ -111,7 +111,7 @@ Details.prototype.init = function () {
   }
 
   // Bind an event to handle summary elements
-  this.handleInputs($module, this.setAttributes.bind(this))
+  this.handleInputs($summary, this.setAttributes.bind(this))
 }
 
 /**

--- a/src/components/details/details.test.js
+++ b/src/components/details/details.test.js
@@ -111,6 +111,15 @@ describe('/components/details', () => {
       expect(detailsOpen).not.toBeNull()
     })
 
+    it('should not be affected when clicking the revealed content', async () => {
+      await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })
+
+      await page.click('.govuk-details__text')
+
+      const summaryAriaExpanded = await page.evaluate(() => document.body.getElementsByTagName('summary')[0].getAttribute('aria-expanded'))
+      expect(summaryAriaExpanded).toBe('true')
+    })
+
     describe('when details is triggered', () => {
       it('should indicate the expanded state of the summary using aria-expanded', async () => {
         await page.goto(baseUrl + '/components/details/expanded/preview', { waitUntil: 'load' })


### PR DESCRIPTION
This fixes an issue where clicking the revealed content in browsers that do not support the native `details` element causes the details element to collapse. (Fixes #911)

It also fixes an issue in all browsers where clicking the revealed content ‘flips’ the aria-expanded attribute on the summary element and the aria-hidden attribute on the content element, causing them to get out of sync with the visible state of the component.

As this mostly affects browsers that do not support the details element natively, I've focused testing on that – this has been tested in IE8-11, Edge 17, Chrome 67, Firefox 61, Firefox 46, Safari 5.1, Safari on iOS 5.1 and IE11 mobile.

https://trello.com/c/teyeHFNS/1214-details-component-collapses-when-content-is-clicked-in-edge-ie11