### PR TITLE
Delay the loading of GOV.UK Frontend to simulate slow connections.

### DIFF
--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -28,7 +28,14 @@
 
 {% block bodyEnd %}
   <script src="/public/all.js"></script>
-  <script>window.GOVUKFrontend.initAll()</script>
+  <script>
+    setTimeout(function () {
+      // In order to simulate a slow connection, we intentionally delay the intialisation
+      // of GOV.UK Frontend.
+      // This allows us to identify any issues such as flashes of original content.
+      window.GOVUKFrontend.initAll()
+    }, 200)
+  </script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.min.js"></script>
   <!--[if lte IE 8]>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/ie8.polyfils.min.js"></script>


### PR DESCRIPTION
With this change you can easily reproduce the issue described here: https://github.com/alphagov/govuk-frontend/issues/787

# Before
![before-fast-execution-js-tabs](https://user-images.githubusercontent.com/2445413/42831376-18c5e4d8-89e6-11e8-920e-8c0e7dcc3f26.gif)
![before-fast-execution-js-reveal](https://user-images.githubusercontent.com/2445413/42831380-191aa536-89e6-11e8-88dc-aa47931041fd.gif)

# After
![after-fast-execution-js-tabs](https://user-images.githubusercontent.com/2445413/42831377-18e1f998-89e6-11e8-96e1-6cbc05b3fdf8.gif)
![after-fast-execution-js-reveal](https://user-images.githubusercontent.com/2445413/42831378-19005546-89e6-11e8-86d9-c3fa923fc372.gif)