### PR TITLE
Use get-function to call Sass functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@
 - Replace conflicting `js-hidden` class used within the tabs component with a new modifier class.
   Because this class is defined and used within the JavaScript, no markup changes are required.
   ([PR #916](https://github.com/alphagov/govuk-frontend/pull/916))
+- Use `get-function` when calling a Sass function as passing a string to `call()``
+  is deprecated and will be illegal in Sass 4.0
+  ([PR #919](https://github.com/alphagov/govuk-frontend/pull/919))
 
 
 ## 1.1.1 (fix release)

--- a/src/tools/_font-url.scss
+++ b/src/tools/_font-url.scss
@@ -21,7 +21,7 @@
     and function-exists($govuk-font-url-function);
 
   @if ($use-custom-function) {
-    @return call($govuk-font-url-function, $filename);
+    @return call(get-function($govuk-font-url-function), $filename);
   } @else {
     @return url($govuk-fonts-path + $filename);
   }

--- a/src/tools/_image-url.scss
+++ b/src/tools/_image-url.scss
@@ -21,7 +21,7 @@
     and function-exists($govuk-image-url-function);
 
   @if ($use-custom-function) {
-    @return call($govuk-image-url-function, $filename);
+    @return call(get-function($govuk-image-url-function), $filename);
   } @else {
     @return url($govuk-images-path + $filename);
   }


### PR DESCRIPTION
Updates `src/tools/_font_url.scss` and `src/tools/_image_url.scss` to use `get-function` instead of passing a string directly.

`get-function($string)` is deprecated and adds warnings to the log:
```
DEPRECATION WARNING: Passing a string to call() is deprecated and will be illegal
in Sass 4.0. Use call(get-function("image-url")) instead.
```

Fixes #918 