### PR TITLE
Only underline logo on hover (with custom colours)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@
   can now be overwritten by setting the `assetUrl` variable.
   ([PR #847](https://github.com/alphagov/govuk-frontend/pull/847))
 
+- Only underline the logo in the header on underline when users have overridden
+  colours in their browser, rather than it appearing underlined all the time
+  ([PR #926](https://github.com/alphagov/govuk-frontend/pull/926))
+
 🔧 Fixes:
 
 - Replace conflicting `js-hidden` class used within the tabs component with a new modifier class.

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -101,14 +101,16 @@
 
     &:link,
     &:visited {
-      margin-bottom: -1px; // Negate transparent bottom border
-      border-bottom: 1px solid transparent;
       text-decoration: none;
     }
 
     &:hover,
     &:active {
-      border-bottom-color: currentColor;
+      // Negate the added border
+      margin-bottom: -1px;
+      // Omitting colour will use default value of currentColor – if we
+      // specified currentColor explicitly IE8 would ignore this rule.
+      border-bottom: 1px solid;
     }
   }
 


### PR DESCRIPTION
Because all borders will become text colour when a user overrides colour in their browser, the transparent border will become always visible.

By only applying the border on hover we avoid this which means we get the correct behaviour even when colours are customised. The layout is not affected because we offset the additional border with a negative margin.

We do however have to add an additional rule for IE8 which does not support customColor and so ignores the rule entirely - which meant it had no border before. This would be fine, except the negative margin _does_ kicks in on hover, which means without a border the header would shrink by 1px on hover in IE8.

## Before

![screen shot 2018-07-23 at 16 55 05-fullpage](https://user-images.githubusercontent.com/121939/43088075-392dca44-8e99-11e8-83b3-a1ba4666fcb3.png)

## After

![jul-23-2018 16-57-16](https://user-images.githubusercontent.com/121939/43088188-7b3fb15e-8e99-11e8-84e5-b83dee61b6ba.gif)


