### PR TITLE
Remove out of date note about versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,12 +93,6 @@ See [tasks](/docs/contributing/tasks.md).
 
 See [deploying](/docs/contributing/deploying.md).
 
-## Versioning
-
-We are not using semantic versioning yet, we are going to talk about this soon.
-
-See `CHANGELOG` for more information.
-
 ## Releasing a new version
 
 See [publishing](/docs/contributing/publishing.md).


### PR DESCRIPTION
We're now trying to apply semantic versioning to Frontend as of 1.0.0.