### PR TITLE
Add test coverage for caller interface

### DIFF
--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -7,6 +7,7 @@ const cheerio = require('cheerio')
 const yaml = require('js-yaml')
 
 const configPaths = require('../config/paths.json')
+const { componentNameToMacroName } = require('./helper-functions.js')
 
 nunjucks.configure(configPaths.components, {
   trimBlocks: true,
@@ -23,7 +24,16 @@ function render (componentName, params) {
   if (typeof params === 'undefined') {
     throw new Error('Parameters passed to `render` should be an object but are undefined')
   }
-  const output = nunjucks.render(componentName + '/template.njk', { params })
+
+  const macroName = componentNameToMacroName(componentName)
+  const macroParams = JSON.stringify(params, null, 2)
+
+  let macroString = `
+{%- from "${componentName}/macro.njk" import ${macroName} -%}
+{{- ${macroName}(${macroParams}) -}}
+`
+
+  const output = nunjucks.renderString(macroString)
   return cheerio.load(output)
 }
 

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -15,12 +15,13 @@ nunjucks.configure(configPaths.components, {
 })
 
 /**
- * Render a component's template for testing
+ * Render a component's macro for testing
  * @param {string} componentName
- * @param {string} params parameters that are used in the component template
- * @returns {function} returns cheerio (jQuery) instance of the template for easy DOM querying
+ * @param {string} params parameters that are used in the component macro
+ * @param {any} children any child components or text, pass the children to the macro
+ * @returns {function} returns cheerio (jQuery) instance of the macro for easy DOM querying
  */
-function render (componentName, params) {
+function render (componentName, params, children = false) {
   if (typeof params === 'undefined') {
     throw new Error('Parameters passed to `render` should be an object but are undefined')
   }
@@ -28,10 +29,15 @@ function render (componentName, params) {
   const macroName = componentNameToMacroName(componentName)
   const macroParams = JSON.stringify(params, null, 2)
 
-  let macroString = `
-{%- from "${componentName}/macro.njk" import ${macroName} -%}
-{{- ${macroName}(${macroParams}) -}}
-`
+  let macroString = `{%- from "${componentName}/macro.njk" import ${macroName} -%}`
+
+  // If we're nesting child components or text, pass the children to the macro
+  // using the 'caller' Nunjucks feature
+  if (children) {
+    macroString += `{%- call ${macroName}(${macroParams}) -%}${children}{%- endcall -%}`
+  } else {
+    macroString += `{{- ${macroName}(${macroParams}) -}}`
+  }
 
   const output = nunjucks.renderString(macroString)
   return cheerio.load(output)

--- a/src/components/fieldset/template.test.js
+++ b/src/components/fieldset/template.test.js
@@ -7,14 +7,14 @@ const { render, getExamples } = require('../../../lib/jest-helpers')
 const examples = getExamples('fieldset')
 
 describe('fieldset', () => {
-  it('default example passes accessibility tests', async () => {
+  it('passes accessibility tests', async () => {
     const $ = render('fieldset', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
-  it('renders a legend element inside a fieldset element for accessibility reasons', () => {
+  it('creates a fieldset', () => {
     const $ = render('fieldset', {
       legend: {
         text: 'What is your address?'
@@ -22,12 +22,32 @@ describe('fieldset', () => {
     })
 
     const $component = $('fieldset.govuk-fieldset')
-    const $legend = $component.find('.govuk-fieldset__legend')
     expect($component.get(0).tagName).toContain('fieldset')
-    expect($legend.get(0).tagName).toContain('legend')
   })
 
-  it('renders classes', () => {
+  it('includes a legend element which captions the fieldset', () => {
+    const $ = render('fieldset', {
+      legend: {
+        text: 'What is your address?'
+      }
+    })
+
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.get(0).tagName).toEqual('legend')
+  })
+
+  it('nests the legend within the fieldset', () => {
+    const $ = render('fieldset', {
+      legend: {
+        text: 'What is your address?'
+      }
+    })
+
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.parent().get(0).tagName).toEqual('fieldset')
+  })
+
+  it('can have additional classes', () => {
     const $ = render('fieldset', {
       classes: 'app-fieldset--custom-modifier'
     })
@@ -36,40 +56,37 @@ describe('fieldset', () => {
     expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
   })
 
-  it('renders legend text using markup that is semantic', () => {
+  it('allows you to set the legend text', () => {
     const $ = render('fieldset', {
       legend: {
         text: 'What is your address?'
       }
     })
 
-    const $component = $('fieldset.govuk-fieldset')
-    const $legend = $component.find('legend.govuk-fieldset__legend')
-    expect($legend.html()).toContain('What is your address?')
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.text().trim()).toEqual('What is your address?')
   })
 
-  it('renders escaped legend text when passing html', () => {
+  it('escapes HTML in the text argument', () => {
     const $ = render('fieldset', {
       legend: {
         text: 'What is <b>your</b> address?'
       }
     })
 
-    const $component = $('.govuk-fieldset')
-    const $legend = $component.find('.govuk-fieldset__legend')
-    expect($legend.html()).toContain('What is &lt;b&gt;your&lt;/b&gt; address?')
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.html()).toContain('&lt;b&gt;your&lt;/b&gt;')
   })
 
-  it('renders legend HTML', () => {
+  it('does not escape HTML in the html argument', () => {
     const $ = render('fieldset', {
       legend: {
         html: 'What is <b>your</b> address?'
       }
     })
 
-    const $component = $('.govuk-fieldset')
-    const $legend = $component.find('.govuk-fieldset__legend')
-    expect($legend.html()).toContain('What is <b>your</b> address?')
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.html()).toContain('<b>your</b>')
   })
 
   it('allows for additional classes on the legend', () => {
@@ -84,7 +101,7 @@ describe('fieldset', () => {
     expect($legend.hasClass('my-custom-class')).toBeTruthy()
   })
 
-  it('can nest the contents of the legend in an H1 if using legend.isPageHeading', () => {
+  it('nests the legend text in an H1 if the legend is a page heading', () => {
     const $ = render('fieldset', {
       legend: {
         text: 'What is your address?',
@@ -96,17 +113,15 @@ describe('fieldset', () => {
     expect($headingInsideLegend.text().trim()).toBe('What is your address?')
   })
 
-  it('renders attributes', () => {
+  it('can have additional attributes', () => {
     const $ = render('fieldset', {
       attributes: {
-        'data-attribute': 'value',
-        'data-another-attribute': 'another-value'
+        'data-attribute': 'value'
       }
     })
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('data-attribute')).toEqual('value')
-    expect($component.attr('data-another-attribute')).toEqual('another-value')
   })
 
   it('renders nested components using `call`', () => {

--- a/src/components/fieldset/template.test.js
+++ b/src/components/fieldset/template.test.js
@@ -47,15 +47,6 @@ describe('fieldset', () => {
     expect($legend.parent().get(0).tagName).toEqual('fieldset')
   })
 
-  it('can have additional classes', () => {
-    const $ = render('fieldset', {
-      classes: 'app-fieldset--custom-modifier'
-    })
-
-    const $component = $('.govuk-fieldset')
-    expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
-  })
-
   it('allows you to set the legend text', () => {
     const $ = render('fieldset', {
       legend: {
@@ -89,18 +80,6 @@ describe('fieldset', () => {
     expect($legend.html()).toContain('<b>your</b>')
   })
 
-  it('allows for additional classes on the legend', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?',
-        classes: 'my-custom-class'
-      }
-    })
-
-    const $legend = $('.govuk-fieldset__legend')
-    expect($legend.hasClass('my-custom-class')).toBeTruthy()
-  })
-
   it('nests the legend text in an H1 if the legend is a page heading', () => {
     const $ = render('fieldset', {
       legend: {
@@ -113,6 +92,33 @@ describe('fieldset', () => {
     expect($headingInsideLegend.text().trim()).toBe('What is your address?')
   })
 
+  it('renders nested components using `call`', () => {
+    const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
+
+    expect($('.govuk-fieldset .app-nested-component').length).toBeTruthy()
+  })
+
+  it('can have additional classes on the legend', () => {
+    const $ = render('fieldset', {
+      legend: {
+        text: 'What is your address?',
+        classes: 'my-custom-class'
+      }
+    })
+
+    const $legend = $('.govuk-fieldset__legend')
+    expect($legend.hasClass('my-custom-class')).toBeTruthy()
+  })
+
+  it('can have additional classes on the fieldset', () => {
+    const $ = render('fieldset', {
+      classes: 'app-fieldset--custom-modifier'
+    })
+
+    const $component = $('.govuk-fieldset')
+    expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
+  })
+
   it('can have additional attributes', () => {
     const $ = render('fieldset', {
       attributes: {
@@ -122,11 +128,5 @@ describe('fieldset', () => {
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('data-attribute')).toEqual('value')
-  })
-
-  it('renders nested components using `call`', () => {
-    const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
-
-    expect($('.govuk-fieldset .app-nested-component').length).toBeTruthy()
   })
 })

--- a/src/components/fieldset/template.test.js
+++ b/src/components/fieldset/template.test.js
@@ -108,4 +108,10 @@ describe('fieldset', () => {
     expect($component.attr('data-attribute')).toEqual('value')
     expect($component.attr('data-another-attribute')).toEqual('another-value')
   })
+
+  it('renders nested components using `call`', () => {
+    const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
+
+    expect($('.govuk-fieldset .app-nested-component').length).toBeTruthy()
+  })
 })


### PR DESCRIPTION
Updates the render method to call the components in the same way our documentation asks users to.

Then adds the ability to pass children to the render function, which will be passed to the component via the [call](https://mozilla.github.io/nunjucks/templating.html#call) Nunjucks feature.

As a side note our render function has a similar signature as a virtual dom function now, such as React.

https://trello.com/c/FaKTvCYz/1289-add-tests-for-call-usage-for-components-that-support-it