### PR TITLE
Remove panel title margin without body text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Fix incorrect panel title bottom margin with optional text
+
+  Margin is only added when panel text is provided
+
+  ([PR #936](https://github.com/alphagov/govuk-frontend/pull/936))
+
 ## 1.2.0 (feature release)
 
 🆕 New features:

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -33,6 +33,10 @@
     @include govuk-font($size: 48, $weight: bold);
   }
 
+  .govuk-panel__title:last-child {
+    margin-bottom: 0;
+  }
+
   .govuk-panel__body {
     @include govuk-font($size: 36);
   }


### PR DESCRIPTION
This pull request patches the styling for `govukPanel()`.

Currently:

1. The element **govuk-panel__body** `{ text }` is optional
2. Margin is always applied to **govuk-panel__title** `{ titleText }`

The title only needs a margin if the optional text is provided, otherwise vertical alignment is affected:

![incorrect margin](https://user-images.githubusercontent.com/415517/43589802-68d4121e-9667-11e8-965b-a2752cce89bd.png)

Once patched, the margin will be optional 👍 