### PR TITLE
Date Input to use inline-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@
 
   ([PR #951](https://github.com/alphagov/govuk-frontend/pull/951))
 
+- Update date input component to use `display: inline-block`
+  ([PR #938](https://github.com/alphagov/govuk-frontend/pull/938))
 
 ## 1.2.0 (feature release)
 

--- a/src/components/date-input/_date-input.scss
+++ b/src/components/date-input/_date-input.scss
@@ -10,18 +10,18 @@
 @include govuk-exports("govuk/component/date-input") {
   .govuk-date-input {
     @include govuk-clearfix;
+    // font-size: 0 removes whitespace caused by inline-block
+    font-size: 0;
   }
 
   .govuk-date-input__item {
+    display: inline-block;
     margin-right: govuk-spacing(4);
     margin-bottom: 0;
-    float: left;
-    clear: none;
   }
 
   .govuk-date-input__label {
     display: block;
-    padding-bottom: 2px;
   }
 
   .govuk-date-input__input {


### PR DESCRIPTION
Update Date Input to use inline block not floats.

When we give support to people wanting to add an element next to an input we often tell them to use `govuk-!-display-inline-block`. It would be good if we followed the same method for components too.

This should also make it easier to insert optional separators in between the fields in a future update.

I've also removed the extra 2px padding on the label, no longer needed.