### PR TITLE
Change spacing relationship on default and small legends and hints 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@
 
 - Update date input component to use `display: inline-block`
   ([PR #938](https://github.com/alphagov/govuk-frontend/pull/938))
+  
+- Change spacing relationship on default and small legends and hints
+  ([PR #940](https://github.com/alphagov/govuk-frontend/pull/940))
 
 ## 1.2.0 (feature release)
 

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -20,7 +20,7 @@
     box-sizing: border-box; // 1
     display: table;         // 2
     max-width: 100%;        // 1
-    margin-bottom: govuk-spacing(3);
+    margin-bottom: govuk-spacing(2);
     padding: 0;
     // Hack to let legends or elements within legends have margins in webkit browsers
     overflow: hidden;
@@ -32,14 +32,17 @@
 
   .govuk-fieldset__legend--xl {
     @include govuk-font($size: 48, $weight: bold);
+    margin-bottom: govuk-spacing(3);
   }
 
   .govuk-fieldset__legend--l {
     @include govuk-font($size: 36, $weight: bold);
+    margin-bottom: govuk-spacing(3);
   }
 
   .govuk-fieldset__legend--m {
     @include govuk-font($size: 24, $weight: bold);
+    margin-bottom: govuk-spacing(3);
   }
 
   .govuk-fieldset__legend--s {

--- a/src/components/hint/_hint.scss
+++ b/src/components/hint/_hint.scss
@@ -16,14 +16,35 @@
   // Reduces margin-bottom of hint when used after the default label (no class)
   // or govuk-label--s for better vertical alignment.
 
-  // This adjustment will not work when the label is inside the <h1>, however
-  // it is unlikely that the default or govuk-label--s class would be used in
-  // this case.
+  // This adjustment will not work when the label is inside the <h1>, however it
+  // is unlikely that the default or govuk-label--s class would be used in this
+  // case.
 
-  // This adjustment will not work in browsers that do not support :not()
-  // Users with these browsers will see the default size margin (5px larger)
+  // This adjustment will not work in browsers that do not support :not(). 
+  // Users with these browsers will see the default size margin (5px larger).
 
   .govuk-label:not(.govuk-label--m):not(.govuk-label--l):not(.govuk-label--xl) + .govuk-hint {
     margin-bottom: govuk-spacing(2);
+  }
+
+  // Reduces margin-bottom of hint when used after the default legend (no class)
+  // or govuk-fieldset__legend--s for better vertical alignment.
+
+  // This adjustment will not work when the legend is outside the <h1>, however
+  // it is unlikely that the default or govuk-fieldset__legend--s class would be
+  // used in this case.
+
+  // This adjustment will not work in browsers that do not support :not(). 
+  // Users with these browsers will see the default size margin (5px larger).
+
+  .govuk-fieldset__legend:not(.govuk-fieldset__legend--m):not(.govuk-fieldset__legend--l):not(.govuk-fieldset__legend--xl) + .govuk-hint {
+    margin-bottom: govuk-spacing(2);
+  }
+
+  // Reduces visual spacing of legend when there is a hint
+
+  .govuk-fieldset__legend + .govuk-hint,
+  .govuk-fieldset__legend + .govuk-hint {
+    margin-top: -(govuk-spacing(1));
   }
 }


### PR DESCRIPTION
Before the release of GOV.UK Frontend we changed the spacing of labels and hints when using the default or `govuk-label--s` class. (https://github.com/alphagov/govuk-frontend/pull/806)

We chose not update the legend and hint, in isolation they looked good.

However when a service uses a small label + hint and a small legend + hint on the same page the inconsistency is noticeable.

Amending the spacing on the `<legend>` is slightly different to the `<label>`, there was also a need to only reduce spacing on the `<legend>` when a hint was applied, hence the use of an adjacent selector and negative margin.

**Before**
<img width="398" alt="screen shot 2018-08-03 at 10 44 36" src="https://user-images.githubusercontent.com/23356842/43636948-71bebefc-970b-11e8-9c71-537f171c701a.png">

**After**
<img width="387" alt="screen shot 2018-08-03 at 10 40 04" src="https://user-images.githubusercontent.com/23356842/43636956-7633e53e-970b-11e8-8c52-09e06127488a.png">
