### PR TITLE
Allow attributes on checkboxes/radios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Allow attributes on checkboxes/radios
+
+  You can now provide attributes on checkbox and radio items
+  `attributes: { 'data-attribute': 'value' }`
+
+  ([PR #942](https://github.com/alphagov/govuk-frontend/pull/942))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -911,6 +911,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the checkbox input tag.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>

--- a/src/components/checkboxes/README.njk
+++ b/src/components/checkboxes/README.njk
@@ -257,6 +257,20 @@
     ],
     [
       {
+        text: 'items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the checkbox input tag.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -55,7 +55,8 @@
       {{-" checked" if item.checked }}
       {{-" disabled" if item.disabled }}
       {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}>
+      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
       {{ govukLabel({
         html: item.html,
         text: item.text,

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -253,6 +253,42 @@ describe('Checkboxes', () => {
       expect($secondInput.attr('checked')).toEqual('checked')
       expect($lastInput.attr('checked')).toEqual('checked')
     })
+
+    describe('when they include attributes', () => {
+      it('it renders the attributes', () => {
+        const $ = render('checkboxes', {
+          name: 'example-name',
+          items: [
+            {
+              value: '1',
+              text: 'Option 1',
+              attributes: {
+                'data-attribute': 'ABC',
+                'data-second-attribute': 'DEF'
+              }
+            },
+            {
+              value: '2',
+              text: 'Option 2',
+              attributes: {
+                'data-attribute': 'GHI',
+                'data-second-attribute': 'JKL'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-checkboxes')
+
+        const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
+        expect($firstInput.attr('data-attribute')).toEqual('ABC')
+        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+
+        const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+        expect($lastInput.attr('data-attribute')).toEqual('GHI')
+        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+      })
+    })
   })
 
   describe('when they include a hint', () => {

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -883,6 +883,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the radio input tag.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>

--- a/src/components/radios/README.njk
+++ b/src/components/radios/README.njk
@@ -270,6 +270,20 @@ Let users select a single option from a list.
     ],
     [
       {
+        text: 'items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the radio input tag.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -57,7 +57,8 @@
       {{-" checked" if item.checked }}
       {{-" disabled" if item.disabled }}
       {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}>
+      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
       {{ govukLabel({
         html: item.html,
         text: item.text,

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -198,6 +198,43 @@ describe('Radios', () => {
       expect($lastInput.attr('checked')).toEqual('checked')
     })
 
+    describe('when they include attributes', () => {
+      it('it renders the attributes', () => {
+        const $ = render('radios', {
+          name: 'example-name',
+          items: [
+            {
+              value: 'yes',
+              text: 'Yes',
+              attributes: {
+                'data-attribute': 'ABC',
+                'data-second-attribute': 'DEF'
+              }
+            },
+            {
+              value: 'no',
+              text: 'No',
+              checked: true,
+              attributes: {
+                'data-attribute': 'GHI',
+                'data-second-attribute': 'JKL'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-radios')
+
+        const $firstInput = $component.find('.govuk-radios__item:first-child input')
+        expect($firstInput.attr('data-attribute')).toEqual('ABC')
+        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+
+        const $lastInput = $component.find('.govuk-radios__item:last-child input')
+        expect($lastInput.attr('data-attribute')).toEqual('GHI')
+        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+      })
+    })
+
     describe('when they include a hint', () => {
       it('it renders the hint text', () => {
         const $ = render('radios', {


### PR DESCRIPTION
Unlike other form controls, the checkbox/radio templates only allow attributes on the wrapping container markup.

Services like ours add data attributes to some checkboxes:

```yaml
items:
  - value: yes
    text: Yes
    attributes:
      data-example: '123'
  - value: no
    text: No
    attributes:
      data-example: '456'
```

Following the same pattern as the other input, textarea and select, details templates etc, the attributes are appended like this:

```html
<input ... value="yes" data-example="123">
<input ... value="no" data-example="456">
```

Hopefully this pull request will help other teams too 😊