### PR TITLE
Remove template whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,12 @@
 
   ([PR #936](https://github.com/alphagov/govuk-frontend/pull/936))
 
+- Remove template whitespace
+
+  Remove leading whitespace before the doctype in the page template.
+  Some older browser will be forced into 'quirks mode' if there is whitespace before the doctype.
+
+  ([PR #949](https://github.com/alphagov/govuk-frontend/pull/949))
 ## 1.2.0 (feature release)
 
 🆕 New features:

--- a/src/template.njk
+++ b/src/template.njk
@@ -1,8 +1,8 @@
-{% from "./components/skip-link/macro.njk" import govukSkipLink %}
-{% from "./components/header/macro.njk" import govukHeader %}
-{% from "./components/footer/macro.njk" import govukFooter %}
+{% from "./components/skip-link/macro.njk" import govukSkipLink -%}
+{% from "./components/header/macro.njk" import govukHeader -%}
+{% from "./components/footer/macro.njk" import govukFooter -%}
 {# specify absolute url for the static assets folder e.g. http://wwww.domain.com/assets #}
-{% set assetUrl = assetUrl | default(assetPath) %}
+{%- set assetUrl = assetUrl | default(assetPath) -%}
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>
@@ -11,30 +11,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}" /> {# Hardcoded value of $govuk-black #}
 
-    {% block headIcons %}
+    {%- block headIcons %}
       <link rel="shortcut icon" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon" />
       <link rel="mask-icon" href="{{ assetPath | default('/assets') }}/images/govuk-mask-icon.svg" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
       <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-180x180.png">
       <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-167x167.png">
       <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-152x152.png">
       <link rel="apple-touch-icon" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon.png">
-    {% endblock %}
+    {% endblock -%}
 
-    {% block head %}{% endblock %}
+    {%- block head %}{% endblock -%}
     {# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
     {# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
     <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-    {% block bodyStart %}{% endblock %}
+    {% block bodyStart %}{% endblock -%}
 
-    {% block skipLink %}
+    {%- block skipLink %}
       {{ govukSkipLink({
         href: '#main-content',
         text: 'Skip to main content'
       }) }}
-    {% endblock %}
+    {% endblock -%}
 
     {% block header %}
       {{ govukHeader({}) }}

--- a/src/template.njk
+++ b/src/template.njk
@@ -11,30 +11,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}" /> {# Hardcoded value of $govuk-black #}
 
-    {%- block headIcons %}
+    {% block headIcons %}
       <link rel="shortcut icon" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon" />
       <link rel="mask-icon" href="{{ assetPath | default('/assets') }}/images/govuk-mask-icon.svg" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
       <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-180x180.png">
       <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-167x167.png">
       <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-152x152.png">
       <link rel="apple-touch-icon" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon.png">
-    {% endblock -%}
+    {% endblock %}
 
-    {%- block head %}{% endblock -%}
+    {% block head %}{% endblock %}
     {# The default og:image is added below head so that scrapers see any custom metatags first, and this is just a fallback #}
     {# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
     <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
   </head>
   <body class="govuk-template__body {{ bodyClasses }}">
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
-    {% block bodyStart %}{% endblock -%}
+    {% block bodyStart %}{% endblock %}
 
-    {%- block skipLink %}
+    {% block skipLink %}
       {{ govukSkipLink({
         href: '#main-content',
         text: 'Skip to main content'
       }) }}
-    {% endblock -%}
+    {% endblock %}
 
     {% block header %}
       {{ govukHeader({}) }}

--- a/src/template.test.js
+++ b/src/template.test.js
@@ -1,0 +1,24 @@
+/* eslint-env jest */
+
+const nunjucks = require('nunjucks')
+const configPaths = require('../config/paths.json')
+
+describe('Template', () => {
+  describe('with default nunjucks configuration', () => {
+    it('should not have any whitespace before the doctype', () => {
+      nunjucks.configure(configPaths.src)
+      const output = nunjucks.render('./template.njk')
+      expect(output.charAt(0)).toEqual('<')
+    })
+  })
+  describe('with nunjucks block trimming enabled', () => {
+    it('should not have any whitespace before the doctype', () => {
+      nunjucks.configure(configPaths.src, {
+        trimBlocks: true,
+        lstripBlocks: true
+      })
+      const output = nunjucks.render('./template.njk')
+      expect(output.charAt(0)).toEqual('<')
+    })
+  })
+})


### PR DESCRIPTION
In my mind I always think it's not good to start an HTML document with whitespace
I think a brower in the past didn't like it, it's something that I have always done
This uses the nunjucks whitespace controls to strip the leading whitespace
And also some other whitespace in the header