### PR TITLE
Fix removal of dotted button outline in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@
   Some older browser will be forced into 'quirks mode' if there is whitespace before the doctype.
 
   ([PR #949](https://github.com/alphagov/govuk-frontend/pull/949))
+
+- Remove additional dotted outline from focussed buttons in Firefox
+
+  This was already the intended behaviour, but a minor typo (: rather than ::)
+  meant that it wasn't being applied.
+
+  ([PR #951](https://github.com/alphagov/govuk-frontend/pull/951))
+
+
 ## 1.2.0 (feature release)
 
 🆕 New features:

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -64,7 +64,7 @@
     }
 
     // Fix unwanted button padding in Firefox
-    &:-moz-focus-inner {
+    &::-moz-focus-inner {
       padding: 0;
       border: 0;
     }


### PR DESCRIPTION
Firefox adds a small dotted border on a button when focussed. This can be overridden by using the `::-moz-focus-inner { }` pseudo-element. We’re currently attempting to do this, but we’re accidentally omitting one of the `:` so this is not being applied.

## Before

<img width="194" alt="screen shot 2018-08-09 at 14 15 40" src="https://user-images.githubusercontent.com/121939/43901477-7b3e4e60-9bdf-11e8-81a9-7827c47edacb.png">

## After

<img width="191" alt="screen shot 2018-08-09 at 14 15 52" src="https://user-images.githubusercontent.com/121939/43901484-827ea58a-9bdf-11e8-80ab-7d81a7d83744.png">
