### PR TITLE
Adjust tag component padding to compensate for font spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
 - Change spacing relationship on default and small legends and hints
   ([PR #940](https://github.com/alphagov/govuk-frontend/pull/940))
 
+- Adjust tag component padding to compensate for font spacing
+  ([PR #955](https://github.com/alphagov/govuk-frontend/pull/955))
+
 ## 1.2.0 (feature release)
 
 🆕 New features:

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -7,7 +7,11 @@
     @include govuk-font($size: 16, $weight: bold, $line-height: 1.25);
 
     display: inline-block;
-    padding: govuk-spacing(1) 8px 0;
+    padding: 4px 8px;
+    // Since New Transport sits slightly higher than other common fonts.
+    // We use intentionally uneven padding to make it balanced, this can be
+    // removed using the version of the font that has a more common vertical spacing.
+    padding-bottom: 1px;
 
     // When a user customises their colours often the background is removed,
     // by adding a outline we ensure that the tag component still keeps it's meaning.


### PR DESCRIPTION
This is in response to [an issue raised on the backlog](https://github.com/alphagov/govuk-design-system-backlog/issues/62#issuecomment-412112217).

Until we update GOV.UK Frontend with the new font, NTA
sits higher than common fonts, so we need to add adjustments
to compensate.

Links for review:

- [Current phase banner](https://govuk-frontend-review.herokuapp.com/components/phase-banner/preview)
- [Changed tag with phase banner](https://govuk-frontend-review-pr-955.herokuapp.com/components/phase-banner/preview)

# Screenshots

## Before changes
### Tag using default font with no changes
<img width="995" alt="screen shot 2018-08-10 at 16 49 54" src="https://user-images.githubusercontent.com/2445413/43968098-0c45f384-9cbe-11e8-9693-1285c150a167.png">

---

## After changes
### Tag using default font with changes
<img width="975" alt="screen shot 2018-08-10 at 16 50 59" src="https://user-images.githubusercontent.com/2445413/43968096-0c110d04-9cbe-11e8-8665-41320c661de9.png">

https://trello.com/c/GV0PxHFL/1319-fix-vertical-text-alignment-in-tag-component