### PR TITLE
Update select component width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,12 @@
 
   ([PR #985](https://github.com/alphagov/govuk-frontend/pull/985))
 
+- Remove the width declaration from the `<select>` component
+
+  The `<select>` component’s width will now be defined by it’s content. This addresses some accessibility issues with the select being 100% wide by default. If you want to style your select to be 100% wide we have added a new override class `.govuk-!-width-full` to allow this.
+
+  ([PR #960](https://github.com/alphagov/govuk-frontend/pull/960))  
+
 - Pull Request Title goes here
 
   Description goes here (optional)
@@ -128,6 +134,12 @@
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
 🆕 New features:
+
+- Add a new width override class `.govuk-!-width-full`
+
+  You can now override elements that have an undefined or smaller percentage  width to be 100% width of their container.
+
+  ([PR #960](https://github.com/alphagov/govuk-frontend/pull/960))
 
 - Pull Request Title goes here
 
@@ -187,7 +199,7 @@
 
 - Update date input component to use `display: inline-block`
   ([PR #938](https://github.com/alphagov/govuk-frontend/pull/938))
-  
+
 - Change spacing relationship on default and small legends and hints
   ([PR #940](https://github.com/alphagov/govuk-frontend/pull/940))
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -176,6 +176,57 @@ Find out when to use the select component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Select with full width override
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/select/with-full-width-override/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="select-1">
+        Label text goes here
+      </label>
+
+      <select class="govuk-select govuk-!-width-full" id="select-1" name="select-1">
+
+        <option value="1">GOV.UK frontend option 1</option>
+
+        <option value="2" selected>GOV.UK frontend option 2</option>
+
+        <option value="3" disabled>GOV.UK frontend option 3</option>
+
+      </select>
+    </div>
+
+#### Macro
+
+    {% from "select/macro.njk" import govukSelect %}
+
+    {{ govukSelect({
+      "id": "select-1",
+      "name": "select-1",
+      "classes": "govuk-!-width-full",
+      "label": {
+        "text": "Label text goes here"
+      },
+      "items": [
+        {
+          "value": 1,
+          "text": "GOV.UK frontend option 1"
+        },
+        {
+          "value": 2,
+          "text": "GOV.UK frontend option 2",
+          "selected": true
+        },
+        {
+          "value": 3,
+          "text": "GOV.UK frontend option 3",
+          "disabled": true
+        }
+      ]
+    }) }}
+
 ## Requirements
 
 ### Build tool configuration

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -12,7 +12,6 @@
     @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
-    width: 100%;
     height: 40px;
 
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -56,3 +56,22 @@ examples:
         value: 3
         text: GOV.UK frontend option 3
         disabled: true
+- name: with full width override
+  data:
+    id: select-1
+    name: select-1
+    classes: govuk-!-width-full
+    label:
+      text: Label text goes here
+    items:
+      -
+        value: 1
+        text: GOV.UK frontend option 1
+      -
+        value: 2
+        text: GOV.UK frontend option 2
+        selected: true
+      -
+        value: 3
+        text: GOV.UK frontend option 3
+        disabled: true

--- a/src/overrides/_width.scss
+++ b/src/overrides/_width.scss
@@ -1,4 +1,8 @@
 @include govuk-exports("govuk/overrides/width") {
+  .govuk-\!-width-full {
+    width: 100% !important;
+  }
+
   .govuk-\!-width-three-quarters {
     width: 100% !important;
 


### PR DESCRIPTION
This PR:

Creates a `govuk-!-width-full` override (previously we only had width to reduce the size of 100% elements

Removes the `width: 100%` declaration on the select so they are the size of the content by default

**Why**

The styling of the `<select>` component (dependant on browser) is very similar to a text input. The arrows on the right hand side indicate the behaviour of this component, however because we made it 100% wide by default, a select with a small amount of content, when zoomed in is not obvious.

For example:
<img width="719" alt="screen shot 2018-08-20 at 12 00 17" src="https://user-images.githubusercontent.com/23356842/44336846-a49f5d00-a470-11e8-8331-353217fbbb0c.png">

This change reverts to the default `<select>` behaviour, being sized by it's content so the icon appears closer to the content.

<img width="1034" alt="screen shot 2018-08-20 at 12 01 31" src="https://user-images.githubusercontent.com/23356842/44336920-df08fa00-a470-11e8-83a9-70984c5cc9a4.png">

If a user would like to resize their select, for example they are sizing it based on being 100% wide within a container this can be done with the override class

<img width="1020" alt="screen shot 2018-08-20 at 12 01 37" src="https://user-images.githubusercontent.com/23356842/44336965-01027c80-a471-11e8-8105-4954177f9a71.png">
 