### PR TITLE
Use production URL rather than cloudapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ for government platforms and services.
 
 See live examples of GOV.UK Frontend components, and guidance on when to use
 them in your service, in the [GOV.UK Design
-System](https://govuk-design-system-production.cloudapps.digital/).
+System](https://design-system.service.gov.uk/).
 
 ## Contact the team
 
@@ -20,7 +20,7 @@ team](mailto:govuk-design-system-support@digital.cabinet-office.gov.uk) or get i
 There are 2 ways to start using GOV.UK Frontend in your app.
 
 Once installed, you will be able to use the code from the examples in the
-[GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/)
+[GOV.UK Design System](https://design-system.service.gov.uk/)
 in your service.
 
 ### 1. Install with npm (recommended)

--- a/package/components/input/README.md
+++ b/package/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-Find out when to use the input component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input).
+Find out when to use the input component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/text-input).
 
 ## Quick start examples
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -6,7 +6,7 @@ A single-line text field.
 
 ## Guidance
 
-Find out when to use the input component in your service in the [GOV.UK Design System](https://govuk-design-system-production.cloudapps.digital/components/text-input).
+Find out when to use the input component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/text-input).
 
 ## Quick start examples
 

--- a/src/components/input/README.njk
+++ b/src/components/input/README.njk
@@ -11,7 +11,7 @@
 {# examples #}
 
 {# override link to design system here if it's different to base url + componentName #}
-{% set componentGuidanceLink = 'https://govuk-design-system-production.cloudapps.digital/components/text-input' %}
+{% set componentGuidanceLink = 'https://design-system.service.gov.uk/components/text-input' %}
 
 {% block componentArguments %}
 {{ govukTable({


### PR DESCRIPTION
A small URL update to prevent an unnecessary redirect for users.

https://govuk-design-system-production.cloudapps.digital/ redirects to https://design-system.service.gov.uk/

Not sure if this warrants a changelog entry or not.