### PR TITLE
Address issue with conditional form content and inline form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@
   You can now pass additional attributes to links in header, footer, breadcrumbs, tabs and error-summary components
 
   ([PR #993](https://github.com/alphagov/govuk-frontend/pull/993))
+  
+- Fix issue with conditional form content and inline form controls
+
+  When inline variant of form controls is used with conditional content, we force
+  it to display block. This is to avoid breaking and confusing styling as it is
+  a combination we don't recommend.
+
+  ([PR #970](https://github.com/alphagov/govuk-frontend/pull/970))
 
 - Pull Request Title goes here
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -143,6 +143,14 @@
         clear: none;
       }
     }
+
+    // Prevent inline modifier being used with conditional reveals
+    &.govuk-radios--conditional {
+      .govuk-radios__item {
+        margin-right: 0;
+        float: none;
+      }
+    }
   }
 
   .govuk-radios__divider {

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -234,6 +234,36 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
+- name: inline with conditional items
+  readme: false
+  data:
+    classes: govuk-radios--inline
+    idPrefix: how-contacted
+    name: how-contacted
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: email
+        text: Email
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Email address</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: phone
+        text: Phone
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-phone">Phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+      - value: text
+        text: Text message
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
+
 - name: with conditional item checked
   readme: false
   data:

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -41,7 +41,7 @@
     text: params.errorMessage.text
   }) | indent(2) | trim }}
 {% endif %}
-  <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}"
+  <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}{%- if isConditional %} govuk-radios--conditional{% endif -%}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="radios"{% endif -%}>
     {% for item in params.items %}


### PR DESCRIPTION
While we don't recommend this combination, we need to address the broken styling.
This work forces 'inline' form controls to become 'block' when used in conjunction with conditional content when created with a Nunjucks macro.

Related to: https://github.com/alphagov/govuk-frontend/issues/754
Trello ticket: https://trello.com/c/bVn1hU8i/1311-2-fix-issue-with-conditional-form-content-and-inline-form-controls

**Before:** 
<img width="639" alt="screen shot 2018-08-30 at 12 27 24" src="https://user-images.githubusercontent.com/3758555/44848904-4fbdcc80-ac50-11e8-8156-33be21ce89c8.png">

**After:**
<img width="854" alt="screen shot 2018-09-20 at 10 30 56" src="https://user-images.githubusercontent.com/3758555/45809556-558f5680-bcc0-11e8-862a-fda3880c5fea.png">


