### PR TITLE
Fix examples that use Date Input component

### DIFF
--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -54,10 +54,12 @@
     name: 'expiry',
     items:[
       {
-        name: 'month'
+        name: 'month',
+        classes: 'govuk-input--width-2'
       },
       {
-        name: 'year'
+        name: 'year',
+        classes: 'govuk-input--width-4'
       }
     ],
     errorMessage: {

--- a/app/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/app/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -45,18 +45,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -126,18 +126,7 @@
         legendHintText: 'For example, 31 3 1980'
       },
       id: 'dob',
-      name: 'dob',
-      items:[
-        {
-          name: 'day'
-        },
-        {
-          name: 'month'
-        },
-        {
-          name: 'year'
-        }
-      ]
+      name: 'dob'
     }) -}}
 
     {% call govukFieldset() %}

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -2444,18 +2444,7 @@
         isPageHeading: true,
         classes: 'govuk-fieldset__legend--xl'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2468,18 +2457,7 @@
         isPageHeading: true,
         classes: 'govuk-fieldset__legend--l'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2492,18 +2470,7 @@
         isPageHeading: true,
         classes: 'govuk-fieldset__legend--m'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2516,18 +2483,7 @@
         isPageHeading: true,
         classes: 'govuk-fieldset__legend--s'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2540,18 +2496,7 @@
         isPageHeading: true,
         classes: ''
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2566,18 +2511,7 @@
         text: '<legend> govuk-fieldset__legend--xl',
         classes: 'govuk-fieldset__legend--xl'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2589,18 +2523,7 @@
         text: '<legend> govuk-fieldset__legend--l',
         classes: 'govuk-fieldset__legend--l'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2612,18 +2535,7 @@
         text: '<legend> govuk-fieldset__legend--m',
         classes: 'govuk-fieldset__legend--m'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2635,18 +2547,7 @@
         text: '<legend> govuk-fieldset__legend--s',
         classes: 'govuk-fieldset__legend--s'
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2658,18 +2559,7 @@
         text: '<legend> No class',
         classes: ''
       }
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2694,18 +2584,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2721,18 +2600,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2748,18 +2616,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2775,18 +2632,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2802,18 +2648,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2832,18 +2667,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2858,18 +2682,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2884,18 +2697,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2910,18 +2712,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2936,18 +2727,7 @@
     },
     hint: {
       text: 'For example 5 12 1987'
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -2976,18 +2756,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3006,18 +2775,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3036,18 +2794,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3067,18 +2814,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3098,18 +2834,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3130,18 +2855,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3159,18 +2873,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3188,18 +2891,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3217,18 +2909,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 
@@ -3246,18 +2927,7 @@
     },
     errorMessage: {
       text: "You must provide your date of birth"
-    },
-    items:[
-      {
-        name: 'day'
-      },
-      {
-        name: 'month'
-      },
-      {
-        name: 'year'
-      }
-    ]
+    }
     })
   }}
 {% endblock %}


### PR DESCRIPTION
Since the class name is no longer automatically added (as changed in #969), we have to either provide the width class ourselves or omit the `items` attribute in order to get the ‘default’ items array, which includes the classes.

Where possible, I’ve opted for the latter – the only case where this isn’t currently possible is the passport expiry date example in the ‘error summary with messages’ example, where I’ve added the width classes.