### PR TITLE
Only allow textareas to be resized vertically; set sane minimum height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@
 
 🔧 Fixes:
 
+- Textareas can now only be resized vertically, to prevent them being resized
+  outside of their container bounds. Additionally, they now have a minimum
+  height to prevent them being resized smaller than a text input.
+
+  ([PR #976](https://github.com/alphagov/govuk-frontend/pull/976))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/config/.sass-lint.yml
+++ b/config/.sass-lint.yml
@@ -296,6 +296,7 @@ rules:
         - 'clip'
         - 'clip-path'
         - 'zoom'
+        - 'resize'
         -
         - 'columns'
         -

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -14,6 +14,7 @@
     box-sizing: border-box; // should this be global?
     display: block;
     width: 100%;
+    min-height: 40px;
     @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(1);
 

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -17,6 +17,8 @@
     @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(1);
 
+    resize: vertical;
+
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
     border-radius: 0;
 


### PR DESCRIPTION
## Before

![textarea-before](https://user-images.githubusercontent.com/121939/44993957-70f62400-af94-11e8-940d-098494ffd0c2.gif)

## After

![textarea-after](https://user-images.githubusercontent.com/121939/44993973-77849b80-af94-11e8-8baa-6692a04ae5e6.gif)

Fixes #966 

https://trello.com/c/fBzdfrTd/1409-textarea-can-be-resized-beyond-container-bounds