### PR TITLE
Added undocumented item label feature of date input component

### DIFF
--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -649,6 +649,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">items.{}.label</th>
+
+<td class="govuk-table__cell ">string</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Optional item-specific label text. If provided, this will be used instead of the items.{}.name.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">hint</th>
 
 <td class="govuk-table__cell ">object</td>

--- a/src/components/date-input/README.njk
+++ b/src/components/date-input/README.njk
@@ -116,6 +116,20 @@
     ],
     [
       {
+        text: 'items.{}.label'
+      },
+      {
+        text: 'string'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Optional item-specific label text. If provided, this will be used instead of the items.{}.name.'
+      }
+    ],
+    [
+      {
         text: 'hint'
       },
       {


### PR DESCRIPTION
Was working with this component and noticed that the docs do not document the ability to add a label text to each item. 

Welcome to rewrite the Description if it does not make sense.