### PR TITLE
[Do not merge] Turn off compatibility mode by default and turn on relative typography (rem) by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,41 @@
 
   ([PR #969](https://github.com/alphagov/govuk-frontend/pull/969))
 
+- Turn off compatibility mode by default for [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit)
+
+  To migrate include the SCSS variables that correspond with the projects you depend on before importing GOV.UK Frontend styles into your app:
+
+  ```SCSS
+  // application.scss
+  $govuk-compatibility-govukfrontendtoolkit: true;
+  $govuk-compatibility-govuktemplate: true;
+  $govuk-compatibility-govukelements: true;
+  @import "govuk-frontend/all";
+  ```
+  ([PR #980](https://github.com/alphagov/govuk-frontend/pull/980))
+
+- Turn on relative typography (rem) by default
+
+  This allows for end-users to adjust GOV.UK Frontend components by setting their font size in their browser.
+
+  If you are using GOV.UK Frontend on with no other frameworks this should not break your project.
+
+  If you need to change this setting for compatibility with [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit) consider enabling [compatibility mode](./docs/installation/installing-with-npm.md#compatibility-mode).
+
+  Otherwise, set `$govuk-typography-use-rem` to `false` before importing GOV.UK Frontend styles into your app:
+  ```SCSS
+  // application.scss
+  $govuk-typography-use-rem: false;
+  @import "govuk-frontend/all";
+  ```
+  ([PR #980](https://github.com/alphagov/govuk-frontend/pull/980))
+
+- Pull Request Title goes here
+
+  Description goes here (optional)
+
+  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+
 🆕 New features:
 
 - Pull Request Title goes here

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -103,6 +103,23 @@ $govuk-global-styles: true;
 @import "govuk-frontend/all";
 ```
 
+### Compatibility mode
+GOV.UK Frontend includes additional styles that can be enabled to allow support for deprecated projects such as [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
+
+Setting compatibility SCSS variables will change how GOV.UK Frontend's CSS renders to work around global styles that conflict with GOV.UK Frontend.
+
+To enable this feature include the SCSS variables that correspond with the projects you depend on before importing GOV.UK Frontend styles into your app:
+
+```
+// application.scss
+
+$govuk-compatibility-govukfrontendtoolkit: true;
+$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govukelements: true;
+
+@import "govuk-frontend/all";
+```
+
 ## Using JavaScript
 
 Some of the JavaScript included in GOV.UK Frontend improves the usability and

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -41,14 +41,14 @@ imports) if you want to override GOV.UK Frontend with your own styles.
 
 1. To import all components, add the below to your Sass file:
 
-  ```CSS
+  ```SCSS
   @import "node_modules/govuk-frontend/all";
   ```
 
 2. To import an individual component (for example a button), add the below to
 your Sass file:
 
-  ```CSS
+  ```SCSS
   @import "node_modules/govuk-frontend/components/button/button";
   ```
 
@@ -81,7 +81,7 @@ to include add `includePaths` to it.
 
 After resolving the import paths you can import GOV.UK Frontend by using:
 
-```CSS
+```SCSS
 @import "govuk-frontend/components/button/button";
 ```
 
@@ -95,7 +95,7 @@ Hovever, we do include some global styles in the [GOV.UK Prototype Kit](https://
 
 These [global styles](../../src/core/_global-styles.scss) are are not included by default in GOV.UK Frontend. To include these global styles in your app, you can set `$govuk-global-styles` variable to `true` before importing GOV.UK Frontend styles into your app:
 
-```
+```SCSS
 // application.scss
 
 $govuk-global-styles: true;
@@ -110,7 +110,7 @@ Setting compatibility SCSS variables will change how GOV.UK Frontend's CSS rende
 
 To enable this feature include the SCSS variables that correspond with the projects you depend on before importing GOV.UK Frontend styles into your app:
 
-```
+```SCSS
 // application.scss
 
 $govuk-compatibility-govukfrontendtoolkit: true;

--- a/src/settings/_compatibility.scss
+++ b/src/settings/_compatibility.scss
@@ -16,7 +16,7 @@
 /// @type Boolean
 /// @access public
 
-$govuk-compatibility-govukfrontendtoolkit: true !default;
+$govuk-compatibility-govukfrontendtoolkit: false !default;
 
 /// Compatibility Mode: alphagov/govuk_template
 ///
@@ -25,7 +25,7 @@ $govuk-compatibility-govukfrontendtoolkit: true !default;
 /// @type Boolean
 /// @access public
 
-$govuk-compatibility-govuktemplate: true !default;
+$govuk-compatibility-govuktemplate: false !default;
 
 /// Compatibility Mode: alphagov/govuk_elements
 ///
@@ -34,7 +34,7 @@ $govuk-compatibility-govuktemplate: true !default;
 /// @type Boolean
 /// @access public
 
-$govuk-compatibility-govukelements: true !default;
+$govuk-compatibility-govukelements: false !default;
 
 /// Compatibility Product Map
 ///

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -19,14 +19,20 @@ $govuk-typography-use-rem: true !default;
 /// in order to allow it to scale with user-preference, in which case this
 /// should be set to 16px.
 ///
-/// If you are integrating Frontend into an existing project that also uses
-/// alphagov/govuk_template then you should set this to 10px to match the 62.5%
-/// (10px) base font size that govuk_template sets on the <html> element.
-///
 /// @type Number
 /// @access public
 
-$govuk-root-font-size: 16px !default;
+// To dynamically set a variable you need to use a function
+@function _set-govuk-root-font-size() {
+  // match the 62.5% (10px) base font size that alphagov/govuk_template sets on the <html> element.
+  @if ($govuk-compatibility-govuktemplate == true) {
+    @return 10px;
+  } @else {
+    @return 16px;
+  }
+}
+
+$govuk-root-font-size: _set-govuk-root-font-size() !default;
 
 /// Responsive typography font map
 ///

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -8,7 +8,8 @@
 /// @type Boolean
 /// @access public
 
-$govuk-typography-use-rem: true !default;
+// Set the default to true unless compatibility mode is enabled for GOV.UK Template
+$govuk-typography-use-rem: if($govuk-compatibility-govuktemplate, false, true) !default;
 
 /// Root font size
 ///
@@ -22,17 +23,7 @@ $govuk-typography-use-rem: true !default;
 /// @type Number
 /// @access public
 
-// To dynamically set a variable you need to use a function
-@function _set-govuk-root-font-size() {
-  // match the 62.5% (10px) base font size that alphagov/govuk_template sets on the <html> element.
-  @if ($govuk-compatibility-govuktemplate == true) {
-    @return 10px;
-  } @else {
-    @return 16px;
-  }
-}
-
-$govuk-root-font-size: _set-govuk-root-font-size() !default;
+$govuk-root-font-size: 16px !default;
 
 /// Responsive typography font map
 ///

--- a/src/settings/_typography-responsive.scss
+++ b/src/settings/_typography-responsive.scss
@@ -3,17 +3,12 @@
 ////
 
 /// Whether or not to define font sizes in rem, improving accessibility by
-/// allowing users to adjust the base font-size. This is currently off by
-/// default, but will be enabled by default for projects that do not use
-/// alphagov/govuk_template in the next major release.
-///
-/// If you enable this, you should make sure that `$govuk-root-font-size` is set
-/// correctly for your project.
+/// allowing users to adjust the base font-size.
 ///
 /// @type Boolean
 /// @access public
 
-$govuk-typography-use-rem: false !default;
+$govuk-typography-use-rem: true !default;
 
 /// Root font size
 ///


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/868

https://trello.com/c/8iqDncHe/1389-2-enable-rem-based-typography-by-default