### PR TITLE
Use text colour on focus for better contrast

### DIFF
--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -44,7 +44,7 @@
     outline-offset: -1px;
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable
-    color: $govuk-text-colour;
+    color: $govuk-focus-text-colour;
     background: $govuk-focus-colour;
   }
 

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -42,6 +42,9 @@
     // -1px offset fixes gap between background and outline in Firefox
     outline: ($govuk-focus-width + 1px) solid $govuk-focus-colour;
     outline-offset: -1px;
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable
+    color: $govuk-text-colour;
     background: $govuk-focus-colour;
   }
 

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -56,7 +56,7 @@
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable
     &:focus {
-      color: $govuk-text-colour;
+      color: $govuk-focus-text-colour;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -49,10 +49,14 @@
     &:link,
     &:visited,
     &:hover,
-    &:active,
-    &:focus {
+    &:active {
       color: $govuk-error-colour;
-      text-decoration: underline;
+    }
+
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable
+    &:focus {
+      color: $govuk-text-colour;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -43,9 +43,10 @@
       color: $govuk-footer-link-hover;
     }
 
-    // Use text colour when focussed
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable
     &:focus {
-      color: $govuk-text-colour;
+      color: $govuk-focus-text-colour;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -76,8 +76,10 @@
       text-decoration: underline;
     }
 
+    // When focussed, the text colour needs to be darker to ensure that colour
+    // contrast is still acceptable
     &:focus {
-      color: govuk-colour("black");
+      color: $govuk-text-colour;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector
@@ -238,6 +240,12 @@
       &:hover,
       &:visited {
         color: $govuk-header-link-active;
+      }
+
+      // When focussed, the text colour needs to be darker to ensure that colour
+      // contrast is still acceptable
+      &:focus {
+        color: $govuk-text-colour;
       }
     }
   }

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -79,7 +79,7 @@
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable
     &:focus {
-      color: $govuk-text-colour;
+      color: $govuk-focus-text-colour;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector
@@ -245,7 +245,7 @@
       // When focussed, the text colour needs to be darker to ensure that colour
       // contrast is still acceptable
       &:focus {
-        color: $govuk-text-colour;
+        color: $govuk-focus-text-colour;
       }
     }
   }

--- a/src/core/_links.scss
+++ b/src/core/_links.scss
@@ -21,20 +21,7 @@
     @include govuk-link-style-text;
   }
 
-  // 'No visited state' link mixin
-  //
-  // Used in cases where it is not helpful to distinguish between visited and
-  // non-visited links.
-  //
-  // For example, navigation links to pages with dynamic content like admin
-  // dashboards. The content on the page is changing all the time, so the fact
-  // that you’ve visited it before is not important.
-  //
-  // This is not abstracted as a mixin because it does not provide states for
-  // all pseudo-selectors so it does not make sense to use it in composition.
   .govuk-link--no-visited-state {
-    &:visited {
-      color: $govuk-link-colour;
-    }
+    @include govuk-link-style-no-visited-state;
   }
 }

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -128,6 +128,51 @@
   }
 }
 
+
+/// No visited state link mixin
+///
+/// Used in cases where it is not helpful to distinguish between visited and
+/// non-visited links.
+///
+/// For example, navigation links to pages with dynamic content like admin
+/// dashboards. The content on the page is changing all the time, so the fact
+/// that you’ve visited it before is not important.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-no-visited-state;
+///   }
+///
+/// @access public
+
+@mixin govuk-link-style-no-visited-state {
+  &:link {
+    color: $govuk-link-colour;
+  }
+
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:active {
+    color: $govuk-link-active-colour;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+}
+
 /// Print friendly link mixin
 ///
 /// When printing, append the the destination URL to the link text, as long

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -44,6 +44,12 @@
   &:active {
     color: $govuk-link-active-colour;
   }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-text-colour;
+  }
 }
 
 /// Muted style link mixin

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -48,7 +48,7 @@
   // When focussed, the text colour needs to be darker to ensure that colour
   // contrast is still acceptable
   &:focus {
-    color: $govuk-text-colour;
+    color: $govuk-focus-text-colour;
   }
 }
 
@@ -79,7 +79,7 @@
   // When focussed, the text colour needs to be darker to ensure that colour
   // contrast is still acceptable
   &:focus {
-    color: $govuk-text-colour;
+    color: $govuk-focus-text-colour;
   }
 
   // alphagov/govuk_template includes a specific a:link:focus selector designed

--- a/src/settings/_colours-applied.scss
+++ b/src/settings/_colours-applied.scss
@@ -68,6 +68,16 @@ $govuk-secondary-text-colour: govuk-colour("grey-1") !default;
 
 $govuk-focus-colour: govuk-colour("yellow") !default;
 
+/// Focused text colour
+///
+/// Ensure that the contrast between the text and background colour passes
+/// WCAG Level AA contrast requirements.
+///
+/// @type Colour
+/// @access public
+
+$govuk-focus-text-colour: govuk-colour("black") !default;
+
 /// Error colour
 ///
 /// Used to highlight error messages and form controls in an error state


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/944

This pull request updates the focus styles of links in GOV.UK Frontend to they pass WCAG contrast requirements.

You can compare https://govuk-frontend-review-pr-982.herokuapp.com/examples/links vs https://govuk-frontend-review.herokuapp.com/examples/links

## Screenshots

### back link
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2445413/45155775-fa476980-b1d3-11e8-9264-706df82aa81b.png) | ![image](https://user-images.githubusercontent.com/2445413/45155775-fa476980-b1d3-11e8-9264-706df82aa81b.png) |

### breadcrumbs
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2445413/45155568-59f14500-b1d3-11e8-96b7-16135d636528.png) | ![image](https://user-images.githubusercontent.com/2445413/45155568-59f14500-b1d3-11e8-96b7-16135d636528.png) |

### details
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2445413/45155424-dc2d3980-b1d2-11e8-8f11-389f0a3782bc.png) | ![image](https://user-images.githubusercontent.com/2445413/45155514-2ca49700-b1d3-11e8-8c75-85ae28421f5a.png) |

### skip link
| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2445413/45155537-4219c100-b1d3-11e8-99a1-927a6876d04d.png) | ![image](https://user-images.githubusercontent.com/2445413/45155537-4219c100-b1d3-11e8-99a1-927a6876d04d.png) |

### header
| Before | After |
|-|-|
| <img width="148" alt="screen shot 2018-09-06 at 15 07 20" src="https://user-images.githubusercontent.com/2445413/45162811-c0cc2980-b1e6-11e8-821d-b98e459dbc3f.png"> | <img width="148" alt="screen shot 2018-09-06 at 15 07 06" src="https://user-images.githubusercontent.com/2445413/45162835-cfb2dc00-b1e6-11e8-9a41-491cc1d770fa.png"> |

### govuk-link
| Before | After |
|-|-|
| ![govuk-frontend-review herokuapp com_examples_links](https://user-images.githubusercontent.com/2445413/45155881-57dbb600-b1d4-11e8-97b7-3d6ac43f9520.png) | ![govuk-frontend-review-pr-982 herokuapp com_examples_links](https://user-images.githubusercontent.com/2445413/45155885-59a57980-b1d4-11e8-9f39-7d884de8aeec.png) |

https://trello.com/c/XQPpwofN/1381-1-modify-focus-state-to-use-text-colour