### PR TITLE
Defend tables against GOV.UK Elements code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,9 @@
 
   ([PR #976](https://github.com/alphagov/govuk-frontend/pull/976))
 
+- Defend tables against GOV.UK Elements code
+  ([PR #983](https://github.com/alphagov/govuk-frontend/pull/983))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -22,6 +22,12 @@
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
+    // GOV.UK Elements sets the font-size and line-height for all headers and cells
+    // in tables.
+    @include govuk-compatibility(govuk_elements) {
+      font-size: inherit;
+      line-height: inherit;
+    }
   }
 
   .govuk-table__cell--numeric {

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -15,12 +15,9 @@
 
   .govuk-table__header {
     @include govuk-typography-weight-bold;
-
-    padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
-    border-bottom: 1px solid $govuk-border-colour;
-    text-align: left;
   }
 
+  .govuk-table__header,
   .govuk-table__cell {
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
     border-bottom: 1px solid $govuk-border-colour;


### PR DESCRIPTION
In the example in our review application, we set an override class onto the table to force the text to be smaller (16px), when including GOV.UK Elements alongside GOV.UK Frontend that override no longer works since the headers and cells are set to 19px.

This pull request forces headers and cells to be inherited when using GOV.UK Frontend with GOV.UK Elements.

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/2445413/45158138-02ef6e00-b1db-11e8-8c52-baaf20dc191f.png) | ![image](https://user-images.githubusercontent.com/2445413/45158151-097de580-b1db-11e8-8a97-c8124edba2b6.png) |
