### PR TITLE
Rename `name` of date-input component to `namePrefix`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@
 
   ([PR #969](https://github.com/alphagov/govuk-frontend/pull/969))
 
+- Rename `name` argument of date-input component to `namePrefix`.
+
+  This is better reflective of the purpose of the argument, which is to prefix the `name` attribute of `items`. This is consistent with other components which use the name `idPrefix` to explain similar functionality.
+
+  If your project currently uses this optional argument with the date-input macro, you need to rename all instances of it to `namePrefix` (NB: this argument shouldn't be confused with the `items.{}.name` attribute which hasn't changed.)
+
+  ([PR #984](https://github.com/alphagov/govuk-frontend/pull/984))
+
 - Turn off [compatibility mode](./docs/installation/installing-with-npm.md#compatibility-mode) by default for [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit)
 
   You do not need to make any changes if you do not use these projects alongside GOV.UK Frontend.

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -70,7 +70,7 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
     {{ govukDateInput({
       "id": "dob",
-      "name": "dob",
+      "namePrefix": "dob",
       "fieldset": {
         "legend": {
           "text": "What is your date of birth?"
@@ -250,7 +250,7 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
     {{ govukDateInput({
       "id": "dob-day-error",
-      "name": "dob-day-error",
+      "namePrefix": "dob-day-error",
       "fieldset": {
         "legend": {
           "text": "What is your date of birth?"
@@ -342,7 +342,7 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
     {{ govukDateInput({
       "id": "dob-month-error",
-      "name": "dob-month-error",
+      "namePrefix": "dob-month-error",
       "fieldset": {
         "legend": {
           "text": "What is your date of birth?"
@@ -434,7 +434,7 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
     {{ govukDateInput({
       "id": "dob-year-error",
-      "name": "dob-year-error",
+      "namePrefix": "dob-year-error",
       "fieldset": {
         "legend": {
           "text": "What is your date of birth?"
@@ -522,7 +522,7 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
     {{ govukDateInput({
       "id": "dob",
-      "name": "dob",
+      "namePrefix": "dob",
       "fieldset": {
         "legend": {
           "text": "What is your date of birth?"
@@ -589,13 +589,13 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
-<th class="govuk-table__header" scope="row">name</th>
+<th class="govuk-table__header" scope="row">namePrefix</th>
 
 <td class="govuk-table__cell ">string</td>
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Optional name. This is used to compose the name attribute for each item.</td>
+<td class="govuk-table__cell ">Optional prefix. This is used to prefix each `item.name` using `-`.</td>
 
 </tr>
 

--- a/src/components/date-input/README.njk
+++ b/src/components/date-input/README.njk
@@ -46,7 +46,7 @@
     ],
     [
       {
-        text: 'name'
+        text: 'namePrefix'
       },
       {
         text: 'string'
@@ -55,7 +55,7 @@
         text: 'No'
       },
       {
-        text: 'Optional name. This is used to compose the name attribute for each item.'
+        text: 'Optional prefix. This is used to prefix each `item.name` using `-`.'
       }
     ],
     [

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -2,7 +2,7 @@ examples:
 - name: default
   data:
     id: dob
-    name: dob
+    namePrefix: dob
     fieldset:
       legend:
         text: What is your date of birth?
@@ -41,7 +41,7 @@ examples:
 - name: with error on day input
   data:
     id: dob-day-error
-    name: dob-day-error
+    namePrefix: dob-day-error
     fieldset:
       legend:
         text: What is your date of birth?
@@ -62,7 +62,7 @@ examples:
 - name: with error on month input
   data:
     id: dob-month-error
-    name: dob-month-error
+    namePrefix: dob-month-error
     fieldset:
       legend:
         text: What is your date of birth?
@@ -83,7 +83,7 @@ examples:
 - name: with error on year input
   data:
     id: dob-year-error
-    name: dob-year-error
+    namePrefix: dob-year-error
     fieldset:
       legend:
         text: What is your date of birth?
@@ -104,7 +104,7 @@ examples:
 - name: with default items
   data:
     id: dob
-    name: dob
+    namePrefix: dob
     fieldset:
       legend:
         text: What is your date of birth?

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -61,7 +61,7 @@
         },
         id: item.id if item.id else (params.id + "-" + item.name),
         classes: "govuk-date-input__input " + (item.classes if item.classes),
-        name: (params.name + "-" + item.name) if params.name else item.name,
+        name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
         type: "number",
         attributes: {

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -180,7 +180,7 @@ describe('Date input', () => {
 
     it('renders item with suffixed name for input', () => {
       const $ = render('date-input', {
-        name: 'my-date-input',
+        namePrefix: 'my-date-input',
         items: [
           {
             'name': 'day'


### PR DESCRIPTION
The `name` argument on the date-input component acts as a prefix for each input's name, but this behaviour is not clear or consistent with how we use `name` in other components.

This PR renames it to `namePrefix`. This is consistent with other components (like checkboxes and radios) which use the name `idPrefix` to explain similar functionality.

Fixes https://github.com/alphagov/govuk-frontend/issues/909

https://trello.com/c/CFN5bvev/1392-2-behaviour-of-date-inputs-name-argument-is-not-clear