### PR TITLE
Remove anchor styling in govuk-lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,16 @@
   ```
   ([PR #981](https://github.com/alphagov/govuk-frontend/pull/981))
 
+- Remove anchor styling in govuk-lists
+
+  This was an undocumented feature of lists.
+
+  To migrate we recommend using adding `.govuk-link` class to any anchors within a govuk-list.
+
+  If you would like to replicate this functionality without adding a class you can also enable [global styles](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#global-styles) (Note: global styles are enabled by default in the GOV.UK Prototype Kit)
+
+  ([PR #985](https://github.com/alphagov/govuk-frontend/pull/985))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/core/_lists.scss
+++ b/src/core/_lists.scss
@@ -20,24 +20,6 @@
     }
   }
 
-  %govuk-list a {
-    &:link {
-      color: $govuk-link-colour;
-    }
-
-    &:visited {
-      color: $govuk-link-visited-colour;
-    }
-
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
-
-    &:active {
-      color: $govuk-link-active-colour;
-    }
-  }
-
   .govuk-list {
     @extend %govuk-list;
   }


### PR DESCRIPTION
These styles partially implement the `.govuk-link` styles, but fail to implement the correct focus styles.

Additionally this need can be satisfied by enabling global styles, which is on by default in the GOV.UK Prototype Kit.

I have checked our [documentation](https://design-system.service.gov.uk/styles/typography/#lists) and we do not recommend our users do this.

With this both in mind this feels reasonable to remove this functionality as a breaking change, without a deprecation period.