### PR TITLE
Allow attributes to be added to anchor items in header, footer, breadcrumbs, tabs and error-summary components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 
   ([PR #990](https://github.com/alphagov/govuk-frontend/pull/990))
 
+- Allow attributes to be added to some child items in header, footer, breadcrumbs, tabs and error-summary components
+
+  You can now pass additional attributes to links in header, footer, breadcrumbs, tabs and error-summary components
+
+  ([PR #993](https://github.com/alphagov/govuk-frontend/pull/993))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -288,6 +288,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>

--- a/src/components/breadcrumbs/README.njk
+++ b/src/components/breadcrumbs/README.njk
@@ -73,6 +73,20 @@ The Breadcrumbs component helps users to understand where they are within a webs
     ],
     [
       {
+        text: 'items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/breadcrumbs/template.njk
+++ b/src/components/breadcrumbs/template.njk
@@ -3,7 +3,7 @@
   {% for item in params.items %}
     {% if item.href %}
     <li class="govuk-breadcrumbs__list-item">
-      <a class="govuk-breadcrumbs__link" href="{{ item.href }}">{{ item.html | safe if item.html else item.text }}</a>
+      <a class="govuk-breadcrumbs__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.html | safe if item.html else item.text }}</a>
     </li>
     {% else %}
     <li class="govuk-breadcrumbs__list-item" aria-current="page">{{ item.html | safe if item.html else item.text }}</li>

--- a/src/components/breadcrumbs/template.test.js
+++ b/src/components/breadcrumbs/template.test.js
@@ -79,6 +79,25 @@ describe('Breadcrumbs', () => {
       expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
     })
 
+    it('renders item anchor with attributes', () => {
+      const $ = render('breadcrumbs', {
+        items: [
+          {
+            'text': 'Section 1',
+            'href': '/section',
+            'attributes': {
+              'data-attribute': 'my-attribute',
+              'data-attribute-2': 'my-attribute-2'
+            }
+          }
+        ]
+      })
+
+      const $breadcrumbLink = $('.govuk-breadcrumbs__link')
+      expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($breadcrumbLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
+
     it('renders item with html', () => {
       const $ = render('breadcrumbs', {
         items: [

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -168,6 +168,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">errorList.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error link anchor.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">classes</th>
 
 <td class="govuk-table__cell ">string</td>

--- a/src/components/error-summary/README.njk
+++ b/src/components/error-summary/README.njk
@@ -103,6 +103,20 @@
     ],
     [
       {
+        text: 'errorList.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the error link anchor.'
+      }
+    ],
+    [
+      {
         text: 'classes'
       },
       {

--- a/src/components/error-summary/template.njk
+++ b/src/components/error-summary/template.njk
@@ -14,7 +14,7 @@
     {% for item in params.errorList %}
       <li>
       {% if item.href %}
-        <a href="{{ item.href }}">{{ item.html | safe if item.html else item.text }}</a>
+        <a href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.html | safe if item.html else item.text }}</a>
       {% else %}
         {{ item.html | safe if item.html else item.text }}
       {% endif %}

--- a/src/components/error-summary/template.test.js
+++ b/src/components/error-summary/template.test.js
@@ -128,6 +128,25 @@ describe('Error-summary', () => {
     expect(errorItem.attr('href')).toEqual('#example-error-1')
   })
 
+  it('renders anchor tag with attributes', () => {
+    const $ = render('error-summary', {
+      errorList: [
+        {
+          'text': 'Error-1',
+          'href': '#item',
+          'attributes': {
+            'data-attribute': 'my-attribute',
+            'data-attribute-2': 'my-attribute-2'
+          }
+        }
+      ]
+    })
+
+    const $component = $('.govuk-error-summary__list a')
+    expect($component.attr('data-attribute')).toEqual('my-attribute')
+    expect($component.attr('data-attribute-2')).toEqual('my-attribute-2')
+  })
+
   it('renders error item text', () => {
     const $ = render('error-summary', examples.default)
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -177,6 +177,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">meta.items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer meta section.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">navigation</th>
 
 <td class="govuk-table__cell ">array</td>
@@ -244,6 +256,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">navigation.items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.</td>
 
 </tr>
 

--- a/src/components/footer/README.njk
+++ b/src/components/footer/README.njk
@@ -116,6 +116,20 @@
     ],
     [
       {
+        text: 'meta.items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the anchor in the footer meta section.'
+      }
+    ],
+    [
+      {
         text: 'navigation'
       },
       {
@@ -196,6 +210,20 @@
       },
       {
         text: 'List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.'
+      }
+    ],
+    [
+      {
+        text: 'navigation.items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.'
       }
     ],
     [

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -16,7 +16,7 @@
                 {% for item in item.items %}
                   {% if item.href and item.text %}
                     <li class="govuk-footer__list-item">
-                      <a class="govuk-footer__link" href="{{ item.href }}">
+                      <a class="govuk-footer__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
                         {{ item.text }}
                       </a>
                     </li>
@@ -37,7 +37,7 @@
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}
                 <li class="govuk-footer__inline-list-item">
-                  <a class="govuk-footer__link" href="{{ item.href }}">
+                  <a class="govuk-footer__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
                     {{ item.text }}
                   </a>
                 </li>

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -105,6 +105,27 @@ describe('footer', () => {
       const $custom = $component.find('.govuk-footer__meta-custom')
       expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
     })
+
+    it('renders attributes on meta links', () => {
+      const $ = render('footer', {
+        meta: {
+          items: [
+            {
+              href: '#1',
+              text: 'meta item 1',
+              attributes: {
+                'data-attribute': 'my-attribute',
+                'data-attribute-2': 'my-attribute-2'
+              }
+            }
+          ]
+        }
+      })
+
+      const $metaLink = $('.govuk-footer__meta .govuk-footer__link')
+      expect($metaLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($metaLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
   })
 
   describe('navigation', () => {
@@ -137,6 +158,29 @@ describe('footer', () => {
       expect($items.length).toEqual(9)
       expect($firstItem.attr('href')).toEqual('#1')
       expect($firstItem.text()).toContain('Navigation item 1')
+    })
+
+    it('renders attributes on links', () => {
+      const $ = render('footer', {
+        navigation: [
+          {
+            items: [
+              {
+                href: '#1',
+                text: 'Navigation item 1',
+                attributes: {
+                  'data-attribute': 'my-attribute',
+                  'data-attribute-2': 'my-attribute-2'
+                }
+              }
+            ]
+          }
+        ]
+      })
+
+      const $navigationLink = $('.govuk-footer__list .govuk-footer__link')
+      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
     })
 
     it('renders lists in columns', () => {

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -473,6 +473,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">navigation.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the navigation item anchor.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">navigationClasses</th>
 
 <td class="govuk-table__cell ">string</td>

--- a/src/components/header/README.njk
+++ b/src/components/header/README.njk
@@ -158,6 +158,20 @@
     ],
     [
       {
+        text: 'navigation.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the navigation item anchor.'
+      }
+    ],
+    [
+      {
         text: 'navigationClasses'
       },
       {

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -69,7 +69,7 @@
         {% for item in params.navigation %}
           {% if item.href and item.text %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">
-              <a class="govuk-header__link" href="{{ item.href }}">
+              <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
                 {{ item.text }}
               </a>
             </li>

--- a/src/components/header/template.test.js
+++ b/src/components/header/template.test.js
@@ -104,6 +104,24 @@ describe('header', () => {
       expect($firstItem.text()).toContain('Navigation item 1')
     })
 
+    it('renders navigation item anchor with attributes', () => {
+      const $ = render('header', {
+        navigation: [
+          {
+            'text': 'Item',
+            'href': '/link',
+            'attributes': {
+              'data-attribute': 'my-attribute',
+              'data-attribute-2': 'my-attribute-2'
+            }
+          }
+        ]
+      })
+
+      const $navigationLink = $('.govuk-header__navigation-item a')
+      expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
     describe('menu button', () => {
       it('has an explicit type="button" so it does not act as a submit button', () => {
         const $ = render('header', examples['with navigation'])

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -286,7 +286,7 @@ If you are using Nunjucks,then macros take the following arguments
 
 <td class="govuk-table__cell ">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the details element</td>
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tabs container</td>
 
 </tr>
 
@@ -340,6 +340,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">items.{}.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tab item anchor.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">items.{}.panel.text (or) items.{}.panel.html</th>
 
 <td class="govuk-table__cell ">string</td>
@@ -347,6 +359,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell ">No</td>
 
 <td class="govuk-table__cell ">Text or HTML to use within each tab panel. If `html` is provided, the `text` argument will be ignored.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">items.{}.panel.attributes</th>
+
+<td class="govuk-table__cell ">object</td>
+
+<td class="govuk-table__cell ">No</td>
+
+<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tab panel.</td>
 
 </tr>
 

--- a/src/components/tabs/README.njk
+++ b/src/components/tabs/README.njk
@@ -70,7 +70,7 @@
         text: 'No'
       },
       {
-        text: 'Any extra HTML attributes (for example data attributes) to add to the details element'
+        text: 'Any extra HTML attributes (for example data attributes) to add to the tabs container'
       }
     ],
     [
@@ -131,6 +131,20 @@
     ],
     [
       {
+        text: 'items.{}.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the tab item anchor.'
+      }
+    ],
+    [
+      {
         text: 'items.{}.panel.text (or) items.{}.panel.html'
       },
       {
@@ -141,6 +155,20 @@
       },
       {
         text: 'Text or HTML to use within each tab panel. If `html` is provided, the `text` argument will be ignored.'
+      }
+    ],
+    [
+      {
+        text: 'items.{}.panel.attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the tab panel.'
       }
     ]
   ]

--- a/src/components/tabs/template.njk
+++ b/src/components/tabs/template.njk
@@ -12,7 +12,7 @@
     {% for item in params.items %}
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
       <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab" href="#{{ id }}">
+        <a class="govuk-tabs__tab" href="#{{ id }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
           {{ item.label }}
         </a>
       </li>
@@ -22,7 +22,7 @@
 
   {% for item in params.items %}
   {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
-  <section class="govuk-tabs__panel" id="{{ id }}">
+  <section class="govuk-tabs__panel" id="{{ id }}"{% for attribute, value in item.panel.attributes %} {{attribute}}="{{value}}"{% endfor %}>
     {{ item.panel.html | safe if item.panel.html else item.panel.text }}
   </section>
   {% endfor %}

--- a/src/components/tabs/template.test.js
+++ b/src/components/tabs/template.test.js
@@ -165,6 +165,47 @@ describe('Tabs', () => {
         const $firstPanel = $component.find('.govuk-tabs__panel')
         expect($firstPanel.html().trim()).toEqual('<p>Panel 1 content</p>')
       })
+
+      it('render a tab anchor with attributes', () => {
+        const $ = render('tabs', {
+          items: [
+            {
+              id: 'tab-1',
+              label: 'Tab 1',
+              attributes: {
+                'data-attribute': 'my-attribute',
+                'data-attribute-2': 'my-attribute-2'
+              }
+            }
+          ]
+        })
+
+        const $tabItemLink = $('.govuk-tabs__tab')
+        expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
+        expect($tabItemLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+      })
+
+      it('render a tab panel with attributes', () => {
+        const $ = render('tabs', {
+          items: [
+            {
+              id: 'tab-1',
+              label: 'Tab 1',
+              panel: {
+                text: 'Panel text',
+                attributes: {
+                  'data-attribute': 'my-attribute',
+                  'data-attribute-2': 'my-attribute-2'
+                }
+              }
+            }
+          ]
+        })
+
+        const $tabPanelItems = $('.govuk-tabs__panel')
+        expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')
+        expect($tabPanelItems.attr('data-attribute-2')).toEqual('my-attribute-2')
+      })
     })
   })
 })


### PR DESCRIPTION
This has been requested though support and in our own work on the Prototype Kit.

Allow attributes to be added with Nunjucks macros to:
- breadcrumb links
- header navigation links
- tabs links and tabs panels
- error-summary links
- footer navigation and meta links

For each of the components the work includes
- Enabling HTML attributes to be added in the component's Nunjucks template
- Adding tests to check that attributes render correctly
- Documenting new functionality in README.njk
- Generating an updated README.md file


Trello ticket: https://trello.com/c/9BPK4u7M/414-1-allow-attributes-to-be-specified-on-items-using-macro

Fixes: #904 