### PR TITLE
Add component options (args) to YAML, add as JSON to `package`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
   ([PR #993](https://github.com/alphagov/govuk-frontend/pull/993))
 
+- Add component options (arguments) as `macro-options.json` to `package`
+
+  We want to be able to expose these options to GOV.UK Design System. This change includes them as `yaml` in `src/components` and adds a build step to transform them to `JSON` and copy them to `package/components`. It also adds a test to check if the copied files are valid JSON and contain expected attributes.
+
+  ([PR #998](https://github.com/alphagov/govuk-frontend/pull/998))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cheerio": "^1.0.0-rc.2",
     "cssnano": "^3.10.0",
     "express": "^4.16.3",
+    "glob": "^4.5.3",
     "gulp": "^3.9.1",
     "gulp-better-rollup": "3.1.0",
     "gulp-changed": "^3.2.0",

--- a/src/components/back-link/back-link.yaml
+++ b/src/components/back-link/back-link.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+- name: href
+  type: string
+  required: true
+  description: The value of the link href attribute.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the anchor tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
 examples:
 - name: default
   data:

--- a/src/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/components/breadcrumbs/breadcrumbs.yaml
@@ -1,3 +1,30 @@
+params:
+- name: items
+  type: array
+  required: true
+  description: Array of breadcrumbs item objects.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.
+  - name: href
+    type: string
+    required: false
+    description: Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the breadcrumbs container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the breadcrumbs container.
+
 examples:
 - name: default
   data:

--- a/src/components/button/button.yaml
+++ b/src/components/button/button.yaml
@@ -1,3 +1,45 @@
+params:
+- name: element
+  type: string
+  required: false
+  description: Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.
+- name: name
+  type: string
+  required: true
+  description: Name for the `input` or `button`. This has no effect on `a` elements.
+- name: type
+  type: string
+  required: true
+  description: Type of `input` or `button` – `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.
+- name: value
+  type: string
+  required: true
+  description: Value for the `button` tag. This has no effect on `a` or `input` elements.
+- name: disabled
+  type: boolean
+  required: false
+  description: Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.
+- name: href
+  type: string
+  required: false
+  description: The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the button component.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the button component.
+
 examples:
 - name: default
   data:

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -1,3 +1,91 @@
+params:
+- name: fieldset
+  type: object
+  required: false
+  description: Options for the fieldset component (e.g. legend).
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component (e.g. text).
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component (e.g. text).
+  isComponent: true
+- name: idPrefix
+  type: string
+  required: false
+  description: String to prefix id for each checkbox item if no id is specified on each item. If not passed, fall back to using the name option instead.
+- name: name
+  type: string
+  required: true
+  description: Name attribute for all checkbox items.
+- name: items
+  type: array
+  required: true
+  description: Array of checkbox items objects.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.
+  - name: id
+    type: string
+    required: false
+    description: Specific id attribute for the checkbox item. If omitted, then idPrefix option will be applied.
+  - name: name
+    type: string
+    required: true
+    description: Specific name for the checkbox item. If omitted, then component global `name` string will be applied.
+  - name: value
+    type: string
+    required: true
+    description: Value for the checkbox input.
+  - name: label
+    type: object
+    required: false
+    description: Provide attributes and classes to each checkbox item label.
+    isComponent: true
+  - name: hint
+    type: object
+    required: false
+    description: Provide hint to each checkbox item.
+    isComponent: true
+  - name: checked
+    type: boolean
+    required: false
+    description: If true, checkbox will be checked.
+  - name: conditional
+    type: boolean
+    required: false
+    description: If true, content provided will be revealed when the item is checked.
+  - name: conditional.html
+    type: string
+    required: false
+    description: Provide content for the conditional reveal.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If true, checkbox will be disabled.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the checkbox input tag.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the checkboxes container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
 accessibilityCriteria: |
   ## Conditional reveals
   Must:

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -1,3 +1,61 @@
+params:
+- name: id
+  type: string
+  required: false
+  description: This is used for the main component and to compose id attribute for each item.
+- name: namePrefix
+  type: string
+  required: false
+  description: Optional prefix. This is used to prefix each `item.name` using `-`.
+- name: items
+  type: array
+  required: true
+  description: An array of input objects with name, value and classes.
+  params:
+  - name: id
+    type: string
+    required: false
+    description: Item-specific id. If provided, it will be used instead of the generated id.
+  - name: name
+    type: string
+    required: true
+    description: Item-specific name attribute.
+  - name: label
+    type: string
+    required: true
+    description: Item-specific label text. If provided, this will be used instead of `name` for item label text.
+  - name: value
+    type: string
+    required: false
+    description: If provided, it will be used as the initial value of the input.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to date input item.
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the error message.
+  isComponent: true
+- name: fieldset
+  type: object
+  required: false
+  description: Options for the fieldset component (e.g. legend).
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the date-input container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the date-input container.
+
 examples:
 - name: default
   data:

--- a/src/components/details/details.yaml
+++ b/src/components/details/details.yaml
@@ -1,3 +1,37 @@
+params:
+- name: summaryText
+  type: string
+  required: true
+  description: If `summmaryHtml` is set, this is not required. Text to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.
+- name: summaryHtml
+  type: string
+  required: true
+  description: If `summmaryText` is set, this is not required. HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.
+- name: id
+  type: string
+  required: false
+  description: Id to add to the details element.
+- name: open
+  type: boolean
+  required: false
+  description: If true, details element will be expanded.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the `<details>` element.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the `<details>` element.
+
 examples:
 - name: default
   data:

--- a/src/components/error-message/error-message.yaml
+++ b/src/components/error-message/error-message.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the error message. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the error message. If `html` is provided, the `text` argument will be ignored.
+- name: id
+  type: string
+  required: false
+  description: Id attribute to add to the error message span tag.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the error message span tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the error message span tag
+
 accessibilityCriteria: |
   When used with a single input, the error message MUST:
   - be announced by screen readers when the input is focussed

--- a/src/components/error-summary/error-summary.yaml
+++ b/src/components/error-summary/error-summary.yaml
@@ -1,3 +1,51 @@
+params:
+- name: titleText
+  type: string
+  required: true
+  description: If `titleHtml` is set, this is not required. Text to use for the heading of the error summary block. If `titleHtml` is provided, `titleText` will be ignored.
+- name: titleHtml
+  type: string
+  required: true
+  description: If `titleText` is set, this is not required. HTML to use for the heading of the error summary block. If `titleHtml` is provided, `titleText` will be ignored.
+- name: descriptionText
+  type: string
+  required: false
+  description: If `descriptionHtml` is set, this is not required. Text to use for the description of the errors. If `descriptionHtml` is provided,  `descriptionText` will be ignored.
+- name: descriptionHtml
+  type: string
+  required: true
+  description: If `descriptionText` is set, this is not required. HTML to use for the description of the errors. If `descriptionHtml` is provided, `descriptionText` will be ignored.
+
+- name: errorList
+  type: array
+  required: true
+  description: Contains an array of error link items and all their available arguments.
+  params:
+  - name: href
+    type: string
+    required: false
+    description: Href attribute for the error link item. If provided item will be an anchor.
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text for the error link item. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML for the error link item. If `html` is provided, the `text` argument will be ignored.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the error link anchor.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the error-summary container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the error-summary container.
+
 accessibilityCriteria: |
   - Must be focused when the page loads
 

--- a/src/components/fieldset/fieldset.yaml
+++ b/src/components/fieldset/fieldset.yaml
@@ -1,3 +1,42 @@
+params:
+- name: describedBy
+  type: string
+  required: false
+  description: Text or element id to add to the `aria-describedby` attribute to provide description of the group of fields for screenreader users.
+- name: legend
+  type: object
+  required: false
+  description: Options for the legend
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within the legend. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within the legend. If `html` is provided, the `text` argument will be ignored.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the legend.
+  - name: isPageHeading
+    type: boolean
+    required: false
+    description: Whether the legend also acts as the heading for the page.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the fieldset container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the fieldset container.
+- name: caller
+  type: nunjucks-block
+  required: false
+  description: Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire fielset component in a `call` block. See [checkboxes component](https://github.com/alphagov/govuk-frontend/blob/master/src/components/checkboxes/template.njk#L86) for an example.
+
 examples:
 - name: default
   data:

--- a/src/components/file-upload/file-upload.yaml
+++ b/src/components/file-upload/file-upload.yaml
@@ -1,3 +1,40 @@
+params:
+- name: name
+  type: string
+  required: true
+  description: The name of the input, which is submitted with the form data.
+- name: id
+  type: string
+  required: true
+  description: The id of the input
+- name: value
+  type: string
+  required: false
+  description: 	Optional initial value of the input
+- name: label
+  type: object
+  required: true
+  description: Options for the label component.
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component.
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the file upload component.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the file upload component.
+
 examples:
 - name: default
   data:

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -1,3 +1,69 @@
+params:
+- name: meta
+  type: object
+  required: false
+  description: Object containing options for the meta navigation.
+  arguments:
+  - name: items
+    type: array
+    required: false
+    description: Array of items for use in the meta section of the footer.
+    params:
+    - name: text
+      type: string
+      required: false
+      description: List item text in the meta section of the footer.
+    - name: href
+      type: string
+      required: false
+      description: List item href attribute in the meta section of the footer.
+    - name: attributes
+      type: object
+      required: false
+      description: HTML attributes (for example data attributes) to add to the anchor in the footer meta section.
+- name: navigation
+  type: array
+  required: false
+  description: Array of items for use in the navigation section of the footer.
+  arguments:
+  - name: title
+    type: string
+    required: false
+    description: Title for a section
+  - name: columns
+    type: integer
+    required: false
+    description: Amount of columns to display items in navigation section of the footer.
+  - name: items
+    type: array
+    required: false
+    description: Array of items to display in the list in navigation section of the footer.
+    arguments:
+    - name: text
+      type: string
+      required: false
+      description: List item text in the navigation section of the footer.
+    - name: href
+      type: string
+      required: false
+      description: List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.
+    - name: attributes
+      type: object
+      required: false
+      description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
+- name: containerClasses
+  type: string
+  required: false
+  description: Classes that can be added to the inner container, useful if you want to make the footer full width.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the footer component container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the footer component container.
+
 previewLayout: full-width
 accessibilityCriteria: |
   Text and links in the Footer must:

--- a/src/components/header/header.yaml
+++ b/src/components/header/header.yaml
@@ -1,3 +1,62 @@
+params:
+- name: homepageUrl
+  type: string
+  required: false
+  description: The url of the homepage. Defaults to /
+- name: assetsPath
+  type: string
+  required: false
+  description: The public path for the assets folder. If not provided it defaults to /assets/images
+- name: productName
+  type: string
+  required: false
+  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+- name: serviceName
+  type: string
+  required: false
+  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+- name: serviceUrl
+  type: string
+  required: false
+  description: Url for the service name anchor.
+- name: navigation
+  type: array
+  required: false
+  description: An array of navigation item objects.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: Text of the navigation item.
+  - name: href
+    type: string
+    required: false
+    description: Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.
+  - name: active
+    type: boolean
+    required: false
+    description: Flag to mark the navigation item as active or not.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the navigation item anchor.
+- name: navigationClasses
+  type: string
+  required: false
+  description: Classes for the navigation section of the header.
+- name: containerClasses
+  type: string
+  required: false
+  description: Classes for the container, useful if you want to make the header fixed width.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the header container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the header container.
+
 previewLayout: full-width
 accessibilityCriteria: |
   Text and links in the Header must:

--- a/src/components/hint/hint.yaml
+++ b/src/components/hint/hint.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the hint. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.
+- name: id
+  type: string
+  required: true
+  description: Optional id attribute to add to the hint span tag.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the hint span tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the hint span tag.
+
 accessibilityCriteria: |
   When used with a single input, the hint MUST:
   - be announced by screen readers when the input is focussed

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -1,3 +1,39 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: The id of the input.
+- name: name
+  type: string
+  required: true
+  description: The name of the input, which is submitted with the form data.
+- name: type
+  type: string
+  required: false
+  description: Type of input control to render. Defaults to "text".
+- name: value
+  type: string
+  required: false
+  description: Optional initial value of the input.
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component.
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the anchor tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
 examples:
   - name: default
     data:

--- a/src/components/inset-text/inset-text.yaml
+++ b/src/components/inset-text/inset-text.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+- name: id
+  type: string
+  required: false
+  description: Id attribute to add to the inset text container.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the anchor tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
 examples:
   - name: default
     data:

--- a/src/components/label/label.yaml
+++ b/src/components/label/label.yaml
@@ -1,3 +1,29 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+- name: for
+  type: string
+  required: true
+  description: The value of the for attribute, the id of the input the label is associated with.
+- name: isPageHeading
+  type: boolean
+  required: false
+  description: Whether the label also acts as the heading for the page.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the label tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the label tag.
+
 examples:
   - name: default
     data:

--- a/src/components/panel/panel.yaml
+++ b/src/components/panel/panel.yaml
@@ -1,3 +1,33 @@
+params:
+- name: titleText
+  type: string
+  required: true
+  description: If `titleHtml` is set, this is not required. Text to use within the panel. If `titleHtml` is provided, the `titleText` argument will be ignored.
+- name: titleHtml
+  type: string
+  required: true
+  description: If `titleText` is set, this is not required. HTML to use within the panel. If `titleHtml` is provided, the `titleText` argument will be ignored.
+- name: headingLevel
+  type: integer
+  required: false
+  description: Heading level, from 1 to 6. Default is 1.
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the panel container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the panel container.
+
 examples:
 - name: default
   data:

--- a/src/components/phase-banner/phase-banner.yaml
+++ b/src/components/phase-banner/phase-banner.yaml
@@ -1,3 +1,26 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the phase banner. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the phase banner. If `html` is provided, the `text` argument will be ignored.
+- name: tag
+  type: object
+  required: false
+  description: Options for the tag component.
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the phase banner container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the phase banner container.
+
 examples:
   - name: default
     data:

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -1,3 +1,95 @@
+params:
+- name: fieldset
+  type: object
+  required: false
+  description: Options for the fieldset component (e.g. legend).
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component (e.g. text).
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component (e.g. text).
+  isComponent: true
+- name: idPrefix
+  type: string
+  required: false
+  description: String to prefix id for each checkbox item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
+- name: name
+  type: string
+  required: true
+  description: Name attribute for each radio item.
+- name: items
+  type: array
+  required: true
+  description: Array of radio items objects.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within each radio item label. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.
+  - name: id
+    type: string
+    required: false
+    description: Specific id attribute for the radio item. If omitted, then `idPrefix` string will be applied.
+  - name: name
+    type: string
+    required: true
+    description: Specific name for the radio item. If omitted, then component global `name` string will be applied.
+  - name: value
+    type: string
+    required: true
+    description: Value for the radio input.
+  - name: label
+    type: object
+    required: false
+    description: Provide attributes and classes to each radio item label.
+    isComponent: true
+  - name: hint
+    type: object
+    required: false
+    description: Provide hint to each checkbox item.
+    isComponent: true
+  - name: divider
+    type: string
+    required: false
+    description: Divider text to separate radio items, for example the text "or".
+  - name: checked
+    type: boolean
+    required: false
+    description: If true, radio will be checked.
+  - name: conditional
+    type: string
+    required: false
+    description: If true, content provided will be revealed when the item is checked.
+  - name: conditional.html
+    type: html
+    required: false
+    description: Provide content for the conditional reveal.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If true, radio will be disabled.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the radio input tag.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the radio container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the radio input tag.
+
 accessibilityCriteria: |
   ## Conditional reveals
   Must:

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -1,3 +1,57 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: Id for each select box.
+- name: name
+  type: string
+  required: true
+  description: Name property for the select.
+- name: items
+  type: array
+  required: true
+  description: Array of option items for the select.
+  params:
+  - name: value
+    type: string
+    required: false
+    description: Value for the option item.
+  - name: text
+    type: string
+    required: true
+    description: Text for the option item.
+  - name: selected
+    type: boolean
+    required: false
+    description: Sets the option as the selected.
+  - name: disabled
+    type: boolean
+    required: false
+    description: Sets the option item as disabled.
+- name: label
+  type: object
+  required: false
+  description: Label text or HTML by specifying value for either text or html keys.
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component (e.g. text).
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the anchor tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the anchor tag.
+
 examples:
 - name: default
   data:

--- a/src/components/skip-link/skip-link.yaml
+++ b/src/components/skip-link/skip-link.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the skip link component. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the skip link component. If `html` is provided, the `text` argument will be ignored.
+- name: href
+  type: string
+  required: true
+  description: The value of the skip link href attribute. Defaults to #content
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the skip link.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the skip link.
+
 examples:
 - name: default
   data:

--- a/src/components/table/table.yaml
+++ b/src/components/table/table.yaml
@@ -1,3 +1,75 @@
+params:
+- name: rows
+  type: array
+  required: true
+  description: Array of table rows and cells.
+  params:
+  - name: text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text for cells in table rows. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML for cells in table rows. If `html` is provided, the `text` argument will be ignore
+  - name: format
+    type: string
+    required: false
+    description: Specify format of a cell. Currently we only use "numeric".
+  - name: colspan
+    type: integer
+    required: false
+    description: Specify how many columns a cell extends.
+  - name: rowspan
+    type: integer
+    required: false
+    description: Specify how many rows a cell extends.
+- name: head
+  type: array
+  required: false
+  description: Array of table head cells.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: If `html` is set, this is not required. Text for table head cells. If `html` is provided, the `text` argument will be ignored.
+  - name: html
+    type: string
+    required: false
+    description: If `text` is set, this is not required. HTML for table head cells. If `html` is provided, the `text` argument will be ignore
+  - name: format
+    type: string
+    required: false
+    description: Specify format of a cell. Currently we only use "numeric".
+  - name: colspan
+    type: integer
+    required: false
+    description: Specify how many columns a cell extends.
+  - name: rowspan
+    type: integer
+    required: false
+    description: Specify how many rows a cell extends.
+- name: caption
+  type: string
+  required: false
+  description: Caption text
+- name: captionClasses
+  type: string
+  required: false
+  description: Classes for caption text size. Classes should correspond to the available typography heading classes.
+- name: firstCellIsHeader
+  type: boolean
+  required: false
+  description: If set to true, first cell in table row will be a TH instead of a TD.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the table container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the table container.
+
 examples:
  - name: default
    data:

--- a/src/components/tabs/tabs.yaml
+++ b/src/components/tabs/tabs.yaml
@@ -1,5 +1,43 @@
-examples:
+params:
+- name: id
+  type: string
+  required: false
+  description: This is used for the main component and to compose id attribute for each item.
+- name: idPrefix
+  type: string
+  required: false
+  description: String to prefix id for each tab item if no id is specified on each item
+- name: items
+  type: array
+  required: true
+  description: Array of tab items.
+  params:
+  - name: id
+    type: string
+    required: true
+    description: Specific id attribute for the tab item. If omitted, then `idPrefix` string will be applied.
+  - name: label
+    type: string
+    required: true
+    description: The text label of a tab item.
+  - name: panel.text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within each tab panel. If `html` is provided, the `text` argument will be ignored.
+  - name: panel.html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` argument will be ignored.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the tabs component.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the tabs component.
 
+examples:
 - name: default
   data:
     items:

--- a/src/components/tag/tag.yaml
+++ b/src/components/tag/tag.yaml
@@ -1,3 +1,21 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the tag component. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the tag component. If `html` is provided, the `text` argument will be ignored.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the tag.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the tag.
+
 examples:
  - name: default
    data:

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -1,3 +1,48 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: The id of the textarea.
+- name: describedBy
+  type: string
+  required: false
+  description: Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.
+- name: name
+  type: string
+  required: true
+  description: The name of the textarea, which is submitted with the form data.
+- name: rows
+  type: string
+  required: false
+  description: Optional number of textarea rows (default is 5 rows).
+- name: value
+  type: string
+  required: false
+  description: Optional initial value of the textarea.
+- name: label
+  type: object
+  required: true
+  description: Options for the label component.
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component (e.g. text).
+  isComponent: true
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the textarea.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the textarea.
+
 examples:
   - name: default
     data:

--- a/src/components/warning-text/warning-text.yaml
+++ b/src/components/warning-text/warning-text.yaml
@@ -1,3 +1,25 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the warning text component. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the warning text component. If `html` is provided, the `text` argument will be ignored.
+- name: iconFallbackText
+  type: string
+  required: true
+  description: The fallback text for the icon.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the warning text.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the warning text.
+
 examples:
   - name: default
     data:

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -6,8 +6,14 @@ const postcss = require('gulp-postcss')
 const autoprefixer = require('autoprefixer')
 const taskArguments = require('./task-arguments')
 const filter = require('gulp-filter')
+const fs = require('fs')
+const yamlToJson = require('js-yaml')
+const path = require('path')
+const map = require('map-stream')
+const rename = require('gulp-rename')
 
 let scssFiles = filter([configPaths.src + '**/*.scss'], {restore: true})
+let yamlFiles = filter([configPaths.components + '**/*.yaml'], {restore: true})
 
 gulp.task('copy-files', () => {
   return gulp.src([
@@ -16,7 +22,6 @@ gulp.task('copy-files', () => {
     '!**/*.test.js',
     '!' + configPaths.src + 'README.md', // Don't override the existing README in /package
     '!' + configPaths.components + '**/README.njk',
-    '!' + configPaths.components + '**/*.{yml,yaml}',
     '!' + configPaths.components + '**/__snapshots__/**',
     '!' + configPaths.components + '**/__snapshots__/'
   ])
@@ -25,5 +30,36 @@ gulp.task('copy-files', () => {
       autoprefixer
     ], {syntax: require('postcss-scss')}))
     .pipe(scssFiles.restore)
+    .pipe(yamlFiles)
+    .pipe(map(function (file, done) {
+      let componentName = path.dirname(file.path).split(path.sep).slice(-1).toString()
+      let componentPath = path.join(configPaths.components, componentName, `${componentName}.yaml`)
+      let yaml
+      let json
+      let paramsJson
+
+      try {
+        yaml = fs.readFileSync(componentPath, {encoding: 'utf8', json: true})
+      } catch (e) {
+        console.error('ENOENT: no such file or directory: ', componentPath)
+      }
+
+      if (yaml) {
+        json = yamlToJson.safeLoad(yaml)
+        paramsJson = json.params // We only want the 'params' data from component yaml
+
+        if (paramsJson) {
+          file.contents = Buffer.from(JSON.stringify(paramsJson, null, 4))
+        } else {
+          console.error(componentPath + ' is missing "params"')
+        }
+      }
+      done(null, file)
+    }))
+    .pipe(rename(path => {
+      path.basename = 'macro-options'
+      path.extname = '.json'
+    }))
+    .pipe(yamlFiles.restore)
     .pipe(gulp.dest(taskArguments.destination + '/'))
 })


### PR DESCRIPTION
We want to expose the component options (arguments) to GOV.UK Design System. To do this, they need to be generated for inclusion in `package`.

This PR:
- Adds all component options in the component YAML as `params`. 
- Introduces `isComponent` option (so that the options for that component can be linked to in the Design System).
- Copies the component options as JSON files to `package` when `gulp build:package --destination 'package'` is run.
- Amends the tests for checking contents of `package` to allow filenames with wildcards in `additionalFilesNotInSrc`
- Adds a test to check all `package/components` have a `macro-options.json` that contains valid JSON with the expected attributes `name`, `type`, `required`, `description`

Created this as one PR so that the generated JSON files can be tested against https://github.com/alphagov/govuk-design-system/pull/518 

More on component options:
- We now refer to these as “options” in client facing docs as calling them “arguments” is technically incorrect and “parameters” was felt to be less clear than “options”.
- Regarding the "or" relationship between `text` and `html` attributes, we are continuing to explain this in the description of the attributes, ie. "If `html` is set, this is not required." There didn't seem to be a sensible way of trying to show this relationship in a simple table so using just text appeared to be  the most accessible method.
- This PR retains the convention of referring to them as “params” in component macro and template files - we might want to roll out renaming “params” to “options”  in all component macros and templates as a separate PR that can be quickly merged in without causing too many conflicts with other PRs.

To test, run `npm run build:package`

https://trello.com/c/QN0imhXt/722-define-arguments-for-components-in-the-component-yaml-file 
https://trello.com/c/00iDbQOU/1323-allow-argument-yamls-to-be-transformed-into-json-and-copied-to-package