### PR TITLE
Update `browserslist` in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@
 
   ([PR #986](https://github.com/alphagov/govuk-frontend/pull/986))
 
+- Update `browsersList` in `package.json` to reflect our supported browsers
+
+  `browsersList` is used by PostCSS in our current build to determine which browser prefixes or rules to generate for the built CSS files. This PR adds rules to specify that the browsers in our [browser matrix](https://github.com/alphagov/govuk-frontend#browser-support) should always be prefixed for. Additionally, any browser with more than 0.1% of the global market share is prefixed for.
+
+  In terms of changes to our built CSS, this means that `-webkit-box-sizing` and `-webkit-box-shadow` prefixes will be removed - neither of these prefixes are required by desktop Safari 5.1 or later so this seems a fairly safe change to make.
+
+  ([PR #1002](https://github.com/alphagov/govuk-frontend/pull/1002))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/package.json
+++ b/package.json
@@ -65,10 +65,14 @@
     "fsevents": "*"
   },
   "browserslist": [
-    "last 2 versions",
-    "ie 8",
-    "ie 9",
-    "iOS 9"
+    ">0.1%",
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Edge versions",
+    "last 2 Samsung versions",
+    "Safari >= 9",
+    "ie 8-11",
+    "iOS >= 9"
   ],
   "standard": {
     "ignore": [


### PR DESCRIPTION
This makes `browserslist` specific to the [browsers we support](https://github.com/alphagov/govuk-frontend#browser-support). Once this has been approved, we can raise a PR to make the same change in GOV.UK Design System.

Tested `/components/all` page in (if only we had cross browser visual tests 🤓):
✅ Chrome 68, 69
✅ Firefox 61, 62 (with inverted colours)
✅ Safari 9.1, 10.1, 11.1
✅ Edge 16, 17
✅ iOS Safari 9
✅ Android Chrome 63
✅ Samsung Internet 6.4.0.5
✅ Internet Explorer 8
✅ Internet Explorer 9
✅ Internet Explorer 10
✅ Internet Explorer 11

Issue originally discussed [here](https://github.com/alphagov/govuk-design-system/commit/44fac9d2c07215bb914a7bac2448dda7c1aa2872#commitcomment-30022713).

Syntax follows [browserslist docs](https://github.com/browserslist/browserslist#full-list).

Fixes https://github.com/alphagov/govuk-frontend/issues/952

https://trello.com/c/dvfqTy9D/1360-update-browser-list-in-packagejson