### PR TITLE
Prevent product name in header from wrapping and add some spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,21 @@
 
 🔧 Fixes:
 
-- Apply max-width to the `<select> element
+- Apply max-width to the `<select>` element
 
   The `<select>` element's width is governed by the widths of its `<option>`'s.
 
   When the text in the options grows large, the element can grow to > 100% of the width of its container and break the layout.
 
   ([PR #1013](https://github.com/alphagov/govuk-frontend/pull/1013))
+
+- Prevent product name in header from wrapping
+
+  Currently the product name in the header wraps when the space shrinks which doesn't look great.
+
+  Adding `display: inline-table` prevents that so that the product name as a whole drops to a new line when space is shrunk.
+
+  ([PR #1007](https://github.com/alphagov/govuk-frontend/pull/1007))
 
 - Pull Request Title goes here
 

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -60,6 +60,7 @@
 
   .govuk-header__product-name {
     @include govuk-font($size: 24);
+    display: inline-table;
   }
 
   .govuk-header__link {

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -61,6 +61,7 @@
   .govuk-header__product-name {
     @include govuk-font($size: 24);
     display: inline-table;
+    padding-right: govuk-spacing(2);
   }
 
   .govuk-header__link {


### PR DESCRIPTION
Currently the product name in the header wraps when the space shrinks which doesn't look great.

<img width="809" alt="screen shot 2018-09-21 at 11 40 57" src="https://user-images.githubusercontent.com/3758555/45876787-986e2e80-bd93-11e8-9a58-084487e98f82.png">
<img width="308" alt="screen shot 2018-09-21 at 11 41 06" src="https://user-images.githubusercontent.com/3758555/45876791-9ad08880-bd93-11e8-9c5f-91995e05fe7d.png">


Adding `display:inline-table` prevents that so that the product name as a whole drops to a new line when space is shrunk.

<img width="870" alt="screen shot 2018-09-21 at 11 44 25" src="https://user-images.githubusercontent.com/3758555/45876833-cf444480-bd93-11e8-9ffc-8ff97b5c4a56.png">
<img width="333" alt="screen shot 2018-09-21 at 11 45 03" src="https://user-images.githubusercontent.com/3758555/45876835-d0757180-bd93-11e8-858e-7eb8124ed17e.png">

<details>
<summary>GIFs</summary>
<img src="https://user-images.githubusercontent.com/3758555/45876938-24805600-bd94-11e8-8151-f1b4650a6eeb.gif">
<img src="https://user-images.githubusercontent.com/3758555/45876936-22b69280-bd94-11e8-8453-b64f7a93c1ba.gif">
</details>