### PR TITLE
Set max-width on the <select> element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@
 
 🔧 Fixes:
 
+- Apply max-width to the `<select> element
+
+  The `<select>` element's width is governed by the widths of its `<option>`'s.
+
+  When the text in the options grows large, the element can grow to > 100% of the width of its container and break the layout.
+
+  ([PR #1013](https://github.com/alphagov/govuk-frontend/pull/1013))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -12,8 +12,8 @@
     @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
+    max-width: 100%;
     height: 40px;
-
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
   }


### PR DESCRIPTION
The `<select>` element's width is governed by the widths of its `<option>`'s.

When the text in the options grows large, the element can grow to > 100% of the width of its container and break the layout.

Fixes: #1009 
