### PR TITLE
Ignore .DS_Store files in `after-build-dist` test

### DIFF
--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -11,7 +11,10 @@ describe('dist/', () => {
     it('should include the same files as in src/assets', () => {
       // Build an array of the assets that are present in the src directory.
       const expectedDistAssets = () => {
-        return recursive(path.join(configPaths.src, 'assets')).then(
+        const filesToIgnore = [
+          '.DS_Store'
+        ]
+        return recursive(path.join(configPaths.src, 'assets'), filesToIgnore).then(
           files => {
             return files
               // Remove /package prefix from filenames


### PR DESCRIPTION
Currently the `after-build-dist` test fails as it includes .DS_Store files in the array of expected files.

This work adds an array of files to ignore, similarly to how the `after-build-package` test is set up.

Before:

<img width="294" alt="screen shot 2018-09-27 at 08 41 53" src="https://user-images.githubusercontent.com/3758555/46131095-bf64ae80-c232-11e8-9a63-1ce1e23ed534.png">
<img width="300" alt="screen shot 2018-09-27 at 08 42 01" src="https://user-images.githubusercontent.com/3758555/46131102-c12e7200-c232-11e8-8488-73ac02c27af0.png">

After:
<img width="296" alt="screen shot 2018-09-27 at 08 51 28" src="https://user-images.githubusercontent.com/3758555/46131111-c5f32600-c232-11e8-8545-a78810effb4e.png">
