### PR TITLE
Allow optional classes on table items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@
 
 🆕 New features:
 
-- Pull Request Title goes here
+- Allow classes on table header and row cells
+  
+  Optional classes attribute can now be used on table header and row cell item
+  in the Nunjucks macro
 
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR #1015](https://github.com/alphagov/govuk-frontend/pull/1015))
 
 🔧 Fixes:
 

--- a/src/components/back-link/README.md
+++ b/src/components/back-link/README.md
@@ -89,11 +89,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -101,11 +101,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The value of the link href attribute</td>
+<td class="govuk-table__cell">The value of the link href attribute</td>
 
 </tr>
 
@@ -113,11 +113,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the anchor tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the anchor tag.</td>
 
 </tr>
 
@@ -125,11 +125,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the anchor tag.</td>
 
 </tr>
 

--- a/src/components/breadcrumbs/README.md
+++ b/src/components/breadcrumbs/README.md
@@ -254,11 +254,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of breadcrumbs item objects.</td>
+<td class="govuk-table__cell">Array of breadcrumbs item objects.</td>
 
 </tr>
 
@@ -266,11 +266,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -278,11 +278,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">no</td>
+<td class="govuk-table__cell">no</td>
 
-<td class="govuk-table__cell ">Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item</td>
+<td class="govuk-table__cell">Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item</td>
 
 </tr>
 
@@ -290,11 +290,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the breadcrumb anchor item.</td>
 
 </tr>
 
@@ -302,11 +302,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the breadcrumbs container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the breadcrumbs container.</td>
 
 </tr>
 
@@ -314,11 +314,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the breadcrumbs container.</td>
 
 </tr>
 

--- a/src/components/button/README.md
+++ b/src/components/button/README.md
@@ -190,11 +190,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">element</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.</td>
+<td class="govuk-table__cell">Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.</td>
 
 </tr>
 
@@ -202,11 +202,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.</td>
+<td class="govuk-table__cell">Text or HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.</td>
 
 </tr>
 
@@ -214,11 +214,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Name for the `input` or `button`. This has no effect on `a` elements.</td>
+<td class="govuk-table__cell">Name for the `input` or `button`. This has no effect on `a` elements.</td>
 
 </tr>
 
@@ -226,11 +226,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">type</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Type of `input` or `button` – `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.</td>
+<td class="govuk-table__cell">Type of `input` or `button` – `button`, `submit` or `reset`. Defaults to `submit`. This has no effect on `a` elements.</td>
 
 </tr>
 
@@ -238,11 +238,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Value for the `button` tag. This has no effect on `a` or `input` elements.</td>
+<td class="govuk-table__cell">Value for the `button` tag. This has no effect on `a` or `input` elements.</td>
 
 </tr>
 
@@ -250,11 +250,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">disabled</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.</td>
+<td class="govuk-table__cell">Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically.</td>
 
 </tr>
 
@@ -262,11 +262,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.</td>
+<td class="govuk-table__cell">The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.</td>
 
 </tr>
 
@@ -274,11 +274,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell">Optional additional classes</td>
 
 </tr>
 
@@ -286,11 +286,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the button component.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the button component.</td>
 
 </tr>
 

--- a/src/components/checkboxes/README.md
+++ b/src/components/checkboxes/README.md
@@ -721,11 +721,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">fieldset</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
+<td class="govuk-table__cell">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
 
 </tr>
 
@@ -733,11 +733,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -745,11 +745,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -757,11 +757,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">idPrefix</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">String to prefix id for each checkbox item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
+<td class="govuk-table__cell">String to prefix id for each checkbox item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
 
 </tr>
 
@@ -769,11 +769,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Name attribute for each checkbox item.</td>
+<td class="govuk-table__cell">Name attribute for each checkbox item.</td>
 
 </tr>
 
@@ -781,11 +781,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of checkbox items objects.</td>
+<td class="govuk-table__cell">Array of checkbox items objects.</td>
 
 </tr>
 
@@ -793,11 +793,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -805,11 +805,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specific id attribute for the checkbox item. If ommited, then `idPrefix` string will be applied.</td>
+<td class="govuk-table__cell">Specific id attribute for the checkbox item. If ommited, then `idPrefix` string will be applied.</td>
 
 </tr>
 
@@ -817,11 +817,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Specific name for the checkbox item. If ommited, then component global `name` string will be applied.</td>
+<td class="govuk-table__cell">Specific name for the checkbox item. If ommited, then component global `name` string will be applied.</td>
 
 </tr>
 
@@ -829,11 +829,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Value for the checkbox input.</td>
+<td class="govuk-table__cell">Value for the checkbox input.</td>
 
 </tr>
 
@@ -841,11 +841,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide additional attributes and classes to each checkbox item label. See [label](../label/README.md#component-arguments) component for more details.</td>
+<td class="govuk-table__cell">Provide additional attributes and classes to each checkbox item label. See [label](../label/README.md#component-arguments) component for more details.</td>
 
 </tr>
 
@@ -853,11 +853,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide optional hint to each checkbox item. See `hint` component for more details.</td>
+<td class="govuk-table__cell">Provide optional hint to each checkbox item. See `hint` component for more details.</td>
 
 </tr>
 
@@ -865,11 +865,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.checked</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, checkbox will be checked.</td>
+<td class="govuk-table__cell">If true, checkbox will be checked.</td>
 
 </tr>
 
@@ -877,11 +877,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.conditional</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, content provided will be revealed when the item is checked.</td>
+<td class="govuk-table__cell">If true, content provided will be revealed when the item is checked.</td>
 
 </tr>
 
@@ -889,11 +889,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.conditional.html</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide content for the conditional reveal.</td>
+<td class="govuk-table__cell">Provide content for the conditional reveal.</td>
 
 </tr>
 
@@ -901,11 +901,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.disabled</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, checkbox will be disabled.</td>
+<td class="govuk-table__cell">If true, checkbox will be disabled.</td>
 
 </tr>
 
@@ -913,11 +913,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the checkbox input tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the checkbox input tag.</td>
 
 </tr>
 
@@ -925,11 +925,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the checkboxes container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the checkboxes container.</td>
 
 </tr>
 
@@ -937,11 +937,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the checkboxes container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the checkboxes container.</td>
 
 </tr>
 

--- a/src/components/date-input/README.md
+++ b/src/components/date-input/README.md
@@ -579,11 +579,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional id. This is used for the main component and to compose id attribute for each item.</td>
+<td class="govuk-table__cell">Optional id. This is used for the main component and to compose id attribute for each item.</td>
 
 </tr>
 
@@ -591,11 +591,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">namePrefix</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional prefix. This is used to prefix each `item.name` using `-`.</td>
+<td class="govuk-table__cell">Optional prefix. This is used to prefix each `item.name` using `-`.</td>
 
 </tr>
 
@@ -603,11 +603,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">An array of input objects with name, value and optional classes</td>
+<td class="govuk-table__cell">An array of input objects with name, value and optional classes</td>
 
 </tr>
 
@@ -615,11 +615,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional item-specific id. If provided, it will be used instead of the generated id.</td>
+<td class="govuk-table__cell">Optional item-specific id. If provided, it will be used instead of the generated id.</td>
 
 </tr>
 
@@ -627,11 +627,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.name</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Item-specific name attribute.</td>
+<td class="govuk-table__cell">Item-specific name attribute.</td>
 
 </tr>
 
@@ -639,11 +639,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional item-specific value attribute. If provided, it will be used as the initial value of the input.</td>
+<td class="govuk-table__cell">Optional item-specific value attribute. If provided, it will be used as the initial value of the input.</td>
 
 </tr>
 
@@ -651,11 +651,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.label</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional item-specific label text. If provided, this will be used instead of the items.{}.name.</td>
+<td class="govuk-table__cell">Optional item-specific label text. If provided, this will be used instead of the items.{}.name.</td>
 
 </tr>
 
@@ -663,11 +663,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional hint. See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Optional hint. See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -675,11 +675,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional error message. See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Optional error message. See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -687,11 +687,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">fieldset</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
+<td class="govuk-table__cell">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
 
 </tr>
 
@@ -699,11 +699,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the date-input container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the date-input container.</td>
 
 </tr>
 
@@ -711,11 +711,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the date-input container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the date-input container.</td>
 
 </tr>
 

--- a/src/components/details/README.md
+++ b/src/components/details/README.md
@@ -144,11 +144,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">summaryText (or) summaryHtml</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.</td>
 
 </tr>
 
@@ -156,11 +156,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -168,11 +168,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional id to add to the details element.</td>
+<td class="govuk-table__cell">Optional id to add to the details element.</td>
 
 </tr>
 
@@ -180,11 +180,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">open</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, details element will be expanded.</td>
+<td class="govuk-table__cell">If true, details element will be expanded.</td>
 
 </tr>
 
@@ -192,11 +192,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the details element.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the details element.</td>
 
 </tr>
 
@@ -204,11 +204,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the details element.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the details element.</td>
 
 </tr>
 

--- a/src/components/error-message/README.md
+++ b/src/components/error-message/README.md
@@ -74,11 +74,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text to use within the error message. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text to use within the error message. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -86,11 +86,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional id attribute to add to the error message span tag.</td>
+<td class="govuk-table__cell">Optional id attribute to add to the error message span tag.</td>
 
 </tr>
 
@@ -98,11 +98,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the error message span tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the error message span tag.</td>
 
 </tr>
 
@@ -110,11 +110,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error message span tag</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the error message span tag</td>
 
 </tr>
 

--- a/src/components/error-summary/README.md
+++ b/src/components/error-summary/README.md
@@ -110,11 +110,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">titleText (or) titleHtml</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use for the heading of the error summary block. If `titleHtml` is provided, the `titleText` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use for the heading of the error summary block. If `titleHtml` is provided, the `titleText` argument will be ignored.</td>
 
 </tr>
 
@@ -122,11 +122,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">descriptionText (or) descriptionHtml</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional text or HTML description of the errors. If `descriptionhtml` is provided, the `descriptionText` argument will be ignored.</td>
+<td class="govuk-table__cell">Optional text or HTML description of the errors. If `descriptionhtml` is provided, the `descriptionText` argument will be ignored.</td>
 
 </tr>
 
@@ -134,11 +134,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorList</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Contains an array of error link items and all their available arguments.</td>
+<td class="govuk-table__cell">Contains an array of error link items and all their available arguments.</td>
 
 </tr>
 
@@ -146,11 +146,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorList.{}.href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Href attribute for the error link item. If provided item will be an anchor.</td>
+<td class="govuk-table__cell">Href attribute for the error link item. If provided item will be an anchor.</td>
 
 </tr>
 
@@ -158,11 +158,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorList.{}.text (or) errorList.{}.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML for the error link item. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML for the error link item. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -170,11 +170,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorList.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error link anchor.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the error link anchor.</td>
 
 </tr>
 
@@ -182,11 +182,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the error-summary container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the error-summary container.</td>
 
 </tr>
 
@@ -194,11 +194,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the error-summary container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the error-summary container.</td>
 
 </tr>
 

--- a/src/components/fieldset/README.md
+++ b/src/components/fieldset/README.md
@@ -108,11 +108,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">describedBy</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or element id to add to the `aria-describedby` attribute to provide description of the group of fields for screenreader users.</td>
+<td class="govuk-table__cell">Text or element id to add to the `aria-describedby` attribute to provide description of the group of fields for screenreader users.</td>
 
 </tr>
 
@@ -120,11 +120,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">legend</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the legend</td>
+<td class="govuk-table__cell">Arguments for the legend</td>
 
 </tr>
 
@@ -132,11 +132,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">legend.{}.text (or) legend.{}.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Legend text or HTML. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Legend text or HTML. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -144,11 +144,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">legend.{}.classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the legend container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the legend container.</td>
 
 </tr>
 
@@ -156,11 +156,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">legend.{}.isPageHeading</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Whether the legend also acts as the heading for the page.</td>
+<td class="govuk-table__cell">Whether the legend also acts as the heading for the page.</td>
 
 </tr>
 
@@ -168,11 +168,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the fieldset container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the fieldset container.</td>
 
 </tr>
 
@@ -180,11 +180,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the fieldset container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the fieldset container.</td>
 
 </tr>
 

--- a/src/components/file-upload/README.md
+++ b/src/components/file-upload/README.md
@@ -215,11 +215,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The name of the input, which is submitted with the form data.</td>
+<td class="govuk-table__cell">The name of the input, which is submitted with the form data.</td>
 
 </tr>
 
@@ -227,11 +227,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The id of the input</td>
+<td class="govuk-table__cell">The id of the input</td>
 
 </tr>
 
@@ -239,11 +239,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional initial value of the input</td>
+<td class="govuk-table__cell">Optional initial value of the input</td>
 
 </tr>
 
@@ -251,11 +251,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
+<td class="govuk-table__cell">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
 
 </tr>
 
@@ -263,11 +263,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -275,11 +275,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -287,11 +287,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the input tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the input tag.</td>
 
 </tr>
 
@@ -299,11 +299,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example accept or data attributes) to add to the input tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example accept or data attributes) to add to the input tag.</td>
 
 </tr>
 

--- a/src/components/footer/README.md
+++ b/src/components/footer/README.md
@@ -107,11 +107,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Object containing parameters for the meta navigation.</td>
+<td class="govuk-table__cell">Object containing parameters for the meta navigation.</td>
 
 </tr>
 
@@ -119,11 +119,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.text</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text to add to the meta section of the footer, which will appear below any links specified using meta.items. If meta.html is specified, this option is ignored.</td>
+<td class="govuk-table__cell">Text to add to the meta section of the footer, which will appear below any links specified using meta.items. If meta.html is specified, this option is ignored.</td>
 
 </tr>
 
@@ -131,11 +131,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">HTML to add to the meta section of the footer, which will appear below any links specified using meta.items. If you do not need to use HTML, use meta.text instead.</td>
+<td class="govuk-table__cell">HTML to add to the meta section of the footer, which will appear below any links specified using meta.items. If you do not need to use HTML, use meta.text instead.</td>
 
 </tr>
 
@@ -143,11 +143,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Array of items for use in the meta section of the footer.</td>
+<td class="govuk-table__cell">Array of items for use in the meta section of the footer.</td>
 
 </tr>
 
@@ -155,11 +155,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.items.{}.text</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">List item text in the meta section of the footer.</td>
+<td class="govuk-table__cell">List item text in the meta section of the footer.</td>
 
 </tr>
 
@@ -167,11 +167,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.items.{}.href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">List item href attribute in the meta section of the footer.</td>
+<td class="govuk-table__cell">List item href attribute in the meta section of the footer.</td>
 
 </tr>
 
@@ -179,11 +179,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">meta.items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer meta section.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer meta section.</td>
 
 </tr>
 
@@ -191,11 +191,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Array of items for use in the navigation section of the footer.</td>
+<td class="govuk-table__cell">Array of items for use in the navigation section of the footer.</td>
 
 </tr>
 
@@ -203,11 +203,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.title</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Title for a section</td>
+<td class="govuk-table__cell">Title for a section</td>
 
 </tr>
 
@@ -215,11 +215,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.columns</th>
 
-<td class="govuk-table__cell ">integer</td>
+<td class="govuk-table__cell">integer</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Amount of columns to display items in navigation section of the footer.</td>
+<td class="govuk-table__cell">Amount of columns to display items in navigation section of the footer.</td>
 
 </tr>
 
@@ -227,11 +227,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Array of items to display in the list in navigation section of the footer.</td>
+<td class="govuk-table__cell">Array of items to display in the list in navigation section of the footer.</td>
 
 </tr>
 
@@ -239,11 +239,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.items.{}.text</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">List item text in the navigation section of the footer.</td>
+<td class="govuk-table__cell">List item text in the navigation section of the footer.</td>
 
 </tr>
 
@@ -251,11 +251,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.items.{}.href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.</td>
+<td class="govuk-table__cell">List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.</td>
 
 </tr>
 
@@ -263,11 +263,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.</td>
 
 </tr>
 
@@ -275,11 +275,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">containerClasses</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Classes that can be added to the inner container, useful if you want to make the footer full width.</td>
+<td class="govuk-table__cell">Classes that can be added to the inner container, useful if you want to make the footer full width.</td>
 
 </tr>
 
@@ -287,11 +287,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the footer component container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the footer component container.</td>
 
 </tr>
 
@@ -299,11 +299,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the footer component container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the footer component container.</td>
 
 </tr>
 

--- a/src/components/header/README.md
+++ b/src/components/header/README.md
@@ -367,11 +367,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">homepageUrl</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">The url of the homepage. Defaults to /</td>
+<td class="govuk-table__cell">The url of the homepage. Defaults to /</td>
 
 </tr>
 
@@ -379,11 +379,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">assetsPath</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">The public path for the assets folder. If not provided it defaults to /assets/images</td>
+<td class="govuk-table__cell">The public path for the assets folder. If not provided it defaults to /assets/images</td>
 
 </tr>
 
@@ -391,11 +391,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">productName</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)</td>
+<td class="govuk-table__cell">Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)</td>
 
 </tr>
 
@@ -403,11 +403,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">serviceName</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)</td>
+<td class="govuk-table__cell">Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)</td>
 
 </tr>
 
@@ -415,11 +415,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">serviceUrl</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Url for the service name anchor.</td>
+<td class="govuk-table__cell">Url for the service name anchor.</td>
 
 </tr>
 
@@ -427,11 +427,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">An array of navigation item objects.</td>
+<td class="govuk-table__cell">An array of navigation item objects.</td>
 
 </tr>
 
@@ -439,11 +439,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.text</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text of the navigation item.</td>
+<td class="govuk-table__cell">Text of the navigation item.</td>
 
 </tr>
 
@@ -451,11 +451,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.</td>
+<td class="govuk-table__cell">Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.</td>
 
 </tr>
 
@@ -463,11 +463,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.active</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Flag to mark the navigation item as active or not.</td>
+<td class="govuk-table__cell">Flag to mark the navigation item as active or not.</td>
 
 </tr>
 
@@ -475,11 +475,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigation.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the navigation item anchor.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the navigation item anchor.</td>
 
 </tr>
 
@@ -487,11 +487,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">navigationClasses</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional classes that can be added to the navigation section of the header.</td>
+<td class="govuk-table__cell">Optional classes that can be added to the navigation section of the header.</td>
 
 </tr>
 
@@ -499,11 +499,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">containerClasses</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional classes that can be added to the container, useful if you want to make the header fixed width.</td>
+<td class="govuk-table__cell">Optional classes that can be added to the container, useful if you want to make the header fixed width.</td>
 
 </tr>
 
@@ -511,11 +511,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the header container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the header container.</td>
 
 </tr>
 
@@ -523,11 +523,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the header container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the header container.</td>
 
 </tr>
 

--- a/src/components/hint/README.md
+++ b/src/components/hint/README.md
@@ -92,11 +92,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text or (html) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -104,11 +104,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Optional id attribute o add to the hint span tag.</td>
+<td class="govuk-table__cell">Optional id attribute o add to the hint span tag.</td>
 
 </tr>
 
@@ -116,11 +116,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the hint span tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the hint span tag.</td>
 
 </tr>
 
@@ -128,11 +128,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the hint span tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the hint span tag.</td>
 
 </tr>
 

--- a/src/components/input/README.md
+++ b/src/components/input/README.md
@@ -423,11 +423,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The id of the input.</td>
+<td class="govuk-table__cell">The id of the input.</td>
 
 </tr>
 
@@ -435,11 +435,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The name of the input, which is submitted with the form data.</td>
+<td class="govuk-table__cell">The name of the input, which is submitted with the form data.</td>
 
 </tr>
 
@@ -447,11 +447,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">type</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Type of input control to render. Defaults to "text".</td>
+<td class="govuk-table__cell">Type of input control to render. Defaults to "text".</td>
 
 </tr>
 
@@ -459,11 +459,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional initial value of the input.</td>
+<td class="govuk-table__cell">Optional initial value of the input.</td>
 
 </tr>
 
@@ -471,11 +471,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
+<td class="govuk-table__cell">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
 
 </tr>
 
@@ -483,11 +483,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -495,11 +495,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -507,11 +507,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes add to the input component.</td>
+<td class="govuk-table__cell">Optional additional classes add to the input component.</td>
 
 </tr>
 
@@ -519,11 +519,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the input component.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the input component.</td>
 
 </tr>
 

--- a/src/components/inset-text/README.md
+++ b/src/components/inset-text/README.md
@@ -88,11 +88,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the inset text. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the inset text. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -100,11 +100,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional id attribute to add to the inset text container.</td>
+<td class="govuk-table__cell">Optional id attribute to add to the inset text container.</td>
 
 </tr>
 
@@ -112,11 +112,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the inset text container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the inset text container.</td>
 
 </tr>
 
@@ -124,11 +124,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the inset text container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the inset text container.</td>
 
 </tr>
 

--- a/src/components/label/README.md
+++ b/src/components/label/README.md
@@ -112,11 +112,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the label. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the label. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -124,11 +124,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">for</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The value of the for attribute, the id of the input the label is associated with.</td>
+<td class="govuk-table__cell">The value of the for attribute, the id of the input the label is associated with.</td>
 
 </tr>
 
@@ -136,11 +136,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">isPageHeading</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Whether the label also acts as the heading for the page.</td>
+<td class="govuk-table__cell">Whether the label also acts as the heading for the page.</td>
 
 </tr>
 
@@ -148,11 +148,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the label tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the label tag.</td>
 
 </tr>
 
@@ -160,11 +160,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the label tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the label tag.</td>
 
 </tr>
 

--- a/src/components/panel/README.md
+++ b/src/components/panel/README.md
@@ -109,11 +109,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">titleText (or) titleHtml</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML for the panel title. If `titleHtml` is provided, the `titleText` argument is ignored.</td>
+<td class="govuk-table__cell">Text or HTML for the panel title. If `titleHtml` is provided, the `titleText` argument is ignored.</td>
 
 </tr>
 
@@ -121,11 +121,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">headingLevel</th>
 
-<td class="govuk-table__cell ">number</td>
+<td class="govuk-table__cell">number</td>
 
-<td class="govuk-table__cell ">no</td>
+<td class="govuk-table__cell">no</td>
 
-<td class="govuk-table__cell ">Optional heading level, from 1 to 6\. Default is 2.</td>
+<td class="govuk-table__cell">Optional heading level, from 1 to 6\. Default is 2.</td>
 
 </tr>
 
@@ -133,11 +133,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or HTML for the panel content. If `html` is provided, the `text` argument is ignored.</td>
+<td class="govuk-table__cell">Text or HTML for the panel content. If `html` is provided, the `text` argument is ignored.</td>
 
 </tr>
 
@@ -145,11 +145,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the panel container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the panel container.</td>
 
 </tr>
 
@@ -157,11 +157,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the panel container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the panel container.</td>
 
 </tr>
 

--- a/src/components/phase-banner/README.md
+++ b/src/components/phase-banner/README.md
@@ -83,11 +83,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">HTML to use for the phase-banner message. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">HTML to use for the phase-banner message. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -95,11 +95,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">tag</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the tag object. See <a href="../tag/README.md#component-arguments">tag</a> component.</td>
+<td class="govuk-table__cell">Arguments for the tag object. See <a href="../tag/README.md#component-arguments">tag</a> component.</td>
 
 </tr>
 
@@ -107,11 +107,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the phase banner container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the phase banner container.</td>
 
 </tr>
 
@@ -119,11 +119,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the phase banner container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the phase banner container.</td>
 
 </tr>
 

--- a/src/components/radios/README.md
+++ b/src/components/radios/README.md
@@ -681,11 +681,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">fieldset</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
+<td class="govuk-table__cell">Arguments for the fieldset component (e.g. legend). See <a href="../fieldset/README.md#component-arguments">fieldset</a> component.</td>
 
 </tr>
 
@@ -693,11 +693,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -705,11 +705,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See errorMessage component.</td>
 
 </tr>
 
@@ -717,11 +717,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">idPrefix</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">String to prefix id for each radio item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
+<td class="govuk-table__cell">String to prefix id for each radio item if no id is specified on each item. If`idPrefix` is not passed, fallback to using the name attribute instead.</td>
 
 </tr>
 
@@ -729,11 +729,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Name attribute for each radio item.</td>
+<td class="govuk-table__cell">Name attribute for each radio item.</td>
 
 </tr>
 
@@ -741,11 +741,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of checkbox items objects.</td>
+<td class="govuk-table__cell">Array of checkbox items objects.</td>
 
 </tr>
 
@@ -753,11 +753,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.text (or) items.{}.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -765,11 +765,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specific id attribute for the radio item. If ommited, then `idPrefix` string will be applied.</td>
+<td class="govuk-table__cell">Specific id attribute for the radio item. If ommited, then `idPrefix` string will be applied.</td>
 
 </tr>
 
@@ -777,11 +777,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Specific name for the radio item. If ommited, then component global `name` string will be applied.</td>
+<td class="govuk-table__cell">Specific name for the radio item. If ommited, then component global `name` string will be applied.</td>
 
 </tr>
 
@@ -789,11 +789,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Value for the radio input.</td>
+<td class="govuk-table__cell">Value for the radio input.</td>
 
 </tr>
 
@@ -801,11 +801,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide additional attributes and classes to each radio item label. See [label](../label/README.md#component-arguments) component for more details.</td>
+<td class="govuk-table__cell">Provide additional attributes and classes to each radio item label. See [label](../label/README.md#component-arguments) component for more details.</td>
 
 </tr>
 
@@ -813,11 +813,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide optional hint to each radio item. See `hint` component for more details.</td>
+<td class="govuk-table__cell">Provide optional hint to each radio item. See `hint` component for more details.</td>
 
 </tr>
 
@@ -825,11 +825,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.divider</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional divider text to separate radio items, for example the text "or".</td>
+<td class="govuk-table__cell">Optional divider text to separate radio items, for example the text "or".</td>
 
 </tr>
 
@@ -837,11 +837,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.checked</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, radio will be checked.</td>
+<td class="govuk-table__cell">If true, radio will be checked.</td>
 
 </tr>
 
@@ -849,11 +849,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.conditional</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, content provided will be revealed when the item is checked.</td>
+<td class="govuk-table__cell">If true, content provided will be revealed when the item is checked.</td>
 
 </tr>
 
@@ -861,11 +861,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.conditional.html</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Provide content for the conditional reveal.</td>
+<td class="govuk-table__cell">Provide content for the conditional reveal.</td>
 
 </tr>
 
@@ -873,11 +873,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.disabled</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If true, radio will be disabled.</td>
+<td class="govuk-table__cell">If true, radio will be disabled.</td>
 
 </tr>
 
@@ -885,11 +885,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the radio input tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the radio input tag.</td>
 
 </tr>
 
@@ -897,11 +897,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the radios container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the radios container.</td>
 
 </tr>
 
@@ -909,11 +909,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the radios container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the radios container.</td>
 
 </tr>
 

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -273,11 +273,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Id for each select box</td>
+<td class="govuk-table__cell">Id for each select box</td>
 
 </tr>
 
@@ -285,11 +285,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Name property for the select.</td>
+<td class="govuk-table__cell">Name property for the select.</td>
 
 </tr>
 
@@ -297,11 +297,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of option items for the select.</td>
+<td class="govuk-table__cell">Array of option items for the select.</td>
 
 </tr>
 
@@ -309,11 +309,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">item.value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Value for the option item.</td>
+<td class="govuk-table__cell">Value for the option item.</td>
 
 </tr>
 
@@ -321,11 +321,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">item.text</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text for the option item.</td>
+<td class="govuk-table__cell">Text for the option item.</td>
 
 </tr>
 
@@ -333,11 +333,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">item.selected</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Sets the option as the selected.</td>
+<td class="govuk-table__cell">Sets the option as the selected.</td>
 
 </tr>
 
@@ -345,11 +345,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">item.disabled</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Sets the option item as disabled.</td>
+<td class="govuk-table__cell">Sets the option item as disabled.</td>
 
 </tr>
 
@@ -357,11 +357,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">item.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to the select option tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to the select option tag.</td>
 
 </tr>
 
@@ -369,11 +369,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional label text or HTML by specifying value for either text or html keys. See <a href="../label/README.md#component-arguments">label</a> component.</td>
+<td class="govuk-table__cell">Optional label text or HTML by specifying value for either text or html keys. See <a href="../label/README.md#component-arguments">label</a> component.</td>
 
 </tr>
 
@@ -381,11 +381,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -393,11 +393,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -405,11 +405,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the select component.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the select component.</td>
 
 </tr>
 
@@ -417,11 +417,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the select component.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the select component.</td>
 
 </tr>
 

--- a/src/components/skip-link/README.md
+++ b/src/components/skip-link/README.md
@@ -73,11 +73,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within the skip link. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within the skip link. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -85,11 +85,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">href</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The value of the skip link href attribute. Defaults to #content</td>
+<td class="govuk-table__cell">The value of the skip link href attribute. Defaults to #content</td>
 
 </tr>
 
@@ -97,11 +97,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the skip link.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the skip link.</td>
 
 </tr>
 
@@ -109,11 +109,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the skip link.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the skip link.</td>
 
 </tr>
 

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -384,11 +384,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of table rows and cells.</td>
+<td class="govuk-table__cell">Array of table rows and cells.</td>
 
 </tr>
 
@@ -396,11 +396,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows.[].text (or) rows.[].html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML for cells in table rows. If `html` is specified, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML for cells in table rows. If `html` is specified, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -408,11 +408,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows.[].format</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify format of a cell. Currently we only use "numeric".</td>
+<td class="govuk-table__cell">Specify format of a cell. Currently we only use "numeric".</td>
 
 </tr>
 
@@ -420,11 +420,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows.[].colspan</th>
 
-<td class="govuk-table__cell ">number</td>
+<td class="govuk-table__cell">number</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify how many columns a cell extends.</td>
+<td class="govuk-table__cell">Specify how many columns a cell extends.</td>
 
 </tr>
 
@@ -432,11 +432,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows.[].rowspan</th>
 
-<td class="govuk-table__cell ">number</td>
+<td class="govuk-table__cell">number</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify how many rows a cell extends.</td>
+<td class="govuk-table__cell">Specify how many rows a cell extends.</td>
 
 </tr>
 
@@ -444,11 +444,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">head</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional array of table head cells.</td>
+<td class="govuk-table__cell">Optional array of table head cells.</td>
 
 </tr>
 
@@ -456,11 +456,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">head.[].text or head.[].html</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional array of table head cells. If `html` is specified, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Optional array of table head cells. If `html` is specified, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -468,11 +468,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">head.[].colspan</th>
 
-<td class="govuk-table__cell ">number</td>
+<td class="govuk-table__cell">number</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify how many columns a cell extends.</td>
+<td class="govuk-table__cell">Specify how many columns a cell extends.</td>
 
 </tr>
 
@@ -480,11 +480,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">head.[].rowspan</th>
 
-<td class="govuk-table__cell ">number</td>
+<td class="govuk-table__cell">number</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify how many rows a cell extends.</td>
+<td class="govuk-table__cell">Specify how many rows a cell extends.</td>
 
 </tr>
 
@@ -492,11 +492,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">head.[].format</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Specify format of a cell. Currently we only use "numeric".</td>
+<td class="govuk-table__cell">Specify format of a cell. Currently we only use "numeric".</td>
 
 </tr>
 
@@ -504,11 +504,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">caption</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional caption text.</td>
+<td class="govuk-table__cell">Optional caption text.</td>
 
 </tr>
 
@@ -516,11 +516,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">captionClasses</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional classes for caption text size. Class should correspond to the available typography heading classes.</td>
+<td class="govuk-table__cell">Optional classes for caption text size. Class should correspond to the available typography heading classes.</td>
 
 </tr>
 
@@ -528,11 +528,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">firstCellIsHeader</th>
 
-<td class="govuk-table__cell ">boolean</td>
+<td class="govuk-table__cell">boolean</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">If set to true, first cell in table row will be a TH instead of a TD.</td>
+<td class="govuk-table__cell">If set to true, first cell in table row will be a TH instead of a TD.</td>
 
 </tr>
 
@@ -540,11 +540,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the table container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the table container.</td>
 
 </tr>
 
@@ -552,11 +552,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the table container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the table container.</td>
 
 </tr>
 

--- a/src/components/table/table.yaml
+++ b/src/components/table/table.yaml
@@ -16,6 +16,10 @@ params:
     type: string
     required: false
     description: Specify format of a cell. Currently we only use "numeric".
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the table row cell.
   - name: colspan
     type: integer
     required: false
@@ -41,6 +45,10 @@ params:
     type: string
     required: false
     description: Specify format of a cell. Currently we only use "numeric".
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the table head cell.
   - name: colspan
     type: integer
     required: false

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -9,7 +9,8 @@
     <tr class="govuk-table__row">
     {% for item in params.head %}
       <th class="govuk-table__header
-      {%- if item.format %} govuk-table__header--{{ item.format }}{% endif %}"
+      {%- if item.format %} govuk-table__header--{{ item.format }}{% endif %}
+      {%- if item.classes %} {{ item.classes }}{% endif %}"
       {%- if item.colspan %} colspan="{{ item.colspan }}"{% endif %}
       {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %} scope="col">{{ item.html |safe if item.html else item.text }}</th>
     {% endfor %}
@@ -24,11 +25,14 @@
       <th class="govuk-table__header" scope="row">{{ cell.html | safe if cell.html else cell.text }}</th>
       {% elseif loop.first %}
       <td class="govuk-table__cell
-      {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}"
+      {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
+      {%- if cell.classes %} {{ cell.classes }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
       {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% else %}
-      <td class="govuk-table__cell {% if cell.format %}govuk-table__cell--{{ cell.format }}{% endif %}"
+      <td class="govuk-table__cell 
+      {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
+      {%- if cell.classes %} {{ cell.classes }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
       {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% endif %}

--- a/src/components/table/template.test.js
+++ b/src/components/table/template.test.js
@@ -163,6 +163,29 @@ describe('Table', () => {
     expect($tableHeadCell.eq(1).attr('class')).toMatch('govuk-table__header--numeric')
   })
 
+  it('renders optional classes for the table header cell correctly', () => {
+    const $ = render('table', {
+      'head': [
+        {
+          'text': 'Rate for bicycles',
+          'classes': 'extra-class'
+        }
+      ],
+      'rows': [
+        [
+          {
+            'text': 'January'
+          }
+        ]
+      ]
+    })
+
+    const $component = $('.govuk-table')
+    const $tableHeadCell = $component.find('.govuk-table__head .govuk-table__header:first-child')
+
+    expect($tableHeadCell.hasClass('extra-class')).toBeTruthy()
+  })
+
   describe('rows and cells', () => {
     const $ = render('table', examples.default)
     const $component = $('.govuk-table')
@@ -283,6 +306,23 @@ describe('Table', () => {
     const $tableCell = $component.find('.govuk-table__body .govuk-table__cell')
 
     expect($tableCell.eq(1).attr('class')).toMatch('govuk-table__cell--numeric')
+  })
+
+  it('renders cell‘s optional classes correctly', () => {
+    const $ = render('table', {
+      'rows': [
+        [
+          {
+            'text': '£85',
+            'classes': 'extra-cell-class'
+          }
+        ]
+      ]
+    })
+    const $component = $('.govuk-table')
+    const $tableCell = $component.find('.govuk-table__body .govuk-table__cell:first-child')
+
+    expect($tableCell.hasClass('extra-cell-class')).toBeTruthy()
   })
 
   it('renders cell `colspan` attribute correctly', () => {

--- a/src/components/tabs/README.md
+++ b/src/components/tabs/README.md
@@ -258,11 +258,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional id</td>
+<td class="govuk-table__cell">Optional id</td>
 
 </tr>
 
@@ -270,11 +270,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes</td>
+<td class="govuk-table__cell">Optional additional classes</td>
 
 </tr>
 
@@ -282,11 +282,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tabs container</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the tabs container</td>
 
 </tr>
 
@@ -294,11 +294,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">idPrefix</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">String to prefix id for each tab item if no id is specified on each item</td>
+<td class="govuk-table__cell">String to prefix id for each tab item if no id is specified on each item</td>
 
 </tr>
 
@@ -306,11 +306,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items</th>
 
-<td class="govuk-table__cell ">array</td>
+<td class="govuk-table__cell">array</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Array of tab items</td>
+<td class="govuk-table__cell">Array of tab items</td>
 
 </tr>
 
@@ -318,11 +318,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Specific id attribute for the tab item. If ommited, then `idPrefix` string will be applied.</td>
+<td class="govuk-table__cell">Specific id attribute for the tab item. If ommited, then `idPrefix` string will be applied.</td>
 
 </tr>
 
@@ -330,11 +330,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.label</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The text label of a tab item</td>
+<td class="govuk-table__cell">The text label of a tab item</td>
 
 </tr>
 
@@ -342,11 +342,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tab item anchor.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the tab item anchor.</td>
 
 </tr>
 
@@ -354,11 +354,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.panel.text (or) items.{}.panel.html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within each tab panel. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within each tab panel. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -366,11 +366,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">items.{}.panel.attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tab panel.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the tab panel.</td>
 
 </tr>
 

--- a/src/components/tag/README.md
+++ b/src/components/tag/README.md
@@ -93,11 +93,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or HTML to use within for the tag component. If `html` is provided, the `text` argument will be ignored.</td>
+<td class="govuk-table__cell">Text or HTML to use within for the tag component. If `html` is provided, the `text` argument will be ignored.</td>
 
 </tr>
 
@@ -105,11 +105,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the tag container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the tag container.</td>
 
 </tr>
 
@@ -117,11 +117,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the tag container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the tag container.</td>
 
 </tr>
 

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -209,11 +209,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">id</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The id of the textarea</td>
+<td class="govuk-table__cell">The id of the textarea</td>
 
 </tr>
 
@@ -221,11 +221,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">describedBy</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.</td>
+<td class="govuk-table__cell">Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.</td>
 
 </tr>
 
@@ -233,11 +233,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">name</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The name of the textarea, which is submitted with the form data.</td>
+<td class="govuk-table__cell">The name of the textarea, which is submitted with the form data.</td>
 
 </tr>
 
@@ -245,11 +245,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">rows</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional number of textarea rows (default is 5 rows).</td>
+<td class="govuk-table__cell">Optional number of textarea rows (default is 5 rows).</td>
 
 </tr>
 
@@ -257,11 +257,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">value</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional initial value of the textarea.</td>
+<td class="govuk-table__cell">Optional initial value of the textarea.</td>
 
 </tr>
 
@@ -269,11 +269,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">label</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
+<td class="govuk-table__cell">Arguments for the label component. See <a href="../label/README.md#component-arguments">label</a> component.</td>
 
 </tr>
 
@@ -281,11 +281,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">hint</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
+<td class="govuk-table__cell">Arguments for the hint component (e.g. text). See <a href="../hint/README.md#component-arguments">hint</a> component.</td>
 
 </tr>
 
@@ -293,11 +293,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">errorMessage</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
+<td class="govuk-table__cell">Arguments for the errorMessage component (e.g. text). See <a href="../error-message/README.md#component-arguments">errorMessage</a> component.</td>
 
 </tr>
 
@@ -305,11 +305,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the textarea tag.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the textarea tag.</td>
 
 </tr>
 
@@ -317,11 +317,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the textarea tag.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the textarea tag.</td>
 
 </tr>
 

--- a/src/components/warning-text/README.md
+++ b/src/components/warning-text/README.md
@@ -79,11 +79,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">text (or) html</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">Text or HTML for the warning text content. If `html` is provided, the `text` argument is ignored.</td>
+<td class="govuk-table__cell">Text or HTML for the warning text content. If `html` is provided, the `text` argument is ignored.</td>
 
 </tr>
 
@@ -91,11 +91,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">iconFallbackText</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">Yes</td>
+<td class="govuk-table__cell">Yes</td>
 
-<td class="govuk-table__cell ">The fallback text for the icon</td>
+<td class="govuk-table__cell">The fallback text for the icon</td>
 
 </tr>
 
@@ -103,11 +103,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">classes</th>
 
-<td class="govuk-table__cell ">string</td>
+<td class="govuk-table__cell">string</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Optional additional classes to add to the warning-text container.</td>
+<td class="govuk-table__cell">Optional additional classes to add to the warning-text container.</td>
 
 </tr>
 
@@ -115,11 +115,11 @@ If you are using Nunjucks,then macros take the following arguments
 
 <th class="govuk-table__header" scope="row">attributes</th>
 
-<td class="govuk-table__cell ">object</td>
+<td class="govuk-table__cell">object</td>
 
-<td class="govuk-table__cell ">No</td>
+<td class="govuk-table__cell">No</td>
 
-<td class="govuk-table__cell ">Any extra HTML attributes (for example data attributes) to add to the warning-text container.</td>
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the warning-text container.</td>
 
 </tr>
 


### PR DESCRIPTION
This functionality has been requested a number of times.

- allow classes to be passed to header and row cell items and 
- add additional test to cover new behaviour

Addresses: #887 

Doing this work also addresses: #915 