### PR TITLE
Add character width support to select/textarea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Add width class modifiers to <select> and <textarea>, for example:
+
+  .govuk-select--width-20
+  .govuk-select--width-30
+
+  .govuk-textarea--width-20
+  .govuk-textarea--width-30
+
+  ([PR #1016](https://github.com/alphagov/govuk-frontend/pull/1016))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -40,36 +40,9 @@
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 
-  // The ex measurements are based on the number of W's that can fit inside the input
-  // Extra space is left on the right hand side to allow for the Safari prefill icon
-  // Linear regression estimation based on visual tests: y = 1.76 + 1.81x
-
-  .govuk-input--width-30 {
-    max-width: 56ex + 3ex;
+  @each $width, $value in $govuk-field-widths {
+    .govuk-input--width-#{$width} {
+      max-width: $value;
+    }
   }
-
-  .govuk-input--width-20 {
-    max-width: 38ex + 3ex;
-  }
-
-  .govuk-input--width-10 {
-    max-width: 20ex + 3ex;
-  }
-
-  .govuk-input--width-5 {
-    max-width: 10.8ex;
-  }
-
-  .govuk-input--width-4 {
-    max-width: 9ex;
-  }
-
-  .govuk-input--width-3 {
-    max-width: 7.2ex;
-  }
-
-  .govuk-input--width-2 {
-    max-width: 5.4ex;
-  }
-
 }

--- a/src/components/select/README.md
+++ b/src/components/select/README.md
@@ -176,6 +176,165 @@ Find out when to use the select component in your service in the [GOV.UK Design 
       ]
     }) }}
 
+### Select with width-10 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/select/with-width-10-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="select-width-10">
+          Label text goes here
+        </label>
+
+      </h1>
+
+      <select class="govuk-select govuk-select--width-10" id="select-width-10" name="select-width-10">
+
+        <option value="1">GOV.UK frontend option 1</option>
+
+        <option value="2">GOV.UK frontend option 2</option>
+
+        <option value="3">GOV.UK frontend option 3</option>
+
+      </select>
+    </div>
+
+#### Macro
+
+    {% from "select/macro.njk" import govukSelect %}
+
+    {{ govukSelect({
+      "id": "select-width-10",
+      "name": "select-width-10",
+      "classes": "govuk-select--width-10",
+      "label": {
+        "text": "Label text goes here",
+        "isPageHeading": true
+      },
+      "items": [
+        {
+          "value": 1,
+          "text": "GOV.UK frontend option 1"
+        },
+        {
+          "value": 2,
+          "text": "GOV.UK frontend option 2"
+        },
+        {
+          "value": 3,
+          "text": "GOV.UK frontend option 3"
+        }
+      ]
+    }) }}
+
+### Select with width-20 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/select/with-width-20-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="select-width-20">
+          Label text goes here
+        </label>
+
+      </h1>
+
+      <select class="govuk-select govuk-select--width-20" id="select-width-20" name="select-width-20">
+
+        <option value="1">GOV.UK frontend option 1</option>
+
+        <option value="2">GOV.UK frontend option 2</option>
+
+        <option value="3">GOV.UK frontend option 3</option>
+
+      </select>
+    </div>
+
+#### Macro
+
+    {% from "select/macro.njk" import govukSelect %}
+
+    {{ govukSelect({
+      "id": "select-width-20",
+      "name": "select-width-20",
+      "classes": "govuk-select--width-20",
+      "label": {
+        "text": "Label text goes here",
+        "isPageHeading": true
+      },
+      "items": [
+        {
+          "value": 1,
+          "text": "GOV.UK frontend option 1"
+        },
+        {
+          "value": 2,
+          "text": "GOV.UK frontend option 2"
+        },
+        {
+          "value": 3,
+          "text": "GOV.UK frontend option 3"
+        }
+      ]
+    }) }}
+
+### Select with width-30 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/select/with-width-30-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <h1 class="govuk-label-wrapper">
+        <label class="govuk-label" for="select-width-30">
+          Label text goes here
+        </label>
+
+      </h1>
+
+      <select class="govuk-select govuk-select--width-30" id="select-width-30" name="select-width-30">
+
+        <option value="1">GOV.UK frontend option 1</option>
+
+        <option value="2">GOV.UK frontend option 2</option>
+
+        <option value="3">GOV.UK frontend option 3</option>
+
+      </select>
+    </div>
+
+#### Macro
+
+    {% from "select/macro.njk" import govukSelect %}
+
+    {{ govukSelect({
+      "id": "select-width-30",
+      "name": "select-width-30",
+      "classes": "govuk-select--width-30",
+      "label": {
+        "text": "Label text goes here",
+        "isPageHeading": true
+      },
+      "items": [
+        {
+          "value": 1,
+          "text": "GOV.UK frontend option 1"
+        },
+        {
+          "value": 2,
+          "text": "GOV.UK frontend option 2"
+        },
+        {
+          "value": 3,
+          "text": "GOV.UK frontend option 3"
+        }
+      ]
+    }) }}
+
 ### Select with full width override
 
 [Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/select/with-full-width-override/preview)
@@ -183,11 +342,11 @@ Find out when to use the select component in your service in the [GOV.UK Design 
 #### Markup
 
     <div class="govuk-form-group">
-      <label class="govuk-label" for="select-1">
+      <label class="govuk-label" for="select-width-full">
         Label text goes here
       </label>
 
-      <select class="govuk-select govuk-!-width-full" id="select-1" name="select-1">
+      <select class="govuk-select govuk-!-width-full" id="select-width-full" name="select-width-full">
 
         <option value="1">GOV.UK frontend option 1</option>
 
@@ -203,8 +362,8 @@ Find out when to use the select component in your service in the [GOV.UK Design 
     {% from "select/macro.njk" import govukSelect %}
 
     {{ govukSelect({
-      "id": "select-1",
-      "name": "select-1",
+      "id": "select-width-full",
+      "name": "select-width-full",
       "classes": "govuk-!-width-full",
       "label": {
         "text": "Label text goes here"

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -29,4 +29,13 @@
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
 
+  .govuk-select[class*="--width-"] {
+    width: 100%;
+  }
+
+  @each $width, $value in $govuk-field-widths {
+    .govuk-select--width-#{$width} {
+      max-width: $value;
+    }
+  }
 }

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -110,10 +110,64 @@ examples:
         value: 3
         text: GOV.UK frontend option 3
         disabled: true
+- name: with width-10 class
+  data:
+    id: select-width-10
+    name: select-width-10
+    classes: govuk-select--width-10
+    label:
+      text: Label text goes here
+      isPageHeading: true
+    items:
+      -
+        value: 1
+        text: GOV.UK frontend option 1
+      -
+        value: 2
+        text: GOV.UK frontend option 2
+      -
+        value: 3
+        text: GOV.UK frontend option 3
+- name: with width-20 class
+  data:
+    id: select-width-20
+    name: select-width-20
+    classes: govuk-select--width-20
+    label:
+      text: Label text goes here
+      isPageHeading: true
+    items:
+      -
+        value: 1
+        text: GOV.UK frontend option 1
+      -
+        value: 2
+        text: GOV.UK frontend option 2
+      -
+        value: 3
+        text: GOV.UK frontend option 3
+- name: with width-30 class
+  data:
+    id: select-width-30
+    name: select-width-30
+    classes: govuk-select--width-30
+    label:
+      text: Label text goes here
+      isPageHeading: true
+    items:
+      -
+        value: 1
+        text: GOV.UK frontend option 1
+      -
+        value: 2
+        text: GOV.UK frontend option 2
+      -
+        value: 3
+        text: GOV.UK frontend option 3
 - name: with full width override
   data:
-    id: select-1
-    name: select-1
+    id: select-width-full
+    name: select-width-full
     classes: govuk-!-width-full
     label:
       text: Label text goes here

--- a/src/components/textarea/README.md
+++ b/src/components/textarea/README.md
@@ -163,6 +163,87 @@ Find out when to use the textarea component in your service in the [GOV.UK Desig
       }
     }) }}
 
+### Textarea with width-10 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/textarea/with-width-10-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="textarea-width-10">
+        Full address
+      </label>
+
+      <textarea class="govuk-textarea govuk-textarea--width-10" id="textarea-width-10" name="address" rows="5"></textarea>
+    </div>
+
+#### Macro
+
+    {% from "textarea/macro.njk" import govukTextarea %}
+
+    {{ govukTextarea({
+      "id": "textarea-width-10",
+      "classes": "govuk-textarea--width-10",
+      "name": "address",
+      "label": {
+        "text": "Full address"
+      }
+    }) }}
+
+### Textarea with width-20 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/textarea/with-width-20-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="textarea-width-20">
+        Full address
+      </label>
+
+      <textarea class="govuk-textarea govuk-textarea--width-20" id="textarea-width-20" name="address" rows="5"></textarea>
+    </div>
+
+#### Macro
+
+    {% from "textarea/macro.njk" import govukTextarea %}
+
+    {{ govukTextarea({
+      "id": "textarea-width-20",
+      "classes": "govuk-textarea--width-20",
+      "name": "address",
+      "label": {
+        "text": "Full address"
+      }
+    }) }}
+
+### Textarea with width-30 class
+
+[Preview this example in the Frontend review app](http://govuk-frontend-review.herokuapp.com/components/textarea/with-width-30-class/preview)
+
+#### Markup
+
+    <div class="govuk-form-group">
+      <label class="govuk-label" for="textarea-width-30">
+        Full address
+      </label>
+
+      <textarea class="govuk-textarea govuk-textarea--width-30" id="textarea-width-30" name="address" rows="5"></textarea>
+    </div>
+
+#### Macro
+
+    {% from "textarea/macro.njk" import govukTextarea %}
+
+    {{ govukTextarea({
+      "id": "textarea-width-30",
+      "classes": "govuk-textarea--width-30",
+      "name": "address",
+      "label": {
+        "text": "Full address"
+      }
+    }) }}
+
 ## Requirements
 
 ### Build tool configuration

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -29,4 +29,10 @@
   .govuk-textarea--error {
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
   }
+
+  @each $width, $value in $govuk-field-widths {
+    .govuk-textarea--width-#{$width} {
+      max-width: $value;
+    }
+  }
 }

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -89,3 +89,27 @@ examples:
       label:
         text: Full address
         isPageHeading: true
+
+  - name: with width-10 class
+    data:
+      id: textarea-width-10
+      classes: govuk-textarea--width-10
+      name: address
+      label:
+        text: Full address
+
+  - name: with width-20 class
+    data:
+      id: textarea-width-20
+      classes: govuk-textarea--width-20
+      name: address
+      label:
+        text: Full address
+
+  - name: with width-30 class
+    data:
+      id: textarea-width-30
+      classes: govuk-textarea--width-30
+      name: address
+      label:
+        text: Full address

--- a/src/settings/_measurements.scss
+++ b/src/settings/_measurements.scss
@@ -83,3 +83,28 @@ $govuk-border-width-form-group-error: $govuk-border-width !default;
 /// @access public
 
 $govuk-focus-width: 3px !default;
+
+
+
+// =========================================================
+// Form field widths
+// =========================================================
+
+/// Form field widths
+///
+/// The ex measurements are based on the number of W's that can fit inside the input
+/// Extra space is left on the right hand side to allow for the Safari prefill icon
+/// Linear regression estimation based on visual tests: y = 1.76 + 1.81x
+///
+/// @type Map
+/// @access public
+
+$govuk-field-widths: (
+  30: 56ex + 3ex,
+  20: 38ex + 3ex,
+  10: 20ex + 3ex,
+  5: 10.8ex,
+  4: 9ex,
+  3: 7.2ex,
+  2: 5.4ex
+);


### PR DESCRIPTION
I'm building a prototype at the moment where various `input` fields have the standard modifiers:

```css
.govuk-input--width-20
.govuk-input--width-30
```

Until https://github.com/alphagov/govuk-frontend/pull/1013 is fixed, all `select` menus on the page have varying widths based on their contents.

![widths](https://user-images.githubusercontent.com/415517/46280437-d1608d00-c563-11e8-9f93-884f044190b4.png)

Unfortunately I can't use the width modifier classes on both `select` menus here.

They don't exist!

E.g.

```css
.govuk-select--width-20
.govuk-select--width-30
```

Same with textareas:

```css
.govuk-textarea--width-20
.govuk-textarea--width-30
```

This pull request adds them.

**_measurements.scss**
The standard widths are now in this file
```scss
$govuk-field-widths: (
  30: 56ex + 3ex,
  20: 38ex + 3ex,
  10: 20ex + 3ex,
  5: 10.8ex,
  4: 9ex,
  3: 7.2ex,
  2: 5.4ex
);
```

**_select.scss**
They're looped in the various components they're shared with
```scss
@each $width, $value in $govuk-field-widths {
  .govuk-select--width-#{$width} {
    max-width: $value;
  }
}
```

What do you think?