### PR TITLE
Set text colour for radios divider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@
 
   ([PR #1007](https://github.com/alphagov/govuk-frontend/pull/1007))
 
+- Set text colour for radios divider
+
+  ([PR 1023](https://github.com/alphagov/govuk-frontend/pull/1023))
+
 - Pull Request Title goes here
 
   Description goes here (optional)
@@ -61,7 +65,7 @@
   You can now pass additional attributes to links in header, footer, breadcrumbs, tabs and error-summary components
 
   ([PR #993](https://github.com/alphagov/govuk-frontend/pull/993))
-  
+
 - Fix issue with conditional form content and inline form controls
 
   When inline variant of form controls is used with conditional content, we force
@@ -239,9 +243,9 @@
   ([PR #960](https://github.com/alphagov/govuk-frontend/pull/960))
 
 - Use text colour on focus for better contrast
-  
+
   Updates the focus styles of links in GOV.UK Frontend so they pass WCAG contrast requirements.
-  
+
   ([PR #982](https://github.com/alphagov/govuk-frontend/pull/982))
 
 🆕 New features:

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -156,6 +156,7 @@
   .govuk-radios__divider {
     $govuk-divider-size: $govuk-radios-size !default;
     @include govuk-font($size: 19);
+    @include govuk-text-colour;
     width: $govuk-divider-size;
     margin-bottom: govuk-spacing(2);
     text-align: center;


### PR DESCRIPTION
Hello :wave:, I've enjoyed digging into some bits of GOV.UK Frontend over this firebreak, and I think I found a bug (or I don't properly understand isolation principles)

When testing component isolation on GOV.UK we noticed that text colour isn't applied to a radios_divider and instead it inherits this value. I'm assuming this behaviour isn't intentional as all the neighbouring fieldset components all have a colour set.