### PR TITLE
Fix robots header to prevent indexing

### DIFF
--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -43,6 +43,13 @@ describe(`http://localhost:${PORT}`, () => {
         done(err)
       })
     })
+
+    it('should prevent search indexing', done => {
+      requestPath.get(path, (err, res) => {
+        expect(res.headers['x-robots-tag']).toEqual('none')
+        done(err)
+      })
+    })
   })
 
   describe('/', () => {

--- a/app/app.js
+++ b/app/app.js
@@ -40,6 +40,16 @@ module.exports = (options) => {
   // Set view engine
   app.set('view engine', 'njk')
 
+  // Disallow search index indexing
+  app.use(function (req, res, next) {
+    // none - Equivalent to noindex, nofollow
+    // noindex - Do not show this page in search results and do not show a
+    //   "Cached" link in search results.
+    // nofollow - Do not follow the links on this page
+    res.setHeader('X-Robots-Tag', 'none')
+    next()
+  })
+
   // Set up middleware to serve static assets
   app.use('/public', express.static(configPaths.public))
 
@@ -148,15 +158,6 @@ module.exports = (options) => {
         res.send(html)
       }
     })
-  })
-
-  // Disallow search index indexing
-  app.use(function (req, res, next) {
-    // none - Equivalent to noindex, nofollow
-    // noindex - Do not show this page in search results and do not show a "Cached" link in search results.
-    // nofollow - Do not follow the links on this page
-    res.setHeader('X-Robots-Tag', 'none')
-    next()
   })
 
   app.get('/robots.txt', function (req, res) {


### PR DESCRIPTION
Because the various routes in the review app do not call `next`, the middleware that sets the `X-Robots-Tag` header is currently never called. We could call `next()` from every route, but that seems fragile, so instead we can just move the middleware so that it is defined before the routes, which means it will be called.

Also, we can add tests for this. So we do.