### PR TITLE
Fix anchor links in tabs component panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 🔧 Fixes:
 
+- Fix anchor links in tabs component panels
+
+  ([PR #1031](https://github.com/alphagov/govuk-frontend/pull/1031))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -105,9 +105,11 @@ Tabs.prototype.teardown = function () {
 
 Tabs.prototype.onHashChange = function (e) {
   var hash = window.location.hash
-  if (!this.hasTab(hash)) {
+  var $tabWithHash = this.getTab(hash)
+  if (!$tabWithHash) {
     return
   }
+
   // Prevent changing the hash
   if (this.changingHash) {
     this.changingHash = false
@@ -116,15 +118,10 @@ Tabs.prototype.onHashChange = function (e) {
 
   // Show either the active tab according to the URL's hash or the first tab
   var $previousTab = this.getCurrentTab()
-  var $activeTab = this.getTab(hash) || this.$tabs[0]
 
   this.hideTab($previousTab)
-  this.showTab($activeTab)
-  $activeTab.focus()
-}
-
-Tabs.prototype.hasTab = function (hash) {
-  return this.$module.querySelector(hash)
+  this.showTab($tabWithHash)
+  $tabWithHash.focus()
 }
 
 Tabs.prototype.hideTab = function ($tab) {

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -138,7 +138,7 @@ Tabs.prototype.showTab = function ($tab) {
 }
 
 Tabs.prototype.getTab = function (hash) {
-  return this.$module.querySelector('a[role="tab"][href="' + hash + '"]')
+  return this.$module.querySelector('.govuk-tabs__tab[href="' + hash + '"]')
 }
 
 Tabs.prototype.setAttributes = function ($tab) {

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -133,6 +133,14 @@ describe('/components/tabs', () => {
         const currentTabPanelIsHidden = await page.evaluate(() => document.getElementById('past-week').classList.contains('govuk-tabs__panel--hidden'))
         expect(currentTabPanelIsHidden).toBeFalsy()
       })
+      it('should only update based on hashes that are tabs', async () => {
+        await page.goto(baseUrl + '/components/tabs/tabs-with-anchor-in-panel/preview', { waitUntil: 'load' })
+
+        await page.click('[href="#anchor"]')
+
+        const activeElementId = await page.evaluate(() => document.activeElement.id)
+        expect(activeElementId).toEqual('anchor')
+      })
     })
 
     describe('when rendered on a small device', () => {

--- a/src/components/tabs/tabs.yaml
+++ b/src/components/tabs/tabs.yaml
@@ -165,3 +165,22 @@ examples:
                 </tr>
               </tbody>
             </table>
+
+- name: tabs-with-anchor-in-panel
+  description: Ensure that anchors that are in tab panels work correctly
+  readme: false
+  data:
+    items:
+      - label: Tab 1
+        id: tab-1
+        panel:
+          html: |
+            <h2 class="govuk-heading-l">Tab 1</h2>
+            <p>Testing that when you click the anchor it moves to the anchor point successfully</p>
+            <a class="govuk-link" href="#anchor">Anchor</a>
+            <a id="anchor" tabIndex="0">Anchor Point</a>
+      - label: Tab 2
+        id: tab-2
+        panel:
+          html: |
+            <h2 class="govuk-heading-l">Tab 2</h2>


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1030

When clicking an anchor in the tabs component panel, it will trigger the 'hashchange' event which the tabs component is listening to.
The component then checks to see if there's any tabs within the component that match this hash, but did so in a way that could also include regular anchor links.

This pull request ensures it is only checking that the hash matches available tabs only.

I've also tested the following scenarios manually:

1. Editing the URL directly
2. Clicking the anchor with no existing hash
3. Clicking the anchor when a hash already exists.