### PR TITLE
Fix IE8 in the `dist/` compiled files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
   ([PR #1031](https://github.com/alphagov/govuk-frontend/pull/1031))
 
+- Fix IE8 support in builds in the `dist/` folder
+
+  ([PR #1035](https://github.com/alphagov/govuk-frontend/pull/1035))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -111,7 +111,9 @@ gulp.task('js:compile', () => {
       // UMD allows the published bundle to work in CommonJS and in the browser.
       format: 'umd'
     }))
-    .pipe(gulpif(isDist, uglify()))
+    .pipe(gulpif(isDist, uglify({
+      ie8: true
+    })))
     .pipe(gulpif(isDist,
       rename({
         basename: 'govuk-frontend',


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1033

Since the files in `dist/` are compressed, Uglify will break IE8 support by default.

This pull request enables IE8 mode.

I'm not sure if there's a way we can ensure that this does not break in the future without some kind of dist test page.

We can hope that the Uglify project does not remove IE8 support without it silently failing.

I will leave it up for discussion if we need to do more to protect ourselves against that risk.

I have tested this by placing the built files in JSbin

## [Current build](https://output.jsbin.com/qaraqep)

<img width="717" alt="screen shot 2018-10-16 at 16 55 13" src="https://user-images.githubusercontent.com/2445413/47029996-afbaf480-d164-11e8-9c5c-9892ef8b00a9.png">

## [Build generated from this PR `npm run build:dist`](https://output.jsbin.com/wuyideh)

<img width="706" alt="screen shot 2018-10-16 at 16 54 48" src="https://user-images.githubusercontent.com/2445413/47029997-afbaf480-d164-11e8-9a07-7588a4dfcfb8.png">