### PR TITLE
RFC - add extended grid

### DIFF
--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -98,4 +98,37 @@
       </p>
     </div>
   </div>
+
+  <h2 class="govuk-heading-l">Tablet and Desktop specific breakpoints</h2>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds govuk-grid-column--at-desktop-three-quarters">
+      <h2 class="govuk-heading-m">Desktop: Three-quarters<br>Tablet: Two-thirds</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-grid-column-one-third govuk-grid-column--at-desktop-one-quarter">
+      <h2 class="govuk-heading-m">Desktop: One-quarter<br>Tablet: One-third</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half govuk-grid-column--at-desktop-two-thirds">
+      <h2 class="govuk-heading-m">Desktop: Two-thirds<br>Tablet: One-half</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+    <div class="govuk-grid-column-one-half govuk-grid-column--at-desktop-one-third">
+      <h2 class="govuk-heading-m">Desktop: One-third<br>Tablet: One-half</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
+
 {% endblock %}

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -7,4 +7,33 @@
   @include govuk-grid-column(two-thirds);
   @include govuk-grid-column(three-quarters);
   @include govuk-grid-column(full);
+
+  // Breakpoint specific classes - Tablet sizes
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "full");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "one-half");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "two-thirds");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "one-third");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "three-quarters");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-tablet", $at: tablet, $width: "one-quarter");
+
+
+  // Breakpoint specific classes - Desktop sizes
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "full");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "one-half");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "two-thirds");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "one-third");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "three-quarters");
+
+  @include govuk-grid-column($class: "govuk-grid-column--at-desktop", $at: desktop, $width: "one-quarter");
 }


### PR DESCRIPTION
Add tablet and desktop specific breakpoints by using the existing grid mixin.

Example: 
![grid](https://user-images.githubusercontent.com/23356842/47429849-72bbb700-d78f-11e8-97e9-ce6de7d2eab3.gif)

I would like comments on:

The outputted class names – 
`<div class="govuk-grid-column-one-third govuk-grid-column--at-desktop-one-quarter">` (We will need to modify the grid mixin if we want to change where the `-one-quarter` part of the class name is)

If the outputted CSS increases the bundle size too much – Are there any other options?

If it's right to only provide tablet / desktop breakpoint overrides and continue to have mobile default to 100% wide