### PR TITLE
Allow form group classes on radios and checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,11 @@
 
   ([PR #1045](https://github.com/alphagov/govuk-frontend/pull/1045))
 
-- Pull Request Title goes here
+- Allow form group classes on radios and checkboxes
 
-  Description goes here (optional)
+  We now provide a way to add classes to the radio and checkbox form-group wrapper
 
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR #1043](https://github.com/alphagov/govuk-frontend/pull/1043))
 
 🔧 Fixes:
 

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -14,6 +14,15 @@ params:
   required: false
   description: Options for the errorMessage component (e.g. text).
   isComponent: true
+- name: formGroup
+  type: object
+  required: false
+  description: Options for the form-group wrapper
+  params:
+  - name: classes
+    type: string
+    required: false
+    description: Optional classes to add to the form group (e.g. to show error state for the whole group)
 - name: idPrefix
   type: string
   required: false
@@ -337,6 +346,37 @@ examples:
         html: |
           <label class="govuk-label" for="contact-phone">Phone number</label>
           <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+    - value: text
+      text: Text message
+      conditional:
+        html: |
+          <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+          <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+  
+- name: with optional form-group classes showing group error
+  readme: false
+  data:
+    idPrefix: how-contacted-checked
+    formGroup:
+      classes: 'govuk-form-group--error'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+      conditional:
+        html: |
+          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+    - value: phone
+      text: Phone
+      checked: true
+      conditional:
+        html: |
+          <label class="govuk-label" for="contact-phone">Phone number</label>
+          <span id="contact-phone-error" class="govuk-error-message">Problem with input</span>
+          <input class="govuk-input govuk-input--error govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone" aria-describedby="contact-phone-error">
     - value: text
       text: Text message
       conditional:

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -83,7 +83,7 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
 {% if params.fieldset %}
   {% call govukFieldset({
     describedBy: describedBy,

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -100,6 +100,28 @@ describe('Checkboxes', () => {
     expect($formGroup.length).toBeTruthy()
   })
 
+  it('render a custom class on the form group', () => {
+    const $ = render('checkboxes', {
+      name: 'example-name',
+      items: [
+        {
+          value: '1',
+          text: 'Option 1'
+        },
+        {
+          value: '2',
+          text: 'Option 2'
+        }
+      ],
+      formGroup: {
+        classes: 'custom-group-class'
+      }
+    })
+
+    const $formGroup = $('.govuk-form-group')
+    expect($formGroup.hasClass('custom-group-class')).toBeTruthy()
+  })
+
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
       const $ = render('checkboxes', {

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -14,6 +14,15 @@ params:
   required: false
   description: Options for the errorMessage component (e.g. text).
   isComponent: true
+- name: formGroup
+  type: object
+  required: false
+  description: Options for the form-group wrapper
+  params:
+  - name: classes
+    type: string
+    required: false
+    description: Optional classes to add to the form group (e.g. to show error state for the whole group)
 - name: idPrefix
   type: string
   required: false
@@ -378,6 +387,38 @@ examples:
         html: |
           <label class="govuk-label" for="contact-phone">Phone number</label>
           <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+    - value: text
+      text: Text message
+      conditional:
+        html: |
+          <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+          <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
+- name: with optional form-group classes showing group error
+  readme: false
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-form-group--error'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+      conditional:
+        html: |
+          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+    - value: phone
+      text: Phone
+      checked: true
+      conditional:
+        html: |
+          <label class="govuk-label" for="contact-phone">Phone number</label>
+          <span id="contact-phone-error" class="govuk-error-message">Problem with input</span>
+          <input class="govuk-input govuk-input--error govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone" aria-describedby="contact-phone-error">
     - value: text
       text: Text message
       conditional:

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -86,7 +86,7 @@
   </div>
 {% endset -%}
 
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %}">
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
 {% if params.fieldset %}
   {% call govukFieldset({
     describedBy: describedBy,

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -93,6 +93,28 @@ describe('Radios', () => {
     expect($component.attr('data-second-attribute')).toEqual('second-value')
   })
 
+  it('render a custom class on the form group', () => {
+    const $ = render('radios', {
+      name: 'example-name',
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes'
+        },
+        {
+          value: 'no',
+          text: 'No'
+        }
+      ],
+      formGroup: {
+        classes: 'custom-group-class'
+      }
+    })
+
+    const $formGroup = $('.govuk-form-group')
+    expect($formGroup.hasClass('custom-group-class')).toBeTruthy()
+  })
+
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
       const $ = render('radios', {


### PR DESCRIPTION
## What

Make it possible to toggle the `govuk-form-group--error` class on the form group for radios and checkboxes without having to pass an error message.

## Why

Currently the error state for a conditionally revealed checkbox shows the 'error bar' against the revealed content only.
<img width="987" alt="68747470733a2f2f7472656c6c6f2d6174746163686d656e74732e73332e616d617a6f6e6177732e636f6d2f3539616436653537653761636164313862643863623437362f3562613463663131396438346530343934353038353766352f6437336264323764623664363464363035626634643330316631" src="https://user-images.githubusercontent.com/3758555/47487439-5c1e6a00-d83a-11e8-9c4e-41e1821e707d.png">


We want to move the error bar to the 'question' which will include the revealing checkboxes or radios themselves.

To do this we have in introduced a `formGroupClasses' option in the Nunjucks macro that allows a CSS class to be set directly on the form group.

Example of an error state set on the whole group

<img width="467" alt="screen shot 2018-10-25 at 09 52 31" src="https://user-images.githubusercontent.com/3758555/47488258-f03d0100-d83b-11e8-81d6-dc782d857863.png">
<img width="422" alt="screen shot 2018-10-25 at 09 52 47" src="https://user-images.githubusercontent.com/3758555/47488265-f337f180-d83b-11e8-8988-a6998fac05c3.png">


Trello ticket: https://trello.com/c/LggtR8s5/1455-make-it-possible-to-set-the-error-state-on-checkboxes-and-radios-without-passing-an-error-message