### PR TITLE
Add support for attributes on table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 
   ([PR #1037](https://github.com/alphagov/govuk-frontend/pull/1037))
 
+- Add support for attributes on table cells
+
+  Can now use the familiar `attrubutes: {}` pattern to add various
+  attributes such as `id` or `data-attr` to cells within tables
+
+  ([PR #1045](https://github.com/alphagov/govuk-frontend/pull/1045))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/table/README.md
+++ b/src/components/table/README.md
@@ -442,6 +442,18 @@ If you are using Nunjucks,then macros take the following arguments
 
 <tr class="govuk-table__row">
 
+<th class="govuk-table__header" scope="row">rows.[].attributes</th>
+
+<td class="govuk-table__cell">object</td>
+
+<td class="govuk-table__cell">No</td>
+
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the cell.</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
 <th class="govuk-table__header" scope="row">head</th>
 
 <td class="govuk-table__cell">array</td>
@@ -497,6 +509,18 @@ If you are using Nunjucks,then macros take the following arguments
 <td class="govuk-table__cell">No</td>
 
 <td class="govuk-table__cell">Specify format of a cell. Currently we only use "numeric".</td>
+
+</tr>
+
+<tr class="govuk-table__row">
+
+<th class="govuk-table__header" scope="row">head.[].attributes</th>
+
+<td class="govuk-table__cell">object</td>
+
+<td class="govuk-table__cell">No</td>
+
+<td class="govuk-table__cell">Any extra HTML attributes (for example data attributes) to add to the cell.</td>
 
 </tr>
 

--- a/src/components/table/README.njk
+++ b/src/components/table/README.njk
@@ -103,6 +103,20 @@
     ],
     [
       {
+        text: 'rows.[].attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the cell.'
+      }
+    ],
+    [
+      {
         text: 'head'
       },
       {
@@ -169,6 +183,20 @@
       },
       {
         text: 'Specify format of a cell. Currently we only use "numeric".'
+      }
+    ],
+    [
+      {
+        text: 'head.[].attributes'
+      },
+      {
+        text: 'object'
+      },
+      {
+        text: 'No'
+      },
+      {
+        text: 'Any extra HTML attributes (for example data attributes) to add to the cell.'
       }
     ],
     [

--- a/src/components/table/table.yaml
+++ b/src/components/table/table.yaml
@@ -28,6 +28,10 @@ params:
     type: integer
     required: false
     description: Specify how many rows a cell extends.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the table cell.
 - name: head
   type: array
   required: false
@@ -57,6 +61,10 @@ params:
     type: integer
     required: false
     description: Specify how many rows a cell extends.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the table cell.
 - name: caption
   type: string
   required: false

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -12,7 +12,7 @@
       {%- if item.format %} govuk-table__header--{{ item.format }}{% endif %}
       {%- if item.classes %} {{ item.classes }}{% endif %}"
       {%- if item.colspan %} colspan="{{ item.colspan }}"{% endif %}
-      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %} scope="col">{{ item.html |safe if item.html else item.text }}</th>
+      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %} scope="col">{{ item.html |safe if item.html else item.text }}</th>
     {% endfor %}
     </tr>
   </thead>
@@ -28,13 +28,13 @@
       {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
       {%- if cell.classes %} {{ cell.classes }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.html | safe if cell.html else cell.text }}</td>
+      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% else %}
       <td class="govuk-table__cell 
       {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
       {%- if cell.classes %} {{ cell.classes }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}>{{ cell.html | safe if cell.html else cell.text }}</td>
+      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% endif %}
     {% endfor %}
     </tr>

--- a/src/components/table/template.test.js
+++ b/src/components/table/template.test.js
@@ -418,4 +418,96 @@ describe('Table', () => {
     expect($component.attr('attribute-1')).toEqual('yes')
     expect($component.attr('attribute-2')).toEqual('no')
   })
+
+  it('renders with attributes on a head cell ', () => {
+    const $ = render('table', {
+      'head': [
+        {
+          'text': 'Month you apply',
+          'attributes': {
+            'id': 'some-unique-id'
+          }
+        },
+        {
+          'text': 'Rate for bicycles',
+          'format': 'numeric'
+        },
+        {
+          'text': 'Rate for vehicles',
+          'format': 'numeric'
+        }
+      ],
+      'rows': [
+        [
+          {
+            'text': 'January'
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ],
+        [
+          {
+            'text': 'February'
+          },
+          {
+            'text': '£165',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    const $component = $('.govuk-table')
+    const $tableHeadCell = $component.find('.govuk-table__head .govuk-table__header')
+
+    expect($tableHeadCell.eq(0).attr('id')).toMatch('some-unique-id')
+  })
+
+  it('renders with attributes on a body cell ', () => {
+    const $ = render('table', {
+      'head': [
+        {
+          'text': 'Month you apply'
+        },
+        {
+          'text': 'Rate for bicycles',
+          'format': 'numeric'
+        },
+        {
+          'text': 'Rate for vehicles',
+          'format': 'numeric'
+        }
+      ],
+      'rows': [
+        [
+          {
+            'text': 'January',
+            'attributes': {
+              'id': 'some-unique-id'
+            }
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ],
+        [
+          {
+            'text': 'February'
+          },
+          {
+            'text': '£165',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    const $component = $('.govuk-table')
+    const $tableBodyCell = $component.find('.govuk-table__body .govuk-table__cell')
+
+    expect($tableBodyCell.eq(0).attr('id')).toMatch('some-unique-id')
+  })
 })


### PR DESCRIPTION
It’s currently not possible to attach HTML attributes to table cells.
This PR makes it possible by using the same object pattern that is used
on other components (and also the `<table>` element).

I’ve updated the nunjucks template as well as the YAML and the README
to reflect the new functionality.

### Background

Whilst migrating https://github.com/alphagov/pay-selfservice I’ve tried to use macros where ever possible, but we regularly use ID’s on cells within table so that our various tests can easily get the value.