### PR TITLE
Fix badly formed HTML in docs

### DIFF
--- a/docs/installation/installing-from-dist.md
+++ b/docs/installation/installing-from-dist.md
@@ -33,6 +33,7 @@ Follow the below example to add the CSS and JavaScript files to your HTML templa
 
 ```html
 <!DOCTYPE html>
+<html>
   <head>
     <title>Example</title>
     <!--[if !IE 8]><!-->


### PR DESCRIPTION
This HTML snippet was missing the opening `<html>` tag, but did have the closing one.