### PR TITLE
Scroll to label or legend when linked from error summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Scroll to label or legend when linked from error summary
+
+  When users click links in the error summary, the corresponding label or legend
+  will now be moved to the top of the viewport, rather than the input. This
+  means that the context for the input remains on-screen.
+
+  ([PR #1056](https://github.com/alphagov/govuk-frontend/pull/1056))
+
+- Label or legend are announced for NVDA users when navigating to an input from
+  the error summary
+
+  ([PR #1056](https://github.com/alphagov/govuk-frontend/pull/1056))
+
 - Allow form group classes on date, file upload, input, select and textarea
 
   All remaining form groups should allow additional classes, like with radios and checkboxes

--- a/app/views/examples/error-summary/index.njk
+++ b/app/views/examples/error-summary/index.njk
@@ -18,7 +18,7 @@
 {% endblock %}
 
 {% block content %}
-<form action="/" method="post">
+<form action="/" method="post" style="margin-bottom: 100vh;">
 
   {{ govukErrorSummary({
     "titleText": "There is a problem",
@@ -115,7 +115,8 @@
   {{ govukDateInput({
     fieldset: {
       legend: {
-        text: 'Date Input'
+        text: 'Date Input',
+        classes: 'test-date-input-legend'
       }
     },
     id: 'dateinput',
@@ -143,7 +144,8 @@
   {{ govukDateInput({
     fieldset: {
       legend: {
-        text: 'Date Input'
+        text: 'Date Input',
+        classes: 'test-date-input2-legend'
       }
     },
     id: 'dateinput2',
@@ -185,6 +187,9 @@
     fieldset: {
       legend: {
         text: 'Radios'
+      },
+      attributes: {
+        id: 'test-radios'
       }
     },
     name: "radios",
@@ -208,6 +213,9 @@
     fieldset: {
       legend: {
         text: 'Checkboxes'
+      },
+      attributes: {
+        id: 'test-checkboxes'
       }
     },
     name: "checkboxes",
@@ -275,7 +283,10 @@
       "legend": {
         "text": "Conditional?"
       },
-      "classes": "govuk-radios--error"
+      "classes": "govuk-radios--error",
+      attributes: {
+        id: 'test-conditional-reveal'
+      }
     },
     "error": true,
     "items": [

--- a/app/views/examples/error-summary/index.njk
+++ b/app/views/examples/error-summary/index.njk
@@ -71,7 +71,7 @@
 
   {{ govukInput({
     label: {
-      "text": 'Input'
+      "text": 'Label for input'
     },
     id: "input",
     name: "input",
@@ -82,7 +82,7 @@
 
   {{ govukTextarea({
     label: {
-      "text": 'Textarea'
+      "text": 'Label for textarea'
     },
     id: "textarea",
     name: "textarea",
@@ -93,7 +93,7 @@
 
   {{ govukSelect({
     label: {
-      "text": 'Select'
+      "text": 'Label for select'
     },
     id: "select",
     name: "select",
@@ -115,7 +115,7 @@
   {{ govukDateInput({
     fieldset: {
       legend: {
-        text: 'Date Input',
+        text: 'Label for date input',
         classes: 'test-date-input-legend'
       }
     },
@@ -144,7 +144,7 @@
   {{ govukDateInput({
     fieldset: {
       legend: {
-        text: 'Date Input',
+        text: 'Label for date input',
         classes: 'test-date-input2-legend'
       }
     },
@@ -174,7 +174,7 @@
 
   {{ govukFileUpload({
     label: {
-      "text": 'File'
+      "text": 'Label for file upload'
     },
     id: "file",
     name: "file",
@@ -186,7 +186,7 @@
   {{ govukRadios({
     fieldset: {
       legend: {
-        text: 'Radios'
+        text: 'Legend for radios'
       },
       attributes: {
         id: 'test-radios'
@@ -198,12 +198,12 @@
     },
     items:[
       {
-        text: 'One',
+        text: 'Label for first radio button',
         value: 'one',
         id: 'radios'
       },
       {
-        text: 'Two',
+        text: 'Label for second radio button',
         value: 'two'
       }
     ]
@@ -212,7 +212,7 @@
   {{ govukCheckboxes({
     fieldset: {
       legend: {
-        text: 'Checkboxes'
+        text: 'Legend for checkboxes'
       },
       attributes: {
         id: 'test-checkboxes'
@@ -224,12 +224,12 @@
     },
     items:[
       {
-        text: 'One',
+        text: 'Label for first checkbox',
         value: 'one',
         id: "checkboxes"
       },
       {
-        text: 'Two',
+        text: 'Label for second checkbox',
         value: 'two'
       }
     ]
@@ -243,7 +243,7 @@
     },
     items:[
       {
-        text: 'I agree to send delicious doughnuts to the Design System team at GDS',
+        text: 'Label for single checkbox',
         value: 'agree',
         id: 'single-checkbox'
       }
@@ -253,7 +253,7 @@
   {% set yesField %}
   {{ govukInput({
     label: {
-      "text": 'Text input'
+      "text": 'Label for revealed text input'
     },
     id: "yes-input",
     name: "yes-input",
@@ -266,7 +266,7 @@
   {% set noField %}
   {{ govukInput({
     label: {
-      "text": 'Text input'
+      "text": 'Label for revealed text input'
     },
     id: "no-input",
     name: "no-input",
@@ -281,7 +281,7 @@
     "name": "conditional",
     "fieldset": {
       "legend": {
-        "text": "Conditional?"
+        "text": "Legend for conditionally revealed content"
       },
       "classes": "govuk-radios--error",
       attributes: {

--- a/src/components/error-summary/error-summary.js
+++ b/src/components/error-summary/error-summary.js
@@ -1,4 +1,6 @@
+import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener
+import '../../vendor/polyfills/Element/prototype/closest'
 
 function ErrorSummary ($module) {
   this.$module = $module
@@ -12,6 +14,119 @@ ErrorSummary.prototype.init = function () {
   window.addEventListener('load', function () {
     $module.focus()
   })
+
+  $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+/**
+* Click event handler
+*
+* @param {MouseEvent} event - Click event
+*/
+ErrorSummary.prototype.handleClick = function (event) {
+  var target = event.target
+  if (this.focusTarget(target)) {
+    event.preventDefault()
+  }
+}
+
+/**
+ * Focus the target element
+ *
+ * By default, the browser will scroll the target into view. Because our labels
+ * or legends appear above the input, this means the user will be presented with
+ * an input without any context, as the label or legend will be off the top of
+ * the screen.
+ *
+ * Manually handling the click event, scrolling the question into view and then
+ * focussing the element solves this.
+ *
+ * This also results in the label and/or legend being announced correctly in
+ * NVDA (as tested in 2018.3.2) - without this only the field type is announced
+ * (e.g. "Edit, has autocomplete").
+ *
+ * @param {HTMLElement} $target - Event target
+ * @returns {boolean} True if the target was able to be focussed
+ */
+ErrorSummary.prototype.focusTarget = function ($target) {
+  // If the element that was clicked was not a link, return early
+  if ($target.tagName !== 'A' || $target.href === false) {
+    return false
+  }
+
+  var inputId = this.getFragmentFromUrl($target.href)
+  var $input = document.getElementById(inputId)
+  if (!$input) {
+    return false
+  }
+
+  var $legendOrLabel = this.getAssociatedLegendOrLabel($input)
+  if (!$legendOrLabel) {
+    return false
+  }
+
+  // Prefer using the history API where possible, as updating
+  // window.location.hash causes the viewport to jump to the input briefly
+  // before then scrolling to the label/legend in IE10, IE11 and Edge (as tested
+  // in Edge 17).
+  if (window.history.pushState) {
+    window.history.pushState(null, null, '#' + inputId)
+  } else {
+    window.location.hash = inputId
+  }
+
+  // Scroll the legend or label into view *before* calling focus on the input to
+  // avoid extra scrolling in browsers that don't support `preventScroll` (which
+  // at time of writing is most of them...)
+  $legendOrLabel.scrollIntoView()
+  $input.focus({ preventScroll: true })
+
+  return true
+}
+
+/**
+ * Get fragment from URL
+ *
+ * Extract the fragment (everything after the hash) from a URL, but not including
+ * the hash.
+ *
+ * @param {string} url - URL
+ * @returns {string} Fragment from URL, without the hash
+ */
+ErrorSummary.prototype.getFragmentFromUrl = function (url) {
+  if (url.indexOf('#') === -1) {
+    return false
+  }
+
+  return url.split('#').pop()
+}
+
+/**
+ * Get associated legend or label
+ *
+ * Returns the first element that exists from this list:
+ *
+ * - The `<legend>` associated with the closest `<fieldset>` ancestor
+ * - The first `<label>` that is associated with the input using for="inputId"
+ * - The closest parent `<label>`
+ *
+ * @param {HTMLElement} $input - The input
+ * @returns {HTMLElement} Associated legend or label, or null if no associated
+ *                        legend or label can be found
+ */
+ErrorSummary.prototype.getAssociatedLegendOrLabel = function ($input) {
+  var $fieldset = $input.closest('fieldset')
+
+  if ($fieldset) {
+    var legends = $fieldset.getElementsByTagName('legend')
+
+    if (legends.length) {
+      return legends[0]
+    }
+  }
+
+  return document.querySelector("label[for='" + $input.getAttribute('id') + "']") ||
+    $input.closest('label')
 }
 
 export default ErrorSummary

--- a/src/components/error-summary/error-summary.test.js
+++ b/src/components/error-summary/error-summary.test.js
@@ -23,9 +23,49 @@ afterAll(async (done) => {
 
 describe('Error Summary', () => {
   it('is automatically focused when the page loads', async () => {
-    await page.goto(baseUrl + '/components/error-summary/preview', { waitUntil: 'load' })
+    await page.goto(`${baseUrl}/components/error-summary/preview`, { waitUntil: 'load' })
 
     const moduleName = await page.evaluate(() => document.activeElement.dataset.module)
     expect(moduleName).toBe('error-summary')
+  })
+
+  let inputTypes = [
+    // [description, input id, selector for label or legend]
+    ['an input', 'input', 'label[for="input"]'],
+    ['a textarea', 'textarea', 'label[for="textarea"]'],
+    ['a select', 'select', 'label[for="select"]'],
+    ['a date input', 'dateinput-day', '.test-date-input-legend'],
+    ['a specific field in a date input', 'dateinput2-year', '.test-date-input2-legend'],
+    ['a file upload', 'file', 'label[for="file"]'],
+    ['a group of radio buttons', 'radios', '#test-radios legend'],
+    ['a group of checkboxes', 'checkboxes', '#test-checkboxes legend'],
+    ['a single checkbox', 'single-checkbox', 'label[for="single-checkbox"]'],
+    ['a conditionally revealed input', 'yes-input', '#test-conditional-reveal legend']
+  ]
+
+  describe.each(inputTypes)('when linking to %s', async (_, inputId, legendOrLabelSelector) => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/examples/error-summary`, { waitUntil: 'load' })
+      await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
+    })
+
+    it('focuses the target input', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.id)
+      expect(activeElement).toBe(inputId)
+    })
+
+    it('scrolls the label or legend to the top of the screen', async () => {
+      const legendOrLabelOffsetFromTop = await page.$eval(
+        legendOrLabelSelector,
+        $ => $.getBoundingClientRect().top
+      )
+
+      expect(legendOrLabelOffsetFromTop).toEqual(0)
+    })
+
+    it('updates the hash in the URL', async () => {
+      const hash = await page.evaluate(() => window.location.hash)
+      expect(hash).toBe(`#${inputId}`)
+    })
   })
 })

--- a/src/vendor/polyfills/Element/prototype/closest.js
+++ b/src/vendor/polyfills/Element/prototype/closest.js
@@ -1,0 +1,24 @@
+import './matches'
+
+(function(undefined) {
+
+  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/closest/detect.js
+  var detect = (
+    'document' in this && "closest" in document.documentElement
+  )
+
+  if (detect) return
+
+    // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/closest/polyfill.js
+  Element.prototype.closest = function closest(selector) {
+    var node = this;
+
+    while (node) {
+      if (node.matches(selector)) return node;
+      else node = 'SVGElement' in window && node instanceof SVGElement ? node.parentNode : node.parentElement;
+    }
+
+    return null;
+  };
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/src/vendor/polyfills/Element/prototype/matches.js
+++ b/src/vendor/polyfills/Element/prototype/matches.js
@@ -1,0 +1,23 @@
+(function(undefined) {
+
+  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/matches/detect.js
+  var detect = (
+    'document' in this && "matches" in document.documentElement
+  )
+
+  if (detect) return
+
+  // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/1f3c09b402f65bf6e393f933a15ba63f1b86ef1f/packages/polyfill-library/polyfills/Element/prototype/matches/polyfill.js
+  Element.prototype.matches = Element.prototype.webkitMatchesSelector || Element.prototype.oMatchesSelector || Element.prototype.msMatchesSelector || Element.prototype.mozMatchesSelector || function matches(selector) {
+    var element = this;
+    var elements = (element.document || element.ownerDocument).querySelectorAll(selector);
+    var index = 0;
+
+    while (elements[index] && elements[index] !== element) {
+      ++index;
+    }
+
+    return !!elements[index];
+  };
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});


### PR DESCRIPTION
By default, the browser will scroll the target into view. Because our labels or legends appear above the input, this means the user will be presented with an input without any context, as the label or legend will be off the top of the screen.

<img width="1136" alt="screen shot 2018-11-14 at 12 51 49" src="https://user-images.githubusercontent.com/121939/48483748-39192180-e80c-11e8-9835-842b33f28a58.png">


Manually handling the click event, focussing the element and scrolling the question into view solves this.

<img width="1136" alt="screen shot 2018-11-14 at 12 52 51" src="https://user-images.githubusercontent.com/121939/48483752-3c141200-e80c-11e8-85e3-9fd188862e9d.png">


## To do

- [x] Test in all supported browsers
  - [x] Internet Explorer 8 (Windows)
  - [x] Internet Explorer 9 (Windows)
  - [x] Internet Explorer 10 (Windows)
  - [x] Internet Explorer 11 (Windows)
  - [x] Edge (latest 2 versions) (Windows)
  - [x] Google Chrome (latest 2 versions) (Windows)
  - [x] Mozilla Firefox (latest 2 versions) (Windows)
  - [x] Safari 9+ (macOS)
  - [x] Google Chrome (latest 2 versions) (macOS)
  - [x] Mozilla Firefox (latest 2 versions) (macOS)
  - [x] Safari 9.3+ (iOS)
  - [x] Google Chrome (latest 2 versions) (iOS)
  - [x] Google Chrome (latest 2 versions) (Android)
  - [x] Samsung Internet (latest 2 versions) (Android)

- [x] Test in assistive technologies
  - [x] JAWS + Internet Explorer 11
  - [x] ZoomText + Internet Explorer 11
  - [x] Dragon NaturallySpeaking + Internet Explorer 11
  - [x] NVDA + Firefox
  - [x] VoiceOver (iOS)
  - [x] VoiceOver (macOS)