### PR TITLE
Enable package installation from branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ We love contributions! We've compiled these docs to help you understand our cont
 - [Supported browsers](#supported-browsers)
 - [Commit hygiene](#commit-hygiene)
 - [Updating Changelog](#updating-changelog)
+- [Testing a release](#testing-a-release)
 
 ### For maintainers
 - [Application tasks](#running-application-tasks)
@@ -85,6 +86,9 @@ These sections follow [semantic versioning](https://semver.org/), where:
 See the [`CHANGELOG_TEMPLATE.md`](/docs/contributing/CHANGELOG_TEMPLATE.md) for an example for how this looks.
 
 Include the modified `CHANGELOG` in the PR.
+
+## Testing a release
+If you need to test a release, for example if you're contributing a new component see [Publishing pre-release of GOV.UK Frontend](/docs/contributing/publishing-a-pre-release.md).
 
 ## Application tasks
 

--- a/bin/release-to-branch.sh
+++ b/bin/release-to-branch.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+BRANCH_NAME="pre-release-$CURRENT_BRANCH_NAME"
+
+# Check if there are files that need to be commited
+if [[ -n $(git status --porcelain) ]]; then
+  echo "⚠️ You have unstaged files, please commit these and then try again."
+  exit 1
+fi
+
+# Remove local branch is it already exists
+if [ `git branch --list $BRANCH_NAME` ]; then
+  echo "⚠️ Cleaning up branch $BRANCH_NAME that already exists."
+  git branch -D $BRANCH_NAME
+fi
+
+# Work on the new branch
+git checkout -b $BRANCH_NAME
+
+# Build the package as normal
+npm run build:package
+
+# Check if the new built package has anything new to commit
+if [[ -n $(git status --porcelain) ]]; then
+  echo "✍️ Commiting changed package"
+  git add package/
+
+  git commit -m "Release GOV.UK Frontend to '$BRANCH_NAME' for testing"
+
+  # Create a local branch containing the package directory
+  echo "✨ Filter the branch to only the package/ directory..."
+  git filter-branch --force --subdirectory-filter package
+
+  # Force the push of the branch to the remote Github origin
+  git push origin $BRANCH_NAME:$BRANCH_NAME --force
+
+  echo "⚠️ Branch pushed to '$BRANCH_NAME', do not edit this by hand."
+else
+  echo "⚠️ No new changes to the package."
+fi
+
+git checkout -
+
+echo
+echo "✅ To install the pushed branch release run 'npm install --save alphagov/govuk-frontend#$BRANCH_NAME'"

--- a/docs/contributing/publishing-a-pre-release.md
+++ b/docs/contributing/publishing-a-pre-release.md
@@ -4,7 +4,9 @@ We use pre-releases when:
 - We are working on a new contribution and want to see it in the Design System website
 - We want to try an experimental feature as if it's pushed to npm.
 
-This is done by pushing a release to a new branch which can be installed by npm.
+This is done by pushing the files used for a GOV.UK Frontend release (the contents of the `package` directory) to a new branch which can be installed by npm as if it was a released npm package.
+
+No changes get published to npm as part of the process.
 
 1. Checkout the branch you want to pre-release and pull latest changes.
 

--- a/docs/contributing/publishing-a-pre-release.md
+++ b/docs/contributing/publishing-a-pre-release.md
@@ -1,0 +1,21 @@
+# Publishing pre-release of GOV.UK Frontend
+
+We use pre-releases when:
+- We are working on a new contribution and want to see it in the Design System website
+- We want to try an experimental feature as if it's pushed to npm.
+
+This is done by pushing a release to a new branch which can be installed by npm.
+
+1. Checkout the branch you want to pre-release and pull latest changes.
+
+2. Run `nvm use` to ensure you are using the right version of Node.js and npm.
+
+3. Run `npm install` to ensure you have the latest dependencies installed.
+
+4. Run `npm run release-to-branch`.
+
+There should now be a branch `pre-release-[your-branch-name-here]` pushed to remote, which you can install with:
+
+```bash
+npm install --save alphagov/govuk-frontend#pre-release-[your-branch-name-here]
+```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "heroku": "gulp copy-assets && gulp sassdoc && node app/start.js",
     "pre-release": "node bin/check-nvmrc.js && ./bin/pre-release.sh",
     "release": "node bin/check-nvmrc.js && ./bin/release.sh",
+    "release-to-branch": "node bin/check-nvmrc.js && ./bin/release-to-branch.sh",
     "build:package": "node bin/check-nvmrc.js && gulp build:package --destination 'package' && npm run test:build:package",
     "build:dist": "node bin/check-nvmrc.js && gulp build:dist --destination 'dist' && npm run test:build:dist",
     "test": "standard && gulp test && gulp copy-assets && jest --testPathIgnorePatterns='after-*'",


### PR DESCRIPTION
This is an implementation of the discussion for the [Enable package installation from branch proposal](https://github.com/alphagov/govuk-design-system-architecture/pull/10).

It uses your current branch name and prefixes it with 'pre-release', and then publishes the built package directory to this branch, which can then be installed via npm.

As an example I ran this script on this branch itself resulting in:

- Result from running the script: https://github.com/alphagov/govuk-frontend/tree/pre-release-publish-build-to-branch
- You can see this being consumed in: https://github.com/alphagov/govuk-design-system/pull/629

https://trello.com/c/QqsC621F/1556-work-out-how-to-preview-changes-from-frontend-in-another-app