### PR TITLE
Fix footer styling in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,9 @@
 
 🔧 Fixes:
 
-- Pull Request Title goes here
+- Fix footer styles in IE8
 
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR #1061](https://github.com/alphagov/govuk-frontend/pull/1061))
 
 - Single field with error should have 'aria-describeby' attribute
 

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -22,9 +22,10 @@
 
   .govuk-footer {
     @include govuk-font($size: 16);
-    @include govuk-responsive-padding(7, "top");
-    @include govuk-responsive-padding(5, "bottom");
-
+    @include govuk-not-ie8 {
+      @include govuk-responsive-padding(7, "top");
+      @include govuk-responsive-padding(5, "bottom");
+    }
     border-top: 1px solid $govuk-footer-border-top;
     color: $govuk-footer-text;
     background: $govuk-footer-background;
@@ -70,6 +71,10 @@
     display: flex; // Support: Flexbox
     margin-right: -$govuk-gutter-half;
     margin-left: -$govuk-gutter-half;
+    @include govuk-if-ie8 {
+      @include govuk-responsive-padding(7, "top");
+      @include govuk-responsive-padding(5, "bottom");
+    }
     flex-wrap: wrap; // Support: Flexbox
     align-items: flex-end; // Support: Flexbox
     justify-content: center; // Support: Flexbox


### PR DESCRIPTION
At the moment footer looks broken in IE8. It doesn't like the padding being set on top and bottom of the container, resulting in an increased padding at the bottom and a mispositioned top border.

This work moves the responsive padding to the 'meta' element for IE8, but keeps it on the wrapper for IE9 and modern browsers.

Before:
![bs_win7_ie_8 0](https://user-images.githubusercontent.com/3758555/48266357-0693b100-e427-11e8-9c5c-486cc2d9691f.jpg)

After: 
![bs_win7_ie_8 0 1](https://user-images.githubusercontent.com/3758555/48266471-60947680-e427-11e8-8fc4-ced28cafcbcd.jpg)


