### PR TITLE
Remove implicit dependency on Element for classList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Remove implicit dependency on Element for classList
+
+  ([PR #1063](https://github.com/alphagov/govuk-frontend/pull/1063))
+
 - Single field with error should have 'aria-describeby' attribute
 
   Although we discourage using checkboxes without fieldsets, this fix

--- a/src/vendor/polyfills/Element/prototype/classList.js
+++ b/src/vendor/polyfills/Element/prototype/classList.js
@@ -1,5 +1,6 @@
 import '../../Object/defineProperty'
 import '../../DOMTokenList'
+import '../../Element'
 
 (function(undefined) {
 
@@ -14,7 +15,7 @@ import '../../DOMTokenList'
 
     if (detect) return
 
-    // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-service/8717a9e04ac7aff99b4980fbedead98036b0929a/packages/polyfill-library/polyfills/Element/prototype/classList/polyfill.js
+    // Polyfill from https://cdn.polyfill.io/v2/polyfill.js?features=Element.prototype.classList&flags=always
     (function (global) {
       var dpSupport = true;
       var defineGetter = function (object, name, fn, configurable) {


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1044

I think we should also consider https://github.com/alphagov/govuk-frontend/issues/674 since this will likely happen again.

From: https://cdn.polyfill.io/v2/polyfill.js?features=Element.prototype.classList&flags=always

 - Object.defineProperty, License: CC0 (required by "Element.prototype.classList", "_DOMTokenList", "DOMTokenList")
 - _DOMTokenList, License: ISC (required by "DOMTokenList", "Element.prototype.classList")
- DOMTokenList, License: CC0 (required by "Element.prototype.classList")
- Document, License: CC0 (required by "Element", "Element.prototype.classList")
- Element, License: CC0 (required by "Element.prototype.classList")
- Element.prototype.classList, License: ISC

We can remove the import from the design system after this ships: https://github.com/alphagov/govuk-design-system/pull/596/files#diff-9f975bd4d01eb71ff7e1ecad9f2a0484R2