### PR TITLE
Set 'vertical-align:top' positioning on table headers and cells

### DIFF
--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -22,6 +22,7 @@
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
+    vertical-align: top;
     // GOV.UK Elements sets the font-size and line-height for all headers and cells
     // in tables.
     @include govuk-compatibility(govuk_elements) {


### PR DESCRIPTION
Added `vertical-align: top` for table headers and table cells.

At the moment, content is vertically aligned to the centre of the cell, which means the content starts at different places depending on the row height.

This is harder to scan and read for all users and means a screen magnifier user may not be able to see the contents of the cell without scrolling down and then up to read the next cell. Also, I believe it is a typographic convention in printed documents to align content to the top of the cell.

I think `top` should be the default for all tables but this could be a table class. If that what would be preferred, I could update the PR and when it is merged update the GOV.UK Design System documentation too.