### PR TITLE
Add summary list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Add summary list component
+
+  This component was initially developed to allow us to build the
+  'check your answers' pattern.
+
+  It is mostly the same as in the original pattern with some notable differences:
+
+  - On smaller screens it wraps by default
+  - It's possible to have multiple actions
+
+  ([PR #1065](https://github.com/alphagov/govuk-frontend/pull/1065))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -3,6 +3,7 @@
 @import "button/button";
 @import "checkboxes/checkboxes";
 @import "character-count/character-count";
+@import "summary-list/summary-list";
 @import "date-input/date-input";
 @import "details/details";
 @import "error-message/error-message";

--- a/src/components/summary-list/README.md
+++ b/src/components/summary-list/README.md
@@ -1,0 +1,15 @@
+# Summary list
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the details component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/summary-list).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/summary-list/#options-example-default) for details.

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -47,8 +47,7 @@
   }
 
   .govuk-summary-list__actions {
-    margin-top: govuk-spacing(2);
-    margin-bottom: govuk-spacing(2);
+    margin-bottom: govuk-spacing(3);
     @include govuk-media-query($from: tablet) {
       padding-right: 0;
     }
@@ -60,6 +59,12 @@
     word-break: break-word;
     @include govuk-media-query($from: tablet) {
       width: 30%;
+    }
+  }
+
+  .govuk-summary-list__value {
+    @include govuk-media-query($until: tablet) {
+      margin-bottom: govuk-spacing(3);
     }
   }
 

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -1,0 +1,110 @@
+@import "../../settings/all";
+@import "../../tools/all";
+@import "../../helpers/all";
+
+@include govuk-exports("govuk/component/summary-list") {
+
+  .govuk-summary-list {
+    @include govuk-font($size: 19);
+    @include govuk-text-colour;
+    @include govuk-media-query($from: tablet) {
+      display: table;
+      width: 100%;
+    }
+    margin: 0; // Reset default user agent styles
+    @include govuk-responsive-margin(9, "bottom");
+  }
+
+  .govuk-summary-list__row {
+    @include govuk-media-query($until: tablet) {
+      margin-bottom: govuk-spacing(3);
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+    @include govuk-media-query($from: tablet) {
+      display: table-row;
+    }
+  }
+
+  .govuk-summary-list__key,
+  .govuk-summary-list__value,
+  .govuk-summary-list__actions {
+    margin: 0; // Reset default user agent styles
+
+    @include govuk-media-query($from: tablet) {
+      display: table-cell;
+      padding-right: govuk-spacing(4);
+    }
+  }
+
+  .govuk-summary-list__key,
+  .govuk-summary-list__value,
+  .govuk-summary-list__actions {
+    @include govuk-media-query($from: tablet) {
+      padding-top: govuk-spacing(2);
+      padding-bottom: govuk-spacing(2);
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  }
+
+  .govuk-summary-list__actions {
+    margin-top: govuk-spacing(2);
+    margin-bottom: govuk-spacing(2);
+    @include govuk-media-query($from: tablet) {
+      padding-right: 0;
+    }
+  }
+
+  .govuk-summary-list__key {
+    margin-bottom: govuk-spacing(1);
+    @include govuk-typography-weight-bold;
+    word-break: break-word;
+    @include govuk-media-query($from: tablet) {
+      width: 30%;
+    }
+  }
+
+  .govuk-summary-list__value > p {
+    margin-bottom: govuk-spacing(2);
+  }
+
+  .govuk-summary-list__value > :last-child {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__actions-list {
+    width: 100%;
+    margin: 0; // Reset default user agent styles
+    padding: 0; // Reset default user agent styles
+
+    @include govuk-media-query($from: tablet) {
+      text-align: right;
+    }
+  }
+
+  .govuk-summary-list__actions-list-item {
+    display: inline;
+    margin-right:  govuk-spacing(2);
+    padding-right: govuk-spacing(2);
+  }
+
+  // In older browsers such as IE8, :last-child is not available,
+  // so only show the border divider where it is available.
+  .govuk-summary-list__actions-list-item:not(:last-child) {
+    border-right: 1px solid $govuk-border-colour;
+  }
+
+  .govuk-summary-list__actions-list-item:last-child {
+    margin-right: 0;
+    padding-right: 0;
+    border: 0;
+  }
+
+  .govuk-summary-list--no-border {
+    .govuk-summary-list__key,
+    .govuk-summary-list__value,
+    .govuk-summary-list__actions,
+    .govuk-summary-list__row {
+      border: 0;
+    }
+  }
+}

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -12,7 +12,7 @@
       width: 100%;
     }
     margin: 0; // Reset default user agent styles
-    @include govuk-responsive-margin(9, "bottom");
+    @include govuk-responsive-margin(6, "bottom");
   }
 
   .govuk-summary-list__row {

--- a/src/components/summary-list/macro.njk
+++ b/src/components/summary-list/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukSummaryList(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -108,6 +108,31 @@ examples:
               - href: '#'
                 text: Change
                 visuallyHiddenText: contact information
+  - name: no-actions
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
   - name: no-border
     data:
       classes: govuk-summary-list--no-border

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -1,0 +1,422 @@
+params:
+- name: rows
+  type: array
+  required: true
+  description: Array of row item objects
+  params:
+  - name: key.text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within the each key. If `html` is provided, the `text` argument will be ignored.
+  - name: key.html
+    type: string
+    required: true
+  - name: key.classes
+    type: string
+    required: false
+    description: Classes to add to the key wrapper
+  - name: value.text
+    type: string
+    required: true
+    description: If `html` is set, this is not required. Text to use within the each value. If `html` is provided, the `text` argument will be ignored.
+  - name: value.html
+    type: string
+    required: true
+    description: If `text` is set, this is not required. HTML to use within the each value. If `html` is provided, the `text` argument will be ignored.
+  - name: value.classes
+    type: string
+    required: false
+    description: Classes to add to the value wrapper
+  - name: actions.items
+    type: array
+    required: false
+    description: Array of action item objects
+    params:
+    - name: classes
+      type: string
+      required: false
+      description: Classes to add to the actions wrapper
+    - name: href
+      type: string
+      required: true
+      description: The value of the link href attribute for an action item
+    - name: text
+      type: string
+      required: true
+      description: If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` argument will be ignored.
+    - name: html
+      type: string
+      required: true
+      description: If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` argument will be ignored.
+    - name: visuallyHiddenText
+      type: string
+      required: false
+      description: Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use `html` for more complicated scenarios.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the container.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the container.
+
+examples:
+  - name: default
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
+            items:
+              - href: '#'
+                text: Edit
+                visuallyHiddenText: name
+              - href: '#'
+                text: Delete
+                visuallyHiddenText: name
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: date of birth
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+               email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+          actions:
+            items:
+              - href: '#'
+                text: Edit
+                visuallyHiddenText: contact information
+              - href: '#'
+                text: Change
+                visuallyHiddenText: contact information
+  - name: no-border
+    data:
+      classes: govuk-summary-list--no-border
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+  - name: overridden-widths
+    data:
+      rows:
+        - key:
+            classes: govuk-!-width-one-half
+            text: Name
+          value:
+            classes: govuk-!-width-one-quarter
+            text: Firstname Lastname
+          actions:
+            classes: govuk-!-width-one-half
+            items:
+              - href: '#'
+                text: Edit
+                visuallyHiddenText: name
+              - href: '#'
+                text: Delete
+                visuallyHiddenText: name
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: date of birth
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+          actions:
+            items:
+              - href: '#'
+                text: Edit
+                visuallyHiddenText: contact information
+              - href: '#'
+                text: Change
+                visuallyHiddenText: contact information
+  - name: check-your-answers
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Sarah Philips
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: name
+        - key:
+            text: Date of birth
+          value:
+            text: 5 January 1978
+          actions:
+            items:
+            - href: '#'
+              text: Change
+              visuallyHiddenText: date of birth
+        - key:
+            text: Contact information
+          value:
+            html: |
+              72 Guild Street<br>
+              London<br>
+              SE23 6FH
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: contact information
+        - key:
+            text: Contact details
+          value:
+            html: |
+              07700 900457<br>
+              sarah.phillips@example.com
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: contact details
+        - key:
+            text: Previous application number
+          value:
+            text: 502135326
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: previous application number
+        - key:
+            text: Licence type
+          value:
+            text: For personal use
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: licence type
+        - key:
+            text: Home address
+          value:
+            html: |
+              <p class="govuk-body">
+                72 Guild Street<br>
+                London<br>
+                SE23 6FH
+              </p>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: home address
+        - key:
+            text: Licence period
+          value:
+            html: |
+              <p class="govuk-body">This is a longer paragraph of text provided by the user to provide additional information.</p>
+              <p class="govuk-body">This is a second paragraph of text provided by the user.</p>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: licence period
+  - name: extreme
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Barnaby Marmaduke Aloysius Benjy Cobweb Dartagnan Egbert Felix Gaspar Humbert Ignatius Jayden Kasper Leroy Maximilian Neddy Obiajulu Pepin Quilliam Rosencrantz Sexton Teddy Upwood Vivatma Wayland Xylon Yardley Zachary Usansky
+          actions:
+            items:
+              - href: '#'
+                text: Buy
+              - href: '#'
+                text: Use
+              - href: '#'
+                text: Break
+              - href: '#'
+                text: Fix
+              - href: '#'
+                text: Trash
+              - href: '#'
+                text: Change
+              - href: '#'
+                text: Mail
+              - href: '#'
+                text: Upgrade
+              - href: '#'
+                text: Charge
+              - href: '#'
+                text: Point
+              - href: '#'
+                text: Coom
+              - href: '#'
+                text: Press
+              - href: '#'
+                text: Snap
+              - href: '#'
+                text: Work
+              - href: '#'
+                text: Quick
+              - href: '#'
+                text: Erase
+        - key:
+            text: Pneumonoultramicroscopicsilicovolcanoconiosis
+          value:
+            html: |
+              <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi quis consequat diam. Duis efficitur justo at congue iaculis. Quisque scelerisque ornare justo nec congue. Duis egestas felis nibh, eu cursus metus rutrum eget. In dictum lectus diam, dapibus ullamcorper risus gravida a. Vestibulum tempor mattis sapien, at auctor tellus dignissim non. Praesent dictum felis nec diam tempor, vel lobortis leo ultricies.</p>
+              <p class="govuk-body">Suspendisse potenti. Aliquam dictum eu ipsum sed facilisis. Maecenas hendrerit est eget ultrices venenatis. Nam ex nisl, venenatis eget molestie quis, hendrerit id tellus. Morbi et posuere ex, vel interdum sapien. Mauris ac mattis turpis, interdum eleifend erat. Morbi eget efficitur lectus. Sed suscipit laoreet ipsum et iaculis. Integer ornare ipsum quis aliquet scelerisque. Proin venenatis dictum suscipit. Nunc tristique, felis quis fermentum rhoncus, tortor augue egestas ipsum, non porttitor nulla odio vitae purus. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p>
+          actions:
+            items:
+              - href: '#'
+                text: Write
+              - href: '#'
+                text: Cut
+              - href: '#'
+                text: Paste
+              - href: '#'
+                text: Save
+              - href: '#'
+                text: Load
+              - href: '#'
+                text: Check
+              - href: '#'
+                text: Quick
+              - href: '#'
+                text: Rewrite
+              - href: '#'
+                text: Plug
+              - href: '#'
+                text: Play
+              - href: '#'
+                text: Burn
+              - href: '#'
+                text: Rip
+              - href: '#'
+                text: Drag and drop
+              - href: '#'
+                text: Zip
+              - href: '#'
+                text: Unzip
+              - href: '#'
+                text: Lock
+              - href: '#'
+                text: Fill
+              - href: '#'
+                text: Curl
+              - href: '#'
+                text: Find
+              - href: '#'
+                text: View
+              - href: '#'
+        - key:
+            text: Its vanished trees, the trees that had made way for Gatsby’s house, Pneumonoultramicroscopicsilicovolcanoconiosis had once pandered in whispers to the last and greatest of all human dreams; for a transitory enchanted moment man must have held his breath in the presence of this continent, compelled into an aesthetic contemplation he neither understood nor desired, face to face for the last time in history with something commensurate to his capacity for wonder.
+          value:
+            text: The Great Gatsby
+          actions:
+            items:
+              - href: '#'
+                text: Code
+              - href: '#'
+                text: Jam
+              - href: '#'
+                text: Unlock
+              - href: '#'
+                text: Surf
+              - href: '#'
+                text: Scroll
+              - href: '#'
+                text: Pose
+              - href: '#'
+                text: Click
+              - href: '#'
+                text: Cross
+              - href: '#'
+                text: Crack
+              - href: '#'
+                text: Twitch
+              - href: '#'
+                text: Update
+              - href: '#'
+                text: Name
+              - href: '#'
+                text: Read
+              - href: '#'
+                text: Tune
+              - href: '#'
+                text: Print
+              - href: '#'
+                text: Scan
+              - href: '#'
+                text: Send
+              - href: '#'
+                text: Fax
+              - href: '#'
+                text: Rename
+              - href: '#'
+                text: Touch
+              - href: '#'
+                text: Bring
+              - href: '#'
+                text: Pay
+              - href: '#'
+                text: Watch
+              - href: '#'
+                text: Turn
+              - href: '#'
+                text: Leave
+              - href: '#'
+                text: Stop
+              - href: '#'
+                text: Format

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -384,7 +384,6 @@ examples:
                 text: Find
               - href: '#'
                 text: View
-              - href: '#'
         - key:
             text: Its vanished trees, the trees that had made way for Gatsby’s house, Pneumonoultramicroscopicsilicovolcanoconiosis had once pandered in whispers to the last and greatest of all human dreams; for a transitory enchanted moment man must have held his breath in the presence of this continent, compelled into an aesthetic contemplation he neither understood nor desired, face to face for the last time in history with something commensurate to his capacity for wonder.
           value:

--- a/src/components/summary-list/template.njk
+++ b/src/components/summary-list/template.njk
@@ -1,0 +1,28 @@
+<dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {% for row in params.rows %}
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+        {{ row.key.html | safe if row.key.html else row.key.text }}
+      </dt>
+      <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+        {{ row.value.html | safe if row.value.html else row.value.text }}
+      </dd>
+      {% if row.actions.items %}
+        <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
+          <ul class="govuk-summary-list__actions-list">
+            {% for action in row.actions.items %}
+              <li class="govuk-summary-list__actions-list-item">
+                <a class="govuk-link" href="{{ action.href }}">
+                  {{ action.html | safe if action.html else action.text }}
+                  {%- if action.visuallyHiddenText -%}
+                    <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+                  {%- endif %}
+                </a>
+              </li>
+            {% endfor %}
+          </ul>
+        </dd>
+      {% endif %}
+    </div>
+  {% endfor %}
+</dl>

--- a/src/components/summary-list/template.test.js
+++ b/src/components/summary-list/template.test.js
@@ -1,0 +1,251 @@
+/* eslint-env jest */
+
+const axe = require('../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('summary-list')
+
+describe('Data list', () => {
+  it('default example passes accessibility tests', async () => {
+    const $ = render('summary-list', examples.default)
+
+    const results = await axe($.html(), {
+      rules: {
+        // In newer versions of the HTML specification wrapper
+        // <div>s are allowed in a definition list
+        'dlitem': { enabled: false },
+        'definition-list': { enabled: false }
+      }
+    })
+    expect(results).toHaveNoViolations()
+  })
+  it('renders classes', async () => {
+    const $ = render('summary-list', {
+      classes: 'app-custom-class'
+    })
+
+    const $component = $('.govuk-summary-list')
+    expect($component.hasClass('app-custom-class')).toBeTruthy()
+  })
+  it('renders with attributes', () => {
+    const $ = render('summary-list', {
+      attributes: {
+        'data-attribute-1': 'value-1',
+        'data-attribute-2': 'value-2'
+      }
+    })
+
+    const $component = $('.govuk-summary-list')
+    expect($component.attr('data-attribute-1')).toEqual('value-1')
+    expect($component.attr('data-attribute-2')).toEqual('value-2')
+  })
+  describe('rows', () => {
+    describe('keys', () => {
+      it('renders text', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                text: 'Name'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $key = $component.find('dt.govuk-summary-list__key')
+
+        expect($key.html()).toContain('Name')
+      })
+      it('renders html', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                html: '<b>Name</b>'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $key = $component.find('dt.govuk-summary-list__key')
+
+        expect($key.html()).toContain('<b>Name</b>')
+      })
+      it('renders classes', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                classes: 'app-custom-class',
+                text: 'Name'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $key = $component.find('dt.govuk-summary-list__key')
+        expect($key.hasClass('app-custom-class')).toBeTruthy()
+      })
+    })
+    describe('values', () => {
+      it('renders text', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              value: {
+                text: 'Firstname Lastname'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $value = $component.find('dd.govuk-summary-list__value')
+
+        expect($value.html()).toContain('Firstname Lastname')
+      })
+      it('renders html', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              value: {
+                html: '<span>email@email.com</span>'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $value = $component.find('dd.govuk-summary-list__value')
+
+        expect($value.html()).toContain('<span>email@email.com</span>')
+      })
+      it('renders classes', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              value: {
+                classes: 'app-custom-class',
+                text: 'Firstname Lastname'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $value = $component.find('dd.govuk-summary-list__value')
+        expect($value.hasClass('app-custom-class')).toBeTruthy()
+      })
+    })
+    describe('actions', () => {
+      it('renders href', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              actions: {
+                items: [
+                  {
+                    href: 'https://www.gov.uk'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions-list-item a')
+
+        expect($actionLink.attr('href')).toBe('https://www.gov.uk')
+      })
+      it('renders text', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              actions: {
+                items: [
+                  {
+                    text: 'Edit'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions-list-item a')
+
+        expect($actionLink.text()).toContain('Edit')
+      })
+      it('renders html', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              actions: {
+                items: [
+                  {
+                    html: 'Edit<span class="visually-hidden"> name</span>'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions-list-item a')
+
+        expect($actionLink.html()).toContain('Edit<span class="visually-hidden"> name</span>')
+      })
+      it('renders custom accessible name', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                text: 'Name'
+              },
+              actions: {
+                items: [
+                  {
+                    text: 'Edit',
+                    visuallyHiddenText: 'Custom Accessible Name'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions-list-item a')
+        expect($actionLink.text()).toContain('Edit Custom Accessible Name')
+      })
+      it('renders classes', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              actions: {
+                classes: 'app-custom-class',
+                items: [
+                  {
+                    text: 'Edit'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionList = $component.find('.govuk-summary-list__actions')
+
+        expect($actionList.hasClass('app-custom-class')).toBeTruthy()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This component was initially developed to allow us to build the
'check your answers' pattern.

It is mostly the same as in the original pattern with some notable differences:

- On smaller screens it wraps by default
- It's possible to have multiple actions

## Review
- Review application: https://govuk-frontend-review-pr-1065.herokuapp.com/components/summary-list

- Original GOV.UK Prototype Kit implementation: https://govuk-prototype-kit.herokuapp.com/docs/templates/check-your-answers

## Todo

- [x] Consider visuallyHiddenText feature instead of using `html`
- [x] Improve the options descriptions
- [x] Assistive technology final run through

https://trello.com/c/kh2atSrd/1612-add-summary-list-component-to-govuk-frontend-pair