### PR TITLE
Use commit from branch instead of branch name for install command

### DIFF
--- a/bin/release-to-branch.sh
+++ b/bin/release-to-branch.sh
@@ -43,5 +43,7 @@ fi
 
 git checkout -
 
+BRANCH_COMMIT_SHA=$(git rev-parse --short $BRANCH_NAME)
+
 echo
-echo "✅ To install the pushed branch release run 'npm install --save alphagov/govuk-frontend#$BRANCH_NAME'"
+echo "✅ To install the pushed branch release run 'npm install --save alphagov/govuk-frontend#$BRANCH_COMMIT_SHA'"


### PR DESCRIPTION
We have found that Netlify will cache the branch name.

By using the commit-sha it means we can always keep up-to-date