### PR TITLE
Update padding of govuk-main-wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Update padding of govuk-main-wrapper
+
+  This increases the padding of `govuk-main-wrapper` (on tablet and above) to be more inline with GOV.UK. When updating, your pages will have 10px more white space above and below the 'main' content area.
+
+  ([PR #1073](https://github.com/alphagov/govuk-frontend/pull/1073))
+
 - Remove error-summary dependence on document.onload
 
   ([PR #1215](https://github.com/alphagov/govuk-frontend/pull/1215))

--- a/src/objects/_main-wrapper.scss
+++ b/src/objects/_main-wrapper.scss
@@ -21,12 +21,20 @@
 
 
 @mixin govuk-main-wrapper {
-  @include govuk-responsive-padding(6, "top");
-  @include govuk-responsive-padding(6, "bottom");
   // In IE11 the `main` element can be used, but is not recognized  –
   // meaning it's not defined in IE's default style sheet,
   // so it uses CSS initial value, which is inline.
   display: block;
+  padding-top: govuk-spacing(4);
+  padding-bottom: govuk-spacing(4);
+
+  @include govuk-media-query($from: tablet) {
+    // This spacing is manually adjusted to replicate the margin of
+    // govuk-heading-xl (50px) minus the spacing of back link and
+    // breadcrumbs (10px)
+    padding-top: govuk-spacing(7);
+    padding-bottom: govuk-spacing(7);
+  }
 }
 
 // Use govuk-main-wrapper--l when you page does not have Breadcrumbs, phase banners or back links


### PR DESCRIPTION
After a discussion on the GOV.UK Design System Backlog (https://github.com/alphagov/govuk-design-system-backlog/issues/64#issuecomment-440241559) I looked into the spacing above the h1 to make it equal with the spacing underneath, which is more inline with GOV.UK.

I have made a manual adjustment that increases the padding of `govuk-main-wrapper` by 10px on tablet and up only.

**From:**
30px tablet and up > 20px mobile

**To:**
40px tablet and up > 20px mobile

This breaks the responsive spacing scale intentionally as we are looking to replicate the margin of `govuk-heading-xl` (50px > 30px) whilst accommodating the margin-bottom / white space of the the back link / breadcrumbs (~10px). 

From tablet, 40px padding-top on `govuk-main-wrapper` + 10px margin-bottom of back link = 50px. 

On mobile, 20px padding-top on `govuk-main-wrapper` + 10px margin-bottom of back link = 30px

This now equals `govuk-heading-xl` (50px > 30px)

**Before (GOV.UK | GOV.UK Frontend)**
<img width="1008" alt="screen shot 2018-11-21 at 08 24 16" src="https://user-images.githubusercontent.com/23356842/48831031-e2f93080-ed6d-11e8-97cb-2ce094a18e4a.png">

**After (GOV.UK | GOV.UK Frontend)**
<img width="965" alt="screen shot 2018-11-21 at 08 23 49" src="https://user-images.githubusercontent.com/23356842/48831048-edb3c580-ed6d-11e8-8a03-909676225c22.png">