### PR TITLE
Add 5px bottom margin to bullet-less list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,10 @@
 
 🔧 Fixes:
 
-- Pull Request Title goes here
+- Add 5px bottom margin to list items within lists that do not have bullets or
+  numbers on mobile breakpoints to make each item visually distinct.
 
-  Description goes here (optional)
-
-  ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+  ([PR #1078](https://github.com/alphagov/govuk-frontend/pull/1078))
 
 ## 2.4.0 (Feature release)
 

--- a/src/core/_lists.scss
+++ b/src/core/_lists.scss
@@ -15,9 +15,10 @@
   }
 
   %govuk-list > li {
-    @include govuk-media-query($from: tablet) {
-      margin-bottom: govuk-spacing(1);
-    }
+    // Lists without numbers or bullets should always have extra space between
+    // list items. Lists with numbers or bullets only have this extra space on
+    // tablet and above
+    margin-bottom: govuk-spacing(1);
   }
 
   .govuk-list {
@@ -26,17 +27,25 @@
 
   %govuk-list--bullet {
     padding-left: govuk-spacing(4);
-
     list-style-type: disc;
-  }
-
-  .govuk-list--bullet {
-    @extend %govuk-list--bullet;
   }
 
   %govuk-list--number {
     padding-left: govuk-spacing(4);
     list-style-type: decimal;
+  }
+
+  %govuk-list--bullet > li,
+  %govuk-list--number > li {
+    margin-bottom: 0;
+
+    @include govuk-media-query($from: tablet) {
+      margin-bottom: govuk-spacing(1);
+    }
+  }
+
+  .govuk-list--bullet {
+    @extend %govuk-list--bullet;
   }
 
   .govuk-list--number {


### PR DESCRIPTION
On small screens list items have no bottom margin (with a 5px bottom margin being applied at tablet and above)

When the govuk-list class is applied on it's own without any modifier, the list items appear to run into each other on mobile, as the spacing between the list items is the same as the spacing between each line.

(When a bullet or number modifier is added e.g. class="govuk-list govuk-list--bullet" the bullet or number indicates the start of a new list item, so the spacing does not need to be adjusted in that case.)

This change applies the spacing to the govuk-list class for all breakpoints, then adjusts the behaviour when bullet or number modifiers are added.

Closes #1069 

https://trello.com/c/pUKbZTbi/1629-add-bottom-margin-to-non-bulleted-list-items