### PR TITLE
Clean up warning text component styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 🔧 Fixes:
 
+- Warning text component, remove negative margin left and reduce padding left to match.
+
+  ([PR #1084](https://github.com/alphagov/govuk-frontend/pull/1084))
+
 - Add 5px bottom margin to list items within lists that do not have bullets or
   numbers on mobile breakpoints to make each item visually distinct.
 

--- a/src/components/warning-text/_warning-text.scss
+++ b/src/components/warning-text/_warning-text.scss
@@ -51,7 +51,6 @@
 
   .govuk-warning-text__text {
     display: block;
-    margin-left: -$govuk-gutter-half;
-    padding-left: 65px;
+    padding-left: 50px;
   }
 }


### PR DESCRIPTION
- remove negative margin left and reduce padding left to match

Fixes https://github.com/alphagov/govuk-frontend/issues/1083