### PR TITLE
Improve nvmrc check

### DIFF
--- a/bin/check-nvmrc.js
+++ b/bin/check-nvmrc.js
@@ -17,17 +17,25 @@ fs.readFile(path.join(__dirname, '../.nvmrc'), 'utf8', function (error, data) {
     process.exit()
   }
 
+  var nvmInstallText = 'To do this you can install nvm (https://github.com/creationix/nvm) then run `nvm install`.'
+
   if (versionMatchesMajor) {
     console.log('' +
       'Warning: You are using Node.js version ' + currentVersion + ' which we do not use. ' +
+      '\n\n' +
       'You may encounter issues, consider installing Node.js version ' + expectedVersion + '.' +
+      '\n\n' +
+      nvmInstallText +
     '')
     process.exit()
   }
 
   console.log('' +
     'You are using Node.js version ' + currentVersion + ' which we do not support. ' +
+    '\n\n' +
     'Please install Node.js version ' + expectedVersion + ' and try again.' +
+    '\n\n' +
+    nvmInstallText +
   '')
   process.exit(1) // exit with a failure mode
 })

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "preinstall": "node bin/check-nvmrc.js",
     "prestart": "node bin/check-nvmrc.js",
     "start": "gulp dev",
     "heroku": "gulp copy-assets && gulp sassdoc && node app/start.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "prestart": "node bin/check-nvmrc.js",
     "start": "gulp dev",
     "heroku": "gulp copy-assets && gulp sassdoc && node app/start.js",
     "pre-release": "node bin/check-nvmrc.js && ./bin/pre-release.sh",


### PR DESCRIPTION
Through helping @andysellick get Node.js setup with the right version we found that when running `npm start` on an older version resulted in an error message that was confusing. This is consistent with what we do on the GOV.UK Design System repository.

This pull request adds a `prestart` and `preinstall` command that runs the Node.js verison check, which is more actionable.

It also adds instructions to try and use nvm, since this will be easier than trying to find the right Node.js version online.