### PR TITLE
Remove unused imports from Character Count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
 
 🔧 Fixes:
 
+- Remove unused hint, error message and label imports from the Character Count
+  component
+
+  ([PR #1087](https://github.com/alphagov/govuk-frontend/pull/1087))
+
 - Warning text component, remove negative margin left and reduce padding left to match.
 
   ([PR #1084](https://github.com/alphagov/govuk-frontend/pull/1084))

--- a/src/components/character-count/template.njk
+++ b/src/components/character-count/template.njk
@@ -1,6 +1,3 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
 {% from "../textarea/macro.njk" import govukTextarea %}
 
 <div class="govuk-character-count" data-module="character-count"


### PR DESCRIPTION
The error message, hint and label are all handled by the textarea component which we call from the character count, so there is no need to import them separately.