### PR TITLE
Simplify the grid mixins

### DIFF
--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -2,20 +2,6 @@
 /// @group helpers
 ////
 
-/// Map of grid column widths
-///
-/// @type Map
-/// @access private
-
-$_govuk-grid-widths: (
-  one-quarter: 25%,
-  one-third: 33.3333%,
-  one-half: 50%,
-  two-thirds: 66.6666%,
-  three-quarters: 75%,
-  full: 100%
-) !default;
-
 /// Grid width percentage
 ///
 /// @param {String} $key - Name of grid width (e.g. two-thirds)
@@ -24,8 +10,8 @@ $_govuk-grid-widths: (
 /// @access public
 
 @function grid-width($key) {
-  @if map-has-key($_govuk-grid-widths, $key) {
-    @return map-get($_govuk-grid-widths, $key);
+  @if map-has-key($govuk-grid-widths, $key) {
+    @return map-get($govuk-grid-widths, $key);
   }
 
   @error "Unknown grid width `#{$key}`";

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -9,12 +9,20 @@
 /// @throw if `$key` is not a valid grid width
 /// @access public
 
-@function grid-width($key) {
+@function govuk-grid-width($key) {
   @if map-has-key($govuk-grid-widths, $key) {
     @return map-get($govuk-grid-widths, $key);
   }
 
   @error "Unknown grid width `#{$key}`";
+}
+
+/// Grid width percentage (alias)
+///
+/// @alias govuk-grid-width
+/// @deprecated To be removed in v3.0, replaced by govuk-grid-width
+@function grid-width($key) {
+  @return govuk-grid-width($key);
 }
 
 /// Generate grid row styles
@@ -78,7 +86,7 @@
     }
     padding: 0 $govuk-gutter-half;
     @include govuk-media-query($from: $at) {
-      width: grid-width($width);
+      width: govuk-grid-width($width);
       float: $float;
     }
   }

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -50,37 +50,50 @@
 
 /// Generate grid column styles
 ///
-/// Creates a cross browser grid column with a class of '.govuk-grid-column' by
-/// default, and a standardised gutter between the columns.
+/// Creates a grid column with standard gutter between the columns.
 ///
-/// Common widths are predefined above as keywords in the `$grid-widths` map.
+/// If a `$class` is provided (which is the default, but deprecated behaviour),
+/// the generated rules will be wrapped in a predefined selector in the format
+/// `$class-$width` (e.g. `govuk-grid-column-full`). This behaviour is
+/// deprecated and will be removed in v3.0
 ///
-/// By default their width changes from 100% to specified width at the 'tablet'
-/// breakpoint, but that can be configured to be any other breakpoint by using
-/// the `$at` parameter.
+/// Grid widths are defined in the `$govuk-grid-widths` map.
 ///
-/// @param {String} $class [govuk-grid-column] CSS class name
-/// @param {String} $width [full] one-quarter | one-third | one-half | two-third | three-quarters | full
+/// By default the column width changes from 100% to specified width at the
+/// 'tablet' breakpoint, but other breakpoints can be specified using the `$at`
+/// parameter.
+///
+/// @param {String} $width [full] name of a grid width from $govuk-grid-widths
 /// @param {String} $float [left] left | right
-/// @param {String} $at [tablet] - mobile | tablet | desktop | any custom breakpoint in px or em
+/// @param {String} $at [tablet] - mobile | tablet | desktop | any custom breakpoint
+/// @param {String} $class [govuk-grid-column] CSS class name (deprecated)
 ///
 /// @example scss - Default
-///   @include govuk-grid-column(two-thirds)
-///
-/// @example scss - Customising the class name
-///   @include govuk-grid-column(one-half, $class: "test-column");
+///   .govuk-grid-column-two-thirds {
+///     @include govuk-grid-column(two-thirds, $class: false)
+///   }
 ///
 /// @example scss - Customising the breakpoint where width percentage is applied
-///   @include govuk-grid-column(one-half, $at: desktop);
+///   .govuk-grid-column-one-half-at-desktop {
+///     @include govuk-grid-column(one-half, $at: desktop);
+///   }
 ///
 /// @example scss - Customising the float direction
-///   @include govuk-grid-column(one-half, $float: right);
+///   .govuk-grid-column-one-half-right {
+///     @include govuk-grid-column(two-thirds, $float: right, $class: false);
+///   }
+///
+/// @example scss - Customising the class name (deprecated)
+///   @include govuk-grid-column(one-half, $class: "test-column");
 ///
 /// @access public
 
 @mixin govuk-grid-column($width: full, $float: left, $at: tablet, $class: "govuk-grid-column") {
-
-  .#{$class}-#{$width} {
+  @if ($class) {
+    .#{$class}-#{$width} {
+      @include govuk-grid-column($width, $float, $at, $class: false);
+    }
+  } @else {
     box-sizing: border-box;
     @if $at != desktop {
       width: 100%;

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -38,6 +38,7 @@
 ///   @include govuk-grid-row("app-grid");
 ///
 /// @access public
+/// @deprecated To be removed in v3.0, replaced by the govuk-grid-row class
 
 @mixin govuk-grid-row($class: "govuk-grid-row") {
   .#{$class} {

--- a/src/helpers/grid.test.js
+++ b/src/helpers/grid.test.js
@@ -102,7 +102,130 @@ describe('grid system', () => {
   })
 
   describe('@govuk-grid-column mixin', () => {
-    it('outputs default full width styles for .govuk-grid-column class', async () => {
+    it('outputs the CSS required for a column in the grid', async () => {
+      const sass = `
+        ${sassImports}
+
+        .govuk-grid-column-full {
+          @include govuk-grid-column($class: false);
+        }
+        `
+
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-full {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 40.0625em) {
+            .govuk-grid-column-full {
+              width: 100%;
+              float: left; } }`)
+    })
+
+    it('allows different widths to be specified using $width', async () => {
+      const sass = `
+        ${sassImports}
+
+        .govuk-grid-column-two-thirds {
+          @include govuk-grid-column(two-thirds, $class: false);
+        }
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-two-thirds {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 40.0625em) {
+            .govuk-grid-column-two-thirds {
+              width: 66.6666%;
+              float: left; } }
+        `)
+    })
+
+    it('allows predefined breakpoints to be specified using $at', async () => {
+      const sass = `
+        ${sassImports}
+
+        .govuk-grid-column-one-quarter-at-desktop {
+          @include govuk-grid-column(one-quarter, $at: desktop, $class: false);
+        }
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-quarter-at-desktop {
+          box-sizing: border-box;
+          padding: 0 15px; }
+          @media (min-width: 48.0625em) {
+            .govuk-grid-column-one-quarter-at-desktop {
+              width: 25%;
+              float: left; } }
+        `)
+    })
+    it('allows custom breakpoints to be specified using $at', async () => {
+      const sass = `
+        ${sassImports}
+
+        .govuk-grid-column-one-quarter-at-500px {
+          @include govuk-grid-column(one-quarter, $at: 500px, $class: false);
+        }
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-quarter-at-500px {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 31.25em) {
+            .govuk-grid-column-one-quarter-at-500px {
+              width: 25%;
+              float: left; } }
+        `)
+    })
+
+    it('allows columns to float right using $float: right', async () => {
+      const sass = `
+        ${sassImports}
+
+        .govuk-grid-column-one-half-right {
+          @include govuk-grid-column(one-half, $float: right, $class: false);
+        }
+      `
+      const results = await sassRender({ data: sass, ...sassConfig })
+
+      expect(results.css
+        .toString()
+        .trim())
+        .toBe(outdent`
+        .govuk-grid-column-one-half-right {
+          box-sizing: border-box;
+          width: 100%;
+          padding: 0 15px; }
+          @media (min-width: 40.0625em) {
+            .govuk-grid-column-one-half-right {
+              width: 50%;
+              float: right; } }
+        `)
+    })
+
+    it('includes the class name by default (deprecated)', async () => {
       const sass = `
         ${sassImports}
 
@@ -125,30 +248,7 @@ describe('grid system', () => {
               float: left; } }`)
     })
 
-    it('outputs specified width styles for .govuk-grid-column class', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column(two-thirds);
-      `
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-two-thirds {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
-            .govuk-grid-column-two-thirds {
-              width: 66.6666%;
-              float: left; } }
-        `)
-    })
-
-    it('outputs specified width styles for the defined class', async () => {
+    it('allows the class name to be overridden (deprecated)', async () => {
       const sass = `
         ${sassImports}
 
@@ -168,73 +268,6 @@ describe('grid system', () => {
             .large-column-three-quarters {
               width: 75%;
               float: left; } }
-        `)
-    })
-
-    it('outputs the correct width styles for the defined breakpoint in media queries map', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column(one-quarter, $at: desktop);
-      `
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-quarter {
-          box-sizing: border-box;
-          padding: 0 15px; }
-          @media (min-width: 48.0625em) {
-            .govuk-grid-column-one-quarter {
-              width: 25%;
-              float: left; } }
-        `)
-    })
-    it('outputs the correct width styles for the custom defined breakpoint', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column(one-quarter, $at: 500px);
-      `
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-quarter {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 31.25em) {
-            .govuk-grid-column-one-quarter {
-              width: 25%;
-              float: left; } }
-        `)
-    })
-
-    it('outputs float:right as specified with the $float argument', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column(one-half, $float: right);
-      `
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-half {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
-            .govuk-grid-column-one-half {
-              width: 50%;
-              float: right; } }
         `)
     })
   })

--- a/src/helpers/grid.test.js
+++ b/src/helpers/grid.test.js
@@ -24,13 +24,13 @@ describe('grid system', () => {
 
     @import "tools/exports";
   `
-  describe('grid-width function', () => {
+  describe('govuk-grid-width function', () => {
     it('outputs the specified key value from the map of widths', async () => {
       const sass = `
         ${sassImports}
 
         .foo {
-          content: grid-width(one-quarter);
+          content: govuk-grid-width(one-quarter);
         }`
 
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -44,7 +44,7 @@ describe('grid system', () => {
       const sass = `
         ${sassImports}
 
-        $value: grid-width(seven-fifths);
+        $value: govuk-grid-width(seven-fifths);
         `
 
       await expect(sassRender({ data: sass, ...sassConfig }))

--- a/src/helpers/grid.test.js
+++ b/src/helpers/grid.test.js
@@ -27,7 +27,7 @@ describe('grid system', () => {
   describe('grid-width function', () => {
     it('outputs the specified key value from the map of widths', async () => {
       const sass = `
-        @import "helpers/grid";
+        ${sassImports}
 
         .foo {
           content: grid-width(one-quarter);
@@ -42,7 +42,7 @@ describe('grid system', () => {
 
     it('throws an error that the specified key does not exist in the map of widths', async () => {
       const sass = `
-        @import "helpers/grid";
+        ${sassImports}
 
         $value: grid-width(seven-fifths);
         `

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -1,6 +1,11 @@
 @include govuk-exports("govuk/objects/grid") {
-  //most common usage
-  @include govuk-grid-row;
+
+  .govuk-grid-row {
+    @include govuk-clearfix;
+    margin-right: - ($govuk-gutter-half);
+    margin-left: - ($govuk-gutter-half);
+  }
+
   @include govuk-grid-column(one-quarter);
   @include govuk-grid-column(one-third);
   @include govuk-grid-column(one-half);

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -6,10 +6,9 @@
     margin-left: - ($govuk-gutter-half);
   }
 
-  @include govuk-grid-column(one-quarter);
-  @include govuk-grid-column(one-third);
-  @include govuk-grid-column(one-half);
-  @include govuk-grid-column(two-thirds);
-  @include govuk-grid-column(three-quarters);
-  @include govuk-grid-column(full);
+  @each $width in map-keys($govuk-grid-widths) {
+    .govuk-grid-column-#{$width} {
+      @include govuk-grid-column($width, $class: false)
+    }
+  }
 }

--- a/src/settings/_measurements.scss
+++ b/src/settings/_measurements.scss
@@ -15,6 +15,20 @@
 
 $govuk-page-width: 960px !default;
 
+/// Map of grid column widths
+///
+/// @type Map
+/// @access public
+
+$govuk-grid-widths: (
+  one-quarter: 25%,
+  one-third: 33.3333%,
+  one-half: 50%,
+  two-thirds: 66.6666%,
+  three-quarters: 75%,
+  full: 100%
+) !default;
+
 /// Width of gutter between grid columns
 ///
 /// @type Number


### PR DESCRIPTION
This simplifies the grid to make it easier to add the [extended grid](https://github.com/alphagov/govuk-frontend/pull/1041).

- Move grid widths to the settings layer and make part of the public API
- Rename the `grid-width` function to `govuk-grid-width` to be consistent with other functions, retaining `grid-width` as as deprecated alias
- Copy `govuk-grid-row` mixin to create a new concrete class and mark the mixin as deprecated
- Update the `govuk-grid-column` mixin to allow class name to be suppressed by setting `$class` to `false`.
- Mark the `class` parameter of the `govuk-grid-column` mixin as deprecated
- Create grid classes programatically in objects layer by iterating over the `$govuk-grid-widths` map.

https://trello.com/c/1aBarhHU/1613-add-extended-grid-to-govuk-frontend-pair