### PR TITLE
Add desktop specific grid classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Add desktop specific grid column widths
+
+  This allow you to define different grid behaviour for the tablet and desktop
+  breakpoints. For example, you can make a column two-thirds on desktop but
+  expand to full-width on smaller tablet sized screens.
+
+  ([PR #1094](https://github.com/alphagov/govuk-frontend/pull/1094))
+
 - Add summary list component
 
   This component was initially developed to allow us to build the

--- a/app/views/examples/grid/index.njk
+++ b/app/views/examples/grid/index.njk
@@ -98,4 +98,35 @@
       </p>
     </div>
   </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half govuk-grid-column-three-quarters-from-desktop">
+      <h2 class="govuk-heading-m">One half (three quarters from desktop)</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+
+    <div class="govuk-grid-column-one-half govuk-grid-column-one-quarter-from-desktop">
+      <h2 class="govuk-heading-m">One half (one quarter from desktop)</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop">
+      <h2 class="govuk-heading-m">Three quarters (two thirds from desktop)</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+      <h2 class="govuk-heading-m">Two thirds from desktop</h2>
+      <p class="govuk-body">
+        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+      </p>
+    </div>
+  </div>
 {% endblock %}

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -11,4 +11,13 @@
       @include govuk-grid-column($width, $class: false)
     }
   }
+
+  // These *must* be defined in a separate loop as they have the same
+  // specificity as the non-breakpoint specific classes, so need to appear after
+  // them in the outputted CSS
+  @each $width in map-keys($govuk-grid-widths) {
+    .govuk-grid-column-#{$width}-from-desktop {
+      @include govuk-grid-column($width, $at: desktop, $class: false)
+    }
+  }
 }


### PR DESCRIPTION
This supersedes #1041 and builds on work done in #1090.

These classes allow users to create more advanced layouts, such as used in the ‘check answers’ pattern, where the list of answers users the entire width at tablet, but is restricted to the left two-thirds on desktop.

There may be a need for breakpoint constrained classes in the future (for example, an `at-tablet` class which applies only whilst within the tablet breakpoint) so we’re using `-from-` to signify that the class applies at desktop _and above_.

Closes #1115 