### PR TITLE
Clarify process for deploying a pre-release

### DIFF
--- a/docs/contributing/publishing-a-pre-release.md
+++ b/docs/contributing/publishing-a-pre-release.md
@@ -16,7 +16,9 @@ No changes get published to npm as part of the process.
 
 4. Run `npm run release-to-branch`.
 
-There should now be a branch `pre-release-[your-branch-name-here]` pushed to remote, which you can install with:
+There should now be a branch `pre-release-[your-branch-name-here]` pushed to the GOV.UK Frontend remote origin.
+
+To install this pre-release branch in another project, you can run the following command:
 
 ```bash
 npm install --save alphagov/govuk-frontend#pre-release-[your-branch-name-here]


### PR DESCRIPTION
Something I picked up while pairing with Nick to update the Accordion's preview link.

Changes are needed in two different repos and the existing README does
not explain this well.