### PR TITLE
Add additional tests for the character count

### DIFF
--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -46,15 +46,13 @@ describe('Character count', () => {
       expect(message).toEqual('You have 10 characters remaining')
     })
 
-    describe('when within the character limit', () => {
-      it('counts down to the character limit', async () => {
-        await page.goto(componentUrl, { waitUntil: 'load' })
-        await page.type('.js-character-count', 'A')
+    it('counts down to the character limit', async () => {
+      await page.goto(componentUrl, { waitUntil: 'load' })
+      await page.type('.js-character-count', 'A')
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
-        expect(message).toEqual('You have 9 characters remaining')
-      })
+      expect(message).toEqual('You have 9 characters remaining')
     })
 
     describe('when the character limit is exceeded', () => {

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -109,5 +109,27 @@ describe('Character count', () => {
         expect(messageClasses).toContain('govuk-error-message')
       })
     })
+
+    describe('when the character limit is exceeded on page load', () => {
+      beforeAll(async () => {
+        // Type 11 characters into the character count
+        await goToExample('with-default-value-exceeding-limit')
+      })
+
+      it('shows the number of characters over the limit', async () => {
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 23 characters too many')
+      })
+
+      it('adds error styles to the textarea', async () => {
+        const textareaClasses = await page.$eval('.js-character-count', el => el.className)
+        expect(textareaClasses).toContain('govuk-textarea--error')
+      })
+
+      it('adds error styles to the count message', async () => {
+        const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+        expect(messageClasses).toContain('govuk-error-message')
+      })
+    })
   })
 })

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -71,6 +71,15 @@ describe('Character count', () => {
       expect(message).toEqual('You have 9 characters remaining')
     })
 
+    it('uses the singular when there is only one character remaining', async () => {
+      await goToExample()
+      await page.type('.js-character-count', 'A'.repeat(9))
+
+      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+      expect(message).toEqual('You have 1 character remaining')
+    })
+
     describe('when the character limit is exceeded', () => {
       beforeAll(async () => {
         // Type 11 characters into the character count
@@ -81,6 +90,13 @@ describe('Character count', () => {
       it('shows the number of characters over the limit', async () => {
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
         expect(message).toEqual('You have 1 character too many')
+      })
+
+      it('uses the plural when the limit is exceeded by 2 or more', async () => {
+        await page.type('.js-character-count', 'A')
+
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 2 characters too many')
       })
 
       it('adds error styles to the textarea', async () => {

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -46,108 +46,168 @@ describe('Character count', () => {
   })
 
   describe('when JavaScript is available', () => {
-    it('shows the dynamic message', async () => {
-      await goToExample()
-
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-
-      expect(message).toEqual('You have 10 characters remaining')
-    })
-
-    it('shows the characters remaining if the field is pre-filled', async () => {
-      await goToExample('with-default-value')
-
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-
-      expect(message).toEqual('You have 67 characters remaining')
-    })
-
-    it('counts down to the character limit', async () => {
-      await goToExample()
-      await page.type('.js-character-count', 'A')
-
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-
-      expect(message).toEqual('You have 9 characters remaining')
-    })
-
-    it('uses the singular when there is only one character remaining', async () => {
-      await goToExample()
-      await page.type('.js-character-count', 'A'.repeat(9))
-
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-
-      expect(message).toEqual('You have 1 character remaining')
-    })
-
-    describe('when the character limit is exceeded', () => {
-      beforeAll(async () => {
-        // Type 11 characters into the character count
+    describe('when counting characters', () => {
+      it('shows the dynamic message', async () => {
         await goToExample()
-        await page.type('.js-character-count', 'A'.repeat(11))
-      })
 
-      it('shows the number of characters over the limit', async () => {
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 1 character too many')
+
+        expect(message).toEqual('You have 10 characters remaining')
       })
 
-      it('uses the plural when the limit is exceeded by 2 or more', async () => {
+      it('shows the characters remaining if the field is pre-filled', async () => {
+        await goToExample('with-default-value')
+
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+        expect(message).toEqual('You have 67 characters remaining')
+      })
+
+      it('counts down to the character limit', async () => {
+        await goToExample()
         await page.type('.js-character-count', 'A')
 
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 2 characters too many')
+
+        expect(message).toEqual('You have 9 characters remaining')
       })
 
-      it('adds error styles to the textarea', async () => {
-        const textareaClasses = await page.$eval('.js-character-count', el => el.className)
-        expect(textareaClasses).toContain('govuk-textarea--error')
-      })
+      it('uses the singular when there is only one character remaining', async () => {
+        await goToExample()
+        await page.type('.js-character-count', 'A'.repeat(9))
 
-      it('adds error styles to the count message', async () => {
-        const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
-        expect(messageClasses).toContain('govuk-error-message')
-      })
-    })
-
-    describe('when the character limit is exceeded on page load', () => {
-      beforeAll(async () => {
-        // Type 11 characters into the character count
-        await goToExample('with-default-value-exceeding-limit')
-      })
-
-      it('shows the number of characters over the limit', async () => {
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 23 characters too many')
+
+        expect(message).toEqual('You have 1 character remaining')
       })
 
-      it('adds error styles to the textarea', async () => {
-        const textareaClasses = await page.$eval('.js-character-count', el => el.className)
-        expect(textareaClasses).toContain('govuk-textarea--error')
+      describe('when the character limit is exceeded', () => {
+        beforeAll(async () => {
+          // Type 11 characters into the character count
+          await goToExample()
+          await page.type('.js-character-count', 'A'.repeat(11))
+        })
+
+        it('shows the number of characters over the limit', async () => {
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 1 character too many')
+        })
+
+        it('uses the plural when the limit is exceeded by 2 or more', async () => {
+          await page.type('.js-character-count', 'A')
+
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 2 characters too many')
+        })
+
+        it('adds error styles to the textarea', async () => {
+          const textareaClasses = await page.$eval('.js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        it('adds error styles to the count message', async () => {
+          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
       })
 
-      it('adds error styles to the count message', async () => {
-        const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
-        expect(messageClasses).toContain('govuk-error-message')
+      describe('when the character limit is exceeded on page load', () => {
+        beforeAll(async () => {
+          // Type 11 characters into the character count
+          await goToExample('with-default-value-exceeding-limit')
+        })
+
+        it('shows the number of characters over the limit', async () => {
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 23 characters too many')
+        })
+
+        it('adds error styles to the textarea', async () => {
+          const textareaClasses = await page.$eval('.js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        it('adds error styles to the count message', async () => {
+          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
+      })
+
+      describe('when a threshold is set', () => {
+        beforeAll(async () => {
+          // Type 11 characters into the character count
+          await goToExample('with-threshold')
+        })
+
+        it('does not show the limit until the threshold is reached', async () => {
+          const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+          expect(visibility).toEqual('hidden')
+        })
+
+        it('becomes visible once the threshold is reached', async () => {
+          await page.type('.js-character-count', 'A'.repeat(8))
+
+          const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+          expect(visibility).toEqual('visible')
+        })
       })
     })
 
-    describe('when a threshold is set', () => {
-      beforeAll(async () => {
-        // Type 11 characters into the character count
-        await goToExample('with-threshold')
+    describe('when counting words', () => {
+      it('shows the dynamic message', async () => {
+        await goToExample('with-word-count')
+
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+        expect(message).toEqual('You have 10 words remaining')
       })
 
-      it('does not show the limit until the threshold is reached', async () => {
-        const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
-        expect(visibility).toEqual('hidden')
+      it('counts down to the word limit', async () => {
+        await goToExample('with-word-count')
+        await page.type('.js-character-count', 'Hello world')
+
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+        expect(message).toEqual('You have 8 words remaining')
       })
 
-      it('becomes visible once the threshold is reached', async () => {
-        await page.type('.js-character-count', 'A'.repeat(8))
+      it('uses the singular when there is only one word remaining', async () => {
+        await goToExample('with-word-count')
+        await page.type('.js-character-count', 'Hello '.repeat(9))
 
-        const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
-        expect(visibility).toEqual('visible')
+        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+        expect(message).toEqual('You have 1 word remaining')
+      })
+
+      describe('when the word limit is exceeded', () => {
+        beforeAll(async () => {
+          // Type 11 characters into the character count
+          await goToExample('with-word-count')
+          await page.type('.js-character-count', 'Hello '.repeat(11))
+        })
+
+        it('shows the number of words over the limit', async () => {
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 1 word too many')
+        })
+
+        it('uses the plural when the limit is exceeded by 2 or more', async () => {
+          await page.type('.js-character-count', 'World')
+
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 2 words too many')
+        })
+
+        it('adds error styles to the textarea', async () => {
+          const textareaClasses = await page.$eval('.js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        it('adds error styles to the count message', async () => {
+          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
       })
     })
   })

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -5,10 +5,10 @@
 
 const configPaths = require('../../../config/paths.json')
 const PORT = configPaths.ports.test
+const componentUrl = `http://localhost:${PORT}/components/character-count/preview`
 
 let browser
 let page
-let baseUrl = 'http://localhost:' + PORT
 
 beforeAll(async () => {
   browser = global.__BROWSER__
@@ -21,7 +21,6 @@ afterAll(async () => {
 
 describe('Character count', () => {
   describe('when JavaScript is unavailable or fails', () => {
-
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
     })
@@ -31,7 +30,7 @@ describe('Character count', () => {
     })
 
     it('shows the static message', async () => {
-      await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
+      await page.goto(componentUrl, { waitUntil: 'load' })
       const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
       expect(message).toEqual('You can enter up to 10 characters')
@@ -40,7 +39,7 @@ describe('Character count', () => {
 
   describe('when JavaScript is available', () => {
     it('shows the dynamic message', async () => {
-      await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
+      await page.goto(componentUrl, { waitUntil: 'load' })
 
       const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
@@ -49,7 +48,7 @@ describe('Character count', () => {
 
     describe('when within the character limit', () => {
       it('counts down to the character limit', async () => {
-        await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
+        await page.goto(componentUrl, { waitUntil: 'load' })
         await page.type('.js-character-count', 'A')
 
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
@@ -61,25 +60,22 @@ describe('Character count', () => {
     describe('when the character limit is exceeded', () => {
       beforeAll(async () => {
         // Type 11 characters into the character count
-        await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
+        await page.goto(componentUrl, { waitUntil: 'load' })
         await page.type('.js-character-count', 'A'.repeat(11))
       })
 
       it('shows the number of characters over the limit', async () => {
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 1 character too many')
       })
 
       it('adds error styles to the textarea', async () => {
         const textareaClasses = await page.$eval('.js-character-count', el => el.className)
-
         expect(textareaClasses).toContain('govuk-textarea--error')
       })
 
       it('adds error styles to the count message', async () => {
         const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
-
         expect(messageClasses).toContain('govuk-error-message')
       })
     })

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -131,5 +131,24 @@ describe('Character count', () => {
         expect(messageClasses).toContain('govuk-error-message')
       })
     })
+
+    describe('when a threshold is set', () => {
+      beforeAll(async () => {
+        // Type 11 characters into the character count
+        await goToExample('with-threshold')
+      })
+
+      it('does not show the limit until the threshold is reached', async () => {
+        const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+        expect(visibility).toEqual('hidden')
+      })
+
+      it('becomes visible once the threshold is reached', async () => {
+        await page.type('.js-character-count', 'A'.repeat(8))
+
+        const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+        expect(visibility).toEqual('visible')
+      })
+    })
   })
 })

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -83,7 +83,6 @@ describe('Character count', () => {
 
       describe('when the character limit is exceeded', () => {
         beforeAll(async () => {
-          // Type 11 characters into the character count
           await goToExample()
           await page.type('.js-character-count', 'A'.repeat(11))
         })
@@ -113,7 +112,6 @@ describe('Character count', () => {
 
       describe('when the character limit is exceeded on page load', () => {
         beforeAll(async () => {
-          // Type 11 characters into the character count
           await goToExample('with-default-value-exceeding-limit')
         })
 
@@ -135,7 +133,6 @@ describe('Character count', () => {
 
       describe('when a threshold is set', () => {
         beforeAll(async () => {
-          // Type 11 characters into the character count
           await goToExample('with-threshold')
         })
 
@@ -182,7 +179,6 @@ describe('Character count', () => {
 
       describe('when the word limit is exceeded', () => {
         beforeAll(async () => {
-          // Type 11 characters into the character count
           await goToExample('with-word-count')
           await page.type('.js-character-count', 'Hello '.repeat(11))
         })

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -50,10 +50,8 @@ describe('Character count', () => {
     describe('when within the character limit', () => {
       it('counts down to the character limit', async () => {
         await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
+        await page.type('.js-character-count', 'A')
 
-        // Press 1 character
-        await page.focus('.js-character-count')
-        await page.keyboard.press('A')
         const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 9 characters remaining')
@@ -62,13 +60,9 @@ describe('Character count', () => {
 
     describe('when the character limit is exceeded', () => {
       beforeAll(async () => {
+        // Type 11 characters into the character count
         await page.goto(baseUrl + '/components/character-count/preview', { waitUntil: 'load' })
-
-        // Press 11 characters
-        await page.focus('.js-character-count')
-        for (let i = 0; i < 11; i++) {
-          await page.keyboard.press('A')
-        }
+        await page.type('.js-character-count', 'A'.repeat(11))
       })
 
       it('shows the number of characters over the limit', async () => {


### PR DESCRIPTION
This adds additional tests for the character count component covering some of the functionality that was not previously tested:

- Reporting the character limit for a pre-filled textarea on page load
- Using the 'error state' when a textarea is over the limit on page load
- Counting words rather than characters
- The 'threshold' functionality
- Automated pluralisation of the noun (1 character vs 2 character*s*)

We're still somewhat restricted by the tight coupling of the review app and the tests, which makes it difficult to test some combinations without creating a load more examples in the app. This basically tries to test all the obvious things using the _existing_ examples.

https://trello.com/c/XXWXoz31/1577-write-tests-for-character-count-component