### PR TITLE
Improve publishing workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,21 +71,7 @@ which describes how we prefer git history and commit messages to read.
 
 ## Updating Changelog
 
-If you open a GitHub pull request on this repo, please update `CHANGELOG` to reflect your contribution.
-
-Add your entry under `Unreleased` as `Breaking changes`, `New features`, `Fixes`.
-
-Internal changes to the project that are not part of the public API do not need changelog entries, for example fixing the CI build server.
-
-These sections follow [semantic versioning](https://semver.org/), where:
-
-- `Breaking changes` corresponds to a `major` (1.X.X) change.
-- `New features` corresponds to a `minor` (X.1.X) change.
-- `Fixes` corresponds to a `patch` (X.X.1) change.
-
-See the [`CHANGELOG_TEMPLATE.md`](/docs/contributing/CHANGELOG_TEMPLATE.md) for an example for how this looks.
-
-Include the modified `CHANGELOG` in the PR.
+See the versioning documentation for [updating the changelog](/docs/contributing/versioning.md#updating-changelog))
 
 ## Testing a release
 If you need to test a release, for example if you're contributing a new component see [Publishing pre-release of GOV.UK Frontend](/docs/contributing/publishing-a-pre-release.md).

--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -1,6 +1,22 @@
 #!/bin/sh
 set -e
 
+echo "Starting a pre-release..."
+echo " "
+echo "This will:"
+echo "- run the test suite"
+echo "- build GOV.UK Frontend into the 'package/' directory"
+echo "- build GOV.UK Frontend into the 'dist/' directory"
+echo "- commit all changes and push the branch to remote"
+echo " "
+
+read -r -p "Do you want to continue? [y/N] " continue_prompt
+
+if [[ $continue_prompt != 'y' ]]; then
+    echo "Cancelling pre-release, if this was a mistake, try again and use 'y' to continue."
+    exit 0
+fi
+
 npm run test
 npm run build:package
 npm run build:dist
@@ -15,7 +31,7 @@ if [ $(git tag -l "$TAG") ]; then
 else
     git add .
     git commit -m "Release $TAG"
-    #set upstream so that we can push the branch up
+    # set upstream so that we can push the branch up
     git push --set-upstream origin $CURRENT_BRANCH_NAME
     git push
     echo "🗒 All done. Ready to create a pull request. Once approved, run npm run release"

--- a/bin/release.sh
+++ b/bin/release.sh
@@ -1,6 +1,24 @@
 #!/bin/sh
 set -e
 
+echo "Starting a release..."
+echo " "
+echo "This will:"
+echo "- check that you're logged in to npm as the correct user"
+echo "- publish the package if it has not been published already"
+echo "- check that there is not already a tag published"
+echo "- create a new tag"
+echo "- push the tag to remote origin"
+echo "- create a zip file of the 'dist/' directory locally"
+echo " "
+
+read -r -p "Do you want to continue? [y/N] " continue_prompt
+
+if [[ $continue_prompt != 'y' ]]; then
+    echo "Cancelling release, if this was a mistake, try again and use 'y' to continue."
+    exit 0
+fi
+
 # echo  "Checking that you can publish to npm..."
 
 # at some point we should create a team and check if user exists in a team
@@ -8,8 +26,8 @@ set -e
 
 NPM_USER=$(npm whoami)
 if ! [ "govuk-patterns-and-tools" == "$NPM_USER" ]; then
-  echo "⚠️ FAILURE: You are not logged in with the correct user."
-  exit 1
+    echo "⚠️ FAILURE: You are not logged in with the correct user."
+    exit 1
 fi
 
 echo "📦  Publishing package..."

--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -24,13 +24,7 @@
 
 7. Save the changes. Do not commit.
 
-8. Run `npm run pre-release`.
-
-This will:
-  - copy files from `src/` to `package/` and run tests
-  - add [vendor prefixes](https://github.com/postcss/autoprefixer) to CSS in `package/`
-  - build "govuk-frontend" Sass and JavaScript files into `dist/`
-  - commit all changes and push the branch to remote
+8. Run `npm run pre-release`, you will be prompted to continue or cancel.
 
 9. (Optional) Test in [GOV.UK Design System](git@github.com:alphagov/govuk-design-system.git)
 

--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -7,14 +7,20 @@
 3. Run `npm install` to ensure you have the latest dependencies installed.
 
 4. Create and checkout a new branch (`release-[version-number]`).
+  The version number is determined by looking at the [current "Unreleased" CHANGELOG](../../CHANGELOG.md) changes and updating the previous release number depending on the kind of entries:
+
+  - `Breaking changes` corresponds to a `major` (1.X.X) change.
+  - `New features` corresponds to a `minor` (X.1.X) change.
+  - `Fixes` corresponds to a `patch` (X.X.1) change.
+
+  For example if the previous version is `2.3.0` and there are entries for `Breaking changes` then the new release should be `3.0.0`.
+
+  See the [versioning documentation](../versioning.md) for more information.
 
 5. Update [`CHANGELOG.md`](../../CHANGELOG.md) "Unreleased" heading with the new version number.
-   This should be incremented based on [Semantic versioning](https://semver.org/) from the unreleased changes listed.
-
   Copy the [`CHANGELOG_TEMPLATE.md`](./CHANGELOG_TEMPLATE.md), above the new release to make it easy for new contributors.
 
 6. Update [`package/package.json`](../../package/package.json) version with the new version number.
-This should be incremented based on [Semantic versioning](https://semver.org/) from the unreleased changes listed.
 
 7. Save the changes. Do not commit.
 

--- a/docs/contributing/publishing.md
+++ b/docs/contributing/publishing.md
@@ -53,14 +53,7 @@
 
 13. Log into npm, using team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/master/npm/govuk-patterns-and-tools).
 
-14. Run `npm run release`.
-
-  This will:
-  - check that you're logged in to npm as the correct user.
-  - publish the package has not been published yet
-  - create a new tag if the current git tag does not match the latest published tag
-  - push the tag to remote origin
-  - create a zip file of the `dist` directory
+14. Run `npm run release`, you will be prompted to continue or cancel.
 
 15. Create a release in the [Github interface](https://github.com/alphagov/govuk-frontend/releases/new)
   - select the latest tag version

--- a/docs/contributing/versioning.md
+++ b/docs/contributing/versioning.md
@@ -91,6 +91,24 @@ This includes:
 - SCSS - https://govuk-frontend-review.herokuapp.com/docs/
 - Nunjucks Macros (Templates)
 
+## Updating Changelog
+
+If you open a GitHub pull request on this repo, please update `CHANGELOG` to reflect your contribution.
+
+Add your entry under `Unreleased` as `Breaking changes`, `New features`, `Fixes`.
+
+Internal changes to the project that are not part of the public API do not need changelog entries, for example fixing the CI build server.
+
+These sections follow [semantic versioning](https://semver.org/), where:
+
+- `Breaking changes` corresponds to a `major` (1.X.X) change.
+- `New features` corresponds to a `minor` (X.1.X) change.
+- `Fixes` corresponds to a `patch` (X.X.1) change.
+
+See the [`CHANGELOG_TEMPLATE.md`](/docs/contributing/CHANGELOG_TEMPLATE.md) for an example for how this looks.
+
+Include the modified `CHANGELOG` in the PR.
+
 ## Accidental breaking changes
 If a backward-incompatible change is released unintentionally, we will follow the process outlined on semver.org: https://semver.org/#what-do-i-do-if-i-accidentally-release-a-backwards-incompatible-change-as-a-minor-version
 


### PR DESCRIPTION
When @aliuk2012 and I went through the latest release I took notes and these are the improvements from what we discussed.

Most controversial thing is prompting to continue in the release steps, I'm not a bash genius so would appreciate a good eye on that, happy to remove those improvements too if it's too controversial.

Use https://github.com/alphagov/govuk-frontend/pull/1107/files?w=1 to see diff without whitespace changes.