### PR TITLE
update template.njk to add IE meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,12 @@
 
   ([PR #1109](https://github.com/alphagov/govuk-frontend/pull/1109))
 
+- Improve rendering in older Internet Explorer
+
+  Added a meta tag to ensure that older IE versions always render with the correct rendering engine
+
+  ([PR #1119](https://github.com/alphagov/govuk-frontend/pull/1119))
+
 ## 2.4.1 (fix release)
 
 🔧 Fixes:

--- a/src/template.njk
+++ b/src/template.njk
@@ -10,6 +10,8 @@
     <title>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}" /> {# Hardcoded value of $govuk-black #}
+    {# Ensure that older IE versions always render with the correct rendering engine #}
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 
     {% block headIcons %}
       <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon" />


### PR DESCRIPTION
To ensure that older IE versions always render with the correct rendering engine, added a meta tag