### PR TITLE
Update webpack-dev-server dependency to avoid vulnerability

### DIFF
--- a/docs/installation/examples/webpack/package.json
+++ b/docs/installation/examples/webpack/package.json
@@ -25,7 +25,7 @@
     "url-loader": "1.0.1",
     "webpack": "4.6.0",
     "webpack-cli": "2.0.14",
-    "webpack-dev-server": "3.1.3",
+    "webpack-dev-server": ">=3.1.11",
     "webpack-merge": "4.1.2"
   }
 }


### PR DESCRIPTION
No risk to our current users, but could be to people who follow this example in the future.

https://nvd.nist.gov/vuln/detail/CVE-2018-14732

See security alert https://github.com/alphagov/govuk-frontend/network/alert/docs/installation/examples/webpack/package.json/webpack-dev-server/open