### PR TITLE
Add smaller versions of radio buttons and checkboxes

### DIFF
--- a/app/views/examples/form-controls-states/index.njk
+++ b/app/views/examples/form-controls-states/index.njk
@@ -1,0 +1,310 @@
+{% extends "layout.njk" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "radios/macro.njk" import govukRadios %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<style>
+.x-ray {
+  box-shadow: 0 0 0 3px rgba(175, 175, 175, 0.5);
+}
+
+.x-ray input {
+  opacity: 1 !important;
+  box-shadow: 0 0 0 3px rgba(0, 0, 255, 0.5);
+  -webkit-appearance: none;
+}
+
+.x-ray label {
+  box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.5);
+}
+</style>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group">
+      <div class="govuk-checkboxes govuk-checkboxes--small">
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input" id="foo1" name="foo" type="checkbox" value="bar">
+          <label class="govuk-label govuk-checkboxes__label" for="foo">
+            Unchecked
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input" id="foo2" name="foo" type="checkbox" value="bar" checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foo2">
+            Checked
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-checkboxes__input" id="foo3" name="foo" type="checkbox" value="bar">
+          <label class="govuk-label govuk-checkboxes__label" for="foo3">
+            Hover
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-checkboxes__input" id="foo4" name="foo" type="checkbox" value="bar" checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foo4">
+            Hover, Checked
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :focus" id="foo5" name="foo" type="checkbox" value="bar">
+          <label class="govuk-label govuk-checkboxes__label" for="foo5">
+            Focus
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input :focus" id="foo6" name="foo" type="checkbox" value="bar" checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foo6">
+            Focus, Checked
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-checkboxes__input :focus" id="foo7" name="foo" type="checkbox" value="bar">
+          <label class="govuk-label govuk-checkboxes__label" for="foo7">
+            Focus, Hover
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-checkboxes__input :focus" id="foo8" name="foo" type="checkbox" value="bar" checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foo8">
+            Focus, Checked, Hover
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input" id="foo9" name="foo" type="checkbox" value="bar" disabled>
+          <label class="govuk-label govuk-checkboxes__label" for="foo9">
+            Disabled
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+          <input class="govuk-checkboxes__input" id="foo10" name="foo" type="checkbox" value="bar" disabled checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foo10">
+            Disabled, Checked
+          </label>
+        </div>
+
+        <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 x-ray">
+          <input class="govuk-checkboxes__input" id="foox" name="foo" type="checkbox" value="bar" checked>
+          <label class="govuk-label govuk-checkboxes__label" for="foox">
+            X-Ray
+          </label>
+        </div>
+      </div>
+    </fieldset>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group">
+      <div class="govuk-radios govuk-radios--small">
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input" id="fizz1" name="fizz1" type="radio" value="">
+          <label class="govuk-label govuk-radios__label" for="fizz1">
+            Unchecked
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input" id="fizz2" name="fizz2" type="radio" value="" checked>
+          <label class="govuk-label govuk-radios__label" for="fizz2">
+            Checked
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-radios__input" id="fizz3" name="fizz3" type="radio" value="">
+          <label class="govuk-label govuk-radios__label" for="fizz3">
+            Hover
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-radios__input" id="fizz4" name="fizz4" type="radio" value="" checked>
+          <label class="govuk-label govuk-radios__label" for="fizz4">
+            Hover, Checked
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :focus" id="fizz5" name="fizz5" type="radio" value="">
+          <label class="govuk-label govuk-radios__label" for="fizz5">
+            Focus
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input :focus" id="fizz6" name="fizz6" type="radio" value="" checked>
+          <label class="govuk-label govuk-radios__label" for="fizz6">
+            Focus, Checked
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-radios__input :focus" id="fizz7" name="fizz7" type="radio" value="">
+          <label class="govuk-label govuk-radios__label" for="fizz7">
+            Focus, Hover
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2 :hover">
+          <input class="govuk-radios__input :focus" id="fizz8" name="fizz8" type="radio" value="" checked>
+          <label class="govuk-label govuk-radios__label" for="fizz8">
+            Focus, Checked, Hover
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input" id="fizz9" name="fizz9" type="radio" value="" disabled>
+          <label class="govuk-label govuk-radios__label" for="fizz9">
+            Disabled
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2">
+          <input class="govuk-radios__input" id="fizz10" name="fizz10" type="radio" value="" disabled checked>
+          <label class="govuk-label govuk-radios__label" for="fizz10">
+            Disabled, Checked
+          </label>
+        </div>
+
+        <div class="govuk-radios__item govuk-!-margin-bottom-2 x-ray">
+          <input class="govuk-radios__input" id="fizz10" name="fizzx" type="radio" value="" checked>
+          <label class="govuk-label govuk-radios__label" for="fizzx">
+            X-Ray
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-checkboxes">
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input" id="foo1" name="foo" type="checkbox" value="bar">
+        <label class="govuk-label govuk-checkboxes__label" for="foo">
+          Unchecked
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input" id="foo2" name="foo" type="checkbox" value="bar" checked>
+        <label class="govuk-label govuk-checkboxes__label" for="foo2">
+          Checked
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input :focus" id="foo5" name="foo" type="checkbox" value="bar">
+        <label class="govuk-label govuk-checkboxes__label" for="foo5">
+          Focus
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input :focus" id="foo6" name="foo" type="checkbox" value="bar" checked>
+        <label class="govuk-label govuk-checkboxes__label" for="foo6">
+          Focus, Checked
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input" id="foo9" name="foo" type="checkbox" value="bar" disabled>
+        <label class="govuk-label govuk-checkboxes__label" for="foo9">
+          Disabled
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2">
+        <input class="govuk-checkboxes__input" id="foo10" name="foo" type="checkbox" value="bar" disabled checked>
+        <label class="govuk-label govuk-checkboxes__label" for="foo10">
+          Disabled, Checked
+        </label>
+      </div>
+
+      <div class="govuk-checkboxes__item govuk-!-margin-bottom-2 x-ray">
+        <input class="govuk-checkboxes__input" id="foox" name="foox" type="checkbox" value="bar" checked>
+        <label class="govuk-label govuk-checkboxes__label" for="foox">
+          X-Ray
+        </label>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-radios">
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input" id="radio-large1" name="radio-large1" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="radio-large1">
+          Unchecked
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input" id="radio-large2" name="radio-large2" type="radio" value="" checked>
+        <label class="govuk-label govuk-radios__label" for="radio-large2">
+          Checked
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input :focus" id="radio-large5" name="radio-large5" type="radio" value="">
+        <label class="govuk-label govuk-radios__label" for="radio-large5">
+          Focus
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input :focus" id="radio-large6" name="radio-large6" type="radio" value="" checked>
+        <label class="govuk-label govuk-radios__label" for="radio-large6">
+          Focus, Checked
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input" id="radio-large9" name="radio-large9" type="radio" value="" disabled>
+        <label class="govuk-label govuk-radios__label" for="radio-large9">
+          Disabled
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2">
+        <input class="govuk-radios__input" id="radio-large10" name="radio-large10" type="radio" value="" disabled checked>
+        <label class="govuk-label govuk-radios__label" for="radio-large10">
+          Disabled, Checked
+        </label>
+      </div>
+
+      <div class="govuk-radios__item govuk-!-margin-bottom-2 x-ray">
+        <input class="govuk-radios__input" id="radio-largex" name="radio-largex" type="radio" value="" checked>
+        <label class="govuk-label govuk-radios__label" for="radio-largex">
+          X-Ray
+        </label>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/app/views/examples/small-form-controls/index.njk
+++ b/app/views/examples/small-form-controls/index.njk
@@ -1,0 +1,137 @@
+{% extends "layout.njk" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "radios/macro.njk" import govukRadios %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Small form controls</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    {{ govukCheckboxes({
+      fieldset: {
+        legend: {
+          text: "Display",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      idPrefix: "display",
+      name: "sort",
+      classes: "govuk-checkboxes--small",
+      items: [
+        {
+          value: "consultations",
+          text: "Consultations"
+        },
+        {
+          value: "guidance",
+          text: "Guidance"
+        },
+        {
+          value: "notices",
+          text: "Notices"
+        },
+        {
+          value: "reports",
+          text: "Reports"
+        }
+      ]
+    }) }}
+
+    {{ govukRadios({
+      fieldset: {
+        legend: {
+          text: "Include",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      idPrefix: "include",
+      name: "include",
+      classes: "govuk-radios--small",
+      items: [
+        {
+          value: "everything",
+          text: "Everything"
+        },
+        {
+          value: "something",
+          text: "Something"
+        },
+        {
+          value: "nothing",
+          text: "Nothing"
+        }
+      ]
+    }) }}
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+      {{ govukRadios({
+        fieldset: {
+          legend: {
+            text: "Sort by",
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        formGroup: {
+          classes: "govuk-!-margin-bottom-0"
+        },
+        idPrefix: "sort",
+        name: "sort",
+        classes: "govuk-radios--small govuk-radios--inline",
+        items: [
+          {
+            value: "relevance",
+            text: "Relevance"
+          },
+          {
+            value: "created",
+            text: "Created"
+          },
+          {
+            value: "title",
+            text: "Title"
+          }
+        ]
+      }) }}
+
+      {{ govukCheckboxes({
+        name: "grobulate",
+        classes: "govuk-checkboxes--small",
+        formGroup: {
+          classes: "govuk-!-margin-bottom-0"
+        },
+        items: [
+          {
+            value: "grobulate",
+            text: "Grobulate results"
+          }
+        ]
+      }) }}
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" style="clear: both;">
+
+    <h2 class="govuk-heading-m">Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit</h2>
+
+    <p class="govuk-body">Aenean lacinia bibendum nulla sed consectetur. Vestibulum id ligula porta felis euismod semper. Donec id elit non mi porta gravida at eget metus.</p>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh</h2>
+
+    <p class="govuk-body">Cras justo odio, dapibus ac facilisis in, egestas eget quam. Maecenas sed diam eget risus varius blandit sit amet non magna.</p>
+
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+    <h2 class="govuk-heading-m">Bibendum Commodo Ullamcorper Vulputate</h2>
+
+    <p class="govuk-body">Cras mattis consectetur purus sit amet fermentum. Curabitur blandit tempus porttitor.</p>
+  </div>
+</div>
+{% endblock %}

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -165,13 +165,15 @@
   .govuk-checkboxes--small {
 
     $input-size-with-borders: $govuk-small-checkboxes-size + ($govuk-border-width-form-element * 2);
-    $offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
+    $input-offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
+
+    $label-offset: $input-size-with-borders + $input-offset;
 
     .govuk-checkboxes__item {
       @include govuk-clearfix;
       min-height: 0;
       margin-bottom: 0;
-      padding-left: 35px;
+      padding-left: $label-offset;
     }
 
     // Shift the touch target into the left margin so that the visible edge of
@@ -184,7 +186,7 @@
     //  ▲┆└─ Check box pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
     .govuk-checkboxes__input {
-      left: $offset * -1;
+      left: $input-offset * -1;
     }
 
     // Adjust the size and position of the label.
@@ -207,7 +209,7 @@
     // Reduce the size of the check box [1], vertically center it within the
     // touch target [2]
     .govuk-checkboxes__label::before {
-      top: $offset; // 2
+      top: $input-offset; // 2
       width: $govuk-small-checkboxes-size; // 1
       height: $govuk-small-checkboxes-size; // 1
     }
@@ -236,6 +238,13 @@
     .govuk-checkboxes__hint {
       padding: 0;
       clear: both;
+    }
+
+    // Align conditional reveals with small checkboxes
+    .govuk-checkboxes__conditional {
+      $margin-left: ($govuk-small-checkboxes-size / 2) - ($conditional-border-width / 2);
+      margin-left: $margin-left;
+      padding-left: $label-offset - ($margin-left + $conditional-border-width);
     }
 
     // Hover state for small checkbox.

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -8,7 +8,9 @@
 @import "../label/label";
 
 @include govuk-exports("govuk/component/checkboxes") {
-  $govuk-checkboxes-size: govuk-spacing(7);
+
+  $govuk-touch-target-size: 44px;
+  $govuk-checkboxes-size: 40px;
   $govuk-small-checkboxes-size: 24px;
   $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 
@@ -156,17 +158,40 @@
     }
   }
 
+  // =========================================================
+  // Small checkboxes
+  // =========================================================
+
   .govuk-checkboxes--small {
+
+    $input-size-with-borders: $govuk-small-checkboxes-size + ($govuk-border-width-form-element * 2);
+    $offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
+
     .govuk-checkboxes__item {
+      @include govuk-clearfix;
       min-height: 0;
-      margin-bottom: govuk-spacing(1);
+      margin-bottom: 0;
       padding-left: 35px;
     }
 
+    // Shift the touch target into the left margin so that the visible edge of
+    // the control is aligned
+    //
+    //   ┆What colours do you like?
+    //  ┌┆───┐
+    //  │┆[] │ Purple
+    //  └┆▲──┘
+    //  ▲┆└─ Check box pseudo element, aligned with margin
+    //  └─── Touch target (invisible input), shifted into the margin
     .govuk-checkboxes__input {
-      left: -9px;
+      left: $offset * -1;
     }
 
+    // Adjust the size and position of the label.
+    //
+    // Unlike larger checkboxes, we also have to float the label in order to
+    // 'shrink' it, preventing the hover state from kicking in across the full
+    // width of the parent element.
     .govuk-checkboxes__label {
       margin-top: -2px;
       padding: 13px govuk-spacing(3) 9px 0;
@@ -177,13 +202,19 @@
       }
     }
 
+    // [ ] Check box
+    //
+    // Reduce the size of the check box [1], vertically center it within the
+    // touch target [2]
     .govuk-checkboxes__label::before {
-      top: 8px;
-      left: 0;
-      width: $govuk-small-checkboxes-size;
-      height: $govuk-small-checkboxes-size;
+      top: $offset; // 2
+      width: $govuk-small-checkboxes-size; // 1
+      height: $govuk-small-checkboxes-size; // 1
     }
 
+    // ✔ Check mark
+    //
+    // Reduce the size of the check mark and re-align within the checkbox
     .govuk-checkboxes__label::after {
       top: 15px;
       left: 6px;
@@ -192,16 +223,25 @@
       border-width: 0 0 3px 3px;
     }
 
-    .govuk-checkboxes__input + .govuk-checkboxes__label::after {
-      border-width: 0 0 3px 3px;
+    // Hover state for small checkbox.
+    //
+    // We use a hover state for small checkboxes because the touch target size
+    // is so much larger than their visible size, and so we need to provide
+    // feedback to the user as to which checkbox they will select when their
+    // cursor is outside of the visible area.
+    .govuk-checkboxes__item:hover .govuk-checkboxes__label::before {
+      box-shadow: 0 0 0 $govuk-hover-width $govuk-input-hover-colour;
     }
 
-    .govuk-checkboxes__item:hover > .govuk-checkboxes__label::before {
-      box-shadow: 0 0 0 10px govuk-colour("grey-3");
-    }
-
+    // Because we've overridden the border-shadow provided by the focus state,
+    // we need to redefine that too.
+    //
+    // We use two box shadows, one that restores the original focus state [1]
+    // and another that then applies the hover state [2].
     .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour, 0 0 0 10px govuk-colour("grey-3");
+      // sass-lint:disable indentation
+      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour,       // [1]
+                  0 0 0 $govuk-hover-width $govuk-input-hover-colour; // [2]
     }
   }
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -229,8 +229,8 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
-    .govuk-checkboxes__item:hover .govuk-checkboxes__label::before {
-      box-shadow: 0 0 0 $govuk-hover-width $govuk-input-hover-colour;
+    .govuk-checkboxes__item:not(:disabled):hover .govuk-checkboxes__label::before {
+      box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
     }
 
     // Because we've overridden the border-shadow provided by the focus state,
@@ -241,7 +241,7 @@
     .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
       // sass-lint:disable indentation
       box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour,       // [1]
-                  0 0 0 $govuk-hover-width $govuk-input-hover-colour; // [2]
+                  0 0 0 $govuk-hover-width $govuk-hover-colour; // [2]
     }
   }
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -223,6 +223,21 @@
       border-width: 0 0 3px 3px;
     }
 
+    // Fix position of hint with small checkboxes
+    //
+    // Do not use hints with small checkboxes – because they're within the input
+    // wrapper they trigger the hover state, but clicking them doesn't actually
+    // activate the control.
+    //
+    // (But if you do use them – which you probably will 😩 – they won't look
+    // completely broken)
+    //
+    // (Seriously don't use them though ✋)
+    .govuk-checkboxes__hint {
+      padding: 0;
+      clear: both;
+    }
+
     // Hover state for small checkbox.
     //
     // We use a hover state for small checkboxes because the touch target size

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -9,6 +9,7 @@
 
 @include govuk-exports("govuk/component/checkboxes") {
   $govuk-checkboxes-size: govuk-spacing(7);
+  $govuk-small-checkboxes-size: 24px;
   $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 
   .govuk-checkboxes__item {
@@ -34,11 +35,11 @@
     position: absolute;
 
     z-index: 1;
-    top: 0;
-    left: 0;
+    top: -2px;
+    left: -2px;
 
-    width: $govuk-checkboxes-size;
-    height: $govuk-checkboxes-size;
+    width: $govuk-checkboxes-size + 4px;
+    height: $govuk-checkboxes-size + 4px;
 
     cursor: pointer;
 
@@ -153,5 +154,46 @@
     & > :last-child {
       margin-bottom: 0;
     }
+  }
+
+  .govuk-checkboxes--small {
+    .govuk-checkboxes__item {
+      min-height: 0;
+      margin-bottom: govuk-spacing(1);
+      padding-left: 35px;
+    }
+
+    .govuk-checkboxes__input {
+      left: -9px;
+    }
+
+    .govuk-checkboxes__label {
+      display: block;
+      margin-top: -2px;
+      padding: 13px govuk-spacing(3) 8px 0;
+
+      @include govuk-media-query($from: tablet) {
+        padding: 11px govuk-spacing(3) 8px 0;
+      }
+    }
+
+    .govuk-checkboxes__label::before {
+      top: 8px;
+      left: 0;
+      width: $govuk-small-checkboxes-size;
+      height: $govuk-small-checkboxes-size;
+    }
+
+    .govuk-checkboxes__label::after {
+      top: 15px;
+      left: 6px;
+      width: 9px;
+      height: 3.5px;
+      border-width: 0 0 3px 3px;
+    }
+
+    .govuk-checkboxes__item:hover > .govuk-checkboxes__label {
+      text-decoration: underline;
+     }
   }
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -292,7 +292,7 @@
     // We can't use `@media (hover: hover)` because we wouldn't get the hover
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
-    @media (hover: none) {
+    @media (hover: none), (pointer: coarse) {
       .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
         box-shadow: initial;
       }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -205,11 +205,11 @@
     // width of the parent element.
     .govuk-checkboxes__label {
       margin-top: -2px;
-      padding: 13px govuk-spacing(3) 9px 0;
+      padding: 13px govuk-spacing(3) 13px 1px;
       float: left;
 
       @include govuk-media-query($from: tablet) {
-        padding: 11px govuk-spacing(3) 7px 0;
+        padding: 11px govuk-spacing(3) 10px 1px;
       }
     }
 
@@ -218,7 +218,7 @@
     // Reduce the size of the check box [1], vertically center it within the
     // touch target [2]
     .govuk-checkboxes__label::before {
-      top: $input-offset; // 2
+      top: $input-offset - $govuk-border-width-form-element; // 2
       width: $govuk-small-checkboxes-size; // 1
       height: $govuk-small-checkboxes-size; // 1
     }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -36,26 +36,31 @@
   .govuk-checkboxes__input {
     $input-offset: ($govuk-touch-target-size - $govuk-checkboxes-size) / 2;
 
-    position: absolute;
-
-    z-index: 1;
-    top: $input-offset * -1;
-    left: $input-offset * -1;
-
-    width: $govuk-touch-target-size;
-    height: $govuk-touch-target-size;
-
     cursor: pointer;
 
     // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
     // elements there.
     @include govuk-not-ie8 {
+      position: absolute;
+
+      z-index: 1;
+      top: $input-offset * -1;
+      left: $input-offset * -1;
+
+      width: $govuk-touch-target-size;
+      height: $govuk-touch-target-size;
       margin: 0;
+
       opacity: 0;
     }
 
-    // add focus outline to input element for IE8
     @include govuk-if-ie8 {
+      margin-top: 10px;
+      margin-right: $govuk-checkboxes-size / -2;
+      margin-left: $govuk-checkboxes-size / -2;
+      float: left;
+
+      // add focus outline to input
       &:focus {
         outline: $govuk-focus-width solid $govuk-focus-colour;
       }
@@ -194,7 +199,13 @@
     //  ▲┆└─ Check box pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
     .govuk-checkboxes__input {
-      left: $input-offset * -1;
+      @include govuk-not-ie8 {
+        left: $input-offset * -1;
+      }
+
+      @include govuk-if-ie8 {
+        margin-left: $govuk-small-checkboxes-size * -1;
+      }
     }
 
     // Adjust the size and position of the label.

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -170,10 +170,10 @@
     .govuk-checkboxes__label {
       display: block;
       margin-top: -2px;
-      padding: 13px govuk-spacing(3) 8px 0;
+      padding: 11px govuk-spacing(3) 9px 0;
 
       @include govuk-media-query($from: tablet) {
-        padding: 11px govuk-spacing(3) 8px 0;
+        padding: 9px govuk-spacing(3) 6px 0;
       }
     }
 
@@ -192,8 +192,16 @@
       border-width: 0 0 3px 3px;
     }
 
-    .govuk-checkboxes__item:hover > .govuk-checkboxes__label {
-      text-decoration: underline;
-     }
+    .govuk-checkboxes__input + .govuk-checkboxes__label::after {
+      border-width: 0 0 3px 3px;
+    }
+
+    .govuk-checkboxes__item:hover > .govuk-checkboxes__label::before {
+      box-shadow: 0 0 0 10px govuk-colour("grey-3");
+    }
+
+    .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour, 0 0 0 10px govuk-colour("grey-3");
+    }
   }
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -68,7 +68,6 @@
     padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile
-    -ms-touch-action: manipulation;
     touch-action: manipulation;
   }
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -229,7 +229,7 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
-    .govuk-checkboxes__item:not(:disabled):hover .govuk-checkboxes__label::before {
+    .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
       box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
     }
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -255,7 +255,7 @@
       clear: both;
     }
 
-    // Hover state for small checkbox.
+    // Hover state for small checkboxes.
     //
     // We use a hover state for small checkboxes because the touch target size
     // is so much larger than their visible size, and so we need to provide
@@ -272,8 +272,24 @@
     // and another that then applies the hover state [2].
     .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
       // sass-lint:disable indentation
-      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour,       // [1]
-                  0 0 0 $govuk-hover-width $govuk-hover-colour; // [2]
+      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour, // 1
+                  0 0 0 $govuk-hover-width $govuk-hover-colour; // 2
+    }
+
+    // For devices that explicitly don't support hover, don't provide a hover
+    // state (e.g. on touch devices like iOS).
+    //
+    // We can't use `@media (hover: hover)` because we wouldn't get the hover
+    // state in browsers that don't support `@media (hover)` (like Internet
+    // Explorer) – so we have to 'undo' the hover state instead.
+    @media (hover: none) {
+      .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+        box-shadow: initial;
+      }
+
+      .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+        box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+      }
     }
   }
 }

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -168,9 +168,9 @@
     }
 
     .govuk-checkboxes__label {
-      display: block;
       margin-top: -2px;
       padding: 11px govuk-spacing(3) 9px 0;
+      float: left;
 
       @include govuk-media-query($from: tablet) {
         padding: 9px govuk-spacing(3) 6px 0;

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -169,11 +169,11 @@
 
     .govuk-checkboxes__label {
       margin-top: -2px;
-      padding: 11px govuk-spacing(3) 9px 0;
+      padding: 13px govuk-spacing(3) 9px 0;
       float: left;
 
       @include govuk-media-query($from: tablet) {
-        padding: 9px govuk-spacing(3) 6px 0;
+        padding: 11px govuk-spacing(3) 7px 0;
       }
     }
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -23,7 +23,7 @@
     min-height: $govuk-checkboxes-size;
 
     margin-bottom: govuk-spacing(2);
-    padding: 0 0 0 $govuk-checkboxes-size;
+    padding-left: $govuk-checkboxes-size;
 
     clear: left;
   }
@@ -34,18 +34,21 @@
   }
 
   .govuk-checkboxes__input {
+    $input-offset: ($govuk-touch-target-size - $govuk-checkboxes-size) / 2;
+
     position: absolute;
 
     z-index: 1;
-    top: -2px;
-    left: -2px;
+    top: $input-offset * -1;
+    left: $input-offset * -1;
 
-    width: $govuk-checkboxes-size + 4px;
-    height: $govuk-checkboxes-size + 4px;
+    width: $govuk-touch-target-size;
+    height: $govuk-touch-target-size;
 
     cursor: pointer;
 
-    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there.
+    // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
+    // elements there.
     @include govuk-not-ie8 {
       margin: 0;
       opacity: 0;
@@ -69,13 +72,8 @@
     touch-action: manipulation;
   }
 
-  .govuk-checkboxes__hint {
-    display: block;
-    padding-right: $govuk-checkboxes-label-padding-left-right;
-    padding-left: $govuk-checkboxes-label-padding-left-right;
-  }
-
-  .govuk-checkboxes__input + .govuk-checkboxes__label::before {
+  // [ ] Check box
+  .govuk-checkboxes__label::before {
     content: "";
     box-sizing: border-box;
     position: absolute;
@@ -85,11 +83,13 @@
     height: $govuk-checkboxes-size;
     border: $govuk-border-width-form-element solid currentColor;
     background: transparent;
-
-    // padding-bottom: 1px;
   }
 
-  .govuk-checkboxes__input + .govuk-checkboxes__label::after {
+  // ✔ Check mark
+  //
+  // The check mark is a box with a border on the left and bottom side (└──),
+  // rotated 45 degrees
+  .govuk-checkboxes__label::after {
     content: "";
 
     position: absolute;
@@ -110,10 +110,16 @@
     background: transparent;
   }
 
+  .govuk-checkboxes__hint {
+    display: block;
+    padding-right: $govuk-checkboxes-label-padding-left-right;
+    padding-left: $govuk-checkboxes-label-padding-left-right;
+  }
+
   // Focused state
   .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-    // Since box-shadows are removed when users customise their colours
-    // We set a transparent outline that is shown instead.
+    // Since box-shadows are removed when users customise their colours, we set
+    // a transparent outline that is shown instead.
     // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
     outline: $govuk-focus-width solid transparent;
     outline-offset: $govuk-focus-width;
@@ -134,6 +140,10 @@
   .govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
     opacity: .5;
   }
+
+  // =========================================================
+  // Conditional reveals
+  // =========================================================
 
   $conditional-border-width: $govuk-border-width-mobile;
   // Calculate the amount of padding needed to keep the border centered against the checkbox.
@@ -164,16 +174,15 @@
 
   .govuk-checkboxes--small {
 
-    $input-size-with-borders: $govuk-small-checkboxes-size + ($govuk-border-width-form-element * 2);
-    $input-offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
-
-    $label-offset: $input-size-with-borders + $input-offset;
+    $input-offset: ($govuk-touch-target-size - $govuk-small-checkboxes-size) / 2;
+    $label-offset: $govuk-touch-target-size - $input-offset;
 
     .govuk-checkboxes__item {
       @include govuk-clearfix;
       min-height: 0;
       margin-bottom: 0;
       padding-left: $label-offset;
+      float: left;
     }
 
     // Shift the touch target into the left margin so that the visible edge of
@@ -231,10 +240,8 @@
     // wrapper they trigger the hover state, but clicking them doesn't actually
     // activate the control.
     //
-    // (But if you do use them – which you probably will 😩 – they won't look
-    // completely broken)
-    //
-    // (Seriously don't use them though ✋)
+    // (If you do use them, they won't look completely broken... but seriously,
+    // don't use them)
     .govuk-checkboxes__hint {
       padding: 0;
       clear: both;
@@ -245,6 +252,7 @@
       $margin-left: ($govuk-small-checkboxes-size / 2) - ($conditional-border-width / 2);
       margin-left: $margin-left;
       padding-left: $label-offset - ($margin-left + $conditional-border-width);
+      clear: both;
     }
 
     // Hover state for small checkbox.

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -421,3 +421,122 @@ examples:
         html: |
           <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
           <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
+- name: small
+  data:
+    idPrefix: nationality
+    name: nationality
+    classes: govuk-checkboxes--small
+    fieldset:
+      legend:
+        text: Filter by
+    items:
+      - value: a
+        text: a thing
+      - value: b
+        text: another thing
+      - value: c
+        text: this thing
+
+- name: small with long text
+  data:
+    idPrefix: nationality
+    name: nationality
+    classes: govuk-checkboxes--small
+    fieldset:
+      legend:
+        text: Filter by
+    items:
+      - value: nullam
+        text:
+          Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
+          quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+          Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
+          at eget metus.
+      - value: aenean
+        text:
+          Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
+          nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
+          natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+          mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Cras mattis consectetur purus sit amet
+          fermentum.
+      - value: fusce
+        text:
+          Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
+          nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
+          malesuada magna mollis euismod. Praesent commodo cursus magna, vel
+          scelerisque nisl consectetur et. Etiam porta sem malesuada magna
+          mollis euismod. Etiam porta sem malesuada magna mollis euismod.
+          Donec sed odio dui. Sed posuere consectetur est at lobortis.
+
+- name: small with error
+  data:
+    idPrefix: nationality
+    name: nationality
+    classes: govuk-checkboxes--small
+    errorMessage:
+      text: "Select a thing"
+    fieldset:
+      legend:
+        text: Filter by
+    items:
+      - value: a
+        text: a thing
+      - value: b
+        text: another thing
+      - value: c
+        text: this thing
+
+- name: small with hint
+  data:
+    idPrefix: nationality
+    name: nationality
+    classes: govuk-checkboxes--small
+    fieldset:
+      legend:
+        text: Filter by
+    items:
+      - value: a
+        text: a thing
+        hint:
+          text: hint for a thing
+      - value: b
+        text: another thing
+      - value: c
+        text: this thing
+
+- name: small with disabled
+  data:
+    idPrefix: nationality
+    name: nationality
+    classes: govuk-checkboxes--small
+    fieldset:
+      legend:
+        text: Filter by
+    items:
+      - value: a
+        text: a thing
+      - value: b
+        text: another thing
+      - value: c
+        text: this thing
+        disabled: true
+
+- name: small with conditional reveal
+  data:
+    idPrefix: how-contacted
+    classes: govuk-checkboxes--small
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: a
+        text: a thing
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Foo</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: b
+        text: another thing

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -176,6 +176,10 @@
     text-align: center;
   }
 
+  // =========================================================
+  // Conditional reveals
+  // =========================================================
+
   $conditional-border-width: $govuk-border-width-mobile;
   // Calculate the amount of padding needed to keep the border centered against the radios.
   $conditional-border-padding: ($govuk-radios-size / 2) - ($conditional-border-width / 2);
@@ -199,12 +203,14 @@
     }
   }
 
+  // =========================================================
+  // Small checkboxes
+  // =========================================================
+
   .govuk-radios--small {
 
-    $input-size-with-borders: $govuk-small-radios-size + ($govuk-border-width-form-element * 2);
-    $input-offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
-
-    $label-offset: $input-size-with-borders + $input-offset;
+    $input-offset: ($govuk-touch-target-size - $govuk-small-radios-size) / 2;
+    $label-offset: $govuk-touch-target-size - $input-offset;
 
     .govuk-radios__item {
       @include govuk-clearfix;
@@ -234,11 +240,11 @@
     // width of the parent element.
     .govuk-radios__label {
       margin-top: -2px;
-      padding: 13px govuk-spacing(3) 13px 0;
+      padding: 13px govuk-spacing(3) 13px 1px;
       float: left;
 
       @include govuk-media-query($from: tablet) {
-        padding: 11px govuk-spacing(3) 10px 0;
+        padding: 11px govuk-spacing(3) 10px 1px;
       }
     }
 
@@ -247,7 +253,7 @@
     // Reduce the size of the control [1], vertically centering it within the
     // touch target [2]
     .govuk-radios__label::before {
-      top: $input-offset; // 2
+      top: $input-offset - $govuk-border-width-form-element; // 2
       width: $govuk-small-radios-size; // 1
       height: $govuk-small-radios-size; // 1
     }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -205,9 +205,9 @@
   }
 
   .govuk-radios--small .govuk-radios__label {
-    display: block;
     margin-top: -2px;
     padding: 11px govuk-spacing(3) 9px 0;
+    float: left;
 
     @include govuk-media-query($from: tablet) {
       padding: 9px govuk-spacing(3) 6px 0;

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -19,13 +19,12 @@
     @include govuk-font($size: 19);
 
     display: block;
-
     position: relative;
 
     min-height: $govuk-radios-size;
 
     margin-bottom: govuk-spacing(2);
-    padding: 0 0 0 $govuk-radios-size;
+    padding-left: $govuk-radios-size;
 
     clear: left;
   }
@@ -47,7 +46,8 @@
 
     cursor: pointer;
 
-    // IE8 doesn’t support pseudoelements, so we don’t want to hide native elements there. Double colons get ommited by IE8.
+    // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
+    // elements there.
     @include govuk-not-ie8 {
       margin: 0;
       opacity: 0;
@@ -71,13 +71,8 @@
     touch-action: manipulation;
   }
 
-  .govuk-radios__hint {
-    display: block;
-    padding-right: $govuk-radios-label-padding-left-right;
-    padding-left: $govuk-radios-label-padding-left-right;
-  }
-
-  .govuk-radios__input + .govuk-radios__label::before {
+  // ( ) Radio ring
+  .govuk-radios__label::before {
     content: "";
     box-sizing: border-box;
     position: absolute;
@@ -92,7 +87,8 @@
     background: transparent;
   }
 
-  .govuk-radios__input + .govuk-radios__label::after {
+  //  •  Radio button
+  .govuk-radios__label::after {
     content: "";
 
     position: absolute;
@@ -108,10 +104,16 @@
     background: currentColor;
   }
 
+  .govuk-radios__hint {
+    display: block;
+    padding-right: $govuk-radios-label-padding-left-right;
+    padding-left: $govuk-radios-label-padding-left-right;
+  }
+
   // Focused state
   .govuk-radios__input:focus + .govuk-radios__label::before {
-    // Since box-shadows are removed when users customise their colours
-    // We set a transparent outline that is shown instead.
+    // Since box-shadows are removed when users customise their colours we set a
+    // transparent outline that is shown instead.
     // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
     outline: $govuk-focus-width solid transparent;
     outline-offset: $govuk-focus-width;
@@ -133,7 +135,10 @@
     opacity: .5;
   }
 
-  // Inline variant
+  // =========================================================
+  // Inline radios
+  // =========================================================
+
   .govuk-radios--inline {
     @include mq ($from: tablet) {
       @include govuk-clearfix;
@@ -153,6 +158,10 @@
       }
     }
   }
+
+  // =========================================================
+  // Dividers ('or')
+  // =========================================================
 
   .govuk-radios__divider {
     $govuk-divider-size: $govuk-radios-size !default;
@@ -186,51 +195,110 @@
     }
   }
 
-  .govuk-radios--small .govuk-radios__input {
-    left: -9px;
-  }
+  .govuk-radios--small {
 
-  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::before {
-    top: 8px;
-    left: 0;
-    width: $govuk-small-radios-size;
-    height: $govuk-small-radios-size;
-  }
+    $input-size-with-borders: $govuk-small-radios-size + ($govuk-border-width-form-element * 2);
+    $input-offset: ($govuk-touch-target-size - $input-size-with-borders) / 2;
 
-  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::after {
-    top: 14px;
-    left: 6px;
-    width: 9px;
-    height: 3.5px;
-  }
+    $label-offset: $input-size-with-borders + $input-offset;
 
-  .govuk-radios--small .govuk-radios__label {
-    margin-top: -2px;
-    padding: 13px govuk-spacing(3) 13px 0;
-    float: left;
-
-    @include govuk-media-query($from: tablet) {
-      padding: 11px govuk-spacing(3) 10px 0;
+    .govuk-radios__item {
+      @include govuk-clearfix;
+      min-height: 0;
+      margin-bottom: 0;
+      padding-left: $label-offset;
+      float: left;
     }
 
-  }
+    // Shift the touch target into the left margin so that the visible edge of
+    // the control is aligned
+    //
+    //   ┆Which colour is your favourite?
+    //  ┌┆───┐
+    //  │┆() │ Purple
+    //  └┆▲──┘
+    //  ▲┆└─ Radio pseudo element, aligned with margin
+    //  └─── Touch target (invisible input), shifted into the margin
+    .govuk-radios__input {
+      left: $input-offset * -1;
+    }
 
-  .govuk-radios--small .govuk-radios__item {
-    min-height: 0;
-    padding-left: 35px;
-  }
+    // Adjust the size and position of the label.
+    //
+    // Unlike larger radios, we also have to float the label in order to
+    // 'shrink' it, preventing the hover state from kicking in across the full
+    // width of the parent element.
+    .govuk-radios__label {
+      margin-top: -2px;
+      padding: 13px govuk-spacing(3) 13px 0;
+      float: left;
 
-  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::after {
-    width: 10px;
-    height: 10px;
-    border-width: 1px;
-  }
+      @include govuk-media-query($from: tablet) {
+        padding: 11px govuk-spacing(3) 10px 0;
+      }
+    }
 
-  .govuk-radios--small .govuk-radios__item:hover > .govuk-radios__label::before {
-    box-shadow: 0 0 0 10px govuk-colour("grey-3");
-  }
+    // ( ) Radio ring
+    //
+    // Reduce the size of the control [1], vertically centering it within the
+    // touch target [2]
+    .govuk-radios__label::before {
+      top: $input-offset; // 2
+      width: $govuk-small-radios-size; // 1
+      height: $govuk-small-radios-size; // 1
+    }
 
-  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
-    box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour, 0 0 0 10px govuk-colour("grey-3");
+    //  •  Radio button
+    //
+    // Reduce the size of the 'button' and center it within the ring
+    .govuk-radios__label::after {
+      top: 14px;
+      left: 6px;
+      width: 10px;
+      height: 10px;
+      border-width: 1px;
+    }
+
+    // Fix position of hint with small radios
+    //
+    // Do not use hints with small radios – because they're within the input
+    // wrapper they trigger the hover state, but clicking them doesn't actually
+    // activate the control.
+    //
+    // (If you do use them, they won't look completely broken... but seriously,
+    // don't use them)
+    .govuk-radios__hint {
+      padding: 0;
+      clear: both;
+    }
+
+    // Align conditional reveals with small radios
+    .govuk-radios__conditional {
+      $margin-left: ($govuk-small-radios-size / 2) - ($conditional-border-width / 2);
+      margin-left: $margin-left;
+      padding-left: $label-offset - ($margin-left + $conditional-border-width);
+      clear: both;
+    }
+
+    // Hover state for small radios.
+    //
+    // We use a hover state for small radios because the touch target size
+    // is so much larger than their visible size, and so we need to provide
+    // feedback to the user as to which radio they will select when their
+    // cursor is outside of the visible area.
+    .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+      box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
+    }
+
+    // Because we've overridden the border-shadow provided by the focus state,
+    // we need to redefine that too.
+    //
+    // We use two box shadows, one that restores the original focus state [1]
+    // and another that then applies the hover state [2].
+    .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+      // sass-lint:disable indentation
+      box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour,
+                  0 0 0 $govuk-hover-width        $govuk-hover-colour; // [2]
+    }
   }
 }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -71,7 +71,6 @@
     padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
     // remove 300ms pause on mobile
-    -ms-touch-action: manipulation;
     touch-action: manipulation;
   }
 
@@ -280,6 +279,7 @@
     .govuk-radios__hint {
       padding: 0;
       clear: both;
+      pointer-events: none;
     }
 
     // Align conditional reveals with small radios

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -8,7 +8,9 @@
 @import "../label/label";
 
 @include govuk-exports("govuk/component/radios") {
-  $govuk-radios-size: govuk-spacing(7);
+
+  $govuk-touch-target-size: 44px;
+  $govuk-radios-size: 40px;
   $govuk-small-radios-size: 24px;
   $govuk-radios-label-padding-left-right: govuk-spacing(3);
   // When the default focus width is used on a curved edge it looks visually smaller.
@@ -35,14 +37,16 @@
   }
 
   .govuk-radios__input {
+    $input-offset: ($govuk-touch-target-size - $govuk-radios-size) / 2;
+
     position: absolute;
 
     z-index: 1;
-    top: 0;
-    left: 0;
+    top: $input-offset * -1;
+    left: $input-offset * -1;
 
-    width: $govuk-radios-size;
-    height: $govuk-radios-size;
+    width: $govuk-touch-target-size;
+    height: $govuk-touch-target-size;
 
     cursor: pointer;
 

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -206,11 +206,11 @@
 
   .govuk-radios--small .govuk-radios__label {
     margin-top: -2px;
-    padding: 11px govuk-spacing(3) 9px 0;
+    padding: 13px govuk-spacing(3) 9px 0;
     float: left;
 
     @include govuk-media-query($from: tablet) {
-      padding: 9px govuk-spacing(3) 6px 0;
+      padding: 11px govuk-spacing(3) 7px 0;
     }
 
   }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -39,26 +39,31 @@
   .govuk-radios__input {
     $input-offset: ($govuk-touch-target-size - $govuk-radios-size) / 2;
 
-    position: absolute;
-
-    z-index: 1;
-    top: $input-offset * -1;
-    left: $input-offset * -1;
-
-    width: $govuk-touch-target-size;
-    height: $govuk-touch-target-size;
-
     cursor: pointer;
 
     // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
     // elements there.
     @include govuk-not-ie8 {
+      position: absolute;
+
+      z-index: 1;
+      top: $input-offset * -1;
+      left: $input-offset * -1;
+
+      width: $govuk-touch-target-size;
+      height: $govuk-touch-target-size;
       margin: 0;
+
       opacity: 0;
     }
 
-    // add focus outline to input element for IE8
     @include govuk-if-ie8 {
+      margin-top: 10px;
+      margin-right: $govuk-radios-size / -2;
+      margin-left: $govuk-radios-size / -2;
+      float: left;
+
+      // add focus outline to input
       &:focus {
         outline: $govuk-focus-width solid $govuk-focus-colour;
       }
@@ -229,7 +234,13 @@
     //  ▲┆└─ Radio pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
     .govuk-radios__input {
-      left: $input-offset * -1;
+      @include govuk-not-ie8 {
+        left: $input-offset * -1;
+      }
+
+      @include govuk-if-ie8 {
+        margin-left: $govuk-small-radios-size * -1;
+      }
     }
 
     // Adjust the size and position of the label.

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -333,7 +333,7 @@
     // We can't use `@media (hover: hover)` because we wouldn't get the hover
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
-    @media (hover: none) {
+    @media (hover: none), (pointer: coarse) {
       .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
         box-shadow: initial;
       }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -96,6 +96,9 @@
   }
 
   //  •  Radio button
+  //
+  // We create the 'button' entirely out of 'border' so that they remain
+  // 'filled' even when colours are overridden in the browser.
   .govuk-radios__label::after {
     content: "";
 
@@ -274,9 +277,7 @@
     .govuk-radios__label::after {
       top: 14px;
       left: 6px;
-      width: 10px;
-      height: 10px;
-      border-width: 1px;
+      border-width: 6px;
     }
 
     // Fix position of hint with small radios

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -290,6 +290,11 @@
       clear: both;
     }
 
+    .govuk-radios__divider {
+      width: $govuk-small-radios-size;
+      margin-bottom: govuk-spacing(1);
+    }
+
     // Hover state for small radios.
     //
     // We use a hover state for small radios because the touch target size

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -301,8 +301,24 @@
     // and another that then applies the hover state [2].
     .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
       // sass-lint:disable indentation
-      box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour,
-                  0 0 0 $govuk-hover-width        $govuk-hover-colour; // [2]
+      box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour, // 1
+                  0 0 0 $govuk-hover-width        $govuk-hover-colour; // 2
+    }
+
+    // For devices that explicitly don't support hover, don't provide a hover
+    // state (e.g. on touch devices like iOS).
+    //
+    // We can't use `@media (hover: hover)` because we wouldn't get the hover
+    // state in browsers that don't support `@media (hover)` (like Internet
+    // Explorer) – so we have to 'undo' the hover state instead.
+    @media (hover: none) {
+      .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+        box-shadow: initial;
+      }
+
+      .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+        box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
+      }
     }
   }
 }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -9,6 +9,7 @@
 
 @include govuk-exports("govuk/component/radios") {
   $govuk-radios-size: govuk-spacing(7);
+  $govuk-small-radios-size: 24px;
   $govuk-radios-label-padding-left-right: govuk-spacing(3);
   // When the default focus width is used on a curved edge it looks visually smaller.
   // So for the circular radios we bump the default to make it look visually consistent.
@@ -183,5 +184,53 @@
     & > :last-child {
       margin-bottom: 0;
     }
+  }
+
+  .govuk-radios--small .govuk-radios__input {
+    left: -9px;
+  }
+
+  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::before {
+    top: 8px;
+    left: 0;
+    width: $govuk-small-radios-size;
+    height: $govuk-small-radios-size;
+  }
+
+  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::after {
+    top: 14px;
+    left: 6px;
+    width: 9px;
+    height: 3.5px;
+  }
+
+  .govuk-radios--small .govuk-radios__label {
+    display: block;
+    margin-top: -2px;
+    padding: 11px govuk-spacing(3) 9px 0;
+
+    @include govuk-media-query($from: tablet) {
+      padding: 9px govuk-spacing(3) 6px 0;
+    }
+
+  }
+
+  .govuk-radios--small .govuk-radios__item {
+    min-height: 0;
+    padding-left: 35px;
+  }
+
+  .govuk-radios--small .govuk-radios__input + .govuk-radios__label::after {
+    width: 10px;
+    height: 10px;
+    border-width: 1px;
+  }
+
+  .govuk-radios--small .govuk-radios__item:hover > .govuk-radios__label::before {
+    box-shadow: 0 0 0 10px govuk-colour("grey-3");
+  }
+
+  .govuk-radios--small .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+    box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour, 0 0 0 10px govuk-colour("grey-3");
   }
 }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -206,11 +206,11 @@
 
   .govuk-radios--small .govuk-radios__label {
     margin-top: -2px;
-    padding: 13px govuk-spacing(3) 9px 0;
+    padding: 13px govuk-spacing(3) 13px 0;
     float: left;
 
     @include govuk-media-query($from: tablet) {
-      padding: 11px govuk-spacing(3) 7px 0;
+      padding: 11px govuk-spacing(3) 10px 0;
     }
 
   }

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -417,3 +417,20 @@ examples:
         html: |
           <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
           <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
+- name: small
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-radios--small'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+    - value: phone
+      text: Phone
+    - value: text
+      text: Text message

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -590,3 +590,20 @@ examples:
         text: happiness
       - value: funkiness
         text: funkiness
+
+- name: small with a divider
+  data:
+    idPrefix: example-small-divider
+    name: example
+    fieldset:
+      legend:
+        text: How do you want to sign in?
+    classes: govuk-radios--small
+    items:
+      - value: governement-gateway
+        text: Use Government Gateway
+      - value: govuk-verify
+        text: Use GOV.UK Verify
+      - divider: or
+      - value: create-account
+        text: Create an account

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -434,3 +434,159 @@ examples:
       text: Phone
     - value: text
       text: Text message
+
+- name: small with long text
+  data:
+    idPrefix: foo
+    name: foo
+    classes: govuk-radios--small
+    fieldset:
+      legend:
+        text: Venenatis Condimentum
+    items:
+      - value: nullam
+        text:
+          Nullam id dolor id nibh ultricies vehicula ut id elit. Aenean eu leo
+          quam. Pellentesque ornare sem lacinia quam venenatis vestibulum.
+          Maecenas faucibus mollis interdum. Donec id elit non mi porta gravida
+          at eget metus.
+      - value: aenean
+        text:
+          Aenean eu leo quam. Pellentesque ornare sem lacinia quam venenatis
+          vestibulum. Donec sed odio dui. Duis mollis, est non commodo luctus,
+          nisi erat porttitor ligula, eget lacinia odio sem nec elit. Cum sociis
+          natoque penatibus et magnis dis parturient montes, nascetur ridiculus
+          mus. Aenean eu leo quam. Pellentesque ornare sem lacinia quam
+          venenatis vestibulum. Cras mattis consectetur purus sit amet
+          fermentum.
+      - value: fusce
+        text:
+          Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum
+          nibh, ut fermentum massa justo sit amet risus. Etiam porta sem
+          malesuada magna mollis euismod. Praesent commodo cursus magna, vel
+          scelerisque nisl consectetur et. Etiam porta sem malesuada magna
+          mollis euismod. Etiam porta sem malesuada magna mollis euismod.
+          Donec sed odio dui. Sed posuere consectetur est at lobortis.
+
+- name: small with error
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-radios--small'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    errorMessage:
+      text: "Select a thing"
+    items:
+    - value: email
+      text: Email
+    - value: phone
+      text: Phone
+    - value: text
+      text: Text message
+
+- name: small with hint
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-radios--small'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+      hint:
+        text: Hint for email address
+    - value: phone
+      text: Phone
+    - value: text
+      text: Text message
+
+- name: small with disabled
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-radios--small'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+    - value: phone
+      text: Phone
+    - value: text
+      text: Text message
+      disabled: true
+
+- name: small with conditional reveal
+  data:
+    idPrefix: 'how-contacted-2'
+    name: 'how-contacted-2'
+    formGroup:
+      classes: 'govuk-radios--small'
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+    - value: email
+      text: Email
+      conditional:
+        html: |
+          <label class="govuk-label" for="context-email">Foo</label>
+          <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+    - value: phone
+      text: Phone
+    - value: text
+      text: Text message
+
+- name: small inline
+  data:
+    idPrefix: sort
+    classes: govuk-radios--small govuk-radios--inline
+    name: example
+    fieldset:
+      legend:
+        text: Sort by
+    items:
+      - value: relevance
+        text: relevance
+      - value: title
+        text: title
+      - value: created
+        text: created
+
+- name: small inline extreme
+  data:
+    idPrefix: sort
+    classes: govuk-radios--small govuk-radios--inline
+    name: example
+    fieldset:
+      legend:
+        text: Sort by
+    items:
+      - value: relevance
+        text: relevance
+      - value: title
+        text: title
+      - value: created
+        text: created
+      - value: modified
+        text: modified
+      - value: category
+        text: category
+      - value: votes
+        text: votes
+      - value: flavour
+        text: flavour
+      - value: hue
+        text: hue
+      - value: happiness
+        text: happiness
+      - value: funkiness
+        text: funkiness

--- a/src/objects/_form-group.scss
+++ b/src/objects/_form-group.scss
@@ -5,6 +5,7 @@
 @include govuk-exports("govuk/objects/form-group") {
 
   .govuk-form-group {
+    @include govuk-clearfix;
     @include govuk-responsive-margin(6, "bottom");
 
     .govuk-form-group:last-of-type {

--- a/src/settings/_colours-applied.scss
+++ b/src/settings/_colours-applied.scss
@@ -105,6 +105,14 @@ $govuk-border-colour: govuk-colour("grey-2") !default;
 
 $govuk-input-border-colour: govuk-colour("black") !default;
 
+/// Input border colour
+///
+/// Used for hover states on form controls
+///
+/// @type Colour
+/// @access public
+
+$govuk-input-hover-colour: govuk-colour("grey-3") !default;
 
 
 // =============================================================================

--- a/src/settings/_colours-applied.scss
+++ b/src/settings/_colours-applied.scss
@@ -105,14 +105,14 @@ $govuk-border-colour: govuk-colour("grey-2") !default;
 
 $govuk-input-border-colour: govuk-colour("black") !default;
 
-/// Input border colour
+/// Input hover colour
 ///
 /// Used for hover states on form controls
 ///
 /// @type Colour
 /// @access public
 
-$govuk-input-hover-colour: govuk-colour("grey-3") !default;
+$govuk-hover-colour: govuk-colour("grey-3") !default;
 
 
 // =============================================================================

--- a/src/settings/_measurements.scss
+++ b/src/settings/_measurements.scss
@@ -103,4 +103,4 @@ $govuk-focus-width: 3px !default;
 /// @type Number
 /// @access public
 
-$govuk-input-hover-width: 10px !default;
+$govuk-hover-width: 10px !default;

--- a/src/settings/_measurements.scss
+++ b/src/settings/_measurements.scss
@@ -97,3 +97,10 @@ $govuk-border-width-form-group-error: $govuk-border-width !default;
 /// @access public
 
 $govuk-focus-width: 3px !default;
+
+/// Hover width for form controls with a hover state
+///
+/// @type Number
+/// @access public
+
+$govuk-input-hover-width: 10px !default;

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -14,7 +14,11 @@ const uglify = require('gulp-uglify')
 const eol = require('gulp-eol')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
-const postcsspseudoclasses = require('postcss-pseudo-classes')
+const postcsspseudoclasses = require('postcss-pseudo-classes')({
+  // Work around a bug in pseudo classes plugin that badly transforms
+  // :not(:whatever) pseudo selectors
+  blacklist: [':not(', ':disabled)', ':last-child)', ':focus)']
+})
 
 // Compile CSS and JS task --------------
 // --------------------------------------


### PR DESCRIPTION
Introduces smaller versions of the radios and checkboxes components.

![radios](https://user-images.githubusercontent.com/121939/54704092-07092a80-4b32-11e9-9c19-69d154e3461f.gif)

Despite being visually smaller, these have a target size of 44 x 44px, as the input extends outside of the boundaries of the visual control.

To make it clear which control will be activated when hovering in the gap between the controls, we add a hover state.

This PR also simplifies the way that existing checkboxes and radio buttons are rendered in IE8 and increases the touch area of the existing radios and checkboxes to 44x44px.

👉[Checkbox examples in the review app](https://govuk-frontend-review-pr-1125.herokuapp.com/components/checkboxes)
👉[Radio examples in the review app](https://govuk-frontend-review-pr-1125.herokuapp.com/components/radios)
👉[Radios and checkboxes, big and small, in all the states](https://govuk-frontend-review-pr-1125.herokuapp.com/examples/form-controls-states)
👉[A contrived example](https://govuk-frontend-review-pr-1125.herokuapp.com/examples/small-form-controls)

## Browser and assistive technology testing

- [x] Internet Explorer 8 (Windows 7, Browserstack)
- [x] Internet Explorer 9 (Windows 7, Browserstack)
- [x] Internet Explorer 10 (Windows 8, Browserstack)
- [x] Internet Explorer 11 (Windows 10, Browserstack)
- [x] Edge 18 (Windows 10, Browserstack)
- [x] Edge 17 (Windows 10, Browserstack)
- [x] Google Chrome 73 (mac)
- [x] Mozilla Firefox 65 (mac)
- [x] Safari 12 (mac)
- [x] Safari 11 (mac, Browserstack)
- [x] Safari 10 (mac, Browserstack)
- [x] Safari 9.1 (mac, Browserstack)
- [x] Safari (iOS 12, iPhone X)
- [x] Google Chrome (iOS 12, iPhone X)
- [x] Safari (iOS 11, iPhone X, Browserstack)
- [x] Safari (iOS 10, iPhone 5c)
- [x] Safari (iOS 9.3, iPhone 5)
- [x] Safari (iOS 7, iPhone, iPhone 4)
- [x] Google Chrome, Android 9, Browserstack
- [x] Google Chrome, Android 8, Browserstack
- [x] Samsung Internet, Android 8, Browserstack
- [x] Samsung Internet, Android 7, Browserstack
- [x] Google Chrome 73 - mixed input modes (Chromebook)
- [x] Google Chrome 73 - 400% zoom (macOS)
- [x] Internet Explorer 11 - high contrast mode (Windows 10)
- [x] Internet Explorer 11 - ZoomText (Windows 10)
- [x] Internet Explorer 11 - 400% zoom (Windows 10, Browserstack)
- [x] Internet Explorer 11 - larger text (Windows 10, Browserstack)
- [x] Mozilla Firefox 65 – custom colours (mac)
- [x] Mozilla Firefox 65 – night mode (iOS)

## Physical device testing

### Chrome 69, Android 7.0 (Galaxy S6)

Works as expected

### Chrome 50, Android 5.1.1 (Nexus 10 tablet)

Works as expected

### Chrome 71, Android 4.4.2 (Galaxy Note 2)

Tested with stylus and touch. Worked as expected

### Android Browser, Android 4.4.2 (Galaxy Note 2)

The stylus triggers hover style
Touch triggers the hover style, and clicking once triggers hover style then after a delay triggers the click. Not ideal but still usable.

### Android 2.2 (Galaxy S)

Radios are square – seemingly no support for border-radius – an existing issue.
Small hidden element highlighted on tap. Hover state not visible.

### Safari, iOS 10.3.2 (iPhone 5C)

Works as expected

### Safari, iOS 9.3.2 (iPhone 5)

Works as expected

### Safari, iOS 7.1.2 (iPhone 4)

Hover state is visible and 'sticks', but clicking once still triggers the control

### Internet Explorer, Windows Phone 8.1 (Lumia 630)

Works as expected

## Screenshots

<details>
  <summary>Chrome 70 (macOS Mojave)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703151-269f5380-4b30-11e9-977f-f04815f610e0.png" alt="macmo_chrome_70 0">
</details>

<details>
  <summary>Chrome 70 (Windows 10)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703161-27d08080-4b30-11e9-9ff7-7fb5bf57f6d2.png" alt="win10_chrome_70 0">
</details>

<details>
  <summary>Chrome 71 (macOS Mojave)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703152-269f5380-4b30-11e9-86a2-e1e79e205825.png" alt="macmo_chrome_71 0">
</details>

<details>
  <summary>Chrome 71 (Windows 10)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703162-27d08080-4b30-11e9-87d3-8ed903239d64.png" alt="win10_chrome_71 0">
</details>

<details>
  <summary>Firefox 62 (macOS Mojave)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703154-269f5380-4b30-11e9-90a7-cd7ce75a552d.png" alt="macmo_firefox_62 0">
</details>

<details>
  <summary>Firefox 62 (Windows 10)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703164-27d08080-4b30-11e9-9e68-e6b7ef7472e7.png" alt="win10_firefox_62 0">
</details>

<details>
  <summary>Safari 9.1 (OS X El Capitan)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703149-2606bd00-4b30-11e9-9951-0d8e355c06dd.png" alt="macelc_safari_9 1">
</details>

<details>
  <summary>Safari 10.1 (macOS Sierra)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703156-2737ea00-4b30-11e9-95ea-ddc1a26c841b.png" alt="macsie_safari_10 1">
</details>

<details>
  <summary>Safari 11.1 (macOS High Sierra)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703150-269f5380-4b30-11e9-8dd0-7dbe24f57264.png" alt="machs_safari_11 1">
</details>

<details>
  <summary>Safari 12 (macOS Mojave)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703155-2737ea00-4b30-11e9-9479-910126e8fe82.png" alt="macmo_safari_12 0">
</details>

<details>
  <summary>Internet Explorer 8 (Windows 7)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703157-2737ea00-4b30-11e9-8d5b-64a5e8f0a10c.png" alt="win7_ie_8 0">
</details>

<details>
  <summary>Internet Explorer 9 (Windows 7)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703159-2737ea00-4b30-11e9-8150-82ee6ea75049.png" alt="win7_ie_9 0">
</details>

<details>
  <summary>Internet Explorer 10 (Windows 8)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703160-2737ea00-4b30-11e9-9ffe-1b4d61404c8b.png" alt="win8_ie_10 0">
</details>

<details>
  <summary>Internet Explorer 11 (Windows 10)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703166-27d08080-4b30-11e9-93b7-6b9f382bf6be.png" alt="win10_ie_11 0">
</details>

<details>
  <summary>Edge 18 (Windows 10)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703163-27d08080-4b30-11e9-9c67-b6baac58393c.png" alt="win10_edge_18 0">
</details>

<details>
  <summary>Android 7.1 (Google Pixel)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703139-24d59000-4b30-11e9-92c9-c34efa5ae337.png" alt="7 1_Google-Pixel_portrait_real-mobile">
</details>

<details>
  <summary>Android 8.0 (Google Pixel 2)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703140-24d59000-4b30-11e9-8ed0-79d0291db147.png" alt="8 0_Google-Pixel-2_portrait_real-mobile">
</details>

<details>
  <summary>Android 9.0 (Google Pixel 2)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703141-24d59000-4b30-11e9-8e72-583b9d6a3b65.png" alt="9 0_Google-Pixel-2_portrait_real-mobile">
</details>

<details>
  <summary>iOS 8.3 (iPhone 6)</summary>
  <img src="https://user-images.githubusercontent.com/121939/54703148-2606bd00-4b30-11e9-894a-5c5b0dfcf946.png" alt="ios_iPhone-6_8 3_portrait">
</details>

<details>
  <summary>iOS 10 (iPhone 7)</summary>
  <img width="188" alt="10_iPhone-7_portrait_real-mobile" src="https://user-images.githubusercontent.com/121939/54703142-256e2680-4b30-11e9-945e-441c84e6060d.png">
</details>

<details>
  <summary>iOS 11 (iPhone 8)</summary>
  <img width="188" alt="11_iPhone-8_portrait_real-mobile" src="https://user-images.githubusercontent.com/121939/54703143-256e2680-4b30-11e9-96ae-bf68caed6bd4.png">
</details>

<details>
  <summary>iOS 12 (iPhone XR)</summary>
  <img width="207" alt="12_iPhone-XR_portrait_real-mobile" src="https://user-images.githubusercontent.com/121939/54703144-256e2680-4b30-11e9-974c-9c0dbd7d4b09.png">
</details>

## Known issues

The hover state 'sticks' on devices that support both touch and pointer based interaction, such as Chromebooks and Surfaces.

<details>
<summary>Video showing issue</summary>
<img src="https://user-images.githubusercontent.com/121939/54543478-a218cd80-4995-11e9-8b69-1692b3ccdd8d.gif" alt="" />
</details>

If you try to use a hint with the smaller radios and checkboxes, moving the cursor over the hint will trigger the hover state, but clicking the hint won't actually select the control.

<details>
<summary>Video showing issue</summary>
<img src="https://user-images.githubusercontent.com/121939/54544448-91695700-4997-11e9-9659-445bb5a11f0c.gif" alt="">
</details>

