### PR TITLE
Add gutters to the header consistent with the grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@
 
   ([PR #1147](https://github.com/alphagov/govuk-frontend/pull/1147))
 
+- Make gutters in the header consistent with the grid
+
+  This means that the header will now line up with the grid.
+
+  Thanks to @edwardhorsford for raising this issue.
+
+  ([PR #1144](https://github.com/alphagov/govuk-frontend/pull/1144))
+
 ## 2.5.1 (Fix release)
 
 🔧 Fixes:

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -124,13 +124,18 @@
     @include govuk-font($size: 24, $weight: bold);
   }
 
+  .govuk-header__logo,
+  .govuk-header__content {
+    box-sizing: border-box;
+  }
+
   .govuk-header__logo {
     @include govuk-responsive-margin(2, "bottom");
     padding-right: govuk-spacing(8);
 
     @include mq ($from: desktop) {
       width: 33.33%;
-      padding-right: 0;
+      padding-right: $govuk-gutter-half;
       float: left;
       vertical-align: top;
     }
@@ -139,6 +144,7 @@
   .govuk-header__content {
     @include mq ($from: desktop) {
       width: 66.66%;
+      padding-left: $govuk-gutter-half;
       float: left;
     }
   }


### PR DESCRIPTION
This allows the header to line up with the grid properly.

## Screenshots
### Desktop

<details>
<summary>Before</summary>

![desktop-before](https://user-images.githubusercontent.com/2445413/51266336-e518ed80-19b2-11e9-9ffe-97f629185bb7.png)

</details>

<details>
<summary>After</summary>

![desktop-after](https://user-images.githubusercontent.com/2445413/51266335-e518ed80-19b2-11e9-8d54-dc6e90884a5e.png)

</details>

### Above tablet

<details>
<summary>Before</summary>

![above-tablet-before](https://user-images.githubusercontent.com/2445413/51266333-e518ed80-19b2-11e9-8a89-2a14535f19c5.png)

</details>

<details>
<summary>After</summary>

![above-tablet-after](https://user-images.githubusercontent.com/2445413/51266332-e518ed80-19b2-11e9-9df6-67f3a9730bf3.png)

</details>

### Tablet

<details>
<summary>Before</summary>

![tablet-before](https://user-images.githubusercontent.com/2445413/51266255-a84cf680-19b2-11e9-8cf2-67af207664fa.png)

</details>

<details>
<summary>After</summary>

![tablet-after](https://user-images.githubusercontent.com/2445413/51266297-c581c500-19b2-11e9-814f-e1866f64e07c.png)

</details>

## To do

- [ ] Test cross browser