### PR TITLE
Fix container not being centered in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 
   ([PR #1148](https://github.com/alphagov/govuk-frontend/pull/1148))
 
+- Fix container not being centered in IE8
+
+  Since the header and the footer component use this container it also fixes centering for these components.
+
+  ([PR #1147](https://github.com/alphagov/govuk-frontend/pull/1147))
+
 ## 2.5.1 (Fix release)
 
 🔧 Fixes:

--- a/src/objects/_width-container.scss
+++ b/src/objects/_width-container.scss
@@ -2,10 +2,6 @@
   // Limit the width of the container to the page width
   max-width: $govuk-page-width;
 
-  @include govuk-if-ie8 {
-    width: $govuk-page-width;
-  }
-
   // On mobile, add half width gutters
   margin: 0 $govuk-gutter-half;
 
@@ -17,6 +13,13 @@
   // As soon as the viewport is greater than the width of the page plus the
   // gutters, just centre the content instead of adding gutters.
   @include govuk-media-query($and: "(min-width: #{($govuk-page-width + $govuk-gutter * 2)})") {
+    margin: 0 auto;
+  }
+
+  @include govuk-if-ie8 {
+    width: $govuk-page-width;
+    // Since media queries are not supported in IE8,
+    // we need to duplicate this margin that centers the page.
     margin: 0 auto;
   }
 }


### PR DESCRIPTION
This allows browsers that do not support media queries to be centered without a separate stylesheet.

Since the header and the footer component use this container it also fixes centering for these components.

Fixes #1145 

---

# Screenshots

## Before
<img width="1440" alt="before" src="https://user-images.githubusercontent.com/2445413/51318773-2660da00-1a53-11e9-8a6b-d13e12aa5981.png">


## After
<img width="1440" alt="after" src="https://user-images.githubusercontent.com/2445413/51318774-26f97080-1a53-11e9-861c-674d188e8ac7.png">