### PR TITLE
Remove hover state for accordion sections on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Remove hover state for accordion sections on mobile
+
+  ([PR #1148](https://github.com/alphagov/govuk-frontend/pull/1148))
+
 ## 2.5.1 (Fix release)
 
 🔧 Fixes:

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -83,6 +83,11 @@
     // Section headers have a grey background on hover as an additional affodance
     .govuk-accordion__section-header:hover {
       background-color: govuk-colour("grey-4");
+      // For devices that can't hover such as touch devices,
+      // remove hover state as it can be stuck in that state (iOS).
+      @media (hover: none) {
+        background-color: initial;
+      }
     }
 
     // Setting focus styles on header so that summary that is not part of the button is included in focus


### PR DESCRIPTION
On iOS the hover state could be 'stuck' when the user is not interacting with the accordion component anymore.

One alternative approach would be to only add a hover state when the device has hover capability, I chose not to do this since this feature is techincally still a candidate recommendation which means it could in theory be removed if something happens while they test this new feature.

In the future we could simplify this code if it becomes a stable recommendation.

Fixes https://github.com/alphagov/govuk-frontend/issues/1143