### PR TITLE
Fix Checkboxes and Radios targeting selectors outside it's scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Fix Checkboxes and Radios targeting selectors outside it's scope
+
+  Thanks to [@andysellick](https://github.com/andysellick) and [@bilbof](https://github.com/bilbof) for helping us with this issue.
+
+  ([PR #1156](https://github.com/alphagov/govuk-frontend/pull/1156))
+
 - Fixes styling of the accordion component when there is no JavaScript or it has been turned off
 
   Thanks @dankmitchell for reporting this issue ([#1130](https://github.com/alphagov/govuk-frontend/issues/1130))

--- a/src/components/checkboxes/checkboxes.js
+++ b/src/components/checkboxes/checkboxes.js
@@ -40,8 +40,10 @@ Checkboxes.prototype.setAttributes = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
-  var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
-  $content.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
+  var $content = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  if ($content) {
+    $content.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
+  }
 }
 
 Checkboxes.prototype.handleClick = function (event) {

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -40,8 +40,10 @@ Radios.prototype.setAttributes = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
-  var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
-  $content.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
+  var $content = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  if ($content) {
+    $content.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
+  }
 }
 
 Radios.prototype.handleClick = function (event) {


### PR DESCRIPTION
We only want conditional reveals that are within the module markup to be impacted by changes to inputs.

This scopes the querySelector only to this module.

I wasn't sure if I should add more test coverage for this, it feels as though the existing tests should cover this change and to add a test for what we're fixing would be odd since it'd break isolation.

It's also somewhat blocked by the issue that our tests are tied to the frontend review application.

Happy to hear others' thoughts on how/if you can test this.

Fixes #1153 
Fixes #1142