### PR TITLE
Trigger setAttributes on all radio inputs

### DIFF
--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -45,7 +45,10 @@ Radios.prototype.setAttributes = function ($input) {
 }
 
 Radios.prototype.handleClick = function (event) {
-  nodeListForEach(this.$inputs, function ($input) {
+
+  var allRadioInputs = document.querySelectorAll('input[type="radio"]')
+
+  nodeListForEach(allRadioInputs, function ($input) {
     // If a radio with aria-controls, handle click
     var isRadio = $input.getAttribute('type') === 'radio'
     var hasAriaControls = $input.getAttribute('aria-controls')

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -45,7 +45,6 @@ Radios.prototype.setAttributes = function ($input) {
 }
 
 Radios.prototype.handleClick = function (event) {
-
   var allRadioInputs = document.querySelectorAll('input[type="radio"]')
 
   nodeListForEach(allRadioInputs, function ($input) {


### PR DESCRIPTION
This enables the conditional reveals to work where two different macros are used with the same name attribute (eg to enable grouping of radio inputs).

One possible fix for #1079.