### PR TITLE
Allow describedBy parameter to be passed to the textarea component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@
 
 🆕 New features:
 
-- Pull Request Title goes here
+- Allow describedBy parameter to be passed to the textarea component
 
-  Description goes here (optional)
+  Designed behaviour of that parameter is that if the hint text or error message or both exist, 
+  
+  they take precedence over the custom describedBy parameter.
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -37,7 +37,7 @@
   }) | indent(2) | trim }}
 {% endif %}
   <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
-  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}" {% elif params.describedBy %} aria-describedby="{{ params.describedBy }}" {% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
 </div>

--- a/src/components/textarea/template.test.js
+++ b/src/components/textarea/template.test.js
@@ -262,4 +262,62 @@ describe('Textarea', () => {
       expect($component.attr('autocomplete')).toEqual('street-address')
     })
   })
+
+  describe('when it includes describedBy attribute', () => {
+    it('it renders aria-describedBy with provided text', () => {
+      const $ = render('textarea', {
+        describedBy: 'Custom describedBy text'
+      })
+
+      const $component = $('.govuk-textarea')
+
+      expect($component.attr('aria-describedby'))
+        .toMatch('Custom describedBy text')
+    })
+  })
+
+  describe('when it includes describedBy attribute and hint text', () => {
+    it('associates the textarea as "described by" the hint and not the provided describedBy text', () => {
+      const $ = render('textarea', {
+        describedBy: 'Custom describedBy text',
+        hint: {
+          'text': 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-textarea')
+      const $hint = $('.govuk-hint')
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(hintId)
+    })
+  })
+
+  describe('when it includes describedBy attribute hint text and error message', () => {
+    it('associates the textarea as described by both the hint and the error message and not the provided describedBy text', () => {
+      const $ = render('textarea', {
+        describedBy: 'Custom describedBy text',
+        errorMessage: {
+          'text': 'Error message'
+        },
+        hint: {
+          'text': 'Hint'
+        }
+      })
+
+      const $component = $('.govuk-textarea')
+      const $errorMessageId = $('.govuk-error-message').attr('id')
+      const $hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + $hintId + WHITESPACE + $errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($component.attr('aria-describedby'))
+        .toMatch(combinedIds)
+    })
+  })
 })


### PR DESCRIPTION
In order to fix #1106 the textarea component needs to be able to accept the describedBy parameter.

This PR allows for that and the designed behaviour of that parameter is that if the hint text or error message or both exist, they take precedence over the custom describedBy parameter.

~As describedBy is already listed in the table of available options there is no need to add it here~
being removed in [#1181](https://github.com/alphagov/govuk-frontend/pull/1181/commits/7a705425be6b7767dc7f2ab87017e2d45059ed86)
