### PR TITLE
Fix wrapping of long lines of text in summary list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Fix wrapping of long lines of text in summary list
+
+  Thanks to [@MoJ-Longbeard](https://github.com/MoJ-Longbeard) for raising the issue.
+
+  ([PR #1169](https://github.com/alphagov/govuk-frontend/pull/1169))
+
 ## 2.6.0 (Feature release)
 
 🆕 New features:

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -54,10 +54,17 @@
     }
   }
 
+  .govuk-summary-list__key,
+  .govuk-summary-list__value {
+    // sass-lint:disable no-duplicate-properties
+    // Automatic wrapping for unbreakable text (e.g. URLs)
+    word-break: break-word; // WebKit/Blink only
+    word-break: break-all; // Standards
+  }
+
   .govuk-summary-list__key {
     margin-bottom: govuk-spacing(1);
     @include govuk-typography-weight-bold;
-    word-break: break-word;
     @include govuk-media-query($from: tablet) {
       width: 30%;
     }

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -337,6 +337,36 @@ examples:
               - href: '#'
                 text: Erase
         - key:
+            text: Long website address
+          value:
+            html: |
+              <a class="govuk-link" href="https://cs.wikipedia.org/wiki/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch">https://cs.wikipedia.org/wiki/Llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch</a>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: long website address
+        - key:
+            text: Long email address
+          value:
+            html: |
+              <a class="govuk-link" href="mailto:webmaster@llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.com">webmaster@llanfairpwllgwyngyllgogerychwyrndrobwllllantysiliogogogoch.com</a>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: long email address
+        - key:
+            text: No wrapping allowed
+          value:
+            html: |
+              <p class="govuk-body" style="white-space: nowrap;">michelle.longish.name@example.com</p>
+          actions:
+            items:
+              - href: '#'
+                text: Change
+                visuallyHiddenText: no wrapping allowed
+        - key:
             text: Pneumonoultramicroscopicsilicovolcanoconiosis
           value:
             html: |


### PR DESCRIPTION
As raised by @MoJ-Longbeard, we noticed very long links or lines of text aren't automatically wrapped inside the summary list value (but they are in the summary list key).

This pull request adds automatic wrapping to both key and value.

## Before
Shows the summary list scrolling off the screen

![before](https://user-images.githubusercontent.com/415517/52068414-876ccf80-2574-11e9-9f6c-bfdd79d9f2c4.png)

## After
Shows how text is automatically wrapped, only if it's too long to fit

![after](https://user-images.githubusercontent.com/415517/52068446-98b5dc00-2574-11e9-92b8-bc8063bb7c20.png)

For compatibility with other browsers, we need to provide multiple values for `word-break`:

```scss
.govuk-summary-list__key,
.govuk-summary-list__value {
  // sass-lint:disable no-duplicate-properties
  // Automatic wrapping for unbreakable text (e.g. URLs)
  word-break: break-word; // WebKit/Blink only
  word-break: break-all; // Standards
}
```