### PR TITLE
Enable `pattern` attribute for input (+ custom date input attributes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Allow attributes on date inputs
+
+  You can now provide attributes on day/month/year inputs (e.g. `data-example`) below:
+  ```js
+  {{ govukDateInput({
+    items: [
+      {
+        attributes: {
+          pattern: "[0-9]*",
+          "data-example": "value"
+        }
+      }
+    ]
+  }) }}
+  ```
+
+  ([PR #1172](https://github.com/alphagov/govuk-frontend/pull/1172))
+
 - Prevent horizontal jump as scrollbars appear
 
   As content vertical height grows (e.g. autocomplete results appear), browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,15 +20,23 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
-- Allow attributes on date inputs
+- Enable `pattern` attribute for input
 
-  You can now provide attributes on day/month/year inputs (e.g. `data-example`) below:
+  You can now set the `pattern` attribute on input fields using the component macros:
+  ```js
+  {{ govukInput({
+    name: "example",
+    pattern: "[0-9]*"
+  }) }}
+  ```
+
+  As well as `pattern`, custom attributes can also be added on day/month/year inputs (e.g. `data-example`) shown below:
   ```js
   {{ govukDateInput({
     items: [
       {
+        pattern: "[0-9]*",
         attributes: {
-          pattern: "[0-9]*",
           "data-example": "value"
         }
       }

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -212,5 +212,5 @@ examples:
         autocomplete: bday-month
       -
         name: year
-        classes: govuk-input--width-2
+        classes: govuk-input--width-4
         autocomplete: bday-year

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -36,6 +36,10 @@ params:
     type: string
     required: false
     description: Classes to add to date input item.
+  - name: attributes
+    type: object
+    required: false
+    description: "HTML attributes (for example data attributes) to add to the date input tag. This overrides the default `{ pattern: '[0-9]*' }` so you will need to include this in your attributes."
 - name: hint
   type: object
   required: false
@@ -214,3 +218,31 @@ examples:
         name: year
         classes: govuk-input--width-4
         autocomplete: bday-year
+- name: with input attributes
+  data:
+    id: dob-with-input-attributes
+    namePrefix: dob-with-input-attributes
+    fieldset:
+      legend:
+        text: What is your date of birth?
+    hint:
+      text: For example, 31 3 1980
+    items:
+      -
+        name: day
+        classes: govuk-input--width-2
+        attributes:
+          pattern: '[0-9]*'
+          data-example-day: day
+      -
+        name: month
+        classes: govuk-input--width-2
+        attributes:
+          pattern: '[0-9]*'
+          data-example-month: month
+      -
+        name: year
+        classes: govuk-input--width-4
+        attributes:
+          pattern: '[0-9]*'
+          data-example-year: year

--- a/src/components/date-input/date-input.yaml
+++ b/src/components/date-input/date-input.yaml
@@ -32,6 +32,10 @@ params:
     type: string
     required: false
     description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+  - name: pattern
+    type: string
+    required: false
+    description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
   - name: classes
     type: string
     required: false
@@ -39,7 +43,7 @@ params:
   - name: attributes
     type: object
     required: false
-    description: "HTML attributes (for example data attributes) to add to the date input tag. This overrides the default `{ pattern: '[0-9]*' }` so you will need to include this in your attributes."
+    description: HTML attributes (for example data attributes) to add to the date input tag.
 - name: hint
   type: object
   required: false
@@ -232,17 +236,14 @@ examples:
         name: day
         classes: govuk-input--width-2
         attributes:
-          pattern: '[0-9]*'
           data-example-day: day
       -
         name: month
         classes: govuk-input--width-2
         attributes:
-          pattern: '[0-9]*'
           data-example-month: month
       -
         name: year
         classes: govuk-input--width-4
         attributes:
-          pattern: '[0-9]*'
           data-example-year: year

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -56,7 +56,6 @@
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
-      {% set attributes = item.attributes if item.attributes else { pattern: "[0-9]*" } %}
       {{ govukInput({
         label: {
           text: item.label if item.label else item.name | capitalize,
@@ -68,7 +67,8 @@
         value: item.value,
         type: "number",
         autocomplete: item.autocomplete,
-        attributes: attributes
+        pattern: item.pattern if item.pattern else "[0-9]*",
+        attributes: item.attributes
       }) | indent(6) | trim }}
     </div>
   {% endfor %}

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -56,6 +56,7 @@
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
+      {% set attributes = item.attributes if item.attributes else { pattern: "[0-9]*" } %}
       {{ govukInput({
         label: {
           text: item.label if item.label else item.name | capitalize,
@@ -67,9 +68,7 @@
         value: item.value,
         type: "number",
         autocomplete: item.autocomplete,
-        attributes: {
-          pattern: "[0-9]*"
-        }
+        attributes: attributes
       }) | indent(6) | trim }}
     </div>
   {% endfor %}

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -154,6 +154,20 @@ describe('Date input', () => {
       expect($firstInput.attr('pattern')).toEqual('[0-9]*')
     })
 
+    it('renders inputs with custom pattern attribute', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day',
+            'pattern': '[0-8]*'
+          }
+        ]
+      })
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('pattern')).toEqual('[0-8]*')
+    })
+
     it('renders item with implicit class for label', () => {
       const $ = render('date-input', {
         items: [

--- a/src/components/date-input/template.test.js
+++ b/src/components/date-input/template.test.js
@@ -76,6 +76,39 @@ describe('Date input', () => {
       expect($firstItemInput.attr('name')).toEqual('day')
     })
 
+    it('renders with item attributes', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            'name': 'day',
+            'attributes': {
+              'data-example-day': 'day'
+            }
+          },
+          {
+            'name': 'month',
+            'attributes': {
+              'data-example-month': 'month'
+            }
+          },
+          {
+            'name': 'year',
+            'attributes': {
+              'data-example-year': 'year'
+            }
+          }
+        ]
+      })
+
+      const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
+      const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
+      const $input3 = $('.govuk-date-input__item:nth-of-type(3) input')
+
+      expect($input1.attr('data-example-day')).toEqual('day')
+      expect($input2.attr('data-example-month')).toEqual('month')
+      expect($input3.attr('data-example-year')).toEqual('year')
+    })
+
     it('renders item with capitalised label text', () => {
       const $ = render('date-input', {
         items: [

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -47,6 +47,10 @@ params:
   type: string
   required: false
   description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+- name: pattern
+  type: string
+  required: false
+  description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
 - name: attributes
   type: object
   required: false
@@ -162,3 +166,11 @@ examples:
       id: input-with-autocomplete-attribute
       name: postcode
       autocomplete: postal-code
+  - name: with pattern attribute
+    data:
+      label:
+        text: Numbers only
+      id: input-with-pattern-attribute
+      name: numbers-only
+      type: number
+      pattern: '[0-9]*'

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -41,5 +41,6 @@
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
+  {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
 </div>


### PR DESCRIPTION
We're converting a service from GOV.UK Elements to GOV.UK Frontend and noticed we can't provide custom attributes to our day/month/year fields.

Here's a pull request to add the feature.

As there's no "object merge" nunjucks filter the `pattern: '[0-9]*'` default attribute must be added manually when the entire attributes object is overridden from the defaults.