### PR TITLE
Fix typo

### DIFF
--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -23,7 +23,7 @@
 /// @example scss
 ///   .govuk-component__link {
 ///     @include govuk-link-common;
-///     @include govuk-link-style-muted;
+///     @include govuk-link-style-default;
 ///   }
 ///
 /// @access public


### PR DESCRIPTION
Updated usage example of **@mixin govuk-link-style-default** from `govuk-link-style-muted` to `govuk-link-style-default`