### PR TITLE
Accommodate camera notches on new devices (iPhone X, Google Pixel 3 etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Accommodate camera notches on new devices (iPhone X, Google Pixel 3 etc)
+
+  On newer devices with "camera notches", browsers reserve a safe area in landscape orientation (known as pillarboxing) so content isn't obscured.
+
+  To avoid this, support has been added for `viewport-fit=cover` as shown here:
+  https://webkit.org/blog/7929/designing-websites-for-iphone-x/
+
+  ([PR #1176](https://github.com/alphagov/govuk-frontend/pull/1176))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/docs/installation/examples/webpack/index.html
+++ b/docs/installation/examples/webpack/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <title>GOV.UK Frontend</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
   <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="../../public/css/app.css">
   <!--<![endif]-->

--- a/src/components/skip-link/_skip-link.scss
+++ b/src/components/skip-link/_skip-link.scss
@@ -11,5 +11,16 @@
 
     display: block;
     padding: govuk-spacing(2) govuk-spacing(3);
+
+    // Respect 'display cutout' safe area (avoids notches and rounded corners)
+    @supports (padding: unquote("max(calc(0px))")) {
+      $padding-safe-area-right: calc(#{govuk-spacing(3)} + env(safe-area-inset-right));
+      $padding-safe-area-left: calc(#{govuk-spacing(3)} + env(safe-area-inset-left));
+
+      // Use max() to pick largest padding, default or with safe area
+      // Escaped due to Sass max() vs. CSS native max()
+      padding-right: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-right})");
+      padding-left: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-left})");
+    }
   }
 }

--- a/src/objects/_width-container.scss
+++ b/src/objects/_width-container.scss
@@ -5,15 +5,43 @@
   // On mobile, add half width gutters
   margin: 0 $govuk-gutter-half;
 
+  // Respect 'display cutout' safe area (avoids notches and rounded corners)
+  @supports (margin: unquote("max(calc(0px))")) {
+    $gutter-safe-area-right: calc(#{$govuk-gutter-half} + env(safe-area-inset-right));
+    $gutter-safe-area-left: calc(#{$govuk-gutter-half} + env(safe-area-inset-left));
+
+    // Use max() to pick largest margin, default or with safe area
+    // Escaped due to Sass max() vs. CSS native max()
+    margin-right: unquote("max(#{$govuk-gutter-half}, #{$gutter-safe-area-right})");
+    margin-left: unquote("max(#{$govuk-gutter-half}, #{$gutter-safe-area-left})");
+  }
+
   // On tablet, add full width gutters
   @include govuk-media-query($from: tablet) {
     margin: 0 $govuk-gutter;
+
+    // Respect 'display cutout' safe area (avoids notches and rounded corners)
+    @supports (margin: unquote("max(calc(0px))")) {
+      $gutter-safe-area-right: calc(#{$govuk-gutter-half} + env(safe-area-inset-right));
+      $gutter-safe-area-left: calc(#{$govuk-gutter-half} + env(safe-area-inset-left));
+
+      // Use max() to pick largest margin, default or with safe area
+      // Escaped due to Sass max() vs. CSS native max()
+      margin-right: unquote("max(#{$govuk-gutter}, #{$gutter-safe-area-right})");
+      margin-left: unquote("max(#{$govuk-gutter}, #{$gutter-safe-area-left})");
+    }
   }
 
   // As soon as the viewport is greater than the width of the page plus the
   // gutters, just centre the content instead of adding gutters.
   @include govuk-media-query($and: "(min-width: #{($govuk-page-width + $govuk-gutter * 2)})") {
     margin: 0 auto;
+
+    // Since a safe area may have previously been set above,
+    // we need to duplicate this margin that centers the page.
+    @supports (margin: unquote("max(calc(0px))")) {
+      margin: 0 auto;
+    }
   }
 
   @include govuk-if-ie8 {

--- a/src/template.njk
+++ b/src/template.njk
@@ -8,7 +8,7 @@
   <head>
     <meta charset="utf-8" />
     <title>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}" /> {# Hardcoded value of $govuk-black #}
     {# Ensure that older IE versions always render with the correct rendering engine #}
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />


### PR DESCRIPTION
Noticed this a while ago, thought I'd contribute a new feature for it.

**GOV.UK Frontend** doesn't support the dreaded "notch" (or Display Cutouts as they're known) on various new devices. See the unused white area on the left hand side here:

![notch safe area](https://user-images.githubusercontent.com/415517/52357981-0d828d80-2a2f-11e9-9f03-cd58fd34b288.jpg)

I did a quick check and we now have:

* iPhone X
* iPhone Xs
* Google Pixel 3
* OnePlus 6
* Huawei P20
* LG G7
* Nokia 6.1

The `safe-area-inset-*` variables were [added in iOS 11](https://webkit.org/blog/7929/designing-websites-for-iphone-x/), and recently Android P has added support via Chrome for Android 69: https://www.chromestatus.com/feature/5710044637167616

Firefox just added support in v65:
https://bugzilla.mozilla.org/show_bug.cgi?id=1462233

### Before
<img width="524" alt="before" src="https://user-images.githubusercontent.com/415517/52357028-4d487580-2a2d-11e9-8010-72286a475fa5.png">

### After
<img width="524" alt="after" src="https://user-images.githubusercontent.com/415517/52357054-58030a80-2a2d-11e9-8b73-eb78edc2ab63.png">

This pull request adds the initial support to patch `.govuk-width-container`