### PR TITLE
Disable incorrect iOS/Edge text size adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Disable incorrect iOS/Edge text size adjustments
+
+  To cater for non-responsive websites, iOS and Edge automatically increase font sizes (iOS in landscape, Edge in portrait on HiDPI displays).
+
+  Since we have already considered typography at these device sizes, this feature is now turned off.
+
+  ([PR #1178](https://github.com/alphagov/govuk-frontend/pull/1178))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/src/core/_template.scss
+++ b/src/core/_template.scss
@@ -7,6 +7,10 @@
     // Set the overall page background colour to the same colour as used by the
     // footer to give the illusion of a long footer.
     background-color: $govuk-canvas-background-colour;
+
+    // Prevent automatic text sizing, as we already cater for small devices and
+    // would like the browser to stay on 100% text zoom by default.
+    text-size-adjust: 100%;
   }
 
   // Applied to the <body> element


### PR DESCRIPTION
To cater for non-responsive "desktop only" websites, [iPhone OS launched with a feature](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/AdjustingtheTextSize/AdjustingtheTextSize.html#//apple_ref/doc/uid/TP40006510-SW16) to increase the text size automatically so it was more legible:

To prevent font size tampering, it can be turned off with:

```css
html {
    -webkit-text-size-adjust: 100%;
}
```

![auto text adjustment](https://user-images.githubusercontent.com/415517/52418356-c7d4cc00-2ae5-11e9-97ca-46d549423df5.jpg)

It's also supported by:

1. Windows Phone 8.1
2. Windows 10 Mobile
3. Microsoft Edge

In Edge, it appears to kick in for portrait tablet mode on smaller non-pro Microsoft Surfaces.

Since GOV.UK Frontend already takes care of typography, we should opt out of this as shown:

### Before
19px text in `.govuk-list` has been "boosted" to 25px (auto sizing)
<img width="508" alt="before" src="https://user-images.githubusercontent.com/415517/52418514-1f733780-2ae6-11e9-8b3e-b04947fbdc35.png">

### After
19px text `.govuk-list` remains correctly at 19px (set to 100%)
<img width="508" alt="after" src="https://user-images.githubusercontent.com/415517/52418530-2601af00-2ae6-11e9-8a1f-d59c04ece586.png">

Also found in CSS resets ([normalize.css](https://github.com/necolas/normalize.css/blob/master/normalize.css#L13), [Bootstrap](https://github.com/twbs/bootstrap/blob/b478234cbae80ea13bb19d3eb04d2ee6828b151d/scss/_reboot.scss#L28)) and prevents the subtle "zoom in" when rotated.