### PR TITLE
Update documentation for component options

### DIFF
--- a/src/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/components/breadcrumbs/breadcrumbs.yaml
@@ -16,6 +16,9 @@ params:
     type: string
     required: false
     description: Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item.
+  - name: attributes
+    type: object
+    description: HTML attributes (for example data attributes) to add to the individual crumb.
 - name: classes
   type: string
   required: false

--- a/src/components/character-count/character-count.yaml
+++ b/src/components/character-count/character-count.yaml
@@ -3,10 +3,6 @@ params:
   type: string
   required: true
   description: The id of the textarea.
-- name: describedBy
-  type: string
-  required: false
-  description: Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.
 - name: name
   type: string
   required: true

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -3,7 +3,13 @@ params:
   type: object
   required: false
   description: Object containing options for the meta navigation.
-  arguments:
+  params:
+  - name: html
+    type: string
+    description: HTML to add to the meta section of the footer, which will appear below any links specified using meta.items.
+  - name: text
+    type: string
+    description: Text to add to the meta section of the footer, which will appear below any links specified using meta.items. If meta.html is specified, this option is ignored.
   - name: items
     type: array
     required: false
@@ -25,7 +31,7 @@ params:
   type: array
   required: false
   description: Array of items for use in the navigation section of the footer.
-  arguments:
+  params:
   - name: title
     type: string
     required: false
@@ -38,7 +44,7 @@ params:
     type: array
     required: false
     description: Array of items to display in the list in navigation section of the footer.
-    arguments:
+    params:
     - name: text
       type: string
       required: false

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -3,17 +3,17 @@
   <div class="govuk-width-container {{ params.containerClasses if params.containerClasses }}">
     {% if params.navigation %}
       <div class="govuk-footer__navigation">
-        {% for item in params.navigation %}
+        {% for nav in params.navigation %}
           <div class="govuk-footer__section">
-            <h2 class="govuk-footer__heading govuk-heading-m">{{ item.title }}</h2>
-            {% if item.items %}
+            <h2 class="govuk-footer__heading govuk-heading-m">{{ nav.title }}</h2>
+            {% if nav.items %}
               {% set listClasses %}
-                {% if item.columns %}
-                  govuk-footer__list--columns-{{ item.columns }}
+                {% if nav.columns %}
+                  govuk-footer__list--columns-{{ nav.columns }}
                 {% endif %}
               {% endset %}
               <ul class="govuk-footer__list {{ listClasses | trim }}">
-                {% for item in item.items %}
+                {% for item in nav.items %}
                   {% if item.href and item.text %}
                     <li class="govuk-footer__list-item">
                       <a class="govuk-footer__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -48,10 +48,6 @@ params:
     type: string
     required: false
     description: Specific id attribute for the radio item. If omitted, then `idPrefix` string will be applied.
-  - name: name
-    type: string
-    required: true
-    description: Specific name for the radio item. If omitted, then component global `name` string will be applied.
   - name: value
     type: string
     required: true

--- a/src/components/select/select.yaml
+++ b/src/components/select/select.yaml
@@ -28,6 +28,10 @@ params:
     type: boolean
     required: false
     description: Sets the option item as disabled.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the option.
 - name: label
   type: object
   required: false
@@ -59,7 +63,7 @@ params:
 - name: attributes
   type: object
   required: false
-  description: HTML attributes (for example data attributes) to add to the anchor tag.
+  description: HTML attributes (for example data attributes) to add to the select.
 
 examples:
 - name: default

--- a/src/components/tabs/tabs.yaml
+++ b/src/components/tabs/tabs.yaml
@@ -7,6 +7,10 @@ params:
   type: string
   required: false
   description: String to prefix id for each tab item if no id is specified on each item
+- name: title
+  type: string
+  required: false
+  description: Title for the tabs table of contents
 - name: items
   type: array
   required: true
@@ -20,14 +24,27 @@ params:
     type: string
     required: true
     description: The text label of a tab item.
-  - name: panel.text
-    type: string
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the tab.
+  - name: panel
+    description: Content for the panel
+    type: object
     required: true
-    description: If `html` is set, this is not required. Text to use within each tab panel. If `html` is provided, the `text` argument will be ignored.
-  - name: panel.html
-    type: string
-    required: true
-    description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` argument will be ignored.
+    params:
+      - name: text
+        type: string
+        required: true
+        description: If `html` is set, this is not required. Text to use within each tab panel. If `html` is provided, the `text` argument will be ignored.
+      - name: html
+        type: string
+        required: true
+        description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` argument will be ignored.
+      - name: attributes
+        type: object
+        required: false
+        description: HTML attributes (for example data attributes) to add to the tab panel.
 - name: classes
   type: string
   required: false

--- a/src/components/textarea/textarea.yaml
+++ b/src/components/textarea/textarea.yaml
@@ -3,10 +3,6 @@ params:
   type: string
   required: true
   description: The id of the textarea.
-- name: describedBy
-  type: string
-  required: false
-  description: Text or element id to add to the `aria-describedby` attribute to provide description for screenreader users.
 - name: name
   type: string
   required: true


### PR DESCRIPTION
This corrects a bunch of issues with the documentation for our components, off the back of [some exploratory work into testing the documentation](https://github.com/alphagov/govuk-frontend/compare/update-options?expand=1) – which is really hard, and not something we're ready to merge yet.

See the individual commits for details.