### PR TITLE
Prevent summary list from wrapping mid-word for most browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+
+- Prevent summary list from wrapping mid-word for most browsers
+
+  Thanks to [Malcolm Butler](https://github.com/MoJ-Longbeard) for fixing this issue!
+
+  ([PR #1185](https://github.com/alphagov/govuk-frontend/pull/1185))
+  
+
 ## 2.7.0 (Feature release)
 
 🆕 New features:

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -58,8 +58,8 @@
   .govuk-summary-list__value {
     // sass-lint:disable no-duplicate-properties
     // Automatic wrapping for unbreakable text (e.g. URLs)
-    word-break: break-word; // WebKit/Blink only
     word-break: break-all; // Standards
+    word-break: break-word; // WebKit/Blink only
   }
 
   .govuk-summary-list__key {


### PR DESCRIPTION
As discussed with [Colin Rotherham](https://github.com/colinrotherham)

[PR #1169](https://github.com/alphagov/govuk-frontend/pull/1169) added in some CSS:
- ``word-break: break-word;``, followed by
- ``word-break: break-all;``

``word-break: break-word;`` is the favoured behaviour, but isn't fully supported.  
``word-break: break-all;`` is the fallback behaviour, it sometimes results in unfavourable wrapping mid-word.  

The order for this CSS needs to be changed to, otherwise the less favourable `break-all` takes precedence.
```CSS
word-break: break-all;
word-break: break-word;
```

**caniuse** said:
> Chrome, Safari and other WebKit/Blink browsers also support the unofficial break-word value

The implication here being that it is not fully supported, so ``word-break: break-all;`` is still needed as a fallback.

Below screenshot shows the difference in Google Chrome, note the wrapping of the first column.
![image](https://user-images.githubusercontent.com/32877315/52788190-1b03cd00-3058-11e9-905b-42b5d1d6cfea.png)
