### PR TITLE
Fix error summary linking on the example pages

### DIFF
--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -21,12 +21,12 @@
     "classes": "optional-extra-class",
     "errorList": [
       {
-        "text": "Descriptive link to the question with an error",
-        "href": "#example-error-1"
+        "text": "You must provide your passport number",
+        "href": "#passport-number"
       },
       {
-        "text": "Descriptive link to the question with an error",
-        "href": "#example-error-1"
+        "text": "You must provide your expiry date",
+        "href": "#expiry-month"
       }
     ]
   }) }}
@@ -55,11 +55,11 @@
     items:[
       {
         name: 'month',
-        classes: 'govuk-input--width-2'
+        classes: 'govuk-input--width-2 govuk-input--error'
       },
       {
         name: 'year',
-        classes: 'govuk-input--width-4'
+        classes: 'govuk-input--width-4 govuk-input--error'
       }
     ],
     errorMessage: {

--- a/app/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/app/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -20,12 +20,8 @@
     "classes": "optional-extra-class",
     "errorList": [
       {
-        "text": "Descriptive link to the question with an error",
-        "href": "#example-error-1"
-      },
-      {
-        "text": "Descriptive link to the question with an error",
-        "href": "#example-error-1"
+        "text": "Date of birth must include a month and year",
+        "href": "#dob-month"
       }
     ]
   }) }}
@@ -43,8 +39,23 @@
     hint: {
       text: 'For example 5 12 1987'
     },
+    items:[
+      {
+        name: 'day',
+        classes: 'govuk-input--width-2',
+        value: '22'
+      },
+      {
+        name: 'month',
+        classes: 'govuk-input--width-2 govuk-input--error'
+      },
+      {
+        name: 'year',
+        classes: 'govuk-input--width-4 govuk-input--error'
+      }
+    ],
     errorMessage: {
-      text: "You must provide your date of birth"
+      text: "Date of birth must include a month and year"
     }
     })
   }}


### PR DESCRIPTION
I noticed these two pages don't adhere to https://github.com/alphagov/govuk-frontend/pull/1056 now @36degrees added in the focus handling.

http://govuk-frontend-review.herokuapp.com/examples/error-summary-with-messages
http://govuk-frontend-review.herokuapp.com/examples/error-summary-with-one-thing-per-page

The error summary links should go to specific inputs.

This is now fixed.

But, it opens up another question though:
**Can date inputs with two invalid fields have two error messages like this?**

![date inputs](https://user-images.githubusercontent.com/415517/52788817-fd376780-3059-11e9-9c81-a94c8a40717d.png)

Looking at these notes:
https://design-system.service.gov.uk/components/error-summary/

It sounds like the date component can have multiple fields with errors.

>When a user has to enter their answer into multiple fields, such as the day, month and year fields in the date input component, link to the first field that contains an error.
>
>If you do not know which field contains an error, link to the first field.

Our content designer would love to know.