### PR TITLE
Add passport details full page example

### DIFF
--- a/app/__tests__/app.test.js
+++ b/app/__tests__/app.test.js
@@ -22,6 +22,7 @@ const expectedPages = [
   '/full-page-examples/check-your-answers',
   '/full-page-examples/feedback-page',
   '/full-page-examples/how-do-you-want-to-sign-in',
+  '/full-page-examples/passport-details',
   '/full-page-examples/service-manual-topic',
   '/full-page-examples/start-page',
   '/full-page-examples/upload-your-photo',
@@ -135,6 +136,41 @@ describe(`http://localhost:${PORT}`, () => {
         // Check the page responded correctly
         expect(res.statusCode).toBe(200)
         expect($.html()).toContain('Send your feedback to this service')
+
+        // Check that the error summary is visible
+        let $errorSummary = $('[data-module="error-summary"]')
+        expect($errorSummary.length).toBeTruthy()
+        done(err)
+      })
+    })
+  })
+
+  describe('/full-page-examples/passport-details', () => {
+    it('should not show errors if submit with no input', (done) => {
+      request.get({
+        url: `http://localhost:${PORT}/full-page-examples/passport-details`
+      }, (err, res) => {
+        let $ = cheerio.load(res.body)
+
+        // Check the page responded correctly
+        expect(res.statusCode).toBe(200)
+        expect($.html()).toContain('Passport details')
+
+        // Check that the error summary is not visible
+        let $errorSummary = $('[data-module="error-summary"]')
+        expect($errorSummary.length).toBeFalsy()
+        done(err)
+      })
+    })
+    it('should show errors if form is submitted with no input', (done) => {
+      request.post({
+        url: `http://localhost:${PORT}/full-page-examples/passport-details`
+      }, (err, res) => {
+        let $ = cheerio.load(res.body)
+
+        // Check the page responded correctly
+        expect(res.statusCode).toBe(200)
+        expect($.html()).toContain('Passport details')
 
         // Check that the error summary is visible
         let $errorSummary = $('[data-module="error-summary"]')

--- a/app/app.js
+++ b/app/app.js
@@ -183,6 +183,7 @@ module.exports = (options) => {
 
   require('./views/full-page-examples/feedback-page')(app)
   require('./views/full-page-examples/how-do-you-want-to-sign-in')(app)
+  require('./views/full-page-examples/passport-details')(app)
   require('./views/full-page-examples/upload-your-photo')(app)
   require('./views/full-page-examples/what-is-your-nationality')(app)
   require('./views/full-page-examples/what-is-your-postcode')(app)

--- a/app/views/full-page-examples/passport-details/confirm.njk
+++ b/app/views/full-page-examples/passport-details/confirm.njk
@@ -1,0 +1,19 @@
+{# This example is based of the live "Send your feedback to GOV.UK Verify" start page: https://www.signin.service.gov.uk/feedback #}
+{% extends "_generic.njk" %}
+
+{% from "panel/macro.njk" import govukPanel %}
+
+{% set pageTitle = "Passport details submitted" %}
+{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      {{ govukPanel({
+        titleText: pageTitle
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/full-page-examples/passport-details/index.js
+++ b/app/views/full-page-examples/passport-details/index.js
@@ -1,0 +1,78 @@
+const { body, validationResult } = require('express-validator/check')
+
+// To make it easier to use in the view, might be nicer as a Nunjucks function
+function getErrors (errorsInstance) {
+  if (errorsInstance.isEmpty()) {
+    return false
+  }
+  const errors = errorsInstance.array()
+  const formattedErrors = {}
+  errors.forEach(error => {
+    formattedErrors[error.param] = {
+      id: error.param,
+      href: '#' + error.param,
+      value: error.value,
+      text: error.msg
+    }
+  })
+  return formattedErrors
+}
+
+module.exports = (app) => {
+  app.post(
+    '/full-page-examples/passport-details',
+    [
+      body('passport-number')
+        .exists()
+        .not().isEmpty().withMessage('Enter your passport number'),
+      body('expiry-day')
+        .exists()
+        .not().isEmpty().withMessage('Enter your expiry day'),
+      body('expiry-month')
+        .exists()
+        .not().isEmpty().withMessage('Enter your expiry month'),
+      body('expiry-year')
+        .exists()
+        .not().isEmpty().withMessage('Enter your expiry year')
+    ],
+    (request, response) => {
+      const errors = getErrors(validationResult(request))
+
+      if (!errors) {
+        return response.render('./full-page-examples/passport-details/confirm')
+      }
+
+      // If any of the date inputs error apply a general error.
+      const expiryNamePrefix = 'expiry'
+      const expiryErrors = Object.values(errors).filter(error => error.id.includes(expiryNamePrefix + '-'))
+      if (expiryErrors) {
+        const firstExpiryErrorId = expiryErrors[0].id
+        // Get the first error message and merge it into a single error message.
+        errors[expiryNamePrefix] = {
+          id: expiryNamePrefix,
+          href: '#' + firstExpiryErrorId
+        }
+
+        // Construct a single error message based on all three error messages.
+        errors[expiryNamePrefix].text = 'Enter your expiry '
+        if (expiryErrors.length === 3) {
+          errors[expiryNamePrefix].text += 'date'
+        } else {
+          errors[expiryNamePrefix].text += expiryErrors.map(error => error.text.replace('Enter your expiry ', '')).join(' and ')
+        }
+      }
+
+      let errorSummary = Object.values(errors)
+      if (expiryErrors) {
+        // Remove all other errors from the summary so we only have one message that links to the expiry input.
+        errorSummary = errorSummary.filter(error => !error.id.includes(expiryNamePrefix + '-'))
+      }
+
+      response.render('./full-page-examples/passport-details/index', {
+        errors,
+        errorSummary,
+        values: request.body // In production this should sanitized.
+      })
+    }
+  )
+}

--- a/app/views/full-page-examples/passport-details/index.njk
+++ b/app/views/full-page-examples/passport-details/index.njk
@@ -1,0 +1,102 @@
+{# This example is based of the "Passport details" pattern: https://design-system.service.gov.uk/patterns/question-pages/ #}
+{% extends "_generic.njk" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "input/macro.njk" import govukInput %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "button/macro.njk" import govukButton %}
+
+{% set pageTitle = "Passport details" %}
+{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+	text: "Back"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+	<div class="govuk-grid-column-two-thirds">
+	  {% if errorSummary.length > 0 %}
+		{{ govukErrorSummary({
+		  titleText: "There is a problem",
+		  errorList: errorSummary 
+		}) }}
+	  {% endif %}
+	  <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+
+	  <form method="post" novalidate>
+
+		{{ govukInput({
+		  label: {
+			text: "Passport number",
+			classes: "govuk-label--m"
+		  },
+		  hint: {
+			text: "For example, 502135326"
+		  },
+		  classes: "govuk-input--width-10",
+		  id: "passport-number",
+		  name: "passport-number",
+		  value: values["passport-number"],
+		  errorMessage: errors["passport-number"]
+		}) }}
+
+		{% set dateInputDayClass = "govuk-input--width-2" %}
+		{% set dateInputMonthClass = "govuk-input--width-2" %}
+		{% set dateInputYearClass = "govuk-input--width-4" %}
+
+		{% if errors["expiry-day"] %}
+			{% set dateInputDayClass = dateInputDayClass + " govuk-input--error" %}
+		{% endif %}
+		{% if errors["expiry-month"] %}
+			{% set dateInputMonthClass = dateInputMonthClass + " govuk-input--error" %}
+		{% endif %}
+		{% if errors["expiry-year"] %}
+			{% set dateInputYearClass = dateInputYearClass + " govuk-input--error" %}
+		{% endif %}
+
+		{{ govukDateInput({
+		  id: "expiry",
+		  namePrefix: "expiry",
+		  fieldset: {
+			legend: {
+			  text: "Expiry date",
+			  classes: "govuk-fieldset__legend--m"
+			}
+		  },
+		  hint: {
+			text: "For example, 31 3 1980"
+		  },
+			items: [
+				{
+					classes: dateInputDayClass,
+					name: "day",
+					value: values["expiry-day"]
+				},
+				{
+					classes: dateInputMonthClass,
+					name: "month",
+					value: values["expiry-month"]
+				},
+				{
+					classes: dateInputYearClass,
+					name: "year",
+					value: values["expiry-year"]
+				}
+			],
+		 	errorMessage: errors["expiry"]
+		}) }}
+
+		{{ govukButton({
+		  text: "Continue"
+		}) }}
+
+	  </form>
+	</div>
+  </div>
+{% endblock %}


### PR DESCRIPTION
This is an implementation of the passport details example from the
Design System guidance.

Also demonstrates how difficult it is to use the date input in practice, even with a rudimentary validation that just checks fields are inputted.