### PR TITLE
Conditional reveal for nationality question template

### DIFF
--- a/app/views/full-page-examples/what-is-your-nationality/index.js
+++ b/app/views/full-page-examples/what-is-your-nationality/index.js
@@ -7,7 +7,20 @@ module.exports = (app) => {
     [
       body('confirm-nationality')
         .exists()
-        .not().isEmpty().withMessage('Select your nationality or nationalities')
+        .not().isEmpty().withMessage('Select your nationality or nationalities'),
+      body('country-name')
+        .custom((value, { req: request }) => {
+          // See https://github.com/express-validator/express-validator/pull/658
+          const confirmedNationality = request.body['confirm-nationality'] || []
+          // If the other country option is selected and there's no value.
+          if (
+            confirmedNationality.includes('other-country-nationality') &&
+              !value
+          ) {
+            throw new Error('Enter your country')
+          }
+          return true
+        })
     ],
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))

--- a/app/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/index.njk
@@ -3,6 +3,7 @@
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "input/macro.njk" import govukInput %}
 {% from "details/macro.njk" import govukDetails %}
 {% from "button/macro.njk" import govukButton %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}
@@ -29,6 +30,21 @@
               }) }}
           {% endif %}
 
+        {% set otherCountryHtml %}
+
+          {{ govukInput({
+            id: "country-name",
+            name: "country-name",
+            type: "text",
+            classes: "govuk-!-width-one-third",
+            label: {
+              text: "Country name"
+            },
+            errorMessage: errors["country-name"]
+            }) }}
+
+        {% endset %}
+
         {{ govukCheckboxes({
           idPrefix: "confirm-nationality",
           name: "confirm-nationality",
@@ -47,17 +63,20 @@
               id: "confirm-nationality",
               value: "british-nationality",
               text: "British (including English, Scottish, Welsh or from Northern Ireland)",
-              checked: values["confirm-nationality"] === "british-nationality"
+              checked: values["confirm-nationality"]|length and "british-nationality" in values["confirm-nationality"]
             },
             {
               value: "irish-nationality",
               text: "Irish (including from Northern Ireland)",
-              checked: values["confirm-nationality"] === "irish-nationality"
+              checked: values["confirm-nationality"]|length and "irish-nationality" in values["confirm-nationality"]
             },
             {
               value: "other-country-nationality",
               text: "Citizen of a different country",
-              checked: values["confirm-nationality"] === "other-country-nationality"
+              checked: values["confirm-nationality"]|length and "other-country-nationality" in values["confirm-nationality"],
+              conditional: {
+                html: otherCountryHtml
+              }
             }
           ],
           errorMessage: errors["confirm-nationality"]


### PR DESCRIPTION
This adds a conditional reveal to the nationality question example template as per the [GOV.UK page](https://www.registertovote.service.gov.uk/register-to-vote/nationality).

There could be multiple selected checkboxes. Store boolean on whether the searched value is contained in the array before passing it to `checked`.

