### PR TITLE
Added accordion chevron icon

### DIFF
--- a/src/assets/images/icons-up-down.svg
+++ b/src/assets/images/icons-up-down.svg
@@ -1,0 +1,1 @@
+<svg width="16" height="32" viewBox="0 0 16 32" xmlns="http://www.w3.org/2000/svg"><title>Artboard</title><path d="M8 29.58l8-8L13.42 19 8 24.42 2.58 19 0 21.58zM8 3l-8 8 2.58 2.58L8 8.16l5.42 5.42L16 11z" fill="#0B0C0C"/></svg>


### PR DESCRIPTION
This adds a chevron icon.

It is intended for use as an alternative to the 'plus' and 'minus' icons on the accordion component.

It is currently live on the ['Check the MOT history of a vehicle'](https://www.gov.uk/check-mot-history) service.

**Reference**
GOV.UK Design System [Accordion component discussion](https://github.com/alphagov/govuk-design-system-backlog/issues/1#issuecomment-465977980).
