### PR TITLE
Remove error-summary dependence on document.onload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Remove error-summary dependence on document.onload
+
+  ([PR #1215](https://github.com/alphagov/govuk-frontend/pull/1215))
+
 
 ## 2.8.0 (Feature release)
 

--- a/src/components/error-summary/error-summary.js
+++ b/src/components/error-summary/error-summary.js
@@ -11,9 +11,7 @@ ErrorSummary.prototype.init = function () {
   if (!$module) {
     return
   }
-  window.addEventListener('load', function () {
-    $module.focus()
-  })
+  $module.focus()
 
   $module.addEventListener('click', this.handleClick.bind(this))
 }


### PR DESCRIPTION
The error-summary component is being initialised on an element using a `data-` attribute, which means that at the initialisation moment the element already exists is loaded in the DOM. Hence, we don't need to wait for `document.onload` to happen in order to set the focus on this element.

Background: We're using the error-summary component in a modal dialogue and we're planning to re-initialise the GOVUK Frontend components within the modal using `GOVUKFrontend.initAll()` (yeah, we need to scope it, but I'll raise a separate PR for that).
This component and `Tabs` are the only one relying on `document.onload` to happen.