### PR TITLE
Add error prefix to errored page titles

### DIFF
--- a/app/full-page-examples.test.js
+++ b/app/full-page-examples.test.js
@@ -79,6 +79,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('Send your feedback to GOV.UK Verify')
 
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
+
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
           expect($errorSummary.length).toBeTruthy()
@@ -109,6 +112,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           // Check the page responded correctly
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('Have you changed your name?')
+
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
 
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
@@ -141,6 +147,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('Passport details')
 
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
+
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
           expect($errorSummary.length).toBeTruthy()
@@ -171,6 +180,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           // Check the page responded correctly
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('Update your account details')
+
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
 
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
@@ -203,6 +215,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('Upload your photo')
 
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
+
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
           expect($errorSummary.length).toBeTruthy()
@@ -233,6 +248,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           // Check the page responded correctly
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('How do you want to sign in?')
+
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
 
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
@@ -265,6 +283,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('What is your nationality?')
 
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
+
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
           expect($errorSummary.length).toBeTruthy()
@@ -295,6 +316,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           // Check the page responded correctly
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('What is your address?')
+
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
 
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
@@ -327,6 +351,9 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('What is your home postcode?')
 
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
+
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')
           expect($errorSummary.length).toBeTruthy()
@@ -351,12 +378,15 @@ describe(`http://localhost:${PORT}/full-page-examples/`, () => {
         })
       })
       it('should show errors if form is submitted with no input', (done) => {
-        requestPath.post(`what-was-the-last-country-you-visited`, (err, res) => {
+        requestPath.post('what-was-the-last-country-you-visited', (err, res) => {
           let $ = cheerio.load(res.body)
 
           // Check the page responded correctly
           expect(res.statusCode).toBe(200)
           expect($.html()).toContain('What was the last country you visited?')
+
+          // Check the title has an error
+          expect($('title').text()).toContain('Error:')
 
           // Check that the error summary is visible
           let $errorSummary = $('[data-module="error-summary"]')

--- a/app/views/full-page-examples/feedback/index.njk
+++ b/app/views/full-page-examples/feedback/index.njk
@@ -9,7 +9,7 @@
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "Send your feedback to GOV.UK Verify" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% set mainClasses = "govuk-main-wrapper--l" %}
 

--- a/app/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/app/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -7,7 +7,7 @@
 {% from "button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Have you changed your name?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -9,7 +9,7 @@
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "How do you want to sign in?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/full-page-examples/passport-details/index.njk
+++ b/app/views/full-page-examples/passport-details/index.njk
@@ -8,7 +8,7 @@
 {% from "button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Passport details" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% set mainClasses = "govuk-main-wrapper--l" %}
 

--- a/app/views/full-page-examples/update-your-account-details/index.njk
+++ b/app/views/full-page-examples/update-your-account-details/index.njk
@@ -6,7 +6,7 @@
 {% from "button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Update your account details" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% set mainClasses = "govuk-main-wrapper--l" %}
 

--- a/app/views/full-page-examples/upload-your-photo/index.njk
+++ b/app/views/full-page-examples/upload-your-photo/index.njk
@@ -10,7 +10,7 @@
 {% from "file-upload/macro.njk" import govukFileUpload %}
 
 {% set pageTitle = "Upload your photo" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% set mainClasses = "govuk-main-wrapper--l" %}
 

--- a/app/views/full-page-examples/what-is-your-address/index.njk
+++ b/app/views/full-page-examples/what-is-your-address/index.njk
@@ -8,7 +8,7 @@
 {% from "button/macro.njk" import govukButton %}
 
 {% set pageTitle = "What is your home address?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/index.njk
@@ -10,7 +10,7 @@
 {% from "error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "What is your nationality?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/full-page-examples/what-is-your-postcode/index.njk
+++ b/app/views/full-page-examples/what-is-your-postcode/index.njk
@@ -7,7 +7,7 @@
 {% from "input/macro.njk" import govukInput %}
 
 {% set pageTitle = "What is your home postcode?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/app/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
+++ b/app/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
@@ -8,7 +8,7 @@
 {% from "input/macro.njk" import govukInput %}
 
 {% set pageTitle = "What was the last country you visited?" %}
-{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
 
 {% block beforeContent %}
   {{ govukBackLink({


### PR DESCRIPTION
As part of our guidance we recommend to put error in the title,
alongside the error summary and error messages.

As part of https://github.com/alphagov/govuk-frontend/issues/1160