### PR TITLE
Improve word wrapping in summary list component

### DIFF
--- a/app/views/full-page-examples/check-your-answers/index.njk
+++ b/app/views/full-page-examples/check-your-answers/index.njk
@@ -177,6 +177,39 @@
               }
             ]
           }
+        },
+        {
+          key: {
+            text: "Additional details"
+          },
+          value: {
+            html: '
+              <p class="govuk-body">I have contacted my council for a Temporary Event Notice (<abbr title="Temporary Event Notice">TEN</abbr>) as I want to carry out a ‘licensable activity’ on unlicensed premises in England or Wales.</p>
+
+              <p class="govuk-body">Licensable activity includes:</p>
+
+              <ul class="govuk-list govuk-list--bullet">
+                <li>selling alcohol</li>
+                <li>serving alcohol to members of a private club</li>
+                <li>providing entertainment, such as music, dancing or indoor sporting events</li>
+                <li>serving hot food or drink between 11pm and 5am</li>
+              </ul>
+
+              <p class="govuk-body">
+                To find out more you can visit out website at: 
+                <a class="govuk-link" href="#">https://reallylongurlformyeventthatneedsatemporaryeventsnotice.com</a>
+              </p>
+            '
+          },
+          actions: {
+            items: [
+              {
+                href: "#/additional-details",
+                text: "Change",
+                visuallyHiddenText: "additional details"
+              }
+            ]
+          }
         }
       ]
     }) }}

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -10,6 +10,7 @@
     @include govuk-media-query($from: tablet) {
       display: table;
       width: 100%;
+      table-layout: fixed; // Required to allow us to wrap words that overflow.
     }
     margin: 0; // Reset default user agent styles
     @include govuk-responsive-margin(6, "bottom");
@@ -49,6 +50,7 @@
   .govuk-summary-list__actions {
     margin-bottom: govuk-spacing(3);
     @include govuk-media-query($from: tablet) {
+      width: 20%;
       padding-right: 0;
       text-align: right;
     }
@@ -56,10 +58,9 @@
 
   .govuk-summary-list__key,
   .govuk-summary-list__value {
-    // sass-lint:disable no-duplicate-properties
     // Automatic wrapping for unbreakable text (e.g. URLs)
-    word-break: break-all; // Standards
-    word-break: break-word; // WebKit/Blink only
+    word-wrap: break-word; // Fallback for older browsers only
+    overflow-wrap: break-word;
   }
 
   .govuk-summary-list__key {
@@ -73,6 +74,9 @@
   .govuk-summary-list__value {
     @include govuk-media-query($until: tablet) {
       margin-bottom: govuk-spacing(3);
+    }
+    @include govuk-media-query($from: tablet) {
+      width: 50%;
     }
   }
 

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -370,8 +370,8 @@ examples:
             text: Pneumonoultramicroscopicsilicovolcanoconiosis
           value:
             html: |
-              <p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi quis consequat diam. Duis efficitur justo at congue iaculis. Quisque scelerisque ornare justo nec congue. Duis egestas felis nibh, eu cursus metus rutrum eget. In dictum lectus diam, dapibus ullamcorper risus gravida a. Vestibulum tempor mattis sapien, at auctor tellus dignissim non. Praesent dictum felis nec diam tempor, vel lobortis leo ultricies.</p>
-              <p class="govuk-body">Suspendisse potenti. Aliquam dictum eu ipsum sed facilisis. Maecenas hendrerit est eget ultrices venenatis. Nam ex nisl, venenatis eget molestie quis, hendrerit id tellus. Morbi et posuere ex, vel interdum sapien. Mauris ac mattis turpis, interdum eleifend erat. Morbi eget efficitur lectus. Sed suscipit laoreet ipsum et iaculis. Integer ornare ipsum quis aliquet scelerisque. Proin venenatis dictum suscipit. Nunc tristique, felis quis fermentum rhoncus, tortor augue egestas ipsum, non porttitor nulla odio vitae purus. Interdum et malesuada fames ac ante ipsum primis in faucibus.</p>
+              <p class="govuk-body">Pneumonoultramicroscopicsilicovolcanoconiosis is a word coined by the president of the National Puzzlers' League as a synonym for the disease known as silicosis. It is the longest word in the English language published in a dictionary, the Oxford English Dictionary, which defines it as "an artificial long word said to mean a lung disease caused by inhaling very fine ash and sand dust."</p>
+              <p class="govuk-body">Silicosis is a form of occupational lung disease caused by inhalation of crystalline silica dust, and is marked by inflammation and scarring in the form of nodular lesions in the upper lobes of the lungs. It is a type of pneumoconiosis.</p>
           actions:
             items:
               - href: '#'


### PR DESCRIPTION
Opening a draft of what I've explored so far, this seems like a problem where we have to make some compromises.

The summary list currently wraps text in all browsers, but only in blink/webkit does it wrap entire words, all other browsers it can wrap mid word which can make it more difficult to read.

To make this better we want to try and use `overflow-wrap` which works cross browsers, however...

In order to use `overflow-wrap` with table CSS we need to use a fixed layout since the summary list uses table CSS.

This means we can't rely on a table's automatic resizing, so we have to compromise
with a larger actions column that we have before, so that we can have at least two actions on one line without the actions wrapping.

Welcome any input to an alternative that I may have missed.

I have also considered that this might be best solved with CSS Grid but have discounted that for now based on the support for browsers.

You can take a look at the two by comparing:

## Before

- [Summary list review page](https://govuk-frontend-review.herokuapp.com/components/summary-list)
- [Check your answers review page](https://govuk-frontend-review.herokuapp.com/full-page-examples/check-your-answers)

### Screenshots

![Without changes there's no gap](https://user-images.githubusercontent.com/2445413/53329444-fe7f5480-38e3-11e9-9258-e86c4db286f3.png)

## After

- [Summary list review page](https://govuk-frontend-review-pr-1220.herokuapp.com/components/summary-list)
- [Check your answers review page](https://govuk-frontend-review-pr-1220.herokuapp.com/full-page-examples/check-your-answers)

## Pros

- Works more consistently across all browsers we support

## Cons

- Content cannot decide the size of columns anymore leading to smaller columns than before

### Screenshots

![With changes, there's a gap between columns](https://user-images.githubusercontent.com/2445413/53329401-e7d8fd80-38e3-11e9-880f-e17454cf8b4f.png)

## Related links

- [Handling Long Words and URLs (Forcing Breaks, Hyphenation, Ellipsis, etc)](https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/)
- [Overflow wrap in tables](https://stackoverflow.com/questions/1258416/word-wrap-in-an-html-table)
- [word-break support](https://caniuse.com/#feat=word-break) only Blink/Webkit browser support a word by word wrapping
- [overflow-wrap support](https://caniuse.com/#feat=wordwrap)

Aims to resolve https://github.com/alphagov/govuk-frontend/issues/1211