### PR TITLE
Add extra tracking modifier for inputs

### DIFF
--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -72,7 +72,7 @@
     max-width: 5.4ex;
   }
 
-  .govuk-input--extra-tracking {
+  .govuk-input--extra-letter-spacing {
     @include govuk-font(false, $tabular: true);
     letter-spacing: .05em;
   }

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -72,4 +72,8 @@
     max-width: 5.4ex;
   }
 
+  .govuk-input--extra-tracking {
+    @include govuk-font(false, $tabular: true);
+    letter-spacing: .05em;
+  }
 }

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -162,3 +162,21 @@ examples:
       id: input-with-autocomplete-attribute
       name: postcode
       autocomplete: postal-code
+  - name: extra tracking ni
+    data:
+      label:
+        text: National insurance number
+      classes: govuk-input--width-30 govuk-input--extra-tracking
+      value: QQ 12 34 56 C
+  - name: extra tracking phone
+    data:
+      label:
+        text: Phone number
+      classes: govuk-input--width-30 govuk-input--extra-tracking
+      value: 03069 991234
+  - name: extra tracking reference
+    data:
+      label:
+        text: Driving licence number
+      classes: govuk-input--width-30 govuk-input--extra-tracking
+      value: GLADS101125C95401

--- a/src/components/input/input.yaml
+++ b/src/components/input/input.yaml
@@ -162,21 +162,21 @@ examples:
       id: input-with-autocomplete-attribute
       name: postcode
       autocomplete: postal-code
-  - name: extra tracking ni
+  - name: extra letter spacing ni
     data:
       label:
         text: National insurance number
-      classes: govuk-input--width-30 govuk-input--extra-tracking
+      classes: govuk-input--width-30 govuk-input--extra-letter-spacing
       value: QQ 12 34 56 C
-  - name: extra tracking phone
+  - name: extra letter spacing phone
     data:
       label:
         text: Phone number
-      classes: govuk-input--width-30 govuk-input--extra-tracking
+      classes: govuk-input--width-30 govuk-input--extra-letter-spacing
       value: 03069 991234
-  - name: extra tracking reference
+  - name: extra letter spacing reference
     data:
       label:
         text: Driving licence number
-      classes: govuk-input--width-30 govuk-input--extra-tracking
+      classes: govuk-input--width-30 govuk-input--extra-letter-spacing
       value: GLADS101125C95401


### PR DESCRIPTION
This adds a `--extra-tracking` modifier for inputs which increases the tracking, and turns on tabular numbers.

The idea is that this modifier would be used for inputs asking for e.g. reference or phone numbers, where the user would be checking back one character at a time.

This was inspired by https://github.com/alphagov/notifications-admin/pull/1545

## Without modifier

![localhost_3000_components_input_extra-tracking-reference_preview 1](https://user-images.githubusercontent.com/121939/53399747-744af500-39a4-11e9-9be3-321166f44753.png)

## With modifier

![localhost_3000_components_input_extra-tracking-reference_preview 2](https://user-images.githubusercontent.com/121939/53399802-87f65b80-39a4-11e9-9e84-572ed6595365.png)

## Questions…

- is this useful?
- is there a better name than `--extra-tracking`?
- is it an issue that the width modifiers behave differently, because `1ex` has a different width?