### PR TITLE
Prevent horizontal jump as scrollbars appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Prevent horizontal jump as scrollbars appear
+
+  As content vertical height grows (e.g. autocomplete results appear), browsers
+  may add scroll bars causing the page to jump horizontally in position.
+
+  To avoid this, re-introduce fix from GOV.UK Template:
+  https://github.com/alphagov/govuk-frontend/issues/1204
+
+  ([PR #1230](https://github.com/alphagov/govuk-frontend/pull/1230))
+
 - Accommodate camera notches on new devices (iPhone X, Google Pixel 3 etc)
 
   On newer devices with "camera notches", browsers reserve a safe area in landscape orientation (known as pillarboxing) so content isn't obscured.

--- a/src/core/_template.scss
+++ b/src/core/_template.scss
@@ -11,6 +11,12 @@
     // Prevent automatic text sizing, as we already cater for small devices and
     // would like the browser to stay on 100% text zoom by default.
     text-size-adjust: 100%;
+
+    // Force the scrollbar to always display in IE, to prevent horizontal page
+    // jumps as content height changes (e.g. autocomplete results open).
+    @include govuk-media-query($media-type: screen) {
+      overflow-y: scroll;
+    }
   }
 
   // Applied to the <body> element


### PR DESCRIPTION
As discussed previously with @nickcolley, we're seeing horizontal "jumps" in position as scroll bars appear and disappear in IE11—as page content grows.

Also spotted by @edwardhorsford here: https://github.com/alphagov/govuk-frontend/issues/1204

We've fixed the issue manually (screen-only, not affecting print) by using:

```css
@media only screen {
  .container {
    overflow-y: scroll;
  }
}
```

Also found in GOV.UK Template:
https://github.com/alphagov/govuk_template/blob/f2c10fae7ec7e371fd11c409cd71a399e3342e7f/source/assets/stylesheets/_basic.scss#L111

And inside GOV.UK Elements:
https://github.com/alphagov/govuk_elements/blob/84f485f688e7f796a4c44dd73b17177e8e39538c/assets/sass/elements/_govuk-template-base.scss#L50

Things to discuss:

**1. Do we need to restrict to `@media only screen`**
Does this prevent printable content from being hidden?

~~**2. Do we need the old `-ms-overflow-style: scrollbar` style**~~
~~To force the scrollbar to always display in IE10/11~~

Confirmed: Point 2) was previously required for "tablet mode" Internet Explorer that first came with Windows 8, but since scroll bars auto-hide by default it's not needed anymore.

### Browser testing

- [x] Internet Explorer 8 (Windows)
- [x] Internet Explorer 9 (Windows)
- [x] Internet Explorer 10 (Windows)
- [x] Internet Explorer 11 (Windows)
- [x] Edge (latest 2 versions) (Windows)
- [x] Google Chrome (latest 2 versions) (Windows)
- [x] Mozilla Firefox (latest 2 versions) (Windows)
- [x] Safari 9+ (macOS)
- [x] Google Chrome (latest 2 versions) (macOS)
- [x] Mozilla Firefox (latest 2 versions) (macOS)
- [x] Safari 9.3+ (iOS)
- [x] Google Chrome (latest version) (iOS)
- [x] Google Chrome (latest version) (Android)
- [x] Samsung Internet (latest version) (Android)

Specific screenshots:

### Edge 17 with fix
![edge 17 with fix](https://user-images.githubusercontent.com/415517/53656021-c8c2ce80-3c49-11e9-90b9-27daa8d440a3.png)

### Edge 17 without fix
![edge 17 without fix](https://user-images.githubusercontent.com/415517/53656027-cceeec00-3c49-11e9-814f-265b71507edb.png)

### IE11 with fix
![ie11 with fix](https://user-images.githubusercontent.com/415517/53656002-ba74b280-3c49-11e9-993e-dd732750396d.png)

### IE11 without fix
![ie11 without fix](https://user-images.githubusercontent.com/415517/53656010-bfd1fd00-3c49-11e9-95bb-3893905f1a89.png)

### IE10 with fix
![ie10 with fix](https://user-images.githubusercontent.com/415517/53655969-a7fa7900-3c49-11e9-89a7-1bc9fac81f98.png)

### IE10 without fix
![ie10 without fix](https://user-images.githubusercontent.com/415517/53655983-b34da480-3c49-11e9-897b-c670b7906850.png)

### IE9 with fix
![ie9 with fix](https://user-images.githubusercontent.com/415517/53656047-e132e900-3c49-11e9-90e3-241cc8c871b4.png)

### IE9 without fix
![ie9 without fix](https://user-images.githubusercontent.com/415517/53656056-e728ca00-3c49-11e9-9b31-6eaad70b6c94.png)
