### PR TITLE
Pass visuallyHiddenText when calling errorMessage

### DIFF
--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -42,7 +42,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -47,7 +47,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -33,7 +33,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -33,7 +33,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -39,7 +39,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}{%- if isConditional %} govuk-radios--conditional{% endif -%}"

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -33,7 +33,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <select class="govuk-select

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -33,7 +33,8 @@
     classes: params.errorMessage.classes,
     attributes: params.errorMessage.attributes,
     html: params.errorMessage.html,
-    text: params.errorMessage.text
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
   <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"


### PR DESCRIPTION
For all components that call the error message function with a limited set of params, also pass `params.errorMessage.visuallyHiddenText`.

List of components found by searching the codebase for `params.errorMessage.text`

```
$ ag params.errorMessage.text src
src/components/date-input/template.njk
50:    text: params.errorMessage.text,

src/components/input/template.njk
36:    text: params.errorMessage.text,

src/components/radios/template.njk
42:    text: params.errorMessage.text,

src/components/checkboxes/template.njk
45:    text: params.errorMessage.text,

src/components/textarea/template.njk
36:    text: params.errorMessage.text,

src/components/file-upload/template.njk
36:    text: params.errorMessage.text,

src/components/select/template.njk
36:    text: params.errorMessage.text,
```

The character count also passes params.errorMessage, but passes the entire object so doesn't need modification:

https://github.com/alphagov/govuk-frontend/blob/4e423aaae06c52dded503b0887e31550e0ce04a8/src/components/character-count/template.njk#L23

We don't have a good way to test any of this right now either, unfortunately.

---

> An object merge function, an object merge function! My kingdom for an object merge function.

– King Richard III, probably.