### PR TITLE
Ensure inset component does not misalign nested components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Ensure inset component does not misalign nested components
+
+  Thanks to [Paul Hayes](https://github.com/fofr) for raising this issue.
+
+  ([PR #1232](https://github.com/alphagov/govuk-frontend/pull/1232))
+
 
 - Improve word wrapping in summary list component
 

--- a/src/components/inset-text/_inset-text.scss
+++ b/src/components/inset-text/_inset-text.scss
@@ -16,12 +16,12 @@
 
     border-left: $govuk-border-width-wide solid $govuk-border-colour;
 
-    :first-child {
+    > :first-child {
       margin-top: 0;
     }
 
-    :only-child,
-    :last-child {
+    > :only-child,
+    > :last-child {
       margin-bottom: 0;
     }
   }

--- a/src/components/inset-text/inset-text.yaml
+++ b/src/components/inset-text/inset-text.yaml
@@ -26,4 +26,13 @@ examples:
       text: It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
   - name: with html
     data:
-      html: It can take up to 8 weeks to register a <a class="govuk-link" href="#">lasting power of attorney</a> if there are no mistakes in the application.
+      html: |
+        <p class="govuk-body">It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.</p>
+        <div class="govuk-warning-text">
+          <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+          <strong class="govuk-warning-text__text">
+            <span class="govuk-warning-text__assistive">Warning</span>
+            You can be fined up to £5,000 if you don’t register.
+          </strong>
+        </div>
+        <p class="govuk-body">It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.</p>


### PR DESCRIPTION
Ensures any children of the inset component are only targeted one level deep, which is consistent with the other uses of this pseudo selector in other components.

Fixes #1225 

# Screenshots
## Before

![Before, warning text component is misaligned](https://user-images.githubusercontent.com/2445413/53743363-8f30d400-3e92-11e9-87ff-3bf54f648f5a.png)

## After

![After, warning text component is not misaligned](https://user-images.githubusercontent.com/2445413/53743362-8e983d80-3e92-11e9-8057-98ca9e26e114.png)
