### PR TITLE
Avoid double-escaping example names

### DIFF
--- a/app/views/macros/showExamples.njk
+++ b/app/views/macros/showExamples.njk
@@ -16,7 +16,7 @@
   <section aria-labelledby="heading-{{ exampleSlug }}" class="govuk-!-margin-bottom-9">
     <div class="govuk-width-container">
       <div class="govuk-heading-m">
-        <h3 id="heading-{{ exampleSlug }}" class="app-!-di">{{ heading }}</h3>
+        <h3 id="heading-{{ exampleSlug }}" class="app-!-di">{{ heading | safe }}</h3>
         <a href="{{ path }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
           (open in a new window)
         </a>

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -220,7 +220,7 @@ examples:
       - value: blue
         text: Blue
 
-- name: with single option set 'aria-describeby' on input
+- name: with single option set 'aria-describedby' on input
   data:
     name: t-and-c
     errorMessage:

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -646,7 +646,7 @@ describe('Checkboxes', () => {
 
   describe('single checkbox without a fieldset', () => {
     it('adds aria-describe to input if there is an error', () => {
-      const $ = render('checkboxes', examples["with single option set 'aria-describeby' on input"])
+      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input"])
       const $input = $('input')
       expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
     })


### PR DESCRIPTION
Just a minor one.

I noticed the example names are already HTML escaped before they hit the macro.

Due to Nunjucks `autoescape: true` they were being double-escaped.

#### Before
![before](https://user-images.githubusercontent.com/415517/53798250-c1dcda00-3f2f-11e9-93a8-e9f8168e35f6.png)

#### After
![after](https://user-images.githubusercontent.com/415517/53798227-b8ec0880-3f2f-11e9-8f09-60dc828fccf7.png)
