### PR TITLE
Add rollup guidance

### DIFF
--- a/docs/installation/examples/rollup/assets/main.js
+++ b/docs/installation/examples/rollup/assets/main.js
@@ -1,0 +1,3 @@
+import Button from 'govuk-frontend/components/button/button'
+
+new Button(document).init()

--- a/docs/installation/examples/rollup/index.html
+++ b/docs/installation/examples/rollup/index.html
@@ -7,13 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 </head>
 <body>
-  <div class="govuk-width-container">
-    <div class="app-whitespace-highlight">
-      <a href="/" role="button" class="govuk-button">Link button</a>
-      
-      <p class="govuk-body">Pressing space will activate this button</p>
-    </div>
-  </div>
+  <a href="/" role="button" class="govuk-button">Link button</a>
+  
+  <p class="govuk-body">Pressing space will activate this button</p>
   <script src="public/main.js"></script>
 </body>
 </html>

--- a/docs/installation/examples/rollup/index.html
+++ b/docs/installation/examples/rollup/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>GOV.UK Frontend rollup example</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+</head>
+<body>
+  <div class="govuk-width-container">
+    <div class="app-whitespace-highlight">
+      <a href="/" role="button" class="govuk-button">Link button</a>
+      
+      <p class="govuk-body">Pressing space will activate this button</p>
+    </div>
+  </div>
+  <script src="public/main.js"></script>
+</body>
+</html>

--- a/docs/installation/examples/rollup/package.json
+++ b/docs/installation/examples/rollup/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "name": "rollup-boilerplate",
+  "description": "rollup boilerplate consuming govuk-frontend",
+  "scripts": {
+    "build": "rollup -c",
+    "start": "npm run build && serve"
+  },
+  "dependencies": {
+    "govuk-frontend": "*"
+  },
+  "devDependencies": {
+    "rollup": "0.56.5",
+    "rollup-plugin-commonjs": "^9.2.1",
+    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-uglify": "^6.0.2",
+    "serve": "^10.1.2"
+  }
+}

--- a/docs/installation/examples/rollup/rollup.config.js
+++ b/docs/installation/examples/rollup/rollup.config.js
@@ -1,0 +1,21 @@
+// Forked from https://github.com/rollup/rollup-starter-app
+
+import resolve from 'rollup-plugin-node-resolve'
+import commonjs from 'rollup-plugin-commonjs'
+import { uglify } from 'rollup-plugin-uglify'
+
+export default {
+  input: 'assets/main.js',
+  output: {
+    file: 'public/main.js',
+    format: 'iife', // immediately-invoked function expression — suitable for <script> tags
+    legacy: true // Legacy mode is required for IE8 support (only avaliable in rollup version 0.56.5 and below)
+  },
+  plugins: [
+    resolve(), // tells Rollup how to find date-fns in node_modules
+    commonjs(), // converts date-fns to ES modules
+    uglify({
+      ie8: true
+    })
+  ]
+}

--- a/docs/installation/examples/webpack/index.html
+++ b/docs/installation/examples/webpack/index.html
@@ -3,25 +3,17 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>GOV.UK Frontend</title>
+  <title>GOV.UK Frontend webpack example</title>
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-  <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="../../public/css/app.css">
-  <!--<![endif]-->
-  <!--[if lt IE 9]>
-  <script src="/vendor/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-  <!--[if IE 8]>
-  <link rel="stylesheet" href="/public/css/app-old-ie.css">
-  <![endif]-->
 </head>
 <body>
   <div class="govuk-width-container">
     <div class="app-whitespace-highlight">
       <a href="/" role="button" class="govuk-button">Link button</a>
+      
+      <p class="govuk-body">Pressing space will activate this button</p>
     </div>
   </div>
-  <!--script src="../../../public/all/all.js"></script-->
   <script src="public/main.js"></script>
 </body>
 </html>

--- a/docs/installation/examples/webpack/index.html
+++ b/docs/installation/examples/webpack/index.html
@@ -7,13 +7,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 </head>
 <body>
-  <div class="govuk-width-container">
-    <div class="app-whitespace-highlight">
-      <a href="/" role="button" class="govuk-button">Link button</a>
-      
-      <p class="govuk-body">Pressing space will activate this button</p>
-    </div>
-  </div>
+  <a href="/" role="button" class="govuk-button">Link button</a>
+  
+  <p class="govuk-body">Pressing space will activate this button</p>
   <script src="public/main.js"></script>
 </body>
 </html>

--- a/docs/installation/examples/webpack/package.json
+++ b/docs/installation/examples/webpack/package.json
@@ -1,9 +1,10 @@
 {
+  "private": true,
   "name": "webpack-boilerplate",
-  "description": "Webpack4 boilerplate consuming govuk-frontend",
+  "description": "Webpack boilerplate consuming govuk-frontend",
   "scripts": {
-    "dev": "cross-env NODE_ENV=dev webpack-dev-server --progress --mode development --config webpack.config.js",
-    "build": "webpack -p --progress --mode production --config webpack.config.js"
+    "build": "webpack -p --progress --mode production --config webpack.config.js",
+    "start": "npm run build && serve"
   },
   "dependencies": {
     "govuk-frontend": "*"
@@ -13,19 +14,9 @@
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.1",
     "babel-preset-es3": "^1.0.1",
-    "clean-webpack-plugin": "0.1.19",
-    "cross-env": "5.1.4",
-    "css-loader": "0.28.11",
-    "file-loader": "1.1.11",
-    "html-webpack-plugin": "3.2.0",
-    "node-sass": "^4.7.2",
-    "sass-loader": "7.0.1",
-    "style-loader": "0.20.3",
+    "serve": "^10.1.2",
     "uglifyjs-webpack-plugin": "^1.2.4",
-    "url-loader": "1.0.1",
     "webpack": "4.6.0",
-    "webpack-cli": "2.0.14",
-    "webpack-dev-server": ">=3.1.11",
-    "webpack-merge": "4.1.2"
+    "webpack-cli": "2.0.14"
   }
 }

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -235,6 +235,9 @@ See [JavaScript Coding Standards](/docs/contributing/coding-standards/js.md) for
 #### Using GOV.UK Frontend with Webpack 4
 Here's an example of setting up [`webpack.config.js`](examples/webpack/webpack.config.js) in your project
 
+#### Using GOV.UK Frontend with Rollup
+Here's an example of setting up [`rollup.config.js`](examples/rollup/rollup.config.js) in your project
+
 ## Importing assets
 
 In order to import GOV.UK Frontend images and fonts to your project, you should configure your application to reference or copy the relevant GOV.UK Frontend assets.


### PR DESCRIPTION
Trying to resolve some of my oldest issues raised...

Adds an example that exposes what we've learnt around needing specific configurations for rollup.

I have also cleaned up the webpack example which has a lot of unnecessary code.

I have loaded this example locally and ran it in browserstack Internet Explorer 8 and it behaves as expected.

Closes https://github.com/alphagov/govuk-frontend/issues/866
