### PR TITLE
Ensure font is not loaded twice on slow networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@
 
   ([PR #1215](https://github.com/alphagov/govuk-frontend/pull/1215))
 
+- Ensure font is not loaded twice on slow networks
+
+  This is only an issue for users that are using alphagov/govuk_template alongside GOV.UK Frontend.
+
+  ([PR #1242](https://github.com/alphagov/govuk-frontend/pull/1242))
+
 
 ## 2.8.0 (Feature release)
 

--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -17,8 +17,9 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  // If using NTA, include the font-face definition
-  @if ($govuk-font-family == $govuk-font-family-nta) {
+  // If the user is using the default NTA font we need to include the font-face declarations.
+  // We do not need to include the NTA font-face declarations if alphagov/govuk_template is being used since they will already be included.
+  @if ($govuk-include-default-font-face) {
     @include _govuk-font-face-nta;
   }
 

--- a/src/helpers/typography.test.js
+++ b/src/helpers/typography.test.js
@@ -50,6 +50,93 @@ const sassBootstrap = `
   @import "tools/iff";
   @import "helpers/typography";`
 
+describe('@mixin govuk-typography-common', () => {
+  it('should output a @font-face declaration by default', async () => {
+    const sass = `
+    @import "settings/all";
+    @import "helpers/all";
+
+    :root {
+      @include govuk-typography-common;
+    }
+    :root {
+      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+    }
+    `
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+    const resultsString = results.css.toString()
+
+    expect(resultsString).toContain(`@font-face`)
+    expect(resultsString).toContain(`font-family: "nta"`)
+    expect(resultsString).toContain(`font-family: "ntatabularnumbers"`)
+  })
+  it('should not output a @font-face declaration when the user has changed their font', async () => {
+    const sass = `
+    $govuk-font-family: Helvetica, Arial, sans-serif;
+    $govuk-font-family-tabular: monospace;
+    @import "settings/all";
+    @import "helpers/all";
+
+    :root {
+      @include govuk-typography-common;
+    }
+    :root {
+      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+    }
+    `
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+    const resultsString = results.css.toString()
+
+    expect(resultsString).not.toContain(`@font-face`)
+    expect(resultsString).not.toContain(`font-family: "nta"`)
+    expect(resultsString).not.toContain(`font-family: "ntatabularnumbers"`)
+  })
+  it('should not output a @font-face declaration when the user wants compatibility with GOV.UK Template', async () => {
+    const sass = `
+    $govuk-compatibility-govuktemplate: true;
+    @import "settings/all";
+    @import "helpers/all";
+
+    :root {
+      @include govuk-typography-common;
+    }
+    :root {
+      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+    }
+    `
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+    const resultsString = results.css.toString()
+
+    expect(resultsString).not.toContain(`@font-face`)
+    expect(resultsString).toContain(`font-family: "nta"`)
+    expect(resultsString).toContain(`font-family: "ntatabularnumbers"`)
+  })
+  it('should not output a @font-face declaration when the user has turned off this feature', async () => {
+    const sass = `
+    $govuk-include-default-font-face: false;
+    @import "settings/all";
+    @import "helpers/all";
+
+    :root {
+      @include govuk-typography-common;
+    }
+    :root {
+      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+    }
+    `
+
+    const results = await sassRender({ data: sass, ...sassConfig })
+    const resultsString = results.css.toString()
+
+    expect(resultsString).not.toContain(`@font-face`)
+    expect(resultsString).toContain(`font-family: "nta"`)
+    expect(resultsString).toContain(`font-family: "ntatabularnumbers"`)
+  })
+})
+
 describe('@function _govuk-line-height', () => {
   it('preserves line-height if already unitless', async () => {
     const sass = `

--- a/src/settings/_typography-font.scss
+++ b/src/settings/_typography-font.scss
@@ -29,7 +29,19 @@ $govuk-font-family-tabular: $govuk-font-family-nta-tabular !default;
 
 $govuk-font-family-print: sans-serif !default;
 
+/// Include the default @font-face declarations
+///
+/// If you have set $govuk-font-family to something other than $govuk-font-family-nta this option is disabled by default.
+///
+/// If you are using $govuk-compatibility-govuktemplate this option is disabled by default.
+///
+/// @type Boolean
+/// @access public
 
+$govuk-include-default-font-face: (
+  $govuk-font-family == $govuk-font-family-nta and
+  not($govuk-compatibility-govuktemplate)
+ ) !default;
 
 // =========================================================
 // Font weights


### PR DESCRIPTION
Prior to this change if you were loading GOV.UK Frontend alongside alphagov/govuk_template you would have two @font-face declarations that tell the browser how to load the 'nta' font.

This is normally not an issue since as soon as the browser downloads a version it won't download a second copy of the font.

However when a user is on a slow connection, the browser can try to download the font from both the alphagov/govuk_template declaration and GOV.UK Frontend declaration.
Which means that the end user will download the font twice (and it's variants) resulting in a much slower experience.

This is even more of a problem for users on a slow network since their bandwidth may already be constrained.

To avoid this we check if the user has indicated they are using GOV.UK Template by checking the relevant compatibility flag.

If they have set this flag, we avoid outputting the declarations with the assumption that they will already have them, avoiding the chance of the font being downloaded twice.

We should take care to consider how this could impact bringing the new version of the NTA font @dashouse has been working on.

Fixes #1001

## How to test this in the GOV.UK Frontend review application.

1. Add the following HTML to the `_generic.njk` template to load the GOV.UK Template font

```html
<link rel="stylesheet" media="all" href="/govuk_template/assets/stylesheets/fonts.css?0.26.0">
```

2. Set the compatibility flag for GOV.UK Template on.

3. Throttle network connection in Chrome Developer tools so and check if two fonts load.

You can do the same but changing the flag set in 2. to test the different variations.