### PR TITLE
Prevent Travis CI running when only docs change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ jobs:
   include:
     - stage: Run npm test
       script:
+      # We can skip Travis if there are only changes to files like the CHANGELOG
+      - ./bin/check-skip-ci.sh
       # Ensure Travis aborts without running tests if the package-lock.json file needs updating
-      - set -e
       - ./bin/check-package-lock.sh
       # TravisCI is slower than our local machines, so results in intermittent timeouts
       # using the `--runInBand` flag we can force it to without requiring as much

--- a/bin/check-package-lock.sh
+++ b/bin/check-package-lock.sh
@@ -4,6 +4,9 @@ echo "checking package-lock.json for changes"
 
 if git diff --exit-code --quiet package-lock.json; then
   echo "no changes have been made to package-lock.json"
+#!/bin/sh
+- set -e
+
 else
   echo "package-lock.json needs updating, run npm install with npm@5+ and commit"
   exit 1

--- a/bin/check-skip-ci.sh
+++ b/bin/check-skip-ci.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+echo "Checking if a CI run is needed post commit: ${TRAVIS_COMMIT_RANGE}"
+if ! git diff --name-only ${TRAVIS_COMMIT_RANGE} | grep -qvE '(\.md$)'
+then
+  echo "Only documentation files were updated, not running the CI."
+  exit
+fi


### PR DESCRIPTION
We trigger a lot of builds when we update CHANGELOGs.

We can detect if only markdown files have changed and avoid running Travis CI.

Based on https://reflectoring.io/skip-ci-build/

If we decide to do this we'd want to merge it and do a few quick test pull request branches to double check it still runs the tests as we expect...