### PR TITLE
Fix tabs bullet point character encoding issue when not enhanced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Fix tabs bullet point character encoding issue when not enhanced
+
+  Thanks [Ed Horsford](https://github.com/edwardhorsford) and [Steve Sims](https://github.com/stevesims) for their help on this one.
+
+  ([PR #1247](https://github.com/alphagov/govuk-frontend/pull/1247))
+
 - Update padding of govuk-main-wrapper
 
   This increases the padding of `govuk-main-wrapper` (on tablet and above) to be more inline with GOV.UK. When updating, your pages will have 10px more white space above and below the 'main' content area.

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -29,7 +29,7 @@
     margin-left: govuk-spacing(5);
 
     &::before {
-      content: "\2014 ";
+      content: "\2014 "; // "— "
       margin-left: - govuk-spacing(5);
       padding-right: govuk-spacing(1);
     }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -29,7 +29,7 @@
     margin-left: govuk-spacing(5);
 
     &::before {
-      content: "— ";
+      content: "\2014 ";
       margin-left: - govuk-spacing(5);
       padding-right: govuk-spacing(1);
     }


### PR DESCRIPTION
Will fix any issues with character encoding and is consistent with how we do this elsewhere (breadcrumbs)

I've not actually been able to replicate this, but it doesn't seem controversial to merge if the original contributor can confirm this fixes it.

Fixes #1246