### PR TITLE
Prevent wrapping of individual date inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
 
   ([PR #1265](https://github.com/alphagov/govuk-frontend/pull/1265))
 
+- Prevent wrapping of individual date inputs
+
+  Date inputs should group together as if they're a single field, this fix keeps them together using `white-space: nowrap`.
+
+  ([PR #1257](https://github.com/alphagov/govuk-frontend/pull/1257))
+
 ## 2.9.0 (Feature release)
 
 🆕 New features:

--- a/src/components/date-input/_date-input.scss
+++ b/src/components/date-input/_date-input.scss
@@ -12,12 +12,16 @@
     @include govuk-clearfix;
     // font-size: 0 removes whitespace caused by inline-block
     font-size: 0;
+    white-space: nowrap;
   }
 
   .govuk-date-input__item {
     display: inline-block;
-    margin-right: govuk-spacing(4);
     margin-bottom: 0;
+  }
+
+  .govuk-date-input__item + .govuk-date-input__item {
+    margin-left: govuk-spacing(4);
   }
 
   .govuk-date-input__label {


### PR DESCRIPTION
Date inputs should group together as if they're a single field.

This fix keeps them together using `white-space: nowrap`, and removes the stray right margin from the year (reducing component width to *200px*).

Fixes @andysellick's issue on https://github.com/alphagov/govuk-frontend/issues/1250

![Issue](https://user-images.githubusercontent.com/415517/55094728-d9caf800-50ae-11e9-8f63-a57117e9f4f6.png)