### PR TITLE
Removed macro params unused since v0.0.29-alpha

### DIFF
--- a/app/views/examples/error-messages/index.njk
+++ b/app/views/examples/error-messages/index.njk
@@ -63,7 +63,7 @@
       id: "input-1",
       name: "test-name",
       errorMessage: {
-        text: "National Insurance Number"
+        text: "Enter your National Insurance Number"
       }
     }) }}
 
@@ -171,19 +171,22 @@
         text: 'For example, 31 3 1980'
       },
       errorMessage: {
-        text: 'Error message goes here'
+        text: 'Date of birth must be in the past'
       },
       id: 'dob',
       name: 'dob',
       items:[
         {
-          name: 'day'
+          name: 'day',
+          classes: 'govuk-input--width-2 govuk-input--error'
         },
         {
-          name: 'month'
+          name: 'month',
+          classes: 'govuk-input--width-2 govuk-input--error'
         },
         {
-          name: 'year'
+          name: 'year',
+          classes: 'govuk-input--width-4 govuk-input--error'
         }
       ]
       })
@@ -201,20 +204,24 @@
         text: 'For example, 31 3 1980'
       },
       errorMessage: {
-        text: 'Day not valid'
+        text: 'Date of birth must include a day'
       },
       id: 'dob',
       name: 'dob',
       items:[
         {
           name: 'day',
-          classes: 'govuk-input--error'
+          classes: 'govuk-input--width-2 govuk-input--error'
         },
         {
-          name: 'month'
+          name: 'month',
+          value: '10',
+          classes: 'govuk-input--width-2'
         },
         {
-          name: 'year'
+          name: 'year',
+          value: '1985',
+          classes: 'govuk-input--width-4'
         }
       ]
       })

--- a/app/views/examples/error-messages/index.njk
+++ b/app/views/examples/error-messages/index.njk
@@ -54,9 +54,11 @@
 
     {{ govukInput({
       label: {
-        text: "National Insurance Number",
-        hintText: "It’s on your National Insurance card, benefit letter,
-        payslip or P60. For example, ‘QQ 12 34 56 C’."
+        text: "National Insurance Number"
+      },
+      hint: {
+        text: 'It’s on your National Insurance card, benefit letter,
+        payslip or P60. For example, ‘QQ 12 34 56 C’.'
       },
       id: "input-1",
       name: "test-name",
@@ -103,7 +105,9 @@
 
     {{ govukRadios({
       fieldset: {
-        legendHtml: "<h3 class=\"govuk-heading-m\">How do you want to be contacted?</h3>"
+        legend: {
+          text: "How do you want to be contacted?"
+        }
       },
       errorMessage: {
         text: "Please select an option"
@@ -130,7 +134,9 @@
 
     {{ govukCheckboxes({
       fieldset: {
-        legendHtml: "<h3 class=\"govuk-heading-m\">What type of waste do you want to dispose of?</h3>"
+        legend: {
+          text: "What type of waste do you want to dispose of?"
+        }
       },
       errorMessage: {
         text: "Please select an option"
@@ -157,8 +163,12 @@
 
     {{- govukDateInput({
       fieldset: {
-        legendText: 'What is your date of birth?',
-        legendHintText: 'For example, 31 3 1980'
+        legend: {
+          text: "What is your date of birth?"
+        }
+      },
+      hint: {
+        text: 'For example, 31 3 1980'
       },
       errorMessage: {
         text: 'Error message goes here'
@@ -183,8 +193,12 @@
 
     {{- govukDateInput({
       fieldset: {
-        legendText: 'What is your date of birth?',
-        legendHintText: 'For example, 31 3 1980'
+        legend: {
+          text: "What is your date of birth?"
+        }
+      },
+      hint: {
+        text: 'For example, 31 3 1980'
       },
       errorMessage: {
         text: 'Day not valid'
@@ -240,8 +254,10 @@
       id: "more-detail",
       name: "more-detail",
       label: {
-        text: "Can you provide more detail?",
-        hintText: "Don't include personal or financial information, eg your National Insurance number or credit card details."
+        text: "Can you provide more detail?"
+      },
+      hint: {
+        text: 'Don’t include personal or financial information, for example your National Insurance number or credit card details.'
       },
       "errorMessage": {
         text: "Error message goes here"

--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -71,7 +71,7 @@
       }
     ],
     errorMessage: {
-      "text": "You must provide your expiry date"
+      "text": "Enter your expiry date"
     }
     })
   }}

--- a/app/views/examples/error-summary-with-messages/index.njk
+++ b/app/views/examples/error-summary-with-messages/index.njk
@@ -35,8 +35,11 @@
 
   {{ govukInput({
     label: {
-      "html": '<h3 class="govuk-heading-m govuk-!-margin-bottom-1">Passport number</h3>',
-      "hintText": "For example, 502135326"
+      text: "Passport number",
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "For example, 502135326"
     },
     id: "passport-number",
     name: "passport-number",
@@ -47,8 +50,13 @@
 
   {{ govukDateInput({
     fieldset: {
-      legendHtml: '<h3 class="govuk-heading-m">Expiry date</h3>',
-      legendHintText: 'For example, 08 2014'
+      legend: {
+        text: 'Expiry date',
+        classes: 'govuk-fieldset__legend--m'
+      }
+    },
+    hint: {
+      text: 'For example, 08 2014'
     },
     id: 'expiry',
     name: 'expiry',

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -83,7 +83,7 @@
     <span id="radio-inline"></span>
     {{ govukRadios({
       "fieldset": {},
-      "classes": "govuk-radio--inline",
+      "classes": "govuk-radios--inline",
       "idPrefix": "radio-inline",
       "name": "radio-inline",
       "items": [

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -60,7 +60,10 @@
     <span id="radio-stacked"></span>
     {{ govukRadios({
       "fieldset": {
-        "legendHtml": "<h2 class=\"govuk-heading-l\">How do you want to be contacted?</h2>"
+        "legend": {
+          text: "How do you want to be contacted?",
+          classes: "govuk-fieldset__legend--m"
+        }
       },
       "idPrefix": "radio-stacked",
       "name": "radio-stacked",
@@ -121,12 +124,17 @@
 
     <span id="date"></span>
     {{- govukDateInput({
-      fieldset: {
-        legendText: 'What is your date of birth?',
-        legendHintText: 'For example, 31 3 1980'
+      "fieldset": {
+        "legend": {
+          "text": "What is your date of birth?",
+          "classes": "govuk-fieldset__legend--m"
+        }
       },
-      id: 'dob',
-      name: 'dob'
+      "hint": {
+        "text": "For example, 31 3 1980"
+      },
+      "id": "dob",
+      "name": "dob"
     }) -}}
 
     {% call govukFieldset() %}

--- a/app/views/full-page-examples/bank-holidays/index.njk
+++ b/app/views/full-page-examples/bank-holidays/index.njk
@@ -122,7 +122,7 @@
                 text: "Monday"
               },
               {
-                text: "	Summer bank holiday"
+                text: "Summer bank holiday"
               }
             ],
             [
@@ -1209,7 +1209,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1327,7 +1327,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1448,7 +1448,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1569,7 +1569,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1690,7 +1690,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1811,7 +1811,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -1932,7 +1932,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -2053,7 +2053,7 @@
                 text: "Monday"
               },
               {
-                text: "	St Andrew’s Day"
+                text: "St Andrew’s Day"
               }
             ],
             [
@@ -2206,7 +2206,7 @@
                 text: "Monday"
               },
               {
-                text: "	Early May bank holiday"
+                text: "Early May bank holiday"
               }
             ],
             [

--- a/app/views/full-page-examples/passport-details/index.njk
+++ b/app/views/full-page-examples/passport-details/index.njk
@@ -14,89 +14,89 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-	text: "Back"
+    text: "Back"
   }) }}
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
-	<div class="govuk-grid-column-two-thirds">
-	  {% if errorSummary.length > 0 %}
-		{{ govukErrorSummary({
-		  titleText: "There is a problem",
-		  errorList: errorSummary 
-		}) }}
-	  {% endif %}
-	  <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary.length > 0 %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
-	  <form method="post" novalidate>
+      <form method="post" novalidate>
 
-		{{ govukInput({
-		  label: {
-			text: "Passport number",
-			classes: "govuk-label--m"
-		  },
-		  hint: {
-			text: "For example, 502135326"
-		  },
-		  classes: "govuk-input--width-10",
-		  id: "passport-number",
-		  name: "passport-number",
-		  value: values["passport-number"],
-		  errorMessage: errors["passport-number"]
-		}) }}
+        {{ govukInput({
+          label: {
+            text: "Passport number",
+            classes: "govuk-label--m"
+          },
+          hint: {
+            text: "For example, 502135326"
+          },
+          classes: "govuk-input--width-10",
+          id: "passport-number",
+          name: "passport-number",
+          value: values["passport-number"],
+          errorMessage: errors["passport-number"]
+        }) }}
 
-		{% set dateInputDayClass = "govuk-input--width-2" %}
-		{% set dateInputMonthClass = "govuk-input--width-2" %}
-		{% set dateInputYearClass = "govuk-input--width-4" %}
+        {% set dateInputDayClass = "govuk-input--width-2" %}
+        {% set dateInputMonthClass = "govuk-input--width-2" %}
+        {% set dateInputYearClass = "govuk-input--width-4" %}
 
-		{% if errors["expiry-day"] %}
-			{% set dateInputDayClass = dateInputDayClass + " govuk-input--error" %}
-		{% endif %}
-		{% if errors["expiry-month"] %}
-			{% set dateInputMonthClass = dateInputMonthClass + " govuk-input--error" %}
-		{% endif %}
-		{% if errors["expiry-year"] %}
-			{% set dateInputYearClass = dateInputYearClass + " govuk-input--error" %}
-		{% endif %}
+        {% if errors["expiry-day"] %}
+          {% set dateInputDayClass = dateInputDayClass + " govuk-input--error" %}
+        {% endif %}
+        {% if errors["expiry-month"] %}
+          {% set dateInputMonthClass = dateInputMonthClass + " govuk-input--error" %}
+        {% endif %}
+        {% if errors["expiry-year"] %}
+          {% set dateInputYearClass = dateInputYearClass + " govuk-input--error" %}
+        {% endif %}
 
-		{{ govukDateInput({
-		  id: "expiry",
-		  namePrefix: "expiry",
-		  fieldset: {
-			legend: {
-			  text: "Expiry date",
-			  classes: "govuk-fieldset__legend--m"
-			}
-		  },
-		  hint: {
-			text: "For example, 31 3 1980"
-		  },
-			items: [
-				{
-					classes: dateInputDayClass,
-					name: "day",
-					value: values["expiry-day"]
-				},
-				{
-					classes: dateInputMonthClass,
-					name: "month",
-					value: values["expiry-month"]
-				},
-				{
-					classes: dateInputYearClass,
-					name: "year",
-					value: values["expiry-year"]
-				}
-			],
-		 	errorMessage: errors["expiry"]
-		}) }}
+        {{ govukDateInput({
+          id: "expiry",
+          namePrefix: "expiry",
+          fieldset: {
+            legend: {
+              text: "Expiry date",
+              classes: "govuk-fieldset__legend--m"
+            }
+          },
+          hint: {
+            text: "For example, 31 3 1980"
+          },
+          items: [
+            {
+              classes: dateInputDayClass,
+              name: "day",
+              value: values["expiry-day"]
+            },
+            {
+              classes: dateInputMonthClass,
+              name: "month",
+              value: values["expiry-month"]
+            },
+            {
+              classes: dateInputYearClass,
+              name: "year",
+              value: values["expiry-year"]
+            }
+          ],
+          errorMessage: errors["expiry"]
+        }) }}
 
-		{{ govukButton({
-		  text: "Continue"
-		}) }}
+        {{ govukButton({
+          text: "Continue"
+        }) }}
 
-	  </form>
-	</div>
+      </form>
+    </div>
   </div>
 {% endblock %}

--- a/app/views/full-page-examples/update-your-account-details/index.njk
+++ b/app/views/full-page-examples/update-your-account-details/index.njk
@@ -12,60 +12,60 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-	text: "Back"
+    text: "Back"
   }) }}
 {% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
-		<div class="govuk-grid-column-two-thirds">
-			{% if errorSummary.length > 0 %}
-			{{ govukErrorSummary({
-				titleText: "There is a problem",
-				errorList: errorSummary 
-			}) }}
-			{% endif %}
-			<h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
+    <div class="govuk-grid-column-two-thirds">
+      {% if errorSummary.length > 0 %}
+        {{ govukErrorSummary({
+          titleText: "There is a problem",
+          errorList: errorSummary
+        }) }}
+      {% endif %}
+      <h1 class="govuk-heading-xl">{{ pageTitle }}</h1>
 
-			<form method="post" novalidate>
+      <form method="post" novalidate>
 
-				{{ govukInput({
-					label: {
-						text: "Email address",
-						classes: "govuk-label--m"
-					},
-					type: "email",
-					id: "email",
-					name: "email",
-					value: values["email"],
-					errorMessage: errors["email"],
-					autocomplete: "email",
-					attributes: {
-						spellcheck: false
-					}
-				}) }}
+        {{ govukInput({
+          label: {
+            text: "Email address",
+            classes: "govuk-label--m"
+          },
+          type: "email",
+          id: "email",
+          name: "email",
+          value: values["email"],
+          errorMessage: errors["email"],
+          autocomplete: "email",
+          attributes: {
+            spellcheck: false
+          }
+        }) }}
 
-				{{ govukInput({
-					label: {
-						text: "New password",
-						classes: "govuk-label--m"
-					},
-					type: "password",
-					id: "password",
-					name: "password",
-					value: values["password"],
-					errorMessage: errors["password"],
-					autocomplete: "new-password",
-					attributes: {
-						spellcheck: false
-					}
-				}) }}
+        {{ govukInput({
+          label: {
+            text: "New password",
+            classes: "govuk-label--m"
+          },
+          type: "password",
+          id: "password",
+          name: "password",
+          value: values["password"],
+          errorMessage: errors["password"],
+          autocomplete: "new-password",
+          attributes: {
+            spellcheck: false
+          }
+        }) }}
 
-				{{ govukButton({
-					text: "Save account details"
-				}) }}
+        {{ govukButton({
+          text: "Save account details"
+        }) }}
 
-			</form>
-		</div>
+      </form>
+    </div>
   </div>
 {% endblock %}

--- a/app/views/full-page-examples/what-is-your-address/index.njk
+++ b/app/views/full-page-examples/what-is-your-address/index.njk
@@ -19,7 +19,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-		<div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds">
       <form method="post" novalidate>
         {% if errorSummary.length > 0 %}
             {{ govukErrorSummary({

--- a/docs/contributing/coding-standards/nunjucks-api.md
+++ b/docs/contributing/coding-standards/nunjucks-api.md
@@ -36,23 +36,23 @@ If a component depends on another component, we group the options for the depend
 Example of a component depending on another component
 ```
 {{ govukLabel({
-	"text": "Label text",
-	"errorMessage": {
-		"text": "Error message"
-	}
+  "text": "Label text",
+  "errorMessage": {
+    "text": "Error message"
+  }
 }) }}
 ```
 
 Example of a component depending on two other components
 ```
 {{ govukInput({
-	"name": "example-input",
-	"label": {
-		"text": "Label text"
-	},
-	"errorMessage": {
-		"text": "Error message"
-	}
+  "name": "example-input",
+  "label": {
+    "text": "Label text"
+  },
+  "errorMessage": {
+    "text": "Error message"
+  }
 }) }}
 ```
 
@@ -74,11 +74,11 @@ You cannot use this to set attributes that are already defined, such as class â€
 Example:
 ```
 {{ govukButton({
-	"attributes" : {
-	   "data-target" : "contact-by-text",
-	   "aria-labelledby": "error-summary-heading-example-1",
-	   "tabindex": "-1"
-	}
+  "attributes" : {
+    "data-target" : "contact-by-text",
+    "aria-labelledby": "error-summary-heading-example-1",
+    "tabindex": "-1"
+  }
 }) }}
 ```
 
@@ -106,13 +106,13 @@ When a component has multiple visual presentations, such default button vs start
 Default button example:
 ```
 {{ govukButton({
-	"text" : "Continue"
+  "text" : "Continue"
 }) }}
 ```
 Start button example:
 ```
 {{ govukButton({
-	"text" : "Start",
-	"classes" : "govuk-button--start"
+  "text" : "Start",
+  "classes" : "govuk-button--start"
 }) }}
 ```

--- a/src/components/fieldset/template.njk
+++ b/src/components/fieldset/template.njk
@@ -4,13 +4,13 @@
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.legend.html or params.legend.text %}
   <legend class="govuk-fieldset__legend {%- if params.legend.classes %} {{ params.legend.classes }}{% endif %}">
-  {%- if params.legend.isPageHeading %}
+  {% if params.legend.isPageHeading %}
     <h1 class="govuk-fieldset__heading">
       {{ params.legend.html | safe if params.legend.html else params.legend.text }}
     </h1>
   {% else %}
     {{ params.legend.html | safe if params.legend.html else params.legend.text }}
-  {% endif -%}
+  {% endif %}
   </legend>
   {% endif %}
 {{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}

--- a/src/components/file-upload/file-upload.yaml
+++ b/src/components/file-upload/file-upload.yaml
@@ -10,7 +10,7 @@ params:
 - name: value
   type: string
   required: false
-  description: 	Optional initial value of the input
+  description: Optional initial value of the input
 - name: label
   type: object
   required: true

--- a/src/components/radios/radios.yaml
+++ b/src/components/radios/radios.yaml
@@ -124,7 +124,7 @@ examples:
 
 - name: inline
   data:
-    idPrefix: example'
+    idPrefix: example
     classes: govuk-radios--inline
     name: example
     fieldset:
@@ -330,7 +330,7 @@ examples:
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
 - name: inline with conditional items
-  
+
   data:
     classes: govuk-radios--inline
     idPrefix: how-contacted


### PR DESCRIPTION
Some general fixes and tidy-ups.

**1. Removed unused old macro params**
A few of the examples still set `legendText`, `legendHtml`, `legendHintText`, `hintText` removed by @igloosi a little while ago. These are gone now.

**2. Fixed typo on `govuk-radio--inline` vs. `govuk-radios--inline`**
Notice the missing ‘s’

**3. Add the correct `--error` modifier to date inputs with error messages**
Just in case anyone's looking, this tripped us up recently

**4. Fixed mixed tabs and spaces**
Noticed the indentation was a bit off, this was why