### PR TITLE
Don't output an empty ul if 0 items provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 🆕 New features:
 
+- Add support for custom row classes on the summary list component (including support for some rows without action links)
+
+  ([PR #1259](https://github.com/alphagov/govuk-frontend/pull/1259))
+
 - Add new govuk-shade and govuk-tint functions for creating shades and tints of
   colours.
 
@@ -30,6 +34,16 @@
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
 🔧 Fixes:
+
+- Add various fixes to the summary list component:
+
+  1. Fixes the 1px row height change when borders are removed
+  Padding is now adjusted by 1px instead
+
+  2. Fixes the text alignment when the actions column isn't added
+  So the key column always stays at 30% width
+
+  ([PR #1259](https://github.com/alphagov/govuk-frontend/pull/1259))
 
 - Pull Request Title goes here
 

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -119,12 +119,39 @@
     border: 0;
   }
 
+  // No border on entire summary list
   .govuk-summary-list--no-border {
-    .govuk-summary-list__key,
-    .govuk-summary-list__value,
-    .govuk-summary-list__actions,
-    .govuk-summary-list__row {
+    @include govuk-media-query($until: tablet) {
+      .govuk-summary-list__row {
+        border: 0;
+      }
+    }
+
+    @include govuk-media-query($from: tablet) {
+      .govuk-summary-list__key,
+      .govuk-summary-list__value,
+      .govuk-summary-list__actions {
+        // Remove 1px border, add 1px height back on
+        padding-bottom: govuk-spacing(2) + 1px;
+        border: 0;
+      }
+    }
+  }
+
+  // No border on specific rows
+  .govuk-summary-list__row--no-border {
+    @include govuk-media-query($until: tablet) {
       border: 0;
+    }
+
+    @include govuk-media-query($from: tablet) {
+      .govuk-summary-list__key,
+      .govuk-summary-list__value,
+      .govuk-summary-list__actions {
+        // Remove 1px border, add 1px height back on
+        padding-bottom: govuk-spacing(2) + 1px;
+        border: 0;
+      }
     }
   }
 }

--- a/src/components/summary-list/_summary-list.scss
+++ b/src/components/summary-list/_summary-list.scss
@@ -80,6 +80,13 @@
     }
   }
 
+  // Expand width when value is last column (no action)
+  .govuk-summary-list__value:last-child {
+    @include govuk-media-query($from: tablet) {
+      width: 70%;
+    }
+  }
+
   .govuk-summary-list__value > p {
     margin-bottom: govuk-spacing(2);
   }

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -196,6 +196,32 @@ examples:
                 Address line 4<br>
                 Address line 5
               </p>
+  - name: no-border on last row
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+          classes: govuk-summary-list__row--no-border
   - name: overridden-widths
     data:
       rows:

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -112,13 +112,46 @@ examples:
               - href: '#'
                 text: Change
                 visuallyHiddenText: contact information
-  - name: no-actions
+  - name: without actions
     data:
       rows:
         - key:
             text: Name
           value:
             text: Firstname Lastname
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+  - name: with some actions
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
+            items:
+              - href: '#'
+                text: Edit
+                visuallyHiddenText: name
+              - href: '#'
+                text: Delete
+                visuallyHiddenText: name
         - key:
             text: Date of birth
           value:

--- a/src/components/summary-list/template.njk
+++ b/src/components/summary-list/template.njk
@@ -15,7 +15,7 @@
 
 <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for row in params.rows %}
-    <div class="govuk-summary-list__row">
+    <div class="govuk-summary-list__row {%- if row.classes %} {{ row.classes }}{% endif %}">
       <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
         {{ row.key.html | safe if row.key.html else row.key.text }}
       </dt>

--- a/src/components/summary-list/template.njk
+++ b/src/components/summary-list/template.njk
@@ -19,7 +19,7 @@
         <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
           {% if row.actions.items.length == 1 %}
             {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
-          {% else %}
+          {% elseif row.actions.items.length > 1 %}
             <ul class="govuk-summary-list__actions-list">
               {% for action in row.actions.items %}
                 <li class="govuk-summary-list__actions-list-item">

--- a/src/components/summary-list/template.njk
+++ b/src/components/summary-list/template.njk
@@ -6,6 +6,13 @@
     {% endif -%}
   </a>
 {% endmacro -%}
+
+{# Determine if we need 2 or 3 columns #}
+{% set anyRowHasActions = false %}
+{% for row in params.rows %}
+  {% set anyRowHasActions = true if row.actions.items else anyRowHasActions %}
+{% endfor -%}
+
 <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for row in params.rows %}
     <div class="govuk-summary-list__row">
@@ -15,11 +22,11 @@
       <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
         {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
       </dd>
-      {% if row.actions.items %}
+      {% if row.actions.items.length %}
         <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
           {% if row.actions.items.length == 1 %}
             {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
-          {% elseif row.actions.items.length > 1 %}
+          {% else %}
             <ul class="govuk-summary-list__actions-list">
               {% for action in row.actions.items %}
                 <li class="govuk-summary-list__actions-list-item">
@@ -29,6 +36,9 @@
             </ul>
           {% endif %}
         </dd>
+      {% elseif anyRowHasActions %}
+        {# Add dummy column to extend border #}
+        <span class="govuk-summary-list__actions"></span>
       {% endif %}
     </div>
   {% endfor %}

--- a/src/components/summary-list/template.test.js
+++ b/src/components/summary-list/template.test.js
@@ -317,6 +317,66 @@ describe('Data list', () => {
 
         expect($action.hasClass('govuk-link--no-visited-state')).toBeTruthy()
       })
+      it('skips the action column when none are provided', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                text: 'Name'
+              },
+              value: {
+                text: 'Firstname Lastname'
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $action = $component.find('.govuk-summary-list__actions')
+
+        expect($action.length).toEqual(0)
+      })
+      it('adds dummy action columns when only some rows have actions', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              key: {
+                text: 'Name'
+              },
+              value: {
+                text: 'Firstname Lastname'
+              }
+            },
+            {
+              key: {
+                text: 'Name'
+              },
+              value: {
+                text: 'Firstname Lastname'
+              },
+              actions: {
+                items: [
+                  {
+                    href: '#',
+                    text: 'First action'
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $action = $component.find('.govuk-summary-list__actions')
+
+        // First action column is a dummy
+        expect($action[0].tagName).toEqual('span')
+        expect($($action[0]).text()).toEqual('')
+
+        // Second action column contains link text
+        expect($action[1].tagName).toEqual('dd')
+        expect($($action[1]).text()).toContain('First action')
+      })
     })
   })
 })

--- a/src/components/summary-list/template.test.js
+++ b/src/components/summary-list/template.test.js
@@ -44,6 +44,22 @@ describe('Data list', () => {
     expect($component.attr('data-attribute-2')).toEqual('value-2')
   })
   describe('rows', () => {
+    it('renders classes', async () => {
+      const $ = render('summary-list', {
+        rows: [
+          {
+            key: {
+              text: 'Name'
+            },
+            classes: 'app-custom-class'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-summary-list')
+      const $row = $component.find('.govuk-summary-list__row')
+      expect($row.hasClass('app-custom-class')).toBeTruthy()
+    })
     describe('keys', () => {
       it('renders text', async () => {
         const $ = render('summary-list', {


### PR DESCRIPTION
I need to provide an empty action option so that I don't get weird gaps like this: 
![Screenshot 2019-03-28 at 12 23 55](https://user-images.githubusercontent.com/2204224/55159804-c6c13200-5159-11e9-902f-92d8a06a6136.png)

You can fix this by providing an empty action.items - but right now this results in an empty ul. This pr doesn't spit out the ul if there's 0 items.

NB: untested!