### PR TITLE
Ability to group radio buttons / checkboxes within sub-headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 
   ([PR #1281](https://github.com/alphagov/govuk-frontend/pull/1281))
 
+- Ability to group radio buttons/checkboxes within sub-headings
+
+  New form examples have been added to show multiple lists of radio buttons and checkboxes within a wrapping `govukFormGroup()`.
+
+  The conditional reveal now works across these groups, not just single lists.
+
+  ([PR #1266](https://github.com/alphagov/govuk-frontend/pull/1266))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
+- Remove duplicate form field markup from each macro
+
+  All form fields are now wrapped in `govukFormGroup()` to generate the appropriate hint, error message, fieldset and legend (or label).
+
+  ([PR #1281](https://github.com/alphagov/govuk-frontend/pull/1281))
+
 🔧 Fixes:
 
 - Pull Request Title goes here

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -116,7 +116,13 @@
         },
         {
           "value": "c",
-          "text": "Option C"
+          "text": "Option C",
+          "hint": {
+            "text": "Including conditional reveal"
+          },
+          "conditional": {
+            "html": '<p class="govuk-body">This message should hide when other group radios are checked</p>'
+          }
         }
       ]
     }) }}
@@ -141,7 +147,13 @@
         },
         {
           "value": "c",
-          "text": "Option C"
+          "text": "Option C",
+          "hint": {
+            "text": "Including conditional reveal"
+          },
+          "conditional": {
+            "html": '<p class="govuk-body">This message should hide when other group radios are checked</p>'
+          }
         }
       ]
     }) }}
@@ -166,7 +178,13 @@
         },
         {
           "value": "c",
-          "text": "Option C"
+          "text": "Option C",
+          "hint": {
+            "text": "Including conditional reveal"
+          },
+          "conditional": {
+            "html": '<p class="govuk-body">This message should hide when other group radios are checked</p>'
+          }
         }
       ]
     }) }}

--- a/app/views/examples/form-elements/index.njk
+++ b/app/views/examples/form-elements/index.njk
@@ -1,4 +1,5 @@
 {% from "back-link/macro.njk" import govukBackLink %}
+{% from "form-group/macro.njk" import govukFormGroup %}
 {% from "fieldset/macro.njk" import govukFieldset %}
 {% from "input/macro.njk" import govukInput %}
 {% from "button/macro.njk" import govukButton %}
@@ -23,8 +24,10 @@
     <li><a href="#input" class="govuk-link">Label and text input</a></li>
     <li><a href="#textarea" class="govuk-link">Label and textarea</a></li>
     <li><a href="#radio-stacked" class="govuk-link">Fieldset, legend and radio buttons (stacked)</a></li>
+    <li><a href="#radio-stacked-sub-headings" class="govuk-link">Fieldset, legend and radio buttons with sub-headings (stacked)</a></li>
     <li><a href="#radio-inline" class="govuk-link">Fieldset, legend and radio buttons (inline - yes or no)</a></li>
     <li><a href="#checkboxes-stacked" class="govuk-link">Fieldset, legend and checkboxes (stacked)</a></li>
+    <li><a href="#checkboxes-stacked-sub-headings" class="govuk-link">Fieldset, legend and checkboxes with sub-headings (stacked)</a></li>
     <li><a href="#date" class="govuk-link">Date pattern</a></li>
     <li><a href="#select" class="govuk-link">Select box</a></li>
     <li><a href="#file" class="govuk-link">File upload</a></li>
@@ -83,6 +86,93 @@
       ]
     }) }}
 
+    <span id="radio-stacked-sub-headings"></span>
+    {% call govukFormGroup({
+      fieldset: {
+        legend: {
+          text: "Pick one of the following options:",
+          classes: "govuk-fieldset__legend--m"
+        }
+      }
+    }) %}
+
+    {{ govukRadios({
+      "fieldset": {
+        "legend": {
+          text: "Group 1",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "radio-stacked-sub-headings-group-1",
+      "name": "radio-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {{ govukRadios({
+      "fieldset": {
+        "legend": {
+          text: "Group 2",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "radio-stacked-sub-headings-group-2",
+      "name": "radio-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {{ govukRadios({
+      "fieldset": {
+        "legend": {
+          text: "Group 3",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "radio-stacked-sub-headings-group-3",
+      "name": "radio-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {% endcall %}
+
     <span id="radio-inline"></span>
     {{ govukRadios({
       "fieldset": {},
@@ -121,6 +211,94 @@
         }
       ]
     }) }}
+
+    <span id="checkboxes-stacked-sub-headings"></span>
+    {% call govukFormGroup({
+      id: "checkboxes-stacked-sub-headings",
+      fieldset: {
+        legend: {
+          text: "Which of the following apply?",
+          classes: "govuk-fieldset__legend--m"
+        }
+      }
+    }) %}
+
+    {{ govukCheckboxes({
+      "fieldset": {
+        "legend": {
+          text: "Group 1",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "checkboxes-stacked-sub-headings-group-1",
+      "name": "checkboxes-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {{ govukCheckboxes({
+      "fieldset": {
+        "legend": {
+          text: "Group 2",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "checkboxes-stacked-sub-headings-group-2",
+      "name": "checkboxes-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {{ govukCheckboxes({
+      "fieldset": {
+        "legend": {
+          text: "Group 3",
+          classes: "govuk-fieldset__legend--s"
+        }
+      },
+      "idPrefix": "checkboxes-stacked-sub-headings-group-3",
+      "name": "checkboxes-stacked-sub-headings",
+      "items": [
+        {
+          "value": "a",
+          "text": "Option A"
+        },
+        {
+          "value": "b",
+          "text": "Option B"
+        },
+        {
+          "value": "c",
+          "text": "Option C"
+        }
+      ]
+    }) }}
+
+    {% endcall %}
 
     <span id="date"></span>
     {{- govukDateInput({

--- a/src/components/_all.scss
+++ b/src/components/_all.scss
@@ -12,6 +12,7 @@
 @import "fieldset/fieldset";
 @import "file-upload/file-upload";
 @import "footer/footer";
+@import "form-group/form-group";
 @import "hint/hint";
 @import "header/header";
 @import "input/input";

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -1,15 +1,21 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../form-group/macro.njk" import govukFormGroup %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
-{% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
+{%- set idPrefix = params.idPrefix if params.idPrefix else params.name -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{%- set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" -%}
+
+{%- if params.hint -%}
+  {%- set describedBy = (describedBy + ' ' + idPrefix + "-hint") | trim -%}
+{%- endif -%}
+{%- if params.errorMessage -%}
+  {%- set describedBy = (describedBy + ' ' + idPrefix + "-error") | trim -%}
+{%- endif -%}
 
 {% set isConditional = false %}
 {% for item in params.items %}
@@ -19,33 +25,16 @@
 {% endfor %}
 
 {#- fieldset is false by default -#}
-{% set hasFieldset = true if params.fieldset else false %}
+{%- set hasFieldset = true if params.fieldset else false -%}
 
-{#- Capture the HTML so we can optionally nest it in a fieldset -#}
-{% set innerHtml %}
-{% if params.hint %}
-  {% set hintId = idPrefix + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = idPrefix + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{% call govukFormGroup({
+  id: idPrefix,
+  fieldset: params.fieldset,
+  hint: params.hint,
+  label: params.label,
+  errorMessage: params.errorMessage,
+  formGroup: params.formGroup
+}) %}
   <div class="govuk-checkboxes {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="checkboxes"{% endif -%}>
@@ -71,7 +60,7 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
-      {%- if hasHint %}
+      {% if hasHint %}
       {{ govukHint({
         id: itemHintId,
         classes: 'govuk-checkboxes__hint',
@@ -88,19 +77,4 @@
     {% endif %}
     {% endfor %}
   </div>
-{% endset -%}
-
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-{% if params.fieldset %}
-  {% call govukFieldset({
-    describedBy: describedBy,
-    classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
-</div>
+{% endcall %}

--- a/src/components/date-input/template.njk
+++ b/src/components/date-input/template.njk
@@ -1,11 +1,5 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../fieldset/macro.njk" import govukFieldset %}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../input/macro.njk" import govukInput %}
-
-{#- a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
+{% from "../form-group/macro.njk" import govukFormGroup %}
+{% from "../label/macro.njk" import govukLabel %}
 
 {% if params.items %}
   {% set dateInputItems = params.items %}
@@ -26,72 +20,37 @@
   ] %}
 {% endif %}
 
-{#- Capture the HTML so we can optionally nest it in a fieldset -#}
-{% set innerHtml %}
-{% if params.hint %}
-  {% set hintId = params.id + "-hint" %}
-  {% set describedBy = describedBy + " " + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + "-error" %}
-  {% set describedBy = describedBy + " " + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{#- We override the fieldset's role to 'group' because otherwise JAWS does not
+    announce the description for a fieldset comprised of text inputs, but
+    adding the role to the fieldset always makes the output overly verbose for
+    radio buttons or checkboxes. -#}
+{% call govukFormGroup({
+  id: params.id,
+  fieldset: {
+    attributes: {
+      role: "group"
+    },
+    legend: params.fieldset.legend
+  },
+  hint: params.hint,
+  errorMessage: params.errorMessage,
+  formGroup: params.formGroup
+}) %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
     {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {%- if params.id %} id="{{ params.id }}"{% endif %}>
     {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
-      {{ govukInput({
-        label: {
-          text: item.label if item.label else item.name | capitalize,
-          classes: "govuk-date-input__label"
-        },
-        id: item.id if item.id else (params.id + "-" + item.name),
-        classes: "govuk-date-input__input " + (item.classes if item.classes),
-        name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
-        value: item.value,
-        type: "number",
-        autocomplete: item.autocomplete,
-        pattern: item.pattern if item.pattern else "[0-9]*",
-        attributes: item.attributes
-      }) | indent(6) | trim }}
+      {{ govukLabel({
+        text: item.label if item.label else item.name | capitalize,
+        classes: "govuk-date-input__label",
+        for: item.id if item.id else (params.id + "-" + item.name)
+      }) | indent(4) | trim }}
+      <input class="govuk-input govuk-date-input__input {%- if item.classes %} {{ item.classes }}{% endif %}" id="{{ item.id if item.id else (params.id + '-' + item.name) }}" name="{{ (params.namePrefix + '-' + item.name) if params.namePrefix else item.name }}" type="number" pattern="{{ item.pattern if item.pattern else '[0-9]*' }}"
+      {%- if item.value %} value="{{ item.value }}"{% endif %}
+      {%- if item.autocomplete %} autocomplete="{{ item.autocomplete}}"{% endif %}
+      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
     </div>
   {% endfor %}
   </div>
-{% endset %}
-
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-{% if params.fieldset %}
-{#- We override the fieldset's role to 'group' because otherwise JAWS does not
-    announce the description for a fieldset comprised of text inputs, but
-    adding the role to the fieldset always makes the output overly verbose for
-    radio buttons or checkboxes. -#}
-  {% call govukFieldset({
-    describedBy: describedBy,
-    classes: params.fieldset.classes,
-    attributes: {
-      role: "group"
-    },
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
-</div>
+{% endcall %}

--- a/src/components/file-upload/template.njk
+++ b/src/components/file-upload/template.njk
@@ -1,44 +1,19 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../form-group/macro.njk" import govukFormGroup -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{%- set describedBy = "" -%}
+
+{%- if params.hint -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-hint") | trim -%}
+{%- endif -%}
+{%- if params.errorMessage -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-error") | trim -%}
+{%- endif -%}
+
+{% call govukFormGroup(params) %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-</div>
+{% endcall %}

--- a/src/components/form-group/README.md
+++ b/src/components/form-group/README.md
@@ -1,0 +1,15 @@
+# Form group
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the form group component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/form-group).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/form-group/#options-example-default) for details.

--- a/src/components/form-group/_form-group.scss
+++ b/src/components/form-group/_form-group.scss
@@ -1,8 +1,8 @@
-@import "../settings/all";
-@import "../tools/all";
-@import "../helpers/all";
+@import "../../settings/all";
+@import "../../tools/all";
+@import "../../helpers/all";
 
-@include govuk-exports("govuk/objects/form-group") {
+@include govuk-exports("govuk/component/form-group") {
 
   .govuk-form-group {
     @include govuk-clearfix;

--- a/src/components/form-group/form-group.yaml
+++ b/src/components/form-group/form-group.yaml
@@ -1,0 +1,66 @@
+params:
+- name: id
+  type: string
+  required: true
+  description: The id of the input
+- name: fieldset
+  type: object
+  required: false
+  description: Options for the fieldset component (e.g. legend).
+  isComponent: true
+- name: hint
+  type: object
+  required: false
+  description: Options for the hint component.
+  isComponent: true
+- name: label
+  type: object
+  required: false
+  description: Options for the label component if no fieldset is provided.
+  isComponent: true
+- name: errorMessage
+  type: object
+  required: false
+  description: Options for the errorMessage component.
+  isComponent: true
+- name: formGroup
+  type: object
+  required: false
+  description: Options for the form-group wrapper.
+  params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the form group (e.g. to show error state for the whole group)
+- name: caller
+  type: nunjucks-block
+  required: false
+  description: Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire form group component in a `call` block.
+
+examples:
+- name: default
+  data:
+    id: address
+    label:
+      text: What is your address?
+- name: with label as page heading
+  data:
+    id: address-heading
+    label:
+      text: What is your address?
+      classes: govuk-label--xl
+      isPageHeading: true
+- name: with fieldset legend
+  data:
+    id: address-fieldset
+    fieldset:
+      legend:
+        text: What is your address?
+- name: with fieldset legend as page heading
+  data:
+    id: address-fieldset-heading
+    fieldset:
+      legend:
+        text: What is your address?
+        classes: govuk-fieldset__legend--xl
+        isPageHeading: true

--- a/src/components/form-group/macro.njk
+++ b/src/components/form-group/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukFormGroup(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/components/form-group/template.njk
+++ b/src/components/form-group/template.njk
@@ -1,0 +1,62 @@
+{% from "../error-message/macro.njk" import govukErrorMessage -%}
+{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../hint/macro.njk" import govukHint %}
+{% from "../label/macro.njk" import govukLabel %}
+
+{#- a record of other elements that we need to associate with the input using
+   aria-describedby – for example hints or error messages -#}
+{%- set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" -%}
+
+{#- Capture the HTML so we can optionally nest it in a fieldset -#}
+{%- set innerHtml %}
+{% if params.label and not params.fieldset %}
+  {{ govukLabel({
+    html: params.label.html,
+    text: params.label.text,
+    classes: params.label.classes,
+    isPageHeading: params.label.isPageHeading,
+    attributes: params.label.attributes,
+    for: params.id
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+  {{ govukHint({
+    id: hintId,
+    classes: params.hint.classes,
+    attributes: params.hint.attributes,
+    html: params.hint.html,
+    text: params.hint.text
+  }) | indent(2) | trim }}
+{% endif %}
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+  {{ govukErrorMessage({
+    id: errorId,
+    classes: params.errorMessage.classes,
+    attributes: params.errorMessage.attributes,
+    html: params.errorMessage.html,
+    text: params.errorMessage.text,
+    visuallyHiddenText: params.errorMessage.visuallyHiddenText
+  }) | indent(2) | trim }}
+{% endif %}
+{% endset %}
+
+<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
+{% if params.fieldset %}
+  {% call govukFieldset({
+    describedBy: describedBy,
+    classes: params.fieldset.classes,
+    attributes: params.fieldset.attributes,
+    legend: params.fieldset.legend
+  }) %}
+  {{ innerHtml | trim | safe }}
+{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
+  {% endcall %}
+{% else %}
+  {{ innerHtml | trim | safe }}
+{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
+{% endif %}
+</div>

--- a/src/components/form-group/template.test.js
+++ b/src/components/form-group/template.test.js
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../lib/jest-helpers')
+
+const examples = getExamples('form-group')
+
+describe('Form group', () => {
+  it('passes accessibility tests', async () => {
+    const $ = render('form-group', examples.default)
+
+    const results = await axe($.html())
+    expect(results).toHaveNoViolations()
+  })
+
+  it('creates a form group', () => {
+    const $ = render('form-group', {
+      id: 'sample-question'
+    })
+
+    const $component = $('div.govuk-form-group')
+    expect($component.get(0).tagName).toContain('div')
+  })
+
+  it('allows you to set the legend text', () => {
+    const $ = render('form-group', {
+      id: 'sample-question',
+      fieldset: {
+        legend: {
+          text: 'What is your address?'
+        }
+      }
+    })
+
+    const $legend = $('div.govuk-form-group legend')
+    expect($legend.get(0).tagName).toContain('legend')
+  })
+
+  it('allows you to set the hint text', () => {
+    const $ = render('form-group', {
+      id: 'sample-question',
+      hint: {
+        text: 'Example hint about the address'
+      }
+    })
+
+    const $hint = $('div.govuk-form-group span.govuk-hint')
+    expect($hint.text().trim()).toEqual('Example hint about the address')
+  })
+
+  it('allows you to set the label text', () => {
+    const $ = render('form-group', {
+      id: 'sample-question',
+      label: {
+        text: 'What is your address?'
+      }
+    })
+
+    const $label = $('div.govuk-form-group label')
+    expect($label.text().trim()).toEqual('What is your address?')
+  })
+
+  it('allows you to set the error message text', () => {
+    const $ = render('form-group', {
+      id: 'sample-question',
+      errorMessage: {
+        text: 'Something is wrong with this field'
+      }
+    })
+
+    const $error = $('div.govuk-form-group span.govuk-error-message')
+    expect($error.text().trim()).toEqual('Error: Something is wrong with this field')
+  })
+
+  it('renders nested components using `call`', () => {
+    const $ = render('form-group', {}, '<div class="app-nested-component"></div>')
+
+    expect($('.govuk-form-group .app-nested-component').length).toBeTruthy()
+  })
+
+  it('can have additional classes on the form group', () => {
+    const $ = render('form-group', {
+      formGroup: {
+        classes: 'my-custom-class'
+      }
+    })
+
+    const $component = $('div.govuk-form-group')
+    expect($component.hasClass('my-custom-class')).toBeTruthy()
+  })
+})

--- a/src/components/input/template.njk
+++ b/src/components/input/template.njk
@@ -1,46 +1,22 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../form-group/macro.njk" import govukFormGroup -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{%- set describedBy = "" -%}
+
+{%- if params.hint -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-hint") | trim -%}
+{%- endif -%}
+{%- if params.errorMessage -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-error") | trim -%}
+{%- endif -%}
+
+{% call govukFormGroup(params) %}
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
-</div>
+{% endcall %}
+

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -1,15 +1,23 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
 import '../../vendor/polyfills/Element/prototype/classList'
+import '../../vendor/polyfills/Element/prototype/closest'
 import { nodeListForEach } from '../../common'
 
 function Radios ($module) {
   this.$module = $module
-  this.$inputs = $module.querySelectorAll('input[type="radio"]')
+
+  // Find optional parent group
+  var $wrapper = $module.closest('.govuk-form-group')
+  var $parentWrapper = $wrapper && $wrapper.parentNode.closest('.govuk-form-group')
+
+  // Add radios in optional wrappers up to one level higher
+  this.$formGroup = $parentWrapper || $wrapper || $module
+  this.$inputs = this.$formGroup.querySelectorAll('input[type="radio"]')
 }
 
 Radios.prototype.init = function () {
-  var $module = this.$module
+  var $formGroup = this.$formGroup
   var $inputs = this.$inputs
 
   /**
@@ -22,7 +30,7 @@ Radios.prototype.init = function () {
 
     // Check if input controls anything
     // Check if content exists, before setting attributes.
-    if (!controls || !$module.querySelector('#' + controls)) {
+    if (!controls || !$formGroup.querySelector('#' + controls)) {
       return
     }
 
@@ -33,14 +41,14 @@ Radios.prototype.init = function () {
   }.bind(this))
 
   // Handle events
-  $module.addEventListener('click', this.handleClick.bind(this))
+  $formGroup.addEventListener('click', this.handleClick.bind(this))
 }
 
 Radios.prototype.setAttributes = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
-  var $content = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $content = this.$formGroup.querySelector('#' + $input.getAttribute('aria-controls'))
   if ($content) {
     $content.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
   }

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -1,15 +1,10 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../fieldset/macro.njk" import govukFieldset %}
+{% from "../form-group/macro.njk" import govukFormGroup %}
 {% from "../hint/macro.njk" import govukHint %}
 {% from "../label/macro.njk" import govukLabel %}
 
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
 {% set idPrefix = params.idPrefix if params.idPrefix else params.name %}
-
-{#- a record of other elements that we need to associate with the input using
-   aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
 
 {% set isConditional = false %}
 {% for item in params.items %}
@@ -18,31 +13,14 @@
   {% endif %}
 {% endfor %}
 
-{#- Capture the HTML so we can optionally nest it in a fieldset -#}
-{% set innerHtml %}
-{% if params.hint %}
-  {% set hintId = idPrefix + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = idPrefix + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{% call govukFormGroup({
+  id: idPrefix,
+  fieldset: params.fieldset,
+  hint: params.hint,
+  label: params.label,
+  errorMessage: params.errorMessage,
+  formGroup: params.formGroup
+}) %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}{%- if isConditional %} govuk-radios--conditional{% endif -%}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="radios"{% endif -%}>
@@ -68,7 +46,7 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
-      {%- if hasHint %}
+      {% if hasHint %}
       {{ govukHint({
         id: itemHintId,
         classes: 'govuk-radios__hint',
@@ -86,19 +64,4 @@
     {% endif %}
     {% endfor %}
   </div>
-{% endset -%}
-
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-{% if params.fieldset %}
-  {% call govukFieldset({
-    describedBy: describedBy,
-    classes: params.fieldset.classes,
-    attributes: params.fieldset.attributes,
-    legend: params.fieldset.legend
-  }) %}
-  {{ innerHtml | trim | safe }}
-  {% endcall %}
-{% else %}
-  {{ innerHtml | trim | safe }}
-{% endif %}
-</div>
+{% endcall %}

--- a/src/components/select/template.njk
+++ b/src/components/select/template.njk
@@ -1,42 +1,17 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../form-group/macro.njk" import govukFormGroup -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{%- set describedBy = "" -%}
+
+{%- if params.hint -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-hint") | trim -%}
+{%- endif -%}
+{%- if params.errorMessage -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-error") | trim -%}
+{%- endif -%}
+
+{% call govukFormGroup(params) %}
   <select class="govuk-select
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
@@ -46,4 +21,4 @@
       {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>{{ item.text }}</option>
   {% endfor %}
   </select>
-</div>
+{% endcall %}

--- a/src/components/textarea/template.njk
+++ b/src/components/textarea/template.njk
@@ -1,44 +1,19 @@
-{% from "../error-message/macro.njk" import govukErrorMessage -%}
-{% from "../hint/macro.njk" import govukHint %}
-{% from "../label/macro.njk" import govukLabel %}
+{% from "../form-group/macro.njk" import govukFormGroup -%}
 
 {#- a record of other elements that we need to associate with the input using
    aria-describedby – for example hints or error messages -#}
-{% set describedBy = "" %}
-<div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
-  {{ govukLabel({
-    html: params.label.html,
-    text: params.label.text,
-    classes: params.label.classes,
-    isPageHeading: params.label.isPageHeading,
-    attributes: params.label.attributes,
-    for: params.id
-  }) | indent(2) | trim }}
-{% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
-  {{ govukHint({
-    id: hintId,
-    classes: params.hint.classes,
-    attributes: params.hint.attributes,
-    html: params.hint.html,
-    text: params.hint.text
-  }) | indent(2) | trim }}
-{% endif %}
-{% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
-  {{ govukErrorMessage({
-    id: errorId,
-    classes: params.errorMessage.classes,
-    attributes: params.errorMessage.attributes,
-    html: params.errorMessage.html,
-    text: params.errorMessage.text,
-    visuallyHiddenText: params.errorMessage.visuallyHiddenText
-  }) | indent(2) | trim }}
-{% endif %}
+{%- set describedBy = "" -%}
+
+{%- if params.hint -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-hint") | trim -%}
+{%- endif -%}
+{%- if params.errorMessage -%}
+  {%- set describedBy = (describedBy + ' ' + params.id + "-error") | trim -%}
+{%- endif -%}
+
+{% call govukFormGroup(params) %}
   <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>
-</div>
+{% endcall %}

--- a/src/objects/_all.scss
+++ b/src/objects/_all.scss
@@ -1,4 +1,3 @@
-@import "form-group";
 @import "grid";
 @import "main-wrapper";
 @import "width-container";


### PR DESCRIPTION
This feature adds a new macro `govukFormGroup()`.

This lets us put radios/checkboxes inside a `<div class="govuk-form-group">` wrapper, nested to multiple levels with the `describedBy` variable to be persisted and appended to at each level.

It also allows the component examples to show both regular and fieldset-wrapped variations using the optional `params.fieldset`, useful to confirm bugs like https://github.com/alphagov/govuk-frontend/issues/1264

![Form group](https://user-images.githubusercontent.com/415517/55387663-be863f80-5529-11e9-9fa5-453c9dd978a1.png)

### Why else is it needed?
I've also addressed what looks like a bit of technical debt.

Duplicated inside almost all form control macros is Nunjucks code to generate a `govukLabel()` label, a `govukHint()` hint an a `govukErrorMessage()` error message.

This code here is pretty much copy and pasted 7 times:

```nunjucks
  {{ govukLabel({
    html: params.label.html,
    text: params.label.text,
    classes: params.label.classes,
    isPageHeading: params.label.isPageHeading,
    attributes: params.label.attributes,
    for: params.id
  }) | indent(2) | trim }}
{% if params.hint %}
  {% set hintId = params.id + '-hint' %}
  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
  {{ govukHint({
    id: hintId,
    classes: params.hint.classes,
    attributes: params.hint.attributes,
    html: params.hint.html,
    text: params.hint.text
  }) | indent(2) | trim }}
{% endif %}
{% if params.errorMessage %}
  {% set errorId = params.id + '-error' %}
  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
  {{ govukErrorMessage({
    id: errorId,
    classes: params.errorMessage.classes,
    attributes: params.errorMessage.attributes,
    html: params.errorMessage.html,
    text: params.errorMessage.text,
    visuallyHiddenText: params.errorMessage.visuallyHiddenText
  }) | indent(2) | trim }}
{% endif %}
```

It's used by textarea, select, radios, checkboxes, text input, file upload and date input.

All this boilerplate code is now handled by `govukFormGroup()`.