### PR TITLE
Ensure fieldset never exceeds max-width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@
 
   ([PR #1265](https://github.com/alphagov/govuk-frontend/pull/1265))
 
+- Ensure fieldset never exceeds max-width
+
+  This fix ensures that both WebKit/Blink and Firefox are prevented from expanding their fieldset widths to the content's minimum size.
+
+  This was preventing `max-width: 100%` from being applied to select menus inside a fieldset.
+
+  See discussion in ["Reset your fieldset"](https://thatemil.com/blog/2015/01/03/reset-your-fieldset/) and raised by [issue #1264](https://github.com/alphagov/govuk-frontend/issues/1264)
+
+  ([PR #1269](https://github.com/alphagov/govuk-frontend/pull/1269))
+
 ## 2.9.0 (Feature release)
 
 🆕 New features:

--- a/src/components/fieldset/_fieldset.scss
+++ b/src/components/fieldset/_fieldset.scss
@@ -4,10 +4,20 @@
 
 @include govuk-exports("govuk/component/fieldset") {
   .govuk-fieldset {
+    min-width: 0;
     margin: 0;
     padding: 0;
     border: 0;
     @include govuk-clearfix;
+  }
+
+  // Fix for Firefox < 53
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=504622
+  @supports not (caret-color: auto) {
+    .govuk-fieldset,
+    x:-moz-any-link {
+      display: table-cell;
+    }
   }
 
   .govuk-fieldset__legend {


### PR DESCRIPTION
This fix ensures that both WebKit/Blink and Firefox are prevented from expanding their fieldset widths to the content's minimum size.

**Online demo**
https://tourmaline-spoonbill.glitch.me/

This was preventing `max-width: 100%` from being applied to select menus inside a fieldset. There's further discussion in ["Reset your fieldset"](https://thatemil.com/blog/2015/01/03/reset-your-fieldset/) and raised by @kr8n3r in [issue #1264](https://github.com/alphagov/govuk-frontend/issues/1264).

Due to Firefox's legacy fieldset behaviour, I've also added a workaround for Firefox < 53.

```scss
// Fix for Firefox < 53
// https://bugzilla.mozilla.org/show_bug.cgi?id=504622
@supports not (caret-color: auto) {
  .govuk-fieldset,
  x:-moz-any-link {
    display: table-cell;
  }
}
```

It uses `x:-moz-any-link` to make the snippet Firefox-only, but with `@supports not (caret-color: auto)` to exclude Firefox >= 53 when _caret-color_ support was added.

![Firefox 52](https://user-images.githubusercontent.com/415517/55635196-0ae6af00-57b8-11e9-99dc-7d217a5ce757.png)

