### PR TITLE
Conditionally load in legacy stylesheets along with govuk-frontend

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -71,6 +71,17 @@ module.exports = (options) => {
   // Handle the banner component serverside.
   require('./banner.js')(app)
 
+  // Define middleware for all routes
+  app.use('*', function (request, response, next) {
+    response.locals.legacy = request.query['legacy'] === '1'
+    if (response.locals.legacy) {
+      response.locals.legacy_query = '?legacy=1'
+    } else {
+      response.locals.legacy_query = ''
+    }
+    next()
+  })
+
   // Define routes
 
   // Index page - render the component list template

--- a/app/app.js
+++ b/app/app.js
@@ -75,9 +75,9 @@ module.exports = (options) => {
   app.use('*', function (request, response, next) {
     response.locals.legacy = request.query['legacy'] === '1'
     if (response.locals.legacy) {
-      response.locals.legacy_query = '?legacy=1'
+      response.locals.legacyQuery = '?legacy=1'
     } else {
-      response.locals.legacy_query = ''
+      response.locals.legacyQuery = ''
     }
     next()
   })

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -13,28 +13,26 @@
     <link rel="stylesheet" media="all" href="/vendor/govuk_template/fonts.css"/>
     <!--[if !IE 8]><!-->
       <link rel="stylesheet" href="/public/app-legacy.css">
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
     <!--<![endif]-->
     <!--[if IE 8]>
       <link rel="stylesheet" href="/public/app-legacy-ie8.css">
     <![endif]-->
-    <!--[if lt IE 9]>
-      <script src="/vendor/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
   {% else %}
     <!--[if !IE 8]><!-->
       <link rel="stylesheet" href="/public/app.css">
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
     <!--<![endif]-->
     <!--[if IE 8]>
       <link rel="stylesheet" href="/public/app-ie8.css">
     <![endif]-->
-    <!--[if lt IE 9]>
-      <script src="/vendor/html5-shiv/html5shiv.js"></script>
-    <![endif]-->
   {% endif %}
+
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
+  <!--<![endif]-->
+  <!--[if lt IE 9]>
+    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+  <![endif]-->
 
   {% block styles %}{% endblock %}
 {% endblock %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -1,17 +1,40 @@
 {% extends "template.njk" %}
 
 {% block head %}
-  <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/public/app.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
-  <!--<![endif]-->
-  <!--[if IE 8]>
-    <link rel="stylesheet" href="/public/app-ie8.css">
-  <![endif]-->
-  <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
+
+  {% if legacy %}
+    <!--[if !IE 8]><!-->
+      <link rel="stylesheet" href="/vendor/govuk_template/govuk-template.css">
+    <!--<![endif]-->
+    <!--[if IE 8]>
+      <link rel="stylesheet" href="/vendor/govuk_template/govuk-template-ie8.css">
+    <![endif]-->
+    <link rel="stylesheet" media="print" href="/vendor/govuk_template/govuk-template-print.css">
+    <link rel="stylesheet" media="all" href="/vendor/govuk_template/fonts.css"/>
+    <!--[if !IE 8]><!-->
+      <link rel="stylesheet" href="/public/app-legacy.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
+    <!--<![endif]-->
+    <!--[if IE 8]>
+      <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+    <![endif]-->
+    <!--[if lt IE 9]>
+      <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+  {% else %}
+    <!--[if !IE 8]><!-->
+      <link rel="stylesheet" href="/public/app.css">
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
+    <!--<![endif]-->
+    <!--[if IE 8]>
+      <link rel="stylesheet" href="/public/app-ie8.css">
+    <![endif]-->
+    <!--[if lt IE 9]>
+      <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <![endif]-->
+  {% endif %}
 
   {% block styles %}{% endblock %}
 {% endblock %}

--- a/app/views/layouts/all-components.njk
+++ b/app/views/layouts/all-components.njk
@@ -22,6 +22,6 @@
   {% for data in componentData %}
     {% set componentName = data.componentName %}
     {% set componentNameHuman = componentName | replace("-", " ") %}
-    {{ showExamples(componentName, componentNameHuman, data) }}
+    {{ showExamples(componentName, componentNameHuman, data, legacy_query) }}
   {% endfor %}
 {% endblock %}

--- a/app/views/layouts/all-components.njk
+++ b/app/views/layouts/all-components.njk
@@ -9,7 +9,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    href: "/" + legacy_query
+    href: "/" + legacyQuery
   }) }}
 {% endblock %}
 
@@ -22,6 +22,6 @@
   {% for data in componentData %}
     {% set componentName = data.componentName %}
     {% set componentNameHuman = componentName | replace("-", " ") %}
-    {{ showExamples(componentName, componentNameHuman, data, legacy_query) }}
+    {{ showExamples(componentName, componentNameHuman, data, legacyQuery) }}
   {% endfor %}
 {% endblock %}

--- a/app/views/layouts/all-components.njk
+++ b/app/views/layouts/all-components.njk
@@ -9,7 +9,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    "href": "/"
+    href: "/" + legacy_query
   }) }}
 {% endblock %}
 

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -33,6 +33,6 @@
   </div>
 
   {% block examples %}
-    {{ showExamples(componentName, componentNameHuman, componentData) }}
+    {{ showExamples(componentName, componentNameHuman, componentData,legacy_query) }}
   {% endblock %}
 {% endblock %}

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -17,7 +17,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-    { text: 'GOV.UK Frontend', href: '/' },
+    { text: 'GOV.UK Frontend', href: '/' + legacy_query },
     { text: componentNameHuman | capitalize }
     ]
   }) }}

--- a/app/views/layouts/component.njk
+++ b/app/views/layouts/component.njk
@@ -17,7 +17,7 @@
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     "items": [
-    { text: 'GOV.UK Frontend', href: '/' + legacy_query },
+    { text: 'GOV.UK Frontend', href: '/' + legacyQuery },
     { text: componentNameHuman | capitalize }
     ]
   }) }}
@@ -33,6 +33,6 @@
   </div>
 
   {% block examples %}
-    {{ showExamples(componentName, componentNameHuman, componentData,legacy_query) }}
+    {{ showExamples(componentName, componentNameHuman, componentData,legacyQuery) }}
   {% endblock %}
 {% endblock %}

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -11,9 +11,9 @@
       <h2 class="govuk-heading-m">Components</h2>
 
       <ul class="govuk-list">
-        <li><a href="/components/all" class="govuk-link">All</a></li>
+        <li><a href="/components/all{{ legacy_query }}" class="govuk-link">All</a></li>
         {% for componentName in componentsDirectory | sort %}
-          <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+          <li><a href="/components/{{ componentName }}{{ legacy_query }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
         {% endfor %}
       </ul>
     </div>
@@ -23,7 +23,7 @@
 
       <ul class="govuk-list">
       {% for exampleName in examplesDirectory | sort %}
-        <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+        <li><a href="/examples/{{ exampleName }}{{ legacy_query }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
       </ul>
     </div>
@@ -33,7 +33,7 @@
 
       <ul class="govuk-list">
       {% for exampleName in fullPageExamplesDirectory | sort %}
-        <li><a href="/full-page-examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+        <li><a href="/full-page-examples/{{ exampleName }}{{ legacy_query }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
       </ul>
 

--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -11,9 +11,9 @@
       <h2 class="govuk-heading-m">Components</h2>
 
       <ul class="govuk-list">
-        <li><a href="/components/all{{ legacy_query }}" class="govuk-link">All</a></li>
+        <li><a href="/components/all{{ legacyQuery }}" class="govuk-link">All</a></li>
         {% for componentName in componentsDirectory | sort %}
-          <li><a href="/components/{{ componentName }}{{ legacy_query }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+          <li><a href="/components/{{ componentName }}{{ legacyQuery }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
         {% endfor %}
       </ul>
     </div>
@@ -23,7 +23,7 @@
 
       <ul class="govuk-list">
       {% for exampleName in examplesDirectory | sort %}
-        <li><a href="/examples/{{ exampleName }}{{ legacy_query }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+        <li><a href="/examples/{{ exampleName }}{{ legacyQuery }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
       </ul>
     </div>
@@ -33,7 +33,7 @@
 
       <ul class="govuk-list">
       {% for exampleName in fullPageExamplesDirectory | sort %}
-        <li><a href="/full-page-examples/{{ exampleName }}{{ legacy_query }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+        <li><a href="/full-page-examples/{{ exampleName }}{{ legacyQuery }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
       </ul>
 

--- a/app/views/macros/showExamples.njk
+++ b/app/views/macros/showExamples.njk
@@ -1,9 +1,10 @@
 {% from "details/macro.njk" import govukDetails %}
 
-{% macro showExamples(componentSlug, componentName, data) %}
+{% macro showExamples(componentSlug, componentName, data, legacy_query) %}
 
 {% for example in data.examples %}
   {% set exampleSlug = (example.name | replace(" ", "-")) %}
+  {% set iframePathQuery = legacy_query + '&iframe=true' if legacy_query != '' else '?iframe=true' %}
 
   {% if example.name == 'default' %}
     {% set heading = componentName | capitalize %}
@@ -17,7 +18,7 @@
     <div class="govuk-width-container">
       <div class="govuk-heading-m">
         <h3 id="heading-{{ exampleSlug }}" class="app-!-di">{{ heading | safe }}</h3>
-        <a href="{{ path }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
+        <a href="{{ path }}{{ legacy_query }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
           (open in a new window)
         </a>
       </div>
@@ -31,7 +32,7 @@
     <div class="app-component-preview">
       <iframe
       class="js-component-preview app-component-preview__iframe"
-      src="{{ path }}?iframe=true"
+      src="{{ path + iframePathQuery }}"
       frameBorder="0"
       allowTransparency="true"
       scrolling="auto"

--- a/app/views/macros/showExamples.njk
+++ b/app/views/macros/showExamples.njk
@@ -1,10 +1,10 @@
 {% from "details/macro.njk" import govukDetails %}
 
-{% macro showExamples(componentSlug, componentName, data, legacy_query) %}
+{% macro showExamples(componentSlug, componentName, data, legacyQuery) %}
 
 {% for example in data.examples %}
   {% set exampleSlug = (example.name | replace(" ", "-")) %}
-  {% set iframePathQuery = legacy_query + '&iframe=true' if legacy_query != '' else '?iframe=true' %}
+  {% set iframePathQuery = legacyQuery + '&iframe=true' if legacyQuery != '' else '?iframe=true' %}
 
   {% if example.name == 'default' %}
     {% set heading = componentName | capitalize %}
@@ -18,7 +18,7 @@
     <div class="govuk-width-container">
       <div class="govuk-heading-m">
         <h3 id="heading-{{ exampleSlug }}" class="app-!-di">{{ heading | safe }}</h3>
-        <a href="{{ path }}{{ legacy_query }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
+        <a href="{{ path }}{{ legacyQuery }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
           (open in a new window)
         </a>
       </div>


### PR DESCRIPTION
Legacy mode is a means to test legacy css (GOV.UK Elements, GOV.UK template
etc.) along side govuk-frontend.  The review app will by default only use
govuk-frontend. However, if you add the query string of `?legacy=1` to
the url, the application should load govuk-elements, govuk-template and
govuk-frontend. eg `https://govuk-frontend-review-pr-1279.herokuapp.com/?legacy=1`


It should also remember the mode as you navigate through
the review app.

Part of https://github.com/alphagov/govuk-frontend/issues/1262