### PR TITLE
Add views that use govuk-frontend and legacy elements/template

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -61,7 +61,7 @@ module.exports = (options) => {
   app.use('/vendor/html5-shiv/', express.static('node_modules/html5shiv/dist/'))
 
   // serve legacy code from node node modules
-  app.use('/vendor/govuk_template/', express.static('node_modules/govuk_template_jinja/assets/stylesheets/'))
+  app.use('/vendor/govuk_template/', express.static('node_modules/govuk_template_jinja/assets/'))
 
   app.use('/assets', express.static(path.join(configPaths.src, 'assets')))
 

--- a/app/app.js
+++ b/app/app.js
@@ -19,7 +19,8 @@ const appViews = [
   configPaths.examples,
   configPaths.fullPageExamples,
   configPaths.components,
-  configPaths.src
+  configPaths.src,
+  configPaths.node_modules
 ]
 
 module.exports = (options) => {

--- a/app/assets/scss/app-legacy.scss
+++ b/app/assets/scss/app-legacy.scss
@@ -8,6 +8,9 @@ $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 
+// Set Elements assets path
+$path: "/assets/images/";
+
 // Import GOV.UK frontend toolkit and GOV.UK elements
 @import "govuk-elements-sass/public/sass/govuk-elements";
 

--- a/app/full-page-examples.js
+++ b/app/full-page-examples.js
@@ -1,4 +1,5 @@
 module.exports = (app) => {
+  require('./views/full-page-examples/applicant-details')(app)
   require('./views/full-page-examples/have-you-changed-your-name')(app)
   require('./views/full-page-examples/feedback')(app)
   require('./views/full-page-examples/how-do-you-want-to-sign-in')(app)

--- a/app/views/full-page-examples/applicant-details/confirm.njk
+++ b/app/views/full-page-examples/applicant-details/confirm.njk
@@ -1,0 +1,30 @@
+{% extends "govuk_template_jinja/views/layouts/govuk_template.html" %}
+
+{% from "panel/macro.njk" import govukPanel %}
+
+{% set asset_path = "/vendor/govuk_template/" %}
+{% set homepage_url = "/" %}
+{% set pageTitle = "Applicant details submitted" %}
+{% block pageTitle %}GOV.UK - {{ pageTitle }}{% endblock %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/public/app-legacy.css">
+  <!--<![endif]-->
+  <!--[if IE 8]>
+    <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+  <![endif]-->
+{% endblock %}
+
+{% block content %}
+  <main id="content" role="main">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        {{ govukPanel({
+          titleText: pageTitle,
+          classes: "govuk-!-margin-top-8"
+        }) }}
+      </div>
+    </div>
+</main>
+{% endblock %}

--- a/app/views/full-page-examples/applicant-details/index.js
+++ b/app/views/full-page-examples/applicant-details/index.js
@@ -1,0 +1,61 @@
+const { body, validationResult } = require('express-validator/check')
+const { formatValidationErrors } = require('../../../utils.js')
+
+module.exports = (app) => {
+  app.post(
+    '/full-page-examples/applicant-details',
+    [
+      body('full-name')
+        .exists()
+        .not().isEmpty().withMessage('Enter your full name'),
+      body('dob-day')
+        .exists()
+        .not().isEmpty().withMessage('Enter your date of birth day'),
+      body('dob-month')
+        .exists()
+        .not().isEmpty().withMessage('Enter your date of birth month'),
+      body('dob-year')
+        .exists()
+        .not().isEmpty().withMessage('Enter your date of birth year')
+    ],
+    (request, response) => {
+      const errors = formatValidationErrors(validationResult(request))
+
+      if (!errors) {
+        return response.render('./full-page-examples/applicant-details/confirm')
+      }
+
+      // If any of the date inputs error apply a general error.
+      const dobNamePrefix = 'dob'
+      const dobErrors = Object.values(errors).filter(error => error.id.includes(dobNamePrefix + '-'))
+      if (dobErrors) {
+        const firstdobErrorId = dobErrors[0].id
+        // Get the first error message and merge it into a single error message.
+        errors[dobNamePrefix] = {
+          id: dobNamePrefix,
+          href: '#' + firstdobErrorId
+        }
+
+        // Construct a single error message based on all three error messages.
+        errors[dobNamePrefix].text = 'Enter your date of birth '
+        if (dobErrors.length === 3) {
+          errors[dobNamePrefix].text += 'date'
+        } else {
+          errors[dobNamePrefix].text += dobErrors.map(error => error.text.replace('Enter your date of birth ', '')).join(' and ')
+        }
+      }
+
+      let errorSummary = Object.values(errors)
+      if (dobErrors) {
+        // Remove all other errors from the summary so we only have one message that links to the dob input.
+        errorSummary = errorSummary.filter(error => !error.id.includes(dobNamePrefix + '-'))
+      }
+
+      response.render('./full-page-examples/applicant-details/index', {
+        errors,
+        errorSummary,
+        values: request.body // In production this should sanitized.
+      })
+    }
+  )
+}

--- a/app/views/full-page-examples/applicant-details/index.njk
+++ b/app/views/full-page-examples/applicant-details/index.njk
@@ -1,0 +1,130 @@
+{% extends "govuk_template_jinja/views/layouts/govuk_template.html" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "date-input/macro.njk" import govukDateInput %}
+{% from "button/macro.njk" import govukButton %}
+
+{% set asset_path = "/vendor/govuk_template/" %}
+{% set homepage_url = "/" %}
+{% set pageTitle = "Applicant details" %}
+{% block pageTitle %}{{ "Error: " if errors }}GOV.UK - {{ pageTitle }}{% endblock %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/public/app-legacy.css">
+  <!--<![endif]-->
+  <!--[if IE 8]>
+    <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+  <![endif]-->
+{% endblock %}
+
+{% block content %}
+  <main id="content" role="main">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+
+        {{ govukBackLink({
+          text: "Back"
+        }) }}
+
+       {% if errorSummary.length > 0 %}
+          <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+            <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+              There is a problem
+            </h2>
+
+            <ul class="error-summary-list">
+              {% for item in errorSummary %}
+                <li>
+                  {% if item.href %}
+                    <a href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ item.html | safe if item.html else item.text }}</a>
+                  {% else %}
+                    {{ item.html | safe if item.html else item.text }}
+                  {% endif %}
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        {% endif %}
+
+        <h1 class="heading-xlarge">
+         {{ pageTitle }}
+        </h1>
+
+        <form method="post" novalidate>
+
+          <div class="form-group {%- if errors["full-name"] %} form-group-error {% endif %}">
+            <label class="form-label" for="full-name">
+              Full name
+              <span class="form-hint">
+                Please enter your name as it’s written on official documents such as a passport or driving licence.
+              </span>
+            </label>
+            {% if errors["full-name"] %}
+              <span class="error-message">
+               Enter your full name
+             </span>
+            {% endif %}
+            <input class="form-control {%- if errors["full-name"] %} form-control-error {% endif %}" id="full-name" type="text" name="full-name" value="{{ values['full-name'] }}">
+          </div>
+
+          {% set dateInputDayClass = "govuk-input--width-2" %}
+          {% set dateInputMonthClass = "govuk-input--width-2" %}
+          {% set dateInputYearClass = "govuk-input--width-4" %}
+
+          {% if errors["dob-day"] %}
+            {% set dateInputDayClass = dateInputDayClass + " govuk-input--error" %}
+          {% endif %}
+          {% if errors["dob-month"] %}
+            {% set dateInputMonthClass = dateInputMonthClass + " govuk-input--error" %}
+          {% endif %}
+          {% if errors["dob-year"] %}
+            {% set dateInputYearClass = dateInputYearClass + " govuk-input--error" %}
+          {% endif %}
+
+          {{ govukDateInput({
+            id: "dob",
+            namePrefix: "dob",
+            fieldset: {
+              legend: {
+                text: "Date of birth",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            hint: {
+              text: "For example, 31 3 1980"
+            },
+            items: [
+              {
+                classes: dateInputDayClass,
+                name: "day",
+                value: values["dob-day"]
+              },
+              {
+                classes: dateInputMonthClass,
+                name: "month",
+                value: values["dob-month"]
+              },
+              {
+                classes: dateInputYearClass,
+                name: "year",
+                value: values["dob-year"]
+              }
+            ],
+            errorMessage: errors["dob"]
+          }) }}
+
+          {{ govukButton({
+            text: "Continue"
+          }) }}
+
+        </form>
+      </div>
+    </div>
+  </main>
+{% endblock %}
+
+{% block body_end %}
+  <script src="/public/all.js"></script>
+  <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}

--- a/app/views/full-page-examples/renew-driving-licence/index.njk
+++ b/app/views/full-page-examples/renew-driving-licence/index.njk
@@ -1,0 +1,156 @@
+{# This example is based on the "Renew driving licence"
+example: https://www.gov.uk/renew-driving-licence #}
+{% extends "govuk_template_jinja/views/layouts/govuk_template.html" %}
+
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "inset-text/macro.njk" import govukInsetText %}
+{% from "tabs/macro.njk" import govukTabs %}
+
+{% set asset_path = "/vendor/govuk_template/" %}
+{% set homepage_url = "/" %}
+{% set pageTitle = "Renew your driving licence" %}
+{% block page_title %}GOV.UK - {{ pageTitle }}{% endblock %}
+
+{% block head %}
+  <!--[if !IE 8]><!-->
+    <link rel="stylesheet" href="/public/app-legacy.css">
+  <!--<![endif]-->
+  <!--[if IE 8]>
+    <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+  <![endif]-->
+{% endblock %}
+
+{% block content %}
+  <main id="content" role="main">
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        {{ govukBreadcrumbs({
+          items: [
+            {
+              text: "Home",
+              href: "#/"
+            },
+            {
+              text: "Driving and transport",
+              href: "#/browse/driving"
+            },
+            {
+              text: "Driving licences",
+              href: "#/browse/driving/driving-licences"
+            }
+          ]
+        }) }}
+
+        <h1 class="heading-xlarge">
+         {{ pageTitle }}
+        </h1>
+
+        <p>Renew your driving licence online with DVLA if you have a valid UK passport.</p>
+
+        {{ govukInsetText({
+          html: "There’s a different way to <a href='#'>renew your licence if you’re 70 or over</a> and <a href='#'>renew a 5-year bus or lorry licence</a>."
+        }) }}
+
+        <a class="button button-start govuk-!-margin-top-2 govuk-!-margin-bottom-8" href="#" role="button">Start now</a>
+
+        {% set moreInformationHTML %}
+
+          <p>You must renew a photocard licence every 10 years - you’ll receive a reminder before your current licence ends.</p>
+
+          <h2 class="heading-medium">What you need</h2>
+
+          <p>To renew online, you need:</p>
+
+          <ul class="list list-bullet">
+            <li>a valid UK passport</li>
+            <li>to be a resident of Great Britain - there’s a different service in <a href="http://www.nidirect.gov.uk/index/information-and-services/motoring/driver-licensing/need-a-new-or-updated-licence/renewing-your-driving-licence.htm">Northern Ireland</a>
+            </li>
+            <li>to pay £14 by MasterCard, Visa, Electron or Delta debit or credit card (there’s no fee if you’re over 70 or have a medical short period licence)</li>
+            <li>addresses of where you’ve lived over the last 3 years</li>
+            <li>your current driving licence (if you do not have your licence you must say why in your application)</li>
+            <li>your National Insurance number (if you know it)</li>
+            <li>to not be disqualified from driving</li>
+          </ul>
+
+          <h2 class="heading-medium">How long it takes</h2>
+
+          <p>Your driving licence should arrive within a week if you apply online.</p>
+
+          {{ govukInsetText({
+            html: "You must send your old photocard licence to DVLA when you get your new licence. You’ll be told the address to use when you finish the application."
+          }) }}
+
+          <p>Your new licence will be valid from the date your application is approved, not from the expiry date of your current licence.</p>
+
+          <h2 class="heading-medium">Personal data</h2>
+
+          <p>DVLA will send you a confirmation email once you’ve applied. You might be asked to take part in research by email, but you can opt out.</p>
+        {% endset %}
+
+        {% set otherWaysToApplyHTML %}
+          <h2 class="heading-medium govuk-!-margin-top-1">Apply at a Post Office</h2>
+
+          <p>You’ll get a reminder letter in the post. Take it to a <a href="http://www.postoffice.co.uk/branch-finder">Post Office</a> that deals with DVLA photocard licence renewal.</p>
+
+          <p>You also need to take:</p>
+
+          <ul class="list list-bullet">
+            <li>your photocard licence if you have it</li>
+            <li>the £21.50 fee</li>
+          </ul>
+
+          <p>If you do not have a reminder letter, you’ll need your photocard licence to apply at the Post Office.</p>
+
+          {{ govukInsetText({
+            html: "You cannot apply at the Post Office if your name has changed. You’ll need to apply by post."
+          }) }}
+
+          <h2 class="heading-medium">Apply by post</h2>
+
+          <p><a href="https://forms.dft.gov.uk/order-dvla-forms/">Order a ‘D1 pack’ of forms</a> from DVLA or get one from a <a href="http://www.postoffice.co.uk/branch-finder">Post Office</a> that deals with DVLA photocard renewal or vehicle tax.</p>
+
+          <p>You need to include these things with your completed forms:</p>
+
+          <ul class="list list-bullet">
+            <li>a recent <a href="/photos-for-passports">passport type photo</a> (do not sign the back of the photo)</li>
+            <li>your current photocard licence, if you have it</li>
+            <li>a cheque or postal order for £17, payable to DVLA (no fee is needed if you have a medical short period licence or you’re aged 70 or over)</li>
+          </ul>
+
+          <p>You also need to include <a href="#">identity documents</a> if you’ve changed your name.</p>
+
+          <h2 class="heading-medium">After you apply at a Post Office or by post</h2>
+          <p>Your driving licence should arrive within 3 weeks. It might take longer if your medical or personal details need to be checked.</p>
+
+          <p>You can continue driving while you wait for your new licence to arrive.</p>
+
+        {% endset %}
+
+        {{ govukTabs({
+          items: [
+            {
+              label: "More information",
+              id: "more-information",
+              panel: {
+                html: moreInformationHTML
+              }
+            },
+            {
+              label: "Other ways to apply",
+              id: "other-ways-to-apply",
+              panel: {
+                html: otherWaysToApplyHTML
+              }
+            }
+          ]
+        }) }}
+      </div>
+    </div>
+  </main>
+
+{% endblock %}
+
+{% block body_end %}
+  <script src="/public/all.js"></script>
+  <script>window.GOVUKFrontend.initAll()</script>
+{% endblock %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -4,13 +4,13 @@
 
   {% if legacy %}
     <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="/vendor/govuk_template/govuk-template.css">
+      <link rel="stylesheet" href="/vendor/govuk_template/stylesheets/govuk-template.css">
     <!--<![endif]-->
     <!--[if IE 8]>
       <link rel="stylesheet" href="/vendor/govuk_template/govuk-template-ie8.css">
     <![endif]-->
-    <link rel="stylesheet" media="print" href="/vendor/govuk_template/govuk-template-print.css">
-    <link rel="stylesheet" media="all" href="/vendor/govuk_template/fonts.css"/>
+    <link rel="stylesheet" media="print" href="/vendor/govuk_template/stylesheets/govuk-template-print.css">
+    <link rel="stylesheet" media="all" href="/vendor/govuk_template/stylesheets/fonts.css"/>
     <!--[if !IE 8]><!-->
       <link rel="stylesheet" href="/public/app-legacy.css">
     <!--<![endif]-->

--- a/config/paths.json
+++ b/config/paths.json
@@ -7,6 +7,7 @@
       "layouts": "app/views/layouts/",
   "config": "config/",
   "dist": "dist/",
+  "node_modules": "node_modules/",
   "package": "package/",
   "public": "public/",
   "sassdoc": "sassdoc/",


### PR DESCRIPTION
This PR
- adds start page view which extends govuk_template
- adds applicant details view which extends govuk_template
- exposes `node_modules` to review app for the purposes of extending govuk_template in `app/views`
- fixes template assets path 
- sets assets path for legacy scss

Part of https://github.com/alphagov/govuk-frontend/issues/1262