### PR TITLE
Update colour palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,99 @@
 
 💥 Breaking changes:
 
+- The colour palette has been updated.
+
+  **Note:** If you are using [compatibility mode], the existing palette will be
+  preserved.
+
+  Purple, red, yellow, green, blue and light blue have all been updated to new
+  colours.
+
+  Dark blue has been added, and bright red has been removed.
+
+  Greys 1-through-4 have been replaced with dark, mid and light-grey. As a
+  general rule of thumb, dark grey replaces grey-1 and is designed to be used as
+  a foreground colour; light grey replaces both grey-3 and grey-4 and is
+  designed to be used as a background colour, and mid-grey replaces grey-2 and
+  is designed to be used for borders.
+
+  To migrate you'll need to update any references to bright-red, grey-1, grey-2,
+  grey-3 or grey-4 to use the new colours from the palette.
+
+  | Colour        | Before    | After     | Notes                             |
+  | ------------- | --------- | --------- | --------------------------------- |
+  | purple        | `#2e358b` | `#4c2c92` | updated - matches visited links   |
+  | light-purple  | `#6f72af` | `#6f72af` |                                   |
+  | bright-purple | `#912b88` | `#912b88` |                                   |
+  | pink          | `#d53880` | `#d53880` |                                   |
+  | light-pink    | `#f499be` | `#f499be` |                                   |
+  | red           | `#b10e1e` | `#d4351c` | updated                           |
+  | bright-red    | `#df3034` |           | removed - similar to the new red  |
+  | orange        | `#f47738` | `#f47738` |                                   |
+  | brown         | `#b58840` | `#b58840` |                                   |
+  | yellow        | `#ffbf47` | `#ffdd00` | updated                           |
+  | light-green   | `#85994b` | `#85994b` |                                   |
+  | green         | `#006435` | `#00703c` | updated                           |
+  | turquoise     | `#28a197` | `#28a197` |                                   |
+  | light-blue    | `#2b8cc4` | `#5694ca` | updated                           |
+  | blue          | `#005ea5` | `#1d70b8` | updated                           |
+  | dark-blue     |           | `#003078` | added                             |
+  | black         | `#0b0c0c` | `#0b0c0c` |                                   |
+  | grey-1        | `#6f777b` |           | removed                           |
+  | dark-grey     |           | `#6f777b` | added                             |
+  | grey-2        | `#bfc1c3` |           | removed                           |
+  | mid-grey      |           | `#b1b4b6` | added                             |
+  | grey-3        | `#dee0e2` |           | removed                           |
+  | grey-4        | `#f8f8f8` |           | removed                           |
+  | light-grey    |           | `#f3f2f1` | added                             |
+  | white         | `#ffffff` | `#ffffff` |                                   |
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
+
+- The button component now uses the green from the colour palette, instead of
+  a custom green used only for the button.
+
+  **Note:** If you are using [compatibility mode], the existing button colour
+  will be preserved.
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
+
+- The confirmation panel now uses a green background rather than a turquoise
+  background.
+
+  **Note:** If you are using [compatibility mode], the existing turquoise panel
+  colour will be preserved.
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
+
+- Links now get darker when hovered, rather than lighter.
+
+  **Note:** If you are using [compatibility mode], the existing link hover style
+  will be preserved.
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
+
 - Pull Request Title goes here
 
   Description goes here (optional)
 
-  To migrate you need to change: X
-
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
 
 🆕 New features:
+
+- A new setting `$govuk-use-legacy-palette` has been added, which by default
+  will be true if any of the `$govuk-compatibility-*` settings are true.
+
+  When set to `true`, the existing colour palette from v2.x of GOV.UK Frontend
+  will be used.
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
+
+- The `govuk-colour` function has been updated to add a `$legacy` argument,
+  which allows you to specify a colour (either a literal, or a name of a colour
+  from the legacy palette) to use when `$govuk-use-legacy-palette` is true.
+
+  ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
 
 - Pull Request Title goes here
 
@@ -27,6 +111,8 @@
   Description goes here (optional)
 
   ([PR #N](https://github.com/alphagov/govuk-frontend/pull/N))
+
+[compatibility mode]: https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#compatibility-mode
 
 ## 2.11.0 (Feature release)
 

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -92,7 +92,8 @@
 
     // Section headers have a grey background on hover as an additional affodance
     .govuk-accordion__section-header:hover {
-      background-color: govuk-colour("grey-4");
+      background-color: govuk-colour("light-grey", $legacy: "grey-4");
+
       // For devices that can't hover such as touch devices,
       // remove hover state as it can be stuck in that state (iOS).
       @media (hover: none) {

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -3,14 +3,13 @@
 @import "../../helpers/all";
 
 @include govuk-exports("govuk/component/button") {
-  // Primary button variables
-  $govuk-button-colour: #00823b; // sass-lint:disable no-color-literals
+  $govuk-button-colour: govuk-colour("green", $legacy: #00823b); // sass-lint:disable no-color-literals
   $govuk-button-hover-colour: govuk-shade($govuk-button-colour, 20%);
   $govuk-button-shadow-colour: govuk-shade($govuk-button-colour, 60%);
   $govuk-button-text-colour: govuk-colour("white");
 
   // Secondary button variables
-  $govuk-secondary-button-colour: govuk-colour("grey-3");
+  $govuk-secondary-button-colour: govuk-colour("light-grey", $legacy: "grey-3");
   $govuk-secondary-button-hover-colour: govuk-shade($govuk-secondary-button-colour, 10%);
   $govuk-secondary-button-shadow-colour: govuk-shade($govuk-secondary-button-colour, 40%);
   $govuk-secondary-button-text-colour: govuk-colour("black");

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -7,11 +7,24 @@
 @include govuk-exports("govuk/component/footer") {
 
   $govuk-footer-background: $govuk-canvas-background-colour;
-  $govuk-footer-border-top: #a1acb2;
-  $govuk-footer-border: govuk-colour("grey-2");
-  $govuk-footer-text: #454a4c;
+  $govuk-footer-border: $govuk-border-colour;
+  // This variable can be removed entirely once the legacy palette goes away,
+  // as it'll just be the same as $govuk-footer-border.
+  $govuk-footer-border-top: $govuk-border-colour;
+  $govuk-footer-text: $govuk-text-colour;
   $govuk-footer-link: $govuk-footer-text;
-  $govuk-footer-link-hover: #171819;
+  $govuk-footer-link-hover: false;
+
+  @if ($govuk-use-legacy-palette) {
+    // sass-lint:disable no-color-literals
+    $govuk-footer-border-top: #a1acb2;
+    $govuk-footer-border: govuk-colour("grey-2");
+    $govuk-footer-text: #454a4c;
+    $govuk-footer-link: $govuk-footer-text;
+
+    // Only used with the legacy palette
+    $govuk-footer-link-hover: #171819;
+  }
 
   // Based on the govuk-crest-2x.png image dimensions.
   $govuk-footer-crest-image-width-2x: 250px;
@@ -33,14 +46,23 @@
   .govuk-footer__link {
     @include govuk-focusable-fill;
 
-    &:link,
-    &:visited {
-      color: $govuk-footer-link;
-    }
+    @if ($govuk-use-legacy-palette) {
+      &:link,
+      &:visited {
+        color: $govuk-footer-link;
+      }
 
-    &:hover,
-    &:active {
-      color: $govuk-footer-link-hover;
+      &:hover,
+      &:active {
+        color: $govuk-footer-link-hover;
+      }
+    } @else {
+      &:link,
+      &:visited,
+      &:hover,
+      &:active {
+        color: $govuk-footer-link;
+      }
     }
 
     // When focussed, the text colour needs to be darker to ensure that colour

--- a/src/components/panel/_panel.scss
+++ b/src/components/panel/_panel.scss
@@ -23,7 +23,7 @@
 
   .govuk-panel--confirmation {
     color: govuk-colour("white");
-    background: govuk-colour("turquoise");
+    background: govuk-colour("green", $legacy: "turquoise");
   }
 
   .govuk-panel__title {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -82,7 +82,7 @@
         padding-left: govuk-spacing(4);
         float: left;
         color: govuk-colour("black");
-        background-color: govuk-colour("grey-4");
+        background-color: govuk-colour("light-grey", $legacy: "grey-4");
         text-align: center;
         text-decoration: none;
 

--- a/src/components/tag/_tag.scss
+++ b/src/components/tag/_tag.scss
@@ -28,6 +28,6 @@
   }
 
   .govuk-tag--inactive {
-    background-color: govuk-colour("grey-1");
+    background-color: govuk-colour("dark-grey", $legacy: "grey-1");
   }
 }

--- a/src/helpers/_colour.scss
+++ b/src/helpers/_colour.scss
@@ -1,3 +1,4 @@
+@import "../settings/compatibility";
 @import "../settings/colours-palette";
 @import "../settings/colours-organisations";
 

--- a/src/helpers/_colour.scss
+++ b/src/helpers/_colour.scss
@@ -9,11 +9,32 @@
 ///
 /// @param {String} $colour - Name of colour from the colour palette
 ///   (`$govuk-colours`)
+/// @param {String} $legacy - Either the name of colour from the legacy palette
+///   or a colour literal, to return instead when in 'legacy mode' - matching
+///   the palette from GOV.UK Template, Elements or Frontend Toolkit
 /// @return {Colour} Representation of named colour
+///
+/// @example scss - Using legacy colours from the palette
+///  .foo {
+///    background-colour: govuk-colour("mid-grey", $legacy: "grey-2");
+///  }
+///
+/// @example scss - Using legacy colour literals
+///  .foo {
+///    background-colour: govuk-colour("green", $legacy: #BADA55);
+///  }
+///
 /// @throw if `$colour` is not a colour from the colour palette
 /// @access public
 
-@function govuk-colour($colour) {
+@function govuk-colour($colour, $legacy: false) {
+  @if ($govuk-use-legacy-palette and $legacy) {
+    @if (type-of($legacy) == "color") {
+      @return $legacy;
+    }
+    $colour: $legacy;
+  }
+
   $colour: quote($colour);
 
   @if not map-has-key($govuk-colours, $colour) {

--- a/src/settings/_colours-applied.scss
+++ b/src/settings/_colours-applied.scss
@@ -31,7 +31,7 @@ $govuk-text-colour: govuk-colour("black") !default;
 /// @type Colour
 /// @access public
 
-$govuk-canvas-background-colour: govuk-colour("grey-3") !default;
+$govuk-canvas-background-colour: govuk-colour("light-grey", $legacy: "grey-3") !default;
 
 /// Body background colour
 ///
@@ -56,7 +56,7 @@ $govuk-print-text-colour: #000000 !default;
 /// @type Colour
 /// @access public
 
-$govuk-secondary-text-colour: govuk-colour("grey-1") !default;
+$govuk-secondary-text-colour: govuk-colour("dark-grey", $legacy: "grey-1") !default;
 
 /// Focus colour
 ///
@@ -94,7 +94,7 @@ $govuk-error-colour: govuk-colour("red") !default;
 /// @type Colour
 /// @access public
 
-$govuk-border-colour: govuk-colour("grey-2") !default;
+$govuk-border-colour: govuk-colour("mid-grey", $legacy: "grey-2");
 
 /// Input border colour
 ///
@@ -112,7 +112,7 @@ $govuk-input-border-colour: govuk-colour("black") !default;
 /// @type Colour
 /// @access public
 
-$govuk-hover-colour: govuk-colour("grey-3") !default;
+$govuk-hover-colour: govuk-colour("mid-grey", $legacy: "grey-3");
 
 
 // =============================================================================
@@ -131,18 +131,18 @@ $govuk-link-colour: govuk-colour("blue") !default;
 /// @type Colour
 /// @access public
 
-$govuk-link-visited-colour: #4c2c92 !default;
+$govuk-link-visited-colour: govuk-colour("purple", $legacy: #4c2c92) !default;
 
 /// Link hover colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-link-hover-colour: govuk-colour("light-blue") !default;
+$govuk-link-hover-colour: govuk-colour("dark-blue", $legacy: "light-blue") !default;
 
 /// Active link colour
 ///
 /// @type Colour
 /// @access public
 
-$govuk-link-active-colour: govuk-colour("light-blue") !default;
+$govuk-link-active-colour: govuk-colour("black", $legacy: "light-blue") !default;

--- a/src/settings/_colours-palette.scss
+++ b/src/settings/_colours-palette.scss
@@ -61,6 +61,7 @@ $_govuk-colour-palette-modern: (
   "blue": #1d70b8,
   "dark-blue": #003078,
   "light-blue": #5694ca,
+  "purple": #4c2c92,
 
   "black": #0b0c0c,
   "dark-grey": #6f777b,
@@ -68,7 +69,6 @@ $_govuk-colour-palette-modern: (
   "light-grey": #f3f2f1,
   "white": #ffffff,
 
-  "purple": #2e358b,
   "light-purple": #6f72af,
   "bright-purple": #912b88,
   "pink": #d53880,

--- a/src/settings/_colours-palette.scss
+++ b/src/settings/_colours-palette.scss
@@ -11,7 +11,11 @@
 /// @type Boolean
 /// @access public
 
-$govuk-use-legacy-palette: true !default;
+$govuk-use-legacy-palette: if((
+    $govuk-compatibility-govukfrontendtoolkit or
+    $govuk-compatibility-govuktemplate or
+    $govuk-compatibility-govukelements
+  ), true, false) !default;
 
 /// Legacy colour palette
 ///

--- a/src/settings/_colours-palette.scss
+++ b/src/settings/_colours-palette.scss
@@ -73,7 +73,6 @@ $_govuk-colour-palette-modern: (
   "bright-purple": #912b88,
   "pink": #d53880,
   "light-pink": #f499be,
-  "bright-red": #df3034,
   "orange": #f47738,
   "brown": #b58840,
   "light-green": #85994b,

--- a/src/settings/_colours-palette.scss
+++ b/src/settings/_colours-palette.scss
@@ -2,16 +2,26 @@
 /// @group settings/colours
 ////
 
-/// Colour palette
+/// Use 'legacy' colour palette
 ///
-/// @type Map
+/// Whether or not to use the colour palette from GOV.UK Elements / Frontend
+/// Toolkit, for teams that are migrating to GOV.UK Frontend and may be using
+/// components from both places in a single application.
 ///
-/// @prop $colour - Representation for the given $colour, where $colour is the
-///   friendly name for the colour (e.g. "red": #ff0000);
-///
+/// @type Boolean
 /// @access public
 
-$govuk-colours: (
+$govuk-use-legacy-palette: true !default;
+
+/// Legacy colour palette
+///
+/// This exists only because you cannot easily set a !default variable
+/// conditionally (thanks to the way scope works in Sass) so we set
+/// `$govuk-colour-palette` using the `if` function.
+///
+/// @access private
+
+$_govuk-colour-palette-legacy: (
   "purple": #2e358b,
   "light-purple": #6f72af,
   "bright-purple": #912b88,
@@ -34,4 +44,53 @@ $govuk-colours: (
   "grey-3": #dee0e2,
   "grey-4": #f8f8f8,
   "white": #ffffff
+);
+
+/// Modern colour palette
+///
+/// This exists only because you cannot easily set a !default variable
+/// conditionally (thanks to the way scope works in Sass) so we set
+/// `$govuk-colour-palette` using the `if` function.
+///
+/// @access private
+
+$_govuk-colour-palette-modern: (
+  "red": #d4351c,
+  "yellow": #ffdd00,
+  "green": #00703c,
+  "blue": #1d70b8,
+  "dark-blue": #003078,
+  "light-blue": #5694ca,
+
+  "black": #0b0c0c,
+  "dark-grey": #6f777b,
+  "mid-grey": #b1b4b6,
+  "light-grey": #f3f2f1,
+  "white": #ffffff,
+
+  "purple": #2e358b,
+  "light-purple": #6f72af,
+  "bright-purple": #912b88,
+  "pink": #d53880,
+  "light-pink": #f499be,
+  "bright-red": #df3034,
+  "orange": #f47738,
+  "brown": #b58840,
+  "light-green": #85994b,
+  "turquoise": #28a197
+);
+
+/// Colour palette
+///
+/// @type Map
+///
+/// @prop $colour - Representation for the given $colour, where $colour is the
+///   friendly name for the colour (e.g. "red": #ff0000);
+///
+/// @access public
+
+$govuk-colours: if(
+  $govuk-use-legacy-palette,
+  $_govuk-colour-palette-legacy,
+  $_govuk-colour-palette-modern
 ) !default;

--- a/src/settings/colours.test.js
+++ b/src/settings/colours.test.js
@@ -15,6 +15,7 @@ const sassConfig = {
 describe('Organisation colours', () => {
   it('should define websafe colours that meet contrast requirements', async () => {
     const sass = `
+      @import "settings/compatibility";
       @import "settings/colours-palette";
       @import "settings/colours-organisations";
       @import "settings/colours-applied";


### PR DESCRIPTION
This updates GOV.UK Frontend to use the new palette, as designed by the GOV.UK graphic design community.

This is part of a broader series of work which will be released as part of v3.0, which also includes changes to the hover and focus states of many components.

## Changes to the palette

| Colour        | Before    | After     | Notes                                           |
|---------------|-----------|-----------|-------------------------------------------------|
| purple        | `#2e358b` | `#4c2c92` | updated to match visited link colour            |
| light-purple  | `#6f72af` | `#6f72af` |                                                 |
| bright-purple | `#912b88` | `#912b88` |                                                 |
| pink          | `#d53880` | `#d53880` |                                                 |
| light-pink    | `#f499be` | `#f499be` |                                                 |
| red           | `#b10e1e` | `#d4351c` | updated                                         |
| bright-red    | `#df3034` |           | removed, as it was very similar to the new red  |
| orange        | `#f47738` | `#f47738` |                                                 |
| brown         | `#b58840` | `#b58840` |                                                 |
| yellow        | `#ffbf47` | `#ffdd00` | updated                                         |
| light-green   | `#85994b` | `#85994b` |                                                 |
| green         | `#006435` | `#00703c` | updated                                         |
| turquoise     | `#28a197` | `#28a197` |                                                 |
| light-blue    | `#2b8cc4` | `#5694ca` | updated                                         |
| blue          | `#005ea5` | `#1d70b8` | updated                                         |
| dark-blue     |           | `#003078` | added                                           |
| black         | `#0b0c0c` | `#0b0c0c` |                                                 |
| grey-1        | `#6f777b` |           | removed                                         |
| dark-grey     |           | `#6f777b` | added                                           |
| grey-2        | `#bfc1c3` |           | removed                                         |
| mid-grey      |           | `#b1b4b6` | added                                           |
| grey-3        | `#dee0e2` |           | removed                                         |
| grey-4        | `#f8f8f8` |           | removed                                         |
| light-grey    |           | `#f3f2f1` | added                                           |
| white         | `#ffffff` | `#ffffff` |                                                 |

## Changes to components and styles

It also makes changes to the way that some of these colours are used, including:

- the button component now uses the green from the colour palette, instead of a custom green previously only used for the button
- the confirmation panel now uses a green background rather than a turquoise background
- links now get _darker_ when hovered, rather than lighter
- visited links remain the same colour, but the purple in the palette has been updated to match

## Maintaining compatibility with GOV.UK Template, Frontend Toolkit and Elements

When GOV.UK Frontend is run in 'compatibility mode', the legacy palette will be used and components will continue to use the existing colours (for example, the panel will continue to be turquoise).

This is so that services can continue to adopt GOV.UK Frontend gradually, without having a mix of the two different palettes appearing within a service or a single page.

To support this:

- a new setting `$govuk-use-legacy-palette` has been added, which by default will be `true` if any of `$govuk-compatibility-govukfrontendtoolkit`, `$govuk-compatibility-govuktemplate` or `$govuk-compatibility-govukelements` are `true`.
- the `govuk-colour` function has been updated to add a `$legacy` argument, which specifies the colour (either a literal, or a name of a colour from the legacy palette) to use when `$govuk-use-legacy-palette` is `true`.
- in some places we are conditionally setting variables based on the value of `$govuk-use-legacy-palette`

Any new components that are implemented whilst this arrangement is in place will need to be designed for both contexts.

You can see how 'legacy mode' looks in the review app by appending `?legacy=1` to the URL:
https://govuk-frontend-review-pr-1288.herokuapp.com/?legacy=1