### PR TITLE
Add classes to links

### DIFF
--- a/app/views/full-page-examples/service-manual-topic/index.njk
+++ b/app/views/full-page-examples/service-manual-topic/index.njk
@@ -266,7 +266,7 @@
           Get notifications
         </h2>
         <p class="govuk-body">When any guidance within this topic is updated
-          <a class="related-item__email-link" href="/service-manual/technology/email-signup">email</a></p>
+          <a class="govuk-link related-item__email-link" href="/service-manual/technology/email-signup">email</a></p>
       </aside>
 
     </div>

--- a/app/views/full-page-examples/upload-your-photo/index.njk
+++ b/app/views/full-page-examples/upload-your-photo/index.njk
@@ -85,7 +85,7 @@
                     {
                         id: "terms-and-conditions",
                         value: "true",
-                        html: 'I accept the <a href="#">terms and conditions</a>',
+                        html: 'I accept the <a class="govuk-link" href="#">terms and conditions</a>',
                         checked: values["terms-and-conditions"]
                     }
                 ],

--- a/app/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/index.njk
@@ -98,6 +98,7 @@
           {{ govukTextarea({
             name: "details-cannot-provide-nationality",
             id: "details-cannot-provide-nationality",
+            classes: "govuk-!-margin-bottom-0",
             label: {
               text: "Can you provide more detail on why you cannot confirm your nationality?"
             },


### PR DESCRIPTION
This PR 
- adds omitted `govuk-link` class to two links on the example pages
- removes margin to textarea on nationality page