### PR TITLE
Trigger setAttributes on radio inputs with shared wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ See the [versioning documentation for how to update this changelog](./docs/contr
 
   ([PR #1347](https://github.com/alphagov/govuk-frontend/pull/1347))
 
+- Trigger setAttributes on radio inputs with shared wrapper
+
+  This change allows radio input events (for conditional reveals) to be scoped higher to parent `.govuk-form-group` wrappers, allowing groups with multiple lists to behave correctly.
+
+  ([PR #1297](https://github.com/alphagov/govuk-frontend/pull/1297))
+
 🔧 Fixes:
 
 - Update colour for MHCLG

--- a/src/components/radios/radios.js
+++ b/src/components/radios/radios.js
@@ -1,15 +1,23 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
 import '../../vendor/polyfills/Element/prototype/classList'
+import '../../vendor/polyfills/Element/prototype/closest'
 import { nodeListForEach } from '../../common'
 
 function Radios ($module) {
   this.$module = $module
-  this.$inputs = $module.querySelectorAll('input[type="radio"]')
+
+  // Find optional parent group
+  var $wrapper = $module.closest('.govuk-form-group')
+  var $parentWrapper = $wrapper && $wrapper.parentNode.closest('.govuk-form-group')
+
+  // Add radios in optional wrappers up to one level higher
+  this.$formGroup = $parentWrapper || $wrapper || $module
+  this.$inputs = this.$formGroup.querySelectorAll('input[type="radio"]')
 }
 
 Radios.prototype.init = function () {
-  var $module = this.$module
+  var $formGroup = this.$formGroup
   var $inputs = this.$inputs
 
   /**
@@ -22,7 +30,7 @@ Radios.prototype.init = function () {
 
     // Check if input controls anything
     // Check if content exists, before setting attributes.
-    if (!controls || !$module.querySelector('#' + controls)) {
+    if (!controls || !$formGroup.querySelector('#' + controls)) {
       return
     }
 
@@ -33,14 +41,14 @@ Radios.prototype.init = function () {
   }.bind(this))
 
   // Handle events
-  $module.addEventListener('click', this.handleClick.bind(this))
+  $formGroup.addEventListener('click', this.handleClick.bind(this))
 }
 
 Radios.prototype.setAttributes = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
-  var $content = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $content = this.$formGroup.querySelector('#' + $input.getAttribute('aria-controls'))
   if ($content) {
     $content.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
   }


### PR DESCRIPTION
This change allows radio input events (for conditional reveals) to be scoped higher to parent `.govuk-form-group` wrappers, allowing groups with multiple lists to behave correctly.

Originally proposed by @frankieroberto in https://github.com/alphagov/govuk-frontend/pull/1163 and has been separated from https://github.com/alphagov/govuk-frontend/pull/1266.