### PR TITLE
Fixes an issue with styling links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,15 @@
 
   ([PR #1287](https://github.com/alphagov/govuk-frontend/pull/1287))
 
+- Fixes govuk-template focussed link colour overriding govuk-frontends
+
+  govuk-template uses specific css selector`a:link:focus` whereas
+  govuk-frontend uses `.govuk-link:focus`. This fix makes govuk-frontend
+  selector more specific `.govuk-link:link:focus` but only when compatibility
+  mode is being used.
+
+  ([PR #1310](https://github.com/alphagov/govuk-frontend/pull/1310))
+
 [compatibility mode]: https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#compatibility-mode
 
 ## 2.11.0 (Feature release)

--- a/app/app.js
+++ b/app/app.js
@@ -177,7 +177,9 @@ module.exports = (options) => {
 
   // Example view
   app.get('/examples/:example', function (req, res, next) {
-    res.render(`${req.params.example}/index`, function (error, html) {
+    // Passing a random number used for the links so that they will be unique and not display as "visited"
+    const randomPageHash = (Math.random() * 1000000).toFixed()
+    res.render(`${req.params.example}/index`, { randomPageHash }, function (error, html) {
       if (error) {
         next(error)
       } else {

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -42,7 +42,7 @@
 
       {% for state_description, state_class in states %}
         <p class="govuk-body">
-          <a href="/" class="govuk-link {{ variant_class }} {{ state_class }}">
+          <a href="/#{{ randomPageHash }}" class="govuk-link {{ variant_class }} {{ state_class }}">
             {{ state_description}}
           </a>
         </p>

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -50,6 +50,17 @@
   &:focus {
     color: $govuk-focus-text-colour;
   }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector
+  // designed to make unvisited link  s a slightly darker blue when focussed, so
+  // we need to override the text colour for that combination of selectors so
+  // so that unvisited links styled as buttons do not end up with dark blue
+  // text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
 }
 
 /// Muted style link mixin


### PR DESCRIPTION
When visiting the links example page, if you had previously visited the
home page then the unvisited link and visited link example looked identical.
This commit passes a random number to the view. The view adds the randomId
to the href as a hash.

👉 https://govuk-frontend-review-pr-1310.herokuapp.com/examples/links

# Before
![image](https://user-images.githubusercontent.com/3441519/57015213-7121ee80-6c0b-11e9-829b-a72b2c6e967f.png)


# After

![image](https://user-images.githubusercontent.com/3441519/57015246-a62e4100-6c0b-11e9-8b89-d466aca3c84b.png)
