### PR TITLE
Add name params to all checkbox examples

### DIFF
--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -143,7 +143,6 @@ examples:
 
 - name: with hints on items
   data:
-    name: with-hints-on-items
     fieldset:
       legend:
         text: How do you want to sign in?

--- a/src/components/checkboxes/checkboxes.yaml
+++ b/src/components/checkboxes/checkboxes.yaml
@@ -125,6 +125,7 @@ examples:
 
 - name: with id and name
   data:
+    name: with-id-and-name
     fieldset:
       legend:
         text: What is your nationality?
@@ -142,6 +143,7 @@ examples:
 
 - name: with hints on items
   data:
+    name: with-hints-on-items
     fieldset:
       legend:
         text: How do you want to sign in?
@@ -341,6 +343,7 @@ examples:
 
 - name: with conditional items
   data:
+    name: with-conditional-items
     idPrefix: how-contacted
     fieldset:
       legend:
@@ -367,6 +370,7 @@ examples:
 
 - name: with conditional item checked
   data:
+    name: how-contacted-checked
     idPrefix: how-contacted-checked
     fieldset:
       legend:
@@ -394,6 +398,7 @@ examples:
 
 - name: with optional form-group classes showing group error
   data:
+    name: how-contacted-checked
     idPrefix: how-contacted-checked
     formGroup:
       classes: 'govuk-form-group--error'
@@ -526,6 +531,7 @@ examples:
 
 - name: small with conditional reveal
   data:
+    name: how-contacted
     idPrefix: how-contacted
     classes: govuk-checkboxes--small
     fieldset:


### PR DESCRIPTION
We are using the yaml files in the components to run tests and compare our custom React component outputs with the nunjucks reference versions. However some of the checkbox examples were missing `name` attributes, causing our rendering to behave slightly differently (It causes React to omit the name attribute entirely, whereas in nunjucks it renders an empty name attribute). This pull request remedies that.