### PR TITLE
Update focus state for radios and checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,12 @@
 
 🆕 New features:
 
+- Checkboxes and radios use a new focus state with a thicker border. The
+  transparent outline, previously required to show the focus state when custom
+  colour schemes are used, has been removed.
+
+  ([PR #1316](https://github.com/alphagov/govuk-frontend/pull/1316))
+
 - A new setting `$govuk-use-legacy-palette` has been added, which by default
   will be true if any of the `$govuk-compatibility-*` settings are true.
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -122,12 +122,7 @@
 
   // Focused state
   .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-    // Since box-shadows are removed when users customise their colours, we set
-    // a transparent outline that is shown instead.
-    // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
     border-width: 4px;
-    outline: $govuk-focus-width solid transparent;
-    outline-offset: $govuk-focus-width;
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -125,6 +125,7 @@
     // Since box-shadows are removed when users customise their colours, we set
     // a transparent outline that is shown instead.
     // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+    border-width: 4px;
     outline: $govuk-focus-width solid transparent;
     outline-offset: $govuk-focus-width;
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -126,6 +126,7 @@
     // Since box-shadows are removed when users customise their colours we set a
     // transparent outline that is shown instead.
     // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+    border-width: 4px;
     outline: $govuk-focus-width solid transparent;
     outline-offset: $govuk-focus-width;
     box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -278,9 +278,9 @@
     //
     // Reduce the size of the 'button' and center it within the ring
     .govuk-radios__label::after {
-      top: 14px;
-      left: 6px;
-      border-width: 6px;
+      top: 15px;
+      left: 7px;
+      border-width: 5px;
     }
 
     // Fix position of hint with small radios

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -123,12 +123,7 @@
 
   // Focused state
   .govuk-radios__input:focus + .govuk-radios__label::before {
-    // Since box-shadows are removed when users customise their colours we set a
-    // transparent outline that is shown instead.
-    // https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
     border-width: 4px;
-    outline: $govuk-focus-width solid transparent;
-    outline-offset: $govuk-focus-width;
     box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
   }
 


### PR DESCRIPTION
## Affected components

- Radios
- Checkboxes

## Changes

- When focussed, double the border width to 4px
- Reduce the size of the 'bullet' in small radios by 2px
- Remove transparent outline used when users have overridden colours in their browser

👉 [Preview](https://govuk-frontend-review-pr-1316.herokuapp.com/examples/form-controls-states)
🖥 [Browserstack screenshots](https://www.browserstack.com/screenshots/4d235eceb503877384959277a611e1518ef44b0d)

## Before
![before](https://user-images.githubusercontent.com/121939/57133756-b6752600-6d9b-11e9-9658-ced12bd23b31.png)

## After
![after](https://user-images.githubusercontent.com/121939/57133775-c0972480-6d9b-11e9-8f3c-dc7823337302.png)

## Before (compatibility mode)

![Screenshot_2019-05-03 GOV UK Frontend(2)](https://user-images.githubusercontent.com/121939/57133973-719dbf00-6d9c-11e9-90c0-15d2868d3f4e.png)

## After (compatibility mode)

![Screenshot_2019-05-03 GOV UK Frontend(3)](https://user-images.githubusercontent.com/121939/57133981-7bbfbd80-6d9c-11e9-9db0-8de7aab78b79.png)

## Before (colours overridden, Firefox 66)

![before-cc](https://user-images.githubusercontent.com/121939/57133794-d9073f00-6d9b-11e9-9f22-bf6f2243ca28.png)

## After (colours overridden, Firefox 66)

![after-cc](https://user-images.githubusercontent.com/121939/57133805-de648980-6d9b-11e9-97ff-719d5b2b112b.png)

## Browser testing

  - [x] Internet Explorer 8 (Windows 7)
  - [x] Internet Explorer 9 (Windows 7)
  - [x] Internet Explorer 10 (Windows 8)
  - [x] Internet Explorer 11 (Windows 10)
  - [x] Edge 18 (Windows 10)
  - [x] Edge 17 (Windows 10)
  - [x] Google Chrome 74 (Windows 10)
  - [x] Mozilla Firefox 66 (Windows 10)
  - [x] Safari 12 (macOS Mojave)
  - [x] Google Chrome 74 (macOS Mojave)
  - [x] Mozilla Firefox 66 (macOS Mojave)
  - [x] Safari (iOS 12.2)
  - [x] Google Chrome (iOS 12.2)
  - [x] Google Chrome (Android 9)
  - [x] Samsung Internet (Android 8)

Closes #1304 