### PR TITLE
Update footer links to use new focus style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
   ([PR #1312](https://github.com/alphagov/govuk-frontend/pull/1312))
 
+- Update footer links to use new focus style
+
+  To migrate: [TODO add migration instructions before we ship v3.0.0]
+
+  ([PR #1321](https://github.com/alphagov/govuk-frontend/pull/1321))
+
 - Update links (and things that look like links) to use the new focus style
 
   To migrate: [TODO add migration instructions before we ship v3.0.0]

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -44,7 +44,12 @@
   }
 
   .govuk-footer__link {
-    @include govuk-focusable-fill;
+    text-decoration: none;
+
+    &:hover,
+    &:active {
+      text-decoration: underline;
+    }
 
     @if ($govuk-use-legacy-palette) {
       &:link,
@@ -65,11 +70,7 @@
       }
     }
 
-    // When focussed, the text colour needs to be darker to ensure that colour
-    // contrast is still acceptable
-    &:focus {
-      color: $govuk-focus-text-colour;
-    }
+    @include govuk-focusable-text-link;
 
     // alphagov/govuk_template includes a specific a:link:focus selector
     // designed to make unvisited links a slightly darker blue when focussed, so


### PR DESCRIPTION
## V3 focus styles

![footer-new-focus-styles](https://user-images.githubusercontent.com/2445413/57377401-40593080-719a-11e9-8b68-a44d7395b2e6.gif)

## V3 focus styles with legacy mode turned on

![footer-new-focus-styles-legacy](https://user-images.githubusercontent.com/2445413/57377400-40593080-719a-11e9-832b-edc39870a521.gif)

## Pre-v3 focus styles

![footer-old-focus-styles](https://user-images.githubusercontent.com/2445413/57377402-40593080-719a-11e9-9154-b654897f57e1.gif)

Closes https://github.com/alphagov/govuk-frontend/issues/1320