### PR TITLE
Update "Applicant details" example page

### DIFF
--- a/app/views/full-page-examples/applicant-details/index.njk
+++ b/app/views/full-page-examples/applicant-details/index.njk
@@ -54,7 +54,7 @@
         <form method="post" novalidate>
 
           <div class="form-group {%- if errors["full-name"] %} form-group-error {% endif %}">
-            <label class="form-label" for="full-name">
+            <label class="form-label-bold" for="full-name">
               Full name
               <span class="form-hint">
                 Please enter your name as it’s written on official documents such as a passport or driving licence.
@@ -88,7 +88,7 @@
             fieldset: {
               legend: {
                 text: "Date of birth",
-                classes: "govuk-fieldset__legend--m"
+                classes: "govuk-fieldset__legend--s"
               }
             },
             hint: {


### PR DESCRIPTION
Update "Applicant details" to be a closer match between GOV.UK Elements and GOV.UK Frontend style.

**Before (Normal weight 19px label and bold 24px legend):**

<img width="695" alt="Screen Shot 2019-05-08 at 15 46 19" src="https://user-images.githubusercontent.com/23356842/57384441-8a491300-71a8-11e9-88bd-2a75141650f6.png">

**After (Use elements `form-label-bold` class and reduce legend to `govuk-fieldset__legend--s`:**
<img width="702" alt="Screen Shot 2019-05-08 at 15 46 03" src="https://user-images.githubusercontent.com/23356842/57384480-a0ef6a00-71a8-11e9-9c7b-aedb54d5a09c.png">
