### PR TITLE
Update tabs component to WCAG 2.1 compliant focus style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,17 @@
 
 💥 Breaking changes:
 
+- Update tabs to use new WCAG 2.1 compliant focus style
+
+  To migrate: [TODO add migration instructions before we ship v3.0.0]
+
+  ([PR #1326](https://github.com/alphagov/govuk-frontend/pull/1326))
+
 - Update form inputs to use new WCAG 2.1 compliant focus style
 
   To migrate: [TODO add migration instructions before we ship v3.0.0]
 
-  ([PR #1312](https://github.com/alphagov/govuk-frontend/pull/13))
+  ([PR #1312](https://github.com/alphagov/govuk-frontend/pull/1312))
 
 - Update links (and things that look like links) to use the new focus style
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -84,7 +84,11 @@
         color: govuk-colour("black");
         background-color: govuk-colour("light-grey", $legacy: "grey-4");
         text-align: center;
-        text-decoration: none;
+        text-decoration: underline;
+
+        &:hover {
+          box-shadow: inset 0 4px 0 0 govuk-colour("light-blue");
+        }
 
         &--selected {
           margin-top: - govuk-spacing(1);
@@ -96,13 +100,18 @@
           padding-bottom: govuk-spacing(3) + 1px;
           padding-left: govuk-spacing(4) - 1px;
 
-          border: 1px solid $govuk-border-colour;
-          border-bottom: 0;
+          border-top: 1px solid transparent;
+          border-right: 1px solid $govuk-border-colour;
+          border-bottom: 1px solid transparent;
+          border-left: 1px solid $govuk-border-colour;
+
           color: govuk-colour("black");
           background-color: govuk-colour("white");
+          box-shadow: inset 0 4px 0 0 govuk-colour("blue");
+          text-decoration: none;
 
           &:focus {
-            background-color: transparent;
+            box-shadow: inset 0 4px 0 0 govuk-colour("yellow"), inset 0 8px 0 0 govuk-colour("black");
           }
         }
       }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -86,21 +86,40 @@
         text-align: center;
         text-decoration: underline;
 
+        @include govuk-if-ie8 {
+          // IE8 doesn't support `box-shadow` so add an actual border that is
+          // modified to indicate state.
+          border-top: 4px solid transparent;
+        }
+
         &:hover {
           box-shadow: inset 0 4px 0 0 govuk-colour("light-blue");
+
+          @include govuk-if-ie8 {
+            border-top: 4px solid govuk-colour("light-blue");
+          }
         }
 
         &--selected {
+          $top-border-width: 1px;
+          $top-border-adjustment: 1px;
+
+          @include govuk-if-ie8 {
+            // IE8 already has a top border so no adjustment is needed
+            $top-border-width: 4px;
+            $top-border-adjustment: 0;
+          }
+
           margin-top: - govuk-spacing(1);
           margin-bottom: -1px;
 
           // 1px is compensation for border (otherwise we get a 1px shift)
-          padding-top: govuk-spacing(3) - 1px;
+          padding-top: govuk-spacing(3) - $top-border-adjustment;
           padding-right: govuk-spacing(4) - 1px;
           padding-bottom: govuk-spacing(3) + 1px;
           padding-left: govuk-spacing(4) - 1px;
 
-          border-top: 1px solid transparent;
+          border-top: $top-border-width solid transparent;
           border-right: 1px solid $govuk-border-colour;
           border-bottom: 1px solid transparent;
           border-left: 1px solid $govuk-border-colour;
@@ -110,8 +129,16 @@
           box-shadow: inset 0 4px 0 0 govuk-colour("blue");
           text-decoration: none;
 
+          @include govuk-if-ie8 {
+            border-top: 4px solid govuk-colour("blue");
+          }
+
           &:focus {
             box-shadow: inset 0 4px 0 0 govuk-colour("yellow"), inset 0 8px 0 0 govuk-colour("black");
+
+            @include govuk-if-ie8 {
+              border-top: 4px solid govuk-colour("black");
+            }
           }
         }
       }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -96,7 +96,7 @@
           box-shadow: inset 0 4px 0 0 govuk-colour("light-blue");
 
           @include govuk-if-ie8 {
-            border-top: 4px solid govuk-colour("light-blue");
+            border-top-color: govuk-colour("light-blue");
           }
         }
 
@@ -121,23 +121,22 @@
 
           border-top: $top-border-width solid transparent;
           border-right: 1px solid $govuk-border-colour;
-          border-bottom: 1px solid transparent;
           border-left: 1px solid $govuk-border-colour;
 
-          color: govuk-colour("black");
+          color: $govuk-text-colour;
           background-color: govuk-colour("white");
-          box-shadow: inset 0 4px 0 0 govuk-colour("blue");
+          box-shadow: inset 0 4px 0 0 $govuk-link-colour;
           text-decoration: none;
 
           @include govuk-if-ie8 {
-            border-top: 4px solid govuk-colour("blue");
+            border-top-color: $govuk-link-colour;
           }
 
           &:focus {
-            box-shadow: inset 0 4px 0 0 govuk-colour("yellow"), inset 0 8px 0 0 govuk-colour("black");
+            box-shadow: inset 0 4px 0 0 $govuk-focus-colour, inset 0 8px 0 0 govuk-colour("black");
 
             @include govuk-if-ie8 {
-              border-top: 4px solid govuk-colour("black");
+              border-top-color: govuk-colour("black");
             }
           }
         }


### PR DESCRIPTION
Iterate on https://github.com/alphagov/govuk-frontend/pull/1245 to update the GOV.UK Frontend tabs component.

Solution implemented to support IE8
   - IE8 doesn’t support box-shadow so use border to indicate state.
   - To prevent “jump” in selected state, make adjustments as this state modifies border width.
   - Only use the black top border from the design which uses box-shadow to achieve a double border.

Tested in:
✅ Chrome 74
✅ Firefox 66 (including with overridden colours)
✅ Mac OS Safari 12.1
✅ Android Samsung Galaxy (Chrome)
✅ iOS XS / 8 (Safari)
✅ Edge 18
✅ Edge 16
✅ IE 9-11
✅ IE8 - see comments above

✅With Javascript disabled
✅ In review app "legacy" mode

Fixes https://github.com/alphagov/govuk-frontend/issues/1306