### PR TITLE
Allow custom accordion open and close text

### DIFF
--- a/src/components/accordion/accordion.js
+++ b/src/components/accordion/accordion.js
@@ -55,9 +55,15 @@ Accordion.prototype.init = function () {
 // Initialise controls and set attributes
 Accordion.prototype.initControls = function () {
   // Create "Open all" button and set attributes
+  this.buttonText = {
+    openAll: this.$module.getAttribute('data-open-all-html') ||
+      'Open all <span class="govuk-visually-hidden">sections</span>',
+    closeAll: this.$module.getAttribute('data-close-all-html') ||
+      'Close all <span class="govuk-visually-hidden">sections</span>'
+  }
   this.$openAllButton = document.createElement('button')
   this.$openAllButton.setAttribute('type', 'button')
-  this.$openAllButton.innerHTML = 'Open all <span class="govuk-visually-hidden">sections</span>'
+  this.$openAllButton.innerHTML = this.buttonText.openAll
   this.$openAllButton.setAttribute('class', this.openAllClass)
   this.$openAllButton.setAttribute('aria-expanded', 'false')
   this.$openAllButton.setAttribute('type', 'button')
@@ -197,8 +203,7 @@ Accordion.prototype.checkIfAllSectionsOpen = function () {
 
 // Update "Open all" button
 Accordion.prototype.updateOpenAllButton = function (expanded) {
-  var newButtonText = expanded ? 'Close all' : 'Open all'
-  newButtonText += '<span class="govuk-visually-hidden"> sections</span>'
+  var newButtonText = expanded ? this.buttonText.closeAll : this.buttonText.openAll
   this.$openAllButton.setAttribute('aria-expanded', expanded)
   this.$openAllButton.innerHTML = newButtonText
 }

--- a/src/components/accordion/accordion.test.js
+++ b/src/components/accordion/accordion.test.js
@@ -144,6 +144,28 @@ describe('/components/accordion', () => {
           expect(numberOfIcons).toEqual(numberOfExampleSections)
         })
       })
+
+      describe('with custom open and cllose html', () => {
+        it('should change display the custom Open all button', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-custom-open-and-close-html/preview', { waitUntil: 'load' })
+
+          var openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__open-all').textContent)
+
+          expect(openOrCloseAllButtonText).toEqual('Custom open html')
+        })
+
+        it('should change display the custom Close all button', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-custom-open-and-close-html/preview', { waitUntil: 'load' })
+
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+
+          var openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__open-all').textContent)
+
+          expect(openOrCloseAllButtonText).toEqual('Custom close html')
+        })
+      })
     })
   })
 })

--- a/src/components/accordion/accordion.yaml
+++ b/src/components/accordion/accordion.yaml
@@ -130,3 +130,25 @@ examples:
             <ul class="govuk-list govuk-list--bullet">
               <li>Example item 2</li>
             </ul>
+
+- name: with custom open and close html
+  data:
+    id: custom-open-close-html
+    attributes:
+      data-open-all-html: Custom open <b>html</b>
+      data-close-all-html: Custom close <b>html</b>
+    items:
+      - heading:
+          text: Section A
+        content:
+          html: |
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Example item 1</li>
+            </ul>
+      - heading:
+          text: Section B
+        content:
+          html: |
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Example item 2</li>
+            </ul>


### PR DESCRIPTION
Try to read custom open and close button text from a data attribute and fall back to English text to enable localisation.

fix for #1325