### PR TITLE
Add example using secondary and warning button

### DIFF
--- a/app/views/full-page-examples/confirm-delete/index.njk
+++ b/app/views/full-page-examples/confirm-delete/index.njk
@@ -1,0 +1,48 @@
+{% extends "_generic.njk" %}
+
+{% from "warning-text/macro.njk" import govukWarningText %}
+{% from "button/macro.njk" import govukButton %}
+
+{% set homepage_url = "/" %}
+{% set pageTitle = "Are you sure you want to delete Josh Lyman’s account?" %}
+{% block page_title %}GOV.UK - {{ pageTitle }}{% endblock %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+
+{% block content %}
+  <main id="content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+
+        <h1 class="govuk-heading-xl">
+         {{ pageTitle }}
+        </h1>
+
+        <p class="govuk-body">Josh Lyman last logged in <strong>3 days ago</strong>.</p>
+        
+        <p class="govuk-body">By deleting their administrator account they will no longer have access to this system. All cases that <strong>Josh Lyman</strong> is assigned to will remain open but their name will be removed from the case history.</p>
+
+        {{ govukWarningText({
+          text: "This action is final and cannot be undone.",
+          iconFallbackText: "Warning",
+          classes: "govuk-!-margin-bottom-8"
+        }) }}
+
+        <form method="post" novalidate>
+
+          {{ govukButton({
+            text: "Delete account",
+            classes: "govuk-button--warning govuk-!-margin-right-3"
+          }) }}
+
+          {{ govukButton({
+            text: "Cancel",
+            classes: "govuk-button--secondary"
+          }) }}
+
+        </form>
+
+      </div>
+    </div>
+  </main>
+
+{% endblock %}


### PR DESCRIPTION
Adds an example using Warning and Secondary Button. I don't know if it's the most realistic example but It should be enough for the audit?

<img width="668" alt="Screen Shot 2019-05-10 at 09 32 04" src="https://user-images.githubusercontent.com/23356842/57513672-b24e8880-7306-11e9-856f-d8f86dafbd33.png">
