### PR TITLE
Remove deprecated `@else-if` statement, replace with `@else if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 🔧 Fixes:
 
+- Remove deprecated `@else-if` statement, replace with `@else if`
+
+  ([PR #1333](https://github.com/alphagov/govuk-frontend/pull/1333))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/helpers/_typography.scss
+++ b/src/helpers/_typography.scss
@@ -142,7 +142,7 @@
         font-size: $font-size-rem; // sass-lint:disable no-duplicate-properties
       }
       line-height: $line-height;
-    } @elseif $breakpoint == "print" {
+    } @else if $breakpoint == "print" {
       @include govuk-media-query($media-type: print) {
         font-size: $font-size;
         line-height: $line-height;


### PR DESCRIPTION
When compiling with the [sass](https://www.npmjs.com/package/sass) npm module I'm getting the following deprecation warning:
```
DEPRECATION WARNING on line 145, column 7 of node_modules/govuk-frontend/helpers/_typography.scss:
@elseif is deprecated and will not be supported in future Sass versions.
Use "@else if" instead.
    ╷
145 │     } @elseif $breakpoint == "print" {
    │       ^^^^^^^
    ╵
```
This should fix the issue, while still sucessfully building with the `node-sass` package.