### PR TITLE
Fix app banner contrast for IE8

### DIFF
--- a/app/assets/scss/partials/_banner.scss
+++ b/app/assets/scss/partials/_banner.scss
@@ -9,8 +9,12 @@
     font-size: inherit;
   }
 
-  .govuk-link:not(:focus) {
-    color: inherit;
+  .govuk-link {
+    color: govuk-colour("white");
+   }
+
+  .govuk-link:focus {
+    color: $govuk-text-colour;
   }
 }
 


### PR DESCRIPTION
I think this fix wasn't meant to be taken out. See original code https://github.com/alphagov/govuk-frontend/commit/ea6ac782caac605403fc896b81cc9827a2be6a01#diff-fa4461f64f4ca9ed30f64c87616594fd

This PR fixes the link style in the review app banner to avoid poor contrast in IE8 (which doesn't support `:not`).

Before:
<img width="891" alt="Screen Shot 2019-05-10 at 15 42 05" src="https://user-images.githubusercontent.com/5007934/57535802-d3c96780-733a-11e9-9327-2be0eacc6159.png">

After:
<img width="990" alt="Screen Shot 2019-05-10 at 15 42 24" src="https://user-images.githubusercontent.com/5007934/57535877-f0fe3600-733a-11e9-9718-64737dd9a8f9.png">

