### PR TITLE
Fix HTML validation errors in review app 

### DIFF
--- a/app/views/full-page-examples/bank-holidays/index.njk
+++ b/app/views/full-page-examples/bank-holidays/index.njk
@@ -50,9 +50,9 @@ notes: >-
       {% set englandAndWalesHTML %}
 
         {% set englandAndWalesPanelTitleHtml %}
-          <div class='govuk-!-font-size-36 govuk-!-margin-bottom-4'>
+          <span class='govuk-!-font-size-36 govuk-!-margin-bottom-4 govuk-!-display-block'>
             The next bank holiday in England and Wales is
-          </div>
+          </span>
           19 April
         {% endset %}
 
@@ -1005,9 +1005,9 @@ notes: >-
       {% set scotlandHTML %}
 
         {% set scotlandPanelTitleHtml %}
-          <div class='govuk-!-font-size-36 govuk-!-margin-bottom-4'>
+          <span class='govuk-!-font-size-36 govuk-!-margin-bottom-4 govuk-!-display-block'>
             The next bank holiday in Scotland is
-          </div>
+          </span>
           19 April
         {% endset %}
 
@@ -2144,9 +2144,9 @@ notes: >-
       {% set irelandHTML %}
 
         {% set irelandPanelTitleHtml %}
-          <div class='govuk-!-font-size-36 govuk-!-margin-bottom-4'>
+          <span class='govuk-!-font-size-36 govuk-!-margin-bottom-4 govuk-!-display-block'>
             The next bank holiday in Northern Ireland is
-          </div>
+          </span>
           19 April
         {% endset %}
 

--- a/app/views/full-page-examples/confirm-delete/index.njk
+++ b/app/views/full-page-examples/confirm-delete/index.njk
@@ -9,40 +9,38 @@
 {% set mainClasses = "govuk-main-wrapper--l" %}
 
 {% block content %}
-  <main id="content" role="main">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-        <h1 class="govuk-heading-xl">
-         {{ pageTitle }}
-        </h1>
+      <h1 class="govuk-heading-xl">
+       {{ pageTitle }}
+      </h1>
 
-        <p class="govuk-body">Josh Lyman last logged in <strong>3 days ago</strong>.</p>
-        
-        <p class="govuk-body">By deleting their administrator account they will no longer have access to this system. All cases that <strong>Josh Lyman</strong> is assigned to will remain open but their name will be removed from the case history.</p>
+      <p class="govuk-body">Josh Lyman last logged in <strong>3 days ago</strong>.</p>
 
-        {{ govukWarningText({
-          text: "This action is final and cannot be undone.",
-          iconFallbackText: "Warning",
-          classes: "govuk-!-margin-bottom-8"
+      <p class="govuk-body">By deleting their administrator account they will no longer have access to this system. All cases that <strong>Josh Lyman</strong> is assigned to will remain open but their name will be removed from the case history.</p>
+
+      {{ govukWarningText({
+        text: "This action is final and cannot be undone.",
+        iconFallbackText: "Warning",
+        classes: "govuk-!-margin-bottom-8"
+      }) }}
+
+      <form method="post" novalidate>
+
+        {{ govukButton({
+          text: "Delete account",
+          classes: "govuk-button--warning govuk-!-margin-right-3"
         }) }}
 
-        <form method="post" novalidate>
+        {{ govukButton({
+          text: "Cancel",
+          classes: "govuk-button--secondary"
+        }) }}
 
-          {{ govukButton({
-            text: "Delete account",
-            classes: "govuk-button--warning govuk-!-margin-right-3"
-          }) }}
+      </form>
 
-          {{ govukButton({
-            text: "Cancel",
-            classes: "govuk-button--secondary"
-          }) }}
-
-        </form>
-
-      </div>
     </div>
-  </main>
+  </div>
 
 {% endblock %}


### PR DESCRIPTION
This fixes the following:
- A document must not include more than one visible `main` element.
- Element `div` not allowed as child of element `h2` in this context


