### PR TITLE
Remove grid-width mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,15 @@
 
   ([PR #1343](https://github.com/alphagov/govuk-frontend/pull/1343))
 
+- Remove grid-width mixin
+
+  https://github.com/alphagov/govuk-frontend/pull/1090 deprecated this mixin
+  and left it in as an alias to govuk-grid-width.
+
+  To migrate you'll need to replace any reference to the `grid-width` mixin with `govuk-grid-width`
+
+  ([PR #1342](https://github.com/alphagov/govuk-frontend/pull/1342))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -17,14 +17,6 @@
   @error "Unknown grid width `#{$key}`";
 }
 
-/// Grid width percentage (alias)
-///
-/// @alias govuk-grid-width
-/// @deprecated To be removed in v3.0, replaced by govuk-grid-width
-@function grid-width($key) {
-  @return govuk-grid-width($key);
-}
-
 /// Generate grid column styles
 ///
 /// Creates a grid column with standard gutter between the columns.


### PR DESCRIPTION
https://github.com/alphagov/govuk-frontend/pull/1090 deprecated this mixin
and left it in as an alias to govuk-grid-width.

ACTION: Replace all instances of grid-width with govuk-grid-width

Closes https://github.com/alphagov/govuk-frontend/issues/1091