### PR TITLE
Removes govuk-grid-row mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,15 @@
 
   ([PR #1330](https://github.com/alphagov/govuk-frontend/pull/1330))
 
+- Removes `govuk-grid-row` mixin
+
+  https://github.com/alphagov/govuk-frontend/pull/1090 copied govuk-grid-row
+  mixin to create a new concrete `.govuk-grid-row` class and marked the mixin as deprecated.
+
+  To migrate you'll need to remove any references to `govuk-grid-row` mixin and use `.govuk-grid-row` class instead.
+
+  ([PR #1343](https://github.com/alphagov/govuk-frontend/pull/1343))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -25,29 +25,6 @@
   @return govuk-grid-width($key);
 }
 
-/// Generate grid row styles
-///
-/// Creates a grid row class with a standardised margin.
-///
-/// @param {String} $class [govuk-grid-row] CSS class name
-///
-/// @example scss - Default
-///   @include govuk-grid-row;
-///
-/// @example scss - Customising the class name
-///   @include govuk-grid-row("app-grid");
-///
-/// @access public
-/// @deprecated To be removed in v3.0, replaced by the govuk-grid-row class
-
-@mixin govuk-grid-row($class: "govuk-grid-row") {
-  .#{$class} {
-    @include govuk-clearfix;
-    margin-right: - ($govuk-gutter-half);
-    margin-left: - ($govuk-gutter-half);
-  }
-}
-
 /// Generate grid column styles
 ///
 /// Creates a grid column with standard gutter between the columns.

--- a/src/helpers/grid.test.js
+++ b/src/helpers/grid.test.js
@@ -53,54 +53,6 @@ describe('grid system', () => {
     })
   })
 
-  describe('@govuk-grid-row mixin', () => {
-    it('outputs default defined styles for .govuk-grid-row class', async () => {
-      const sass = `
-        ${sassImports}
-        @import "helpers/clearfix";
-
-        @include govuk-grid-row();
-        `
-
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-row {
-          margin-right: -15px;
-          margin-left: -15px; }
-          .govuk-grid-row:after {
-            content: \"\";
-            display: block;
-            clear: both; }`)
-    })
-    it('outputs styles for the specified class', async () => {
-      const sass = `
-        ${sassImports}
-        @import "helpers/clearfix";
-
-        @include govuk-grid-row('app-grid-row');
-        `
-
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .app-grid-row {
-          margin-right: -15px;
-          margin-left: -15px; }
-          .app-grid-row:after {
-            content: \"\";
-            display: block;
-            clear: both; }
-        `)
-    })
-  })
-
   describe('@govuk-grid-column mixin', () => {
     it('outputs the CSS required for a column in the grid', async () => {
       const sass = `


### PR DESCRIPTION
https://github.com/alphagov/govuk-frontend/pull/1090 copied govuk-grid-row
mixin to create a new concrete `.govuk-grid-row` class and marked the mixin as deprecated.

ACTION TO BE TAKEN: Remove any references to `govuk-grid-row` mixin and
                    use `.govuk-grid-row` class.

closes: https://github.com/alphagov/govuk-frontend/issues/1092