### PR TITLE
Set 'vertical-align:top' positioning on table headers and cells 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@
 
 💥 Breaking changes:
 
+- Update positioning on table headers and cells to help improve readability
+
+  To migrate: If you rely on a centered certain vertical alignment, you could add
+  a custom class to your application.
+
+  ```css
+  .app-table--vertical-align-middle .govuk-table__header,
+  .app-table--vertical-align-middle .govuk-table__cell {
+    vertical-align: middle;
+  }
+  ```
+
+  ([PR #1345](https://github.com/alphagov/govuk-frontend/pull/1345))
+
 - Update tabs to use new WCAG 2.1 compliant focus style
 
   To migrate: [TODO add migration instructions before we ship v3.0.0]

--- a/src/components/table/_table.scss
+++ b/src/components/table/_table.scss
@@ -22,6 +22,7 @@
     padding: govuk-spacing(2) govuk-spacing(4) govuk-spacing(2) 0;
     border-bottom: 1px solid $govuk-border-colour;
     text-align: left;
+    vertical-align: top;
     // GOV.UK Elements sets the font-size and line-height for all headers and cells
     // in tables.
     @include govuk-compatibility(govuk_elements) {


### PR DESCRIPTION
I have created a new branch since I do not have permissions to update the original pull request: https://github.com/alphagov/govuk-frontend/pull/1064/files

Closes https://github.com/alphagov/govuk-frontend/pull/1064