### PR TITLE
Fix tabs label child elements breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,10 @@
 
 🔧 Fixes:
 
+- Fix HTML elements in tabs label breaking
+
+([PR #1351](https://github.com/alphagov/govuk-frontend/pull/1351))
+
 - fixes tabs keyboard navigation bug in IE8
 
   Users were unable to tab between tab panels using the keyboard and had to

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -170,6 +170,10 @@ Tabs.prototype.unsetAttributes = function ($tab) {
 }
 
 Tabs.prototype.onTabClick = function (e) {
+  if (!e.target.classList.contains('govuk-tabs__tab')) {
+  // Allow events on child DOM elements to bubble up to tab parent
+    return false
+  }
   e.preventDefault()
   var $newTab = e.target
   var $currentTab = this.getCurrentTab()

--- a/src/components/tabs/tabs.test.js
+++ b/src/components/tabs/tabs.test.js
@@ -78,6 +78,27 @@ describe('/components/tabs', () => {
         })
         expect(secondTabPanelIsHidden).toBeFalsy()
       })
+
+      describe('when the tab contains a DOM element', () => {
+        it('should display the tab panel associated with the selected tab', async () => {
+          await page.goto(baseUrl + '/components/tabs/preview', { waitUntil: 'load' })
+
+          await page.evaluate(() => {
+            // Replace contents of second tab with a DOM element
+            const secondTab = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab')
+            secondTab.innerHTML = '<span>Tab 2</span>'
+          })
+
+          // Click the DOM element inside the second tab
+          await page.click('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab span')
+
+          const secondTabPanelIsHidden = await page.evaluate(() => {
+            const secondTabAriaControls = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-controls')
+            return document.body.querySelector(`[id="${secondTabAriaControls}"]`).classList.contains('govuk-tabs__panel--hidden')
+          })
+          expect(secondTabPanelIsHidden).toBeFalsy()
+        })
+      })
     })
 
     describe('when first tab is focused and the right arrow key is pressed', () => {


### PR DESCRIPTION
Using HTML elements inside the tabs label breaks as `event.target` is looking at the child element instead of the tab label. 

This fix checks for the class of the target to allow the event to bubble up to the parent which is the label.

(Looks like this can also be fixed by adding

```
    & * {
      pointer-events: none;
    }
```

to https://github.com/alphagov/govuk-frontend/blob/840d019e0412309d6f8ab1032ec3b17b30fcd955/src/components/tabs/_tabs.scss#L46 but it makes more sense to fix this in JS rather than couple the fix with the stylesheet).

~Question: **Should we change the public API to accommodate adding markup inside the label by having a text and html option?** It seems like it would be useful. At the moment it's not possible to add a test (I don't think) to check for this as you can't add Nunjucks from the example yaml to set `| safe`, it needs to be done [in the template](https://github.com/alphagov/govuk-frontend/blob/840d019e0412309d6f8ab1032ec3b17b30fcd955/src/components/tabs/template.njk#L17).  I've tested this locally by amending one of the full page examples following [@fofr's example Nunjucks](https://github.com/alphagov/govuk-frontend/issues/1252).~ Edit: Had a discussion with the team. We currently can't see a user need to make larger changes to the API.

Also created a [tech debt issue](https://trello.com/c/yaKqbyQg) to look at refactoring the tabs Javascript at some point.

### Browser testing:

- [x] Chrome 74
- [x] Firefox 65
- [x] OS Safari 11
- [x] Android Samsung Galaxy (Chrome)
- [x] iOS XS / 8 (Safari) 
- [x] Edge 18
- [x] IE 8 - 11

Fixes https://github.com/alphagov/govuk-frontend/issues/1252