### PR TITLE
Fix improperly indented html output in Design System examples

### DIFF
--- a/src/components/accordion/template.njk
+++ b/src/components/accordion/template.njk
@@ -3,7 +3,6 @@
 
 <div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}"  data-module="accordion" id="{{ id }}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-
   {% for item in params.items %}
     <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">
       <div class="govuk-accordion__section-header">
@@ -23,5 +22,4 @@
       </div>
     </div>
   {% endfor %}
-
 </div>

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -71,7 +71,7 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
-      {%- if hasHint %}
+      {% if hasHint %}
       {{ govukHint({
         id: itemHintId,
         classes: 'govuk-checkboxes__hint',
@@ -79,7 +79,7 @@
         html: item.hint.html,
         text: item.hint.text
       }) | indent(6) | trim }}
-      {%- endif %}
+      {% endif %}
     </div>
     {% if item.conditional %}
       <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -1,11 +1,10 @@
 <header class="govuk-header {{ params.classes if params.classes }}" role="banner" data-module="header"
         {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-header__container {{ params.containerClasses | default('govuk-width-container') }}">
-
     <div class="govuk-header__logo">
       <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
-          {# We use an inline SVG for the crown so that we can cascade the
+          {#- We use an inline SVG for the crown so that we can cascade the
           currentColor into the crown whilst continuing to support older browsers
           which do not support external SVGs without a Javascript polyfill. This
           adds approximately 1kb to every page load.
@@ -30,7 +29,7 @@
               fill="currentColor" fill-rule="evenodd"
               d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
             ></path>
-            {# Fallback PNG image for older browsers.
+            {#- Fallback PNG image for older browsers.
 
             The <image> element is a valid SVG element. In SVG, you would specify
             the URL of the image file with the xlink:href – as we don't reference an
@@ -55,13 +54,11 @@
     </div>
     {% if params.serviceName or params.navigation  %}
     <div class="govuk-header__content">
-
     {% if params.serviceName %}
     <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
       {{ params.serviceName }}
     </a>
     {% endif %}
-
     {% if params.navigation %}
     <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>

--- a/src/components/phase-banner/__snapshots__/template.test.js.snap
+++ b/src/components/phase-banner/__snapshots__/template.test.js.snap
@@ -10,7 +10,7 @@ exports[`Phase banner with dependant components renders the tag component classe
 
 exports[`Phase banner with dependant components renders the tag component html 1`] = `
 
-<strong class="govuk-tag govuk-phase-banner__content__tag ">
+<strong class="govuk-tag govuk-phase-banner__content__tag">
   <em>
     alpha
   </em>
@@ -20,7 +20,7 @@ exports[`Phase banner with dependant components renders the tag component html 1
 
 exports[`Phase banner with dependant components renders the tag component text 1`] = `
 
-<strong class="govuk-tag govuk-phase-banner__content__tag ">
+<strong class="govuk-tag govuk-phase-banner__content__tag">
   alpha
 </strong>
 

--- a/src/components/phase-banner/template.njk
+++ b/src/components/phase-banner/template.njk
@@ -3,13 +3,11 @@
 <div class="govuk-phase-banner
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <p class="govuk-phase-banner__content">
-    {{- govukTag(
-    {
-      "text": params.tag.text,
-      "html": params.tag.html,
-      "classes": "govuk-phase-banner__content__tag " + (params.tag.classes if params.tag.classes)
-    }
-    ) -}}
+    {{ govukTag({
+      text: params.tag.text,
+      html: params.tag.html,
+      classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
+    }) | indent(4) | trim }}
     <span class="govuk-phase-banner__text">
       {{ params.html | safe if params.html else params.text }}
     </span>

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -68,7 +68,7 @@
         attributes: item.label.attributes,
         for: id
       }) | indent(6) | trim }}
-      {%- if hasHint %}
+      {% if hasHint %}
       {{ govukHint({
         id: itemHintId,
         classes: 'govuk-radios__hint',
@@ -76,7 +76,7 @@
         html: item.hint.html,
         text: item.hint.text
       }) | indent(6) | trim }}
-      {%- endif %}
+      {% endif %}
     </div>
     {% if item.conditional %}
       <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">

--- a/src/components/tabs/template.njk
+++ b/src/components/tabs/template.njk
@@ -1,12 +1,11 @@
 {#- If an id 'prefix' is not passed, fall back to using the name attribute
    instead. We need this for error messages and hints as well -#}
-{% set idPrefix = params.idPrefix if params.idPrefix %}
+{% set idPrefix = params.idPrefix if params.idPrefix -%}
 
 <div {%- if params.id %} id="{{params.id}}"{% endif %} class="govuk-tabs {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %} data-module="tabs">
   <h2 class="govuk-tabs__title">
     {{ params.title | default ("Contents") }}
   </h2>
-
   {% if(params.items) %}
   <ul class="govuk-tabs__list">
     {% for item in params.items %}
@@ -20,7 +19,6 @@
     {% endfor %}
   </ul>
   {% endif %}
-
   {% for item in params.items %}
   {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
   <section class="govuk-tabs__panel{% if loop.index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ id }}"{% for attribute, value in item.panel.attributes %} {{attribute}}="{{value}}"{% endfor %}>


### PR DESCRIPTION
From support, I've been told a few times that we ask users to take care to indent their code when prototyping.

This pull request fixes a few issues where the HTML we ask people to copy was indented incorrectly.

Note that this doesnt fix all whitespace and indent issues, just the ones that will be shown up in the design system website...