### PR TITLE
Spike mixin update hybrid

### DIFF
--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -202,7 +202,7 @@
     // We also want to avoid styling when the secttion is pressed or `:active`
     // to avoid the different focus styles from flashing quickly while the user interacts with the section.
     .govuk-accordion__section:not(.govuk-accordion__section--expanded) .govuk-accordion__section-button:focus:not(:active) {
-      @include govuk-focusable-fill-css;
+      @include govuk-focussed-fill;
     }
 
     .govuk-accordion__controls {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -202,7 +202,7 @@
     // We also want to avoid styling when the secttion is pressed or `:active`
     // to avoid the different focus styles from flashing quickly while the user interacts with the section.
     .govuk-accordion__section:not(.govuk-accordion__section--expanded) .govuk-accordion__section-button:focus:not(:active) {
-      @include govuk-focusable-text;
+      @include govuk-focusable-fill-css;
     }
 
     .govuk-accordion__controls {

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -32,7 +32,9 @@
       color: $govuk-link-hover-colour;
     }
 
-    @include govuk-focusable-fill;
+    &:focus {
+      @include govuk-focussed-fill;
+    }
   }
 
   // ...but only underline the text, not the arrow

--- a/src/components/details/_details.scss
+++ b/src/components/details/_details.scss
@@ -32,7 +32,7 @@
       color: $govuk-link-hover-colour;
     }
 
-    @include govuk-focusable-text-link;
+    @include govuk-focusable-fill;
   }
 
   // ...but only underline the text, not the arrow

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -13,6 +13,11 @@
     @include govuk-focusable;
 
     border: $govuk-border-width solid $govuk-error-colour;
+
+    &:focus {
+      // Remove `box-shadow` inherited from `:focus`.
+      box-shadow: none;
+    }
   }
 
   .govuk-error-summary__title {

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -38,7 +38,7 @@
   }
 
   .govuk-error-summary__list a {
-    @include govuk-focusable-text-link;
+    @include govuk-focusable-fill;
     @include govuk-typography-weight-bold;
 
     // Override default link styling to use error colour

--- a/src/components/error-summary/_error-summary.scss
+++ b/src/components/error-summary/_error-summary.scss
@@ -10,13 +10,12 @@
     @include govuk-text-colour;
     @include govuk-responsive-padding(4);
     @include govuk-responsive-margin(8, "bottom");
-    @include govuk-focusable;
 
     border: $govuk-border-width solid $govuk-error-colour;
 
     &:focus {
-      // Remove `box-shadow` inherited from `:focus`.
-      box-shadow: none;
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+      outline-offset: 0;
     }
   }
 
@@ -43,7 +42,6 @@
   }
 
   .govuk-error-summary__list a {
-    @include govuk-focusable-fill;
     @include govuk-typography-weight-bold;
 
     // Override default link styling to use error colour
@@ -54,10 +52,8 @@
       color: $govuk-error-colour;
     }
 
-    // When focussed, the text colour needs to be darker to ensure that colour
-    // contrast is still acceptable
     &:focus {
-      color: $govuk-focus-text-colour;
+      @include govuk-focussed-fill;
     }
   }
 

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -12,7 +12,6 @@
   .govuk-file-upload {
     @include govuk-font($size: 19);
     @include govuk-text-colour;
-    @include govuk-focusable;
     padding-top: $component-padding;
     padding-bottom: $component-padding;
 
@@ -23,6 +22,8 @@
       margin-left: -$component-padding;
       padding-right: $component-padding;
       padding-left: $component-padding;
+
+      @include govuk-focussed-input;
     }
 
     // Set "focus-within" to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1430196
@@ -36,11 +37,7 @@
       padding-right: $component-padding;
       padding-left: $component-padding;
 
-      // Emulate `govuk-focusable` mixin styles for this component in FF
-      outline: $govuk-focus-width solid $govuk-focus-colour;
-      outline-offset: 0;
-
-      box-shadow: inset 0 0 0 4px $govuk-input-border-colour;
+      @include govuk-focussed-input;
     }
   }
 
@@ -54,10 +51,7 @@
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
 
     &:focus {
-      border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `file-upload--error`
-      // already has the thicker border.
-      box-shadow: none;
+      @include govuk-focussed-input-error;
     }
 
     // Repeat `:focus` styles to prevent error styles from being applied when
@@ -66,8 +60,7 @@
     // to recognise `focus-within` and don't set any styles from the block
     // when it's a selector.
     &:focus-within {
-      border-color: $govuk-input-border-colour;
-      box-shadow: none;
+      @include govuk-focussed-input-error;
     }
   }
 }

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -23,15 +23,6 @@
       margin-left: -$component-padding;
       padding-right: $component-padding;
       padding-left: $component-padding;
-      // Use `box-shadow` to add border instead of changing `border-width`
-      // (which changes element size) and since `outline` is already used for the
-      // yellow focus state.
-      box-shadow: inset 0 0 0 4px $govuk-input-border-colour;
-
-      @include govuk-if-ie8 {
-        // IE8 doesn't support `box-shadow` so add an actual border
-        border: 4px solid $govuk-input-border-colour;
-      }
     }
 
     // Set "focus-within" to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1430196

--- a/src/components/file-upload/_file-upload.scss
+++ b/src/components/file-upload/_file-upload.scss
@@ -23,7 +23,7 @@
       padding-right: $component-padding;
       padding-left: $component-padding;
 
-      @include govuk-focussed-input;
+      @include govuk-focussed-input(4px);
     }
 
     // Set "focus-within" to fix https://bugzilla.mozilla.org/show_bug.cgi?id=1430196
@@ -37,7 +37,7 @@
       padding-right: $component-padding;
       padding-left: $component-padding;
 
-      @include govuk-focussed-input;
+      @include govuk-focussed-input(4px);
     }
   }
 

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -63,7 +63,9 @@
       }
     }
 
-    @include govuk-focusable-fill;
+    &:focus {
+      @include govuk-focussed-fill;
+    }
 
     // alphagov/govuk_template includes a specific a:link:focus selector
     // designed to make unvisited links a slightly darker blue when focussed, so

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -63,7 +63,7 @@
       }
     }
 
-    @include govuk-focusable-text-link;
+    @include govuk-focusable-fill;
 
     // alphagov/govuk_template includes a specific a:link:focus selector
     // designed to make unvisited links a slightly darker blue when focussed, so

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -76,12 +76,8 @@
       text-decoration: underline;
     }
 
-    @include govuk-focusable-fill;
-
-    // When focussed, the text colour needs to be darker to ensure that colour
-    // contrast is still acceptable
     &:focus {
-      color: $govuk-focus-text-colour;
+      @include govuk-focussed-fill;
     }
 
     // alphagov/govuk_template includes a specific a:link:focus selector
@@ -170,13 +166,15 @@
       text-decoration: underline;
     }
 
+    &:focus {
+      @include govuk-focussed-fill;
+    }
+
     &::after {
       @include govuk-shape-arrow($direction: down, $base: 10px, $display: inline-block);
       content: "";
       margin-left: govuk-spacing(1);
     }
-
-    @include govuk-focusable-fill;
 
     @include mq ($from: tablet) {
       top: govuk-spacing(3);

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -176,7 +176,7 @@
       margin-left: govuk-spacing(1);
     }
 
-    @include govuk-focusable;
+    @include govuk-focusable-fill;
 
     @include mq ($from: tablet) {
       top: govuk-spacing(3);

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -76,7 +76,7 @@
       text-decoration: underline;
     }
 
-    @include govuk-focusable-text-link;
+    @include govuk-focusable-fill;
 
     // When focussed, the text colour needs to be darker to ensure that colour
     // contrast is still acceptable

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -24,20 +24,6 @@
 
     // Disable inner shadow and remove rounded corners
     appearance: none;
-
-    &:focus {
-      // Double the border by adding its width again. Use `box-shadow` for this // instead of changing `border-width` - this is for consistency with
-      // components such as textarea where we avoid changing `border-width` as
-      // it will change the element size. Also, `outline` cannot be utilised
-      // here as it is already used for the yellow focus state.
-      box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-      @include govuk-if-ie8 {
-        // IE8 doesn't support `box-shadow` so double the border with
-        // `border-width`.
-        border-width: $govuk-border-width-form-element * 2;
-      }
-    }
   }
 
   .govuk-input::-webkit-outer-spin-button,

--- a/src/components/input/_input.scss
+++ b/src/components/input/_input.scss
@@ -9,7 +9,6 @@
 @include govuk-exports("govuk/component/input") {
   .govuk-input {
     @include govuk-font($size: 19);
-    @include govuk-focusable;
 
     box-sizing: border-box;
     width: 100%;
@@ -24,6 +23,10 @@
 
     // Disable inner shadow and remove rounded corners
     appearance: none;
+
+    &:focus {
+      @include govuk-focussed-input;
+    }
   }
 
   .govuk-input::-webkit-outer-spin-button,
@@ -40,10 +43,7 @@
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
 
     &:focus {
-      border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `input--error`
-      // already has the thicker border.
-      box-shadow: none;
+      @include govuk-focussed-input-error;
     }
   }
 

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -16,19 +16,6 @@
     height: 40px;
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
-
-    &:focus {
-      // Double the border by adding its width again. Use `box-shadow` to do
-      // this instead of changing `border-width` (which changes element size) and
-      // since `outline` is already used for the yellow focus state.
-      box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-      @include govuk-if-ie8 {
-        // IE8 doesn't support `box-shadow` so double the border with
-        // `border-width`.
-        border-width: $govuk-border-width-form-element * 2;
-      }
-    }
   }
 
   .govuk-select option:active,

--- a/src/components/select/_select.scss
+++ b/src/components/select/_select.scss
@@ -9,13 +9,16 @@
 @include govuk-exports("govuk/component/select") {
   .govuk-select {
     @include govuk-font($size: 19, $line-height: 1.25);
-    @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
     max-width: 100%;
     height: 40px;
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
+
+    &:focus {
+      @include govuk-focussed-input;
+    }
   }
 
   .govuk-select option:active,
@@ -29,10 +32,7 @@
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
 
     &:focus {
-      border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `select--error`
-      // already has the thicker border.
-      box-shadow: none;
+      @include govuk-focussed-input-error;
     }
   }
 

--- a/src/components/skip-link/_skip-link.scss
+++ b/src/components/skip-link/_skip-link.scss
@@ -6,7 +6,6 @@
   .govuk-skip-link {
     @include govuk-visually-hidden-focusable;
     @include govuk-typography-common;
-    @include govuk-focusable-fill;
     @include govuk-link-style-text;
     @include govuk-typography-responsive($size: 16);
 
@@ -22,6 +21,12 @@
       // Escaped due to Sass max() vs. CSS native max()
       padding-right: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-right})");
       padding-left: unquote("max(#{govuk-spacing(3)}, #{$padding-safe-area-left})");
+    }
+
+    &:focus {
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+      outline-offset: 0;
+      background-color: $govuk-focus-colour;
     }
   }
 }

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -24,19 +24,6 @@
     border-radius: 0;
 
     -webkit-appearance: none;
-
-    &:focus {
-      // Double the border by adding its width again. Use `box-shadow` to do
-      // this instead of changing `border-width` (which changes element size) and
-      // since `outline` is already used for the yellow focus state.
-      box-shadow: inset 0 0 0 $govuk-border-width-form-element;
-
-      @include govuk-if-ie8 {
-        // IE8 doesn't support `box-shadow` so double the border with
-        // `border-width`.
-        border-width: $govuk-border-width-form-element * 2;
-      }
-    }
   }
 
   .govuk-textarea--error {

--- a/src/components/textarea/_textarea.scss
+++ b/src/components/textarea/_textarea.scss
@@ -9,7 +9,6 @@
 @include govuk-exports("govuk/component/textarea") {
   .govuk-textarea {
     @include govuk-font($size: 19, $line-height: 1.25);
-    @include govuk-focusable;
 
     box-sizing: border-box; // should this be global?
     display: block;
@@ -24,16 +23,17 @@
     border-radius: 0;
 
     -webkit-appearance: none;
+
+    &:focus {
+      @include govuk-focussed-input;
+    }
   }
 
   .govuk-textarea--error {
     border: $govuk-border-width-form-element-error solid $govuk-error-colour;
 
     &:focus {
-      border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `textarea--error`
-      // already has the thicker border.
-      box-shadow: none;
+      @include govuk-focussed-input-error;
     }
 
   }

--- a/src/helpers/_focusable.scss
+++ b/src/helpers/_focusable.scss
@@ -27,9 +27,7 @@
 
 @mixin govuk-focusable-fill {
   &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: 0;
-    background-color: $govuk-focus-colour;
+    @include govuk-focusable-text;
   }
 }
 
@@ -54,17 +52,4 @@
   // When link is focussed, hide the default underline since the
   // box shadow adds the "underline"
   text-decoration: none;
-}
-
-/// Focusable with box-shadow
-///
-/// Removes the visible outline and replace with box-shadow and background colour.
-/// Used for interactive text-based elements.
-///
-/// @access public
-
-@mixin govuk-focusable-text-link {
-  &:focus {
-    @include govuk-focusable-text;
-  }
 }

--- a/src/helpers/_focusable.scss
+++ b/src/helpers/_focusable.scss
@@ -27,11 +27,11 @@
 
 @mixin govuk-focusable-fill {
   &:focus {
-    @include govuk-focusable-text;
+    @include govuk-focusable-fill-css;
   }
 }
 
-@mixin govuk-focusable-text {
+@mixin govuk-focusable-fill-css {
   // When colours are overridden, for example when users have a dark mode,
   // backgrounds and box-shadows disappear, so we need to ensure there's a
   // transparent outline which will be set to a visible colour.

--- a/src/helpers/_focusable.scss
+++ b/src/helpers/_focusable.scss
@@ -10,14 +10,14 @@
 ///
 /// @access public
 
-@mixin govuk-focussed-input {
+@mixin govuk-focussed-input($border-width: $govuk-border-width-form-element) {
   outline: $govuk-focus-width solid $govuk-focus-colour;
   outline-offset: 0;
-  box-shadow: inset 0 0 0 $govuk-border-width-form-element $govuk-text-colour;
+  box-shadow: inset 0 0 0 $border-width $govuk-text-colour;
 
   @include govuk-if-ie8 {
     // IE8 doesn't support `box-shadow` so add an actual border
-    border: $govuk-border-width-form-element solid $govuk-text-colour;
+    border: $border-width solid $govuk-text-colour;
   }
 }
 

--- a/src/helpers/_focusable.scss
+++ b/src/helpers/_focusable.scss
@@ -10,10 +10,18 @@
 ///
 /// @access public
 
+$govuk-focus-width-inner: 2px;
+
 @mixin govuk-focusable {
   &:focus {
     outline: $govuk-focus-width solid $govuk-focus-colour;
     outline-offset: 0;
+    box-shadow: inset 0 0 0 $govuk-focus-width-inner $govuk-text-colour;
+
+    @include govuk-if-ie8 {
+      // IE8 doesn't support `box-shadow` so add an actual border
+      border: $govuk-focus-width-inner solid $govuk-text-colour;
+    }
   }
 }
 

--- a/src/helpers/_focusable.scss
+++ b/src/helpers/_focusable.scss
@@ -10,19 +10,22 @@
 ///
 /// @access public
 
-$govuk-focus-width-inner: 2px;
+@mixin govuk-focussed-input {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+  outline-offset: 0;
+  box-shadow: inset 0 0 0 $govuk-border-width-form-element $govuk-text-colour;
 
-@mixin govuk-focusable {
-  &:focus {
-    outline: $govuk-focus-width solid $govuk-focus-colour;
-    outline-offset: 0;
-    box-shadow: inset 0 0 0 $govuk-focus-width-inner $govuk-text-colour;
-
-    @include govuk-if-ie8 {
-      // IE8 doesn't support `box-shadow` so add an actual border
-      border: $govuk-focus-width-inner solid $govuk-text-colour;
-    }
+  @include govuk-if-ie8 {
+    // IE8 doesn't support `box-shadow` so add an actual border
+    border: $govuk-border-width-form-element solid $govuk-text-colour;
   }
+}
+
+@mixin govuk-focussed-input-error {
+  border-color: $govuk-input-border-colour;
+  // Remove `box-shadow` inherited from `:focus` as `textarea--error`
+  // already has the thicker border.
+  box-shadow: none;
 }
 
 /// Focusable with fill helper
@@ -33,13 +36,7 @@ $govuk-focus-width-inner: 2px;
 ///
 /// @access public
 
-@mixin govuk-focusable-fill {
-  &:focus {
-    @include govuk-focusable-fill-css;
-  }
-}
-
-@mixin govuk-focusable-fill-css {
+@mixin govuk-focussed-fill {
   // When colours are overridden, for example when users have a dark mode,
   // backgrounds and box-shadows disappear, so we need to ensure there's a
   // transparent outline which will be set to a visible colour.

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -10,7 +10,10 @@
 
 @mixin govuk-link-common {
   @include govuk-typography-common;
-  @include govuk-focusable-fill;
+
+  &:focus {
+    @include govuk-focussed-fill;
+  }
 }
 
 /// Default link style mixin

--- a/src/helpers/_links.scss
+++ b/src/helpers/_links.scss
@@ -10,7 +10,7 @@
 
 @mixin govuk-link-common {
   @include govuk-typography-common;
-  @include govuk-focusable-text-link;
+  @include govuk-focusable-fill;
 }
 
 /// Default link style mixin


### PR DESCRIPTION
To migrate from `govuk-focusable` and `govuk-focusable-fill`:

If it's an input
```
&:focus {
  @include govuk-focused-input
}
```

If it's something that looks like a link
```

&:focus {
  @include govuk-focused-fill
}
```

If it's something else, you'll need to do non-text focus and use the following variables.
```
&:focus {
  outline: $govuk-focus-width solid $govuk-focus-colour;
  outline-offset: $govuk-focus-offset;
  box-shadow: 0 0 0 3px $govuk-focus-text-colour;
}
```

For example tabs looks like this... accordions look like this...