### PR TITLE
fixes tabs keyboard navigation bug in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,13 @@
 
 🔧 Fixes:
 
+- fixes tabs keyboard navigation bug in IE8
+
+  Users were unable to tab between tab panels using the keyboard and had to
+  use their mouse to toggle between panels.
+
+  ([PR #1359](https://github.com/alphagov/govuk-frontend/pull/1359))
+
 - Update accordion focus styles to remove firefox outlines
 
   ([PR #1324](https://github.com/alphagov/govuk-frontend/pull/1324))

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -204,10 +204,25 @@ Tabs.prototype.onTabKeydown = function (e) {
 }
 
 Tabs.prototype.activateNextTab = function () {
+  // IE doesn't support 'nextElementSibling' this code polyfills IE8
+  // https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling#Polyfill_for_Internet_Explorer_8
+  // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
+  if (!('nextElementSibling' in document.documentElement)) {
+    Object.defineProperty(Element.prototype, 'nextElementSibling', { // eslint-disable-line no-undef
+      get: function () {
+        var e = this.nextSibling
+        while (e && e.nodeType !== 1) {
+          e = e.nextSibling
+        }
+        return e
+      }
+    })
+  }
+
   var currentTab = this.getCurrentTab()
   var nextTabListItem = currentTab.parentNode.nextElementSibling
   if (nextTabListItem) {
-    var nextTab = nextTabListItem.firstElementChild
+    var nextTab = nextTabListItem.querySelector('.govuk-tabs__tab')
   }
   if (nextTab) {
     this.hideTab(currentTab)
@@ -218,10 +233,25 @@ Tabs.prototype.activateNextTab = function () {
 }
 
 Tabs.prototype.activatePreviousTab = function () {
+  // IE doesn't support 'previousElementSibling' this code polyfills IE8
+  // https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling#Polyfill_for_Internet_Explorer_8
+  // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
+  if (!('previousElementSibling' in document.documentElement)) {
+    Object.defineProperty(Element.prototype, 'previousElementSibling', { // eslint-disable-line no-undef
+      get: function () {
+        var e = this.previousSibling
+        while (e && e.nodeType !== 1) {
+          e = e.previousSibling
+        }
+        return e
+      }
+    })
+  }
+
   var currentTab = this.getCurrentTab()
   var previousTabListItem = currentTab.parentNode.previousElementSibling
   if (previousTabListItem) {
-    var previousTab = previousTabListItem.firstElementChild
+    var previousTab = previousTabListItem.querySelector('.govuk-tabs__tab')
   }
   if (previousTab) {
     this.hideTab(currentTab)

--- a/src/components/tabs/tabs.js
+++ b/src/components/tabs/tabs.js
@@ -1,5 +1,7 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Element/prototype/classList'
+import '../../vendor/polyfills/Element/prototype/nextElementSibling'
+import '../../vendor/polyfills/Element/prototype/previousElementSibling'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
 import { nodeListForEach } from '../../common'
 
@@ -204,21 +206,6 @@ Tabs.prototype.onTabKeydown = function (e) {
 }
 
 Tabs.prototype.activateNextTab = function () {
-  // IE doesn't support 'nextElementSibling' this code polyfills IE8
-  // https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/nextElementSibling#Polyfill_for_Internet_Explorer_8
-  // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
-  if (!('nextElementSibling' in document.documentElement)) {
-    Object.defineProperty(Element.prototype, 'nextElementSibling', { // eslint-disable-line no-undef
-      get: function () {
-        var e = this.nextSibling
-        while (e && e.nodeType !== 1) {
-          e = e.nextSibling
-        }
-        return e
-      }
-    })
-  }
-
   var currentTab = this.getCurrentTab()
   var nextTabListItem = currentTab.parentNode.nextElementSibling
   if (nextTabListItem) {
@@ -233,21 +220,6 @@ Tabs.prototype.activateNextTab = function () {
 }
 
 Tabs.prototype.activatePreviousTab = function () {
-  // IE doesn't support 'previousElementSibling' this code polyfills IE8
-  // https://developer.mozilla.org/en-US/docs/Web/API/NonDocumentTypeChildNode/previousElementSibling#Polyfill_for_Internet_Explorer_8
-  // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
-  if (!('previousElementSibling' in document.documentElement)) {
-    Object.defineProperty(Element.prototype, 'previousElementSibling', { // eslint-disable-line no-undef
-      get: function () {
-        var e = this.previousSibling
-        while (e && e.nodeType !== 1) {
-          e = e.previousSibling
-        }
-        return e
-      }
-    })
-  }
-
   var currentTab = this.getCurrentTab()
   var previousTabListItem = currentTab.parentNode.previousElementSibling
   if (previousTabListItem) {

--- a/src/vendor/polyfills/Element/prototype/nextElementSibling.js
+++ b/src/vendor/polyfills/Element/prototype/nextElementSibling.js
@@ -1,0 +1,27 @@
+import '../../Object/defineProperty'
+import '../../Element'
+
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-b09a5d2acf3314b46a6c8f8d0c31b85c
+    var detect = (
+      'Element' in this && "nextElementSibling" in document.documentElement
+    )
+
+    if (detect) return
+
+
+    (function (global) {
+
+      // Polyfill from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-404b69b4750d18dea4174930a49170fd
+      Object.defineProperty(Element.prototype, "nextElementSibling", {
+        get: function(){
+          var el = this.nextSibling;
+          while (el && el.nodeType !== 1) { el = el.nextSibling; }
+          return (el.nodeType === 1) ? el : null;
+        }
+      });
+
+    }(this));
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});

--- a/src/vendor/polyfills/Element/prototype/previousElementSibling.js
+++ b/src/vendor/polyfills/Element/prototype/previousElementSibling.js
@@ -1,0 +1,25 @@
+import '../../Object/defineProperty'
+import '../../Element'
+
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-a162235fbc9c0dd40d4032265f44942e
+    var detect = (
+      'Element' in this && 'previousElementSibling' in document.documentElement
+    )
+
+    if (detect) return
+
+    (function (global) {
+      // Polyfill from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-b45a1197b842728cb76b624b6ba7d739
+      Object.defineProperty(Element.prototype, 'previousElementSibling', {
+        get: function(){
+          var el = this.previousSibling;
+          while (el && el.nodeType !== 1) { el = el.previousSibling; }
+          return (el.nodeType === 1) ? el : null;
+        }
+      });
+
+    }(this));
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});


### PR DESCRIPTION
In IE8, the browser could not find the next/previous tab because it does
not support `nextElementSibling` and `previousElementSibling` DOM traversal
methods. To fix it I applied a polyfill for it.

Once the browser could find the tab we then had to find the `firstChildElement`
(i.e the anchor element) to add/edit the various data attributes to show/hide
the tab panel. Again IE8 doesn't support it and instead of introducing another
polyfill I used `querySelector instead to look up the "a". I assumed the
first element would always be anchor for navigation purposes and also the
nunjucks template uses an anchor with the class name that I'm looking up.

### Before:

![ie8-tab-nav-bug](https://user-images.githubusercontent.com/3441519/57938092-4e583100-78bf-11e9-99e3-2d42d90dfdf6.gif)

### After
![ie8-tab-nav-fix](https://user-images.githubusercontent.com/3441519/57938099-544e1200-78bf-11e9-8cb1-62ec0b6eb962.gif)


fixes: #1327 
👉 https://govuk-frontend-review-pr-1359.herokuapp.com/components/tabs
👉 https://govuk-frontend-review-pr-1359.herokuapp.com/components/tabs/preview