### PR TITLE
Allow for classes, rowspan, colspan and attributes on row headers

### DIFF
--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -21,14 +21,21 @@
     {% for row in params.rows %}
     <tr class="govuk-table__row">
     {% for cell in row %}
+      {% set commonAttributes %}
+        {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
+        {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+      {% endset %}
       {% if loop.first and params.firstCellIsHeader %}
-      <th class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}" scope="row">{{ cell.html | safe if cell.html else cell.text }}</th>
+      <th class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}"
+        scope="row"
+        {{ commonAttributes | safe }}
+      >{{ cell.html | safe if cell.html else cell.text }}</th>
       {% else %}
       <td class="govuk-table__cell
-      {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
-      {%- if cell.classes %} {{ cell.classes }}{% endif %}"
-      {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ cell.html | safe if cell.html else cell.text }}</td>
+        {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
+        {%- if cell.classes %} {{ cell.classes }}{% endif %}"
+        {{ commonAttributes | safe }}
+      >{{ cell.html | safe if cell.html else cell.text }}</td>
       {% endif %}
     {% endfor %}
     </tr>

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -23,14 +23,8 @@
     {% for cell in row %}
       {% if loop.first and params.firstCellIsHeader %}
       <th class="govuk-table__header" scope="row">{{ cell.html | safe if cell.html else cell.text }}</th>
-      {% elseif loop.first %}
-      <td class="govuk-table__cell
-      {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
-      {%- if cell.classes %} {{ cell.classes }}{% endif %}"
-      {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-      {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ cell.html | safe if cell.html else cell.text }}</td>
       {% else %}
-      <td class="govuk-table__cell 
+      <td class="govuk-table__cell
       {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
       {%- if cell.classes %} {{ cell.classes }}{% endif %}"
       {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -8,11 +8,11 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
     {% for item in params.head %}
-      <th class="govuk-table__header
+      <th scope="col" class="govuk-table__header
       {%- if item.format %} govuk-table__header--{{ item.format }}{% endif %}
       {%- if item.classes %} {{ item.classes }}{% endif %}"
       {%- if item.colspan %} colspan="{{ item.colspan }}"{% endif %}
-      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %} scope="col">{{ item.html |safe if item.html else item.text }}</th>
+      {%- if item.rowspan %} rowspan="{{ item.rowspan }}"{% endif %}{% for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>{{ item.html |safe if item.html else item.text }}</th>
     {% endfor %}
     </tr>
   </thead>
@@ -26,15 +26,14 @@
         {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
       {% endset %}
       {% if loop.first and params.firstCellIsHeader %}
-      <th class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}"
-        scope="row"
-        {{ commonAttributes | safe }}
+      <th scope="row" class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}"
+        {{- commonAttributes | safe -}}
       >{{ cell.html | safe if cell.html else cell.text }}</th>
       {% else %}
       <td class="govuk-table__cell
         {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
         {%- if cell.classes %} {{ cell.classes }}{% endif %}"
-        {{ commonAttributes | safe }}
+        {{- commonAttributes | safe -}}
       >{{ cell.html | safe if cell.html else cell.text }}</td>
       {% endif %}
     {% endfor %}

--- a/src/components/table/template.njk
+++ b/src/components/table/template.njk
@@ -22,7 +22,7 @@
     <tr class="govuk-table__row">
     {% for cell in row %}
       {% if loop.first and params.firstCellIsHeader %}
-      <th class="govuk-table__header" scope="row">{{ cell.html | safe if cell.html else cell.text }}</th>
+      <th class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}" scope="row">{{ cell.html | safe if cell.html else cell.text }}</th>
       {% else %}
       <td class="govuk-table__cell
       {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}

--- a/src/components/table/template.test.js
+++ b/src/components/table/template.test.js
@@ -129,6 +129,68 @@ describe('Table', () => {
     expect($('.govuk-table__row *:first-child').hasClass('my-custom-class')).toBeTruthy()
   })
 
+  it('includes rowspan when the first row is a header', () => {
+    const $ = render('table', {
+      'firstCellIsHeader': true,
+      'rows': [
+        [
+          {
+            'text': 'January',
+            'rowspan': 2
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    expect($('.govuk-table__row *:first-child').attr('rowspan')).toEqual('2')
+  })
+
+  it('includes colspan when the first row is a header', () => {
+    const $ = render('table', {
+      'firstCellIsHeader': true,
+      'rows': [
+        [
+          {
+            'text': 'January',
+            'colspan': 2
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    expect($('.govuk-table__row *:first-child').attr('colspan')).toEqual('2')
+  })
+
+  it('includes additional attributes when the first row is a header', () => {
+    const $ = render('table', {
+      'firstCellIsHeader': true,
+      'rows': [
+        [
+          {
+            'text': 'January',
+            'attributes': {
+              'data-foo': 'bar'
+            }
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    expect($('.govuk-table__row *:first-child').attr('data-foo')).toEqual('bar')
+  })
+
   it('renders with thead', () => {
     const args = examples['table with head']
     const $ = render('table', args)

--- a/src/components/table/template.test.js
+++ b/src/components/table/template.test.js
@@ -109,6 +109,26 @@ describe('Table', () => {
     expect($lastTableHeader.hasClass('govuk-table__header')).toBeTruthy()
   })
 
+  it('includes additional classes when the first row is a header', () => {
+    const $ = render('table', {
+      'firstCellIsHeader': true,
+      'rows': [
+        [
+          {
+            'text': 'January',
+            'classes': 'my-custom-class'
+          },
+          {
+            'text': '£85',
+            'format': 'numeric'
+          }
+        ]
+      ]
+    })
+
+    expect($('.govuk-table__row *:first-child').hasClass('my-custom-class')).toBeTruthy()
+  })
+
   it('renders with thead', () => {
     const args = examples['table with head']
     const $ = render('table', args)


### PR DESCRIPTION
This change allows you to pass classes, rowspan, colspan and attributes to the first cell in each row when `firstCellIsHeader` is `true`.

~~It also simplifies the logic of the table template, and tidies up the tests to use a single assertion per test, improve coverage and use a consistent format.~~ (Split into a future PR)

Fixes #1261