### PR TITLE
Clarify productName vs serviceName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,13 @@
 
   ([PR #1310](https://github.com/alphagov/govuk-frontend/pull/1310))
 
+- Fixes the description for serviceName option in header component (used in the
+  GOV.UK Design System)
+
+  Thanks to [Ed Horsford](https://github.com/edwardhorsford) for reporting.
+
+  ([PR #1368](https://github.com/alphagov/govuk-frontend/pull/1368))
+
 [compatibility mode]: https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#compatibility-mode
 
 ## 2.11.0 (Feature release)

--- a/src/components/header/header.yaml
+++ b/src/components/header/header.yaml
@@ -10,11 +10,11 @@ params:
 - name: productName
   type: string
   required: false
-  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+  description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use serviceName.
 - name: serviceName
   type: string
   required: false
-  description: Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)
+  description: The name of your service, included in the header.
 - name: serviceUrl
   type: string
   required: false


### PR DESCRIPTION
At the minute the serviceName description incorrectly duplicates the productName description.

In most cases, we expect people to use service name, so this is an attempt to clarify what each is for and when to use them.

Fixes #1286 