### PR TITLE
Ensure start now icon is ignored by screenreaders

### DIFF
--- a/src/components/button/template.njk
+++ b/src/components/button/template.njk
@@ -24,7 +24,7 @@
 {#- The SVG needs `focusable="false"` so that Internet Explorer does not
 treat it as an interactive element - without this it will be
 'focusable' when using the keyboard to navigate. #}
-<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" focusable="false">
+<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
   <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
 </svg>
   {% endset %}


### PR DESCRIPTION
By putting `role=presentation` on the SVG icon we ensure that it is not added to the accessibility tree and can't cause any issues for people using screen readers.

This is also consistent with what we do in the header for the crown icon.