### PR TITLE
Support custom attributes on summary list action links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 🆕 New features:
 
+- Support custom attributes on summary list action links
+
+  You can now use the `attributes` macro option to add additional HTML attributes to summary list action links.
+
+  ([PR #1372](https://github.com/alphagov/govuk-frontend/pull/1372))
+
 - Support aria-describedby on all form fields
 
   All form fields now support an initial `aria-describedby` value, populated before the optional hint and error message IDs are appended.

--- a/src/components/summary-list/summary-list.yaml
+++ b/src/components/summary-list/summary-list.yaml
@@ -55,7 +55,11 @@ params:
     - name: classes
       type: string
       required: false
-      description: Classes to add to the action item
+      description: Classes to add to the action item.
+    - name: attributes
+      type: object
+      required: false
+      description: HTML attributes (for example data attributes) to add to the action item.
 - name: classes
   type: string
   required: false

--- a/src/components/summary-list/template.njk
+++ b/src/components/summary-list/template.njk
@@ -1,5 +1,5 @@
 {%- macro _actionLink(action) %}
-  <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}">
+  <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
     {{ action.html | safe if action.html else action.text }}
     {%- if action.visuallyHiddenText -%}
       <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>

--- a/src/components/summary-list/template.test.js
+++ b/src/components/summary-list/template.test.js
@@ -265,6 +265,31 @@ describe('Data list', () => {
 
         expect($actionList.hasClass('app-custom-class')).toBeTruthy()
       })
+      it('renders attributes', async () => {
+        const $ = render('summary-list', {
+          rows: [
+            {
+              actions: {
+                items: [
+                  {
+                    text: 'Edit',
+                    attributes: {
+                      'data-test-attribute': 'value',
+                      'data-test-attribute-2': 'value-2'
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions > a')
+
+        expect($actionLink.attr('data-test-attribute')).toEqual('value')
+        expect($actionLink.attr('data-test-attribute-2')).toEqual('value-2')
+      })
       it('renders a single anchor with one action', async () => {
         const $ = render('summary-list', {
           rows: [


### PR DESCRIPTION
We've spotted a requirement in our service to add attributes to the "Check Answers" action links.

I've added support via this pull request. Thanks!

```js
{{ govukSummaryList({
  rows: [
    {
      actions: {
        items: [
          {
            text: 'Edit',
            attributes: {
              'data-attribute-1': 'ABC',
              'data-attribute-2': '123'
            }
          }
        ]
      }
    }
  ]
}) }}
```