### PR TITLE
Document table improvements in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,14 @@
 
   ([PR #1288](https://github.com/alphagov/govuk-frontend/pull/1288))
 
+- Table row headers (the first cell in each row when firstCellIsHeader is true)
+  can now have additional classes, rowspan, colspan and additional attributes,
+  in line with other table cells.
+
+  Thanks to [Ed Horsford](https://github.com/edwardhorsford) for reporting.
+
+  ([PR #1367](https://github.com/alphagov/govuk-frontend/pull/1367))
+
 - Pull Request Title goes here
 
   Description goes here (optional)


### PR DESCRIPTION
This was accidentally removed from #1367 when I removed the test refactoring commits.