### PR TITLE
Fix tab bevelled edge

### DIFF
--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -106,37 +106,40 @@
       box-shadow: 0 2px 0 $govuk-focus-text-colour;
     }
 
-    // The following adjustments do not work for <input type="button"> as
-    // non-container elements cannot include pseudo elements (i.e. ::before).
+    // Internet Explorer 8 does not support box-shadow, which this CSS is used for.
+    @include govuk-not-ie8 {
+      // The following adjustments do not work for <input type="button"> as
+      // non-container elements cannot include pseudo elements (i.e. ::before).
 
-    // Use a pseudo element to expand the click target area to include the
-    // button's shadow as well, in case users try to click it.
-    &::before {
-      content: "";
-      display: block;
+      // Use a pseudo element to expand the click target area to include the
+      // button's shadow as well, in case users try to click it.
+      &::before {
+        content: "";
+        display: block;
 
-      position: absolute;
+        position: absolute;
 
-      top: -$govuk-border-width-form-element;
-      right: -$govuk-border-width-form-element;
-      bottom: -($govuk-border-width-form-element + $button-shadow-size);
-      left: -$govuk-border-width-form-element;
+        top: -$govuk-border-width-form-element;
+        right: -$govuk-border-width-form-element;
+        bottom: -($govuk-border-width-form-element + $button-shadow-size);
+        left: -$govuk-border-width-form-element;
 
-      background: transparent;
-    }
+        background: transparent;
+      }
 
-    // When the button is active it is shifted down by $button-shadow-size to
-    // denote a 'pressed' state. If the user happened to click at the very top
-    // of the button, their mouse is no longer over the button (because it has
-    // 'moved beneath them') and so the click event is not fired.
-    //
-    // This corrects that by shifting the top of the pseudo element so that it
-    // continues to cover the area that the user originally clicked, which means
-    // the click event is still fired.
-    //
-    // 🎉
-    &:active::before {
-      top: -($govuk-border-width-form-element + $button-shadow-size);
+      // When the button is active it is shifted down by $button-shadow-size to
+      // denote a 'pressed' state. If the user happened to click at the very top
+      // of the button, their mouse is no longer over the button (because it has
+      // 'moved beneath them') and so the click event is not fired.
+      //
+      // This corrects that by shifting the top of the pseudo element so that it
+      // continues to cover the area that the user originally clicked, which means
+      // the click event is still fired.
+      //
+      // 🎉
+      &:active::before {
+        top: -($govuk-border-width-form-element + $button-shadow-size);
+      }
     }
   }
 

--- a/src/components/checkboxes/_checkboxes.scss
+++ b/src/components/checkboxes/_checkboxes.scss
@@ -76,42 +76,45 @@
     touch-action: manipulation;
   }
 
-  // [ ] Check box
-  .govuk-checkboxes__label::before {
-    content: "";
-    box-sizing: border-box;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: $govuk-checkboxes-size;
-    height: $govuk-checkboxes-size;
-    border: $govuk-border-width-form-element solid currentColor;
-    background: transparent;
-  }
+  // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+  @include govuk-not-ie8 {
+    // [ ] Check box
+    .govuk-checkboxes__label::before {
+      content: "";
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: $govuk-checkboxes-size;
+      height: $govuk-checkboxes-size;
+      border: $govuk-border-width-form-element solid currentColor;
+      background: transparent;
+    }
 
-  // ✔ Check mark
-  //
-  // The check mark is a box with a border on the left and bottom side (└──),
-  // rotated 45 degrees
-  .govuk-checkboxes__label::after {
-    content: "";
+    // ✔ Check mark
+    //
+    // The check mark is a box with a border on the left and bottom side (└──),
+    // rotated 45 degrees
+    .govuk-checkboxes__label::after {
+      content: "";
 
-    position: absolute;
-    top: 11px;
-    left: 9px;
-    width: 18px;
-    height: 7px;
+      position: absolute;
+      top: 11px;
+      left: 9px;
+      width: 18px;
+      height: 7px;
 
-    transform: rotate(-45deg);
-    border: solid;
-    border-width: 0 0 $govuk-border-width $govuk-border-width;
-    // Fix bug in IE11 caused by transform rotate (-45deg).
-    // See: alphagov/govuk_elements/issues/518
-    border-top-color: transparent;
+      transform: rotate(-45deg);
+      border: solid;
+      border-width: 0 0 $govuk-border-width $govuk-border-width;
+      // Fix bug in IE11 caused by transform rotate (-45deg).
+      // See: alphagov/govuk_elements/issues/518
+      border-top-color: transparent;
 
-    opacity: 0;
+      opacity: 0;
 
-    background: transparent;
+      background: transparent;
+    }
   }
 
   .govuk-checkboxes__hint {
@@ -120,15 +123,18 @@
     padding-left: $govuk-checkboxes-label-padding-left-right;
   }
 
-  // Focused state
-  .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-    border-width: 4px;
-    box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
-  }
+  // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+  @include govuk-not-ie8 {
+    // Focused state
+    .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+      border-width: 4px;
+      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+    }
 
-  // Selected state
-  .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
-    opacity: 1;
+    // Selected state
+    .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
+      opacity: 1;
+    }
   }
 
   // Disabled state
@@ -221,25 +227,28 @@
       }
     }
 
-    // [ ] Check box
-    //
-    // Reduce the size of the check box [1], vertically center it within the
-    // touch target [2]
-    .govuk-checkboxes__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
-      width: $govuk-small-checkboxes-size; // 1
-      height: $govuk-small-checkboxes-size; // 1
-    }
+    // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+    @include govuk-not-ie8 {
+      // [ ] Check box
+      //
+      // Reduce the size of the check box [1], vertically center it within the
+      // touch target [2]
+      .govuk-checkboxes__label::before {
+        top: $input-offset - $govuk-border-width-form-element; // 2
+        width: $govuk-small-checkboxes-size; // 1
+        height: $govuk-small-checkboxes-size; // 1
+      }
 
-    // ✔ Check mark
-    //
-    // Reduce the size of the check mark and re-align within the checkbox
-    .govuk-checkboxes__label::after {
-      top: 15px;
-      left: 6px;
-      width: 9px;
-      height: 3.5px;
-      border-width: 0 0 3px 3px;
+      // ✔ Check mark
+      //
+      // Reduce the size of the check mark and re-align within the checkbox
+      .govuk-checkboxes__label::after {
+        top: 15px;
+        left: 6px;
+        width: 9px;
+        height: 3.5px;
+        border-width: 0 0 3px 3px;
+      }
     }
 
     // Fix position of hint with small checkboxes
@@ -263,40 +272,43 @@
       clear: both;
     }
 
-    // Hover state for small checkboxes.
-    //
-    // We use a hover state for small checkboxes because the touch target size
-    // is so much larger than their visible size, and so we need to provide
-    // feedback to the user as to which checkbox they will select when their
-    // cursor is outside of the visible area.
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
-      box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
-    }
-
-    // Because we've overridden the border-shadow provided by the focus state,
-    // we need to redefine that too.
-    //
-    // We use two box shadows, one that restores the original focus state [1]
-    // and another that then applies the hover state [2].
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-      // sass-lint:disable indentation
-      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour, // 1
-                  0 0 0 $govuk-hover-width $govuk-hover-colour; // 2
-    }
-
-    // For devices that explicitly don't support hover, don't provide a hover
-    // state (e.g. on touch devices like iOS).
-    //
-    // We can't use `@media (hover: hover)` because we wouldn't get the hover
-    // state in browsers that don't support `@media (hover)` (like Internet
-    // Explorer) – so we have to 'undo' the hover state instead.
-    @media (hover: none), (pointer: coarse) {
+    // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+    @include govuk-not-ie8 {
+      // Hover state for small checkboxes.
+      //
+      // We use a hover state for small checkboxes because the touch target size
+      // is so much larger than their visible size, and so we need to provide
+      // feedback to the user as to which checkbox they will select when their
+      // cursor is outside of the visible area.
       .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
-        box-shadow: initial;
+        box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
       }
 
+      // Because we've overridden the border-shadow provided by the focus state,
+      // we need to redefine that too.
+      //
+      // We use two box shadows, one that restores the original focus state [1]
+      // and another that then applies the hover state [2].
       .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
-        box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+        // sass-lint:disable indentation
+        box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour, // 1
+                    0 0 0 $govuk-hover-width $govuk-hover-colour; // 2
+      }
+
+      // For devices that explicitly don't support hover, don't provide a hover
+      // state (e.g. on touch devices like iOS).
+      //
+      // We can't use `@media (hover: hover)` because we wouldn't get the hover
+      // state in browsers that don't support `@media (hover)` (like Internet
+      // Explorer) – so we have to 'undo' the hover state instead.
+      @media (hover: none), (pointer: coarse) {
+        .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+          box-shadow: initial;
+        }
+
+        .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+          box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+        }
       }
     }
   }

--- a/src/components/radios/_radios.scss
+++ b/src/components/radios/_radios.scss
@@ -41,7 +41,7 @@
 
     cursor: pointer;
 
-    // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
+    // IE8 doesn’t support border-radius and transforms, so we don’t want to hide native
     // elements there.
     @include govuk-not-ie8 {
       position: absolute;
@@ -79,40 +79,43 @@
     touch-action: manipulation;
   }
 
-  // ( ) Radio ring
-  .govuk-radios__label::before {
-    content: "";
-    box-sizing: border-box;
-    position: absolute;
-    top: 0;
-    left: 0;
+  // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+  @include govuk-not-ie8 {
+    // ( ) Radio ring
+    .govuk-radios__label::before {
+      content: "";
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      left: 0;
 
-    width: $govuk-radios-size;
-    height: $govuk-radios-size;
+      width: $govuk-radios-size;
+      height: $govuk-radios-size;
 
-    border: $govuk-border-width-form-element solid currentColor;
-    border-radius: 50%;
-    background: transparent;
-  }
+      border: $govuk-border-width-form-element solid currentColor;
+      border-radius: 50%;
+      background: transparent;
+    }
 
-  //  •  Radio button
-  //
-  // We create the 'button' entirely out of 'border' so that they remain
-  // 'filled' even when colours are overridden in the browser.
-  .govuk-radios__label::after {
-    content: "";
+    //  •  Radio button
+    //
+    // We create the 'button' entirely out of 'border' so that they remain
+    // 'filled' even when colours are overridden in the browser.
+    .govuk-radios__label::after {
+      content: "";
 
-    position: absolute;
-    top: govuk-spacing(2);
-    left: govuk-spacing(2);
+      position: absolute;
+      top: govuk-spacing(2);
+      left: govuk-spacing(2);
 
-    width: 0;
-    height: 0;
+      width: 0;
+      height: 0;
 
-    border: govuk-spacing(2) solid currentColor;
-    border-radius: 50%;
-    opacity: 0;
-    background: currentColor;
+      border: govuk-spacing(2) solid currentColor;
+      border-radius: 50%;
+      opacity: 0;
+      background: currentColor;
+    }
   }
 
   .govuk-radios__hint {
@@ -121,15 +124,18 @@
     padding-left: $govuk-radios-label-padding-left-right;
   }
 
-  // Focused state
-  .govuk-radios__input:focus + .govuk-radios__label::before {
-    border-width: 4px;
-    box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
-  }
+  // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+  @include govuk-not-ie8 {
+    // Focused state
+    .govuk-radios__input:focus + .govuk-radios__label::before {
+      border-width: 4px;
+      box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
+    }
 
-  // Selected state
-  .govuk-radios__input:checked + .govuk-radios__label::after {
-    opacity: 1;
+    // Selected state
+    .govuk-radios__input:checked + .govuk-radios__label::after {
+      opacity: 1;
+    }
   }
 
   // Disabled state
@@ -259,23 +265,26 @@
       }
     }
 
-    // ( ) Radio ring
-    //
-    // Reduce the size of the control [1], vertically centering it within the
-    // touch target [2]
-    .govuk-radios__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
-      width: $govuk-small-radios-size; // 1
-      height: $govuk-small-radios-size; // 1
-    }
+    // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+    @include govuk-not-ie8 {
+      // ( ) Radio ring
+      //
+      // Reduce the size of the control [1], vertically centering it within the
+      // touch target [2]
+      .govuk-radios__label::before {
+        top: $input-offset - $govuk-border-width-form-element; // 2
+        width: $govuk-small-radios-size; // 1
+        height: $govuk-small-radios-size; // 1
+      }
 
-    //  •  Radio button
-    //
-    // Reduce the size of the 'button' and center it within the ring
-    .govuk-radios__label::after {
-      top: 15px;
-      left: 7px;
-      border-width: 5px;
+      //  •  Radio button
+      //
+      // Reduce the size of the 'button' and center it within the ring
+      .govuk-radios__label::after {
+        top: 15px;
+        left: 7px;
+        border-width: 5px;
+      }
     }
 
     // Fix position of hint with small radios
@@ -305,40 +314,43 @@
       margin-bottom: govuk-spacing(1);
     }
 
-    // Hover state for small radios.
-    //
-    // We use a hover state for small radios because the touch target size
-    // is so much larger than their visible size, and so we need to provide
-    // feedback to the user as to which radio they will select when their
-    // cursor is outside of the visible area.
-    .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
-      box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
-    }
-
-    // Because we've overridden the border-shadow provided by the focus state,
-    // we need to redefine that too.
-    //
-    // We use two box shadows, one that restores the original focus state [1]
-    // and another that then applies the hover state [2].
-    .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
-      // sass-lint:disable indentation
-      box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour, // 1
-                  0 0 0 $govuk-hover-width        $govuk-hover-colour; // 2
-    }
-
-    // For devices that explicitly don't support hover, don't provide a hover
-    // state (e.g. on touch devices like iOS).
-    //
-    // We can't use `@media (hover: hover)` because we wouldn't get the hover
-    // state in browsers that don't support `@media (hover)` (like Internet
-    // Explorer) – so we have to 'undo' the hover state instead.
-    @media (hover: none), (pointer: coarse) {
+    // Internet Explorer 8 does not all the features needed for the custom inputs, so avoid showing them.
+    @include govuk-not-ie8 {
+      // Hover state for small radios.
+      //
+      // We use a hover state for small radios because the touch target size
+      // is so much larger than their visible size, and so we need to provide
+      // feedback to the user as to which radio they will select when their
+      // cursor is outside of the visible area.
       .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
-        box-shadow: initial;
+        box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
       }
 
+      // Because we've overridden the border-shadow provided by the focus state,
+      // we need to redefine that too.
+      //
+      // We use two box shadows, one that restores the original focus state [1]
+      // and another that then applies the hover state [2].
       .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
-        box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
+        // sass-lint:disable indentation
+        box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour, // 1
+                    0 0 0 $govuk-hover-width        $govuk-hover-colour; // 2
+      }
+
+      // For devices that explicitly don't support hover, don't provide a hover
+      // state (e.g. on touch devices like iOS).
+      //
+      // We can't use `@media (hover: hover)` because we wouldn't get the hover
+      // state in browsers that don't support `@media (hover)` (like Internet
+      // Explorer) – so we have to 'undo' the hover state instead.
+      @media (hover: none), (pointer: coarse) {
+        .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+          box-shadow: initial;
+        }
+
+        .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+          box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
+        }
       }
     }
   }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -75,6 +75,7 @@
       }
 
       .govuk-tabs__tab {
+        position: relative;
         margin-right: govuk-spacing(1);
         padding-right: govuk-spacing(4);
         padding-left: govuk-spacing(4);
@@ -90,57 +91,76 @@
           padding-bottom: govuk-spacing(2);
         }
 
-        @include govuk-if-ie8 {
-          // IE8 doesn't support `box-shadow` so add an actual border that is
-          // modified to indicate state.
-          border-top: 4px solid transparent;
+        // Since borders are joined with a  45 degree angle bevel 'mitre joint',
+        // we can't set the top border color.
+        //
+        // +-------------+
+        // | \=========/ |
+        // |   +-----+   |
+        // |   | Tab |   |
+        // +---+     +---+
+        //
+        // To get around this we float a border above the tab
+        // so that it'll be 90 degree angle 'butt joint'.
+        //
+        // +---+-----+---+
+        // |   |=====|   |
+        // |   +-----+   |
+        // |   | Tab |   |
+        // +---+     +---+
+        //
+        &::after {
+          content: "";
+          position: absolute;
+          top: -1px;
+          right: 0;
+          left: 0;
+          border: 0 solid transparent;
         }
 
         &:hover {
-          box-shadow: inset 0 4px 0 0 govuk-colour("light-blue");
+          // Remove outline from unenhanced focus state
+          outline: none;
+          // Remove styles from unenhanced focus state
+          box-shadow: none;
 
-          @include govuk-if-ie8 {
+          &::after {
+            border-top-width: 4px;
             border-top-color: govuk-colour("light-blue");
           }
         }
 
         &--selected {
-          $top-border-width: 1px;
-          $top-border-adjustment: 1px;
-
-          @include govuk-if-ie8 {
-            // IE8 already has a top border so no adjustment is needed
-            $top-border-width: 4px;
-            $top-border-adjustment: 0;
-          }
-
-          margin-top: - govuk-spacing(1);
+          margin-top: - (govuk-spacing(1) - 1px);
           margin-bottom: -1px;
 
-          // 1px is compensation for border (otherwise we get a 1px shift)
-          padding-top: govuk-spacing(3) - $top-border-adjustment;
+          padding-top: govuk-spacing(3) - 2px;
           padding-right: govuk-spacing(4) - 1px;
           padding-bottom: govuk-spacing(3) + 1px;
           padding-left: govuk-spacing(4) - 1px;
 
-          border-top: $top-border-width solid transparent;
-          border-right: 1px solid $govuk-border-colour;
-          border-left: 1px solid $govuk-border-colour;
+          border: 1px solid $govuk-border-colour;
+          border-bottom: 0;
 
           color: $govuk-text-colour;
           background-color: govuk-colour("white");
-          box-shadow: inset 0 4px 0 0 $govuk-link-colour;
           text-decoration: none;
 
-          @include govuk-if-ie8 {
+          &::after {
+            border-top-width: 4px;
             border-top-color: $govuk-link-colour;
           }
 
           &:focus {
-            box-shadow: inset 0 4px 0 0 $govuk-focus-colour, inset 0 8px 0 0 $govuk-focus-text-colour;
+            // Remove outline from unenhanced focus state
+            outline: none;
+            // Remove styles from unenhanced focus state
+            box-shadow: none;
 
-            @include govuk-if-ie8 {
-              border-top-color: $govuk-focus-text-colour;
+            &::after {
+              border-bottom-width: 4px;
+              border-top-color: $govuk-focus-colour;
+              border-bottom-color: $govuk-focus-text-colour;
             }
           }
         }

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -74,8 +74,7 @@ gulp.task('scss:compile', () => {
       require('oldie')({
         rgba: { filter: true },
         rem: { disable: true },
-        unmq: { disable: true },
-        pseudo: { disable: true }
+        unmq: { disable: true }
       })
     ])))
     .pipe(gulpif(!isDist, postcss([
@@ -83,9 +82,7 @@ gulp.task('scss:compile', () => {
       require('oldie')({
         rgba: { filter: true },
         rem: { disable: true },
-        unmq: { disable: true },
-        pseudo: { disable: true }
-        // more rules go here
+        unmq: { disable: true }
       })
     ])))
     .pipe(gulpif(isDist,
@@ -123,8 +120,7 @@ gulp.task('scss:compile', () => {
         require('oldie')({
           rgba: { filter: true },
           rem: { disable: true },
-          unmq: { disable: true },
-          pseudo: { disable: true }
+          unmq: { disable: true }
         })
       ]))
       .pipe(gulp.dest(taskArguments.destination + '/'))


### PR DESCRIPTION
Update the tabs component to use an absolutely positioned element above the tab, which allows for 90 degree crisp rendering.

# Screenshots

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/58193490-04a28880-7cbb-11e9-9e78-9d0bd60f3eab.png) | ![](https://user-images.githubusercontent.com/2445413/58193504-0a986980-7cbb-11e9-8104-d9d8d08994ba.png) |

## Focused

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/58193877-fbfe8200-7cbb-11e9-8b90-8e7a239bedd5.png) | ![](https://user-images.githubusercontent.com/2445413/58193896-04ef5380-7cbc-11e9-95a4-882c3069cedf.png) |


## Overridden colours

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/58193679-724eb480-7cbb-11e9-8db9-2d709dc78081.gif) | ![](https://user-images.githubusercontent.com/2445413/58193678-724eb480-7cbb-11e9-80fa-1dc6888bbe93.gif) |

## Internet Explorer 8

| Before | After |
| - | - |
| ![](https://user-images.githubusercontent.com/2445413/58194166-ad051c80-7cbc-11e9-990d-5ed28ec8ced2.gif) | ![](https://user-images.githubusercontent.com/2445413/58194165-ac6c8600-7cbc-11e9-9b3e-0b3b0d24b850.gif) |

- [x] Cross browser testing: IE 8-11, Edge, Firefox, Safari, Chrome (latest for all)

Fixes https://github.com/alphagov/govuk-frontend/issues/1362