### PR TITLE
Remove $class param from @govuk-grid-column mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,26 @@
 
   ([PR #1342](https://github.com/alphagov/govuk-frontend/pull/1342))
 
+- Remove the deprecated `$class` parameter from the `@govuk-grid-column` mixin
+
+  To migrate, you'll need to update any places in your code where you use the
+  `@govuk-grid-column` mixin.
+
+  If you are currently passing a class name (`$class: 'foo'`) you should remove
+  the `$class` argument and wrap your call to the mixin in the class name
+  instead:
+
+  ```
+  .foo {
+    @include govuk-grid-column(...)
+  }
+  ```
+
+  If you are currently passing `$class: false` then you can just remove the
+  `$class` argument, as this is now the default behaviour.
+
+  ([PR #1376](https://github.com/alphagov/govuk-frontend/pull/1376))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/helpers/_grid.scss
+++ b/src/helpers/_grid.scss
@@ -21,11 +21,6 @@
 ///
 /// Creates a grid column with standard gutter between the columns.
 ///
-/// If a `$class` is provided (which is the default, but deprecated behaviour),
-/// the generated rules will be wrapped in a predefined selector in the format
-/// `$class-$width` (e.g. `govuk-grid-column-full`). This behaviour is
-/// deprecated and will be removed in v3.0
-///
 /// Grid widths are defined in the `$govuk-grid-widths` map.
 ///
 /// By default the column width changes from 100% to specified width at the
@@ -35,11 +30,10 @@
 /// @param {String} $width [full] name of a grid width from $govuk-grid-widths
 /// @param {String} $float [left] left | right
 /// @param {String} $at [tablet] - mobile | tablet | desktop | any custom breakpoint
-/// @param {String} $class [govuk-grid-column] CSS class name (deprecated)
 ///
 /// @example scss - Default
 ///   .govuk-grid-column-two-thirds {
-///     @include govuk-grid-column(two-thirds, $class: false)
+///     @include govuk-grid-column(two-thirds)
 ///   }
 ///
 /// @example scss - Customising the breakpoint where width percentage is applied
@@ -49,28 +43,18 @@
 ///
 /// @example scss - Customising the float direction
 ///   .govuk-grid-column-one-half-right {
-///     @include govuk-grid-column(two-thirds, $float: right, $class: false);
-///   }
-///
-/// @example scss - Customising the class name (deprecated)
-///   @include govuk-grid-column(one-half, $class: "test-column");
+///     @include govuk-grid-column(two-thirds, $float: right);
 ///
 /// @access public
 
-@mixin govuk-grid-column($width: full, $float: left, $at: tablet, $class: "govuk-grid-column") {
-  @if ($class) {
-    .#{$class}-#{$width} {
-      @include govuk-grid-column($width, $float, $at, $class: false);
-    }
-  } @else {
-    box-sizing: border-box;
-    @if $at != desktop {
-      width: 100%;
-    }
-    padding: 0 $govuk-gutter-half;
-    @include govuk-media-query($from: $at) {
-      width: govuk-grid-width($width);
-      float: $float;
-    }
+@mixin govuk-grid-column($width: full, $float: left, $at: tablet) {
+  box-sizing: border-box;
+  @if $at != desktop {
+    width: 100%;
+  }
+  padding: 0 $govuk-gutter-half;
+  @include govuk-media-query($from: $at) {
+    width: govuk-grid-width($width);
+    float: $float;
   }
 }

--- a/src/helpers/grid.test.js
+++ b/src/helpers/grid.test.js
@@ -59,7 +59,7 @@ describe('grid system', () => {
         ${sassImports}
 
         .govuk-grid-column-full {
-          @include govuk-grid-column($class: false);
+          @include govuk-grid-column();
         }
         `
 
@@ -84,7 +84,7 @@ describe('grid system', () => {
         ${sassImports}
 
         .govuk-grid-column-two-thirds {
-          @include govuk-grid-column(two-thirds, $class: false);
+          @include govuk-grid-column(two-thirds);
         }
       `
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -109,7 +109,7 @@ describe('grid system', () => {
         ${sassImports}
 
         .govuk-grid-column-one-quarter-at-desktop {
-          @include govuk-grid-column(one-quarter, $at: desktop, $class: false);
+          @include govuk-grid-column(one-quarter, $at: desktop);
         }
       `
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -132,7 +132,7 @@ describe('grid system', () => {
         ${sassImports}
 
         .govuk-grid-column-one-quarter-at-500px {
-          @include govuk-grid-column(one-quarter, $at: 500px, $class: false);
+          @include govuk-grid-column(one-quarter, $at: 500px);
         }
       `
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -157,7 +157,7 @@ describe('grid system', () => {
         ${sassImports}
 
         .govuk-grid-column-one-half-right {
-          @include govuk-grid-column(one-half, $float: right, $class: false);
+          @include govuk-grid-column(one-half, $float: right);
         }
       `
       const results = await sassRender({ data: sass, ...sassConfig })
@@ -174,52 +174,6 @@ describe('grid system', () => {
             .govuk-grid-column-one-half-right {
               width: 50%;
               float: right; } }
-        `)
-    })
-
-    it('includes the class name by default (deprecated)', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column();
-        `
-
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-full {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
-            .govuk-grid-column-full {
-              width: 100%;
-              float: left; } }`)
-    })
-
-    it('allows the class name to be overridden (deprecated)', async () => {
-      const sass = `
-        ${sassImports}
-
-        @include govuk-grid-column(three-quarters, $class:'large-column');
-      `
-      const results = await sassRender({ data: sass, ...sassConfig })
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .large-column-three-quarters {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
-            .large-column-three-quarters {
-              width: 75%;
-              float: left; } }
         `)
     })
   })

--- a/src/objects/_grid.scss
+++ b/src/objects/_grid.scss
@@ -12,7 +12,7 @@
 
   @each $width in map-keys($govuk-grid-widths) {
     .govuk-grid-column-#{$width} {
-      @include govuk-grid-column($width, $class: false)
+      @include govuk-grid-column($width)
     }
   }
 
@@ -21,7 +21,7 @@
   // them in the outputted CSS
   @each $width in map-keys($govuk-grid-widths) {
     .govuk-grid-column-#{$width}-from-desktop {
-      @include govuk-grid-column($width, $at: desktop, $class: false)
+      @include govuk-grid-column($width, $at: desktop)
     }
   }
 }


### PR DESCRIPTION
This functionality was previously [deprecated in v2.5.0][1], although it was unfortunately not mentioned in the release notes.

[1]: https://github.com/alphagov/govuk-frontend/pull/1090

Closes https://github.com/alphagov/govuk-frontend/issues/1093