### PR TITLE
removing hard coded text and replacing with title param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ See the [versioning documentation for how to update this changelog](./docs/contr
 
 🆕 New features:
 
-- Meta title
+- Support custom text on meta title 
 
-  Hard coded 'Support Links' is replaced by `params.meta.title`
+  Hard coded 'Support Links' is replaced by `params.meta.visuallyHiddenTitle` this has a default off Support links.
 
   ([PR #1387](https://github.com/alphagov/govuk-frontend/pull/1387))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,19 @@
 
 See the [versioning documentation for how to update this changelog](./docs/contributing/versioning.md#updating-changelog).
 
+🆕 New features:
+
+- Meta title
+
+  Hard coded 'Support Links' is replaced by `params.meta.title`
+
+  ([PR #1387](https://github.com/alphagov/govuk-frontend/pull/1387))
+
 🔧 Fixes:
 
 - Fixes the color of disabled secondary and warning button variants
+
+  ([PR #1392](https://github.com/alphagov/govuk-frontend/pull/1392))
 
 ## 2.12.0
 

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -4,9 +4,9 @@ params:
   required: false
   description: Object containing options for the meta navigation.
   params:
-  - name: title
+  - name: visuallyHiddenTitle
     type: string
-    description: Title for a meta item section
+    description: Title for a meta item section, which defaults to Support links
   - name: html
     type: string
     description: HTML to add to the meta section of the footer, which will appear below any links specified using meta.items.
@@ -114,7 +114,7 @@ examples:
   description: Secondary navigation with meta information relating to the site
   data:
     meta:
-      title: Items
+      visuallyHiddenTitle: Items
       items:
         - href: '#1'
           text: Item 1

--- a/src/components/footer/footer.yaml
+++ b/src/components/footer/footer.yaml
@@ -4,6 +4,9 @@ params:
   required: false
   description: Object containing options for the meta navigation.
   params:
+  - name: title
+    type: string
+    description: Title for a meta item section
   - name: html
     type: string
     description: HTML to add to the meta section of the footer, which will appear below any links specified using meta.items.
@@ -111,6 +114,7 @@ examples:
   description: Secondary navigation with meta information relating to the site
   data:
     meta:
+      title: Items
       items:
         - href: '#1'
           text: Item 1

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -32,8 +32,8 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         {% if params.meta %}
+          <h2 class="govuk-visually-hidden">{{ params.meta.title }}</h2>
           {% if params.meta.items %}
-            <h2 class="govuk-visually-hidden">Support links</h2>
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}
                 <li class="govuk-footer__inline-list-item">

--- a/src/components/footer/template.njk
+++ b/src/components/footer/template.njk
@@ -32,7 +32,7 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         {% if params.meta %}
-          <h2 class="govuk-visually-hidden">{{ params.meta.title }}</h2>
+          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links") }}</h2>
           {% if params.meta.items %}
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -70,7 +70,7 @@ describe('footer', () => {
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
-      expect($heading.text()).toEqual('Support links')
+      expect($heading.text()).toEqual('Items')
     })
 
     it('renders links', () => {

--- a/src/components/footer/template.test.js
+++ b/src/components/footer/template.test.js
@@ -73,6 +73,16 @@ describe('footer', () => {
       expect($heading.text()).toEqual('Items')
     })
 
+    it('renders default heading when none supplied', () => {
+      const $ = render('footer', {
+        meta: {}
+      })
+
+      const $component = $('.govuk-footer')
+      const $heading = $component.find('h2.govuk-visually-hidden')
+      expect($heading.text()).toEqual('Support links')
+    })
+
     it('renders links', () => {
       const $ = render('footer', examples['with meta'])
 


### PR DESCRIPTION
I noticed when I was doing some Welsh language conversion that this is currently hard coded.