### PR TITLE
Fixes after build package test failure

### DIFF
--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -10,7 +10,7 @@ var glob = require('glob')
 const configPaths = require('../../../config/paths.json')
 const lib = require('../../../lib/file-helper')
 
-const { renderSass } = require('../../lib/jest-helpers')
+const { renderSass } = require('../../../lib/jest-helpers')
 
 const readFile = util.promisify(fs.readFile)
 


### PR DESCRIPTION
While trying to create a v3 pre-release I discovered a test was failing when I ran `npm run pre-release-branch`. There was a minor issue where the test could not find `lib/jest-helper.js`.

