### PR TITLE
Fixes the colour of disabled secondary and warning button variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 See the [versioning documentation for how to update this changelog](./docs/contributing/versioning.md#updating-changelog).
 
+🔧 Fixes:
+
+- Fixes the color of disabled secondary and warning button variants
+
 ## 2.12.0
 
 🆕 New features:

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -178,6 +178,7 @@
     &:hover,
     &:focus {
       background-color: $govuk-secondary-button-hover-colour;
+
       &[disabled] {
         background-color: $govuk-secondary-button-colour;
       }
@@ -210,6 +211,7 @@
     &:hover,
     &:focus {
       background-color: $govuk-warning-button-hover-colour;
+
       &[disabled] {
         background-color: $govuk-warning-button-colour;
       }

--- a/src/components/button/_button.scss
+++ b/src/components/button/_button.scss
@@ -133,7 +133,6 @@
   .govuk-button[disabled="disabled"],
   .govuk-button[disabled] {
     opacity: (.5);
-    background: $govuk-button-colour;
 
     &:hover {
       background-color: $govuk-button-colour;
@@ -179,6 +178,9 @@
     &:hover,
     &:focus {
       background-color: $govuk-secondary-button-hover-colour;
+      &[disabled] {
+        background-color: $govuk-secondary-button-colour;
+      }
     }
   }
 
@@ -208,6 +210,9 @@
     &:hover,
     &:focus {
       background-color: $govuk-warning-button-hover-colour;
+      &[disabled] {
+        background-color: $govuk-warning-button-colour;
+      }
     }
   }
 

--- a/src/components/button/button.yaml
+++ b/src/components/button/button.yaml
@@ -104,6 +104,12 @@ examples:
     name: secondary
     text: Secondary button
     classes: govuk-button--secondary
+- name: Secondary disabled
+  data:
+    name: secondary
+    text: Secondary button disabled
+    classes: govuk-button--secondary
+    disabled: true
 - name: Secondary link
   description: A link button for secondary actions
   data:
@@ -117,6 +123,12 @@ examples:
     name: Warning
     text: Warning button
     classes: govuk-button--warning
+- name: Warning disabled
+  data:
+    name: warning
+    text: Warning button disabled
+    classes: govuk-button--warning
+    disabled: true
 - name: Warning link
   description: A link button for actions that need a warning
   data:


### PR DESCRIPTION
The secondary and warning button variants introduced in v2.12.0 revert to the primary button colour state when disabled.