### PR TITLE
Fixes for header fallback 'crown' PNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ See the [versioning documentation for how to update this changelog](./docs/contr
 
   ([PR #1392](https://github.com/alphagov/govuk-frontend/pull/1392))
 
+- Adds missing height and width attributes to the fallback crown PNG in the header.
+
+  ([PR #1419](https://github.com/alphagov/govuk-frontend/pull/1419))
+
+- Fixes alignment of the fallback crown PNG with 'GOV.UK' in the header in IE8
+
+  ([PR #1419](https://github.com/alphagov/govuk-frontend/pull/1419))
+
 ## 2.12.0
 
 🆕 New features:

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -289,8 +289,7 @@
 
   // Begin adjustments for font baseline offset
   // These should be removed when the font is updated with the correct baseline
-  .govuk-header__logotype-crown,
-  .govuk-header__logotype-crown-fallback-image {
+  .govuk-header__logotype-crown {
     position: relative;
     top: -4px;
   }

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -40,7 +40,7 @@
 
             In other browsers <image> is synonymous for the <img> tag and will be
             interpreted as such, displaying the fallback image. #}
-            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image"></image>
+            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
           </svg>
           <span class="govuk-header__logotype-text">
             GOV.UK


### PR DESCRIPTION
Fixes a couple of issues with the fallback 'crown' PNG in the header, which is displayed in browsers that don't support SVG (like IE8)

- Adds width and height attributes - fixes #1298
- Fixes alignment of the fallback PNG with 'GOV.UK'

Before:
<img width="1136" alt="Screen Shot 2019-06-03 at 09 41 48" src="https://user-images.githubusercontent.com/121939/58788597-1e5d9d00-85e4-11e9-9635-c6c8ca0d2445.png">

After:
<img width="1136" alt="Screen Shot 2019-06-03 at 09 41 50" src="https://user-images.githubusercontent.com/121939/58788604-20276080-85e4-11e9-892f-bdef37b0edba.png">


