### PR TITLE
Fix footer links hover focus state

### DIFF
--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -77,13 +77,16 @@
     }
   }
 
-  .govuk-footer__inline-list .govuk-footer__link,
-  .govuk-footer__list .govuk-footer__link {
-    text-decoration: none;
+  // Internet Explorer 8 does not support `:not()` selectors, so don't conditionally show underlines.
+  @include govuk-not-ie8 {
+    .govuk-footer__inline-list .govuk-footer__link,
+    .govuk-footer__list .govuk-footer__link {
+      text-decoration: none;
 
-    &:hover,
-    &:active {
-      text-decoration: underline;
+      &:hover:not(:focus),
+      &:active:not(:focus) {
+        text-decoration: underline;
+      }
     }
   }
 


### PR DESCRIPTION
I think I unintentionally introduced this when changing the link underline behaviour to only be present on certain footer links...

When a link is focused and a pointer is hovering of it, it should not show an underline.

## Before
<img width="99" alt="" src="https://user-images.githubusercontent.com/2445413/58799464-50c7c400-85fd-11e9-86b4-acb6b3436e82.png">

## After
<img width="91" alt="" src="https://user-images.githubusercontent.com/2445413/58799466-50c7c400-85fd-11e9-9070-a2d19edf9449.png">
