### PR TITLE
Make radios and checkboxes components easier to link to from error summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 💥 Breaking changes:
 
+- Make radios and checkboxes components easier to link to from the error summary component
+
+  You should check that clicking a link from the error summary to radios or checkboxes results in the first input being focused.
+
+  The `id` of the first input in a set of radios or checkboxes will no longer be suffixed with `-1`. This means that it will be the same as your `idPrefix`, or if `idPrefix` is not set it'll be the same as the `name`.
+
+  We've made this change to make it easier to link from the error summary to radios or checkboxes, if you we're working around this before by setting the first input's `item.id` to the same as the `name` you can now remove this.
+
+  To migrate you can update your error summary so it links to the first element, for example if you are using an `idPrefix` option of `question`, your error summary can now link to `#question` instead of `#question-1`.
+
+  If you cannot change your error summary, you could change your component to set the `item.id` option for the first input, for example:
+
+  ```javascript
+  {{ govukRadios({
+    idPrefix: "question",
+    name: "question",
+    items: [
+      {
+        id: "question-1",
+        value: "yes",
+        text: "Yes"
+      },
+      {
+        value: "no",
+        text: "No"
+      }
+    ]
+  }) }}
+  ```
+
+  ([PR #1426](https://github.com/alphagov/govuk-frontend/pull/1426))
+
 - Remove `govuk-focusable`, `govuk-focusable-fill` mixins, introduce `govuk-focus-text` mixin.
 
   To migrate:

--- a/app/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/app/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -55,7 +55,6 @@ scenario: >-
       },
       items: [
         {
-          id: "changed-name",
           value: "yes",
           text: "Yes"
         },

--- a/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -55,7 +55,6 @@ notes: Based on https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-i
           },
           items: [
             {
-              id: "sign-in",
               value: "government-gateway",
               text: "Sign in with Government Gateway",
               checked: values["sign-in"] === "government-gateway",

--- a/app/views/full-page-examples/upload-your-photo/index.njk
+++ b/app/views/full-page-examples/upload-your-photo/index.njk
@@ -91,7 +91,6 @@ scenario: >-
                 name: "terms-and-conditions",
                 items: [
                     {
-                        id: "terms-and-conditions",
                         value: "true",
                         html: 'I accept the <a class="govuk-link" href="#">terms and conditions</a>',
                         checked: values["terms-and-conditions"]

--- a/app/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/index.njk
@@ -81,7 +81,6 @@ scenario: >-
           },
           items: [
             {
-              id: "confirm-nationality",
               value: "british-nationality",
               text: "British",
               checked: values["confirm-nationality"]|length and "british-nationality" in values["confirm-nationality"],

--- a/src/all.test.js
+++ b/src/all.test.js
@@ -77,20 +77,20 @@ describe('GOV.UK Frontend', () => {
       // that we can interact with to check if they're interactive.
 
       // Check that the conditional reveal component has a conditional section that would open if enhanced.
-      await page.waitForSelector('#conditional-not-scoped-1', { hidden: true })
+      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
 
-      await page.click('[for="not-scoped-1"]')
+      await page.click('[for="not-scoped"]')
 
       // Check that when it is clicked that nothing opens, which shows that it has not been enhanced.
-      await page.waitForSelector('#conditional-not-scoped-1', { hidden: true })
+      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
 
       // Check the other conditional reveal which has been enhanced based on it's scope.
-      await page.waitForSelector('#conditional-scoped-1', { hidden: true })
+      await page.waitForSelector('#conditional-scoped', { hidden: true })
 
-      await page.click('[for="scoped-1"]')
+      await page.click('[for="scoped"]')
 
       // Check that it has opened as expected.
-      await page.waitForSelector('#conditional-scoped-1', { hidden: false })
+      await page.waitForSelector('#conditional-scoped', { hidden: false })
     })
   })
   describe('global styles', () => {

--- a/src/components/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/components/checkboxes/__snapshots__/template.test.js.snap
@@ -33,7 +33,7 @@ exports[`Checkboxes nested dependant components passes through label params with
 <label class="govuk-label govuk-checkboxes__label"
        data-attribute="value"
        data-second-attribute="second-value"
-       for="example-name-1"
+       for="example-name"
 >
   <b>
     Option 1

--- a/src/components/checkboxes/template.njk
+++ b/src/components/checkboxes/template.njk
@@ -50,7 +50,17 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="checkboxes"{% endif -%}>
     {% for item in params.items %}
-    {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
+    {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+    {%- if item.id -%}
+      {%- set id = item.id -%}
+    {%- else -%}
+      {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+      {%- if loop.first -%}
+        {%- set id = idPrefix %}
+      {% else %}
+        {%- set id = idPrefix + "-" + loop.index -%}
+      {%- endif -%}
+    {%- endif -%}
     {% set name = item.name if item.name else params.name %}
     {% set conditionalId = "conditional-" + id %}
     {% set hasHint = true if item.hint.text or item.hint.html %}

--- a/src/components/checkboxes/template.test.js
+++ b/src/components/checkboxes/template.test.js
@@ -145,8 +145,8 @@ describe('Checkboxes', () => {
 
       const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
       const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('example-name-1')
-      expect($firstLabel.attr('for')).toEqual('example-name-1')
+      expect($firstInput.attr('id')).toEqual('example-name')
+      expect($firstLabel.attr('for')).toEqual('example-name')
 
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
       const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
@@ -174,8 +174,8 @@ describe('Checkboxes', () => {
 
       const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
       const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('custom-1')
-      expect($firstLabel.attr('for')).toEqual('custom-1')
+      expect($firstInput.attr('id')).toEqual('custom')
+      expect($firstLabel.attr('for')).toEqual('custom')
 
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
       const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
@@ -202,7 +202,7 @@ describe('Checkboxes', () => {
       const $component = $('.govuk-checkboxes')
 
       const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      expect($firstInput.attr('id')).toBe('example-name-1')
+      expect($firstInput.attr('id')).toBe('example-name')
 
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
       const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
@@ -450,8 +450,8 @@ describe('Checkboxes', () => {
       const $firstInput = $component.find('.govuk-checkboxes__input').first()
       const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
 
-      expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional-1')
-      expect($firstConditional.attr('id')).toBe('conditional-example-conditional-1')
+      expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional')
+      expect($firstConditional.attr('id')).toBe('conditional-example-conditional')
     })
   })
 
@@ -539,9 +539,12 @@ describe('Checkboxes', () => {
 
       const $inputs = $('input')
 
-      $inputs.each((i, input) => {
-        expect($(input).attr('aria-describedby'))
-          .toEqual(`waste-${(i + 1)}-item-hint`)
+      $inputs.each((index, input) => {
+        let expectedDescribedById = `waste-${(index + 1)}-item-hint`
+        if (index === 0) {
+          expectedDescribedById = `waste-item-hint`
+        }
+        expect($(input).attr('aria-describedby')).toEqual(expectedDescribedById)
       })
     })
 
@@ -670,7 +673,7 @@ describe('Checkboxes', () => {
     it('adds aria-describedby to input if there is an error and a hint', () => {
       const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input"])
       const $input = $('input')
-      expect($input.attr('aria-describedby')).toMatch('t-and-c-with-hint-error t-and-c-with-hint-1-item-hint')
+      expect($input.attr('aria-describedby')).toMatch('t-and-c-with-hint-error t-and-c-with-hint-item-hint')
     })
   })
 })

--- a/src/components/radios/__snapshots__/template.test.js.snap
+++ b/src/components/radios/__snapshots__/template.test.js.snap
@@ -33,7 +33,7 @@ exports[`Radios nested dependant components passes through label params without 
 <label class="govuk-label govuk-radios__label"
        data-attribute="value"
        data-second-attribute="second-value"
-       for="example-name-1"
+       for="example-name"
 >
   <b>
     Yes

--- a/src/components/radios/template.njk
+++ b/src/components/radios/template.njk
@@ -47,7 +47,17 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="radios"{% endif -%}>
     {% for item in params.items %}
-    {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
+    {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+    {%- if item.id -%}
+      {%- set id = item.id -%}
+    {%- else -%}
+      {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+      {%- if loop.first -%}
+        {%- set id = idPrefix %}
+      {% else %}
+        {%- set id = idPrefix + "-" + loop.index -%}
+      {%- endif -%}
+    {%- endif -%}
     {% set conditionalId = "conditional-" + id %}
     {%- if item.divider %}
     <div class="govuk-radios__divider">{{ item.divider }}</div>

--- a/src/components/radios/template.test.js
+++ b/src/components/radios/template.test.js
@@ -138,8 +138,8 @@ describe('Radios', () => {
 
       const $firstInput = $component.find('.govuk-radios__item:first-child input')
       const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('example-name-1')
-      expect($firstLabel.attr('for')).toEqual('example-name-1')
+      expect($firstInput.attr('id')).toEqual('example-name')
+      expect($firstLabel.attr('for')).toEqual('example-name')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
@@ -167,8 +167,8 @@ describe('Radios', () => {
 
       const $firstInput = $component.find('.govuk-radios__item:first-child input')
       const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('custom-1')
-      expect($firstLabel.attr('for')).toEqual('custom-1')
+      expect($firstInput.attr('id')).toEqual('custom')
+      expect($firstLabel.attr('for')).toEqual('custom')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
@@ -384,8 +384,8 @@ describe('Radios', () => {
         const $firstInput = $component.find('.govuk-radios__input').first()
         const $firstConditional = $component.find('.govuk-radios__conditional').first()
 
-        expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional-1')
-        expect($firstConditional.attr('id')).toBe('conditional-example-conditional-1')
+        expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional')
+        expect($firstConditional.attr('id')).toBe('conditional-example-conditional')
       })
     })
 


### PR DESCRIPTION
Updates the radios, checkboxes and date input components so it's easier to link to their first items from the error summary component.

I have tried to simplify the date input component in a similar way but the complexity was the same after I changed it, if not worse. So if we want to make the date input component easier to use in the future we'll need to think about something else.

Closes https://github.com/alphagov/govuk-frontend/issues/929