### PR TITLE
Remove appending hash behaviour when error summary link clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -270,6 +270,12 @@
 
 🔧 Fixes:
 
+- Stop appending hash when error summary link clicked
+
+  This prevents incorrectly focusing the form element with the hash id, instead of the error summary, when form is re-submitted with the hash in the URL and there are further errors.
+
+  ([PR #1435](https://github.com/alphagov/govuk-frontend/pull/1435))
+
 - Fix settings layer being implicitly dependant on itself.
 
   ([PR #1381](https://github.com/alphagov/govuk-frontend/pull/1381))

--- a/src/components/error-summary/error-summary.js
+++ b/src/components/error-summary/error-summary.js
@@ -63,16 +63,6 @@ ErrorSummary.prototype.focusTarget = function ($target) {
     return false
   }
 
-  // Prefer using the history API where possible, as updating
-  // window.location.hash causes the viewport to jump to the input briefly
-  // before then scrolling to the label/legend in IE10, IE11 and Edge (as tested
-  // in Edge 17).
-  if (window.history.pushState) {
-    window.history.pushState(null, null, '#' + inputId)
-  } else {
-    window.location.hash = inputId
-  }
-
   // Scroll the legend or label into view *before* calling focus on the input to
   // avoid extra scrolling in browsers that don't support `preventScroll` (which
   // at time of writing is most of them...)

--- a/src/components/error-summary/error-summary.test.js
+++ b/src/components/error-summary/error-summary.test.js
@@ -47,9 +47,9 @@ describe('Error Summary', () => {
       expect(legendOrLabelOffsetFromTop).toEqual(0)
     })
 
-    it('updates the hash in the URL', async () => {
+    it('does not include a hash in the URL', async () => {
       const hash = await page.evaluate(() => window.location.hash)
-      expect(hash).toBe(`#${inputId}`)
+      expect(hash).toBe('')
     })
   })
 })


### PR DESCRIPTION
When error summary links were clicked, a hash with the clicked linked id would be added to the URL. As reported in https://github.com/alphagov/govuk-frontend/issues/1398, if the form is submitted again with further errors, the hash stopped the error summary being focused as should happen, and instead the element with the hash id was scrolled to. This was confusing to the user, especially as they might have already corrected the error in the now focused form element.

[This behaviour was prevented in GOV.UK Elements](https://github.com/alphagov/govuk_elements/blob/ef0baed92fabbbfdc0f6ea09d7dd76bffa994bf8/assets/javascripts/application.js#L29). When the error summary component was added to GOV.UK Frontend, this behaviour wasn't reintroduced as we didn't know the reason for it. We use `preventDefault()` to improve the user experience when the error summary links are clicked on by showing the error message above the form field, instead of scrolling down to the form field itself. We programmatically reintroduced the hash to the URL to replicate browser behaviour.

Following the bug report, the code for appending the hash is redundant and can be removed.

Fixes https://github.com/alphagov/govuk-frontend/issues/1398