### PR TITLE
Document how to use the legacy palette

### DIFF
--- a/docs/installation/compatibility.md
+++ b/docs/installation/compatibility.md
@@ -1,0 +1,53 @@
+# Use GOV.UK Frontend with old frameworks or colours
+
+You can configure GOV.UK Frontend to work with the following 'legacy'
+frameworks:
+
+- [GOV.UK Frontend toolkit]
+- [GOV.UK Template]
+- [GOV.UK Elements]
+
+You cannot use the following features if you installed GOV.UK Frontend from
+`dist`. [Install with node package manager](installing-from-npm.md) instead.
+
+If you use these features, your service will not have GOV.UK Frontend's many
+accessibility and usability improvements.
+
+## Turn on 'compatibility mode'
+
+You can turn on 'compatibility mode' if you want to use both GOV.UK Frontend
+components and a legacy framework in a service.
+
+GOV.UK Frontend will:
+
+- use the old colour palette
+- use the old GOV.UK font from GOV.UK Template
+- override some of the CSS in the legacy frameworks
+- no longer use `rem` for font sizes
+
+To turn on compatibility mode for all 3 legacy frameworks, add the following
+variables to your project's Sass file, above `@import "govuk-frontend/all"`:
+
+```SCSS
+$govuk-compatibility-govukfrontendtoolkit: true;
+$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govukelements: true;
+```
+
+You can leave out a variable to turn off compatibility mode for that framework.
+
+## Use the old colour palette
+
+If you are not using any of the legacy frameworks, you can still configure
+GOV.UK Frontend to use the old colour palette.
+
+Add the following variable to your project's Sass file, above
+`@import "govuk-frontend/all"`:
+
+```scss
+$govuk-use-legacy-palette: true;
+```
+
+[GOV.UK Frontend Toolkit]: https://github.com/alphagov/govuk_frontend_toolkit
+[GOV.UK Template]: https://github.com/alphagov/govuk_template
+[GOV.UK Elements]: https://github.com/alphagov/govuk_elements

--- a/docs/installation/installing-with-npm.md
+++ b/docs/installation/installing-with-npm.md
@@ -103,22 +103,9 @@ $govuk-global-styles: true;
 @import "govuk-frontend/all";
 ```
 
-### Compatibility mode
-GOV.UK Frontend includes additional styles that can be enabled to allow support for deprecated projects such as [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit).
+### Using GOV.UK Frontend with old frameworks
 
-Setting compatibility SCSS variables will change how GOV.UK Frontend's CSS renders to work around global styles that conflict with GOV.UK Frontend.
-
-To enable this feature include the SCSS variables that correspond with the projects you depend on before importing GOV.UK Frontend styles into your app:
-
-```SCSS
-// application.scss
-
-$govuk-compatibility-govukfrontendtoolkit: true;
-$govuk-compatibility-govuktemplate: true;
-$govuk-compatibility-govukelements: true;
-
-@import "govuk-frontend/all";
-```
+Find out how to [configure GOV.UK Frontend for compatibility](compatibility.md) with GOV.UK Frontend Toolkit, GOV.UK Template or GOV.UK Elements.
 
 ## Using JavaScript
 


### PR DESCRIPTION
It’s hard to talk about this option without also talking about compatibility mode, so this also splits the documentation on compatibility mode out from the installation instructions and adds more detail about what it actually does.

There is some duplication between this and the compatibility mode Sass documentation updated in #1438 – it feels like it does need to be explained in both places. Open to ideas on how to reduce that duplication.

Closes #1432 