### PR TITLE
Move aria-label to nav element in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,6 +268,27 @@
 
   ([PR #1376](https://github.com/alphagov/govuk-frontend/pull/1376))
 
+- The 'aria-label' in the header is now correctly applied to the `<nav>` element
+  rather than the `<ul>` within it, and has been changed from 'Top Level
+  Navigation' to 'top level' as screen readers will already announce the role.
+
+  If you are using navigation within your header, and you are not using the
+  nunjucks templates, you should make this change in your own code, replacing
+
+  ```html
+  <nav>
+    <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+  ```
+
+  with:
+
+  ```html
+  <nav aria-label="top level">
+      <ul id="navigation" class="govuk-header__navigation">
+  ```
+
+  ([PR #1440](https://github.com/alphagov/govuk-frontend/pull/1440))
+
 - Pull Request Title goes here
 
   Description goes here (optional)

--- a/src/components/header/template.njk
+++ b/src/components/header/template.njk
@@ -61,8 +61,8 @@
     {% endif %}
     {% if params.navigation %}
     <button type="button" role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-    <nav>
-      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
+    <nav aria-label="top level">
+      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
         {% for item in params.navigation %}
           {% if item.href and item.text %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">


### PR DESCRIPTION
HTML validator flagged this as a ‘possible misuse of aria-label.’

This pattern of applying aria-label to the `<ul>` was [copied from GOV.UK Template][1].

Best practise is to [add the aria-label to the element with the navigation role][2], which in this case would be the `<nav>`.

When a label is used on a navigation element, [the term ‘navigation’ should be omitted][3], as ‘the screen reader will read both the role and the contents of the label’, so I’ve also removed the word ’navigation’ from the label.

Closes #1340.

[1]: https://github.com/alphagov/govuk_template/blob/f164b2825b1479d7c7d4bdbec4ba9c8e171f504c/docs/usage.md#propositional-title-and-navigation
[2]: https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html
[3]: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Navigation_Role#Associated_WAI-ARIA_Roles_States_and_Properties