### PR TITLE
Ensure character count message is hidden to assistive technologies when not visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -351,6 +351,10 @@
 
   ([PR #1441](https://github.com/alphagov/govuk-frontend/pull/1441))
 
+- Ensure character count message is hidden to assistive technologies when not visible
+
+  ([PR #1442](https://github.com/alphagov/govuk-frontend/pull/1442))
+
 - Stop appending hash when error summary link clicked
 
   This prevents incorrectly focusing the form element with the hash id, instead of the error summary, when form is re-submitted with the hash in the URL and there are further errors.

--- a/src/components/character-count/character-count.js
+++ b/src/components/character-count/character-count.js
@@ -144,8 +144,12 @@ CharacterCount.prototype.updateCountMessage = function () {
   var thresholdValue = maxLength * thresholdPercent / 100
   if (thresholdValue > currentLength) {
     countMessage.classList.add('govuk-character-count__message--disabled')
+    // Ensure threshold is hidden for users of assistive technologies
+    countMessage.setAttribute('aria-hidden', true)
   } else {
     countMessage.classList.remove('govuk-character-count__message--disabled')
+    // Ensure threshold is visible for users of assistive technologies
+    countMessage.removeAttribute('aria-hidden')
   }
 
   // Update styles

--- a/src/components/character-count/character-count.test.js
+++ b/src/components/character-count/character-count.test.js
@@ -124,6 +124,10 @@ describe('Character count', () => {
         it('does not show the limit until the threshold is reached', async () => {
           const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('hidden')
+
+          // Ensure threshold is hidden for users of assistive technologies
+          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
+          expect(ariaHidden).toEqual('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
@@ -131,6 +135,10 @@ describe('Character count', () => {
 
           const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
+
+          // Ensure threshold is visible for users of assistive technologies
+          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
+          expect(ariaHidden).toBeFalsy()
         })
       })
     })


### PR DESCRIPTION
When using the threshold feature in the character count component it is possible to access the message when it is visually hidden using a screen reader.

This change makes sure that the visual behaviour is consistent with the screen reader behaviour by hiding the content from the accessibility tree using `aria-hidden`.


## Screen reader testing

Test URL: http://localhost:3000/components/character-count/with-threshold/preview

### NVDA 2019 with Firefox 60.7.0esr

When the message first appears it is not announced, but after it is visible any other changes will cause an announcement, for example if another character is entered. I do not think this is a barrier.

### JAWS 2018 with Internet Explorer 11
Message is read out as expected

### VoiceOver with Safari 12.1.1
Message is read out as expected

Fixes https://github.com/alphagov/govuk-frontend/issues/1406