### PR TITLE
Update tabs and accordion components to use simpler focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,12 +113,14 @@
   To migrate: [TODO add migration instructions before we ship v3.0.0]
 
   ([PR #1326](https://github.com/alphagov/govuk-frontend/pull/1326))
+  ([PR #1445](https://github.com/alphagov/govuk-frontend/pull/1445))
 
 - Update accordion to use new WCAG 2.1 compliant focus style
 
   To migrate: [TODO add migration instructions before we ship v3.0.0]
 
   ([PR #1324](https://github.com/alphagov/govuk-frontend/pull/1324))
+  ([PR #1445](https://github.com/alphagov/govuk-frontend/pull/1445))
 
 - Update form inputs to use new WCAG 2.1 compliant focus style
 

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -105,16 +105,6 @@
       cursor: pointer;
     }
 
-    .govuk-accordion__section--expanded .govuk-accordion__section-header {
-      border-top-color: $govuk-accordion-link-colour;
-      box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-accordion-link-colour;
-    }
-
-    .govuk-accordion__section-header:hover {
-      border-top-color: $govuk-accordion-link-hover-colour;
-      box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-accordion-link-hover-colour;
-    }
-
     // For devices that can't hover such as touch devices,
     // remove hover state as it can be stuck in that state (iOS).
     @media (hover: none) {
@@ -122,21 +112,6 @@
         border-top-color: $govuk-accordion-link-colour;
         box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-accordion-link-colour;
       }
-    }
-
-    .govuk-accordion__section--expanded .govuk-accordion__section-header--focused {
-      @include govuk-not-ie8 {
-        border-top-color: $govuk-focus-colour;
-      }
-      // When colours are overridden, for example when users have a dark mode,
-      // backgrounds and box-shadows disappear, so we need to ensure there's a
-      // transparent outline which will be set to a visible colour.
-      outline: $govuk-focus-width solid transparent;
-      color: $govuk-text-colour;
-      // sass-lint:disable indentation
-      box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-focus-colour,
-                  inset 0 ($govuk-accordion-border-width + $govuk-focus-width) 0 0 $govuk-text-colour;
-      // sass-lint:enable indentation
     }
 
     // Buttons within the headers don’t need default styling
@@ -153,19 +128,8 @@
       cursor: pointer;
       -webkit-appearance: none;
 
-      @include govuk-not-ie8 {
-        // Ensure the default focus styles are not shown for buttons
-        &:focus {
-          outline: none;
-          background: none;
-        }
-      }
-
-      @include govuk-if-ie8 {
-        &:focus {
-          color: $govuk-text-colour;
-          background: $govuk-focus-colour;
-        }
+      &:focus {
+        @include govuk-focused-text;
       }
 
       // Remove default button focus outline in Firefox
@@ -195,13 +159,6 @@
       .govuk-accordion__section-button:hover {
         text-decoration: none;
       }
-    }
-
-    // The accordion component has two focus state depending on if a section is expanded or closed.
-    // We also want to avoid styling when the secttion is pressed or `:active`
-    // to avoid the different focus styles from flashing quickly while the user interacts with the section.
-    .govuk-accordion__section:not(.govuk-accordion__section--expanded) .govuk-accordion__section-button:focus:not(:active) {
-      @include govuk-focused-text;
     }
 
     .govuk-accordion__controls {

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -49,6 +49,12 @@
       color: govuk-colour("black");
       text-decoration: none;
     }
+
+    @include govuk-if-ie8 {
+      &:focus {
+        outline: $govuk-focus-width solid $govuk-focus-colour;
+      }
+    }
   }
 
   .govuk-tabs__panel {
@@ -92,16 +98,11 @@
         text-align: center;
         text-decoration: underline;
 
-
-        @include govuk-if-ie8 {
-          // IE8 doesn't support `box-shadow` so add an outline to indicate
-          // state.
-          outline: $govuk-focus-width solid transparent;
-        }
-
-        &:focus {
-          // Hide browser default outline when link is pressed
-          outline: $govuk-focus-width solid transparent;
+        @include govuk-not-ie8 {
+          &:focus {
+            // Hide browser default outline when link is pressed
+            outline: $govuk-focus-width solid transparent;
+          }
         }
 
         &--selected {
@@ -135,10 +136,6 @@
               margin-right: 7px;
               margin-left: 7px;
               box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
-            }
-
-            @include govuk-if-ie8 {
-              outline: $govuk-focus-width solid $govuk-focus-colour;
             }
           }
         }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -36,10 +36,6 @@
   .govuk-tabs__tab {
     @include govuk-link-style-default;
 
-    @include govuk-media-query($until: tablet) {
-      @include govuk-link-common;
-    }
-
     @include govuk-font($size: 19);
 
     display: inline-block;
@@ -50,6 +46,13 @@
       text-decoration: none;
     }
 
+    // Focus state for mobile and when JavaScript is disabled
+    // It is removed for JS-enabled desktop styles
+    &:focus {
+      @include govuk-focused-text;
+    }
+
+    // IE8 doesn't support `box-shadow` so add an outline to indicate focus
     @include govuk-if-ie8 {
       &:focus {
         outline: $govuk-focus-width solid $govuk-focus-colour;
@@ -100,8 +103,8 @@
 
         @include govuk-not-ie8 {
           &:focus {
-            // Hide browser default outline when link is pressed
-            outline: $govuk-focus-width solid transparent;
+            // Remove no-JS styles
+            box-shadow: none;
           }
         }
 

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -80,19 +80,18 @@
 
       .govuk-tabs__tab {
         margin-right: govuk-spacing(1);
+        margin-bottom: 0;
+        padding-top: govuk-spacing(2);
         padding-right: govuk-spacing(4);
+        padding-bottom: govuk-spacing(2);
         padding-left: govuk-spacing(4);
+
         float: left;
         color: govuk-colour("black");
         background-color: govuk-colour("light-grey", $legacy: "grey-4");
         text-align: center;
         text-decoration: underline;
 
-        @include govuk-media-query($from: tablet) {
-          margin-bottom: 0;
-          padding-top: govuk-spacing(2);
-          padding-bottom: govuk-spacing(2);
-        }
 
         @include govuk-if-ie8 {
           // IE8 doesn't support `box-shadow` so add an outline to indicate

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -106,20 +106,21 @@
         }
 
         &--selected {
+          $border-width: 1px;
+
           position: relative;
 
           margin-top: - govuk-spacing(1);
-          margin-bottom: -1px;
 
-          // 1px is compensation for border (otherwise we get a 1px shift)
-          padding-top: govuk-spacing(3) - 1px;
-          padding-right: govuk-spacing(4) - 1px;
-          padding-bottom: govuk-spacing(3) + 1px;
-          padding-left: govuk-spacing(4) - 1px;
+          // Compensation for border (otherwise we get a shift)
+          margin-bottom: -$border-width;
+          padding-top: govuk-spacing(3) - $border-width;
+          padding-right: govuk-spacing(4) - $border-width;
+          padding-bottom: govuk-spacing(3) + $border-width;
+          padding-left: govuk-spacing(4) - $border-width;
 
-          border-top: $top-border-width solid $govuk-border-colour;
-          border-right: 1px solid $govuk-border-colour;
-          border-left: 1px solid $govuk-border-colour;
+          border: $border-width solid $govuk-border-colour;
+          border-bottom: 0;
 
           color: $govuk-text-colour;
           background-color: govuk-colour("white");

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -36,7 +36,7 @@
   .govuk-tabs__tab {
     @include govuk-link-style-default;
 
-    @include mq($until: tablet) {
+    @include govuk-media-query($until: tablet) {
       @include govuk-link-common;
     }
 
@@ -58,7 +58,7 @@
   // JavaScript enabled
   .js-enabled {
 
-    @include mq($from: tablet) {
+    @include govuk-media-query($from: tablet) {
 
       .govuk-tabs__list {
         @include govuk-clearfix;
@@ -88,7 +88,7 @@
         text-align: center;
         text-decoration: underline;
 
-        @include mq($from: tablet) {
+        @include govuk-media-query($from: tablet) {
           margin-bottom: 0;
           padding-top: govuk-spacing(2);
           padding-bottom: govuk-spacing(2);

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -34,8 +34,12 @@
   }
 
   .govuk-tabs__tab {
-    @include govuk-link-common;
     @include govuk-link-style-default;
+
+    @include mq($until: tablet) {
+      @include govuk-link-common;
+    }
+
     @include govuk-font($size: 19);
 
     display: inline-block;
@@ -91,56 +95,50 @@
         }
 
         @include govuk-if-ie8 {
-          // IE8 doesn't support `box-shadow` so add an actual border that is
-          // modified to indicate state.
-          border-top: 4px solid transparent;
+          // IE8 doesn't support `box-shadow` so add an outline to indicate
+          // state.
+          outline: $govuk-focus-width solid transparent;
         }
 
-        &:hover {
-          box-shadow: inset 0 4px 0 0 govuk-colour("light-blue");
-
-          @include govuk-if-ie8 {
-            border-top-color: govuk-colour("light-blue");
-          }
+        &:focus {
+          // Hide browser default outline when link is pressed
+          outline: $govuk-focus-width solid transparent;
         }
 
         &--selected {
-          $top-border-width: 1px;
-          $top-border-adjustment: 1px;
-
-          @include govuk-if-ie8 {
-            // IE8 already has a top border so no adjustment is needed
-            $top-border-width: 4px;
-            $top-border-adjustment: 0;
-          }
+          position: relative;
 
           margin-top: - govuk-spacing(1);
           margin-bottom: -1px;
 
           // 1px is compensation for border (otherwise we get a 1px shift)
-          padding-top: govuk-spacing(3) - $top-border-adjustment;
+          padding-top: govuk-spacing(3) - 1px;
           padding-right: govuk-spacing(4) - 1px;
           padding-bottom: govuk-spacing(3) + 1px;
           padding-left: govuk-spacing(4) - 1px;
 
-          border-top: $top-border-width solid transparent;
+          border-top: $top-border-width solid $govuk-border-colour;
           border-right: 1px solid $govuk-border-colour;
           border-left: 1px solid $govuk-border-colour;
 
           color: $govuk-text-colour;
           background-color: govuk-colour("white");
-          box-shadow: inset 0 4px 0 0 $govuk-link-colour;
           text-decoration: none;
 
-          @include govuk-if-ie8 {
-            border-top-color: $govuk-link-colour;
-          }
-
           &:focus {
-            box-shadow: inset 0 4px 0 0 $govuk-focus-colour, inset 0 8px 0 0 $govuk-focus-text-colour;
+
+            &:after {
+              // Add "highlight" on focused link
+              $highlight-space: 13px;
+              content: "";
+              display: block;
+              margin-right: 7px;
+              margin-left: 7px;
+              box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
+            }
 
             @include govuk-if-ie8 {
-              border-top-color: $govuk-focus-text-colour;
+              outline: $govuk-focus-width solid $govuk-focus-colour;
             }
           }
         }


### PR DESCRIPTION
As per #1424, iterate on accordion and tabs focus states which we found were confusing for some users. This follows work done by @dashouse in #1394 to simplify the states.

## Accordion

<details>
<summary>IE8</summary>

![ie8-tabs](https://user-images.githubusercontent.com/5007934/59267542-6f077280-8c42-11e9-9011-5880247d3498.gif)

</details>

<details>
<summary>IE11</summary>

![ie11-tabs](https://user-images.githubusercontent.com/5007934/59267567-8181ac00-8c42-11e9-847f-58b800e5a5d0.gif)

</details>

<details>
<summary>Edge 18</summary>

![edge-tabs](https://user-images.githubusercontent.com/5007934/59267718-ce658280-8c42-11e9-8eb6-255b1df6e038.gif)

</details>

<details>
<summary>Firefox with changed colours</summary>

![ff-tabs](https://user-images.githubusercontent.com/5007934/59267619-96f6d600-8c42-11e9-99c6-aac136cd3fe7.gif)

</details>

<details>
<summary>Safari 12</summary>

![safari-tabs](https://user-images.githubusercontent.com/5007934/59267796-010f7b00-8c43-11e9-9dc5-3e5d47a3df78.gif)


</details>

<details>
<summary>Chrome 75 (Mac)</summary>

![chrome-tabs](https://user-images.githubusercontent.com/5007934/59267821-197f9580-8c43-11e9-90f2-ffb2b27adad7.gif)

</details>

<details>
<summary>Chrome (Galaxy S9) </summary>

![chrome-mobile-tabs](https://user-images.githubusercontent.com/5007934/59267847-2ef4bf80-8c43-11e9-98e6-d0e69959e3cc.gif)


</details>

## Tabs

<details>
<summary>IE8</summary>

![acc-ie8](https://user-images.githubusercontent.com/5007934/59270524-97df3600-8c49-11e9-82c4-86f84e7c9843.gif)



</details>

<details>
<summary>IE11</summary>

![acc-ie11](https://user-images.githubusercontent.com/5007934/59270533-9dd51700-8c49-11e9-856c-4baaf41c8aec.gif)

</details>

<details>
<summary>Edge 18</summary>

![tabs-edge-18](https://user-images.githubusercontent.com/5007934/59271333-8303a200-8c4b-11e9-9d2c-5dbf080630af.gif)


</details>

<details>
<summary>Firefox with changed colours</summary>

![tabs-ff](https://user-images.githubusercontent.com/5007934/59271474-cfe77880-8c4b-11e9-89b0-0f293694d450.gif)


</details>

<details>
<summary>Safari 12</summary>

![tabs-safari](https://user-images.githubusercontent.com/5007934/59271604-16d56e00-8c4c-11e9-8533-da47c6019d5c.gif)


</details>

<details>
<summary>Chrome 75 (Mac)</summary>

![acc-chrome](https://user-images.githubusercontent.com/5007934/59271037-e8a35e80-8c4a-11e9-9c2e-3a91db186553.gif)


</details>

<details>
<summary>Chrome (Galaxy S9) </summary>


![acc-chrome-mobile](https://user-images.githubusercontent.com/5007934/59271140-1c7e8400-8c4b-11e9-854e-a3bfd01ec7f4.gif)


</details>

Note: tabs don't have a hover state - discussed this with @dashouse, we might wish to review it together with https://github.com/alphagov/govuk-frontend/issues/1417.


Fixes https://github.com/alphagov/govuk-frontend/issues/1424
Closes https://github.com/alphagov/govuk-frontend/pull/1394

