### PR TITLE
Avoid styling second address line field when errored

### DIFF
--- a/app/views/full-page-examples/what-is-your-address/index.njk
+++ b/app/views/full-page-examples/what-is-your-address/index.njk
@@ -63,8 +63,7 @@ scenario: >-
             },
             id: "address-line-2",
             name: "address-line-2",
-            value: values["address-line-2"],
-            errorMessage: (not not errors["address-line-1"])
+            value: values["address-line-2"]
           }) }}
 
           {{ govukInput({


### PR DESCRIPTION
This ensures there is no confusion between the two inputs,
as the second field is optional.

Fixes https://github.com/alphagov/govuk-frontend/issues/1448