### PR TITLE
Add example of brackets bug

### DIFF
--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -5,6 +5,8 @@
     GOV.UK Frontend
   </h1>
 
+  <p class="govuk-body">Yes (<a class="govuk-link" href="#">Edit</a>)</p>
+
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-one-third">


### PR DESCRIPTION
Raised by a community member.

We could consider giving links a raised z-index, but I think that could introduce other issues.

![](https://user-images.githubusercontent.com/2445413/60505309-5f1c0500-9cbb-11e9-88db-9e1214f392f7.png)
