### PR TITLE
Improve reasoning for 'tabIndex' property usage

### DIFF
--- a/src/govuk/components/details/details.js
+++ b/src/govuk/components/details/details.js
@@ -89,7 +89,9 @@ Details.prototype.init = function () {
   $summary.setAttribute('aria-controls', $content.id)
 
   // Set tabIndex so the summary is keyboard accessible for non-native elements
-  // http://www.saliences.com/browserBugs/tabIndex.html
+  //
+  // We have to use the camelcase `tabIndex` property as there is a bug in IE6/IE7 when we set the correct attribute lowercase:
+  // See http://web.archive.org/web/20170120194036/http://www.saliences.com/browserBugs/tabIndex.html for more information.
   if (!NATIVE_DETAILS) {
     $summary.tabIndex = 0
   }


### PR DESCRIPTION
We normally use `setAttribute` but if we were to set the attribute to the correct `tabindex` value it fails in IE6/7

I consider this a documentation pull request, as it's only really useful for maintainers so I won't be adding a CHANGELOG entry.