### PR TITLE
Update Prototype Kit conf for new folder structure

### DIFF
--- a/package/govuk-prototype-kit.config.json
+++ b/package/govuk-prototype-kit.config.json
@@ -1,15 +1,14 @@
 {
   "nunjucksPaths": [
-    "/",
-    "/components"
+    "/"
   ],
   "scripts": [
-    "/all.js"
+    "/govuk/all.js"
   ],
   "assets": [
-    "/assets"
+    "/govuk/assets"
   ],
   "sass": [
-    "/all.scss"
+    "/govuk/all.scss"
   ]
 }


### PR DESCRIPTION
Now that files are within a 'govuk' folder 'script', 'assets' and
'sass', need to be updated.

We remove the reference to components for Nunjucks as we will now
recommend people to import the entire path, for example:

'govuk/components/button/macro.njk'

I was able to get things wired up in this branch: https://github.com/alphagov/govuk-prototype-kit/pull/768

Closes https://github.com/alphagov/govuk-frontend/issues/1484