### PR TITLE
Fix focus state overlapping surrounding content

### DIFF
--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -35,6 +35,14 @@
         Links
       </h1>
 
+      <p class="govuk-body">
+        <a class="govuk-link" href="#">Link with that wraps over two lines to test that the focus style works as expected</a>
+      </p>
+
+      <p class="govuk-body">
+        (<a class="govuk-link" href="#">Link with surrounding brackets</a>) test that the focus style does not overlap.
+      </p>
+
     {% for variant_description, variant_class in variants %}
 
       <section class="govuk-!-margin-top-8">

--- a/src/govuk/components/accordion/_accordion.scss
+++ b/src/govuk/components/accordion/_accordion.scss
@@ -77,7 +77,6 @@
       position: relative;
       z-index: 1;
       margin: 0;
-      margin-right: 5px;
       padding: 0;
       border-width: 0;
       color: $govuk-link-colour;

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -136,8 +136,8 @@
               $highlight-space: 13px;
               content: "";
               display: block;
-              margin-right: 7px;
-              margin-left: 7px;
+              margin-right: $highlight-space;
+              margin-left: $highlight-space;
               box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
             }
           }

--- a/src/govuk/helpers/_focused.scss
+++ b/src/govuk/helpers/_focused.scss
@@ -21,12 +21,7 @@
   }
   color: $govuk-focus-text-colour;
   background-color: $govuk-focus-colour;
-  // sass-lint:disable indentation
-  box-shadow: -5px -1px 0 1px $govuk-focus-colour,
-              5px -1px 0 1px $govuk-focus-colour,
-              -3px 1px 0 3px $govuk-focus-text-colour,
-              3px 1px 0 3px $govuk-focus-text-colour;
-  // sass-lint:enable indentation
+  box-shadow: 0 -2px $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
   // When link is focussed, hide the default underline since the
   // box shadow adds the "underline"
   text-decoration: none;


### PR DESCRIPTION
In order to prevent the new focus style from overlapping surrounding text, we have made the decision to remove the horizontal padding.

# Screenshots

## Links
| Before | After |
|--------|------|
| ![](https://user-images.githubusercontent.com/2445413/61122236-20dfcc00-a499-11e9-9d08-6050f6b92624.png) | ![](https://user-images.githubusercontent.com/2445413/61122244-26d5ad00-a499-11e9-82c3-daba9d1e6efa.png) |
| ![](https://user-images.githubusercontent.com/2445413/61122284-45d43f00-a499-11e9-8783-cc765dd56ad7.png) | ![](https://user-images.githubusercontent.com/2445413/61122293-4a98f300-a499-11e9-95e1-c50a5dcf2089.png) |

## Accordion

| Before | After |
|--------|------|
| ![](https://user-images.githubusercontent.com/2445413/61122615-2984d200-a49a-11e9-979f-cea871d44d69.png) | ![](https://user-images.githubusercontent.com/2445413/61122625-2f7ab300-a49a-11e9-8611-edf77ab7979c.png) |
| ![](https://user-images.githubusercontent.com/2445413/61122660-4b7e5480-a49a-11e9-9014-f8d8b57e912b.png) | ![](https://user-images.githubusercontent.com/2445413/61122663-50430880-a49a-11e9-9282-82f22dd68774.png) |

## Back link

| Before | After |
|--------|------|
| ![](https://user-images.githubusercontent.com/2445413/61122711-6c46aa00-a49a-11e9-857a-d8c364b94503.png) | ![](https://user-images.githubusercontent.com/2445413/61122722-71a3f480-a49a-11e9-8caf-52aa4663f6a3.png) |

## Details

| Before | After |
|--------|------|
| ![](https://user-images.githubusercontent.com/2445413/61122765-8b453c00-a49a-11e9-83bd-2619e44b1453.png) | ![](https://user-images.githubusercontent.com/2445413/61122769-8ed8c300-a49a-11e9-8872-37afc9ccf902.png) |


## Tabs

| Before | After |
|--------|------|
| ![](https://user-images.githubusercontent.com/2445413/61122103-d8281300-a498-11e9-8738-9e74144f409c.png) | ![](https://user-images.githubusercontent.com/2445413/61122111-df4f2100-a498-11e9-996b-8c6c6704d9cc.png) |

This change also reduces the amount of [visual artefacts in Internet Explorer 11](https://github.com/alphagov/govuk-frontend/pull/1309).

I have tested this change in IE8-11, Edge, Chrome, Firefox, Safari

Fixes: https://github.com/alphagov/govuk-frontend/issues/1477