### PR TITLE
Make accordion component documentation more accurate

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -22,11 +22,11 @@ params:
   params:
     - name: heading.text
       type: string
-      required: false
+      required: true
       description: The title of each section. If `heading.html` is supplied, this is ignored. This is used both as the title for each section, and as the button to open or close each section.
     - name: heading.html
       type: string
-      required: false
+      required: true
       description: The HTML content of the header for each section which is used both as the title for each section, and as the button to open or close each section.
     - name: summary.text
       type: string

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -36,6 +36,10 @@ params:
       type: string
       required: false
       description: HTML content for summary line.
+    - name: content.text
+      type: string
+      required: true
+      description: The text content of each section, which is hidden when the section is closed. If `content.html` is supplied, this is ignored.
     - name: content.html
       type: string
       required: true


### PR DESCRIPTION
While exploring https://github.com/alphagov/govuk-frontend/issues/1494 I found that the accordion documentation needed some updates:

- Headings are required
- Content can be given as text, not only html