### PR TITLE
Update tab focus state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,22 @@ If there are links back to radios or checkboxes components in your error summary
 
 [Pull request #1426: Make radios and checkboxes components easier to link to from error summary](https://github.com/alphagov/govuk-frontend/pull/1426)
 
+### Update the markup for tabs
+
+You do not need to do anything if you're using the Nunjucks macros.
+
+If you are not using the Nunjucks macros, remove the `govuk-tabs__tab--selected` class from the first tab's link, then add the `govuk-tabs__list-item--selected` class to the link's parent list item.
+
+```html
+<li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+  <a class="govuk-tabs__tab" href="#tab1">
+    Tab 1
+  </a>
+</li>
+```
+
+[Pull request #1496: Update the focus state for tabs](https://github.com/alphagov/govuk-frontend/pull/1443)
+
 ### Update start button icon
 
 [Start buttons](https://design-system.service.gov.uk/components/button/#start-buttons) have a new icon. Your start buttons will lose their current icons unless you replace the old icon with the new one.

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -22,6 +22,7 @@
   }
 
   .govuk-tabs__list-item {
+    @include govuk-font($size: 19);
     margin-left: govuk-spacing(5);
 
     &::before {
@@ -33,7 +34,6 @@
 
   .govuk-tabs__tab {
     @include govuk-link-style-default;
-    @include govuk-font($size: 19);
 
     display: inline-block;
     margin-bottom: govuk-spacing(2);

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -83,27 +83,6 @@
         text-align: center;
         text-decoration: underline;
 
-        &--selected {
-          $border-width: 1px;
-
-          position: relative;
-
-          margin-top: - govuk-spacing(1);
-
-          // Compensation for border (otherwise we get a shift)
-          margin-bottom: -$border-width;
-          padding-top: govuk-spacing(3) - $border-width;
-          padding-right: govuk-spacing(4) - $border-width;
-          padding-bottom: govuk-spacing(3) + $border-width;
-          padding-left: govuk-spacing(4) - $border-width;
-
-          border: $border-width solid $govuk-border-colour;
-          border-bottom: 0;
-
-          background-color: $govuk-body-background-colour;
-          text-decoration: none;
-        }
-
         &:focus {
 
           // IE8 doesn't support `box-shadow` so add an outline to indicate focus instead
@@ -128,19 +107,40 @@
         }
       }
 
+      .govuk-tabs__tab--selected {
+        $border-width: 1px;
+
+        position: relative;
+
+        margin-top: - govuk-spacing(1);
+
+        // Compensation for border (otherwise we get a shift)
+        margin-bottom: -$border-width;
+        padding-top: govuk-spacing(3) - $border-width;
+        padding-right: govuk-spacing(4) - $border-width;
+        padding-bottom: govuk-spacing(3) + $border-width;
+        padding-left: govuk-spacing(4) - $border-width;
+
+        border: $border-width solid $govuk-border-colour;
+        border-bottom: 0;
+
+        background-color: $govuk-body-background-colour;
+        text-decoration: none;
+      }
+
       .govuk-tabs__panel {
         @include govuk-responsive-margin(0, "bottom");
         padding: govuk-spacing(6) govuk-spacing(4);
         border: 1px solid $govuk-border-colour;
         border-top: 0;
 
-        &--hidden {
-          display: none;
-        }
-
         & > :last-child {
           margin-bottom: 0;
         }
+      }
+
+      .govuk-tabs__panel--hidden {
+        display: none;
       }
     }
 

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -75,7 +75,6 @@
         float: left;
         background-color: govuk-colour("light-grey", $legacy: "grey-4");
         text-align: center;
-        text-decoration: underline;
 
         &::before {
           content: none;

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -11,6 +11,7 @@
 
   .govuk-tabs__title {
     @include govuk-font($size: 19);
+    @include govuk-text-colour;
     margin-bottom: govuk-spacing(2);
   }
 
@@ -26,6 +27,7 @@
     margin-left: govuk-spacing(5);
 
     &::before {
+      @include govuk-text-colour;
       content: "\2014 "; // "— "
       margin-left: - govuk-spacing(5);
       padding-right: govuk-spacing(1);

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -46,13 +46,6 @@
     &:focus {
       @include govuk-focused-text;
     }
-
-    // IE8 doesn't support `box-shadow` so add an outline to indicate focus
-    @include govuk-if-ie8 {
-      &:focus {
-        outline: $govuk-focus-width solid $govuk-focus-colour;
-      }
-    }
   }
 
   .govuk-tabs__panel {
@@ -96,13 +89,6 @@
         text-align: center;
         text-decoration: underline;
 
-        @include govuk-not-ie8 {
-          &:focus {
-            // Remove no-JS styles
-            box-shadow: none;
-          }
-        }
-
         &--selected {
           $border-width: 1px;
 
@@ -123,18 +109,28 @@
           color: $govuk-text-colour;
           background-color: govuk-colour("white");
           text-decoration: none;
+        }
 
-          &:focus {
+        &:focus {
 
-            &:after {
-              // Add "highlight" on focused link
-              $highlight-space: 13px;
-              content: "";
-              display: block;
-              margin-right: $highlight-space;
-              margin-left: $highlight-space;
-              box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
-            }
+          // IE8 doesn't support `box-shadow` so add an outline to indicate focus instead
+          @include govuk-if-ie8 {
+            outline: $govuk-focus-width solid $govuk-focus-colour;
+          }
+
+          // Move the focus style from the entire tab to the link
+          @include govuk-not-ie8 {
+            box-shadow: none;
+          }
+
+          &:after {
+            // Add "highlight" on focused link
+            $highlight-space: 13px;
+            content: "";
+            display: block;
+            margin-right: $highlight-space;
+            margin-left: $highlight-space;
+            box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
           }
         }
       }

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -41,11 +41,6 @@
     display: inline-block;
     margin-bottom: govuk-spacing(2);
 
-    &[aria-current = "true"] {
-      color: govuk-colour("black");
-      text-decoration: none;
-    }
-
     // Focus state for mobile and when JavaScript is disabled
     // It is removed for JS-enabled desktop styles
     &:focus {

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -60,22 +60,16 @@
         border-bottom: 1px solid $govuk-border-colour;
       }
 
-      .govuk-tabs__list-item {
-        margin-left: 0;
-
-        &::before {
-          content: none;
-        }
-      }
-
       .govuk-tabs__title {
         display: none;
       }
 
-      .govuk-tabs__tab {
-        @include govuk-link-style-text;
+      .govuk-tabs__list-item {
+        position: relative;
+
         margin-right: govuk-spacing(1);
         margin-bottom: 0;
+        margin-left: 0;
         padding: govuk-spacing(2) govuk-spacing(4);
 
         float: left;
@@ -83,31 +77,12 @@
         text-align: center;
         text-decoration: underline;
 
-        &:focus {
-
-          // IE8 doesn't support `box-shadow` so add an outline to indicate focus instead
-          @include govuk-if-ie8 {
-            outline: $govuk-focus-width solid $govuk-focus-colour;
-          }
-
-          // Move the focus style from the entire tab to the link
-          @include govuk-not-ie8 {
-            box-shadow: none;
-          }
-
-          &:after {
-            // Add "highlight" on focused link
-            $highlight-space: 13px;
-            content: "";
-            display: block;
-            margin-right: $highlight-space;
-            margin-left: $highlight-space;
-            box-shadow: 0 (-$highlight-space) 0 $highlight-space $govuk-focus-colour, 0 -9px 0 $highlight-space govuk-colour("black");
-          }
+        &::before {
+          content: none;
         }
       }
 
-      .govuk-tabs__tab--selected {
+      .govuk-tabs__list-item--selected {
         $border-width: 1px;
 
         position: relative;
@@ -125,7 +100,25 @@
         border-bottom: 0;
 
         background-color: $govuk-body-background-colour;
-        text-decoration: none;
+
+        .govuk-tabs__tab {
+          text-decoration: none;
+        }
+      }
+
+      .govuk-tabs__tab {
+        @include govuk-link-style-text;
+
+        margin-bottom: 0;
+
+        &::after {
+          content: "";
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 0;
+          left: 0;
+        }
       }
 
       .govuk-tabs__panel {

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -76,10 +76,7 @@
         @include govuk-link-style-text;
         margin-right: govuk-spacing(1);
         margin-bottom: 0;
-        padding-top: govuk-spacing(2);
-        padding-right: govuk-spacing(4);
-        padding-bottom: govuk-spacing(2);
-        padding-left: govuk-spacing(4);
+        padding: govuk-spacing(2) govuk-spacing(4);
 
         float: left;
         background-color: govuk-colour("light-grey", $legacy: "grey-4");
@@ -133,10 +130,7 @@
 
       .govuk-tabs__panel {
         @include govuk-responsive-margin(0, "bottom");
-        padding-top: govuk-spacing(6);
-        padding-right: govuk-spacing(4);
-        padding-bottom: govuk-spacing(6);
-        padding-left: govuk-spacing(4);
+        padding: govuk-spacing(6) govuk-spacing(4);
         border: 1px solid $govuk-border-colour;
         border-top: 0;
 

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -100,7 +100,7 @@
           border: $border-width solid $govuk-border-colour;
           border-bottom: 0;
 
-          background-color: govuk-colour("white");
+          background-color: $govuk-body-background-colour;
           text-decoration: none;
         }
 

--- a/src/govuk/components/tabs/_tabs.scss
+++ b/src/govuk/components/tabs/_tabs.scss
@@ -5,8 +5,6 @@
 @include govuk-exports("govuk/component/tabs") {
 
   .govuk-tabs {
-    @include govuk-font($size: 19);
-    @include govuk-text-colour;
     @include govuk-responsive-margin(1, "top");
     @include govuk-responsive-margin(6, "bottom");
   }
@@ -35,7 +33,6 @@
 
   .govuk-tabs__tab {
     @include govuk-link-style-default;
-
     @include govuk-font($size: 19);
 
     display: inline-block;
@@ -76,6 +73,7 @@
       }
 
       .govuk-tabs__tab {
+        @include govuk-link-style-text;
         margin-right: govuk-spacing(1);
         margin-bottom: 0;
         padding-top: govuk-spacing(2);
@@ -84,7 +82,6 @@
         padding-left: govuk-spacing(4);
 
         float: left;
-        color: govuk-colour("black");
         background-color: govuk-colour("light-grey", $legacy: "grey-4");
         text-align: center;
         text-decoration: underline;
@@ -106,7 +103,6 @@
           border: $border-width solid $govuk-border-colour;
           border-bottom: 0;
 
-          color: $govuk-text-colour;
           background-color: govuk-colour("white");
           text-decoration: none;
         }

--- a/src/govuk/components/tabs/tabs.js
+++ b/src/govuk/components/tabs/tabs.js
@@ -146,6 +146,7 @@ Tabs.prototype.setAttributes = function ($tab) {
   $tab.setAttribute('id', 'tab_' + panelId)
   $tab.setAttribute('role', 'tab')
   $tab.setAttribute('aria-controls', panelId)
+  $tab.setAttribute('aria-selected', 'false')
   $tab.setAttribute('tabindex', '-1')
 
   // set panel attributes
@@ -160,6 +161,7 @@ Tabs.prototype.unsetAttributes = function ($tab) {
   $tab.removeAttribute('id')
   $tab.removeAttribute('role')
   $tab.removeAttribute('aria-controls')
+  $tab.removeAttribute('aria-selected')
   $tab.removeAttribute('tabindex')
 
   // unset panel attributes

--- a/src/govuk/components/tabs/tabs.js
+++ b/src/govuk/components/tabs/tabs.js
@@ -254,18 +254,18 @@ Tabs.prototype.hidePanel = function (tab) {
 
 Tabs.prototype.unhighlightTab = function ($tab) {
   $tab.setAttribute('aria-selected', 'false')
-  $tab.classList.remove('govuk-tabs__tab--selected')
+  $tab.parentNode.classList.remove('govuk-tabs__list-item--selected')
   $tab.setAttribute('tabindex', '-1')
 }
 
 Tabs.prototype.highlightTab = function ($tab) {
   $tab.setAttribute('aria-selected', 'true')
-  $tab.classList.add('govuk-tabs__tab--selected')
+  $tab.parentNode.classList.add('govuk-tabs__list-item--selected')
   $tab.setAttribute('tabindex', '0')
 }
 
 Tabs.prototype.getCurrentTab = function () {
-  return this.$module.querySelector('.govuk-tabs__tab--selected')
+  return this.$module.querySelector('.govuk-tabs__list-item--selected .govuk-tabs__tab')
 }
 
 // this is because IE doesn't always return the actual value but a relative full path

--- a/src/govuk/components/tabs/tabs.test.js
+++ b/src/govuk/components/tabs/tabs.test.js
@@ -33,8 +33,8 @@ describe('/components/tabs', () => {
         const firstTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:first-child .govuk-tabs__tab').getAttribute('aria-selected'))
         expect(firstTabAriaSelected).toEqual('true')
 
-        const firstTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:first-child .govuk-tabs__tab').className)
-        expect(firstTabClasses).toContain('govuk-tabs__tab--selected')
+        const firstTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:first-child').className)
+        expect(firstTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
       it('should display the first tab panel', async () => {
@@ -62,8 +62,8 @@ describe('/components/tabs', () => {
         const secondTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-selected'))
         expect(secondTabAriaSelected).toEqual('true')
 
-        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').className)
-        expect(secondTabClasses).toContain('govuk-tabs__tab--selected')
+        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2)').className)
+        expect(secondTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
       it('should display the tab panel associated with the selected tab', async () => {
@@ -112,8 +112,8 @@ describe('/components/tabs', () => {
         const secondTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-selected'))
         expect(secondTabAriaSelected).toEqual('true')
 
-        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').className)
-        expect(secondTabClasses).toContain('govuk-tabs__tab--selected')
+        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2)').className)
+        expect(secondTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
       it('should display the tab panel associated with the selected tab', async () => {
@@ -138,8 +138,8 @@ describe('/components/tabs', () => {
         const currentTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__tab[href="#past-week"]').getAttribute('aria-selected'))
         expect(currentTabAriaSelected).toEqual('true')
 
-        const currentTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__tab[href="#past-week"]').className)
-        expect(currentTabClasses).toContain('govuk-tabs__tab--selected')
+        const currentTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__tab[href="#past-week"]').parentNode.className)
+        expect(currentTabClasses).toContain('govuk-tabs__list-item--selected')
 
         const currentTabPanelIsHidden = await page.evaluate(() => document.getElementById('past-week').classList.contains('govuk-tabs__panel--hidden'))
         expect(currentTabPanelIsHidden).toBeFalsy()

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -192,9 +192,9 @@ examples:
         panel:
           html: |
             <h2 class="govuk-heading-l">Tab 1</h2>
-            <p>Testing that when you click the anchor it moves to the anchor point successfully</p>
-            <a class="govuk-link" href="#anchor">Anchor</a>
-            <a id="anchor" tabIndex="0">Anchor Point</a>
+            <p class="govuk-body">Testing that when you click the anchor it moves to the anchor point successfully</p>
+            <p class="govuk-body"><a class="govuk-link" href="#anchor">Anchor</a></p>
+            <p class="govuk-body"><a id="anchor" tabIndex="0">Anchor Point</a></p>
       - label: Tab 2
         id: tab-2
         panel:

--- a/src/govuk/components/tabs/template.njk
+++ b/src/govuk/components/tabs/template.njk
@@ -10,8 +10,8 @@
   <ul class="govuk-tabs__list">
     {% for item in params.items %}
     {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
-      <li class="govuk-tabs__list-item">
-        <a class="govuk-tabs__tab{% if loop.index == 1 %} govuk-tabs__tab--selected{% endif %}" href="#{{ id }}"
+      <li class="govuk-tabs__list-item{% if loop.index == 1 %} govuk-tabs__list-item--selected{% endif %}">
+        <a class="govuk-tabs__tab" href="#{{ id }}"
            {%- for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
           {{ item.label }}
         </a>

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -227,22 +227,35 @@ describe('Tabs', () => {
             panel: {
               text: 'Panel text 2'
             }
+          }
+        ]
+      })
+
+      const $tab = $('[href="#tab-1"]').parent()
+      expect($tab.hasClass('govuk-tabs__list-item--selected')).toBeTruthy()
+    })
+
+    it('hides all but the first panel', () => {
+      const $ = render('tabs', {
+        items: [
+          {
+            id: 'tab-1',
+            label: 'Tab 1',
+            panel: {
+              text: 'Panel text'
+            }
           },
           {
-            id: 'tab-3',
-            label: 'Tab 3',
+            id: 'tab-2',
+            label: 'Tab 2',
             panel: {
-              text: 'Panel text 3'
+              text: 'Panel text 2'
             }
           }
         ]
       })
 
-      const $tabs = $('.govuk-tabs')
-      const $selectedTabs = $tabs.find('.govuk-tabs__tab--selected')
-      const $hiddenTabPanels = $tabs.find('.govuk-tabs__panel--hidden')
-      expect($hiddenTabPanels.length).toBe(2)
-      expect($selectedTabs.length).toBe(1)
+      expect($('#tab-2').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
The ‘tab styling’ is currently applied to the link, with the list item doing very little in terms of presentation.

This is problematic when it comes to presenting the focus state, which we want to be tight around the tab text, and thus visually smaller than the tab. Our current approach, which creates the focus state using an `::after` pseudo-element, [doesn't render correctly in IE 11](https://github.com/alphagov/govuk-frontend/issues/1472).

By moving the tab styling to the list item, we can then make the link element smaller, and use an `::after` pseudo element to make the target area for the link fill the entire tab (the ['pseudo-content trick'](https://inclusive-components.design/cards/#thepseudocontenttrick)).

This also:

- generally tidies up the Sass a bit
- removes an unused `aria-current` ruleset in the Sass
- simplifies the focus state as we can just use the default link styles for IE8 as we do for accordions
- avoids setting the font on the entire tab panel content (it was being set on `govuk-tabs`)
- matches the tab colour to the background colour of the page rather than hardcoding to white
- tears down and restores the `aria-selected` attribute when moving to and from mobile

Fixes #1472. I suggest reviewing commit-by-commit.

## Screenshots

<details>
<summary>Chrome (macOS)</summary>
<img src="https://user-images.githubusercontent.com/121939/61299880-da5fd980-a7d8-11e9-8d68-f984c41c2b67.gif" alt="Chrome (macOS)" />
</details>

<details>
<summary>Safari (macOS)</summary>
<img src="https://user-images.githubusercontent.com/121939/61300110-4c382300-a7d9-11e9-90cf-ac455af0fe75.gif" alt="Safari (macOS)" />
</details>

<details>
<summary>Firefox (macOS, custom colours)</summary>
<img src="https://user-images.githubusercontent.com/121939/61300073-39255300-a7d9-11e9-9bb4-2d46df27e819.gif" alt="Firefox (macOS, custom colours)" />
</details>

<details>
<summary>IE 8</summary>
<img src="https://user-images.githubusercontent.com/121939/61299900-e3e94180-a7d8-11e9-88dc-c6ffa652caad.gif" alt="IE 8" />
</details>

<details>
<summary>IE 9</summary>
<img src="https://user-images.githubusercontent.com/121939/61299919-eea3d680-a7d8-11e9-8f6d-648c435aee40.gif" alt="IE 9" />
</details>

<details>
<summary>IE 10</summary>
<img src="https://user-images.githubusercontent.com/121939/61299935-f5324e00-a7d8-11e9-8f44-523e861ce31d.gif" alt="IE 10" />
</details>

<details>
<summary>IE 11</summary>
<img src="https://user-images.githubusercontent.com/121939/61300035-227efc00-a7d9-11e9-9502-6474f30c6e77.gif" alt="IE 11" />
</details>