### PR TITLE
Minor fixes to header component

### DIFF
--- a/src/govuk/components/header/_header.scss
+++ b/src/govuk/components/header/_header.scss
@@ -61,7 +61,7 @@
   }
 
   .govuk-header__product-name {
-    @include govuk-font($size: 24);
+    @include govuk-font($size: 24, $line-height: 1);
     display: inline-table;
     padding-right: govuk-spacing(2);
   }
@@ -117,6 +117,7 @@
 
     // Remove any borders that show when focused and hovered.
     &:focus {
+      margin-bottom: 0;
       border-bottom: 0;
     }
   }


### PR DESCRIPTION
- Fix a bug where hovering the GOV.UK logo whilst it is focused results in the header shrinking by 1px
- Reduce the line-height on the product name, which was causing the height of the header to increase by 2px (from 60px to 62px) when a product name was added.