### PR TITLE
Update description of serviceName macro option

### DIFF
--- a/package/components/header/macro-options.json
+++ b/package/components/header/macro-options.json
@@ -21,7 +21,7 @@
         "name": "serviceName",
         "type": "string",
         "required": false,
-        "description": "Header title that is placed next to GOV.UK. Used for product names (i.e. Pay, Verify)"
+        "description": "Header title that is placed separately from GOV.UK. Used for service names such as 'Register to vote'"
     },
     {
         "name": "serviceUrl",


### PR DESCRIPTION
Fixes what looks like a copy-and-paste mistake with the macro option descriptions for the Header component.