### PR TITLE
Add example of fixed-width header w/ product name

### DIFF
--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -155,6 +155,11 @@ examples:
       - href: '/browse/working'
         text: Working, jobs and pensions
 
+- name: with product name
+  data:
+    navigationClasses: govuk-header__navigation--end
+    productName: Product Name
+
 - name: full width
   data:
     containerClasses: govuk-header__container--full-width


### PR DESCRIPTION
The only examples we currently have for headers with product names are all full width.

We know that in many cases a product name will be used without the header being full width, so we should support this.

At the minute, this example does not render as we’d want it to – the ‘Product Name’ wraps onto a new line – so we’ll need to look at fixing this in the future.

![localhost_3000_components_header_with-product-name_preview](https://user-images.githubusercontent.com/121939/61457852-1de54f80-a961-11e9-80f3-0aeb4fbc8eb1.png)
