### PR TITLE
Add guidance links to v3 (unreleased) changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,11 +117,11 @@ Pull requests:
 
 The focus state of components now meets the new WCAG 2.1 level AA requirements.
 
-You must update your component’s focus state to make your design consistent with our new focus styles.
+You must [update your component’s focus state](https://design-system.service.gov.uk/get-started/focus-states/) to make your design consistent with our new focus styles.
 
 If you've extended or created components, you can no longer use the `govuk-focusable` or `govuk-focusable-fill` mixins in your Sass files.
 
-If you're using `govuk-focusable`, you must remove it. There’s no direct replacement, so you must use our Sass variables to make your components consistent with GOV.UK Frontend.
+If you're using `govuk-focusable`, you must remove it. There’s no direct replacement, so you must [use our Sass variables to make your components consistent](https://design-system.service.gov.uk/get-started/focus-states/#make-other-focusable-elements-accessible) with GOV.UK Frontend.
 
 If you're using `govuk-focusable-fill`, include the `govuk-focused-text` mixin inside your component's `:focus` selector. For example:
 
@@ -181,6 +181,8 @@ We've also changed the background of the following components:
 - links in their hover state - `dark-blue` instead of `light-blue`
 
 If you're using legacy projects like GOV.UK Elements, you can keep your current colours by [turning on compatibility mode](https://github.com/alphagov/govuk-frontend/docs/installation/compatibility.md).
+
+Read our [blog post about why we changed the colour palette](https://designnotes.blog.gov.uk/2019/07/29/were-updating-the-gov-uk-colours-and-font)
 
 [Pull request #1288: Update colour palette](https://github.com/alphagov/govuk-frontend/pull/1288).
 


### PR DESCRIPTION
This pull request adds links to pending guidance from the v3 (unreleased) changelog.

Do not merge until the we've replaced the TODOs with the guidance links.
