### PR TITLE
Update heroku stack from v.16 to v.18

### DIFF
--- a/app.json
+++ b/app.json
@@ -16,5 +16,6 @@
     {
       "url": "heroku/nodejs"
     }
-  ]
+  ],
+  "stack": "heroku-18"
 }


### PR DESCRIPTION
Updates Heroku from [heroku-16](https://devcenter.heroku.com/articles/heroku-16-stack) to [heroku-18](https://devcenter.heroku.com/articles/heroku-18-stack).

I've tested the review app and everything still works as expected. 

Login to team heroku account and visit https://dashboard.heroku.com/apps/govuk-frontend-review-pr-1508/settings to confirm the stack that's being used