### PR TITLE
Update components to only output items when they are defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- [Pull request #1512: Update components to only output items when they are defined](https://github.com/alphagov/govuk-frontend/pull/1512).
+
 ## 3.0.0 (Breaking release)
 
 ### Breaking changes

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -4,22 +4,24 @@
 <div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}" data-module="govuk-accordion" id="{{ id }}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}
-    <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">
-      <div class="govuk-accordion__section-header">
-        <h{{ headingLevel }} class="govuk-accordion__section-heading">
-          <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">
-            {{ item.heading.html | safe if item.heading.html else item.heading.text }}
-          </span>
-        </h{{ headingLevel }}>
-        {% if item.summary.html or item.summary.text %}
-          <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
-            {{ item.summary.html | safe if item.summary.html else item.summary.text }}
-          </div>
-        {% endif %}
+    {% if item %}
+      <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">
+        <div class="govuk-accordion__section-header">
+          <h{{ headingLevel }} class="govuk-accordion__section-heading">
+            <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">
+              {{ item.heading.html | safe if item.heading.html else item.heading.text }}
+            </span>
+          </h{{ headingLevel }}>
+          {% if item.summary.html or item.summary.text %}
+            <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
+              {{ item.summary.html | safe if item.summary.html else item.summary.text }}
+            </div>
+          {% endif %}
+        </div>
+        <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="{{ id }}-heading-{{ loop.index }}">
+          {{ item.content.html | safe if item.content.html else item.content.text }}
+        </div>
       </div>
-      <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="{{ id }}-heading-{{ loop.index }}">
-        {{ item.content.html | safe if item.content.html else item.content.text }}
-      </div>
-    </div>
+    {% endif %}
   {% endfor %}
 </div>

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -75,6 +75,37 @@ describe('Accordion', () => {
       expect($componentContent.text().trim()).toEqual('Some content')
     })
 
+    it('renders list without falsely values', () => {
+      const $ = render('accordion', {
+        headingLevel: '3',
+        items: [
+          {
+            heading: {
+              text: 'Section A'
+            },
+            content: {
+              text: 'Some content'
+            }
+          },
+          false,
+          undefined,
+          null,
+          {
+            heading: {
+              text: 'Section B'
+            },
+            content: {
+              text: 'Some content'
+            }
+          }
+        ]
+      })
+      const $component = $('.govuk-accordion')
+      const $items = $component.find('.govuk-accordion__section')
+
+      expect($items.length).toEqual(2)
+    })
+
     it('renders with classes', () => {
       const $ = render('accordion', {
         classes: 'app-accordion--custom-modifier'

--- a/src/govuk/components/checkboxes/template.njk
+++ b/src/govuk/components/checkboxes/template.njk
@@ -53,52 +53,54 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="govuk-checkboxes"{% endif -%}>
     {% for item in params.items %}
-    {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-    {%- if item.id -%}
-      {%- set id = item.id -%}
-    {%- else -%}
-      {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-      {%- if loop.first -%}
-        {%- set id = idPrefix %}
-      {% else %}
-        {%- set id = idPrefix + "-" + loop.index -%}
-      {%- endif -%}
-    {%- endif -%}
-    {% set name = item.name if item.name else params.name %}
-    {% set conditionalId = "conditional-" + id %}
-    {% set hasHint = true if item.hint.text or item.hint.html %}
-    {% set itemHintId = id + "-item-hint" if hasHint else "" %}
-    {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
-    {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
-    <div class="govuk-checkboxes__item">
-      <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
-      {{-" checked" if item.checked }}
-      {{-" disabled" if item.disabled }}
-      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
-      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
-      {{ govukLabel({
-        html: item.html,
-        text: item.text,
-        classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
-        attributes: item.label.attributes,
-        for: id
-      }) | indent(6) | trim }}
-      {% if hasHint %}
-      {{ govukHint({
-        id: itemHintId,
-        classes: 'govuk-checkboxes__hint',
-        attributes: item.hint.attributes,
-        html: item.hint.html,
-        text: item.hint.text
-      }) | indent(6) | trim }}
+      {% if item %}
+        {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+        {%- if item.id -%}
+          {%- set id = item.id -%}
+        {%- else -%}
+          {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+          {%- if loop.first -%}
+            {%- set id = idPrefix %}
+          {% else %}
+            {%- set id = idPrefix + "-" + loop.index -%}
+          {%- endif -%}
+        {%- endif -%}
+        {% set name = item.name if item.name else params.name %}
+        {% set conditionalId = "conditional-" + id %}
+        {% set hasHint = true if item.hint.text or item.hint.html %}
+        {% set itemHintId = id + "-item-hint" if hasHint else "" %}
+        {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
+        {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
+        <div class="govuk-checkboxes__item">
+          <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
+          {{-" checked" if item.checked }}
+          {{-" disabled" if item.disabled }}
+          {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+          {%- if itemDescribedBy %} aria-describedby="{{ itemDescribedBy }}"{% endif -%}
+          {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+          {{ govukLabel({
+            html: item.html,
+            text: item.text,
+            classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
+            attributes: item.label.attributes,
+            for: id
+          }) | indent(6) | trim }}
+          {% if hasHint %}
+          {{ govukHint({
+            id: itemHintId,
+            classes: 'govuk-checkboxes__hint',
+            attributes: item.hint.attributes,
+            html: item.hint.html,
+            text: item.hint.text
+          }) | indent(6) | trim }}
+          {% endif %}
+        </div>
+        {% if item.conditional %}
+          <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+            {{ item.conditional.html | safe }}
+          </div>
+        {% endif %}
       {% endif %}
-    </div>
-    {% if item.conditional %}
-      <div class="govuk-checkboxes__conditional{% if not item.checked %} govuk-checkboxes__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-        {{ item.conditional.html | safe }}
-      </div>
-    {% endif %}
     {% endfor %}
   </div>
 {% endset -%}

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -50,6 +50,30 @@ describe('Checkboxes', () => {
     expect($lastLabel.text()).toContain('Option 2')
   })
 
+  it('render example without falsely values', () => {
+    const $ = render('checkboxes', {
+      name: 'example-name',
+      items: [
+        {
+          value: '1',
+          text: 'Option 1'
+        },
+        undefined,
+        null,
+        false,
+        {
+          value: '2',
+          text: 'Option 2'
+        }
+      ]
+    })
+
+    const $component = $('.govuk-checkboxes')
+    const $items = $component.find('.govuk-checkboxes__item')
+
+    expect($items.length).toEqual(2)
+  })
+
   it('render classes', () => {
     const $ = render('checkboxes', {
       name: 'example-name',

--- a/src/govuk/components/radios/template.njk
+++ b/src/govuk/components/radios/template.njk
@@ -47,53 +47,55 @@
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
     {%- if isConditional %} data-module="govuk-radios"{% endif -%}>
     {% for item in params.items %}
-    {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
-    {%- if item.id -%}
-      {%- set id = item.id -%}
-    {%- else -%}
-      {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
-      {%- if loop.first -%}
-        {%- set id = idPrefix %}
-      {% else %}
-        {%- set id = idPrefix + "-" + loop.index -%}
-      {%- endif -%}
-    {%- endif -%}
-    {% set conditionalId = "conditional-" + id %}
-    {%- if item.divider %}
-    <div class="govuk-radios__divider">{{ item.divider }}</div>
-    {%- else %}
-    {% set hasHint = true if item.hint.text or item.hint.html %}
-    {% set itemHintId = id + '-item-hint' %}
-    <div class="govuk-radios__item">
-      <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
-      {{-" checked" if item.checked }}
-      {{-" disabled" if item.disabled }}
-      {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
-      {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
-      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
-      {{ govukLabel({
-        html: item.html,
-        text: item.text,
-        classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
-        attributes: item.label.attributes,
-        for: id
-      }) | indent(6) | trim }}
-      {% if hasHint %}
-      {{ govukHint({
-        id: itemHintId,
-        classes: 'govuk-radios__hint',
-        attributes: item.hint.attributes,
-        html: item.hint.html,
-        text: item.hint.text
-      }) | indent(6) | trim }}
+      {% if item %}
+        {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}
+        {%- if item.id -%}
+          {%- set id = item.id -%}
+        {%- else -%}
+          {#- The first id should not have a number suffix so it's easy to link to from the error summary component -#}
+          {%- if loop.first -%}
+            {%- set id = idPrefix %}
+          {% else %}
+            {%- set id = idPrefix + "-" + loop.index -%}
+          {%- endif -%}
+        {%- endif -%}
+        {% set conditionalId = "conditional-" + id %}
+        {%- if item.divider %}
+        <div class="govuk-radios__divider">{{ item.divider }}</div>
+        {%- else %}
+        {% set hasHint = true if item.hint.text or item.hint.html %}
+        {% set itemHintId = id + '-item-hint' %}
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="{{ id }}" name="{{ params.name }}" type="radio" value="{{ item.value }}"
+          {{-" checked" if item.checked }}
+          {{-" disabled" if item.disabled }}
+          {%- if item.conditional %} data-aria-controls="{{ conditionalId }}"{% endif -%}
+          {%- if hasHint %} aria-describedby="{{ itemHintId }}"{% endif -%}
+          {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
+          {{ govukLabel({
+            html: item.html,
+            text: item.text,
+            classes: 'govuk-radios__label' + (' ' + item.label.classes if item.label.classes),
+            attributes: item.label.attributes,
+            for: id
+          }) | indent(6) | trim }}
+          {% if hasHint %}
+          {{ govukHint({
+            id: itemHintId,
+            classes: 'govuk-radios__hint',
+            attributes: item.hint.attributes,
+            html: item.hint.html,
+            text: item.hint.text
+          }) | indent(6) | trim }}
+          {% endif %}
+        </div>
+        {% if item.conditional %}
+          <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
+            {{ item.conditional.html | safe }}
+          </div>
+        {% endif %}
+        {% endif %}
       {% endif %}
-    </div>
-    {% if item.conditional %}
-      <div class="govuk-radios__conditional{% if not item.checked %} govuk-radios__conditional--hidden{% endif %}" id="{{ conditionalId }}">
-        {{ item.conditional.html | safe }}
-      </div>
-    {% endif %}
-    {% endif %}
     {% endfor %}
   </div>
 {% endset -%}

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -50,6 +50,28 @@ describe('Radios', () => {
     expect($lastLabel.text()).toContain('No')
   })
 
+  it('renders without falsely items', () => {
+    const $ = render('radios', {
+      name: 'example-name',
+      items: [
+        {
+          value: 'yes',
+          text: 'Yes'
+        },
+        undefined,
+        null,
+        {
+          value: 'no',
+          text: 'No'
+        }
+      ]
+    })
+
+    const $component = $('.govuk-radios')
+    const $items = $component.find('.govuk-radios__item input')
+    expect($items.length).toEqual(2)
+  })
+
   it('render classes', () => {
     const $ = render('radios', {
       name: 'example-name',

--- a/src/govuk/components/select/template.njk
+++ b/src/govuk/components/select/template.njk
@@ -40,10 +40,12 @@
   <select class="govuk-select
     {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
-    <option value="{{ item.value }}"
-      {{-" selected" if item.selected }}
-      {{-" disabled" if item.disabled }}
-      {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>{{ item.text }}</option>
+    {% if item %}
+      <option value="{{ item.value }}"
+        {{-" selected" if item.selected }}
+        {{-" disabled" if item.disabled }}
+        {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>{{ item.text }}</option>
+    {% endif %}
   {% endfor %}
   </select>
 </div>

--- a/src/govuk/components/select/template.test.js
+++ b/src/govuk/components/select/template.test.js
@@ -63,6 +63,24 @@ describe('Select', () => {
       expect($items.length).toEqual(2)
     })
 
+    it('renders without falsely items', () => {
+      const $ = render('select', {
+        items: [
+          {
+            text: 'Option 1'
+          },
+          undefined,
+          null,
+          false,
+          {
+            text: 'Options 2'
+          }
+        ]
+      })
+      const $items = $('.govuk-select option')
+      expect($items.length).toEqual(2)
+    })
+
     it('renders item with value', () => {
       const $ = render('select', {
         value: '2',

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -2,7 +2,7 @@ params:
 - name: rows
   type: array
   required: true
-  description: Array of row item objects
+  description: Array of row item objects.
   params:
   - name: key.text
     type: string

--- a/src/govuk/components/summary-list/template.njk
+++ b/src/govuk/components/summary-list/template.njk
@@ -15,31 +15,33 @@
 
 <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for row in params.rows %}
-    <div class="govuk-summary-list__row {%- if row.classes %} {{ row.classes }}{% endif %}">
-      <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
-        {{ row.key.html | safe if row.key.html else row.key.text }}
-      </dt>
-      <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
-        {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
-      </dd>
-      {% if row.actions.items.length %}
-        <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
-          {% if row.actions.items.length == 1 %}
-            {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
-          {% else %}
-            <ul class="govuk-summary-list__actions-list">
-              {% for action in row.actions.items %}
-                <li class="govuk-summary-list__actions-list-item">
-                  {{ _actionLink(action) | indent(18) | trim }}
-                </li>
-              {% endfor %}
-            </ul>
-          {% endif %}
+    {% if row %}
+      <div class="govuk-summary-list__row {%- if row.classes %} {{ row.classes }}{% endif %}">
+        <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+          {{ row.key.html | safe if row.key.html else row.key.text }}
+        </dt>
+        <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+          {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
         </dd>
-      {% elseif anyRowHasActions %}
-        {# Add dummy column to extend border #}
-        <span class="govuk-summary-list__actions"></span>
-      {% endif %}
-    </div>
+        {% if row.actions.items.length %}
+          <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
+            {% if row.actions.items.length == 1 %}
+              {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
+            {% else %}
+              <ul class="govuk-summary-list__actions-list">
+                {% for action in row.actions.items %}
+                  <li class="govuk-summary-list__actions-list-item">
+                    {{ _actionLink(action) | indent(18) | trim }}
+                  </li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </dd>
+        {% elseif anyRowHasActions %}
+          {# Add dummy column to extend border #}
+          <span class="govuk-summary-list__actions"></span>
+        {% endif %}
+      </div>
+    {% endif %}
   {% endfor %}
 </dl>

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -44,6 +44,31 @@ describe('Data list', () => {
     expect($component.attr('data-attribute-2')).toEqual('value-2')
   })
   describe('rows', () => {
+    it('renders list without falsely values', async () => {
+      const $ = render('summary-list', {
+        rows: [
+          {
+            key: {
+              text: 'Name'
+            },
+            classes: 'app-custom-class'
+          },
+          null,
+          undefined,
+          false,
+          {
+            key: {
+              text: 'Name 2'
+            },
+            classes: 'app-custom-class'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-summary-list')
+      const $row = $component.find('.govuk-summary-list__row')
+      expect($row.length).toBe(2)
+    })
     it('renders classes', async () => {
       const $ = render('summary-list', {
         rows: [

--- a/src/govuk/components/table/template.njk
+++ b/src/govuk/components/table/template.njk
@@ -19,25 +19,27 @@
   {% endif %}
   <tbody class="govuk-table__body">
     {% for row in params.rows %}
-    <tr class="govuk-table__row">
-    {% for cell in row %}
-      {% set commonAttributes %}
-        {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
-        {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
-      {% endset %}
-      {% if loop.first and params.firstCellIsHeader %}
-      <th scope="row" class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}"
-        {{- commonAttributes | safe -}}
-      >{{ cell.html | safe if cell.html else cell.text }}</th>
-      {% else %}
-      <td class="govuk-table__cell
-        {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
-        {%- if cell.classes %} {{ cell.classes }}{% endif %}"
-        {{- commonAttributes | safe -}}
-      >{{ cell.html | safe if cell.html else cell.text }}</td>
+      {% if row %}
+        <tr class="govuk-table__row">
+        {% for cell in row %}
+          {% set commonAttributes %}
+            {%- if cell.colspan %} colspan="{{ cell.colspan }}"{% endif %}
+            {%- if cell.rowspan %} rowspan="{{ cell.rowspan }}"{% endif %}{% for attribute, value in cell.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
+          {% endset %}
+          {% if loop.first and params.firstCellIsHeader %}
+          <th scope="row" class="govuk-table__header{%- if cell.classes %} {{ cell.classes }}{% endif %}"
+            {{- commonAttributes | safe -}}
+          >{{ cell.html | safe if cell.html else cell.text }}</th>
+          {% else %}
+          <td class="govuk-table__cell
+            {%- if cell.format %} govuk-table__cell--{{ cell.format }}{% endif %}
+            {%- if cell.classes %} {{ cell.classes }}{% endif %}"
+            {{- commonAttributes | safe -}}
+          >{{ cell.html | safe if cell.html else cell.text }}</td>
+          {% endif %}
+        {% endfor %}
+        </tr>
       {% endif %}
-    {% endfor %}
-    </tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/govuk/components/table/template.test.js
+++ b/src/govuk/components/table/template.test.js
@@ -397,6 +397,31 @@ describe('Table', () => {
       ])
     })
 
+    it('can be skipped when falsely', () => {
+      const $ = render('table', {
+        rows: [
+          [{ text: 'A' }, { text: '1' }],
+          null,
+          undefined,
+          false,
+          [{ text: 'B' }, { text: '2' }],
+          [{ text: 'C' }, { text: '3' }]
+        ]
+      })
+
+      const cells = $('.govuk-table').find('tbody tr')
+        .map((_, tr) => {
+          return [$(tr).find('td').map((_, td) => $(td).text()).get()]
+        })
+        .get()
+
+      expect(cells).toEqual([
+        ['A', '1'],
+        ['B', '2'],
+        ['C', '3']
+      ])
+    })
+
     it('have HTML escaped when passed as text', () => {
       const $ = render('table', {
         rows: [

--- a/src/govuk/components/tabs/template.njk
+++ b/src/govuk/components/tabs/template.njk
@@ -9,20 +9,24 @@
   {% if(params.items) %}
   <ul class="govuk-tabs__list">
     {% for item in params.items %}
-    {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
-      <li class="govuk-tabs__list-item{% if loop.index == 1 %} govuk-tabs__list-item--selected{% endif %}">
-        <a class="govuk-tabs__tab" href="#{{ id }}"
-           {%- for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-          {{ item.label }}
-        </a>
-      </li>
+      {% if item %}
+        {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
+        <li class="govuk-tabs__list-item{% if loop.index == 1 %} govuk-tabs__list-item--selected{% endif %}">
+          <a class="govuk-tabs__tab" href="#{{ id }}"
+            {%- for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+            {{ item.label }}
+          </a>
+        </li>
+      {% endif %}
     {% endfor %}
   </ul>
   {% endif %}
   {% for item in params.items %}
-  {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
-  <section class="govuk-tabs__panel{% if loop.index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ id }}"{% for attribute, value in item.panel.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-    {{ item.panel.html | safe if item.panel.html else item.panel.text }}
-  </section>
+    {% if item %}
+      {% set id = item.id if item.id else idPrefix + "-" + loop.index %}
+      <section class="govuk-tabs__panel{% if loop.index > 1 %} govuk-tabs__panel--hidden{% endif %}" id="{{ id }}"{% for attribute, value in item.panel.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+        {{ item.panel.html | safe if item.panel.html else item.panel.text }}
+      </section>
+    {% endif %}
   {% endfor %}
 </div>

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -81,6 +81,31 @@ describe('Tabs', () => {
         expect($firstPanel.attr('id')).toEqual('tab-1')
       })
 
+      it('render without falsely values', () => {
+        const $ = render('tabs', {
+          items: [
+            {
+              id: 'tab-1',
+              label: 'Tab 1',
+              panel: { text: 'Panel 1 content' }
+            },
+            undefined,
+            null,
+            false,
+            {
+              id: 'tab-2',
+              label: 'Tab 2',
+              panel: { text: 'Panel 2 content' }
+            }
+          ]
+        })
+
+        const $component = $('.govuk-tabs')
+
+        const $items = $component.find('.govuk-tabs__list-item')
+        expect($items.length).toEqual(2)
+      })
+
       it('render a matching tab and panel using custom idPrefix', () => {
         const $ = render('tabs', {
           idPrefix: 'custom',


### PR DESCRIPTION
Just a follow up to https://github.com/alphagov/govuk-frontend/issues/1494

I've had a similar issue on the summary list where peopled ended up adding classes to hide content.

This currently covers:

- Radios items
- Checkbox items
- summary items
- accordion items
- tab items
- Select options
- table rows

Not 100% where else it would be needed to be added, but this at least makes the higher level ones consistent .

Also I wasn't sure how best to describe this in the docs - "An array of sections within the accordion, undefined values are skipped." doesn't seem quite right but opening as WIP for eyes.