### PR TITLE
Simplify accordion README

### DIFF
--- a/src/govuk/components/accordion/README.md
+++ b/src/govuk/components/accordion/README.md
@@ -12,6 +12,4 @@ Find out when to use the details component in your service in the [GOV.UK Design
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-`id` option given to instances of the component must be **unique** across the domain of your service (as the expanded state of individual instances of the component persists across page loads using [`localStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)).
-
 See [options table](https://design-system.service.gov.uk/components/accordion/#options-example-default) for details.


### PR DESCRIPTION
This content is duplicated in the options table, I intend to [create a first timer issue to fix a content issue](https://github.com/alphagov/govuk-frontend/issues/1511) so don't want to confuse a first time contributor by having to update both of these.

This change brings the README in line with the other components which rely on directing the user to the options table.

I've also noticed that the link no longer works, but raised that separately as I think it'll be an issue for all our READMEs: https://github.com/alphagov/govuk-design-system/issues/1008