### PR TITLE
 Fix disabled radios and checkboxes not being greyed out in IE9-11

### DIFF
--- a/src/govuk/components/checkboxes/_checkboxes.scss
+++ b/src/govuk/components/checkboxes/_checkboxes.scss
@@ -69,6 +69,8 @@
 
   .govuk-checkboxes__label {
     display: inline-block;
+    // In order for Internet Explorer 9 - 11 to inherit opacity on pseudo elements the parent needs to be relative to it's direct children.
+    position: relative;
     margin-bottom: 0;
     padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
@@ -82,7 +84,7 @@
     box-sizing: border-box;
     position: absolute;
     top: 0;
-    left: 0;
+    left: -$govuk-checkboxes-size;
     width: $govuk-checkboxes-size;
     height: $govuk-checkboxes-size;
     border: $govuk-border-width-form-element solid currentColor;
@@ -98,7 +100,7 @@
 
     position: absolute;
     top: 11px;
-    left: 9px;
+    left: 9px - $govuk-checkboxes-size;
     width: 18px;
     height: 7px;
 
@@ -178,6 +180,7 @@
 
     $input-offset: ($govuk-touch-target-size - $govuk-small-checkboxes-size) / 2;
     $label-offset: $govuk-touch-target-size - $input-offset;
+    $label-offset-top: -2px;
 
     .govuk-checkboxes__item {
       @include govuk-clearfix;
@@ -212,7 +215,7 @@
     // 'shrink' it, preventing the hover state from kicking in across the full
     // width of the parent element.
     .govuk-checkboxes__label {
-      margin-top: -2px;
+      margin-top: $label-offset-top;
       padding: 13px govuk-spacing(3) 13px 1px;
       float: left;
 
@@ -226,7 +229,8 @@
     // Reduce the size of the check box [1], vertically center it within the
     // touch target [2]
     .govuk-checkboxes__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
+      top: $input-offset - $govuk-border-width-form-element - $label-offset-top; // 2
+      left: -($input-offset + $govuk-small-checkboxes-size);
       width: $govuk-small-checkboxes-size; // 1
       height: $govuk-small-checkboxes-size; // 1
     }
@@ -235,8 +239,8 @@
     //
     // Reduce the size of the check mark and re-align within the checkbox
     .govuk-checkboxes__label::after {
-      top: 15px;
-      left: 6px;
+      top: 17px;
+      left: 6px - ($input-offset + $govuk-small-checkboxes-size);
       width: 9px;
       height: 3.5px;
       border-width: 0 0 3px 3px;

--- a/src/govuk/components/radios/_radios.scss
+++ b/src/govuk/components/radios/_radios.scss
@@ -72,6 +72,8 @@
 
   .govuk-radios__label {
     display: inline-block;
+    // In order for Internet Explorer 9 - 11 to inherit opacity on pseudo elements the parent needs to be relative to it's direct children.
+    position: relative;
     margin-bottom: 0;
     padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
     cursor: pointer;
@@ -85,7 +87,7 @@
     box-sizing: border-box;
     position: absolute;
     top: 0;
-    left: 0;
+    left: -$govuk-radios-size;
 
     width: $govuk-radios-size;
     height: $govuk-radios-size;
@@ -104,7 +106,7 @@
 
     position: absolute;
     top: govuk-spacing(2);
-    left: govuk-spacing(2);
+    left: govuk-spacing(2) - $govuk-radios-size;
 
     width: 0;
     height: 0;
@@ -216,6 +218,7 @@
 
     $input-offset: ($govuk-touch-target-size - $govuk-small-radios-size) / 2;
     $label-offset: $govuk-touch-target-size - $input-offset;
+    $label-offset-top: -2px;
 
     .govuk-radios__item {
       @include govuk-clearfix;
@@ -250,7 +253,7 @@
     // 'shrink' it, preventing the hover state from kicking in across the full
     // width of the parent element.
     .govuk-radios__label {
-      margin-top: -2px;
+      margin-top: $label-offset-top;
       padding: 13px govuk-spacing(3) 13px 1px;
       float: left;
 
@@ -264,7 +267,8 @@
     // Reduce the size of the control [1], vertically centering it within the
     // touch target [2]
     .govuk-radios__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
+      top: $input-offset - $govuk-border-width-form-element - $label-offset-top; // 2
+      left: -($input-offset + $govuk-small-radios-size);
       width: $govuk-small-radios-size; // 1
       height: $govuk-small-radios-size; // 1
     }
@@ -273,8 +277,8 @@
     //
     // Reduce the size of the 'button' and center it within the ring
     .govuk-radios__label::after {
-      top: 15px;
-      left: 7px;
+      top: 17px;
+      left: 7px - ($input-offset + $govuk-small-radios-size);
       border-width: 5px;
     }
 


### PR DESCRIPTION
This feels like a pretty big change to the positioning of these elements so would welcome some thoughts of how this could break things for users...

See https://github.com/alphagov/govuk-frontend/issues/1253#issuecomment-518200978 for more details

Fixes https://github.com/alphagov/govuk-frontend/issues/1253