### PR TITLE
Add isStartButton (which is used in the examples) to the params in bu…

### DIFF
--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -46,7 +46,7 @@ params:
 - name: isStartButton
   type: boolean
   required: false
-  description: If set to true this button will have an arrow icon added to it. Use for the main call to action on your service's start page.
+  description: Use for the main call to action on your service's start page.
 
 examples:
 - name: default

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -43,6 +43,10 @@ params:
   type: boolean
   required: false
   description: Prevent accidental double clicks on submit buttons from submitting forms multiple times
+- name: isStartButton
+  type: boolean
+  required: false
+  description: If set to true this button will have an arrow icon added to it. Use for the main call to action on your service's start page.
 
 examples:
 - name: default


### PR DESCRIPTION
…tton.yaml

isStartButton is used in button.yaml in the data for the examples (and then used in the template file) but it is never defined in the params. This PR adds it to the params.