### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,9 @@
+<!--
+Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.
+
+During this time, we will not be able to review your issue. Sorry about that.  
+
+You’re welcome to raise it anyway, and we will get back to you as quickly as we can. 
+
+Thank you!
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+<!--
+Just to let you know, the GOV.UK Design System team are assisting with urgent Brexit-related work being undertaken by GDS between 13 and 26 August.
+
+During this time, we will not be able to review your pull request. Sorry about that.  
+
+You’re welcome to open it anyway, and we will get back to you as quickly as we can. 
+
+Thank you!
+-->


### PR DESCRIPTION
Between 13-26 August, the GOV.UK Design System team is assisting with urgent and critical Brexit-related work being undertaken by GDS and will not be able to respond to support requests.

We're adding issue and pull request templates to let users know what's going on, and to set expectations around how quickly we'll be able to respond.