### PR TITLE
Simplify button types to avoid unnecessary type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ govukInput({
 ### Fixes
 
 - [Pull request #1512: Update components to only output items when they are defined](https://github.com/alphagov/govuk-frontend/pull/1512).
+- [Pull request #1538: Simplify button types to avoid unnecessary type attribute](https://github.com/alphagov/govuk-frontend/pull/1538).
 
 ## 3.0.0 (Breaking release)
 

--- a/src/govuk/components/button/template.njk
+++ b/src/govuk/components/button/template.njk
@@ -37,7 +37,7 @@ treat it as an interactive element - without this it will be
 
 {#- Define common attributes we can use for both button and input types #}
 
-{%- set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %} type="{{ params.type if params.type else 'submit' }}"{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% if params.preventDoubleClick %} data-prevent-double-click="true"{% endif %}{% endset %}
+{%- set buttonAttributes %}{% if params.name %} name="{{ params.name }}"{% endif %}{% if params.disabled %} disabled="disabled" aria-disabled="true"{% endif %}{% if params.preventDoubleClick %} data-prevent-double-click="true"{% endif %}{% endset %}
 
 {#- Actually create a button... or a link! #}
 
@@ -49,12 +49,12 @@ treat it as an interactive element - without this it will be
 </a>
 
 {%- elseif element == 'button' %}
-<button {%- if params.value %} value="{{ params.value }}"{% endif %} {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
+<button {%- if params.value %} value="{{ params.value }}"{% endif %}{%- if params.type %} type="{{ params.type }}"{% endif %} {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
   {{ params.html | safe if params.html else params.text }}
 {# Indentation is intentional to output HTML nicely #}
 {{- iconHtml | safe | trim | indent(2, true) if iconHtml -}}
 </button>
 
 {%- elseif element == 'input' %}
-<input value="{{ params.text }}" {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
+<input value="{{ params.text }}" type="{{ params.type if params.type else 'submit' }}" {{- buttonAttributes | safe }} {{- commonAttributes | safe }}>
 {%- endif %}

--- a/src/govuk/components/button/template.test.js
+++ b/src/govuk/components/button/template.test.js
@@ -256,7 +256,6 @@ describe('Button', () => {
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('button')
-      expect($component.attr('type')).toEqual('submit')
     })
   })
 


### PR DESCRIPTION
The button element as an implicit type of submit if it it's not set, since this is what most people need this change reduces a bit of markup for people to copy and paste.

## Markup before

```html
<button type="submit" class="govuk-button" data-module="govuk-button">
  Save and continue
</button>
```

## Markup After

```html
<button class="govuk-button" data-module="govuk-button">
  Save and continue
</button>
```