### PR TITLE
Add missing govuk-body classes to tabs example

### DIFF
--- a/app/views/full-page-examples/start-page/index.njk
+++ b/app/views/full-page-examples/start-page/index.njk
@@ -54,19 +54,19 @@ notes: The buttons and links on this page are not functional.
       }) }}
 
       {% set moreInformationHTML %}
-        <p>You’ll need a debit or credit card to use this service.</p>
+        <p class="govuk-body">You’ll need a debit or credit card to use this service.</p>
 
-        <p><a class="govuk-link" href="#">It’s £9.50 cheaper</a> to apply for a passport online than by post.</p>
+        <p class="govuk-body"><a class="govuk-link" href="#">It’s £9.50 cheaper</a> to apply for a passport online than by post.</p>
 
-        <p>It should take around 6 weeks to get your first UK adult passport, but it can take longer.</p>
+        <p class="govuk-body">It should take around 6 weeks to get your first UK adult passport, but it can take longer.</p>
 
-        <p>All other application types (for example, renewing a passport or getting a child passport) should take 3 weeks. It can take longer if more information is needed or your application hasn’t been filled out correctly.</p>
+        <p class="govuk-body">All other application types (for example, renewing a passport or getting a child passport) should take 3 weeks. It can take longer if more information is needed or your application hasn’t been filled out correctly.</p>
 
-        <p>You should use a different service if you <a class="govuk-link" href="#">need your passport urgently</a>.</p>
+        <p class="govuk-body">You should use a different service if you <a class="govuk-link" href="#">need your passport urgently</a>.</p>
       {% endset %}
 
       {% set otherWaysToApplyHTML %}
-        <p>You can pick up passport application forms from your <a class="govuk-link" rel="external" href="http://www.postoffice.co.uk/branch-finder">local Post Office</a> and apply by post, or use the <a class="govuk-link" href="#">Post Office Check and Send service</a>.</p>
+        <p class="govuk-body">You can pick up passport application forms from your <a class="govuk-link" rel="external" href="http://www.postoffice.co.uk/branch-finder">local Post Office</a> and apply by post, or use the <a class="govuk-link" href="#">Post Office Check and Send service</a>.</p>
       {% endset %}
 
       {{ govukTabs({


### PR DESCRIPTION
In #1496 we removed a font declaration that was affecting everything within the tabs.

This means we now need to use the correct classes (govuk-body) on paragraphs within the tabs. This also means that we’ll be using the correct spacing and font size.

Fixes #1524