### PR TITLE
Allow date input fieldset attributes to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 ## Unreleased
 
-###  Inputmode
+### New features
+
+#### Add attributes to the date input fieldset
+
+You can now pass attributes to add to the fieldset on the date input component.
+
+[Pull request #1541: Allow date input fieldset attributes to be set](https://github.com/alphagov/govuk-frontend/pull/1541). Thanks to [andrew-mcgregor](https://github.com/andrew-mcgregor) for raising this.
+
+#### Add ARIA role to the fieldset component
+
+You can now pass an ARIA role to the fieldset component.
+
+[Pull request #1541: Allow date input fieldset attributes to be set](https://github.com/alphagov/govuk-frontend/pull/1541).
+
+#### Inputmode
 
 Adds the ability to pass an optional [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode) into the input component
 

--- a/src/govuk/components/date-input/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/date-input/__snapshots__/template.test.js.snap
@@ -23,8 +23,8 @@ exports[`Date input nested dependant components passes through label params with
 exports[`Date input passes through fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset"
-          aria-describedby="dob-hint"
           role="group"
+          aria-describedby="dob-hint"
 >
   <legend class="govuk-fieldset__legend">
     What is your date of birth?
@@ -36,8 +36,8 @@ exports[`Date input passes through fieldset params without breaking 1`] = `
 exports[`Date input passes through html fieldset params without breaking 1`] = `
 
 <fieldset class="govuk-fieldset"
-          aria-describedby="dob-error"
           role="group"
+          aria-describedby="dob-error"
 >
   <legend class="govuk-fieldset__legend">
     What is your

--- a/src/govuk/components/date-input/template.njk
+++ b/src/govuk/components/date-input/template.njk
@@ -84,9 +84,8 @@
   {% call govukFieldset({
     describedBy: describedBy,
     classes: params.fieldset.classes,
-    attributes: {
-      role: "group"
-    },
+    role: 'group',
+    attributes: params.fieldset.attributes,
     legend: params.fieldset.legend
   }) %}
   {{ innerHtml | trim | safe }}

--- a/src/govuk/components/fieldset/fieldset.yaml
+++ b/src/govuk/components/fieldset/fieldset.yaml
@@ -28,6 +28,10 @@ params:
   type: string
   required: false
   description: Classes to add to the fieldset container.
+- name: role
+  type: string
+  required: false
+  description: Optional ARIA role attribute.
 - name: attributes
   type: object
   required: false

--- a/src/govuk/components/fieldset/template.njk
+++ b/src/govuk/components/fieldset/template.njk
@@ -1,5 +1,6 @@
 <fieldset class="govuk-fieldset
   {%- if params.classes %} {{ params.classes }}{% endif %}"
+  {%- if params.role %} role="{{ params.role }}"{% endif %}
   {%- if params.describedBy %} aria-describedby="{{ params.describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% if params.legend.html or params.legend.text %}

--- a/src/govuk/components/fieldset/template.test.js
+++ b/src/govuk/components/fieldset/template.test.js
@@ -131,6 +131,15 @@ describe('fieldset', () => {
     expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
   })
 
+  it('can have an explicit role', () => {
+    const $ = render('fieldset', {
+      role: 'group'
+    })
+
+    const $component = $('.govuk-fieldset')
+    expect($component.attr('role')).toEqual('group')
+  })
+
   it('can have additional attributes', () => {
     const $ = render('fieldset', {
       attributes: {


### PR DESCRIPTION
- Promote the `role` attribute to a ‘first-class’ option of the fieldset component, as we currently pass it in within ‘attributes’ from the date input component.
- Update the date input component to pass `role` directly rather than as part of `attributes`, meaning that `params.fieldset.attributes` can be set, which is consistent with other components.

Fixes #1478 