### PR TITLE
Only default two thirds/one-third layout when footer has two sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ govukInput({
 - [Pull request #1523: Improve accessibility of details component by polyfilling only where the native element is not available](https://github.com/alphagov/govuk-frontend/pull/1523).
 - [Pull request #1512: Update components to only output items when they are defined](https://github.com/alphagov/govuk-frontend/pull/1512).
 - [Pull request #1538: Simplify button types to avoid unnecessary type attribute](https://github.com/alphagov/govuk-frontend/pull/1538).
+- [Pull request #1542: Only default two thirds/one-third layout when footer has two sections](https://github.com/alphagov/govuk-frontend/pull/1542).
 
 ## 3.0.0 (Breaking release)
 

--- a/src/govuk/components/footer/_footer.scss
+++ b/src/govuk/components/footer/_footer.scss
@@ -196,9 +196,11 @@
     }
   }
 
-  // Sections two-third:one-third on desktop
+  // If there are only two sections, set the layout to be two-third:one-third on desktop
   @include mq ($from: desktop) {
-    .govuk-footer__section:first-child {
+    // We match the first section with `:first-child`.
+    // To ensure the section is one of two, we can count backwards using `:nth-last-child(2)`.
+    .govuk-footer__section:first-child:nth-last-child(2) {
       flex-grow: 2; // Support: Flexbox
     }
   }

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -251,3 +251,53 @@ examples:
         - href: '/cymraeg'
           text: Rhestr o Wasanaethau Cymraeg
       html: Built by the <a class="govuk-footer__link" href="#">Government Digital Service</a>
+
+- name: Three equal columns
+  description: A full example to demonstrate three equal width columns
+  data:
+    navigation:
+      - title: Single column list 1
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+      - title: Single column list 2
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6
+      - title: Single column list 3
+        columns: 1
+        items:
+          - href: '#1'
+            text: Navigation item 1
+          - href: '#2'
+            text: Navigation item 2
+          - href: '#3'
+            text: Navigation item 3
+          - href: '#4'
+            text: Navigation item 4
+          - href: '#5'
+            text: Navigation item 5
+          - href: '#6'
+            text: Navigation item 6


### PR DESCRIPTION
This approach is from: http://lea.verou.me/2011/01/styling-children-based-on-their-number-with-css3/

Changes the default layout of two-thirds/one-third only when there's two sections.

The first section can only be also the the 2nd last section (counted backwards) if there's two overall sections.

## Screenshots

### Before
![Before equal columns](https://user-images.githubusercontent.com/2445413/63874898-4e85c380-c9ba-11e9-9091-0ed0027cabac.png)

### After
![After equal columns](https://user-images.githubusercontent.com/2445413/63874877-40d03e00-c9ba-11e9-896e-cd6bacf464b4.png)

Improves https://github.com/alphagov/govuk-frontend/issues/1539