### PR TITLE
Fix fieldset legend text clipping when using a custom or fallback font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #1548: Fix fieldset legend text clipping when using a custom or fallback font](https://github.com/alphagov/govuk-frontend/pull/1548).
+
 ## 3.1.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/fieldset/_fieldset.scss
+++ b/src/govuk/components/fieldset/_fieldset.scss
@@ -32,8 +32,6 @@
     max-width: 100%;        // 1
     margin-bottom: govuk-spacing(2);
     padding: 0;
-    // Hack to let legends or elements within legends have margins in webkit browsers
-    overflow: hidden;
 
     white-space: normal;    // 1
   }


### PR DESCRIPTION
This hack was only required when we had hint text in the legends, which we no longer recommend.

I found this one hard to test since I could not reproduce the original issue, this was my approach:

I have tested the [Labels, legends and headings](https://govuk-frontend-review.herokuapp.com/examples/labels-legends-and-headings?hide-banner=true) example page  cross browser, and it seems to be good:

https://www.browserstack.com/screenshots/a1c3019648921af4ae59eb1a0a100a1570104b82

I've also checked the `document.body.clientHeight` before and after in Safari (webkit) and they're the same, which suggests no layout has changed.

Fixes https://github.com/alphagov/govuk-frontend/issues/1239