### PR TITLE
Change case of 'Tag' component

### DIFF
--- a/src/govuk/components/phase-banner/template.njk
+++ b/src/govuk/components/phase-banner/template.njk
@@ -6,7 +6,7 @@
     {{ govukTag({
       text: params.tag.text,
       html: params.tag.html,
-      classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
+      classes: "govuk-phase-banner__content__tag govuk-tag--uppercase" + (" " + params.tag.classes if params.tag.classes)
     }) | indent(4) | trim }}
     <span class="govuk-phase-banner__text">
       {{ params.html | safe if params.html else params.text }}

--- a/src/govuk/components/tag/_tag.scss
+++ b/src/govuk/components/tag/_tag.scss
@@ -38,6 +38,20 @@
     }
   }
 
+  .govuk-tag--uppercase {
+    letter-spacing: 1px;
+    text-transform: uppercase;
+  }
+
+  .govuk-tag--lowercase {
+    letter-spacing: normal;
+    text-transform: lowercase;
+
+    &:first-letter {
+      text-transform: capitalize;
+    }
+  }
+
   .govuk-tag--inactive {
     background-color: govuk-colour("dark-grey", $legacy: "grey-1");
   }

--- a/src/govuk/components/tag/_tag.scss
+++ b/src/govuk/components/tag/_tag.scss
@@ -15,9 +15,13 @@
 
     color: govuk-colour("white");
     background-color: govuk-colour("blue");
+    // Deprecation warning: This will be removed in v4. 
+    // Use the .govuk-tag--uppercase modifier to make tag uppercase / spaced out if required.
     letter-spacing: 1px;
 
     text-decoration: none;
+    // Deprecation warning: This will be removed in v4. 
+    // Use the .govuk-tag--uppercase modifier to make tag uppercase / spaced out if required.
     text-transform: uppercase;
 
     @if $govuk-use-legacy-font {
@@ -48,6 +52,7 @@
     text-transform: lowercase;
 
     &:first-letter {
+      // Force first letter to be a capital after transformation.
       text-transform: capitalize;
     }
   }

--- a/src/govuk/components/tag/tag.yaml
+++ b/src/govuk/components/tag/tag.yaml
@@ -20,7 +20,19 @@ examples:
  - name: default
    data:
     text: alpha
+ - name: uppercase
+   data:
+    text: alpha
+    classes: govuk-tag--uppercase
+ - name: lowercase
+   data:
+    text: completed
+    classes: govuk-tag--lowercase
+ - name: lowercase multi-word
+   data:
+    text: not started yet
+    classes: govuk-tag--lowercase
  - name: inactive
    data:
     text: alpha
-    classes: govuk-tag--inactive
+    classes: govuk-tag--inactive    


### PR DESCRIPTION
This PR:
- Creates modifiers for `.govuk-tag--uppercase` and `.govuk-tag--lowercase` (which also removes the letter-spacing)
- Adds `.govuk-tag--uppercase` modifier to Phase banner component

I think we need to remove the `text-decoration` / `letter-spacing` declaration from the component all together, however to avoid waiting for a breaking change I have put in deprecation warnings into the component SCSS and used the modifier in the phase banner even though it's not currently needed.

<img width="455" alt="Screen Shot 2019-09-03 at 14 27 07" src="https://user-images.githubusercontent.com/23356842/64177906-5204c900-ce58-11e9-9448-d872baf16ab6.png">

<img width="465" alt="Screen Shot 2019-09-03 at 14 27 12" src="https://user-images.githubusercontent.com/23356842/64177907-5204c900-ce58-11e9-90e8-565adcfc0862.png">

The lowercase modifier, because it will be used to override lowercase on something that is already uppercase uses `:first-letter { text-transform: capitalize; }`. This wouldn't be needed if we did the breaking change straight away as we wouldn't need a lowercase modifier.

Let me know what you think is the best approach for this is?

