### PR TITLE
Document missing summary list row.classes option

### DIFF
--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -4,6 +4,10 @@ params:
   required: true
   description: Array of row item objects.
   params:
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the row `div`
   - name: key.text
     type: string
     required: true


### PR DESCRIPTION
Fixes #1555 