### PR TITLE
Stop IE8 from downloading GDS Transport font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - [Pull request #1548: Fix fieldset legend text clipping when using a custom or fallback font](https://github.com/alphagov/govuk-frontend/pull/1548).
+- [Pull request #1559: Stop IE8 from downloading GDS Transport font](https://github.com/alphagov/govuk-frontend/pull/1559).
 
 ## 3.1.0 (Feature release)
 

--- a/src/govuk/helpers/_font-faces.scss
+++ b/src/govuk/helpers/_font-faces.scss
@@ -15,26 +15,28 @@
 /// @access private
 
 @mixin _govuk-font-face-gds-transport {
-  @include govuk-exports("govuk/helpers/font-faces") {
-    @at-root {
-      /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
+  @include govuk-not-ie8 { // In IE8, which cannot render WOFF format, we fall back to system fonts
+    @include govuk-exports("govuk/helpers/font-faces") {
+      @at-root {
+        /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */
 
-      @font-face {
-        font-family: "GDS Transport";
-        src: govuk-font-url("light-94a07e06a1-v2.woff2") format("woff2"),
-             govuk-font-url("light-f591b13f7d-v2.woff") format("woff");
-        font-weight: normal;
-        font-style: normal;
-        font-display: fallback;
-      }
+        @font-face {
+          font-family: "GDS Transport";
+          src: govuk-font-url("light-94a07e06a1-v2.woff2") format("woff2"),
+               govuk-font-url("light-f591b13f7d-v2.woff") format("woff");
+          font-weight: normal;
+          font-style: normal;
+          font-display: fallback;
+        }
 
-      @font-face {
-        font-family: "GDS Transport";
-        src: govuk-font-url("bold-b542beb274-v2.woff2") format("woff2"),
-             govuk-font-url("bold-affa96571d-v2.woff") format("woff");
-        font-weight: bold;
-        font-style: normal;
-        font-display: fallback;
+        @font-face {
+          font-family: "GDS Transport";
+          src: govuk-font-url("bold-b542beb274-v2.woff2") format("woff2"),
+               govuk-font-url("bold-affa96571d-v2.woff") format("woff");
+          font-weight: bold;
+          font-style: normal;
+          font-display: fallback;
+        }
       }
     }
   }

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -131,6 +131,28 @@ describe('@mixin govuk-typography-common', () => {
     expect(resultsString).toContain(`font-family: "GDS Transport"`)
     expect(resultsString).toContain(`font-family: "GDS Transport"`)
   })
+  it('should not output a @font-face declaration when the browser is IE8', async () => {
+    const sass = `
+    $govuk-is-ie8: true;
+
+    @import "settings/all";
+    @import "helpers/all";
+    @import "tools/ie8";
+
+    :root {
+      @include govuk-typography-common;
+    }
+    :root {
+      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+    }
+    `
+
+    const results = await renderSass({ data: sass, ...sassConfig })
+    const resultsString = results.css.toString()
+
+    expect(resultsString).not.toContain(`@font-face`)
+    expect(resultsString).toContain(`font-family: "GDS Transport"`)
+  })
 })
 
 describe('@function _govuk-line-height', () => {

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -50,6 +50,7 @@ describe('@mixin govuk-typography-common', () => {
     const sass = `
     @import "settings/all";
     @import "helpers/all";
+    @import "tools/ie8";
 
     :root {
       @include govuk-typography-common;


### PR DESCRIPTION
Internet Explorer 8 was making [unsuccessful requests](https://github.com/alphagov/govuk-frontend/issues/1550) for the new font files because 3.0.0 no longer [postfixes them with `?#iefix`](https://stackoverflow.com/questions/8050640/how-does-iefix-solve-web-fonts-loading-in-ie6-ie8/) as we did in [v2](https://github.com/alphagov/govuk-frontend/blame/88f28d949daedcf11d2cac2f2ff323d7c23a51c9/src/helpers/_font-faces.scss#L25).

3.0.0 [dropped support for rendering GDS Transport for IE8](https://github.com/alphagov/govuk-frontend/pull/1434). This PR removes the `font-face` declarations from the IE8 stylesheet to stop IE8 trying to unsuccessfully to download the font files. This means that IE8 will fall back to system fonts (`Arial` by default). Our previous approach of postfixing the paths with `?#iefix` wouldn't work here as IE8 would still download the redundant WOFF files.

The downside of this new approach is that `GDS Transport` is still shown in `font-family` in the IE8 stylesheet.

I've also tried an [alternative approach](https://github.com/alphagov/govuk-frontend/compare/fix-ie8-fonts-alt-approach?expand=1) that sets `font-family` for IE8 on a higher level and removes the above issue, but has other downsides.

This also imports the IE8 tools for `govuk-typography-common` tests, and tests that `font-face` is not declared for IE8.

Fixes https://github.com/alphagov/govuk-frontend/issues/1550