### PR TITLE
Ensure legacy styles do not override button active state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@
 
 #### Add formGroup parameter to character count component
 
-- [Pull request #1553: Include formGroup on character count and pass through to textarea to allow class to be added to character count form group](https://github.com/alphagov/govuk-frontend/pull/1553)
+- [Pull request #1553: Include formGroup on character count and pass through to textarea to allow class to be added to character count form group](https://github.com/alphagov/govuk-frontend/pull/1553).
 
 ### Fixes
 
 - [Pull request #1548: Fix fieldset legend text clipping when using a custom or fallback font](https://github.com/alphagov/govuk-frontend/pull/1548).
 - [Pull request #1559: Stop IE8 from downloading GDS Transport font](https://github.com/alphagov/govuk-frontend/pull/1559).
+- [Pull request #1564: Ensure legacy styles do not override button active state](https://github.com/alphagov/govuk-frontend/pull/1564).
 
 ## 3.1.0 (Feature release)
 

--- a/src/govuk/components/button/_button.scss
+++ b/src/govuk/components/button/_button.scss
@@ -98,6 +98,17 @@
       box-shadow: inset 0 0 0 1px $govuk-focus-colour;
     }
 
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors so
+    // so that unvisited links styled as buttons do not end up with dark blue
+    // text when focussed.
+    @include govuk-compatibility(govuk_template) {
+      &:link:focus {
+        color: $govuk-button-text-colour;
+      }
+    }
+
     &:focus:not(:active):not(:hover) {
       border-color: $govuk-focus-colour;
       color: $govuk-focus-text-colour;


### PR DESCRIPTION
**This bug only impacts users that are using the legacy project GOV.UK Template alongside GOV.UK Frontend.**

Add additional selector only when GOV.UK Template is loaded to ensure it does not override GOV.UK Frontend's active state.

This was missed because the links are all visited which gives the selectors a higher specificity.

To reproduce this you will need to change the link href in the example yaml file so that is not a visited link.

## All link styles tested

- Button start link (fixed)
- Tabs unenhanced mode (good)
- Back link (good)
- Breadcrumbs (good)
- Error summary links (good)
- Footer links (good)
- Header links (good)
- Skip-link (good)


Fixes https://github.com/alphagov/govuk-frontend/issues/1562