### PR TITLE
Make form elements scale correctly when text resized by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
+
 ## 3.2.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/input/_input.scss
+++ b/src/govuk/components/input/_input.scss
@@ -13,6 +13,9 @@
     box-sizing: border-box;
     width: 100%;
     height: 40px;
+    @if $govuk-typography-use-rem {
+      height: govuk-px-to-rem(40px);
+    }
     margin-top: 0;
 
     padding: govuk-spacing(1);

--- a/src/govuk/components/select/_select.scss
+++ b/src/govuk/components/select/_select.scss
@@ -13,6 +13,9 @@
     box-sizing: border-box; // should this be global?
     max-width: 100%;
     height: 40px;
+    @if $govuk-typography-use-rem {
+      height: govuk-px-to-rem(40px);
+    }
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
 


### PR DESCRIPTION
## Requirement

WCAG 2.1 requires that user can resize text to at least 200%.

## Fix
The current versions of `<select>` and `<input>` do not scale well when text is resized by user as they're constrained by `height` set in pixels. Changing the height to use `rem` relative units makes them scalable.

Thanks @nickcolley and @andysellick for the suggestion to use relative units.

## Chrome 76, with text resized to 200%

### Before
![chrome-before](https://user-images.githubusercontent.com/5007934/64866532-82581e80-d633-11e9-984e-55ffbec1680a.png)
![chrome-before-2](https://user-images.githubusercontent.com/5007934/64869349-21334980-d639-11e9-9d11-17d399d28ce2.png)

### After
<img width="519" alt="Screen Shot 2019-09-13 at 14 48 10" src="https://user-images.githubusercontent.com/5007934/64869567-7ff8c300-d639-11e9-8270-9d3a563c6223.png">
<img width="437" alt="Screen Shot 2019-09-13 at 14 48 20" src="https://user-images.githubusercontent.com/5007934/64869575-838c4a00-d639-11e9-8402-76b6135067ed.png">

## Firefox 69, with text resized to 200%:

### Before
![ff-before](https://user-images.githubusercontent.com/5007934/64869379-33ad8300-d639-11e9-9b6e-5ca629c31cee.png)
![firefox-before-2](https://user-images.githubusercontent.com/5007934/64869388-38723700-d639-11e9-9334-be4753af9982.png)


### After
<img width="376" alt="Screen Shot 2019-09-13 at 15 20 04" src="https://user-images.githubusercontent.com/5007934/64869973-5ab88480-d63a-11e9-9dea-ad16dd350c9d.png">
<img width="401" alt="Screen Shot 2019-09-13 at 15 23 20" src="https://user-images.githubusercontent.com/5007934/64870039-758af900-d63a-11e9-8f5b-5935e6203c45.png">

## Safari 12.1, with text resized to 200%:

### Before
![safari-before](https://user-images.githubusercontent.com/5007934/64869400-3f00ae80-d639-11e9-8ecf-7bd614335459.png)
![safari-before-2](https://user-images.githubusercontent.com/5007934/64869421-49bb4380-d639-11e9-9286-e3ea4a9c8c11.png)

### After
<img width="427" alt="Screen Shot 2019-09-13 at 15 20 47" src="https://user-images.githubusercontent.com/5007934/64870093-8d627d00-d63a-11e9-8e4a-65a8d44297d5.png">
<img width="437" alt="Screen Shot 2019-09-13 at 15 20 41" src="https://user-images.githubusercontent.com/5007934/64870095-8d627d00-d63a-11e9-85a8-7f53f52945a8.png">


## IE11, with text resized to Largest:

### Before
![edge-before](https://user-images.githubusercontent.com/5007934/64869477-5cce1380-d639-11e9-8832-71f793d0b645.png)
![ie11-before-2](https://user-images.githubusercontent.com/5007934/64869485-60fa3100-d639-11e9-9b56-7adfc7db8dd1.png)


### After
<img width="265" alt="Screen Shot 2019-09-13 at 15 21 52" src="https://user-images.githubusercontent.com/5007934/64870120-9b180280-d63a-11e9-83b4-d4fab543d861.png">
<img width="261" alt="Screen Shot 2019-09-13 at 15 22 06" src="https://user-images.githubusercontent.com/5007934/64870119-9a7f6c00-d63a-11e9-816a-12c8be0a574e.png">

Fixes https://github.com/alphagov/govuk-frontend/issues/1519

<details>
<summary>
How text was resized in browsers
</summary>
### Chrome 
Settings > Appearance > Customise fonts

## Firefox
Set View > Zoom > Zoom text only. Press +/-
or Preferences > Language and appearance > Font size

## Safari
To increase the font size, press Option-Command-Plus sign (+)
To decrease the font size, press Option-Command-Minus sign (-)

## Edge 
Can't resize text apart from "Reading view" which removes form elements from the view.

## IE 8-11
Page > Text size > Largest

## iOS 
**Text can't resized in browser. See https://github.com/alphagov/govuk-frontend/issues/882**

## Android Chrome/Firefox
Settings > Accessibility > Text scaling
</details>

