### PR TITLE
Allow language to be set on <title> and <main> of page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### New features
+
+#### Allow `lang` to be set on `<title>` and `<main>` of template
+
+You can now set the [lang attribute](https://www.w3.org/International/questions/qa-html-language-declarations) in the title and main of page template.
+
+This will help with scenarios where some of the elements, such as navigation and footer, are in English whereas the title and page content are in a different language.
+
+- [Pull request #1576: Allow `lang` to be set on title and main of template](https://github.com/alphagov/govuk-frontend/pull/1576).
+
 ### Fixes
 - [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
 

--- a/src/govuk/template.njk
+++ b/src/govuk/template.njk
@@ -7,7 +7,7 @@
 <html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
   <head>
     <meta charset="utf-8" />
-    <title>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
+    <title{% if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}" /> {# Hardcoded value of $govuk-black #}
     {# Ensure that older IE versions always render with the correct rendering engine #}
@@ -45,7 +45,7 @@
     {% block main %}
       <div class="govuk-width-container">
         {% block beforeContent %}{% endblock %}
-        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
+        <main class="govuk-main-wrapper {{ mainClasses }}" id="main-content" role="main"{% if mainLang %} lang="{{ mainLang }}"{% endif %}>
           {% block content %}{% endblock %}
         </main>
       </div>


### PR DESCRIPTION
This allows for cases when some of the page elements, such as navigation and footer, are in eg. English whereas the title and page content are in a different language.

From [W3C](https://www.w3.org/International/questions/qa-html-language-declarations):  
> Always use a language attribute on the html tag to declare the default language of the text in the page. When the page contains content in another language, add a language attribute to an element surrounding that content.

Also discussed [here](https://github.com/alphagov/govuk_template/issues/342).

Fixes https://github.com/alphagov/govuk-frontend/issues/1292

See also [proposed guidance](https://github.com/alphagov/govuk-design-system/pull/1046).