### PR TITLE
Change position and spacing relationship of warning text icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This will help with scenarios where some of the elements, such as navigation and
 
 - [Pull request #1576: Allow `lang` to be set on title and main of template](https://github.com/alphagov/govuk-frontend/pull/1576).
 
+#### Visual updates to the warning text component
+
+Align ‘Warning text’ icon with first line of the content fixing [#1352](https://github.com/alphagov/govuk-frontend/issues/1352) Some changes were made to the size and spacing of the icon to help with positioning.
+
+- [Pull request #1578: Change position and spacing relationship of warning text icon](https://github.com/alphagov/govuk-frontend/pull/1578)
+
 ### Fixes
 - [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
 - [Pull request #1584: Fix text resize issue with warning text icon](https://github.com/alphagov/govuk-frontend/pull/1584)

--- a/src/govuk/components/warning-text/_warning-text.scss
+++ b/src/govuk/components/warning-text/_warning-text.scss
@@ -23,13 +23,15 @@
     display: inline-block;
 
     position: absolute;
-    top: 50%;
     left: 0;
 
-    min-width: 32px;
+    min-width: 29px;
     min-height: 29px;
-    margin-top: -20px; // Half the height of the circle (adjusted for NTA)
-    padding-top: 3px;
+    margin-top: -7px;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: -5px;
+    }
 
     // When a user customises their colours the background colour will often be removed.
     // Adding a border to the component keeps it's shape as a circle.
@@ -51,6 +53,6 @@
 
   .govuk-warning-text__text {
     display: block;
-    padding-left: 50px;
+    padding-left: 45px;
   }
 }

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -25,3 +25,7 @@ examples:
     data:
       text: You can be fined up to £5,000 if you don’t register.
       iconFallbackText: Warning
+  - name: multiple lines
+    data:
+      text: "If you are not covered by this License), You must: (a) comply with the terms stated above for the purpose of this license. It explains, for example, the production of a Source form, including but not limited to, the implied warranties or conditions of this License, without any additional file created by such Respondent to you under Sections 2.1 and 2.2 above. Larger Works. You may choose to distribute such a notice and a brief idea of what it does."
+      iconFallbackText: Warning


### PR DESCRIPTION
This PR addresses - https://github.com/alphagov/govuk-frontend/issues/1352

The primary purpose of the this PR was to align the icon with the top line, so that when the content wraps the icon doesn't vertically align with the entire block and potentially end up out of sight when the user starts reading the warning text.

To do this I had to also reduce the size of the icon slightly, and reduce the gap between the icon and the text accordingly.

It may seem a random size (29px) but this is helped it align with the first line, 30px created an unequal distribution of space.

### Before: Single line
<img width="588" alt="Screen Shot 2019-09-19 at 09 32 44" src="https://user-images.githubusercontent.com/23356842/65227770-207b3700-dac1-11e9-85c8-8abe2b815705.png">
 
### Before: Wrapping
<img width="655" alt="Screen Shot 2019-09-19 at 09 33 10" src="https://user-images.githubusercontent.com/23356842/65227812-37ba2480-dac1-11e9-8e69-51ed47e3cfc9.png">

### After: Single line
<img width="524" alt="Screen Shot 2019-09-19 at 09 28 02" src="https://user-images.githubusercontent.com/23356842/65228001-997a8e80-dac1-11e9-895e-3beeeb551d92.png">

### After: Wrapping
<img width="650" alt="Screen Shot 2019-09-19 at 09 28 53" src="https://user-images.githubusercontent.com/23356842/65227929-7223c180-dac1-11e9-9011-647604d0d20b.png">

I also removed some of the (I think) New Transport adjustments.
