### PR TITLE
Fix text resize issue with warning text icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This will help with scenarios where some of the elements, such as navigation and
 
 ### Fixes
 - [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
+- [Pull request #1584: Fix text resize issue with warning text icon](https://github.com/alphagov/govuk-frontend/pull/1584)
 - [Pull request ##1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
 
 ## 3.2.0 (Feature release)

--- a/src/govuk/components/warning-text/_warning-text.scss
+++ b/src/govuk/components/warning-text/_warning-text.scss
@@ -39,7 +39,7 @@
     color: govuk-colour("white");
     background: govuk-colour("black");
 
-    font-size: 1.6em;
+    font-size: 30px;
     line-height: 29px;
 
     text-align: center;


### PR DESCRIPTION
The font size of the exclamation mark within the warning text component is currently specified as 1.6 em, within a 19px context which means that the calculated font-size is 30.4px.

Because the height and width of the circle the exclamation mark sits within are specified in px, the exclamation mark increases in size when the page is zoomed text-only, whilst the circle does not. This results in the mark overflowing outside of the circle.

Specifying the font-size in px solves this problem. Whilst the icon is used to add emphasis, the text is also inset and bold, so we can treat it as presentational.

In Safari, the exclamation mark actually ends up slightly larger, but is still contained entirely within the circle.


|  Browser | Before  | After |
|---|---|---|
| Chrome  | ![Chrome Before](https://user-images.githubusercontent.com/121939/65337960-19d3e900-dbc1-11e9-8a47-d844c9948453.png)  | ![Chrome After](https://user-images.githubusercontent.com/121939/65337959-193b5280-dbc1-11e9-946e-350243db30ca.png)  |
| Firefox |  ![FF Before](https://user-images.githubusercontent.com/121939/65338031-425be300-dbc1-11e9-96d2-103b621a4cf6.png) | ![FF After](https://user-images.githubusercontent.com/121939/65338030-425be300-dbc1-11e9-8772-3bd2a8ec43bb.png) | 
| Safari | ![Safari Before](https://user-images.githubusercontent.com/121939/65338069-59023a00-dbc1-11e9-917b-bdc772bf329f.png) | ![Safari After](https://user-images.githubusercontent.com/121939/65338070-59023a00-dbc1-11e9-8950-ce4d39747a35.png) |
| IE | <img width="561" alt="IE Before" src="https://user-images.githubusercontent.com/121939/65338097-65869280-dbc1-11e9-969e-b54a176107ba.png"> | <img width="558" alt="IE After" src="https://user-images.githubusercontent.com/121939/65338095-65869280-dbc1-11e9-9f38-3c7ce270d667.png"> |

Fixes #1569