### PR TITLE
Explicitly set font weight on warning-text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ This will help with scenarios where some of the elements, such as navigation and
 ### Fixes
 - [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
 - [Pull request #1584: Fix text resize issue with warning text icon](https://github.com/alphagov/govuk-frontend/pull/1584)
-- [Pull request ##1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
+- [Pull request #1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
+- [Pull request #1585: Explicitly set font weight on warning-text component](https://github.com/alphagov/govuk-frontend/pull/1585)
 
 ## 3.2.0 (Feature release)
 

--- a/src/govuk/components/warning-text/_warning-text.scss
+++ b/src/govuk/components/warning-text/_warning-text.scss
@@ -5,9 +5,6 @@
 @include govuk-exports("govuk/component/warning-text") {
 
   .govuk-warning-text {
-    @include govuk-font($size: 19);
-    @include govuk-text-colour;
-
     position: relative;
     @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(2) 0;
@@ -50,6 +47,8 @@
   }
 
   .govuk-warning-text__text {
+    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-text-colour;
     display: block;
     padding-left: 50px;
   }


### PR DESCRIPTION
Explicitly set the font-weight of the warning text component, and move the font styles to the `__text` element (the `__icon` element has its own size, weight and colour)

Warning text is otherwise only bold because of the user-agent styling of `<strong>` elements. When used with GOV.UK Elements, which includes a reset stylesheet, [the `font-weight` is reset to `normal`](https://github.com/alphagov/govuk_elements/blob/84f485f688e7f796a4c44dd73b17177e8e39538c/assets/sass/elements/_reset.scss#L85-L119), which means the warning text is currently set in a normal weight.

## Before

### Legacy mode OFF

![WT Before](https://user-images.githubusercontent.com/121939/65414028-ba592180-ddea-11e9-88f1-3e5a20ff67d7.png)

### Legacy mode ON

![WT Legacy Before](https://user-images.githubusercontent.com/121939/65414025-b9c08b00-ddea-11e9-90fe-66531e43f9cb.png)

## After

### Legacy mode OFF

![WT After](https://user-images.githubusercontent.com/121939/65414074-d0ff7880-ddea-11e9-89e4-1d3e3d4d7afc.png)

### Legacy mode ON

![WT Legacy after](https://user-images.githubusercontent.com/121939/65414091-d8bf1d00-ddea-11e9-9a07-17d223f1ff41.png)
