### PR TITLE
Add display none override class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This will help with scenarios where some of the elements, such as navigation and
 
 - [Pull request #1576: Allow `lang` to be set on title and main of template](https://github.com/alphagov/govuk-frontend/pull/1576).
 
+#### Add new override class to hide elements
+
+You can now use the `.govuk-!-display-none` override class to hide elements.
+
+- [Pull request #1586: Add display none override class](https://github.com/alphagov/govuk-frontend/pull/1586).
+
 #### Visual updates to the warning text component
 
 Align ‘Warning text’ icon with first line of the content fixing [#1352](https://github.com/alphagov/govuk-frontend/issues/1352) Some changes were made to the size and spacing of the icon to help with positioning.

--- a/src/govuk/overrides/_display.scss
+++ b/src/govuk/overrides/_display.scss
@@ -15,4 +15,8 @@
   .govuk-\!-display-block {
     display: block !important;
   }
+
+  .govuk-\!-display-none {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
Sometimes users need to hide elements without wanting to use inline styles.

The [hidden] attribute is a good way to do this but needs patching with custom code and will not behave as expected in Internet Explorer 8.

This pull requests adds the new override class `.govuk-!-display-none` to help users who do not want to use `[hidden]`.

## Why not `govuk-hidden`?

We already have classes for display:
- `.govuk-!-display-inline`
- `.govuk-!-display-inline-block`
- `.govuk-!-display-block`

So while `govuk-hidden` is consistent with `govuk-visually-hidden`, adding a new override feels more appropriate in this case.

Resolves https://github.com/alphagov/govuk-frontend/issues/1060

