### PR TITLE
Fix height and alignment issue within header in Chrome 76+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Align ‘Warning text’ icon with first line of the content fixing [#1352](http
 - [Pull request #1584: Fix text resize issue with warning text icon](https://github.com/alphagov/govuk-frontend/pull/1584)
 - [Pull request #1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
 - [Pull request #1585: Explicitly set font weight on warning-text component](https://github.com/alphagov/govuk-frontend/pull/1585)
+- [Pull request #1587: Fix height and alignment issue within header in Chrome 76+](https://github.com/alphagov/govuk-frontend/pull/1587)
 
 ## 3.2.0 (Feature release)
 

--- a/src/govuk/components/header/_header.scss
+++ b/src/govuk/components/header/_header.scss
@@ -42,6 +42,7 @@
   }
 
   .govuk-header__logotype {
+    display: inline-block;
     margin-right: govuk-spacing(1);
   }
 


### PR DESCRIPTION
A change in Chrome 76 means that the header is currently being rendered 64px high (rather than the expected 60px), with mis-alignment between the crown and the GOV.UK logotype.

Adding `display: inline-block` to the __logotype element fixes it ([h/t @trevorsaint](https://github.com/alphagov/govuk-frontend/issues/1575#issuecomment-533610517)).

(We are not sure what exactly changed in Chrome 76, nor why this fixes it.)

Fixes #1575 

👉 [Browser Screenshots](https://www.browserstack.com/screenshots/38a4e8401a166947d4c22804c12293d78105a22c)
👉 [Preview](https://govuk-frontend-review-pr-1587.herokuapp.com/components/header)

## Before
![Header Before](https://user-images.githubusercontent.com/121939/65428835-0321d200-de0d-11e9-8fa3-af45e147aa42.png)

## After
![Header After](https://user-images.githubusercontent.com/121939/65428836-0321d200-de0d-11e9-96a8-3d227a3a3a5f.png)