### PR TITLE
Remove `role="button"` from header button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Align ‘Warning text’ icon with first line of the content fixing [#1352](http
 - [Pull request #1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
 - [Pull request #1585: Explicitly set font weight on warning-text component](https://github.com/alphagov/govuk-frontend/pull/1585)
 - [Pull request #1587: Fix height and alignment issue within header in Chrome 76+](https://github.com/alphagov/govuk-frontend/pull/1587)
+- [Pull request #1589: Remove role="button" from header button](https://github.com/alphagov/govuk-frontend/pull/1589)
 
 ## 3.2.0 (Feature release)
 

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -60,7 +60,7 @@
     </a>
     {% endif %}
     {% if params.navigation %}
-    <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav>
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
         {% for item in params.navigation %}


### PR DESCRIPTION
Since the HTML5 button element has the role of button already setting the role attribute to button is not necessary.

Fixes https://github.com/alphagov/govuk-frontend/issues/1588