### PR TITLE
Fix package README namespaces

### DIFF
--- a/package/README.md
+++ b/package/README.md
@@ -37,7 +37,7 @@ imports) if you want to override GOV.UK Frontend with your own styles.
 To import add the below to your Sass file:
 
   ```scss
-  @import "node_modules/govuk-frontend/all";
+  @import "node_modules/govuk-frontend/govuk/all";
   ```
 
 [More details on importing styles](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#importing-styles)
@@ -48,7 +48,7 @@ Some of the JavaScript included in GOV.UK Frontend improves the usability and
 accessibility of the components. You should make sure that you are importing and
 initialising Javascript in your application to ensure that all users can use it successfully.
 
-You can include Javascript for all components either by copying the `all.js` from `node_modules/govuk-frontend` into your application or referencing the file directly:
+You can include Javascript for all components either by copying the `all.js` from `node_modules/govuk-frontend/govuk/` into your application or referencing the file directly:
 
 ```html
 <script src="<path-to-govuk-frontend-all-file>/all.js"></script>


### PR DESCRIPTION
These have now changed when we namespaced GOV.UK Frontend.

I think these may have been missed because the majority of content in the package directory is auto-generated.