### PR TITLE
Update date input items documentation so they're not required

### DIFF
--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -9,7 +9,7 @@ params:
   description: Optional prefix. This is used to prefix each `item.name` using `-`.
 - name: items
   type: array
-  required: true
+  required: false
   description: An array of input objects with name, value and classes.
   params:
   - name: id


### PR DESCRIPTION
Items have a default if they're not passed to the component, so they're not required.

Fixes https://github.com/alphagov/govuk-frontend/issues/1528