### PR TITLE
Refactor handling of count message in character count JS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Align ‘Warning text’ icon with first line of the content fixing [#1352](http
 - [Pull request #1587: Fix height and alignment issue within header in Chrome 76+](https://github.com/alphagov/govuk-frontend/pull/1587)
 - [Pull request #1589: Remove role="button" from header button](https://github.com/alphagov/govuk-frontend/pull/1589)
 - [Pull request #1595: Do not output conditionally revealed content for radios or checkboxes when it's empty](https://github.com/alphagov/govuk-frontend/pull/1595)
+- [Pull request #1594: Refactor handling of count message in character count Javascript](https://github.com/alphagov/govuk-frontend/pull/1594)
 
 ## 3.2.0 (Feature release)
 

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -26,6 +26,10 @@ CharacterCount.prototype.init = function () {
     return
   }
 
+  // We move count message right after the field
+  // Kept for backwards compatibility
+  $textarea.insertAdjacentElement('afterend', $countMessage)
+
   // Read options set using dataset ('data-' values)
   this.options = this.getDataset($module)
 
@@ -43,9 +47,6 @@ CharacterCount.prototype.init = function () {
     return
   }
 
-  // Generate and reference message
-  var boundCreateCountMessage = this.createCountMessage.bind(this)
-  this.countMessage = boundCreateCountMessage()
 
   // If there's a maximum length defined and the count message exists
   if (this.countMessage) {
@@ -88,27 +89,6 @@ CharacterCount.prototype.count = function (text) {
     length = text.length
   }
   return length
-}
-
-// Generate count message and bind it to the input
-// returns reference to the generated element
-CharacterCount.prototype.createCountMessage = function () {
-  var countElement = this.$textarea
-  var elementId = countElement.id
-  // Check for existing info count message
-  var countMessage = document.getElementById(elementId + '-info')
-  // If there is no existing info count message we add one right after the field
-  if (elementId && !countMessage) {
-    countElement.insertAdjacentHTML('afterend', '<span id="' + elementId + '-info" class="govuk-hint govuk-character-count__message" aria-live="polite"></span>')
-    this.describedBy = countElement.getAttribute('aria-describedby')
-    this.describedByInfo = this.describedBy + ' ' + elementId + '-info'
-    countElement.setAttribute('aria-describedby', this.describedByInfo)
-    countMessage = document.getElementById(elementId + '-info')
-  } else {
-  // If there is an existing info count message we move it right after the field
-    countElement.insertAdjacentElement('afterend', countMessage)
-  }
-  return countMessage
 }
 
 // Bind input propertychange to the elements and update based on the change

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -47,20 +47,16 @@ CharacterCount.prototype.init = function () {
     return
   }
 
+  // Remove hard limit if set
+  $module.removeAttribute('maxlength')
 
-  // If there's a maximum length defined and the count message exists
-  if (this.countMessage) {
-    // Remove hard limit if set
-    $module.removeAttribute('maxlength')
+  // Bind event changes to the textarea
+  var boundChangeEvents = this.bindChangeEvents.bind(this)
+  boundChangeEvents()
 
-    // Bind event changes to the textarea
-    var boundChangeEvents = this.bindChangeEvents.bind(this)
-    boundChangeEvents()
-
-    // Update count message
-    var boundUpdateCountMessage = this.updateCountMessage.bind(this)
-    boundUpdateCountMessage()
-  }
+  // Update count message
+  var boundUpdateCountMessage = this.updateCountMessage.bind(this)
+  boundUpdateCountMessage()
 }
 
 // Read data attributes

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -5,6 +5,9 @@ import '../../vendor/polyfills/Element/prototype/classList'
 function CharacterCount ($module) {
   this.$module = $module
   this.$textarea = $module.querySelector('.govuk-js-character-count')
+  if (this.$textarea) {
+    this.$countMessage = $module.querySelector('[id=' + this.$textarea.id + '-info]')
+  }
 }
 
 CharacterCount.prototype.defaults = {
@@ -17,7 +20,9 @@ CharacterCount.prototype.init = function () {
   // Check for module
   var $module = this.$module
   var $textarea = this.$textarea
-  if (!$textarea) {
+  var $countMessage = this.$countMessage
+
+  if (!$textarea || !$countMessage) {
     return
   }
 
@@ -132,7 +137,7 @@ CharacterCount.prototype.checkIfValueChanged = function () {
 CharacterCount.prototype.updateCountMessage = function () {
   var countElement = this.$textarea
   var options = this.options
-  var countMessage = this.countMessage
+  var countMessage = this.$countMessage
 
   // Determine the remaining number of characters/words
   var currentLength = this.count(countElement.value)


### PR DESCRIPTION
The “count message” refers to the “You have x characters remaining” message in the character count (`govuk-character-count__message`).

## Original issue

The original issue #1106 raised by @36degrees was fixed by https://github.com/alphagov/govuk-frontend/pull/1347. This allowed a value for `aria-describedby` to be passed through to the textarea component. This means that the character count component can correctly pass the id of the count message to the textarea component to associate the two.

## Fixes in this PR

There was a bit of refactoring to do in terms of how the JS of the character count handles defining the count message so this PR does that. I’ve tried to break the changes into smaller commits to make it clear what’s going on but can squash them before merging if that makes more sense. 

### Making the count message markup required

The count message markup is now always present (since https://github.com/alphagov/govuk-frontend/commit/7b534bf734cd0a1be2cff34d64018aa89abdabb6). This PR makes the markup for it required, instead of giving the option to add it with Javascript - the message markup should always exist so that user is notified of the character limit, even if JS doesn’t run. 

This PR removes the branching logic and the code that added the count message markup dynamically in `createCountMessage()`. It’s worth nothing that the code inside the block hasn’t been executed since https://github.com/alphagov/govuk-frontend/commit/7b534bf734cd0a1be2cff34d64018aa89abdabb6.  As using the character count without  the count message markup and relying it to be added with JS is not part of the public API, removing this functionality is not considered a breaking change.

### Defining the count message

The count message DOM element is now defined at the top of the module with the other required DOM elements. 

[We check whether the textarea is present](https://github.com/alphagov/govuk-frontend/compare/character-count-associate-textarea?expand=1#diff-4243571b7fc266600817b0d8eb6a392bR8) before getting its `id` to get the count message DOM element - the check prevents an error with getting `$textarea.id` if the script is run without component markup being present present on the page. Alternatively we could define the count message in `init()` after doing a check for textarea which would require another check for it and wouldn’t make it as clear that it’s required as when placed at the top of module. See below for the code. Thoughts?

```
CharacterCount.prototype.init = function () {
  var $module = this.$module
  var $textarea = this.$textarea

  if (!$textarea) {
    return
  }

  this.$countMessage = $module.querySelector('[id=' + this.$textarea.id + '-info]')

  if (!$countMessage) {
    return
  }
```

### Moving the count message markup inside `govuk-form-group`

The original code for checking/creating the count message markup [moves it in the DOM](https://github.com/alphagov/govuk-frontend/blob/f4818118a71462972d4ec5d4b6409e89c8fbc56c/src/govuk/components/character-count/character-count.js#L104 ) to be inside `govuk-form-group`. This was probably useful when the message markup was created dynamically. This PR retains the bit of code that moves the element for backwards compatibility. It’s important that the count message markup is inside `govuk-form-group` so that it gets wrapped within the error block (see screen grab below).

![Screen Shot 2019-09-26 at 17 57 26](https://user-images.githubusercontent.com/5007934/65713384-fc0af600-e090-11e9-90d3-33230813d538.png)

However we should look to remove moving the markup with JS and instead change the component markup so that the count message is inside `govuk-form-group`. This would be a breaking change so shall leave it for now and create an issue. 