### PR TITLE
WIP: Updating date component to be type text and allow inputmode

### DIFF
--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -20,6 +20,14 @@ params:
     type: string
     required: true
     description: Item-specific name attribute.
+  - name: type
+    type: string
+    required: false
+    description: Sets the input type, default is text.
+  - name: inputmode
+    type: string
+    required: false
+    description: Sets the input inputmode, default is numric.
   - name: label
     type: string
     required: true

--- a/src/govuk/components/date-input/template.njk
+++ b/src/govuk/components/date-input/template.njk
@@ -65,7 +65,8 @@
         classes: "govuk-date-input__input " + (item.classes if item.classes),
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
-        type: "number",
+        type: item.type if item.type else "text",
+        inputmode: item.inputmode if item.inputmode else "numeric",
         autocomplete: item.autocomplete,
         pattern: item.pattern if item.pattern else "[0-9]*",
         attributes: item.attributes

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -131,7 +131,7 @@ describe('Date input', () => {
       expect($firstItems.text().trim()).toEqual('Day')
     })
 
-    it('renders inputs with type="number"', () => {
+    it('renders inputs with type="text"', () => {
       const $ = render('date-input', {
         items: [
           {
@@ -141,7 +141,20 @@ describe('Date input', () => {
       })
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('type')).toEqual('number')
+      expect($firstInput.attr('type')).toEqual('text')
+    })
+
+    it('renders inputs with inputmode="numric"', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            name: 'day'
+          }
+        ]
+      })
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('inputmode')).toEqual('numeric')
     })
 
     it('renders inputs with pattern="[0-9]*" to trigger numeric keypad on iOS', () => {
@@ -169,6 +182,34 @@ describe('Date input', () => {
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('pattern')).toEqual('[0-8]*')
+    })
+
+    it('renders inputs with custom type', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            name: 'day',
+            type: 'password'
+          }
+        ]
+      })
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('type')).toEqual('password')
+    })
+
+    it('renders inputs with custom inputmode attribute', () => {
+      const $ = render('date-input', {
+        items: [
+          {
+            name: 'day',
+            inputmode: 'url'
+          }
+        ]
+      })
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('inputmode')).toEqual('url')
     })
 
     it('renders item with implicit class for label', () => {


### PR DESCRIPTION
Opening for discussion, following on from [pull request 1527](https://github.com/alphagov/govuk-frontend/pull/1527) - I've applied this to the date component.

Before I go too far I figured there is a couple that probably needs talking through.

- I've allowed type and inputmode to be overridden - should this be the case?

- Given we recommend not using html5 validation, should we remove the pattern params?

- We should update the example with maxlength attribute?

My thoughts where no, yes and yes.

Happy to take onboard any addtional comments 👍 

I've done manual testing in on Browserstack and had a Dragon user test it.

Following on from https://github.com/alphagov/govuk-frontend/issues/1449#issuecomment-504006087

