### PR TITLE
Fix options component options table links

### DIFF
--- a/src/govuk/components/accordion/README.md
+++ b/src/govuk/components/accordion/README.md
@@ -12,4 +12,4 @@ Find out when to use the details component in your service in the [GOV.UK Design
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/accordion/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/accordion/#options-accordion-example) for details.

--- a/src/govuk/components/back-link/README.md
+++ b/src/govuk/components/back-link/README.md
@@ -12,4 +12,4 @@ Find out when to use the back link component in your service in the [GOV.UK Desi
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/back-link/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/back-link/#options-back-link-example) for details.

--- a/src/govuk/components/breadcrumbs/README.md
+++ b/src/govuk/components/breadcrumbs/README.md
@@ -12,4 +12,4 @@ Find out when to use the breadcrumbs component in your service in the [GOV.UK De
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/breadcrumbs/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/breadcrumbs/#options-breadcrumbs-example) for details.

--- a/src/govuk/components/button/README.md
+++ b/src/govuk/components/button/README.md
@@ -12,4 +12,4 @@ Find out when to use the button component in your service in the [GOV.UK Design 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/button/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/button/#options-button-example) for details.

--- a/src/govuk/components/character-count/README.md
+++ b/src/govuk/components/character-count/README.md
@@ -12,4 +12,4 @@ Find out when to use the character count component in your service in the [GOV.U
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/character-count/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/character-count/#options-character-count-example) for details.

--- a/src/govuk/components/checkboxes/README.md
+++ b/src/govuk/components/checkboxes/README.md
@@ -12,4 +12,4 @@ Find out when to use the checkboxes component in your service in the [GOV.UK Des
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/checkboxes/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/checkboxes/#options-checkboxes-example) for details.

--- a/src/govuk/components/date-input/README.md
+++ b/src/govuk/components/date-input/README.md
@@ -12,4 +12,4 @@ Find out when to use the date input component in your service in the [GOV.UK Des
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/date-input/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/date-input/#options-date-input-example) for details.

--- a/src/govuk/components/details/README.md
+++ b/src/govuk/components/details/README.md
@@ -12,4 +12,4 @@ Find out when to use the details component in your service in the [GOV.UK Design
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/details/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/details/#options-details-example) for details.

--- a/src/govuk/components/error-message/README.md
+++ b/src/govuk/components/error-message/README.md
@@ -12,4 +12,4 @@ Find out when to use the error message component in your service in the [GOV.UK 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/error-message/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/error-message/#options-error-message-example) for details.

--- a/src/govuk/components/error-summary/README.md
+++ b/src/govuk/components/error-summary/README.md
@@ -12,4 +12,4 @@ Find out when to use the error summary component in your service in the [GOV.UK 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/error-summary/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/error-summary/#options-error-summary-example) for details.

--- a/src/govuk/components/fieldset/README.md
+++ b/src/govuk/components/fieldset/README.md
@@ -12,4 +12,4 @@ Find out when to use the fieldset component in your service in the [GOV.UK Desig
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/fieldset/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/fieldset/#options-fieldset-example) for details.

--- a/src/govuk/components/file-upload/README.md
+++ b/src/govuk/components/file-upload/README.md
@@ -12,4 +12,4 @@ Find out when to use the file upload component in your service in the [GOV.UK De
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/file-upload/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/file-upload/#options-file-upload-example) for details.

--- a/src/govuk/components/footer/README.md
+++ b/src/govuk/components/footer/README.md
@@ -12,4 +12,4 @@ Find out when to use the footer component in your service in the [GOV.UK Design 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/footer/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/footer/#options-footer-example) for details.

--- a/src/govuk/components/header/README.md
+++ b/src/govuk/components/header/README.md
@@ -12,4 +12,4 @@ Find out when to use the header component in your service in the [GOV.UK Design 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/header/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/header/#options-header-example) for details.

--- a/src/govuk/components/hint/README.md
+++ b/src/govuk/components/hint/README.md
@@ -12,4 +12,4 @@ The label component is used in other input components, to see an example of it i
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/file-upload/#options-example-default--hint) for details.
+See [options table](https://design-system.service.gov.uk/components/text-input/#options-text-input-example--hint) for details.

--- a/src/govuk/components/input/README.md
+++ b/src/govuk/components/input/README.md
@@ -12,4 +12,4 @@ Find out when to use the input component in your service in the [GOV.UK Design S
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/text-input/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/text-input/#options-input-example) for details.

--- a/src/govuk/components/inset-text/README.md
+++ b/src/govuk/components/inset-text/README.md
@@ -12,4 +12,4 @@ Find out when to use the inset text component in your service in the [GOV.UK Des
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/inset-text/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/inset-text/#options-inset-text-example) for details.

--- a/src/govuk/components/label/README.md
+++ b/src/govuk/components/label/README.md
@@ -12,4 +12,4 @@ The label component is used in other input components, to see an example of it i
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/file-upload/#options-example-default--label) for details.
+See [options table](https://design-system.service.gov.uk/components/text-input/#options-text-input-example--label) for details.

--- a/src/govuk/components/panel/README.md
+++ b/src/govuk/components/panel/README.md
@@ -12,4 +12,4 @@ Find out when to use the panel component in your service in the [GOV.UK Design S
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/panel/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/panel/#options-panel-example) for details.

--- a/src/govuk/components/phase-banner/README.md
+++ b/src/govuk/components/phase-banner/README.md
@@ -12,4 +12,4 @@ Find out when to use the phase banner component in your service in the [GOV.UK D
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/phase-banner/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/phase-banner/#options-phase-banner-example) for details.

--- a/src/govuk/components/radios/README.md
+++ b/src/govuk/components/radios/README.md
@@ -12,4 +12,4 @@ Find out when to use the radios component in your service in the [GOV.UK Design 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/radios/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/radios/#options-radios-example) for details.

--- a/src/govuk/components/select/README.md
+++ b/src/govuk/components/select/README.md
@@ -12,4 +12,4 @@ Find out when to use the select component in your service in the [GOV.UK Design 
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/select/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/select/#options-select-example) for details.

--- a/src/govuk/components/skip-link/README.md
+++ b/src/govuk/components/skip-link/README.md
@@ -12,4 +12,4 @@ Find out when to use the skip link component in your service in the [GOV.UK Desi
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/skip-link/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/skip-link/#options-skip-link-example) for details.

--- a/src/govuk/components/summary-list/README.md
+++ b/src/govuk/components/summary-list/README.md
@@ -12,4 +12,4 @@ Find out when to use the details component in your service in the [GOV.UK Design
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/summary-list/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/summary-list/#options-summary-list-example) for details.

--- a/src/govuk/components/table/README.md
+++ b/src/govuk/components/table/README.md
@@ -12,4 +12,4 @@ Find out when to use the table component in your service in the [GOV.UK Design S
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/table/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/table/#options-table-example) for details.

--- a/src/govuk/components/tabs/README.md
+++ b/src/govuk/components/tabs/README.md
@@ -12,4 +12,4 @@ Find out when to use the tabs component in your service in the [GOV.UK Design Sy
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/tabs/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/tabs/#options-tabs-example) for details.

--- a/src/govuk/components/tag/README.md
+++ b/src/govuk/components/tag/README.md
@@ -12,4 +12,4 @@ Find out when to use the tag component in your service in the [GOV.UK Design Sys
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/tag/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/tag/#options-tag-example) for details.

--- a/src/govuk/components/textarea/README.md
+++ b/src/govuk/components/textarea/README.md
@@ -12,4 +12,4 @@ Find out when to use the textarea component in your service in the [GOV.UK Desig
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/textarea/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/textarea/#options-textarea-example) for details.

--- a/src/govuk/components/warning-text/README.md
+++ b/src/govuk/components/warning-text/README.md
@@ -12,4 +12,4 @@ Find out when to use the warning text component in your service in the [GOV.UK D
 
 Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
 
-See [options table](https://design-system.service.gov.uk/components/warning-text/#options-example-default) for details.
+See [options table](https://design-system.service.gov.uk/components/warning-text/#options-warning-text-example) for details.


### PR DESCRIPTION
Since we updated how ids are generated on the Design System website, these need to be updated.

Continuation of https://github.com/alphagov/govuk-design-system/issues/1008