### PR TITLE
Change `font-display: fallback` to `font-display: swap` to improve percieved performance

### DIFF
--- a/src/govuk/helpers/_font-faces.scss
+++ b/src/govuk/helpers/_font-faces.scss
@@ -26,7 +26,7 @@
                govuk-font-url("light-f591b13f7d-v2.woff") format("woff");
           font-weight: normal;
           font-style: normal;
-          font-display: fallback;
+          font-display: swap;
         }
 
         @font-face {
@@ -35,7 +35,7 @@
                govuk-font-url("bold-affa96571d-v2.woff") format("woff");
           font-weight: bold;
           font-style: normal;
-          font-display: fallback;
+          font-display: swap;
         }
       }
     }


### PR DESCRIPTION
## Hypothesis
Changing `font-display: fallback` to `font-display: swap` will improve perceived performance for users.

## Reasons for Hypothesis
According to the [specification](https://drafts.csswg.org/css-fonts-4/#font-display-desc):

> swap - Gives the font face an extremely small block period (100ms or less is recommended in most cases) and an infinite swap period. 

> fallback - Gives the font face an extremely small block period (100ms or less is recommended in most cases) and a short swap period (3s is recommended in most cases). 

So for `swap`, the browser will draw the text immediately (within 100ms) with a fallback font, then the browser has infinite time to swap the font out for the web font once loaded. 

With `fallback` the browser will draw the text immediately (within 100ms) with the fallback font. But the browser only has a finite period of time to swap to the web font once loaded. If the font isn't loaded in 3 seconds, the fallback font will be used for the lifetime of the page.

Others have suggested changing `font-display` from `fallback` to `swap` too. To quote from Addy Osmani:

> ...self-hosted Web Fonts have a zero second block period and an infinite swap period. Browsers would draw text immediately with a fallback used if the font face isn't loaded, but swap as soon as it does load.

More discussion about this can be seen [here](https://github.com/WICG/interventions/issues/58), [here](https://twitter.com/cramforce/status/910962151958835200) and [here](https://www.zachleat.com/web/comprehensive-webfonts/#font-display).

## Cloudflare Results
I tested both `font-display` settings using under different conditions, browsers and devices. All tests were run using [WebPageTest](https://www.webpagetest.org), and the visual output of each test observed to see which completed in a way that is best for the user.

**Note**: Tests on the `govuk-frontend-review-pr-*` domains link to third-party resources (CSS, JS) from Cloudflare and sometimes Google Fonts. The reliance on this third-party CSS could be the cause of some of the fluctuations in performance due to network congestion at the time the test is run.




### Chrome - 3G - Announcements
![announcements-3g-chrome](https://user-images.githubusercontent.com/1223960/66641447-b0208b00-ec12-11e9-9939-a1ea43ce500e.png)


**Observations**

`Fallback` renders pixels to the page 32ms before `swap`, FOIT occurs. `Swap` shows the web font at the same time as the page renders. In this case `fallback` has better perceived performance.

_Fallback_

* First Paint (FP): 4134ms
* First Contentful Paint (FCP): 4168ms
* Web font shown at: 4168ms

_Swap_

* First Paint (FP): 4168ms
* First Contentful Paint (FCP): 4168ms
* Web font shown at: 4168ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_KS_bdd8f80cc70a075c535612ce808491df%2C191009_2F_3eec0afda380ceb9befc2390f01d7ccb&thumbSize=200&ival=16.67&end=visual).





### Chrome - 3G - Applicant 
![applicant-3g-chrome](https://user-images.githubusercontent.com/1223960/66641473-bdd61080-ec12-11e9-9d26-2af5ea9ed172.png)

**Observations**

`fallback` renders pixels to the page before `swap`, FOIT occurs. `fallback` shows content before `swap`. `swap` loads and displays the web font 700ms quicker than `fallback`

_Fallback_

* First Paint (FP): 4067ms
* First Contentful Paint (FCP): 4101ms
* Web font shown at: 5835ms

_Swap_

* First Paint (FP): 4334ms
* First Contentful Paint (FCP): 4401ms
* Web font shown at: 5134ms

**Perceived performance winner**

`fallback`


**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_M9_acc82670241122d299742fd666bd6dba%2C191009_PT_5011330138e7baaa3d8d5d25b9f9ecfc&thumbSize=200&ival=100&end=visual).







### Chrome - 3G - Bank Holidays 
![bank-holidays-3g-chrome](https://user-images.githubusercontent.com/1223960/66641505-d34b3a80-ec12-11e9-8df1-eb881b185806.png)

**Observations**

`fallback` renders pixels to the page before swap, FOIT occurs. `fallback` renders content to the page quicker than `swap` (300ms). Web font for `swap` loads 300ms slower than `fallback`. 

_Fallback_

* First Paint (FP): 4067ms
* First Contentful Paint (FCP): 4168ms
* Web font shown at: 5068ms

_Swap_

* First Paint (FP): 4401ms
* First Contentful Paint (FCP): 4401ms
* Web font shown at: 5401ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_3E_c67e4f9a88e0f9981198ad2c6eb1e729%2C191009_ZW_b80757284b2ee26784a9396bef908dcb&thumbSize=200&ival=100&end=visual).





### Firefox - 3G - Announcements
![announcements-3g-firefox](https://user-images.githubusercontent.com/1223960/66641532-dd6d3900-ec12-11e9-88d0-7538aa7bcbf4.png)

**Observations**

`fallback` renders pixels to the viewport, content to the page, and loads the web font 200ms quicker than `swap`. 

_Fallback_

* First Paint (FP): 4268ms
* First Contentful Paint (FCP): 4368ms
* Web font shown at: 4834ms

_Swap_

* First Paint (FP): 4434ms
* First Contentful Paint (FCP): 4534ms
* Web font shown at: 5001ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_EP_31800a182c187446e215a383e7808646%2C191009_GV_8f853dbfafe412e6dd2a8674577d167c&thumbSize=200&ival=100&end=visual).






### Firefox - 3G - Applicant
![applicant-3g-firefox](https://user-images.githubusercontent.com/1223960/66641578-ebbb5500-ec12-11e9-8a99-dfa01310392e.png)

**Observations**

FOIT observed when using `fallback`. It renders pixels and content to the viewport quicker (100ms). Web font also loads 100ms quicker.

_Fallback_

* First Paint (FP): 5301ms
* First Contentful Paint (FCP): 5334ms
* Web font shown at: 6701ms

_Swap_

* First Paint (FP): 5434ms
* First Contentful Paint (FCP): 5434ms
* Web font shown at: 6801ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_Z7_8bbffe614188cc6f8d4fe3703439f1b0%2C191009_BQ_6314528159d8ec721f3d2d9503d0c370&thumbSize=200&ival=100&end=visual).





### Firefox - 3G - Bank Holidays
![bank-holiday-3g-firefox](https://user-images.githubusercontent.com/1223960/66641603-f7a71700-ec12-11e9-99b7-7395c8cd3e35.png)

**Observations**

FOIT visible for 100ms for both. `fallback` renders pixels to the viewport 200ms quicker. Font loads and displays quicker for `fallback`.

_Fallback_

* First Paint (FP): 4434ms
* First Contentful Paint (FCP): 4534ms
* Web font shown at: 5268ms

_Swap_

* First Paint (FP): 4668ms
* First Contentful Paint (FCP): 4737ms
* Web font shown at: 5468ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_HJ_132aade08c2786c3d742e1442ec60bf1%2C191009_EG_3f605caa23d518e67981e85f2fd9d510&thumbSize=200&ival=100&end=visual).






### Moto G4 - Chrome - 3G - Announcements
Tested on a real device, based in Dulles, VA.
![announcements-3g-moto-g4-chrome](https://user-images.githubusercontent.com/1223960/66641629-04c40600-ec13-11e9-9443-f0aad32052cb.png)


**Observations**

`swap` page rendered extremely quickly once resources were loaded, within a single frame (~16ms). FOIT only visible for the `fallback` for 100ms.

_Fallback_

* First Paint (FP): 5218ms
* First Contentful Paint (FCP): 5384ms
* Web font shown at: 5384ms

_Swap_

* First Paint (FP): 5168ms
* First Contentful Paint (FCP): 5168ms
* Web font shown at: 5168ms

**Perceived performance winner**

`swap`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_CQ_91e1a9b4972d04dc12c5fee795a37d78%2C191009_D1_1e292800ffd24f50dc0650d98070dd6e&thumbSize=200&ival=100&end=visual).






### Moto G4 - Chrome - 3G - Applicant
Tested on a real device, based in Dulles, VA.
![applicant-3g-moto-g4-chrome](https://user-images.githubusercontent.com/1223960/66641662-0f7e9b00-ec13-11e9-9383-7edba7694503.png)

**Observations**

FOIT seen for first 100ms in both cases. `swap` renders pixels to the page some 500ms before `fallback` in this case. Page completion delayed due to the loading of the crown icon (not relevant).

_Fallback_

* First Paint (FP): 5618ms
* First Contentful Paint (FCP): 5701ms
* Web font shown at: 5701ms

_Swap_

* First Paint (FP): 5168ms
* First Contentful Paint (FCP): 5301ms
* Web font shown at: 5301ms

**Perceived performance winner**

`swap`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_1Q_52e8ad6a87f3d0fe9c38c39b465be9cc%2C191009_84_0ea434f6d592a1bc5d857f1fbaf27bd5&thumbSize=200&ival=100&end=visual).





### Moto G4 - Chrome - 3G - Bank Holidays
Tested on a real device, based in Dulles, VA.
![bank-holidays-3g-moto-g4-chrome](https://user-images.githubusercontent.com/1223960/66641697-21603e00-ec13-11e9-867d-555db8566518.png)

**Observations**

FOIT visible for around 200ms with `fallback`, and it renders pixels to the screen before `swap`. Content is rendered to the viewport at a similar time for both cases. Same applies for the actual web font download.

_Fallback_

* First Paint (FP): 5168ms
* First Contentful Paint (FCP): 5318ms
* Web font shown at: 5318ms

_Swap_

* First Paint (FP): 5351ms
* First Contentful Paint (FCP): 5351ms
* Web font shown at: 5351ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_D1_35cbd53b5f316e6d4c1fe205c56045d2%2C191009_YN_ab9e342152a8369506f0432e2caaf1b3&thumbSize=200&ival=100&end=visual).







## Fastly Results
Sample pages taken from GOV.UK were tested to understand what the results were without the third-party dependencies. In this case the assets domain has also been removed which will remove the performance bottleneck when using HTTP/2.

HTTP/1.1 and HTTP/2 were tested to see how the protocol effected the results.



### GOV.UK Homepage - HTTP/1.1 - 3G - Chrome
![homepage-h1-3g-chrome](https://user-images.githubusercontent.com/1223960/66641723-3046f080-ec13-11e9-979d-556501447ef0.png)


**Observations**

FOIT seen in the `fallback` version for 100ms, but not for `swap`. Initial page render contains the fallback font for `swap`, so perceived performance is better for this case. Actual font load is slower for `swap` by 100ms.

_Fallback_

* First Paint (FP): 3434ms
* First Contentful Paint (FCP): 3567ms
* Webfont shown at: 4601ms

_Swap_

* First Paint (FP): 3501ms
* First Contentful Paint (FCP): 3501ms
* Web font shown at: 4734ms

**Perceived performance winner**

`swap`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_21_69e08e9e2ab19ad5cc7502b84a7bb47f%2C191009_8W_282f9709826d623bc73803137cbc520c&thumbSize=200&ival=100&end=visual).




### GOV.UK Homepage - HTTP/2 - 3G - Chrome
![homepage-h2-3g-chrome](https://user-images.githubusercontent.com/1223960/66641740-3a68ef00-ec13-11e9-96a2-28a27b8bef19.png)

**Observations**

FOIT seen with `fallback` but not `swap`. Pixels rendered to the viewport 100ms quicker with `fallback`, actual content rendered at the same time. Font loads in a similar time.

_Fallback_

* First Paint (FP): 3434ms
* First Contentful Paint (FCP): 3534ms
* Web font shown at: 4501ms

_Swap_

* First Paint (FP): 3534ms
* First Contentful Paint (FCP): 3534ms
* Web font shown at: 4534ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_K1_8a1557381e15aac849d704e9f466e0aa,191009_3C_7367360b311dbd2a953f0f6756282572).





### Start Page - HTTP/1.1 - 3G - Moto G4 - Chrome
Tested on a real device, based in Dulles, VA.
![start-h1-3g-moto-g4-chrome](https://user-images.githubusercontent.com/1223960/66641760-45238400-ec13-11e9-9c35-6c192f98378a.png)

**Observations**

`fallback` renders pixels to the viewport quicker, but FOIT is seen for 100ms. Content rendered 200ms quicker for `swap`, but the web font loads 400ms slower.

_Fallback_

* First Paint (FP): 4017ms
* First Contentful Paint (FCP): 4301ms
* Web font shown at: 5218ms

_Swap_

* First Paint (FP): 4184ms
* First Contentful Paint (FCP): 4184ms
* Web font shown at: 5618ms


**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_EF_7088f6ba00821fc1c88f4f68e6a94a4b%2C191009_N3_6ae58ea67f8bc0ea2f9c985cc593ce82&thumbSize=200&ival=100&end=visual).





### Start Page - HTTP/2 - 3G - Moto G4 - Chrome
Tested on a real device, based in Dulles, VA.
![start-h2-3g-moto-g4-chrome](https://user-images.githubusercontent.com/1223960/66641796-55d3fa00-ec13-11e9-8a27-d5c269dd095c.png)


**Observations**

`fallback` renders pixels to the viewport quicker, but FOIT is seen for 300ms. `swap` renders the fallback at the same time as it draws the page. Web font loads slightly quicker for `swap`.

_Fallback_

* First Paint (FP): 3651ms
* First Contentful Paint (FCP): 3984ms
* Web font shown at: 4834ms

_Swap_

* First Paint (FP): 3751ms
* First Contentful Paint (FCP): 3751ms
* Web font shown at: 4618ms

**Perceived performance winner**

`fallback`

**Full results**

Full comparison results can be [found here](https://www.webpagetest.org/video/compare.php?tests=191009_4W_4b8c061715a8403ca0a0cd41ce2042e8%2C191009_8T_15135f9a8fff87cdb89334b802bb70de&thumbSize=200&ival=100&end=visual).



## Conclusion
From the test results above, many of the tests look to show better perceived performance when `fallback` is used. This is assuming that painting any pixel to the viewport is perceived as quicker (open to interpretation). From the tests run, `fallback` was better for 10 out of 13 tests.


## Recommendation
Off the back of the results above my recommendation would be to keep the `font-display` setting at `fallback` rather than `swap`, since it allows _any_ type of pixels to be rendered to the viewport quicker.

We should do a similar test to see if `font-display: optional` may be a better alternative for older devices, since it allows a browser to cancel the web font download completely if the connection is very slow.