### PR TITLE
Add banner to all full page examples

### DIFF
--- a/app/views/full-page-examples/announcements/index.njk
+++ b/app/views/full-page-examples/announcements/index.njk
@@ -11,6 +11,7 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
+{% include "../../partials/banner.njk" %}
 {{ govukHeader({
   navigation: [
     {

--- a/app/views/layouts/legacy.njk
+++ b/app/views/layouts/legacy.njk
@@ -4,6 +4,8 @@
 {% set homepage_url = "/" %}
 {% block page_title %}{{ "Error: " if errors }}{{ page_title }} - GOV.UK{% endblock %}
 
+{% block cookie_message %}<p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a></p>{% endblock %}
+
 {% block head %}
   <!--[if !IE 8]><!-->
     <link rel="stylesheet" href="/public/app-legacy.css">
@@ -11,6 +13,10 @@
   <!--[if IE 8]>
     <link rel="stylesheet" href="/public/app-legacy-ie8.css">
   <![endif]-->
+{% endblock %}
+
+{% block body_start %}
+  {% include "../partials/banner.njk" %}
 {% endblock %}
 
 {% block body_end %}


### PR DESCRIPTION
It's currently missing from these examples:

- announcements
- applicant details
- service manual topic
- renew driving license