### PR TITLE
Wrap component text with <p> where semantics are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #1613: Wrap component text with <p> where semantics are missing](https://github.com/alphagov/govuk-frontend/pull/1574).
+
 ## 3.3.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/accordion/_accordion.scss
+++ b/src/govuk/components/accordion/_accordion.scss
@@ -41,7 +41,13 @@
     margin-bottom: 0;
   }
 
-  // Remove the bottom margin from the last item inside the content
+  // Remove the top margin from the first p inside the summary
+  .govuk-accordion__section-summary > p:first-child {
+    margin-top: 0;
+  }
+
+  // Remove the bottom margin from the last item inside the summary/content
+  .govuk-accordion__section-summary > :last-child,
   .govuk-accordion__section-content > :last-child {
     margin-bottom: 0;
   }

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -88,7 +88,7 @@ examples:
       - heading:
          text: Test 2
         summary:
-          html: <span class="govuk-!-font-weight-regular">Additional description</span>
+          html: <p class="govuk-body"><span class="govuk-!-font-weight-regular">Additional description</span></p>
         content:
           html: |
             <ul class="govuk-list govuk-list--bullet">
@@ -142,8 +142,8 @@ examples:
       - heading:
           text: Section A
         content:
-          html: <a class="govuk-link" href="#">Link A</a>
+          html: <p class="govuk-body"><a class="govuk-link" href="#">Link A</a></p>
       - heading:
           text: Section B
         content:
-          html: <a class="govuk-link" href="#">Link B</a>
+          html: <p class="govuk-body"><a class="govuk-link" href="#">Link B</a></p>

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -13,13 +13,21 @@
             </span>
           </h{{ headingLevel }}>
           {% if item.summary.html or item.summary.text %}
-            <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
-              {{ item.summary.html | safe if item.summary.html else item.summary.text }}
+            <div class="govuk-accordion__section-summary" id="{{ id }}-summary-{{ loop.index }}">
+            {% if item.summary.html %}
+              {{ item.summary.html | safe }}
+            {% else %}
+              <p class="govuk-body">{{ item.summary.text }}</p>
+            {% endif %}
             </div>
           {% endif %}
         </div>
         <div id="{{ id }}-content-{{ loop.index }}" class="govuk-accordion__section-content" aria-labelledby="{{ id }}-heading-{{ loop.index }}">
-          {{ item.content.html | safe if item.content.html else item.content.text }}
+        {% if item.content.html %}
+          {{ item.content.html | safe }}
+        {% else %}
+          <p class="govuk-body">{{ item.content.text }}</p>
+        {% endif %}
         </div>
       </div>
     {% endif %}

--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -53,8 +53,8 @@ examples:
   data:
     summaryText: Where to find your National Insurance Number
     html: |
-      Your National Insurance number can be found on
-      <ul>
+      <p class="govuk-body">Your National Insurance number can be found on</p>
+      <ul class="govuk-list govuk-list--bullet">
         <li>your National Insurance card</li>
         <li>your payslip</li>
         <li>P60</li>

--- a/src/govuk/components/details/template.njk
+++ b/src/govuk/components/details/template.njk
@@ -5,6 +5,10 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    {{ params.html | safe if params.html else params.text }}
+  {% if params.html %}
+    {{ params.html | safe }}
+  {% else %}
+    <p class="govuk-body">{{ params.text }}</p>
+  {% endif %}
   </div>
 </details>

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -38,16 +38,16 @@ describe('Details', () => {
     })
 
     const detailsText = $('.govuk-details__text').html().trim()
-    expect(detailsText).toEqual('More about the greater than symbol (&gt;)')
+    expect(detailsText).toEqual('<p class="govuk-body">More about the greater than symbol (&gt;)</p>')
   })
 
   it('allows HTML to be passed un-escaped', () => {
     const $ = render('details', {
-      html: 'More about <b>bold text</b>'
+      html: '<p class="govuk-body">More about <b>bold text</b></p>'
     })
 
     const detailsText = $('.govuk-details__text').html().trim()
-    expect(detailsText).toEqual('More about <b>bold text</b>')
+    expect(detailsText).toEqual('<p class="govuk-body">More about <b>bold text</b></p>')
   })
 
   it('allows summary text to be passed whilst escaping HTML entities', () => {

--- a/src/govuk/components/inset-text/_inset-text.scss
+++ b/src/govuk/components/inset-text/_inset-text.scss
@@ -4,8 +4,6 @@
 
 @include govuk-exports("govuk/component/inset-text") {
   .govuk-inset-text {
-    @include govuk-font($size: 19);
-    @include govuk-text-colour;
     padding: govuk-spacing(3);
     // Margin top intended to collapse
     // This adds an additional 10px to the paragraph above

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -30,9 +30,11 @@ examples:
         <p class="govuk-body">It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.</p>
         <div class="govuk-warning-text">
           <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-          <strong class="govuk-warning-text__text">
-            <span class="govuk-warning-text__assistive">Warning</span>
-            You can be fined up to £5,000 if you don’t register.
-          </strong>
+          <p class="govuk-warning-text__text">
+            <strong>
+              <span class="govuk-warning-text__assistive">Warning</span>
+              You can be fined up to £5,000 if you don’t register.
+            </strong>
+          </p>
         </div>
         <p class="govuk-body">It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.</p>

--- a/src/govuk/components/inset-text/template.njk
+++ b/src/govuk/components/inset-text/template.njk
@@ -1,4 +1,8 @@
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-inset-text {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  {{ params.html | safe if params.html else params.text }}
+{% if params.html %}
+  {{ params.html | safe }}
+{% else %}
+  <p class="govuk-body">{{ params.text }}</p>
+{% endif %}
 </div>

--- a/src/govuk/components/inset-text/template.test.js
+++ b/src/govuk/components/inset-text/template.test.js
@@ -42,16 +42,16 @@ describe('Inset text', () => {
       })
 
       const content = $('.govuk-inset-text').html().trim()
-      expect(content).toEqual('It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.')
+      expect(content).toEqual('<p class="govuk-body">It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.</p>')
     })
 
     it('allows HTML to be passed un-escaped', () => {
       const $ = render('inset-text', {
-        html: 'It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.'
+        html: '<p class="govuk-body">It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.</p>'
       })
 
       const content = $('.govuk-inset-text').html().trim()
-      expect(content).toEqual('It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.')
+      expect(content).toEqual('<p class="govuk-body">It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.</p>')
     })
 
     it('renders with attributes', () => {

--- a/src/govuk/components/panel/_panel.scss
+++ b/src/govuk/components/panel/_panel.scss
@@ -41,4 +41,14 @@
     @include govuk-font($size: 36);
   }
 
+  .govuk-panel__body p {
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  .govuk-panel__body > :last-child {
+    margin-bottom: 0;
+  }
+
 }

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -31,8 +31,12 @@ params:
 examples:
 - name: default
   data:
-    titleHtml: Application complete
+    titleText: Application complete
     text: 'Your reference number: HDJ2123F'
+- name: with html
+  data:
+    titleHtml: Application complete
+    html: '<p class="govuk-body">Your reference number: <span>HDJ2123F</span></p>'
 - name: custom heading level
   data:
     titleText: Application complete

--- a/src/govuk/components/panel/template.njk
+++ b/src/govuk/components/panel/template.njk
@@ -7,7 +7,11 @@
   </h{{ headingLevel }}>
   {% if params.html or params.text %}
   <div class="govuk-panel__body">
-    {{ params.html | safe if params.html else params.text }}
+  {% if params.html %}
+    {{ params.html | safe }}
+  {% else %}
+    <p class="govuk-body">{{ params.text }}</p>
+  {% endif %}
   </div>
   {% endif %}
 </div>

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -71,16 +71,16 @@ describe('Panel', () => {
     })
 
     const panelBodyText = $('.govuk-panel__body').html().trim()
-    expect(panelBodyText).toEqual('Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;')
+    expect(panelBodyText).toEqual('<p class="govuk-body">Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;</p>')
   })
 
   it('allows body HTML to be passed un-escaped', () => {
     const $ = render('panel', {
-      html: 'Your reference number<br><strong>HDJ2123F</strong>'
+      html: '<p class="govuk-body">Your reference number<br><strong>HDJ2123F</strong></p>'
     })
 
     const panelBodyText = $('.govuk-panel__body').html().trim()
-    expect(panelBodyText).toEqual('Your reference number<br><strong>HDJ2123F</strong>')
+    expect(panelBodyText).toEqual('<p class="govuk-body">Your reference number<br><strong>HDJ2123F</strong></p>')
   })
 
   it('allows additional classes to be added to the component', () => {

--- a/src/govuk/components/warning-text/_warning-text.scss
+++ b/src/govuk/components/warning-text/_warning-text.scss
@@ -50,8 +50,8 @@
 
   .govuk-warning-text__text {
     @include govuk-font($size: 19, $weight: bold);
-    @include govuk-text-colour;
     display: block;
+    margin: 0;
     padding-left: 45px;
   }
 }

--- a/src/govuk/components/warning-text/template.njk
+++ b/src/govuk/components/warning-text/template.njk
@@ -2,8 +2,10 @@
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor -%}
   >
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-  <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">{{ params.iconFallbackText }}</span>
-    {{ params.html | safe if params.html else params.text }}
-  </strong>
+  <p class="govuk-warning-text__text govuk-body">
+    <strong>
+      <span class="govuk-warning-text__assistive">{{ params.iconFallbackText }}</span>
+      {{ params.html | safe if params.html else params.text }}
+    </strong>
+  </p>
 </div>


### PR DESCRIPTION
The **Inset text** and **Panel** components are styled `<div>` tags.

Plain text via `params.text` should be wrapped with `<p></p>` to improve semantics, and it's better to have sensible defaults than to assume developers will use `params.html`.

I've also included a fix for **Warning text** but due to enclosing `<strong>` and `<span>` it's a slightly different fix to the other two.

Fixes https://github.com/alphagov/govuk-frontend/issues/1611 and https://github.com/alphagov/govuk-design-system/issues/822

**Before**
![Before](https://user-images.githubusercontent.com/415517/66661719-5f735700-ec3f-11e9-8dfe-08b54bb0853e.png)

**After**
![After](https://user-images.githubusercontent.com/415517/66661729-639f7480-ec3f-11e9-8afa-7165897a6a50.png)