### PR TITLE
aria hide summary list action text if visually hidden text is set

### DIFF
--- a/src/govuk/components/summary-list/template.njk
+++ b/src/govuk/components/summary-list/template.njk
@@ -1,8 +1,10 @@
 {%- macro _actionLink(action) %}
   <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-    {{ action.html | safe if action.html else action.text }}
+    {% set actionText = action.html | safe if action.html else action.text %}
     {%- if action.visuallyHiddenText -%}
-      <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+      <span aria-hidden="true">{{ actionText }}</span><span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+    {%- else -%}
+      {{ actionText }}
     {% endif -%}
   </a>
 {% endmacro -%}

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -257,7 +257,7 @@ describe('Data list', () => {
                 items: [
                   {
                     text: 'Edit',
-                    visuallyHiddenText: 'Custom Accessible Name'
+                    visuallyHiddenText: 'Edit Custom Accessible Name'
                   }
                 ]
               }
@@ -266,8 +266,10 @@ describe('Data list', () => {
         })
 
         const $component = $('.govuk-summary-list')
-        const $actionLink = $component.find('.govuk-summary-list__actions > a')
-        expect($actionLink.text()).toContain('Edit Custom Accessible Name')
+        const $actionVisableText = $component.find('.govuk-summary-list__actions > a > span[aria-hidden="true"]')
+        const $actionHiddenText = $component.find('.govuk-summary-list__actions > a > .govuk-visually-hidden')
+        expect($actionVisableText.text()).toContain('Edit')
+        expect($actionHiddenText.text()).toContain('Edit Custom Accessible Name')
       })
       it('renders classes', async () => {
         const $ = render('summary-list', {


### PR DESCRIPTION
Currently the summary-list component offers a `visuallyHiddenText` property to add hidden text to action links for use with screen readers, the only problem is it is designed on the assumption that the text will follow on naturally from the action text. While fine in English, the gramatical order of the sentence may be completely different once translated - where a 'change' verb could be in the middle of a sentence rather at the beginning, or when written as sentence may be a completely different word from that which you'd use as a singular call to action.

Because of this I currently have locales files full of spans which I'm passing to the html text prop, which is a bit messy.

With this pull request I've refactored the component to wrap the normal action text in an aria hidden span if visually hidden text is set, so you can use entirely separate pieces of content for both sighted and screen reader users.

The only downside is it would be a breaking change as you'd have to refactor your use of the component from:

```javascript
{
  actions: {
    items: [
      {
        text: "Change",
        visuallyHiddenText: "name"
      }
    ]
  }
}
```
to
```javascript
{
  actions: {
    items: [
      {
        text: "Change",
        visuallyHiddenText: "Change name"
      }
    ]
  }
}
```
