### PR TITLE
Update GOV.UK Frontend accessibility documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,72 +33,33 @@ We recommend [installing GOV.UK Frontend using node package manager
 You can also [download the compiled and minified assets (CSS, JavaScript) from
 GitHub](docs/installation/installing-from-dist.md).
 
-## Browser support
+## Browser and assistive technology support
 
-GOV.UK Frontend will allow you to build services that comply with the [guidance
-in the Service Manual][service-manual-browsers].
+GOV.UK Frontend supports:
 
-Currently, GOV.UK Frontend officially supports the following browsers:
+- [recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in)
+- [recommended assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test)
+- Internet Explorer 8, 9 and 10, although components may not look perfect
+- your users overriding colours in Windows, Firefox and Chrome
 
-| Operating system | Browser                                | Support     |
-|----------------- |----------------------------------------|-------------|
-| Windows          | Internet Explorer 8-10                 | functional  |
-| Windows          | Internet Explorer 11                   | compliant   |
-| Windows          | Edge (latest 2 versions)               | compliant   |
-| Windows          | Google Chrome (latest 2 versions)      | compliant   |
-| Windows          | Mozilla Firefox (latest 2 versions)    | compliant   |
-| macOS            | Safari 9+                              | compliant   |
-| macOS            | Google Chrome (latest 2 versions)      | compliant   |
-| macOS            | Mozilla Firefox (latest 2 versions)    | compliant   |
-| iOS              | Safari for iOS 9.3+                    | compliant   |
-| iOS              | Google Chrome (latest 2 versions)      | compliant   |
-| Android          | Google Chrome (latest 2 versions)      | compliant   |
-| Android          | Samsung Internet (latest 2 versions)   | compliant   |
+## Accessibility
 
-‘Compliant’ means that the components must look as good and function as well as
-they do in other modern browsers.
+The GOV.UK Design System team works hard to ensure that GOV.UK Frontend is accessible.
 
-'Functional' means the components may not look perfect in the given browser, but
-must still be usable without errors and without 'looking broken'.
+Using Frontend will help your service meet [level AA of WCAG 2.1](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag). But you must still [check that your service meets accessibility requirements](https://www.gov.uk/service-manual/helping-people-to-use-your-service/making-your-service-accessible-an-introduction), especially if you extend or modify components.
 
-If you are including GOV.UK Frontend as part of a stylesheet that you are
-generating in your application's build pipeline, you will need to [generate and
-include a separate stylesheet in order to support Internet Explorer
-8](docs/installation/supporting-internet-explorer-8.md).
+You should also use:
 
-[service-manual-browsers]: https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in
+- [the JavaScript from GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#using-javascript)
+- [a separate stylesheet](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md) if you support Internet Explorer 8
 
-## Assistive technology support
+^ Your service will not meet level AA of WCAG 2.1 if you use [compatibility mode](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md) to use GOV.UK Frontend with old frameworks or the old colour palette.
 
-GOV.UK Frontend will allow you to build services that comply with the [guidance
-in the Service Manual][service-manual-assistive-technologies].
+You can also read the [accessibility statement for the GOV.UK Design System](https://design-system.service.gov.uk/accessibility/).
 
-Currently, GOV.UK Frontend officially supports the following assistive technologies:
+### Accessibility warnings
 
-| Software                 | Version        | Type               | Browser                   |
-|--------------------------|----------------|--------------------|---------------------------|
-| JAWS                     | 15 or later    | screen reader      | Internet Explorer 11      |
-| ZoomText                 | 10.11 or later | screen magnifier   | Internet Explorer 11      |
-| Dragon NaturallySpeaking | 11 or later    | speech recognition | Internet Explorer 11      |
-| NVDA                     | 2016 or later  | screen reader      | Firefox (latest versions) |
-| VoiceOver                | 7.0 or later   | screen reader      | Safari on iOS10 and OS X  |
-
-In addition, we test that all content is accessible with keyboard only.
-
-We aim to support [users who adjust or override the colours of websites they visit][how-users-change-colours-on-websites]. We test this by [changing colours in Firefox][changing-colours-in-firefox], by [enabling 'High Contrast' mode in Windows][enabling-high-contrast-mode-in-windows] and by using the [High Contrast plugin for Chrome][high-contrast-plugin-for-chrome].
-
-[service-manual-assistive-technologies]: https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test
-
-[changing-colours-in-firefox]:
-https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use
-
-[enabling-high-contrast-mode-in-windows]:
-https://support.microsoft.com/en-gb/help/13862/windows-use-high-contrast-mode
-
-[high-contrast-plugin-for-chrome]: https://chrome.google.com/webstore/detail/high-contrast/djcfdncoelnlbldjfhinnjlhdjlikmph?hl=en-US
-
-[how-users-change-colours-on-websites]:
-https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/
+If you get a warning from a linter or accessibility checker, check our list of [issues you should not need to fix](https://github.com/alphagov/govuk-frontend/issues/1280#issuecomment-509588851).
 
 ## Getting updates
 

--- a/docs/installation/compatibility.md
+++ b/docs/installation/compatibility.md
@@ -10,8 +10,7 @@ frameworks:
 You cannot use the following features if you installed GOV.UK Frontend from
 `dist`. [Install with node package manager](installing-from-npm.md) instead.
 
-If you use these features, your service will not have GOV.UK Frontend's many
-accessibility and usability improvements.
+If you use these features, your service will not meet [level AA of WCAG 2.1](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) because your users will not be able to change the font size.
 
 ## Turn on 'compatibility mode'
 


### PR DESCRIPTION
This updates the Frontend README and compatibility mode documentation with information about Frontend's accessibility.

To keep the README as concise as possible and reduce duplication, I've also linked to content (such as https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in) rather than repeat it here.

Ready to merge when:

- [ ] Nick and Hanna have checked the facts - in particular please check that the list of issues and accessibility checker warnings is accurate
- [ ] Amy has 2i'd
- [ ] A technical writer has 2i'd