### PR TITLE
Only add underline to back link when href exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Fixes
+- [Pull request #1620: Only add underline to back link when href exists ](https://github.com/alphagov/govuk-frontend/pull/1620).
+
 ## 3.3.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/back-link/_back-link.scss
+++ b/src/govuk/components/back-link/_back-link.scss
@@ -17,7 +17,10 @@
 
     // Allow space for the arrow
     padding-left: 14px;
+  }
 
+  // Only add a custom underline if the component is linkable
+  .govuk-back-link[href] {
     // Use border-bottom rather than text-decoration so that the arrow is
     // underlined as well.
     border-bottom: 1px solid govuk-colour("black");
@@ -30,22 +33,22 @@
     &:focus {
       border-bottom-color: transparent;
     }
+  }
 
-    // Prepend left pointing arrow
-    &:before {
-      @include govuk-shape-arrow($direction: left, $base: 10px, $height: 6px);
+  // Prepend left pointing arrow
+  .govuk-back-link:before {
+    @include govuk-shape-arrow($direction: left, $base: 10px, $height: 6px);
 
-      content: "";
+    content: "";
 
-      // Vertically align with the parent element
-      position: absolute;
+    // Vertically align with the parent element
+    position: absolute;
 
-      top: 0;
-      bottom: 0;
-      left: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
 
-      margin: auto;
-    }
+    margin: auto;
   }
 
   @if $govuk-use-legacy-font {


### PR DESCRIPTION
"Browser default behaviour is to underline anchors only when an href is provided. This is to ensure users can identify links on a page (an anchor without an href is not considered a link by default).

This feature also has the side effect of helping developers realise that
they may have missed an href attribute - as they can visually see on the
page that a link is not underlined."

Fixes https://github.com/alphagov/govuk-frontend/issues/1171