### PR TITLE
Remove stray '^' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You should also use:
 - [the JavaScript from GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#using-javascript)
 - [a separate stylesheet](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md) if you support Internet Explorer 8
 
-^ Your service will not meet level AA of WCAG 2.1 if you use [compatibility mode](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md) to use GOV.UK Frontend with old frameworks or the old colour palette.
+Your service will not meet level AA of WCAG 2.1 if you use [compatibility mode](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/compatibility.md) to use GOV.UK Frontend with old frameworks or the old colour palette.
 
 You can also read the [accessibility statement for the GOV.UK Design System](https://design-system.service.gov.uk/accessibility/).
 


### PR DESCRIPTION
A tiny PR to remove a stray '^' in the accessibility docs we just updated.