### PR TITLE
Allow attributes to be set on template <body>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New features
+
+#### Allow attributes to be set on `<body>` of template
+
+You can now set attributes in the `<body>` element of page template.
+
+- [Pull request #1623: Allow attributes to be set on template <body>](https://github.com/alphagov/govuk-frontend/pull/1623).
+
 ### Fixes
 - [Pull request #1620: Only add underline to back link when href exists ](https://github.com/alphagov/govuk-frontend/pull/1620).
 

--- a/src/govuk/template.njk
+++ b/src/govuk/template.njk
@@ -27,7 +27,7 @@
     {# image url needs to be absolute e.g. http://wwww.domain.com/.../govuk-opengraph-image.png #}
     <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
   </head>
-  <body class="govuk-template__body {{ bodyClasses }}">
+  <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     {% block bodyStart %}{% endblock %}
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1293

Corresponding guidance added in https://github.com/alphagov/govuk-design-system/pull/1071