### PR TITLE
Add tests for the template

### DIFF
--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -14,7 +14,7 @@ const sassRender = util.promisify(sass.render)
 const configPaths = require('../config/paths.json')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-nunjucks.configure(configPaths.components, {
+nunjucks.configure([configPaths.src, configPaths.components], {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -45,6 +45,11 @@ function render (componentName, params, children = false) {
   }
 
   const output = nunjucks.renderString(macroString)
+  return cheerio.load(output)
+}
+
+function renderTemplate (params = {}) {
+  const output = nunjucks.render('template.njk', params)
   return cheerio.load(output)
 }
 
@@ -101,4 +106,4 @@ function htmlWithClassName ($, className) {
   return $.html($component)
 }
 
-module.exports = { render, getExamples, htmlWithClassName, renderSass }
+module.exports = { render, getExamples, htmlWithClassName, renderSass, renderTemplate }

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -6,6 +6,7 @@ const util = require('util')
 
 const cheerio = require('cheerio')
 const nunjucks = require('nunjucks')
+const outdent = require('outdent')
 const yaml = require('js-yaml')
 
 const sass = require('node-sass')
@@ -48,8 +49,18 @@ function render (componentName, params, children = false) {
   return cheerio.load(output)
 }
 
-function renderTemplate (params = {}) {
-  const output = nunjucks.render('template.njk', params)
+function renderTemplate (params = {}, blocks = {}) {
+  let viewString = `{% extends "template.njk" %}`
+
+  for (const [blockName, blockContent] of Object.entries(blocks)) {
+    viewString += outdent`
+
+      {% block ${blockName} -%}
+        ${blockContent}
+      {%- endblock %}`
+  }
+
+  const output = nunjucks.renderString(viewString, params)
   return cheerio.load(output)
 }
 

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -43,6 +43,24 @@ describe('Template', () => {
   })
 
   describe('<head>', () => {
+    it('can have custom social media icons specified using the headIcons block', () => {
+      const headIcons = `<link rel="govuk-icon" href="/images/ytf-icon.png">`
+
+      const $ = renderTemplate({}, { headIcons })
+
+      // Build a list of the rel values of all links with a rel ending 'icon'
+      const icons = $('link[rel$="icon"]').map((_, link) => $(link).attr('rel')).get()
+      expect(icons).toEqual(['govuk-icon'])
+    })
+
+    it('can have additional content added to the <head> using the head block', () => {
+      const head = `<meta property="foo" content="bar">`
+
+      const $ = renderTemplate({}, { head })
+
+      expect($('head meta[property="foo"]').attr('content')).toEqual('bar')
+    })
+
     describe('<meta name="theme-color">', () => {
       it('has a default content of #0b0c0c', () => {
         const $ = renderTemplate()
@@ -60,6 +78,11 @@ describe('Template', () => {
       it(`defaults to '${expectedTitle}'`, () => {
         const $ = renderTemplate()
         expect($('title').text()).toEqual(expectedTitle)
+      })
+
+      it('can be overridden using the pageTitle block', () => {
+        const $ = renderTemplate({}, { pageTitle: 'Foo' })
+        expect($('title').text()).toEqual('Foo')
       })
 
       it('does not have a lang attribute by default', () => {
@@ -85,6 +108,44 @@ describe('Template', () => {
       expect($('body').attr('data-foo')).toEqual('bar')
     })
 
+    it('can have additional content added after the opening tag using bodyStart block', () => {
+      const bodyStart = `<div>bodyStart</div>`
+
+      const $ = renderTemplate({}, { bodyStart })
+
+      expect($('body > div:first-of-type').text()).toEqual('bodyStart')
+    })
+
+    it('can have additional content added before the closing tag using bodyEnd block', () => {
+      const bodyEnd = `<div>bodyEnd</div>`
+
+      const $ = renderTemplate({}, { bodyEnd })
+
+      expect($('body > div:last-of-type').text()).toEqual('bodyEnd')
+    })
+
+    describe('skip link', () => {
+      it('can be overridden using the skipLink block', () => {
+        const skipLink = `<div class="my-skip-link">skipLink</div>`
+
+        const $ = renderTemplate({}, { skipLink })
+
+        expect($('.my-skip-link').length).toEqual(1)
+        expect($('.govuk-skip-link').length).toEqual(0)
+      })
+    })
+
+    describe('header', () => {
+      it('can be overridden using the header block', () => {
+        const header = `<div class="my-header">header</div>`
+
+        const $ = renderTemplate({}, { header })
+
+        expect($('.my-header').length).toEqual(1)
+        expect($('.govuk-header').length).toEqual(0)
+      })
+    })
+
     describe('<main>', () => {
       it('has role="main", supporting browsers that do not natively support HTML5 elements', () => {
         const $ = renderTemplate()
@@ -104,6 +165,42 @@ describe('Template', () => {
       it('can have a lang attribute specified using mainLang', () => {
         const $ = renderTemplate({ mainLang: 'zu' })
         expect($('main').attr('lang')).toEqual('zu')
+      })
+
+      it('can be overridden using the main block', () => {
+        const main = `<main class="my-main">header</main>`
+
+        const $ = renderTemplate({}, { main })
+
+        expect($('main').length).toEqual(1)
+        expect($('main').hasClass('my-main')).toBe(true)
+      })
+
+      it('can have content injected before it using the beforeContent block', () => {
+        const beforeContent = `<div class="before-content">beforeContent</div>`
+
+        const $ = renderTemplate({}, { beforeContent })
+
+        expect($('.before-content').next().is('main')).toBe(true)
+      })
+
+      it('can have content specified using the content block', () => {
+        const content = 'Foo'
+
+        const $ = renderTemplate({}, { content })
+
+        expect($('main').text().trim()).toEqual('Foo')
+      })
+    })
+
+    describe('footer', () => {
+      it('can be overridden using the footer block', () => {
+        const footer = `<div class="my-footer">footer</div>`
+
+        const $ = renderTemplate({}, { footer })
+
+        expect($('.my-footer').length).toEqual(1)
+        expect($('.govuk-footer').length).toEqual(0)
       })
     })
   })

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -86,6 +86,11 @@ describe('Template', () => {
     })
 
     describe('<main>', () => {
+      it('has role="main", supporting browsers that do not natively support HTML5 elements', () => {
+        const $ = renderTemplate()
+        expect($('main').attr('role')).toEqual('main')
+      })
+
       it('can have custom classes added using mainClasses', () => {
         const $ = renderTemplate({ mainClasses: 'custom-main-class' })
         expect($('main').hasClass('custom-main-class')).toBeTruthy()

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -61,6 +61,34 @@ describe('Template', () => {
       expect($('head meta[property="foo"]').attr('content')).toEqual('bar')
     })
 
+    it('uses a default assets path of /assets', () => {
+      const $ = renderTemplate()
+      const $icon = $('link[rel="shortcut icon"]')
+
+      expect($icon.attr('href')).toEqual('/assets/images/favicon.ico')
+    })
+
+    it('can have the assets path overridden using assetPath', () => {
+      const $ = renderTemplate({ assetPath: '/whatever' })
+      const $icon = $('link[rel="shortcut icon"]')
+
+      expect($icon.attr('href')).toEqual('/whatever/images/favicon.ico')
+    })
+
+    it('uses a default assets URL of whatever assetPath is', () => {
+      const $ = renderTemplate({ assetPath: '/whatever' })
+      const $ogImage = $('meta[property="og:image"]')
+
+      expect($ogImage.attr('content')).toEqual('/whatever/images/govuk-opengraph-image.png')
+    })
+
+    it('can have the assets URL overridden using assetUrl', () => {
+      const $ = renderTemplate({ assetUrl: '//a.gov.uk' })
+      const $ogImage = $('meta[property="og:image"]')
+
+      expect($ogImage.attr('content')).toEqual('//a.gov.uk/images/govuk-opengraph-image.png')
+    })
+
     describe('<meta name="theme-color">', () => {
       it('has a default content of #0b0c0c', () => {
         const $ = renderTemplate()

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -3,6 +3,8 @@
 const nunjucks = require('nunjucks')
 const configPaths = require('../../config/paths.json')
 
+const { renderTemplate } = require('../../lib/jest-helpers')
+
 describe('Template', () => {
   describe('with default nunjucks configuration', () => {
     it('should not have any whitespace before the doctype', () => {
@@ -11,6 +13,7 @@ describe('Template', () => {
       expect(output.charAt(0)).toEqual('<')
     })
   })
+
   describe('with nunjucks block trimming enabled', () => {
     it('should not have any whitespace before the doctype', () => {
       nunjucks.configure(configPaths.src, {
@@ -19,6 +22,84 @@ describe('Template', () => {
       })
       const output = nunjucks.render('./template.njk')
       expect(output.charAt(0)).toEqual('<')
+    })
+  })
+
+  describe('<html>', () => {
+    it('defaults to lang="en"', () => {
+      const $ = renderTemplate()
+      expect($('html').attr('lang')).toEqual('en')
+    })
+
+    it('can have a custom lang set using htmlLang', () => {
+      const $ = renderTemplate({ htmlLang: 'zu' })
+      expect($('html').attr('lang')).toEqual('zu')
+    })
+
+    it('can have custom classes added using htmlClasses', () => {
+      const $ = renderTemplate({ htmlClasses: 'my-custom-class' })
+      expect($('html').hasClass('my-custom-class')).toBeTruthy()
+    })
+  })
+
+  describe('<head>', () => {
+    describe('<meta name="theme-color">', () => {
+      it('has a default content of #0b0c0c', () => {
+        const $ = renderTemplate()
+        expect($('meta[name="theme-color"]').attr('content')).toEqual('#0b0c0c')
+      })
+
+      it('can be overridden using themeColor', () => {
+        const $ = renderTemplate({ themeColor: '#ff69b4' })
+        expect($('meta[name="theme-color"]').attr('content')).toEqual('#ff69b4')
+      })
+    })
+
+    describe('<title>', () => {
+      const expectedTitle = 'GOV.UK - The best place to find government services and information'
+      it(`defaults to '${expectedTitle}'`, () => {
+        const $ = renderTemplate()
+        expect($('title').text()).toEqual(expectedTitle)
+      })
+
+      it('does not have a lang attribute by default', () => {
+        const $ = renderTemplate()
+        expect($('title').attr('lang')).toBeUndefined()
+      })
+
+      it('can have a lang attribute specified using pageTitleLang', () => {
+        const $ = renderTemplate({ pageTitleLang: 'zu' })
+        expect($('title').attr('lang')).toEqual('zu')
+      })
+    })
+  })
+
+  describe('<body>', () => {
+    it('can have custom classes added using bodyClasses', () => {
+      const $ = renderTemplate({ bodyClasses: 'custom-body-class' })
+      expect($('body').hasClass('custom-body-class')).toBeTruthy()
+    })
+
+    it('can have custom attributes added using bodyAttributes', () => {
+      const $ = renderTemplate({ bodyAttributes: { 'data-foo': 'bar' } })
+      expect($('body').attr('data-foo')).toEqual('bar')
+    })
+
+    describe('<main>', () => {
+      it('can have custom classes added using mainClasses', () => {
+        const $ = renderTemplate({ mainClasses: 'custom-main-class' })
+        expect($('main').hasClass('custom-main-class')).toBeTruthy()
+      })
+
+      it('does not have a lang attribute by default', () => {
+        const $ = renderTemplate()
+        expect($('main').attr('lang')).toBeUndefined()
+      })
+
+      it('can have a lang attribute specified using mainLang', () => {
+        const $ = renderTemplate({ mainLang: 'zu' })
+        expect($('main').attr('lang')).toEqual('zu')
+      })
     })
   })
 })


### PR DESCRIPTION
Add tests for the variables and blocks used by the [page template](https://design-system.service.gov.uk/styles/page-template/).

Fixes #1624 

## Example output

```
  Template
    with default nunjucks configuration
      ✓ should not have any whitespace before the doctype (55ms)
    with nunjucks block trimming enabled
      ✓ should not have any whitespace before the doctype (24ms)
    <html>
      ✓ defaults to lang="en" (28ms)
      ✓ can have a custom lang set using htmlLang (6ms)
      ✓ can have custom classes added using htmlClasses (9ms)
    <head>
      ✓ can have custom social media icons specified using the headIcons block (7ms)
      ✓ can have additional content added to the <head> using the head block (6ms)
      ✓ uses a default assets path of /assets (5ms)
      ✓ can have the assets path overridden using assetPath (5ms)
      ✓ uses a default assets URL of whatever assetPath is (4ms)
      ✓ can have the assets URL overridden using assetUrl (6ms)
      <meta name="theme-color">
        ✓ has a default content of #0b0c0c (5ms)
        ✓ can be overridden using themeColor (5ms)
      <title>
        ✓ defaults to 'GOV.UK - The best place to find government services and information' (5ms)
        ✓ can be overridden using the pageTitle block (5ms)
        ✓ does not have a lang attribute by default (5ms)
        ✓ can have a lang attribute specified using pageTitleLang (9ms)
    <body>
      ✓ can have custom classes added using bodyClasses (5ms)
      ✓ can have custom attributes added using bodyAttributes (4ms)
      ✓ can have additional content added after the opening tag using bodyStart block (6ms)
      ✓ can have additional content added before the closing tag using bodyEnd block (6ms)
      skip link
        ✓ can be overridden using the skipLink block (5ms)
      header
        ✓ can be overridden using the header block (4ms)
      <main>
        ✓ has role="main", supporting browsers that do not natively support HTML5 elements (4ms)
        ✓ can have custom classes added using mainClasses (4ms)
        ✓ does not have a lang attribute by default (4ms)
        ✓ can have a lang attribute specified using mainLang (5ms)
        ✓ can be overridden using the main block (6ms)
        ✓ can have content injected before it using the beforeContent block (5ms)
        ✓ can have content specified using the content block (6ms)
      footer
        ✓ can be overridden using the footer block (4ms)
```