### PR TITLE
Ensure all *.scss files are linted

### DIFF
--- a/app/assets/scss/partials/_app.scss
+++ b/app/assets/scss/partials/_app.scss
@@ -6,13 +6,12 @@
   @include govuk-width-container(1200px);
 }
 
+// Injected into the preview page, that is then put in an iframe
 .app-iframe-in-component-preview {
   margin: 15px 0;
 }
-/* Injected into the preview page, that is then put in an iframe */
-.app-iframe-in-component-preview {}
 
-/* Removes the breakpoint sass-mq debug display */
+// Removes the breakpoint sass-mq debug display
 .app-iframe-in-component-preview:before {
   display: none;
 }
@@ -23,33 +22,35 @@
 
 .app-component-preview {
   position: relative;
+  width: 100%;
   margin-top: -15px;
   margin-bottom: 15px;
-  width: 100%;
 }
 
 .app-component-preview__iframe {
-  z-index: 20;
   display: block;
   position: relative;
-  border: none;
+  z-index: 20;
   width: 100%;
+  border: 0;
 }
 
 // Highlight the whitespace around a component, so you can see without having to
 // inspect it.
 .app-iframe-in-component-preview {
+  $app-preview-border-colour: #e4f2ff;
+
   .app-whitespace-highlight {
     @include govuk-clearfix;
 
     content: " ";
     display: table;
-    clear: both;
     width: 100%;
-    box-shadow: 0 0 0 5px #e4f2ff;
+    clear: both;
+    box-shadow: 0 0 0 5px $app-preview-border-colour;
 
     @include govuk-if-ie8 {
-      outline: 5px solid #e4f2ff;
+      outline: 5px solid $app-preview-border-colour;
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "ie 8-11",
     "iOS >= 9"
   ],
+  "sasslintConfig": "config/.sass-lint.yml",
   "standard": {
     "globals": [
       "page",

--- a/tasks/gulp/lint.js
+++ b/tasks/gulp/lint.js
@@ -7,10 +7,11 @@ const sasslint = require('gulp-sass-lint')
 // Scss lint check -----------------------
 // ---------------------------------------
 gulp.task('scss:lint', () => {
-  return gulp.src(configPaths.src + '**/*.scss')
-    .pipe(sasslint({
-      configFile: configPaths.config + '.sass-lint.yml'
-    }))
+  return gulp.src([
+    configPaths.app + '**/*.scss',
+    configPaths.src + '**/*.scss'
+  ])
+    .pipe(sasslint())
     .pipe(sasslint.format())
     .pipe(sasslint.failOnError())
 })


### PR DESCRIPTION
Morning 👋 

I've been working on a different pull request to this one, but I've split this out:

1. My code editor (and others) don't _see_ the **.sass-lint.yaml** config
Why? In this project it has a custom path `./config/.sass-lint.yml`

2. Only `./src` _*.scss_ files get run through **sass-lint**, not `./app`
I've updated the paths and fixed the linting issues.

There was a "magic hex" value used by the iframe component previews:

```css
.app-iframe-in-component-preview {
  box-shadow: 0 0 0 5px #e4f2ff;
}
```

Which I've moved to a variable, it's not quite a variation on a palette colour.