### PR TITLE
Update links for polyfilling guidance

### DIFF
--- a/docs/contributing/polyfilling.md
+++ b/docs/contributing/polyfilling.md
@@ -9,23 +9,23 @@ You can use resources such as [caniuse.com](https://caniuse.com/) and [developer
 In this example we’ve looked at [caniuse addEventListener](https://caniuse.com/#search=addEventListener) and seen that it’s not supported in IE8.
 
 2. Use polyfill.io service to generate the polyfill required
-You can [use the library](https://github.com/Financial-Times/polyfill-service#getpolyfillsoptions-method) to do this or [use their CDN](https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always) directly: `https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always`
+You can [use the library](https://github.com/Financial-Times/polyfill-library) to do this or [use their CDN](https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always) directly: `https://cdn.polyfill.io/v2/polyfill.js?features=Event&flags=always`
 
-Then save this in the same structure that is used in the main project (https://github.com/Financial-Times/polyfill-service/tree/master/packages/polyfill-library/polyfills)
+Then save this in the same structure that is used in the main project (https://github.com/Financial-Times/polyfill-library/tree/master/polyfills)
 
 3. Use polyfill.io service to get detection script
 
 We need to make sure we only run the polyfills if they’re needed.
 
 We can take the associated detection code from
-https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/Event/detect.js
 
 4. Put everything together
 
 ```js
 (function(undefined) {
 
-    // Detection from https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Event/detect.js
+    // Detection from https://github.com/Financial-Times/polyfill-library/blob/master/polyfills/Event/detect.js
     var detect = (
       // code goes here
     )


### PR DESCRIPTION
The project has now split the library out from the service itself, note that could be improvements to our polyfilling strategy in the future based on this too.