### PR TITLE
Ensure footer links look clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ If you're using Nunjucks, you can now add classes to the character count compone
 ### Fixes
 
 - [Pull request #1676: Fix skip link component focus style with global styles enabled](https://github.com/alphagov/govuk-frontend/pull/1676).
+- [Pull request #1672: Ensure footer links look clickable](https://github.com/alphagov/govuk-frontend/pull/1672).
 - [Pull request #1670: Make width-container margins more targetted to avoid specificity issues](https://github.com/alphagov/govuk-frontend/pull/1670).
 - [Pull request #1655: Ensure components use public `govuk-media-query` mixin](https://github.com/alphagov/govuk-frontend/pull/1655).
 - [Pull request #1648: Update checkboxes and radio buttons to include item hint classes on item hint](https://github.com/alphagov/govuk-frontend/pull/1648)

--- a/src/govuk/components/footer/_footer.scss
+++ b/src/govuk/components/footer/_footer.scss
@@ -77,19 +77,6 @@
     }
   }
 
-  // Internet Explorer 8 does not support `:not()` selectors, so don't conditionally show underlines.
-  @include govuk-not-ie8 {
-    .govuk-footer__inline-list .govuk-footer__link,
-    .govuk-footer__list .govuk-footer__link {
-      text-decoration: none;
-
-      &:hover:not(:focus),
-      &:active:not(:focus) {
-        text-decoration: underline;
-      }
-    }
-  }
-
   .govuk-footer__section-break {
     margin: 0; // Reset `<hr>` default margins
     @include govuk-responsive-margin(8, "bottom");


### PR DESCRIPTION
We originally removed the underlines from these links to make them consistent with the approach we have for the header component.

Many community members have asked why we have made this change, and justification seems to be related to allowing a better hover state.

This makes sense but is not consistent with our other components, for example:

- back link
- breadcrumbs
- error summary links
- tabs component 

do not have a distinct hover state.

I think we should [consider hover states (and touch states) at a system level](https://github.com/alphagov/govuk-frontend/issues/1417#issuecomment-561601401) separately.

In the meantime we can make sure that the links in the footer have the affordance of links, as we did not have any evidence from users that removing these underlines is helpful.

Original reasoning for removing underlines: https://github.com/alphagov/govuk-frontend/pull/1321#issuecomment-549364442

## Screenshots

### Before without underlines
![](https://user-images.githubusercontent.com/2445413/70452102-78ad4e00-1a9e-11ea-8967-5d9b05e32160.png)

### After with underlines
![](https://user-images.githubusercontent.com/2445413/70452116-7f3bc580-1a9e-11ea-8953-a8ddc2483a11.png)

