### PR TITLE
Fix skip link component focus style with global styles enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- [Pull request #1676: Fix skip link component focus style with global styles enabled](https://github.com/alphagov/govuk-frontend/pull/1676).
 - [Pull request #1670: Make width-container margins more targetted to avoid specificity issues](https://github.com/alphagov/govuk-frontend/pull/1670).
 - [Pull request #1655: Ensure components use public `govuk-media-query` mixin](https://github.com/alphagov/govuk-frontend/pull/1655).
 - [Pull request #1638: Check component item arrays are not empty before outputting markup](https://github.com/alphagov/govuk-frontend/pull/1638).

--- a/src/govuk/components/skip-link/_skip-link.scss
+++ b/src/govuk/components/skip-link/_skip-link.scss
@@ -26,6 +26,12 @@
     &:focus {
       outline: $govuk-focus-width solid $govuk-focus-colour;
       background-color: $govuk-focus-colour;
+
+      // Undo unwanted changes when global styles are enabled
+      @if ($govuk-global-styles) {
+        box-shadow: none;
+        text-decoration: underline;
+      }
     }
   }
 }


### PR DESCRIPTION
When global styles are enabled the skip link focus state is changed removing the underline which is not consistent with the regular component.

## Screenshots

### Before
<img width="642" alt="" src="https://user-images.githubusercontent.com/2445413/70535501-19f6db80-1b55-11ea-8885-5618540c2cbf.png">

### After
<img width="650" alt="" src="https://user-images.githubusercontent.com/2445413/70535502-1a8f7200-1b55-11ea-8e72-35b570ed7f2c.png">

Fixes https://github.com/alphagov/govuk-frontend/issues/1641