### PR TITLE
Fix tabs component throwing JavaScript errors in Internet Explorer 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you're using Nunjucks, you can now add classes to the character count compone
 
 ### Fixes
 
+- [Pull request #1678: Fix tabs component throwing JavaScript errors in Internet Explorer 8](https://github.com/alphagov/govuk-frontend/pull/1678).
 - [Pull request #1676: Fix skip link component focus style with global styles enabled](https://github.com/alphagov/govuk-frontend/pull/1676).
 - [Pull request #1672: Ensure footer links look clickable](https://github.com/alphagov/govuk-frontend/pull/1672).
 - [Pull request #1670: Make width-container margins more targetted to avoid specificity issues](https://github.com/alphagov/govuk-frontend/pull/1670).

--- a/src/govuk/vendor/polyfills/Element/prototype/nextElementSibling.js
+++ b/src/govuk/vendor/polyfills/Element/prototype/nextElementSibling.js
@@ -13,12 +13,13 @@ import '../../Element'
 
     (function (global) {
 
-      // Polyfill from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-404b69b4750d18dea4174930a49170fd
+      // There is no polyfill in polyfill-library (https://github.com/Financial-Times/polyfill-library/issues/338)
+      // So we source this from https://github.com/Alhadis/Snippets/blob/e09b4dfb7ffc9e250bc28319051e39ead3e5f70a/js/polyfills/IE8-child-elements.js#L28-L33
       Object.defineProperty(Element.prototype, "nextElementSibling", {
         get: function(){
           var el = this.nextSibling;
           while (el && el.nodeType !== 1) { el = el.nextSibling; }
-          return (el.nodeType === 1) ? el : null;
+          return el;
         }
       });
 

--- a/src/govuk/vendor/polyfills/Element/prototype/previousElementSibling.js
+++ b/src/govuk/vendor/polyfills/Element/prototype/previousElementSibling.js
@@ -11,12 +11,13 @@ import '../../Element'
     if (detect) return
 
     (function (global) {
-      // Polyfill from https://github.com/Financial-Times/polyfill-service/pull/1062/files#diff-b45a1197b842728cb76b624b6ba7d739
+      // There is no polyfill in polyfill-library (https://github.com/Financial-Times/polyfill-library/issues/338)
+      // So we source this from https://github.com/Alhadis/Snippets/blob/e09b4dfb7ffc9e250bc28319051e39ead3e5f70a/js/polyfills/IE8-child-elements.js#L35-L40
       Object.defineProperty(Element.prototype, 'previousElementSibling', {
         get: function(){
           var el = this.previousSibling;
           while (el && el.nodeType !== 1) { el = el.previousSibling; }
-          return (el.nodeType === 1) ? el : null;
+          return el;
         }
       });
 


### PR DESCRIPTION
In Internet Explorer 8 errors are thrown when checking the nodeType as nextSibling is undefined, so to fix this issue I've reverted to a previous version of the code.

We previously updated this pull request to mirror a pull request in the polyfill-service repository for consistency here: https://github.com/alphagov/govuk-frontend/pull/1359/commits/4997c72ff5d070ca193fd0021bd61f7d3ce199bc

Interestingly these polyfills are not in the new library so I cannot upstream this fix but I've raised an issue to see why they did not port it to the new library: https://github.com/Financial-Times/polyfill-library/issues/338

Fixes #1490