### PR TITLE
Fix date input documentation

### DIFF
--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -1,7 +1,7 @@
 params:
 - name: id
   type: string
-  required: false
+  required: true
   description: This is used for the main component and to compose id attribute for each item.
 - name: namePrefix
   type: string


### PR DESCRIPTION
I think this should ideally be called `idPrefix` instead of `id` but as that would be a breaking change we should consider this in another change.

I'm not sure the potential confusion from inconsistency between components for users warrants making this breaking change.

Closes https://github.com/alphagov/govuk-frontend/issues/1557