### PR TITLE
Remove unused id date input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you're using Nunjucks, you can now add classes to the character count compone
 
 ### Fixes
 
+- [Pull request #1699: Remove unused id in date input component wrapper](https://github.com/alphagov/govuk-frontend/pull/1699)
 - [Pull request #1690: Don't unneccesarily self-close tags](https://github.com/alphagov/govuk-frontend/pull/1690)
 - [Pull request #1678: Fix tabs component throwing JavaScript errors in Internet Explorer 8](https://github.com/alphagov/govuk-frontend/pull/1678).
 - [Pull request #1676: Fix skip link component focus style with global styles enabled](https://github.com/alphagov/govuk-frontend/pull/1676).

--- a/src/govuk/components/date-input/template.njk
+++ b/src/govuk/components/date-input/template.njk
@@ -52,8 +52,7 @@
   }) | indent(2) | trim }}
 {% endif %}
   <div class="govuk-date-input {%- if params.classes %} {{ params.classes }}{% endif %}"
-    {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {%- if params.id %} id="{{ params.id }}"{% endif %}>
+    {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
     {% for item in dateInputItems %}
     <div class="govuk-date-input__item">
       {{ govukInput({

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -30,15 +30,6 @@ describe('Date input', () => {
       expect($component.hasClass('app-date-input--custom-modifier')).toBeTruthy()
     })
 
-    it('renders with id', () => {
-      const $ = render('date-input', {
-        id: 'my-date-input'
-      })
-
-      const $component = $('.govuk-date-input')
-      expect($component.attr('id')).toEqual('my-date-input')
-    })
-
     it('renders with attributes', () => {
       const $ = render('date-input', {
         attributes: {


### PR DESCRIPTION
We link to the inputs from the error summary so I think this attribute is not used for anything.

For reviewers:

Am I right in thinking this isn't being used for anything?

Is this a breaking change? My gut feeling is no if this was not doing anything but wonder what your thoughts are...

Related https://github.com/alphagov/govuk-frontend/issues/1557