### PR TITLE
Update error summary macro options descriptions

### DIFF
--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -10,11 +10,11 @@ params:
 - name: descriptionText
   type: string
   required: false
-  description: Text to use for the description of the errors. If `descriptionHtml` is provided,  `descriptionText` will be ignored.
+  description: Text to use for the description of the errors. If you set `descriptionHtml`, the component will ignore `descriptionText`.
 - name: descriptionHtml
   type: string
   required: false
-  description: HTML to use for the description of the errors. If `descriptionHtml` is provided, `descriptionText` will be ignored.
+  description: HTML to use for the description of the errors. If you set this option, the component will ignore `descriptionText`.
 
 - name: errorList
   type: array

--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -10,11 +10,11 @@ params:
 - name: descriptionText
   type: string
   required: false
-  description: If `descriptionHtml` is set, this is not required. Text to use for the description of the errors. If `descriptionHtml` is provided,  `descriptionText` will be ignored.
+  description: Text to use for the description of the errors. If `descriptionHtml` is provided,  `descriptionText` will be ignored.
 - name: descriptionHtml
   type: string
-  required: true
-  description: If `descriptionText` is set, this is not required. HTML to use for the description of the errors. If `descriptionHtml` is provided, `descriptionText` will be ignored.
+  required: false
+  description: HTML to use for the description of the errors. If `descriptionHtml` is provided, `descriptionText` will be ignored.
 
 - name: errorList
   type: array


### PR DESCRIPTION
Neither `descriptionText` nor `descriptionHtml` are required, so this updates the documentation to make this clearer.