### PR TITLE
Additional Tag modifier classes for different colours

### DIFF
--- a/src/govuk/components/tag/_tag.scss
+++ b/src/govuk/components/tag/_tag.scss
@@ -41,4 +41,50 @@
   .govuk-tag--inactive {
     background-color: govuk-colour("dark-grey", $legacy: "grey-1");
   }
+
+  .govuk-tag--grey {
+    color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
+    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+  }
+
+  .govuk-tag--purple {
+    color: govuk-shade(govuk-colour("purple"), 20);
+    background: govuk-tint(govuk-colour("purple"), 80);
+  }
+
+  .govuk-tag--turquoise {
+    color: govuk-shade(govuk-colour("turquoise"), 60);
+    background: govuk-tint(govuk-colour("turquoise"), 70);
+  }
+
+  .govuk-tag--blue {
+    color: govuk-shade(govuk-colour("blue"), 30);
+    background: govuk-tint(govuk-colour("blue"), 80);
+  }
+
+  .govuk-tag--yellow {
+    color: govuk-shade(govuk-colour("yellow"), 65);
+    background: govuk-tint(govuk-colour("yellow"), 75);
+  }
+
+  .govuk-tag--orange {
+    color: govuk-shade(govuk-colour("orange"), 55);
+    background: govuk-tint(govuk-colour("orange"), 70);
+  }
+
+  .govuk-tag--red {
+    color: govuk-shade(govuk-colour("red"), 30);
+    background: govuk-tint(govuk-colour("red"), 80);
+  }
+
+  .govuk-tag--pink {
+    color: govuk-shade(govuk-colour("pink"), 40);
+    background: govuk-tint(govuk-colour("pink"), 80);
+  }
+
+  .govuk-tag--green {
+    color: govuk-shade(govuk-colour("green"), 20);
+    background: govuk-tint(govuk-colour("green"), 80);
+  }
+
 }

--- a/src/govuk/components/tag/_tag.scss
+++ b/src/govuk/components/tag/_tag.scss
@@ -38,6 +38,7 @@
     }
   }
 
+  // Deprecated. We'll remove this class in a future release. Use `.govuk-tag--grey` instead.
   .govuk-tag--inactive {
     background-color: govuk-colour("dark-grey", $legacy: "grey-1");
   }

--- a/src/govuk/components/tag/tag.yaml
+++ b/src/govuk/components/tag/tag.yaml
@@ -24,3 +24,39 @@ examples:
    data:
     text: alpha
     classes: govuk-tag--inactive
+ - name: grey
+   data:
+    text: Grey
+    classes: govuk-tag--grey
+ - name: blue
+   data:
+    text: Blue
+    classes: govuk-tag--blue
+ - name: turquoise
+   data:
+    text: Turquoise
+    classes: govuk-tag--turquoise
+ - name: green
+   data:
+    text: Green
+    classes: govuk-tag--green
+ - name: purple
+   data:
+    text: Purple
+    classes: govuk-tag--purple
+ - name: pink
+   data:
+    text: Pink
+    classes: govuk-tag--pink
+ - name: red
+   data:
+    text: Red
+    classes: govuk-tag--red
+ - name: orange
+   data:
+    text: Orange
+    classes: govuk-tag--orange
+ - name: yellow
+   data:
+    text: Yellow
+    classes: govuk-tag--yellow


### PR DESCRIPTION
I spoke with @36degrees and then @timpaul about contributing additional Tag component styles via modifier classes. A lot of services (citizen-facing and internal) use the Tag component for different statuses.

Most of the time, different colours are used as an enhancement to spot those different states easily. Most of the designs I've seen put white text on coloured backgrounds. At DfE we did the same but they fail contrast requirements.

So we now uses these styles which are accessible and use the tints and shades of the GOV.UK colour palette.

More information here:
https://github.com/alphagov/govuk-design-system-backlog/issues/62#issuecomment-570575887

Note:

1. I would usually look for meaningful names for modifier classes like ‘urgent’ but statuses are often unique to the system and so I used colours for the class names giving users flexibility.

2. I still need to add guidance / examples to the design system repo. I'm not sure what the process is on that i.e. do I wait for this to be merged or something more elaborate?

Screenshot:

![image](https://user-images.githubusercontent.com/37163/73183304-7ec0c200-4112-11ea-91ff-164bada88a2e.png)


