### PR TITLE
Add display override for hiding content when printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### New features
 
+#### Add display override for hiding content when printing
+
+Introduce a CSS class that can be used to hide any given element from the print view: `govuk-!-display-none-print`
+
+[Pull request #1723: Add display override for hiding content when printing](https://github.com/alphagov/govuk-frontend/pull/1723).
+
 ### Fixes
 
 ## 3.5.0 (Feature release)

--- a/src/govuk/overrides/_display.scss
+++ b/src/govuk/overrides/_display.scss
@@ -19,4 +19,10 @@
   .govuk-\!-display-none {
     display: none !important;
   }
+
+  @include govuk-media-query($media-type: print) {
+    .govuk-\!-display-none-print {
+      display: none !important;
+    }
+  }
 }


### PR DESCRIPTION
When printing users often need to print the content without the surrounding site furniture (eg menus, breadcrumbs, back links and footers).

Introduce a helper so that a class can be used to hide any given element from the print view:
```
govuk-!-print-display-none
```

This is explicit and preferable to listing all the selectors for things that shouldn't be printed. These lists grow unwieldy over time. ([An example of one of these lists](https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/blob/bdd9c0a51dc89a1ef8aca04b3faa2354227ebafd/app/assets/sass/application.scss#L32-L41))

(We've been using this pattern on [Apply for teacher training](https://www.apply-for-teacher-training.education.gov.uk/candidate) and [Becoming a teacher: Design History](https://bat-design-history.herokuapp.com/))