### PR TITLE
Fix fallback logo being detected by chromes image description feature

### DIFF
--- a/src/govuk/components/button/template.njk
+++ b/src/govuk/components/button/template.njk
@@ -24,7 +24,7 @@
 {#- The SVG needs `focusable="false"` so that Internet Explorer does not
 treat it as an interactive element - without this it will be
 'focusable' when using the keyboard to navigate. #}
-<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" role="presentation" focusable="false">
+<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
   <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"/>
 </svg>
   {% endset %}

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -54,7 +54,7 @@
         treat it as an interactive element - without this it will be
         'focusable' when using the keyboard to navigate. #}
         <svg
-          role="presentation"
+          aria-hidden="true"
           focusable="false"
           class="govuk-footer__licence-logo"
           xmlns="http://www.w3.org/2000/svg"

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -17,7 +17,7 @@
           treat it as an interactive element - without this it will be
           'focusable' when using the keyboard to navigate. #}
           <svg
-            role="presentation"
+            aria-hidden="true"
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -144,8 +144,8 @@ describe('header', () => {
       expect($svg.attr('focusable')).toEqual('false')
     })
 
-    it('sets role="presentation" so that it is ignored by assistive technologies', () => {
-      expect($svg.attr('focusable')).toEqual('false')
+    it('sets aria-hidden="true" so that it is ignored by assistive technologies', () => {
+      expect($svg.attr('aria-hidden')).toEqual('true')
     })
 
     describe('fallback PNG', () => {


### PR DESCRIPTION
role="none"/"presentational" does not do enough to hide the child fallback image used in older browsers.

We have found that Chrome's new "Get image descriptions from Google" feature will notice this fallback image.

This means when screenreaders such as NVDA visit the logo, it'll announce "Unlabelled graphic, To get missing image descriptions, open the context menu." for this fallback image.

By using aria-hidden="true" we can ensure that the SVG and it's children are all hidden from the accessibility tree, which I have confirmed in NVDA + Chrome.

I have also made this change to the other places we're using role="presentation" in this way for consistency.

- [Get image descriptions on Chrome](https://support.google.com/chrome/answer/9311597?hl=en)
- [The Difference Between role=”presentation” and aria-hidden=”true”](https://timwright.org/blog/2016/11/19/difference-rolepresentation-aria-hiddentrue/)

Closes https://github.com/alphagov/govuk-frontend/issues/1636