### PR TITLE
Update skip link macro param documentation

### DIFF
--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -10,7 +10,7 @@ params:
 - name: href
   type: string
   required: false
-  description: The value of the skip link's `href` attribute. Defaults to `#content` if you do not provide a value.
+  description: The value of the skip link’s `href` attribute. Defaults to `#content` if you do not provide a value.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -10,7 +10,7 @@ params:
 - name: href
   type: string
   required: false
-  description: The value of the skip link href attribute. Defaults to `#content` if not provided.
+  description: The value of the skip link's `href` attribute. Defaults to `#content` if you do not provide a value.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -9,8 +9,8 @@ params:
   description: If `text` is set, this is not required. HTML to use within the skip link component. If `html` is provided, the `text` argument will be ignored.
 - name: href
   type: string
-  required: true
-  description: The value of the skip link href attribute. Defaults to #content
+  required: false
+  description: The value of the skip link href attribute. Defaults to `#content` if not provided.
 - name: classes
   type: string
   required: false


### PR DESCRIPTION
The `#content` is currently not displaying on https://design-system.service.gov.uk/components/skip-link/ as it is being interpreted as a comment within the YAML file.

The `href` param also doesn't seem to be strictly "required", as a default value is specified.