### PR TITLE
Deprecate iff function

### DIFF
--- a/src/govuk/helpers/_spacing.scss
+++ b/src/govuk/helpers/_spacing.scss
@@ -82,16 +82,16 @@
     @if $breakpoint == null {
 
       @if $direction == all {
-        #{$property}: $breakpoint-value iff($important, !important);
+        #{$property}: $breakpoint-value if($important, !important, null);
       } @else {
-        #{$property}-#{$direction}: $breakpoint-value iff($important, !important);
+        #{$property}-#{$direction}: $breakpoint-value if($important, !important, null);
       }
     } @else {
       @include govuk-media-query($from: $breakpoint) {
         @if $direction == all {
-          #{$property}: $breakpoint-value iff($important, !important);
+          #{$property}: $breakpoint-value if($important, !important, null);
         } @else {
-          #{$property}-#{$direction}: $breakpoint-value iff($important, !important);
+          #{$property}-#{$direction}: $breakpoint-value if($important, !important, null);
         }
       }
     }

--- a/src/govuk/helpers/_typography.scss
+++ b/src/govuk/helpers/_typography.scss
@@ -53,7 +53,7 @@
 /// @access public
 
 @mixin govuk-typography-weight-regular($important: false) {
-  font-weight: $govuk-font-weight-regular iff($important, !important);
+  font-weight: $govuk-font-weight-regular if($important, !important, null);
 }
 
 /// Bold font weight helper
@@ -63,7 +63,7 @@
 /// @access public
 
 @mixin govuk-typography-weight-bold($important: false) {
-  font-weight: $govuk-font-weight-bold iff($important, !important);
+  font-weight: $govuk-font-weight-bold if($important, !important, null);
 }
 
 /// Convert line-heights specified in pixels into a relative value, unless
@@ -137,9 +137,9 @@
     // Mark rules as !important if $important is true - this will result in
     // these variables becoming strings, so this needs to happen *after* they
     // are used in calculations
-    $font-size: $font-size iff($important, !important);
-    $font-size-rem: $font-size-rem iff($important, !important);
-    $line-height: $line-height iff($important, !important);
+    $font-size: $font-size if($important, !important, null);
+    $font-size-rem: $font-size-rem if($important, !important, null);
+    $line-height: $line-height if($important, !important, null);
 
     @if $breakpoint == null {
       font-size: $font-size; // sass-lint:disable no-duplicate-properties

--- a/src/govuk/helpers/_visually-hidden.scss
+++ b/src/govuk/helpers/_visually-hidden.scss
@@ -14,25 +14,25 @@
 /// @access public
 
 @mixin govuk-visually-hidden($important: true) {
-  position: absolute iff($important, !important);
+  position: absolute if($important, !important, null);
 
-  width: 1px iff($important, !important);
-  height: 1px iff($important, !important);
+  width: 1px if($important, !important, null);
+  height: 1px if($important, !important, null);
   // If margin is set to a negative value it can cause text to be announced in
   // the wrong order in VoiceOver for OSX
-  margin: 0 iff($important, !important);
-  padding: 0 iff($important, !important);
+  margin: 0 if($important, !important, null);
+  padding: 0 if($important, !important, null);
 
-  overflow: hidden iff($important, !important);
-  clip: rect(0 0 0 0) iff($important, !important);
-  clip-path: inset(50%) iff($important, !important);
+  overflow: hidden if($important, !important, null);
+  clip: rect(0 0 0 0) if($important, !important, null);
+  clip-path: inset(50%) if($important, !important, null);
 
-  border: 0 iff($important, !important);
+  border: 0 if($important, !important, null);
 
   // For long content, line feeds are not interpreted as spaces and small width
   // causes content to wrap 1 word per line:
   // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-  white-space: nowrap iff($important, !important);
+  white-space: nowrap if($important, !important, null);
 }
 
 /// Hide an element visually, but have it available for screen readers whilst
@@ -47,35 +47,35 @@
 /// @access public
 
 @mixin govuk-visually-hidden-focusable($important: true) {
-  position: absolute iff($important, !important);
+  position: absolute if($important, !important, null);
 
-  width: 1px iff($important, !important);
-  height: 1px iff($important, !important);
+  width: 1px if($important, !important, null);
+  height: 1px if($important, !important, null);
   // If margin is set to a negative value it can cause text to be announced in
   // the wrong order in VoiceOver for OSX
-  margin: 0 iff($important, !important);
+  margin: 0 if($important, !important, null);
 
-  overflow: hidden iff($important, !important);
-  clip: rect(0 0 0 0) iff($important, !important);
-  clip-path: inset(50%) iff($important, !important);
+  overflow: hidden if($important, !important, null);
+  clip: rect(0 0 0 0) if($important, !important, null);
+  clip-path: inset(50%) if($important, !important, null);
 
   // For long content, line feeds are not interpreted as spaces and small width
   // causes content to wrap 1 word per line:
   // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
-  white-space: nowrap iff($important, !important);
+  white-space: nowrap if($important, !important, null);
 
   &:active,
   &:focus {
-    position: static iff($important, !important);
+    position: static if($important, !important, null);
 
-    width: auto iff($important, !important);
-    height: auto iff($important, !important);
-    margin: inherit iff($important, !important);
+    width: auto if($important, !important, null);
+    height: auto if($important, !important, null);
+    margin: inherit if($important, !important, null);
 
-    overflow: visible iff($important, !important);
-    clip: auto iff($important, !important);
-    clip-path: none iff($important, !important);
+    overflow: visible if($important, !important, null);
+    clip: auto if($important, !important, null);
+    clip-path: none if($important, !important, null);
 
-    white-space: inherit iff($important, !important);
+    white-space: inherit if($important, !important, null);
   }
 }

--- a/src/govuk/tools/_iff.scss
+++ b/src/govuk/tools/_iff.scss
@@ -8,8 +8,10 @@
 /// @param {Boolean} $condition - Whether to return the value of `$if-true`
 /// @param {Mixed} $if-true - Value to return if `$condition` is truthy
 /// @return {Mixed} Value of `$if-true` if `$condition` is truthy, else null
-/// @access public
+/// @access private
+/// @deprecated We will be removing this function in a future release, use `if($condition, $if-true, null);` instead.
 
 @function iff($condition, $if-true) {
+  @warn "The `iff` function will be removed in a future release, use `if($condition, $if-true, null);` instead.";
   @return if($condition, $if-true, null);
 }


### PR DESCRIPTION
- make the function a private function to indicate it should not be
used.
- add warning and deprecation sassdoc to indicate it will be removed in
the future.

My main motivation for this is to ensure the Sassdocs output with only what we want users to use as they'll be public soon.

This pull request marks the function as deprecated without removing it, meaning we can give users a heads up before getting rid of it.

It also assigns it as 'private' which'll prevent it from being output in our Sassdocs output.

Related: https://github.com/alphagov/govuk-frontend/issues/1735