### PR TITLE
Update link to alphagov's CoC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/code-of-conduct).
+This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/.github/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Link to the Code of Conduct has change - this updates it to the most recent location.