### PR TITLE
Test Sass compilation against supported compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,46 @@
 language: node_js
 notifications:
   email: false
-sudo: false
-before_deploy:
-- test $TRAVIS_TEST_RESULT = 0
+
 jobs:
   include:
-    - stage: Run npm test
+    - name: 🧪 Run test suite
       script:
-      # Ensure Travis aborts without running tests if the package-lock.json file needs updating
+      # Ensure Travis aborts without running tests if the package-lock.json file
+      # needs updating
       - set -e
       - ./bin/check-package-lock.sh
-      # TravisCI is slower than our local machines, so results in intermittent timeouts
-      # using the `--runInBand` flag we can force it to without requiring as much
-      # resources (https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server)
+      # TravisCI is slower than our local machines, so results in intermittent
+      # timeouts using the `--runInBand` flag we can force it to without
+      # requiring as much resource.
+      # https://facebook.github.io/jest/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server
       - npm test -- --runInBand
-    # Heroku is configured to automatically deploy the following branches
-    # once CI passes:
-    # master         -> http://govuk-frontend-review.herokuapp.com/
+
+    # Ensure that the Sass compiles using the minimum versions of the compilers
+    # that we aim to support
+
+    - name: 📚 Test Sass compiles using LibSass v3.3.0
+      node_js: 4 # Node 4 required for oldest version of node-sass we support
+      install: npm install -g node-sass@v3.4.0 # node-sass v3.4.0 = libsass v3.3.0
+      script: 
+        - node-sass -v
+        - time node-sass src/govuk/all.scss > /dev/null
+
+    - name: 🎯 Test Sass compiles using Dart Sass v1.0.0
+      node_js: 8 # Assumed based on release date of dart-sass v1.0.0
+      install: npm install -g sass@v1.0.0
+      script: 
+        - sass --version
+        - time sass src/govuk/all.scss > /dev/null
+
+    - name: 💎 Test Sass compiles using Ruby Sass v3.4.0 (deprecated)
+      language: ruby
+      rvm: 1.9.3-p551 # Assumed based on release date of Ruby Sass v3.4.0
+      install: gem install sass -v 3.4.0
+      script: 
+        - sass -v
+        - time sass src/govuk/all.scss > /dev/null
+
+# Heroku is configured to automatically deploy the following branches
+# once CI passes:
+# master         -> http://govuk-frontend-review.herokuapp.com/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
       node_js: 4 # Node 4 required for oldest version of node-sass we support
       install: npm install -g node-sass@v3.4.0 # node-sass v3.4.0 = libsass v3.3.0
       script: 
-        - node-sass -v
+        - node-sass --version
         - time node-sass src/govuk/all.scss > /dev/null
 
     - name: 🎯 Test Sass compiles using Dart Sass v1.0.0
@@ -38,7 +38,7 @@ jobs:
       rvm: 1.9.3-p551 # Assumed based on release date of Ruby Sass v3.4.0
       install: gem install sass -v 3.4.0
       script: 
-        - sass -v
+        - sass --version
         - time sass src/govuk/all.scss > /dev/null
 
 # Heroku is configured to automatically deploy the following branches


### PR DESCRIPTION
Compile the GOV.UK Frontend Sass using the minimum version of each of the Sass compilers that we support:

- LibSass v3.3.0
- Dart Sass v1.0.0
- Ruby Sass v3.4.0 (deprecated; not recommended)

Fail the build if it fails to compile using any one of them.

We're doing this so that we have the confidence to ship releases whilst knowing that they should work with any of the Sass compilers that we support.

This also removes a before_deploy step (because we no longer have a deploy step) and the sudo key as according to Travis' config linter it has no effect any more.

Closes #1684