### PR TITLE
Update `errorMessage` option documentation with falsy value behaviour

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -40,7 +40,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component (e.g. text).
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -16,7 +16,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component (e.g. text).
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -52,7 +52,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the error message.
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -28,7 +28,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component.
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -36,7 +36,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component.
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -12,7 +12,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component (e.g. text).
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -49,7 +49,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component (e.g. text).
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -32,7 +32,7 @@ params:
 - name: errorMessage
   type: object
   required: false
-  description: Options for the errorMessage component (e.g. text).
+  description: Options for the error message component. The error message component will not display if you use a falsy value for `errorMessage`, for example `false` or `null`.
   isComponent: true
 - name: formGroup
   type: object


### PR DESCRIPTION
Updates the description of the `errorMessage` option (in all the component pages it appears) so that it's clearer that a falsy value will be ignored.

Please check if factually correct.