### PR TITLE
Update back link to same style as breadcrumbs

### DIFF
--- a/src/govuk/components/back-link/_back-link.scss
+++ b/src/govuk/components/back-link/_back-link.scss
@@ -19,25 +19,26 @@
     padding-left: 14px;
   }
 
+
   // Only add a custom underline if the component is linkable
   .govuk-back-link[href] {
     // Use border-bottom rather than text-decoration so that the arrow is
     // underlined as well.
-    border-bottom: 1px solid govuk-colour("black");
+    border-bottom: 1px solid transparent;
 
     // Underline is provided by a bottom border
-    text-decoration: none;
+    text-decoration: underline;
 
     // When the back link is focused, hide the bottom link border as the
     // focus styles has a bottom border.
     &:focus {
       border-bottom-color: transparent;
+      text-decoration: none;
     }
   }
 
-  // Prepend left pointing arrow
+  // Prepend left pointing chevron
   .govuk-back-link:before {
-    @include govuk-shape-arrow($direction: left, $base: 10px, $height: 6px);
 
     content: "";
 
@@ -45,10 +46,29 @@
     position: absolute;
 
     top: 0;
-    bottom: 0;
-    left: 0;
+    bottom: 1px;
+    left: 3px;
+    width: 7px;
+    height: 7px;
 
     margin: auto;
+    clip-path: inherit;
+    transform: rotate(225deg);
+    border: solid;
+    border-width: 1px 1px 0 0;
+
+    -webkit-transform: rotate(225deg);
+    -ms-transform: rotate(225deg);
+  }
+
+  //Append pseudo element to increase touch target
+  .govuk-back-link:after {
+    content: "";
+    position: absolute;
+    top: -14px;
+    right: 0;
+    bottom: -14px;
+    left: 0;
   }
 
   @if $govuk-use-legacy-font {
@@ -61,5 +81,4 @@
       bottom: $offset;
     }
   }
-
 }


### PR DESCRIPTION
Update styling of back link component.

Note: This is being fed back to design system from "govuk_publishing_components" used on GOV.UK

## What
Update styling on back link component and increase touch target on mobile devices. The left facing solid arrow to be replace by a left facing chevron, the underline to repositioned to be under the workding only.

## Why
Back links use an inconsistent icon from the breadcrumbs, The link also has a small touch target on mobiles. There should be consistent design patterns across GOV.UK. 

## Visual Changes
![Screenshot 2020-02-17 at 13 43 32](https://user-images.githubusercontent.com/54625020/74659295-f6bb5e80-518b-11ea-926d-9ee80ae44c7a.png)
Before change - mobile

![Screenshot 2020-02-17 at 13 44 11](https://user-images.githubusercontent.com/54625020/74659311-fde26c80-518b-11ea-8013-f655945b0347.png)
Before Change - desktop


![Screenshot 2020-02-17 at 13 42 50](https://user-images.githubusercontent.com/54625020/74659322-033fb700-518c-11ea-956b-9818de91e0be.png)
After change - mobile

![Screenshot 2020-02-17 at 13 44 54](https://user-images.githubusercontent.com/54625020/74659330-06d33e00-518c-11ea-9fd9-f73b280939ee.png)
After Change - desktop
<!-- If the change results in visual changes, show a before and after -->
