### PR TITLE
Mobile breadcrumbs show first and last only

### DIFF
--- a/src/govuk/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/govuk/components/breadcrumbs/_breadcrumbs.scss
@@ -111,4 +111,45 @@
     @include govuk-link-common;
     @include govuk-link-style-text;
   }
+
+  @include govuk-media-query($until: tablet) {
+
+    .govuk-breadcrumbs__list {
+      display: flex;
+    }
+
+    .govuk-breadcrumbs__list-item {
+      display: none;
+    }
+
+    .govuk-breadcrumbs__list-item {
+      &:first-child,
+      &:last-child {
+        display: inherit;
+      }
+    }
+
+    .govuk-breadcrumbs__list-item {
+      padding-top: 14px;
+      padding-bottom: 14px;
+    }
+
+    .govuk-breadcrumbs__list-item:before {
+      top: 18px;
+      margin: 0;
+    }
+
+    .govuk-breadcrumbs__link {
+      position: relative;
+    }
+
+    .govuk-breadcrumbs__link::after {
+      content: "";
+      position: absolute;
+      top: -14px;
+      right: 0;
+      bottom: -14px;
+      left: 0;
+    }
+  }
 }

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -68,14 +68,15 @@ examples:
       -
         text: Agile Delivery
         href: '/service-manual/agile-delivery'
-- name: with last breadcrumb as current page
+- name: with long taxon on mobile
   data:
     items:
-      -
-        text: Home
-        href: '/'
-      -
-        text: Passports, travel and living abroad
-        href: '/browse/abroad'
-      -
-        text: Travel abroad
+    -
+      text: 'Home'
+      href: '/'
+    -
+      text: 'Education, training and skills'
+      href: '/education'
+    -
+      text: 'Education of disadvantaged children appended with some extra long content to make this a very very very very long taxon'
+      href: '/education'


### PR DESCRIPTION
On mobile devices collapse the breadcrumb to first and last items instead of showing all breadcrumb items.

## What
Apply mobile enhancement designs to the GOV.UK Breadcrumb component, specifically:

- Collapse breadcrumb to show only the first and last item (the parent item) on devices less than 640px wide
- Increase the touch target padding on mobile devices
- Collapse on Mobile to be de facto behaviour
- Update the sample yaml file to show how the breadcrumb would handle long taxons

## Why


The reasoning is taken from this snippet in the trello card:

> This [article by NNG](https://www.nngroup.com/articles/breadcrumbs/) lays out the pros and cons of showing a full breadcrumb path on mobile. In short, the drawbacks of having a multi-line breadcrumb, and the need to save space on mobile, make it less useful to users. By truncating the breadcrumb we at least allow users to go backwards by one level, or home.


## Visual Changes
![Screenshot 2020-02-05 at 14 57 28](https://user-images.githubusercontent.com/54625020/74435767-22250d00-4e5d-11ea-8f6c-1719a206d193.png)
Before Change

![Screenshot 2020-02-05 at 14 56 20](https://user-images.githubusercontent.com/54625020/74435827-3a952780-4e5d-11ea-81b7-90f3f4aa0af6.png)
After Change