### PR TITLE
Make back link arrow consistent with breadcrumb component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- [Pull request #1753: Make back link arrow consistent with breadcrumb component](https://github.com/alphagov/govuk-frontend/pull/1753)
 - [Pull request #1765: Import textarea from character count](https://github.com/alphagov/govuk-frontend/pull/1765).
 - [Pull request #1778: Fix accordion underline hover state being removed when hovering plus/minus symbol](https://github.com/alphagov/govuk-frontend/pull/1778).
 

--- a/src/govuk/components/back-link/_back-link.scss
+++ b/src/govuk/components/back-link/_back-link.scss
@@ -28,19 +28,13 @@
     padding-left: 14px;
   }
 
-  // Only add a custom underline if the component is linkable
+  // Only underline if the component is linkable
   .govuk-back-link[href] {
-    // Use border-bottom rather than text-decoration so that the arrow is
-    // underlined as well.
-    border-bottom: 1px solid govuk-colour("black");
-
-    // Underline is provided by a bottom border
-    text-decoration: none;
+    text-decoration: underline;
 
     // When the back link is focused, hide the bottom link border as the
     // focus styles has a bottom border.
     &:focus {
-      border-bottom-color: transparent;
       text-decoration: none;
 
       &:before {

--- a/src/govuk/components/back-link/_back-link.scss
+++ b/src/govuk/components/back-link/_back-link.scss
@@ -4,6 +4,15 @@
 
 @include govuk-exports("govuk/component/back-link") {
 
+  // Size of chevron (excluding border)
+  $chevron-size: 7px;
+
+  // Size of chevron border
+  $chevron-border-width: 1px;
+
+  // Colour of chevron
+  $chevron-border-colour: $govuk-secondary-text-colour;
+
   .govuk-back-link {
     @include govuk-typography-responsive($size: 16);
     @include govuk-link-common;
@@ -32,23 +41,58 @@
     // focus styles has a bottom border.
     &:focus {
       border-bottom-color: transparent;
+      text-decoration: none;
+
+      &:before {
+        border-color: $govuk-text-colour;
+      }
     }
   }
 
-  // Prepend left pointing arrow
+  // Prepend left pointing chevron
   .govuk-back-link:before {
-    @include govuk-shape-arrow($direction: left, $base: 10px, $height: 6px);
-
     content: "";
+    display: block;
 
     // Vertically align with the parent element
     position: absolute;
 
-    top: 0;
-    bottom: 0;
-    left: 0;
+    @if $govuk-use-legacy-font {
+      // Begin adjustments for font baseline offset
+      // These should be removed when legacy font support is dropped
+      top: -1px;
+      bottom: 1px;
 
-    margin: auto;
+    } @else {
+      top: 0;
+      bottom: 0;
+    }
+
+    left: 3px;
+
+    width: $chevron-size;
+    height: $chevron-size;
+
+    margin: auto 0;
+
+    transform: rotate(225deg);
+
+    border: solid;
+    border-width: $chevron-border-width $chevron-border-width 0 0;
+    border-color: $chevron-border-colour;
+
+    // Fall back to a less than sign for IE8
+    @include govuk-if-ie8 {
+      content: "\003c"; // Less than sign (<)
+      width: auto;
+      height: auto;
+      border: 0;
+      color: $chevron-border-colour;
+
+      // IE8 doesn't seem to like rendering pseudo-elements using @font-faces,
+      // so fall back to using another sans-serif font to render the chevron.
+      font-family: Arial, sans-serif;
+    }
   }
 
   @if $govuk-use-legacy-font {

--- a/src/govuk/components/back-link/_back-link.scss
+++ b/src/govuk/components/back-link/_back-link.scss
@@ -89,6 +89,15 @@
     }
   }
 
+  .govuk-back-link:after {
+    content: "";
+    position: absolute;
+    top: -14px;
+    right: 0;
+    bottom: -14px;
+    left: 0;
+  }
+
   @if $govuk-use-legacy-font {
     // Begin adjustments for font baseline offset
     // These should be removed when legacy font support is dropped


### PR DESCRIPTION
## What
This PR contains a few small changes to the back link component:

- updates the back link arrow to be consistent with the breadcrumbs component
- increase the touch target of the back link

Note: this change has been [implemented on GOVUK](https://github.com/alphagov/govuk_publishing_components/pull/1299) and we wish to contribute this change back to the design system.

## Why

- Back links use an inconsistent icon from the breadcrumbs and there should be consistent design patterns across GOV.UK.
- The touch target of the back link should be a minimum of 44x44px as recommended by [WCAG guidelines](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)
- The touch target has been implemented regardless of device to handle people interacting with the link, for example, on touchscreen laptops.

## Before
<img width="71" alt="Screenshot 2020-03-02 at 13 57 42" src="https://user-images.githubusercontent.com/29889908/75682761-dca27580-5c8d-11ea-8991-97bf5edd9596.png">
<img width="73" alt="Screenshot 2020-03-02 at 13 57 54" src="https://user-images.githubusercontent.com/29889908/75682763-dd3b0c00-5c8d-11ea-98e5-9c2cc4834e26.png">

## After
<img width="60" alt="Screenshot 2020-03-02 at 13 58 02" src="https://user-images.githubusercontent.com/29889908/75682776-e4621a00-5c8d-11ea-9737-cd8b63706e46.png">
<img width="57" alt="Screenshot 2020-03-02 at 13 58 08" src="https://user-images.githubusercontent.com/29889908/75682778-e4621a00-5c8d-11ea-9bd0-542189fac633.png">