### PR TITLE
Add collapseOnMobile breadcrumbs flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@
 
 ### New features
 
+#### Add collapseOnMobile breadcrumbs flag
+
+Add a collapseOnMobile flag to breadcrumbs which, when set to true, means the breadcrumb collapses to the first and last items only on mobile and doesn't wrap onto a new line.
+
+[Pull request #1754: Add collapseOnMobile breadcrumbs flag](https://github.com/alphagov/govuk-frontend/pull/1754)
+
 #### New list modifier to add extra spacing between list items
 
 If a list is hard to read becuse the items run across multiple lines you can now [add extra spacing using the `govuk-list--spaced` modifier class](http://design-system.service.gov.uk//styles/typography/#adding-extra-spacing-between-list-items).
 
 [Pull request #1775: Add list--spaced modifier](https://github.com/alphagov/govuk-frontend/pull/1775).
-
 
 #### Improved Sass compilation times
 

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -107,4 +107,17 @@
     @include govuk-link-common;
     @include govuk-link-style-text;
   }
+
+  .govuk-breadcrumbs--collapse-on-mobile {
+    @include govuk-media-query($until: tablet) {
+      .govuk-breadcrumbs__list-item {
+        display: none;
+
+        &:first-child,
+        &:last-child {
+          display: inline-block;
+        }
+      }
+    }
+  }
 }

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -117,6 +117,15 @@
         &:last-child {
           display: inline-block;
         }
+
+        &:before {
+          top: 6px;
+          margin: 0;
+        }
+      }
+
+      .govuk-breadcrumbs__list {
+        display: flex;
       }
     }
   }

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -23,6 +23,10 @@ params:
   type: string
   required: false
   description: Classes to add to the breadcrumbs container.
+- name: collapseOnMobile
+  type: boolean
+  required: false
+  description: When true, the breadcrumbs will collapse to the first and last item only on tablet breakpoint and below.
 - name: attributes
   type: object
   required: false
@@ -79,3 +83,17 @@ examples:
         href: '/browse/abroad'
       -
         text: Travel abroad
+- name: with collapse on mobile
+  data:
+    collapseOnMobile: true
+    items:
+      -
+        text: Home
+        href: '/'
+      -
+        text: Education, training and skills
+        href: '/education'
+      -
+        text: Special educational needs and disability (SEND) and high needs
+        href: '/education/special-educational-needs-and-disability-send-and-high-needs'
+

--- a/src/govuk/components/breadcrumbs/template.njk
+++ b/src/govuk/components/breadcrumbs/template.njk
@@ -1,4 +1,15 @@
-<div class="govuk-breadcrumbs{%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+{# Set classes for this component #}
+{%- set classNames = "govuk-breadcrumbs " -%}
+
+{% if params.classes %}
+  {% set classNames = classNames + params.classes %}
+{% endif -%}
+
+{% if params.collapseOnMobile %}
+  {% set classNames = classNames + " govuk-breadcrumbs--collapse-on-mobile" %}
+{% endif -%}
+
+<div class="{{classNames}}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <ol class="govuk-breadcrumbs__list">
   {% for item in params.items %}
     {% if item.href %}

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -144,6 +144,21 @@ describe('Breadcrumbs', () => {
       const $anchor = $('.govuk-breadcrumbs__list-item a')
       expect($anchor.html()).toEqual('<em>Section 1</em>')
     })
+
+    it('renders item as collapse on mobile if specified', () => {
+      const $ = render('breadcrumbs', {
+        collapseOnMobile: true,
+        items: [
+          {
+            html: '<em>Section 1</em>',
+            href: '/section'
+          }
+        ]
+      })
+
+      const $component = $('.govuk-breadcrumbs')
+      expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()
+    })
   })
 
   describe('default example', () => {


### PR DESCRIPTION
## What
Adds a collapseOnMobile flag to the breadcrumbs component. When set to true, this flag means the breadcrumb component will:

- Collapse to only showing the first and last item on tablet breakpoint and below
- Long breadcrumb text will wrap over multiple lines instead of the whole breadcrumb moving to a new line

Note: this change has been implemented on GOVUK and we wish to contribute this change back to the design system.

## Why
<img width="940" alt="Screenshot 2020-03-02 at 16 14 10" src="https://user-images.githubusercontent.com/29889908/75694700-e1bcf000-5ca0-11ea-91f5-3cf5f3cdc012.png">
<img width="938" alt="Screenshot 2020-03-02 at 16 14 15" src="https://user-images.githubusercontent.com/29889908/75694701-e2ee1d00-5ca0-11ea-8ad2-0e6ea83ee4d7.png">

<img width="882" alt="Screenshot 2020-03-02 at 16 07 54" src="https://user-images.githubusercontent.com/29889908/75694402-5fccc700-5ca0-11ea-8f0c-c3e25e2d2013.png">
<img width="312" alt="Screenshot 2020-03-02 at 16 08 02" src="https://user-images.githubusercontent.com/29889908/75694403-60655d80-5ca0-11ea-8bb3-d1d1414923a7.png">