### PR TITLE
Import textarea from character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [Pull request #1765: Import textarea from character count](https://github.com/alphagov/govuk-frontend/pull/1765).
+
 ## 3.6.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/character-count/_character-count.scss
+++ b/src/govuk/components/character-count/_character-count.scss
@@ -5,6 +5,7 @@
 @import "../error-message/error-message";
 @import "../hint/hint";
 @import "../label/label";
+@import "../textarea/textarea";
 
 @include govuk-exports("govuk/component/character-count") {
   .govuk-character-count {


### PR DESCRIPTION
The character count component wraps the textarea component, but does not currently import it.

This means that, for example, if you only `@import govuk/components/character-count` the textarea would be unstyled.

Import the textarea component so that the styles are included correctly.