### PR TITLE
Use aria-describedby relationship for count message

### DIFF
--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -6,7 +6,8 @@ function CharacterCount ($module) {
   this.$module = $module
   this.$textarea = $module.querySelector('.govuk-js-character-count')
   if (this.$textarea) {
-    this.$countMessage = $module.querySelector('[id=' + this.$textarea.id + '-info]')
+    var describedById = this.$textarea.getAttribute('aria-describedby')
+    this.$countMessage = document.getElementById(describedById)
   }
 }
 


### PR DESCRIPTION
Since aria-describedby is required for the hint message to announced by assistive technologies when interacting with the textarea we can use it to find the count message.

This makes the JavaScript slightly less reliant on the HTML for the component, for example if someone wants to use a different ID on their count message.