### PR TITLE
Group helpers and objects into logical groups

### DIFF
--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -1,5 +1,7 @@
 /* eslint-env jest */
 
+const sassdoc = require('sassdoc')
+
 const configPaths = require('../../config/paths.json')
 const PORT = configPaths.ports.test
 
@@ -152,5 +154,26 @@ describe('GOV.UK Frontend', () => {
     const functionCalls = css.match(/_?govuk-[\w-]+\(.*?\)/g)
 
     expect(functionCalls).toBeNull()
+  })
+
+  describe('Sass documentation', () => {
+    it('associates everything with a group', async () => {
+      return sassdoc.parse([
+        `${configPaths.src}/**/*.scss`,
+        `!${configPaths.src}/vendor/*.scss`
+      ])
+        .then(docs => docs.forEach(doc => {
+          return expect(doc).toMatchObject({
+            // Include doc.context.name in the expected result when this fails,
+            // giving you the context to be able to fix it
+            context: {
+              name: doc.context.name
+            },
+            group: [
+              expect.not.stringMatching('undefined')
+            ]
+          })
+        }))
+    })
   })
 })

--- a/src/govuk/helpers/_clearfix.scss
+++ b/src/govuk/helpers/_clearfix.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/layout
 ////
 
 /// Clear floated content within a container using a pseudo element

--- a/src/govuk/helpers/_focused.scss
+++ b/src/govuk/helpers/_focused.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/accessibility
 ////
 
 /// Focused text

--- a/src/govuk/helpers/_grid.scss
+++ b/src/govuk/helpers/_grid.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/layout
 ////
 
 /// Grid width percentage

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/links
 ////
 
 /// Common link mixin

--- a/src/govuk/helpers/_media-queries.scss
+++ b/src/govuk/helpers/_media-queries.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/layout
 ////
 
 

--- a/src/govuk/helpers/_shape-arrow.scss
+++ b/src/govuk/helpers/_shape-arrow.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/shapes
 ////
 
 /// Calculate the height of an equilateral triangle

--- a/src/govuk/helpers/_spacing.scss
+++ b/src/govuk/helpers/_spacing.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/spacing
 ////
 
 /// Single point spacing

--- a/src/govuk/helpers/_typography.scss
+++ b/src/govuk/helpers/_typography.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/typography
 ////
 
 @import "../tools/px-to-rem";

--- a/src/govuk/helpers/_visually-hidden.scss
+++ b/src/govuk/helpers/_visually-hidden.scss
@@ -1,5 +1,5 @@
 ////
-/// @group helpers
+/// @group helpers/accessibility
 ////
 
 /// Hide an element visually, but have it available for screen readers

--- a/src/govuk/helpers/helpers.test.js
+++ b/src/govuk/helpers/helpers.test.js
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 
+const glob = require('glob')
 const path = require('path')
 
-const glob = require('glob')
+const sassdoc = require('sassdoc')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
@@ -19,5 +20,23 @@ describe('The helpers layer', () => {
 
   it.each(sassFiles)('%s renders to CSS without errors', (file) => {
     return renderSass({ file: file })
+  })
+
+  describe('Sass documentation', () => {
+    it('associates everything with a "helpers" group', async () => {
+      return sassdoc.parse(path.join(configPaths.src, 'helpers', '*.scss'))
+        .then(docs => docs.forEach(doc => {
+          return expect(doc).toMatchObject({
+            // Include doc.context.name in the expected result when this fails,
+            // giving you the context to be able to fix it
+            context: {
+              name: doc.context.name
+            },
+            group: [
+              expect.stringMatching(/^helpers/)
+            ]
+          })
+        }))
+    })
   })
 })

--- a/src/govuk/objects/_main-wrapper.scss
+++ b/src/govuk/objects/_main-wrapper.scss
@@ -1,5 +1,9 @@
 @import "../base";
 
+////
+/// @group objects/layout
+////
+
 // Example usage with Breadcrumbs, phase banners, back links:
 // <div class="govuk-width-container">
 //   <!-- Breadcrumbs, phase banners, back links are placed in here. -->

--- a/src/govuk/objects/_width-container.scss
+++ b/src/govuk/objects/_width-container.scss
@@ -1,7 +1,7 @@
 @import "../base";
 
 ////
-/// @group objects
+/// @group objects/layout
 ////
 
 /// Width container mixin

--- a/src/govuk/objects/objects.test.js
+++ b/src/govuk/objects/objects.test.js
@@ -1,11 +1,34 @@
 /* eslint-env jest */
 
 const glob = require('glob')
+const path = require('path')
+
+const sassdoc = require('sassdoc')
+
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
 
 const sassFiles = glob.sync(`${configPaths.src}/objects/**/*.scss`)
 
-it.each(sassFiles)('%s renders to CSS without errors', (file) => {
-  return renderSass({ file: file })
+describe('The objects layer', () => {
+  it.each(sassFiles)('%s renders to CSS without errors', (file) => {
+    return renderSass({ file: file })
+  })
+  describe('Sass documentation', () => {
+    it('associates everything with a "objects" group', async () => {
+      return sassdoc.parse(path.join(configPaths.src, 'objects', '*.scss'))
+        .then(docs => docs.forEach(doc => {
+          return expect(doc).toMatchObject({
+            // Include doc.context.name in the expected result when this fails,
+            // giving you the context to be able to fix it
+            context: {
+              name: doc.context.name
+            },
+            group: [
+              expect.stringMatching(/^objects/)
+            ]
+          })
+        }))
+    })
+  })
 })

--- a/src/govuk/settings/_ie8.scss
+++ b/src/govuk/settings/_ie8.scss
@@ -1,5 +1,5 @@
 ////
-/// @group settings/ie8
+/// @group settings/internet-explorer-8
 ////
 
 /// Whether the stylesheet being built is targeting Internet Explorer 8.

--- a/src/govuk/settings/settings.test.js
+++ b/src/govuk/settings/settings.test.js
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 
+const glob = require('glob')
 const path = require('path')
 
-const glob = require('glob')
+const sassdoc = require('sassdoc')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
@@ -19,5 +20,23 @@ describe('The settings layer', () => {
 
   it.each(sassFiles)('%s renders to CSS without errors', (file) => {
     return renderSass({ file: file })
+  })
+
+  describe('Sass documentation', () => {
+    it('associates everything with a "settings" group', async () => {
+      return sassdoc.parse(path.join(configPaths.src, 'settings', '*.scss'))
+        .then(docs => docs.forEach(doc => {
+          return expect(doc).toMatchObject({
+            // Include doc.context.name in the expected result when this fails,
+            // giving you the context to be able to fix it
+            context: {
+              name: doc.context.name
+            },
+            group: [
+              expect.stringMatching(/^settings/)
+            ]
+          })
+        }))
+    })
   })
 })

--- a/src/govuk/tools/_compatibility.scss
+++ b/src/govuk/tools/_compatibility.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/compatibility-mode
 ////
 
 /// Conditional Compatibility Mixin

--- a/src/govuk/tools/_font-url.scss
+++ b/src/govuk/tools/_font-url.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/assets
 ////
 
 // Disable indentation linting in this file only

--- a/src/govuk/tools/_ie8.scss
+++ b/src/govuk/tools/_ie8.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/internet-explorer-8
 ////
 
 /// Conditionally include rules only for IE8

--- a/src/govuk/tools/_image-url.scss
+++ b/src/govuk/tools/_image-url.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/assets
 ////
 
 // Disable indentation linting in this file only

--- a/src/govuk/tools/_px-to-em.scss
+++ b/src/govuk/tools/_px-to-em.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/unit-conversion
 ////
 
 /// Convert pixels to em

--- a/src/govuk/tools/_px-to-rem.scss
+++ b/src/govuk/tools/_px-to-rem.scss
@@ -1,5 +1,5 @@
 ////
-/// @group tools
+/// @group tools/unit-conversion
 ////
 
 /// Convert pixels to rem

--- a/src/govuk/tools/tools.test.js
+++ b/src/govuk/tools/tools.test.js
@@ -1,8 +1,9 @@
 /* eslint-env jest */
 
+const glob = require('glob')
 const path = require('path')
 
-const glob = require('glob')
+const sassdoc = require('sassdoc')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
@@ -19,5 +20,23 @@ describe('The tools layer', () => {
 
   it.each(sassFiles)('%s renders to CSS without errors', (file) => {
     return renderSass({ file: file })
+  })
+
+  describe('Sass documentation', () => {
+    it('associates everything with a "tools" group', async () => {
+      return sassdoc.parse(path.join(configPaths.src, 'tools', '*.scss'))
+        .then(docs => docs.forEach(doc => {
+          return expect(doc).toMatchObject({
+            // Include doc.context.name in the expected result when this fails,
+            // giving you the context to be able to fix it
+            context: {
+              name: doc.context.name
+            },
+            group: [
+              expect.stringMatching(/^tools/)
+            ]
+          })
+        }))
+    })
   })
 })

--- a/tasks/gulp/sassdoc.js
+++ b/tasks/gulp/sassdoc.js
@@ -7,6 +7,13 @@ gulp.task('sassdoc', function () {
     .pipe(sassdoc({
       dest: paths.sassdoc,
       groups: {
+        'helpers/accessibility': 'Helpers / Accessibility',
+        'helpers/colour': 'Helpers / Colour',
+        'helpers/layout': 'Helpers / Layout',
+        'helpers/links': 'Helpers / Links',
+        'helpers/shapes': 'Helpers / Shapes',
+        'helpers/spacing': 'Helpers / Spacing',
+        'helpers/typography': 'Helpers / Typography',
         'settings/assets': 'Settings / Assets',
         'settings/colours': 'Settings / Colours',
         'settings/compatibility': 'Settings / Compatibility',
@@ -18,7 +25,9 @@ gulp.task('sassdoc', function () {
         'settings/typography': 'Settings / Typography',
         tools: 'Tools',
         helpers: 'Helpers',
-        overrides: 'Overrides'
+        overrides: 'Overrides',
+        objects: 'Objects',
+        'objects/layout': 'Objects / Layout'
       }
     }))
     .resume()


### PR DESCRIPTION
Improve the navigation within Sass Docs by grouping helpers and objects into logical groups.