### PR TITLE
Update guidance on using pre-releases

### DIFF
--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -14,12 +14,6 @@ No changes get published to npm as part of the process.
 
 3. Run `npm install` to ensure you have the latest dependencies installed.
 
-4. Run `npm run release-to-branch`.
+4. Run `npm run release-to-branch`. This will create and push a new branch `pre-release-[your-branch-name-here]` to GitHub.
 
-There should now be a branch `pre-release-[your-branch-name-here]` pushed to the GOV.UK Frontend remote origin.
-
-To install this pre-release branch in another project, you can run the following command:
-
-```bash
-npm install --save alphagov/govuk-frontend#pre-release-[your-branch-name-here]
-```
+5. Use the command provided by the script to update other projects to use the pre-release.


### PR DESCRIPTION
In 5b69d36 we updated the pre-release script to use the commit SHA rather than the branch name, as we found that Netlify caches the resolved branches and so won't update when we update an existing pre-release.

This updates the guidance on pre-releases so that the documentation does not contradict the instructions provided by the script.