### PR TITLE
Fix accordion underline hover state being removed when hovering plus/minus symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [Pull request #1765: Import textarea from character count](https://github.com/alphagov/govuk-frontend/pull/1765).
+- [Pull request #1778: Fix accordion underline hover state being removed when hovering plus/minus symbol](https://github.com/alphagov/govuk-frontend/pull/1778).
 
 ## 3.6.0 (Feature release)
 

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -135,7 +135,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   icon.className = this.iconClass
   icon.setAttribute('aria-hidden', 'true')
 
-  $heading.appendChild(icon)
+  $button.appendChild(icon)
 }
 
 // When section toggled, set and store state


### PR DESCRIPTION
At present, when you hover over a section the section title gets the affordance of an underline to show which element is being interacted with – except if you hover over the plus/minus 'control', in which case the underline disappears again.

This happens because the icon is appended to the heading, rather than the button, and so the button and icon are siblings, and the icon being absolutely positioned overlays the button.

(The only reason that you can click the control to toggle the section is that the click handler is bound to the heading, rather than the button. If the click handler was bound to the button, clicking the icon would not work.)

Append the icon to the button rather than the heading, which makes it part of the button, and thus hovering the icon will correctly trigger the button hover styles.

## Browser testing

- [x] IE8 (Windows) – does not get the hover state, but this matches the existing behaviour
- [x] IE9 (Windows)
- [x] IE10 (Windows)
- [x] IE11 (Windows)
- [x] Edge (Windows)
- [x] Chrome (Windows)
- [x] Firefox (Windows)
- [x] Safari (macOS)
- [x] Chrome (macOS)
- [x] Firefox (macOS)
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)

Fixes #1769 