### PR TITLE
Update homepage in package.json

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -18,7 +18,7 @@
   "bugs": {
     "url": "https://github.com/alphagov/govuk-frontend/issues"
   },
-  "homepage": "https://github.com/alphagov/govuk-frontend#readme",
+  "homepage": "https://frontend.design-system.service.gov.uk/",
   "keywords": [
     "govuk",
     "frontend",


### PR DESCRIPTION
This will update the homepage as listed on e.g. https://www.npmjs.com/package/govuk-frontend, which means users who come via npm will hopefully be able to find the documentation.

Closes #1781.