### PR TITLE
Fix link typo and Sass API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To be notified when there’s a new release, you can either:
 - [watch the govuk-frontend Github repository](https://help.github.com/en/articles/watching-and-unwatching-repositories)
 - join the [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
 
-Find out how to [update with npm](hhttps://frontend.design-system.service.gov.uk/updating-with-npm/).
+Find out how to [update with npm](https://frontend.design-system.service.gov.uk/updating-with-npm/).
 
 ## Licence
 

--- a/docs/contributing/versioning.md
+++ b/docs/contributing/versioning.md
@@ -96,7 +96,7 @@ The other primary way is through what is [published to npm](https://github.com/a
 This includes:
 
 - [JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript)
-- SCSS - https://govuk-frontend-review.herokuapp.com/docs/
+- [SCSS](https://frontend.design-system.service.gov.uk/sass-api-reference/#sass-api-reference)
 - Nunjucks Macros (Templates)
 
 ## Updating Changelog


### PR DESCRIPTION
This fixes 2 small issues I found from previous PRs that changed links so they point to the new Tech Docs Template Frontend docs.