### PR TITLE
Lint _banner.scss

### DIFF
--- a/app/assets/scss/partials/_banner.scss
+++ b/app/assets/scss/partials/_banner.scss
@@ -2,7 +2,7 @@
   padding-top: govuk-spacing(6);
   padding-bottom: govuk-spacing(6);
   overflow: hidden;
-  @include govuk-font($size: 36, $line-height: 1.5)
+  @include govuk-font($size: 36, $line-height: 1.5);
 
   .govuk-body {
     color: inherit;


### PR DESCRIPTION
Fix tiny lint issue with `;` missing at the end of the include statement.