### PR TITLE
Standardise accordion section headings font size (reduce height of section headings on mobile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ For example:
 - [Pull request #1753: Make back link arrow consistent with breadcrumb component](https://github.com/alphagov/govuk-frontend/pull/1753)
 - [Pull request #1765: Import textarea from character count](https://github.com/alphagov/govuk-frontend/pull/1765).
 - [Pull request #1778: Fix accordion underline hover state being removed when hovering plus/minus symbol](https://github.com/alphagov/govuk-frontend/pull/1778).
+- [Pull request #1796: Standardise accordion section headings font size (reduce height of section headings on mobile)](https://github.com/alphagov/govuk-frontend/pull/1796).
 
 ## 3.6.0 (Feature release)
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -19,6 +19,10 @@
   }
 
   .govuk-accordion__section-heading {
+    // Override browser defaults to ensure consistent element height
+    // Font size is set in .govuk-accordion__section-button
+    @include govuk-font(24);
+
     margin-top: 0; // Override browser default
     margin-bottom: 0; // Override browser default
   }


### PR DESCRIPTION
As reported in https://github.com/alphagov/govuk_publishing_components/pull/1386, the height of accordion sections on mobile doesn't match GOV.UK Design System if Elements stylesheet is included. This is because of the inclusion of GOV.UK Elements which resets `<h2>` to inherit font-size and line-height from `<body>`.   

We currently rely on browser defaults for font size on the accordion heading sections (although the text font size is actually set in the enclosed button and the font size in the section headings impacts only the height of the sections).  

This PR sets the font size on the section headings to match our standard font sizing for `<h2>` elements so that we don't rely on browser defaults. However this means that the height of the accordion sections is reduced by ~9px on mobile devices. 

<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/5007934/81842295-af9ef880-9543-11ea-91e4-1eb53658c666.png"><img width="309" alt="Before change" src="https://user-images.githubusercontent.com/5007934/81842295-af9ef880-9543-11ea-91e4-1eb53658c666.png" style="max-width:100%;"></a></td>
<td><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/5007934/81842340-c3e2f580-9543-11ea-9356-737085e6a388.png"><img width="303" alt="After change" src="https://user-images.githubusercontent.com/5007934/81842340-c3e2f580-9543-11ea-9356-737085e6a388.png" style="max-width:100%;"></a></td>
</tr>
</tbody>
</table>

#### Exact changes on different OS

| OS / browser        | Before | After |
|---------------------|--------|-------|
| iOS 13 / Safari     | 60px   | 50px  |
| iOS 12 / Safari     | 60px   | 49px  |
| Android 10 / Chrome | 58px   | 50px  |
| Android 9 / Chrome  | 58px   | 50px  |

WCAG 2.1 states that a [minimum target size must be 44 by 44 CSS pixels](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html) which this will meet.

Fixes https://github.com/alphagov/govuk-frontend/issues/1789