### PR TITLE
Warn if importing core, overrides w/o dependencies

### DIFF
--- a/src/govuk/core/_global-styles.scss
+++ b/src/govuk/core/_global-styles.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @import "links";

--- a/src/govuk/core/_links.scss
+++ b/src/govuk/core/_links.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/core/links") {

--- a/src/govuk/core/_lists.scss
+++ b/src/govuk/core/_lists.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/core/lists") {

--- a/src/govuk/core/_section-break.scss
+++ b/src/govuk/core/_section-break.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/core/section-break") {

--- a/src/govuk/core/_template.scss
+++ b/src/govuk/core/_template.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/core/template") {

--- a/src/govuk/core/_typography.scss
+++ b/src/govuk/core/_typography.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the core layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/core/typography") {

--- a/src/govuk/core/core.test.js
+++ b/src/govuk/core/core.test.js
@@ -1,11 +1,31 @@
 /* eslint-env jest */
 
+const sass = require('node-sass')
+
 const glob = require('glob')
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
 
 const sassFiles = glob.sync(`${configPaths.src}/core/**/*.scss`)
 
-it.each(sassFiles)('%s renders to CSS without errors', (file) => {
-  return renderSass({ file: file })
+it.each(sassFiles)('%s renders with a deprecation warning', (file) => {
+  // Create a mock warn function that we can use to override the native @warn
+  // function, that we can make assertions about post-render.
+  const mockWarnFunction = jest.fn()
+    .mockReturnValue(sass.NULL)
+
+  return renderSass({
+    file: file,
+    functions: {
+      '@warn': mockWarnFunction
+    }
+  }).then(() => {
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the deprecation notice
+    return expect(mockWarnFunction.mock.calls[0][0].getValue())
+      .toEqual(
+        'Importing items from the core layer without first importing `base` ' +
+        'is deprecated, and will no longer work as of GOV.UK Frontend v4.0.'
+      )
+  })
 })

--- a/src/govuk/overrides/_display.scss
+++ b/src/govuk/overrides/_display.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the overrides layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/overrides/display") {

--- a/src/govuk/overrides/_spacing.scss
+++ b/src/govuk/overrides/_spacing.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the overrides layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 ////

--- a/src/govuk/overrides/_typography.scss
+++ b/src/govuk/overrides/_typography.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the overrides layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/overrides/typography") {

--- a/src/govuk/overrides/_width.scss
+++ b/src/govuk/overrides/_width.scss
@@ -1,3 +1,7 @@
+@if not mixin-exists("govuk-exports") {
+  @warn "Importing items from the overrides layer without first importing `base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.";
+}
+
 @import "../base";
 
 @include govuk-exports("govuk/overrides/width") {

--- a/src/govuk/overrides/overrides.test.js
+++ b/src/govuk/overrides/overrides.test.js
@@ -1,11 +1,31 @@
 /* eslint-env jest */
 
+const sass = require('node-sass')
+
 const glob = require('glob')
 const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.json')
 
 const sassFiles = glob.sync(`${configPaths.src}/overrides/**/*.scss`)
 
-it.each(sassFiles)('%s renders to CSS without errors', (file) => {
-  return renderSass({ file: file })
+it.each(sassFiles)('%s renders with a deprecation warning', (file) => {
+  // Create a mock warn function that we can use to override the native @warn
+  // function, that we can make assertions about post-render.
+  const mockWarnFunction = jest.fn()
+    .mockReturnValue(sass.NULL)
+
+  return renderSass({
+    file: file,
+    functions: {
+      '@warn': mockWarnFunction
+    }
+  }).then(() => {
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the deprecation notice
+    return expect(mockWarnFunction.mock.calls[0][0].getValue())
+      .toEqual(
+        'Importing items from the overrides layer without first importing ' +
+        '`base` is deprecated, and will no longer work as of GOV.UK Frontend v4.0.'
+      )
+  })
 })


### PR DESCRIPTION
Add deprecation warnings if users import files from the core and overrides layers without first importing the settings, helpers and tools layers.

We'll [remove the imports of "base" from files in these layers in 4.0][1], so this will no longer work.

Closes #1798 

[1]: https://github.com/alphagov/govuk-frontend/issues/1800