### PR TITLE
Add serviceUrl to latest header example which includes serviceName

### DIFF
--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -187,6 +187,7 @@ examples:
 - name: navigation item with html
   data:
     serviceName: Service Name
+    serviceUrl: '/components/header'
     navigation:
       - href: '#1'
         html: <em>Navigation item 1</em>


### PR DESCRIPTION
The latest example (_"navigation item with html"_) added to the header component's examples yaml causes a small issue downstream in the [govuk-react-jsx](https://github.com/surevine/govuk-react-jsx) test suite. 

In the Nunjucks template when `serviceName` is used in the header, it should be in conjunction with `serviceUrl`, otherwise it renders a link with an empty href. i.e:

```
    {% if params.serviceName %}
    <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
      {{ params.serviceName }}
    </a>
    {% endif %}
```

The requirement isn't forced in any way (Neither param is marked as required), but the pairing of `serviceName` and `serviceUrl` is somewhat implied. If you have one, you should have the other (Unless I have missed some use case here?)

In the React implementation, the _absence_ of a `serviceUrl` param means that React doesn't render the `href` attribute at all, meaning that my tests which diff the html output between the Nunjucks reference implementation and my JSX components fails.

To address this, I have added `serviceUrl` to this latest example.