### PR TITLE
Make dark grey darker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### New features
+
+#### Darkened secondary text colour
+
+We darkened `govuk-colour("dark-grey")` to improve the readability of hint text. It now has a contrast ratio of 7:1 and helps hint text meet the WCAG 2.1 (AAA) accessibility standard.
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/src/govuk/settings/_colours-palette.scss
+++ b/src/govuk/settings/_colours-palette.scss
@@ -70,7 +70,7 @@ $_govuk-colour-palette-modern: (
   "purple": #4c2c92,
 
   "black": #0b0c0c,
-  "dark-grey": #626a6e,
+  "dark-grey": #505a5f,
   "mid-grey": #b1b4b6,
   "light-grey": #f3f2f1,
   "white": #ffffff,


### PR DESCRIPTION
The grey hint text continues to cause issues for users, with many struggling to read it or missing it because it's too pale. For an example see this [comment on the text input component](https://github.com/alphagov/govuk-design-system-backlog/issues/51#issuecomment-584223652).

This PR changes `govuk-colour("dark-grey")` from `#626a6e` to `#505a5f`. This is the one of the palest greys I could find that meets AAA contrast for body copy:

<img width="1079" alt="Screenshot 2020-05-20 at 11 07 15" src="https://user-images.githubusercontent.com/19834460/83656103-0d5cb880-a5b7-11ea-97e8-84c17e830fb3.png">

I appreciate we have darkened this grey before and that we probably shouldn't go any darker than this because it'll get so close to being black as to be pointless. This grey has a bit less contrast with the black than before, though I'd argue that this shouldn't affect the usability of form elements for those that can't detect the difference in colour.

This is the simplest change we can make now with the fewest repercussions across the system. If we continue to see problems after this change, we clearly can't make it any darker so will look into an alternative approach like bolding labels and making hint text black.

This change will need to be accompanied by changes to the [colour](https://design-system.service.gov.uk/styles/colour/) page in the Design System.

Relates to https://github.com/alphagov/govuk-design-system/issues/1222