### PR TITLE
Add default value of / for Header component's serviceUrl param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Breaking changes
+
+#### Header `serviceUrl` param now defaults to `/`
+
+When specifying `serviceName` to render a link in the header component, `serviceUrl` now defaults to `/` where previously it would have rendered an empty `href` attribute on the link.
+
 ## 3.7.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -18,7 +18,7 @@ params:
 - name: serviceUrl
   type: string
   required: false
-  description: Url for the service name anchor.
+  description: Url for the service name anchor. Defaults to / but is only rendered if serviceName is also present
 - name: navigation
   type: array
   required: false

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -55,7 +55,7 @@
     {% if params.serviceName or params.navigation  %}
     <div class="govuk-header__content">
     {% if params.serviceName %}
-    <a href="{{ params.serviceUrl }}" class="govuk-header__link govuk-header__link--service-name">
+    <a href="{{ params.serviceUrl | default('/') }}" class="govuk-header__link govuk-header__link--service-name">
       {{ params.serviceName }}
     </a>
     {% endif %}

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -84,6 +84,18 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__link--service-name')
       expect($serviceName.text().trim()).toEqual('Service Name')
+      expect($serviceName.attr('href')).toEqual('/components/header')
+    })
+
+    it('renders with a default serviceUrl', () => {
+      const $ = render('header', {
+        serviceName: 'Service Name'
+      })
+
+      const $component = $('.govuk-header')
+      const $serviceName = $component.find('.govuk-header__link--service-name')
+      expect($serviceName.text().trim()).toEqual('Service Name')
+      expect($serviceName.attr('href')).toEqual('/')
     })
   })
 


### PR DESCRIPTION
Add default value of `/` for Header component's `serviceUrl` param. Prior to this if you passed `serviceName` to the Header component but omitted `serviceUrl`, it would be rendered with an empty href.

Original issue at #1826 