### PR TITLE
Correctly camel case SVG attributes in the header and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#1838: Correctly camel case SVG attributes in the header and footer](https://github.com/alphagov/govuk-frontend/pull/1838)
+
 ## 3.7.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -58,7 +58,7 @@
           focusable="false"
           class="govuk-footer__licence-logo"
           xmlns="http://www.w3.org/2000/svg"
-          viewbox="0 0 483.2 195.7"
+          viewBox="0 0 483.2 195.7"
           height="17"
           width="41"
         >

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -21,7 +21,7 @@
             focusable="false"
             class="govuk-header__logotype-crown"
             xmlns="http://www.w3.org/2000/svg"
-            viewbox="0 0 132 97"
+            viewBox="0 0 132 97"
             height="30"
             width="36"
           >


### PR DESCRIPTION
As raised in #1780, lowercasing this attribute causes issue with Angular.

I've searched the codebase for any other camel-cased SVG attributes and viewBox is the only one that we use:

```
$ ag 'allowReorder|attributeName|attributeType|autoReverse|baseFrequency|baseProfile|calcMode|clipPathUnits|contentScriptType|contentStyleType|diffuseConstant|edgeMode|externalResourcesRequired|filterRes|filterUnits|glyphRef|gradientTransform|gradientUnits|kernelMatrix|kernelUnitLength|keyPoints|keySplines|keyTimes|lengthAdjust|limitingConeAngle|markerHeight|markerUnits|markerWidth|maskContentUnits|maskUnits|numOctaves|pathLength|patternContentUnits|patternTransform|patternUnits|pointsAtX|pointsAtY|pointsAtZ|preserveAlpha|preserveAspectRatio|primitiveUnits|referrerPolicy|refX|refY|repeatCount|repeatDur|requiredExtensions|requiredFeatures|specularConstant|specularExponent|spreadMethod|startOffset|stdDeviation|stitchTiles|surfaceScale|systemLanguage|tableValues|targetX|targetY|textLength|viewBox|viewTarget|xChannelSelector|yChannelSelector|zoomAndPan' src

src/govuk/components/footer/template.njk
61:          viewBox="0 0 483.2 195.7"

src/govuk/components/button/template.njk
27:<svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">

src/govuk/components/header/template.njk
24:            viewBox="0 0 132 97"

src/govuk/assets/images/govuk-mask-icon.svg
1:<svg xmlns="http://www.w3.org/2000/svg" width="132" height="97" viewBox="0 0 132 97" version="1.1">
```

Fixes #1780.