### PR TITLE
Preserve the state of conditional reveals when navigating 'back' in the browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#1838: Correctly camel case SVG attributes in the header and footer](https://github.com/alphagov/govuk-frontend/pull/1838)
+- [#1842: Preserve the state of conditional reveals when navigating 'back' in the browser](https://github.com/alphagov/govuk-frontend/pull/1842)
 
 ## 3.7.0 (Feature release)
 

--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -52,9 +52,7 @@ Checkboxes.prototype.init = function () {
 }
 
 Checkboxes.prototype.syncAll = function () {
-  nodeListForEach(this.$inputs, function ($input) {
-    this.syncWithInputState($input)
-  }.bind(this))
+  nodeListForEach(this.$inputs, this.syncWithInputState.bind(this))
 }
 
 Checkboxes.prototype.syncWithInputState = function ($input) {

--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -32,19 +32,20 @@ Checkboxes.prototype.init = function () {
     $input.removeAttribute('data-aria-controls')
   })
 
-  if (document.readyState === 'loading') {
-    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
-  } else {
-    this.syncState()
-  }
-
   // When the page is restored after navigating 'back' in some browsers the
   // state of form controls is not restored until *after* the DOMContentLoaded
-  // event is fired, so we need to sync after the pageshow event is fired as
-  // well.
-  //
-  // (Older browsers don't have a pageshow event, so we do both.)
-  window.addEventListener('pageshow', this.syncState.bind(this))
+  // event is fired, so we need to sync after the pageshow event in browsers
+  // that support it.
+  if ('onpageshow' in window) {
+    window.addEventListener('pageshow', this.syncState.bind(this))
+  } else {
+    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
+  }
+
+  // Although we've set up handlers to sync state on the pageshow or
+  // DOMContentLoaded event, init could be called after those events have fired,
+  // for example if they are added to the page dynamically, so sync now too.
+  this.syncState()
 
   // Handle events
   $module.addEventListener('click', this.handleClick.bind(this))

--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -37,27 +37,27 @@ Checkboxes.prototype.init = function () {
   // event is fired, so we need to sync after the pageshow event in browsers
   // that support it.
   if ('onpageshow' in window) {
-    window.addEventListener('pageshow', this.syncState.bind(this))
+    window.addEventListener('pageshow', this.syncAll.bind(this))
   } else {
-    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
+    window.addEventListener('DOMContentLoaded', this.syncAll.bind(this))
   }
 
   // Although we've set up handlers to sync state on the pageshow or
   // DOMContentLoaded event, init could be called after those events have fired,
   // for example if they are added to the page dynamically, so sync now too.
-  this.syncState()
+  this.syncAll()
 
   // Handle events
   $module.addEventListener('click', this.handleClick.bind(this))
 }
 
-Checkboxes.prototype.syncState = function () {
+Checkboxes.prototype.syncAll = function () {
   nodeListForEach(this.$inputs, function ($input) {
-    this.setAttributes($input)
+    this.syncWithInputState($input)
   }.bind(this))
 }
 
-Checkboxes.prototype.setAttributes = function ($input) {
+Checkboxes.prototype.syncWithInputState = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
@@ -74,7 +74,7 @@ Checkboxes.prototype.handleClick = function (event) {
   var isCheckbox = $target.getAttribute('type') === 'checkbox'
   var hasAriaControls = $target.getAttribute('aria-controls')
   if (isCheckbox && hasAriaControls) {
-    this.setAttributes($target)
+    this.syncWithInputState($target)
   }
 }
 

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -32,19 +32,20 @@ Radios.prototype.init = function () {
     $input.removeAttribute('data-aria-controls')
   })
 
-  if (document.readyState === 'loading') {
-    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
-  } else {
-    this.syncState()
-  }
-
   // When the page is restored after navigating 'back' in some browsers the
   // state of form controls is not restored until *after* the DOMContentLoaded
-  // event is fired, so we need to sync after the pageshow event is fired as
-  // well.
-  //
-  // (Older browsers don't have a pageshow event, so we do both.)
-  window.addEventListener('pageshow', this.syncState.bind(this))
+  // event is fired, so we need to sync after the pageshow event in browsers
+  // that support it.
+  if ('onpageshow' in window) {
+    window.addEventListener('pageshow', this.syncState.bind(this))
+  } else {
+    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
+  }
+
+  // Although we've set up handlers to sync state on the pageshow or
+  // DOMContentLoaded event, init could be called after those events have fired,
+  // for example if they are added to the page dynamically, so sync now too.
+  this.syncState()
 
   // Handle events
   $module.addEventListener('click', this.handleClick.bind(this))

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -1,15 +1,17 @@
 import '../../vendor/polyfills/Function/prototype/bind'
-import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
+// addEventListener, event.target normalization and DOMContentLoaded
+import '../../vendor/polyfills/Event'
 import '../../vendor/polyfills/Element/prototype/classList'
 import { nodeListForEach } from '../../common'
 
 function Radios ($module) {
   this.$module = $module
+  this.$inputs = $module.querySelectorAll('input[type="radio"]')
 }
 
 Radios.prototype.init = function () {
   var $module = this.$module
-  var $inputs = $module.querySelectorAll('input[type="radio"]')
+  var $inputs = this.$inputs
 
   /**
   * Loop over all items with [data-controls]
@@ -28,11 +30,30 @@ Radios.prototype.init = function () {
     // If we have content that is controlled, set attributes.
     $input.setAttribute('aria-controls', controls)
     $input.removeAttribute('data-aria-controls')
-    this.setAttributes($input)
-  }.bind(this))
+  })
+
+  if (document.readyState === 'loading') {
+    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
+  } else {
+    this.syncState()
+  }
+
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of form controls is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event is fired as
+  // well.
+  //
+  // (Older browsers don't have a pageshow event, so we do both.)
+  window.addEventListener('pageshow', this.syncState.bind(this))
 
   // Handle events
   $module.addEventListener('click', this.handleClick.bind(this))
+}
+
+Radios.prototype.syncState = function () {
+  nodeListForEach(this.$inputs, function ($input) {
+    this.setAttributes($input)
+  }.bind(this))
 }
 
 Radios.prototype.setAttributes = function ($input) {

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -52,9 +52,7 @@ Radios.prototype.init = function () {
 }
 
 Radios.prototype.syncAll = function () {
-  nodeListForEach(this.$inputs, function ($input) {
-    this.syncWithInputState($input)
-  }.bind(this))
+  nodeListForEach(this.$inputs, this.syncWithInputState.bind(this))
 }
 
 Radios.prototype.syncWithInputState = function ($input) {

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -37,27 +37,27 @@ Radios.prototype.init = function () {
   // event is fired, so we need to sync after the pageshow event in browsers
   // that support it.
   if ('onpageshow' in window) {
-    window.addEventListener('pageshow', this.syncState.bind(this))
+    window.addEventListener('pageshow', this.syncAll.bind(this))
   } else {
-    window.addEventListener('DOMContentLoaded', this.syncState.bind(this))
+    window.addEventListener('DOMContentLoaded', this.syncAll.bind(this))
   }
 
   // Although we've set up handlers to sync state on the pageshow or
   // DOMContentLoaded event, init could be called after those events have fired,
   // for example if they are added to the page dynamically, so sync now too.
-  this.syncState()
+  this.syncAll()
 
   // Handle events
   $module.addEventListener('click', this.handleClick.bind(this))
 }
 
-Radios.prototype.syncState = function () {
+Radios.prototype.syncAll = function () {
   nodeListForEach(this.$inputs, function ($input) {
-    this.setAttributes($input)
+    this.syncWithInputState($input)
   }.bind(this))
 }
 
-Radios.prototype.setAttributes = function ($input) {
+Radios.prototype.syncWithInputState = function ($input) {
   var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
 
   if ($content && $content.classList.contains('govuk-radios__conditional')) {
@@ -87,7 +87,7 @@ Radios.prototype.handleClick = function (event) {
     // In radios, only radios with the same name will affect each other.
     var hasSameName = ($input.name === $clickedInput.name)
     if (hasSameName && hasSameFormOwner) {
-      this.setAttributes($input)
+      this.syncWithInputState($input)
     }
   }.bind(this))
 }


### PR DESCRIPTION
When the user navigates back to a previous page that includes a conditional reveal, the visible state of the conditionally revealed content is currently only preserved in some browsers.

Firefox / Safari
----------------

Recent versions of Firefox and Safari [use a Back-Forward Cache ('bfcache')][1] which preserves the entire page, which means the JavaScript is not re-evaluated but the browser 'remembers' that the conditional reveal was visible.

Internet Explorer
-----------------

In Internet Explorer the state of the form controls has not been restored at the point we currently call the init function, and so the conditional reveal state is not preserved.

To fix this, wait for the `DOMContentLoaded` event before syncing the visibility of the conditional reveals to their checkbox / radio state. As the checkbox state in IE8-11 has been restored before the `DOMContentLoaded` event fires, this fixes the preservation of the reveal state in Internet Explorer.

We already polyfill document.addEventListener and the DOMContentLoaded event for IE8, so we don't have to treat it as a special case.

Edge Legacy
-----------

In Edge 18, the state of the form controls does not seem to be restored at all when navigating back, so there is nothing to sync the conditional reveal state to 😢

Chromium based browsers (Chrome, Edge, Opera)
---------------------------------------------

In browsers based on Chromium 78 or older, the state of the form controls has been restored at the point we invoke the init function, and so the reveal state currently displays correctly, even without waiting for the `DOMContentLoaded` event.

In Chromium 79, the ['timing of restoring control state was changed so that it is done as a task posted just after DOMContentLoaded'][2]. This means that even after the `DOMContentLoaded` event the form state has not yet been restored. The recommended approach seems to be to wait for the `pageshow` event, however in Chromium 79 the form control state [has not been restored at the point this event fires either][3]! This was [fixed in Chromium 80][4].

So:

- in Chrome ≤ 78, the form control state is restored before the script is evaluated, before both the `DOMContentLoaded` and `pageshow` events.
- in Chrome = 79, the form control state is restored after both the `DOMContentLoaded` and `pageshow` events.
- in Chrome ≥ 80, the form control state is restored after the `DOMContentLoaded` but before the `pageshow` event.

Syncing the conditional reveal state after the `pageshow` event preserves the conditional reveal state except for Chromium 79 where it remains broken. Given that [Chrome 79's usage is already trending towards 0][5] (0.29% in May 2020) and there's seemingly no other event we can listen for that'll guarantee the state is restored, we'll accept that it'll remain broken in this specific version (affecting Chrome 79, Edge 79 and Opera 66).

The `pageshow` event is not supported in older browsers including IE8-10 so we need to listen for both. This means that we 'sync' twice in browsers that support `pageshow`, but the performance impact should be minimal.

[1]: https://www.chromestatus.com/feature/5815270035685376
[2]: https://chromium.googlesource.com/chromium/src.git/+/069ad65654655b7bdfb9b760f188395840bc4be4
[3]: https://bugs.chromium.org/p/chromium/issues/detail?id=1035662
[4]: https://crrev.com/069ad65654655b7bdfb9b760f188395840bc4be4
[5]: https://gs.statcounter.com/browser-version-market-share

## Browser testing (against 82c5bf0)

- [x] IE8 (Windows)
- [x] IE9 (Windows)
- [x] IE10 (Windows)
- [x] IE11 (Windows)
- [x] Edge (Windows)
- [x] Chrome (Windows)
- [x] Firefox (Windows)
- [x] Safari (macOS)
- [x] Chrome (macOS)
- [x] Firefox (macOS)
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)

Fixes #1794
Fixes #1552 