### PR TITLE
Fix conditional reveals failing if the id of the revealed element contains special characters

### DIFF
--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -41,7 +41,7 @@ Checkboxes.prototype.setAttributes = function ($input) {
   $input.setAttribute('aria-expanded', inputIsChecked)
 
   var $content = document.getElementById($input.getAttribute('aria-controls'))
-  if ($content) {
+  if ($content && $content.classList.contains('govuk-checkboxes__conditional')) {
     $content.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
   }
 }

--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -22,7 +22,7 @@ Checkboxes.prototype.init = function () {
 
     // Check if input controls anything
     // Check if content exists, before setting attributes.
-    if (!controls || !$module.querySelector('#' + controls)) {
+    if (!controls || !document.getElementById(controls)) {
       return
     }
 
@@ -40,7 +40,7 @@ Checkboxes.prototype.setAttributes = function ($input) {
   var inputIsChecked = $input.checked
   $input.setAttribute('aria-expanded', inputIsChecked)
 
-  var $content = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $content = document.getElementById($input.getAttribute('aria-controls'))
   if ($content) {
     $content.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
   }

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -364,6 +364,33 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
+- name: with conditional items with square brackets in id
+  data:
+    name: with-conditional-items
+    idPrefix: user[how-contacted]
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: email
+        text: Email
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: phone
+        text: Phone
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-phone">Phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+      - value: text
+        text: Text message
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
 - name: with conditional item checked
   data:
     name: how-contacted-checked

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -21,7 +21,7 @@ Radios.prototype.init = function () {
 
     // Check if input controls anything
     // Check if content exists, before setting attributes.
-    if (!controls || !$module.querySelector('#' + controls)) {
+    if (!controls || !document.getElementById(controls)) {
       return
     }
 
@@ -36,7 +36,7 @@ Radios.prototype.init = function () {
 }
 
 Radios.prototype.setAttributes = function ($input) {
-  var $content = document.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $content = document.getElementById($input.getAttribute('aria-controls'))
 
   if ($content && $content.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -323,6 +323,32 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
+- name: with conditional items with square brackets in id
+  data:
+    name: user[how-contacted]
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: email
+        text: Email
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: phone
+        text: Phone
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-phone">Phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+      - value: text
+        text: Text message
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
 - name: inline with conditional items
 
   data:


### PR DESCRIPTION
If the conditionally revealed element has an ID that contains characters that have a special meaning in CSS, such as `[]`, the call to `querySelector` fails because as it's being evaluated as a selector the ID needs to be escaped:

```
Uncaught DOMException: Failed to execute 'querySelector' on 'Element': '#conditional-person-1[how-contacted]-2' is not a valid selector.
    at Radios.<anonymous> (http://localhost:3000/public/all.js:1978:31)
    at NodeList.forEach (<anonymous>)
    at nodeListForEach (http://localhost:3000/public/all.js:14:18)
    at Radios.init (http://localhost:3000/public/all.js:1973:3)
    at http://localhost:3000/public/all.js:2384:24
    at NodeList.forEach (<anonymous>)
    at nodeListForEach (http://localhost:3000/public/all.js:14:18)
    at Object.initAll (http://localhost:3000/public/all.js:2383:3)
    at http://localhost:3000/components/radios/with-conditional-items-and-square-brackets/preview:98:32
```

In some cases the selector may be valid but still incorrect, like `#conditional-rejectionReasons[candidate-actions]` which would select any element with ID conditional-rejectionReasons, also having the attribute `candidate-actions`.

We can avoid all of this by using `document.getElementById` instead, avoiding the ID being evaluated as a selector. The downside is that we can't constrain the scope to the `$module`. However, I don't think this should cause any issues (especially as the ID should be unique) and this avoids alternatives like using `CSS.escape` to escape the ID, which we'd then need to polyfill.

Fixes #1808 