### PR TITLE
Add example of Slack release message

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -67,7 +67,7 @@
 npm logout
 ```
 
-17. Publish a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels. For example:
+17. Post a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels. For example:
 
     🚀 We’ve just released GOV.‌UK Frontend v3.7.0. It's now easier and faster to use our Sass. We've also made improvements to back links, breadcrumbs, lists and the header. [https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0)
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -67,8 +67,9 @@
 npm logout
 ```
 
-17. Send a message to our users in both the X-GOV and GDS #govuk-design-system slack channels that indicates
-there's a new release with a short summary.
+17. Publish a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels. For example:
+
+    🚀 We’ve just released GOV.‌UK Frontend v3.7.0. It's now easier and faster to use our Sass. We've also made improvements to back links, breadcrumbs, lists and the header. [https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0)
 
 18. Move cards on the [Sprint board](https://github.com/orgs/alphagov/projects/4) from "Ready to Release" column to "Done".
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -69,7 +69,7 @@ npm logout
 
 17. Post a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels. For example:
 
-    🚀 We’ve just released GOV.‌UK Frontend v3.7.0. It's now easier and faster to use our Sass. We've also made improvements to back links, breadcrumbs, lists and the header. [https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0)
+    🚀 We’ve just released GOV.‌UK Frontend v3.7.0. It's now easier and faster to use our Sass. We've also made improvements to back links, breadcrumbs, lists and the header. Thanks to @<SLACK-NAME> and @<SLACK-NAME> for helping with this release. [https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.7.0)
 
 18. Move cards on the [Sprint board](https://github.com/orgs/alphagov/projects/4) from "Ready to Release" column to "Done".
 


### PR DESCRIPTION
This adds an example of the Slack message we send when we publish a release, in the release documentation.