### PR TITLE
Use better 'autocomplete' example for date input

### DIFF
--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -31,7 +31,7 @@ params:
   - name: autocomplete
     type: string
     required: false
-    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "bday-day". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
   - name: pattern
     type: string
     required: false


### PR DESCRIPTION
You'd never use "postal-code" or "username" as an autocomplete attribute on an input in the date input component, but you might use "bday-day" if the date input was asking for the user's birthday.

Provide "bday-day" as a more realistic example to help users understand how the attribute can be used effectively with this component.