### PR TITLE
Add spellcheck option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 We darkened `govuk-colour("dark-grey")` to improve the readability of hint text. It now has a contrast ratio of 7:1 and helps hint text meet the WCAG 2.1 (AAA) accessibility standard.
 
+#### Add spellcheck parameter to input and textarea components
+
+Optional parameter added to the input and textarea components to enable or disable the spellcheck attribute
+
+([PR #1859](https://github.com/alphagov/govuk-frontend/pull/1859))
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/app/views/full-page-examples/update-your-account-details/index.njk
+++ b/app/views/full-page-examples/update-your-account-details/index.njk
@@ -48,9 +48,7 @@ scenario: >-
           value: values["email"],
           errorMessage: errors["email"],
           autocomplete: "email",
-          attributes: {
-            spellcheck: false
-          }
+          spellcheck: false
         }) }}
 
         {{ govukInput({
@@ -64,9 +62,7 @@ scenario: >-
           value: values["password"],
           errorMessage: errors["password"],
           autocomplete: "new-password",
-          attributes: {
-            spellcheck: false
-          }
+          spellcheck: false
         }) }}
 
         {{ govukButton({

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -59,6 +59,10 @@ params:
   type: string
   required: false
   description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+- name: spellcheck
+  type: boolean
+  required: false
+  description: Optional field to enable or disable the spellcheck attribute on the input.
 - name: attributes
   type: object
   required: false
@@ -182,3 +186,19 @@ examples:
       name: numbers-only
       type: number
       pattern: '[0-9]*'
+  - name: with spellcheck enabled
+    data:
+      label:
+        text: Spellcheck is enabled
+      id: input-with-spellcheck-enabled
+      name: spellcheck
+      type: text
+      spellcheck: true
+  - name: with spellcheck disabled
+    data:
+      label:
+        text: Spellcheck is disabled
+      id: input-with-spellcheck-disabled
+      name: spellcheck
+      type: text
+      spellcheck: false

--- a/src/govuk/components/input/template.njk
+++ b/src/govuk/components/input/template.njk
@@ -38,6 +38,7 @@
   }) | indent(2) | trim }}
 {% endif %}
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+  {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}

--- a/src/govuk/components/input/template.test.js
+++ b/src/govuk/components/input/template.test.js
@@ -244,6 +244,36 @@ describe('Input', () => {
     })
   })
 
+  describe('when it has the spellcheck attribute', () => {
+    it('renders with spellcheck attribute set to true', () => {
+      const $ = render('input', {
+        spellcheck: true
+      })
+
+      const $component = $('.govuk-input')
+      expect($component.attr('spellcheck')).toEqual('true')
+    })
+
+    it('renders with spellcheck attribute set to false', () => {
+      const $ = render('input', {
+        name: 'my-input-name',
+        spellcheck: false
+      })
+
+      const $component = $('.govuk-input')
+      expect($component.attr('spellcheck')).toEqual('false')
+    })
+
+    it('renders without spellcheck attribute by default', () => {
+      const $ = render('input', {
+        name: 'my-input-name'
+      })
+
+      const $component = $('.govuk-input')
+      expect($component.attr('spellcheck')).toBeUndefined()
+    })
+  })
+
   describe('when it includes both a hint and an error message', () => {
     it('associates the input as described by both the hint and the error message', () => {
       const $ = render('input', {

--- a/src/govuk/components/textarea/template.njk
+++ b/src/govuk/components/textarea/template.njk
@@ -38,6 +38,7 @@
   }) | indent(2) | trim }}
 {% endif %}
   <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
+  {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>

--- a/src/govuk/components/textarea/template.test.js
+++ b/src/govuk/components/textarea/template.test.js
@@ -103,6 +103,36 @@ describe('Textarea', () => {
     })
   })
 
+  describe('when it has the spellcheck attribute', () => {
+    it('renders with spellcheck attribute set to true', () => {
+      const $ = render('textarea', {
+        spellcheck: true
+      })
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('spellcheck')).toEqual('true')
+    })
+
+    it('renders with spellcheck attribute set to false', () => {
+      const $ = render('textarea', {
+        name: 'my-textarea-name',
+        spellcheck: false
+      })
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('spellcheck')).toEqual('false')
+    })
+
+    it('renders without spellcheck attribute by default', () => {
+      const $ = render('textarea', {
+        name: 'my-textarea-name'
+      })
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('spellcheck')).toBeUndefined()
+    })
+  })
+
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
       const $ = render('textarea', {

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -7,6 +7,10 @@ params:
   type: string
   required: true
   description: The name of the textarea, which is submitted with the form data.
+- name: spellcheck
+  type: boolean
+  required: false
+  description: Optional field to enable or disable the spellcheck attribute on the textarea.
 - name: rows
   type: string
   required: false
@@ -119,3 +123,21 @@ examples:
       label:
         text: Full address
       autocomplete: street-address
+
+  - name: with spellcheck enabled
+    data:
+      label:
+        text: Spellcheck is enabled
+      id: textarea-with-spellcheck-enabled
+      name: spellcheck
+      type: text
+      spellcheck: true
+
+  - name: with spellcheck disabled
+    data:
+      label:
+        text: Spellcheck is disabled
+      id: textarea-with-spellcheck-disabled
+      name: spellcheck
+      type: text
+      spellcheck: false


### PR DESCRIPTION
Resolves https://github.com/alphagov/govuk-frontend/issues/1832

## What
Adds a Boolean `spellcheck` param to the input and textarea components

## Why
Currently, users can add a spellcheck attribute to these components by using the `attributes` param and passing the String value, for example:

```
attributes: {
    spellcheck: "true"
}
```

We want to make the spellcheck attribute more explicit. Making it a Boolean also leaves less room for human error.

<img width="664" alt="Screenshot 2020-07-10 at 10 58 54" src="https://user-images.githubusercontent.com/29889908/87142387-61387c80-c29c-11ea-84ad-5b84ea12f97b.png">

Examples:

- [input](https://govuk-frontend-review-pr-1859.herokuapp.com/components/input)
- [textarea](https://govuk-frontend-review-pr-1859.herokuapp.com/components/textarea)
- [full page example using spellcheck:false](https://govuk-frontend-review-pr-1859.herokuapp.com/full-page-examples/update-your-account-details)