### PR TITLE
Fix the display of checkboxes when border-box box sizing is applied globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#1838: Correctly camel case SVG attributes in the header and footer](https://github.com/alphagov/govuk-frontend/pull/1838)
 - [#1842: Preserve the state of conditional reveals when navigating 'back' in the browser](https://github.com/alphagov/govuk-frontend/pull/1842)
 - [#1855: Hint component can render block-level elements as valid HTML](https://github.com/alphagov/govuk-frontend/pull/1855)
+- [#1861: Fix the display of checkboxes when border-box box sizing is applied globally](https://github.com/alphagov/govuk-frontend/pull/1861)
 
 ## 3.7.0 (Feature release)
 

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -91,16 +91,17 @@
   // rotated 45 degrees
   .govuk-checkboxes__label::after {
     content: "";
+    box-sizing: border-box;
 
     position: absolute;
     top: 11px;
     left: 9px;
-    width: 18px;
-    height: 7px;
+    width: 23px;
+    height: 12px;
 
     transform: rotate(-45deg);
     border: solid;
-    border-width: 0 0 $govuk-border-width $govuk-border-width;
+    border-width: 0 0 5px 5px;
     // Fix bug in IE11 caused by transform rotate (-45deg).
     // See: alphagov/govuk_elements/issues/518
     border-top-color: transparent;
@@ -233,8 +234,8 @@
     .govuk-checkboxes__label::after {
       top: 15px;
       left: 6px;
-      width: 9px;
-      height: 3.5px;
+      width: 12px;
+      height: 6.5px;
       border-width: 0 0 3px 3px;
     }
 


### PR DESCRIPTION
If a user applies a [global box-sizing reset][1], the checkmarks shrink towards the top left corner of the box.

The ::before pseudo-element already uses `box-sizing: border-box`, so update the `::after` pseudo element to use border-box sizing model in order to be consistent. As the box-sizing model is now set explicitly, it should display correctly whether the reset is applied or not.

Increase the width and height of the pseudo elements to include the border widths to accomodate the width of the border (adding an additional 5px to the width and height of normal-sized checkboxes, and 3px to smaller ones).

Switch out the use of `$govuk-border-width` for a hardcoded 5px width for the check marks, as we don't currently factor this in when positioning the check mark, which means if you change the border width setting the checkbox will no longer be centered (I also just don't think it makes sense to tie the width of the check marks to the border width?)

Fixes #1849 

## Before

![localhost_3000_examples_form-controls-states (4)](https://user-images.githubusercontent.com/121939/87527859-a38b0080-c684-11ea-9b41-1fc5b74341d1.png)

## After

![localhost_3000_examples_form-controls-states (2)](https://user-images.githubusercontent.com/121939/87527745-73dbf880-c684-11ea-84b8-dccb72601d12.png)

[1]: https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/