### PR TITLE
Preserve the state of character count when navigating 'back'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#1855: Hint component can render block-level elements as valid HTML](https://github.com/alphagov/govuk-frontend/pull/1855)
 - [#1861: Fix the display of checkboxes when border-box box sizing is applied globally](https://github.com/alphagov/govuk-frontend/pull/1861)
 - [#1862: Fix display of warning text icon when border-box box sizing is applied globally #1862](https://github.com/alphagov/govuk-frontend/pull/1862)
+- [#1848: Preserve the state of the character count when navigating 'back' in the browser](https://github.com/alphagov/govuk-frontend/pull/1848)
 
 ## 3.7.0 (Feature release)
 

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -50,6 +50,20 @@ CharacterCount.prototype.init = function () {
   // Remove hard limit if set
   $module.removeAttribute('maxlength')
 
+  // When the page is restored after navigating 'back' in some browsers the
+  // state of the character count is not restored until *after* the DOMContentLoaded
+  // event is fired, so we need to sync after the pageshow event in browsers
+  // that support it.
+  if ('onpageshow' in window) {
+    window.addEventListener('pageshow', this.sync.bind(this))
+  } else {
+    window.addEventListener('DOMContentLoaded', this.sync.bind(this))
+  }
+
+  this.sync()
+}
+
+CharacterCount.prototype.sync = function () {
   this.bindChangeEvents()
   this.updateCountMessage()
 }


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1848

## What
When the user navigates back to a previous page that includes a character count, the character count message should reflect the text currently in the textarea.

## Why
Fix based on https://github.com/alphagov/govuk-frontend/pull/1842
Previously, when navigating back to a page with a character count, the character count message wouldn't update (reflect the text currently in the textarea) until the textarea received focus.

Current behaviour: http://govuk-frontend-review.herokuapp.com/full-page-examples/feedback
Preview new behaviour: https://govuk-frontend-review-pr-1868.herokuapp.com/full-page-examples/feedback

## Notes
On slow connections there may be a flash of the default character count text before it updates. From testing with a 4x CPU slowdown, the default text may show for 0.03s before it updates. Given how small this is even with slowdown, we've decided to leave it as-is. If we decide this is an issue in the future, we'd also need to look at other components (e.g: radios and checkboxes) which are affected in a similar way.

## Browser testing
 
- [x] IE8 (Windows)
- [x] IE9 (Windows)
- [x] IE10 (Windows)
- [x] IE11 (Windows)
- [x] Edge (Windows)
- [x] Chrome (Windows)
- [x] Firefox (Windows)
- [x] Safari (macOS)
- [x] Chrome (macOS)
- [x] Firefox (macOS)
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)