### PR TITLE
Reduce border width of form inputs in the error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,33 @@
 
 We darkened `govuk-colour("dark-grey")` to improve the readability of hint text. It now has a contrast ratio of 7:1 and helps hint text meet the WCAG 2.1 (AAA) accessibility standard.
 
+#### Updated error styling for text input, select, textarea and file upload components
+
+The error styling for the text input, select and textarea components no longer makes the border thicker.
+
+The error styling for the file upload component no longer includes a border around the file upload input.
+
+We're making these changes to ensure that the focus state is always perceivable.
+
+When an error message relates to multiple fields, ensure you are explicit about which field has the error. You must not rely on users being able to perceive which field has the error styling.
+
+([PR #1870](https://github.com/alphagov/govuk-frontend/pull/1870))
+
 #### Add spellcheck parameter to input and textarea components
 
 Optional parameter added to the input and textarea components to enable or disable the spellcheck attribute
 
 ([PR #1859](https://github.com/alphagov/govuk-frontend/pull/1859))
+
+### Deprecated features
+
+#### The `$govuk-border-width-form-element-error` setting
+
+The `$govuk-border-width-form-element-error` setting has been deprecated, and will be removed in GOV.UK Frontend v4.0.
+
+Update any references to `$govuk-border-width-form-element-error` in your application's styles to reference `$govuk-border-width-form-element` instead.
+
+([PR #1870](https://github.com/alphagov/govuk-frontend/pull/1870))
 
 ### Fixes
 

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -47,27 +47,4 @@
       box-shadow: inset 0 0 0 4px $govuk-input-border-colour;
     }
   }
-
-  .govuk-file-upload--error {
-    // As `upload--error` has border, it needs to have the same padding as
-    // the standard focused element.
-    margin-right: -$component-padding;
-    margin-left: -$component-padding;
-    padding-right: $component-padding;
-    padding-left: $component-padding;
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
-
-    &:focus {
-      border-color: $govuk-input-border-colour;
-    }
-
-    // Repeat `:focus` styles to prevent error styles from being applied when
-    // input button is pressed as this moves the focus to "within".
-    // This can't be set together with `:focus` as all versions of IE fail
-    // to recognise `focus-within` and don't set any styles from the block
-    // when it's a selector.
-    &:focus-within {
-      border-color: $govuk-input-border-colour;
-    }
-  }
 }

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -59,9 +59,6 @@
 
     &:focus {
       border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `file-upload--error`
-      // already has the thicker border.
-      box-shadow: none;
     }
 
     // Repeat `:focus` styles to prevent error styles from being applied when
@@ -71,7 +68,6 @@
     // when it's a selector.
     &:focus-within {
       border-color: $govuk-input-border-colour;
-      box-shadow: none;
     }
   }
 }

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -56,9 +56,6 @@
 
     &:focus {
       border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `input--error`
-      // already has the thicker border.
-      box-shadow: none;
     }
   }
 

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -44,9 +44,6 @@
 
     &:focus {
       border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `select--error`
-      // already has the thicker border.
-      box-shadow: none;
     }
   }
 

--- a/src/govuk/components/textarea/_index.scss
+++ b/src/govuk/components/textarea/_index.scss
@@ -42,9 +42,6 @@
 
     &:focus {
       border-color: $govuk-input-border-colour;
-      // Remove `box-shadow` inherited from `:focus` as `textarea--error`
-      // already has the thicker border.
-      box-shadow: none;
     }
 
   }

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -82,7 +82,7 @@ $govuk-border-width-form-element: 2px !default;
 /// @type Number
 /// @access public
 
-$govuk-border-width-form-element-error: 4px !default;
+$govuk-border-width-form-element-error: 2px !default;
 
 /// Form group border width when in error state
 ///

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -81,6 +81,9 @@ $govuk-border-width-form-element: 2px !default;
 ///
 /// @type Number
 /// @access public
+/// @deprecated Use $govuk-border-width-form-element instead. There should be no
+///   difference in thickness for inputs in the error state, in order to
+///   maintain a distinct focus state.
 
 $govuk-border-width-form-element-error: 2px !default;
 


### PR DESCRIPTION
Reduce border width of form inputs in error state.

We rely on the [input border getting thicker][1] in order to meet [WCAG 2.1 1.4.11: Non-text Contrast][2].

However, when the text input or textarea is in the error state, it already has a thicker border, and so the border only changes from red to black (alongside the addition of the yellow outline). The contrast between the red and the black is only 2.75:1, so the change in state from error to focused may not be perceivable by some users.

Reduce the error border width on inputs down to 2px, which is the same as the normal border width for a form input.

As the border width is now no thicker than the normal border width, remove the overrides that suppress the focus state's box shadow from errored inputs.

For components with multiple inputs, like the date input,this change does make it even more important to ensure that the error message clearly explains which field has the error. Although fields with an error continue to be differentiated from others by the thicker left border and the bold error text, the red border around the specific input can now only be seen as an enhancement. We are [updating the documentation in the Design System to stress the importance of being explicit about which field an error message relates to][3].

Remove the border from the file input in its error state, aligning it with radios / checkboxes, where the error state is indicated by the red left-hand border on the form group and the error message.

Finally, deprecate `$govuk-border-width-form-element-error` to be removed in v4.0.

Fixes #1820

[1]: https://design-system.service.gov.uk/get-started/focus-states/
[2]: https://www.w3.org/TR/WCAG21/#non-text-contrast
[3]: https://www.github.com/alphagov/govuk-design-system/pull/1302

| Before | After |
|---|---|
| ![localhost_3000_examples_error-summary](https://user-images.githubusercontent.com/121939/87799008-987ece80-c844-11ea-893d-588eb6d8be9c.png)  | ![localhost_3000_examples_error-summary (1)](https://user-images.githubusercontent.com/121939/87799016-9ae12880-c844-11ea-884b-176c1d73a969.png) |


