### PR TITLE
Remove 'etc' and negative contractions from Sass code comments

### DIFF
--- a/package/govuk/helpers/_colour.scss
+++ b/package/govuk/helpers/_colour.scss
@@ -52,7 +52,7 @@
 ///   colour will be returned which meets contrast requirements . If you want to
 ///   use the non-websafe version you can set this to `false` but your should
 ///   ensure that you still meets contrast requirements for accessibility - for
-///   example, don't use the non-websafe version for text.
+///   example, do not use the non-websafe version for text.
 ///
 /// @return {Colour} Representation of colour for organisation
 /// @throw if `$organisation` is not a known organisation

--- a/package/govuk/settings/_colours-applied.scss
+++ b/package/govuk/settings/_colours-applied.scss
@@ -52,7 +52,7 @@ $govuk-print-text-colour: #000000 !default;
 
 /// Secondary text colour
 ///
-/// Used for 'muted' text, help text, etc.
+/// Used in for example 'muted' text and help text.
 ///
 /// @type Colour
 /// @access public
@@ -90,7 +90,7 @@ $govuk-error-colour: govuk-colour("red") !default;
 
 /// Border colour
 ///
-/// Used for borders, separators, rules, keylines etc.
+/// Used in for example borders, separators, rules and keylines.
 ///
 /// @type Colour
 /// @access public

--- a/src/govuk/helpers/_colour.scss
+++ b/src/govuk/helpers/_colour.scss
@@ -52,7 +52,7 @@
 ///   colour will be returned which meets contrast requirements . If you want to
 ///   use the non-websafe version you can set this to `false` but your should
 ///   ensure that you still meets contrast requirements for accessibility - for
-///   example, don't use the non-websafe version for text.
+///   example, do not use the non-websafe version for text.
 ///
 /// @return {Colour} Representation of colour for organisation
 /// @throw if `$organisation` is not a known organisation

--- a/src/govuk/settings/_colours-applied.scss
+++ b/src/govuk/settings/_colours-applied.scss
@@ -52,7 +52,7 @@ $govuk-print-text-colour: #000000 !default;
 
 /// Secondary text colour
 ///
-/// Used for 'muted' text, help text, etc.
+/// Used in for example 'muted' text and help text.
 ///
 /// @type Colour
 /// @access public
@@ -90,7 +90,7 @@ $govuk-error-colour: govuk-colour("red") !default;
 
 /// Border colour
 ///
-/// Used for borders, separators, rules, keylines etc.
+/// Used in for example borders, separators, rules and keylines.
 ///
 /// @type Colour
 /// @access public


### PR DESCRIPTION
As part of the work to [audit and fix accessibility issues in GOV.UK Frontend docs](https://github.com/alphagov/design-system-team-internal/issues/312), this replaces instances of 'etc' and negative contractions in the Sass comments that generate our [Sass API reference](https://frontend.design-system.service.gov.uk/sass-api-reference/).