### PR TITLE
Explicitly set outline-offset to remove 1px transparent border in chrome v84

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#1861: Fix the display of checkboxes when border-box box sizing is applied globally](https://github.com/alphagov/govuk-frontend/pull/1861)
 - [#1862: Fix display of warning text icon when border-box box sizing is applied globally #1862](https://github.com/alphagov/govuk-frontend/pull/1862)
 - [#1848: Preserve the state of the character count when navigating 'back' in the browser](https://github.com/alphagov/govuk-frontend/pull/1848)
+- [#1879: Explicitly set outline-offset to remove 1px transparent border in chrome v84](https://github.com/alphagov/govuk-frontend/pull/1879)
 
 ## 3.7.0 (Feature release)
 

--- a/src/govuk/components/skip-link/_index.scss
+++ b/src/govuk/components/skip-link/_index.scss
@@ -21,6 +21,7 @@
 
     &:focus {
       outline: $govuk-focus-width solid $govuk-focus-colour;
+      outline-offset: 0;
       background-color: $govuk-focus-colour;
 
       // Undo unwanted changes when global styles are enabled


### PR DESCRIPTION
Chrome appears to have changed the default outline-offset to 1px, which then adds a transparent border to the skip link. This explicitly sets it to 0 to hide that border.