### PR TITLE
Test if page template inline script matches hash we will publish in docs

### DIFF
--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -2,6 +2,7 @@
 
 const nunjucks = require('nunjucks')
 const configPaths = require('../../config/paths.json')
+const crypto = require('crypto')
 
 const { renderTemplate } = require('../../lib/jest-helpers')
 
@@ -150,6 +151,20 @@ describe('Template', () => {
       const $ = renderTemplate({}, { bodyEnd })
 
       expect($('body > div:last-of-type').text()).toEqual('bodyEnd')
+    })
+
+    describe('inline script that adds "js-enabled" class', () => {
+      it('should match the hash published in docs', () => {
+        const $ = renderTemplate()
+        const script = $('body > script').first().html()
+
+        // Create a base64 encoded hash of the contents of the script tag
+        const hash = crypto.createHash('sha256').update(script).digest('base64')
+
+        // A change to the inline script would be a breaking change, and it would also require
+        // updating the hash published in https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-isn-t-working-properly
+        expect('sha256-' + hash).toEqual('sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=')
+      })
     })
 
     describe('skip link', () => {


### PR DESCRIPTION
We're going to [document how to configure Content Security Policy (CSP) to work with the inline 'js-enabled' script](https://github.com/alphagov/govuk-frontend-docs/issues/68) in Frontend page template.

This PR adds a test that
- uses Node.js Crypto to create a base64 encoded hash of the contents of the inline script tag in Frontend page template
- compares the generated hash it to the hash we're going to publish in developer docs
- adds a comment about the changes required if the script tag changes

We don't yet have the docs URL that needs to be updated if the hash changes, so I've used a placeholder. 

Fixes https://github.com/alphagov/govuk-frontend/issues/1882