### PR TITLE
Remove "type: text" from textarea example yaml

### DIFF
--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -130,7 +130,6 @@ examples:
         text: Spellcheck is enabled
       id: textarea-with-spellcheck-enabled
       name: spellcheck
-      type: text
       spellcheck: true
 
   - name: with spellcheck disabled
@@ -139,5 +138,4 @@ examples:
         text: Spellcheck is disabled
       id: textarea-with-spellcheck-disabled
       name: spellcheck
-      type: text
       spellcheck: false


### PR DESCRIPTION
The textarea component does not have a type parameter so this does not need to be specified in the yaml examples. I suspect this was copied and pasted from the input component's examples during the addition of the spellcheck parameter.

This causes me a slight issue downstream in govuk-react-jsx since I "spread" any additional attributes like this into the React components, which is causing my tests to fail whilst trying to update to govuk-frontend@3.8.0. I realise these yaml files are more for your consumption (Particularly referencing the discussion about fixtures.json files going on elsewhere) but if it's possible to merge this and remove the type attribute that would be great.