### PR TITLE
Swap modern and legacy palettes in colour settings

### DIFF
--- a/src/govuk/settings/_colours-palette.scss
+++ b/src/govuk/settings/_colours-palette.scss
@@ -19,39 +19,6 @@ $govuk-use-legacy-palette: if((
     $govuk-compatibility-govukelements
   ), true, false) !default;
 
-/// Legacy colour palette
-///
-/// This exists only because you cannot easily set a !default variable
-/// conditionally (thanks to the way scope works in Sass) so we set
-/// `$govuk-colour-palette` using the `if` function.
-///
-/// @access private
-
-$_govuk-colour-palette-legacy: (
-  "purple": #2e358b,
-  "light-purple": #6f72af,
-  "bright-purple": #912b88,
-  "pink": #d53880,
-  "light-pink": #f499be,
-  "red": #b10e1e,
-  "bright-red": #df3034,
-  "orange": #f47738,
-  "brown": #b58840,
-  "yellow": #ffbf47,
-  "light-green": #85994b,
-  "green": #006435,
-  "turquoise": #28a197,
-  "light-blue": #2b8cc4,
-  "blue": #005ea5,
-
-  "black": #0b0c0c,
-  "grey-1": #6f777b,
-  "grey-2": #bfc1c3,
-  "grey-3": #dee0e2,
-  "grey-4": #f8f8f8,
-  "white": #ffffff
-);
-
 /// Modern colour palette
 ///
 /// This exists only because you cannot easily set a !default variable
@@ -83,6 +50,39 @@ $_govuk-colour-palette-modern: (
   "brown": #b58840,
   "light-green": #85994b,
   "turquoise": #28a197
+);
+
+/// Legacy colour palette
+///
+/// This exists only because you cannot easily set a !default variable
+/// conditionally (thanks to the way scope works in Sass) so we set
+/// `$govuk-colour-palette` using the `if` function.
+///
+/// @access private
+
+$_govuk-colour-palette-legacy: (
+  "purple": #2e358b,
+  "light-purple": #6f72af,
+  "bright-purple": #912b88,
+  "pink": #d53880,
+  "light-pink": #f499be,
+  "red": #b10e1e,
+  "bright-red": #df3034,
+  "orange": #f47738,
+  "brown": #b58840,
+  "yellow": #ffbf47,
+  "light-green": #85994b,
+  "green": #006435,
+  "turquoise": #28a197,
+  "light-blue": #2b8cc4,
+  "blue": #005ea5,
+
+  "black": #0b0c0c,
+  "grey-1": #6f777b,
+  "grey-2": #bfc1c3,
+  "grey-3": #dee0e2,
+  "grey-4": #f8f8f8,
+  "white": #ffffff
 );
 
 /// Colour palette


### PR DESCRIPTION
I refer to the colour palette file quite a lot in order to grab colour hex values (for example, to check colour contrast combinations or use them in presentations).

Because the legacy colour palette appears first, it's easy to accidentally grab the colour from the legacy palette rather than the current colour palette.

Swap the order so that the current colour palette appears first in the file.