### PR TITLE
Set navigation and mobile menu labels of the header component with new options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### New features
+
+#### Set navigation and mobile menu labels of the header with new options
+
+You can now customise the `aria-label` attributes of the navigation and mobile menu of the header component using the new `navigationLabel` and `menuButtonLabel` options.
+
+For example:
+
+```javascript
+{{ govukHeader({
+    navigationLabel: "Custom navigation label",
+    menuButtonLabel: "Custom menu label"
+}) }}
+```
+
+This was added in [pull request #1905: Set navigation and mobile menu labels of the header component with new options](https://github.com/alphagov/govuk-frontend/pull/1905).
+
 ## 3.8.1 (Fix release)
 
 ### Fixes

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -48,6 +48,14 @@ params:
   type: string
   required: false
   description: Classes for the navigation section of the header.
+- name: navigationLabel
+  type: string
+  required: false
+  description: Text for the `aria-label` attribute of the navigation. Defaults to "Top Level Navigation".
+- name: menuButtonLabel
+  type: string
+  required: false
+  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to "Show or hide Top Level Navigation".
 - name: containerClasses
   type: string
   required: false
@@ -95,6 +103,34 @@ examples:
 
 - name: with navigation
   data:
+    navigation:
+      - href: '#1'
+        text: Navigation item 1
+        active: true
+      - href: '#2'
+        text: Navigation item 2
+      - href: '#3'
+        text: Navigation item 3
+      - href: '#4'
+        text: Navigation item 4
+
+- name: with custom navigation label
+  data:
+    navigationLabel: Custom navigation label
+    navigation:
+      - href: '#1'
+        text: Navigation item 1
+        active: true
+      - href: '#2'
+        text: Navigation item 2
+      - href: '#3'
+        text: Navigation item 3
+      - href: '#4'
+        text: Navigation item 4
+
+- name: with custom menu button label
+  data:
+    menuButtonLabel: Custom button label
     navigation:
       - href: '#1'
         text: Navigation item 1

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -60,9 +60,9 @@
     </a>
     {% endif %}
     {% if params.navigation %}
-    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide Top Level Navigation') }}">Menu</button>
     <nav>
-      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
+      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="{{ params.navigationLabel | default('Top Level Navigation') }}">
         {% for item in params.navigation %}
           {% if item.href and (item.text or item.html) %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -107,6 +107,24 @@ describe('header', () => {
       expect($firstItem.text()).toContain('Navigation item 1')
     })
 
+    it('renders navigation default label correctly', () => {
+      const $ = render('header', examples['with navigation'])
+
+      const $component = $('.govuk-header')
+      const $list = $component.find('ul.govuk-header__navigation')
+
+      expect($list.attr('aria-label')).toEqual('Top Level Navigation')
+    })
+
+    it('allows navigation label to be customised', () => {
+      const $ = render('header', examples['with custom navigation label'])
+
+      const $component = $('.govuk-header')
+      const $list = $component.find('ul.govuk-header__navigation')
+
+      expect($list.attr('aria-label')).toEqual('Custom navigation label')
+    })
+
     it('renders navigation item with html', () => {
       const $ = render('header', {
         navigation: [
@@ -146,6 +164,20 @@ describe('header', () => {
         const $button = $('.govuk-header__menu-button')
 
         expect($button.attr('type')).toEqual('button')
+      })
+      it('renders default label correctly', () => {
+        const $ = render('header', examples['with navigation'])
+
+        const $button = $('.govuk-header__menu-button')
+
+        expect($button.attr('aria-label')).toEqual('Show or hide Top Level Navigation')
+      })
+      it('allows label to be customised', () => {
+        const $ = render('header', examples['with custom menu button label'])
+
+        const $button = $('.govuk-header__menu-button')
+
+        expect($button.attr('aria-label')).toEqual('Custom button label')
       })
     })
   })


### PR DESCRIPTION
This PR:
- adds macro options for localising the menu button and navigation label of the header
- makes the previously hardcoded content the default text
- adds tests to check for default and customised content

Fixes https://github.com/alphagov/govuk-frontend/issues/1682

Have split localising the 'menu' text into https://github.com/alphagov/govuk-frontend/issues/1904 following a chat with @christopherthomasdesign.