### PR TITLE
Demo of possible fix for checkbox label focus glitch

### DIFF
--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -30,6 +30,7 @@
   }
   
   .govuk-checkboxes__item:focus {
+    
     outline: none;
 
     & .govuk-checkboxes__label:before {

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -31,7 +31,8 @@
   
   .govuk-checkboxes__item:focus {
     outline: none;
-    & .govuk-checkboxes__label:before {
+    
+    & .govuk-checkboxes__label:before { 
       border-width: 4px;
       box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
     }

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -28,6 +28,15 @@
   .govuk-checkboxes__item:last-of-type {
     margin-bottom: 0;
   }
+  
+  .govuk-checkboxes__item:focus {
+    outline: none;
+
+    & .govuk-checkboxes__label:before {
+      border-width: 4px;
+      box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+    }
+  }
 
   .govuk-checkboxes__input {
     $input-offset: ($govuk-touch-target-size - $govuk-checkboxes-size) / 2;

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -28,11 +28,11 @@
   .govuk-checkboxes__item:last-of-type {
     margin-bottom: 0;
   }
-  
+
   .govuk-checkboxes__item:focus {
     outline: none;
-    
-    & .govuk-checkboxes__label:before { 
+
+    & .govuk-checkboxes__label:before {
       border-width: 4px;
       box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
     }

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -30,9 +30,7 @@
   }
   
   .govuk-checkboxes__item:focus {
-    
     outline: none;
-
     & .govuk-checkboxes__label:before {
       border-width: 4px;
       box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;

--- a/src/govuk/components/checkboxes/template.njk
+++ b/src/govuk/components/checkboxes/template.njk
@@ -71,7 +71,7 @@
         {% set itemHintId = id + "-item-hint" if hasHint else "" %}
         {% set itemDescribedBy = describedBy if not hasFieldset else "" %}
         {% set itemDescribedBy = (itemDescribedBy + " " + itemHintId) | trim %}
-        <div class="govuk-checkboxes__item">
+        <div class="govuk-checkboxes__item" tabindex="-1">
           <input class="govuk-checkboxes__input" id="{{ id }}" name="{{ name }}" type="checkbox" value="{{ item.value }}"
           {{-" checked" if item.checked }}
           {{-" disabled" if item.disabled }}


### PR DESCRIPTION
This PR demonstrates a possible fix to #1906.

I don't necessarily expect it to get merged - but the review app can help demonstrate how it works and possibly be used for testing.

I've tried it in Voiceover on mac and it seems to have no impact. 

As it's fiddling with focus it would want to be well tested - but you can't directly focus these items anyway so it mostly makes changes only when mouse-down on a label.