### PR TITLE
Fix character count shrinking as you go over limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#1912: Fix character count shrinking as you go over limit](https://github.com/alphagov/govuk-frontend/pull/1912)
+
 ## 3.8.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/character-count/_index.scss
+++ b/src/govuk/components/character-count/_index.scss
@@ -11,10 +11,6 @@
     .govuk-textarea {
       margin-bottom: govuk-spacing(1);
     }
-
-    .govuk-textarea--error {
-      padding: govuk-spacing(1) - 2; // Stop a "jump" when width of border changes
-    }
   }
 
   .govuk-character-count__message {


### PR DESCRIPTION
The character count still compensates for the error state having a thicker border, by reducing the padding by 2px when the `--error` modifier is applied.

Since we removed the thicker border from the error state In 6bdca06, this now 'over-compensates', causing the padding on the character count's textarea to shrink by 2px when the user goes over the character limit.

![](https://user-images.githubusercontent.com/121939/90113205-e3f3a200-dd48-11ea-9498-3397a71a2618.gif)

Remove the padding override on the `--error` modifier as it's no longer needed.

👉🏻 [Preview](https://govuk-frontend-review-pr-1912.herokuapp.com/components/character-count)

Fixes #1910 