### PR TITLE
Make it possible to exclude link from header navigation item

### DIFF
--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -35,7 +35,7 @@ params:
   - name: href
     type: string
     required: false
-    description: Url of the navigation item anchor. Both `href` and `text` attributes for navigation items need to be provided to create an item.
+    description: Url of the navigation item anchor.
   - name: active
     type: boolean
     required: false
@@ -232,3 +232,23 @@ examples:
         html: <em>Navigation item 2</em>
       - href: '#3'
         html: <em>Navigation item 3</em>
+
+- name: navigation item with text without link
+  data:
+    serviceName: Service Name
+    serviceUrl: '/components/header'
+    navigation:
+      - text: Navigation item 1
+        active: true
+      - text: Navigation item 2
+      - text: Navigation item 3
+
+- name: navigation item with html without link
+  data:
+    serviceName: Service Name
+    serviceUrl: '/components/header'
+    navigation:
+      - html: <em>Navigation item 1</em>
+        active: true
+      - html: <em>Navigation item 2</em>
+      - html: <em>Navigation item 3</em>

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -64,11 +64,15 @@
     <nav>
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="{{ params.navigationLabel | default('Top Level Navigation') }}">
         {% for item in params.navigation %}
-          {% if item.href and (item.text or item.html) %}
+          {% if item.text or item.html %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">
-              <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+              {% if item.href %}
+                <a class="govuk-header__link" href="{{ item.href }}"{% for attribute, value in item.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+              {% endif %}
                 {{ item.html | safe if item.html else item.text }}
-              </a>
+              {% if item.href %}
+                </a>
+              {% endif %}
             </li>
           {% endif %}
         {% endfor %}

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -139,6 +139,20 @@ describe('header', () => {
       expect($navigationLink.html()).toContain('<em>Nav item</em>')
     })
 
+    it('renders navigation item with text without a link', () => {
+      const $ = render('header', examples['navigation item with text without link'])
+
+      const $navigationItem = $('.govuk-header__navigation-item')
+      expect($navigationItem.html()).toContain('Navigation item 1')
+    })
+
+    it('renders navigation item with html without a link', () => {
+      const $ = render('header', examples['navigation item with html without link'])
+
+      const $navigationItem = $('.govuk-header__navigation-item')
+      expect($navigationItem.html()).toContain('<em>Navigation item 1</em>')
+    })
+
     it('renders navigation item anchor with attributes', () => {
       const $ = render('header', {
         navigation: [


### PR DESCRIPTION
This PR:
- makes rendering the link in the header navigation item conditional on `item.href` being set
- adds tests to check that `item.text` and `item.html` can render a navigation item without a link

We would expect this to be mainly useful for rendering a form for instance for adding a log out button. The team would need to manually style any enclosed form elements or buttons.

I considered not allowing this behaviour for `item.text` as it seems unlikely you'd want to omit the link when passing through simple text content. However I decided against in order to keep the API simpler, the fork would require documentation under `navigation.item.href` eg.
> Both `href` and `text` attributes for navigation items need to be provided to create an item. Using `html` attribute does not require `href` to create an item.

But happy to re-consider this.

Fixes https://github.com/alphagov/govuk-frontend/issues/1573