### PR TITLE
Add note for contributors on using hidden:true in yaml files

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -60,6 +60,10 @@ You should write new tests if you’ve created a new component, or changed the w
 - changing or adding to the component's Nunjucks macro
 - creating or updating a Sass mixin or function
 
+Test files use examples from each component’s `.yaml` file, for example `src/govuk/components/button/button.yaml`. When you add or update tests, you can use the existing examples or add new ones.
+
+Use `hidden: true` in a new example if you do not want to include the example in the review app. The example will still appear in our [test fixtures](http://frontend.design-system.service.gov.uk/testing-your-html/).
+
 ### If you created a component
 
 Create the following files in the `src/govuk/components` folder:


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/1830

As part of [adding docs on testing with HTML fixtures](https://github.com/alphagov/govuk-frontend-docs/pull/74), this adds a note in our contributing docs about using `hidden: true` in yaml files if you want your example to appear in the fixtures files but not the review app. 