### PR TITLE
Fix typos in radios documentation

### DIFF
--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -9,7 +9,6 @@ params:
   description: If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.
 - name: id
   type: string
-  required: true
   description: Optional id attribute to add to the hint span tag.
 - name: classes
   type: string

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -26,7 +26,7 @@ params:
 - name: idPrefix
   type: string
   required: false
-  description: String to prefix id for each checkbox item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
+  description: String to prefix id for each radio item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
 - name: name
   type: string
   required: true
@@ -60,7 +60,7 @@ params:
   - name: hint
     type: object
     required: false
-    description: Provide hint to each checkbox item.
+    description: Provide hint to each radio item.
     isComponent: true
   - name: divider
     type: string


### PR DESCRIPTION
While reading the Nunjucks options on the Design System website I noticed what I think are some typos in the documentation files for radios and hint.