### PR TITLE
Component test files use examples

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -26,9 +26,13 @@ exports.readFileContents = readFileContents
 const getComponentData = componentName => {
   try {
     const yamlPath = path.join(configPaths.components, componentName, `${componentName}.yaml`)
-    return yaml.safeLoad(
+    const yamlObj = yaml.safeLoad(
       fs.readFileSync(yamlPath, 'utf8'), { json: true }
     )
+
+    yamlObj.examples = yamlObj.examples.filter(function (example) { return !example.hidden })
+
+    return yamlObj
   } catch (error) {
     return new Error(error)
   }

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -53,9 +53,6 @@ examples:
 - name: default
   data:
     id: default-example
-    classes: myClass
-    attributes:
-      data-attribute: value
     items:
       - heading:
           text: Section A
@@ -94,6 +91,7 @@ examples:
             <ul class="govuk-list govuk-list--bullet">
               <li>Example item 2</li>
             </ul>
+
 - name: with one section open
   data:
     id: one-section-open-example
@@ -149,6 +147,25 @@ examples:
           html: <a class="govuk-link" href="#">Link B</a>
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: classes
+  hidden: true
+  data:
+    classes: myClass
+    items:
+      - heading:
+          text: Section A
+        content:
+          text: Some content
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-attribute: value
+    items:
+      - heading:
+          text: Section A
+        content:
+          text: Some content
 - name: custom heading level
   hidden: true
   data:

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -147,3 +147,38 @@ examples:
           text: Section B
         content:
           html: <a class="govuk-link" href="#">Link B</a>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: custom heading level
+  hidden: true
+  data:
+    headingLevel: 3
+    items:
+      - heading:
+          text: Section A
+        content:
+          text: Some content
+- name: heading html
+  hidden: true
+  data:
+    items:
+      - heading:
+          html: <span class="myClass">Section A</span>
+        content:
+          text: Some content
+- name: with falsey values
+  hidden: true
+  data:
+    items:
+      - heading:
+          text: Section A
+        content:
+          text: Some content
+      - false
+      - ""
+      - null
+      - heading:
+          text: Section B
+        content:
+          text: Some content
+

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -19,87 +19,35 @@ describe('Accordion', () => {
     })
 
     it('renders with specified heading level', () => {
-      const $ = render('accordion', {
-        headingLevel: '3',
-        items: [
-          {
-            heading: {
-              text: 'Section A'
-            },
-            content: {
-              text: 'Some content'
-            }
-          }
-        ]
-      })
+      const $ = render('accordion', examples['custom heading level'])
       const $componentHeading = $('.govuk-accordion__section-heading')
 
       expect($componentHeading.get(0).tagName).toEqual('h3')
     })
 
     it('renders with heading button text', () => {
-      const $ = render('accordion', {
-        headingLevel: '3',
-        items: [
-          {
-            heading: {
-              html: '<span class="myClass">Section A</span>'
-            },
-            content: {
-              text: 'Some content'
-            }
-          }
-        ]
-      })
+      const $ = render('accordion', examples.default)
+      const $componentHeadingButton = $('.govuk-accordion__section-button')
+
+      expect($componentHeadingButton.html().trim()).toEqual('Section A')
+    })
+
+    it('renders with heading button html', () => {
+      const $ = render('accordion', examples['heading html'])
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
       expect($componentHeadingButton.html().trim()).toEqual('<span class="myClass">Section A</span>')
     })
 
     it('renders with content', () => {
-      const $ = render('accordion', {
-        headingLevel: '3',
-        items: [
-          {
-            heading: {
-              text: 'Section A'
-            },
-            content: {
-              text: 'Some content'
-            }
-          }
-        ]
-      })
-      const $componentContent = $('.govuk-accordion__section-content')
+      const $ = render('accordion', examples.default)
+      const $componentContent = $('.govuk-accordion__section-content').first()
 
-      expect($componentContent.text().trim()).toEqual('Some content')
+      expect($componentContent.text().trim()).toEqual('Example item 1')
     })
 
     it('renders list without falsely values', () => {
-      const $ = render('accordion', {
-        headingLevel: '3',
-        items: [
-          {
-            heading: {
-              text: 'Section A'
-            },
-            content: {
-              text: 'Some content'
-            }
-          },
-          false,
-          undefined,
-          null,
-          {
-            heading: {
-              text: 'Section B'
-            },
-            content: {
-              text: 'Some content'
-            }
-          }
-        ]
-      })
+      const $ = render('accordion', examples['with falsey values'])
       const $component = $('.govuk-accordion')
       const $items = $component.find('.govuk-accordion__section')
 
@@ -107,74 +55,37 @@ describe('Accordion', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('accordion', {
-        classes: 'app-accordion--custom-modifier'
-      })
+      const $ = render('accordion', examples.default)
 
       const $component = $('.govuk-accordion')
-      expect($component.hasClass('app-accordion--custom-modifier')).toBeTruthy()
+      expect($component.hasClass('myClass')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('accordion', {
-        id: 'my-accordion'
-      })
+      const $ = render('accordion', examples.default)
 
       const $component = $('.govuk-accordion')
-      expect($component.attr('id')).toEqual('my-accordion')
+      expect($component.attr('id')).toEqual('default-example')
     })
 
     it('renders with attributes', () => {
-      const $ = render('accordion', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('accordion', examples.default)
       const $component = $('.govuk-accordion')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('data-attribute')).toEqual('value')
     })
 
     it('renders with section expanded class', () => {
-      const $ = render('accordion', {
-        items: [
-          {
-            expanded: true,
-            heading: {
-              text: 'Section A'
-            },
-            content: {
-              text: 'Some content'
-            }
-          }
-        ]
-      })
-      const $componentSection = $('.govuk-accordion__section')
+      const $ = render('accordion', examples['with one section open'])
+      const $componentSection = $('.govuk-accordion__section').first()
 
       expect($componentSection.hasClass('govuk-accordion__section--expanded')).toBeTruthy()
     })
 
-    describe('when it includes a summary', () => {
-      it('renders with summary', () => {
-        const $ = render('accordion', {
-          headingLevel: '3',
-          items: [
-            {
-              heading: {
-                text: 'Section A'
-              },
-              summary: {
-                text: 'Summary of content'
-              },
-              content: {
-                text: 'Some content'
-              }
-            }
-          ]
-        })
-        const $componentSummary = $('.govuk-accordion__section-summary')
+    it('renders with summary', () => {
+      const $ = render('accordion', examples['with additional descriptions'])
+      const $componentSummary = $('.govuk-accordion__section-summary').first()
 
-        expect($componentSummary.text().trim()).toEqual('Summary of content')
-      })
+      expect($componentSummary.text().trim()).toEqual('Additional description')
     })
   })
 })

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -10,19 +10,12 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('accordion')
 
 describe('Accordion', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('accordion', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
-    })
-
-    it('renders with specified heading level', () => {
-      const $ = render('accordion', examples['custom heading level'])
-      const $componentHeading = $('.govuk-accordion__section-heading')
-
-      expect($componentHeading.get(0).tagName).toEqual('h3')
     })
 
     it('renders with heading button text', () => {
@@ -32,33 +25,11 @@ describe('Accordion', () => {
       expect($componentHeadingButton.html().trim()).toEqual('Section A')
     })
 
-    it('renders with heading button html', () => {
-      const $ = render('accordion', examples['heading html'])
-      const $componentHeadingButton = $('.govuk-accordion__section-button')
-
-      expect($componentHeadingButton.html().trim()).toEqual('<span class="myClass">Section A</span>')
-    })
-
     it('renders with content', () => {
       const $ = render('accordion', examples.default)
       const $componentContent = $('.govuk-accordion__section-content').first()
 
       expect($componentContent.text().trim()).toEqual('Example item 1')
-    })
-
-    it('renders list without falsely values', () => {
-      const $ = render('accordion', examples['with falsey values'])
-      const $component = $('.govuk-accordion')
-      const $items = $component.find('.govuk-accordion__section')
-
-      expect($items.length).toEqual(2)
-    })
-
-    it('renders with classes', () => {
-      const $ = render('accordion', examples.default)
-
-      const $component = $('.govuk-accordion')
-      expect($component.hasClass('myClass')).toBeTruthy()
     })
 
     it('renders with id', () => {
@@ -67,11 +38,34 @@ describe('Accordion', () => {
       const $component = $('.govuk-accordion')
       expect($component.attr('id')).toEqual('default-example')
     })
+  })
+
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('accordion', examples.classes)
+
+      const $component = $('.govuk-accordion')
+      expect($component.hasClass('myClass')).toBeTruthy()
+    })
 
     it('renders with attributes', () => {
-      const $ = render('accordion', examples.default)
+      const $ = render('accordion', examples.attributes)
       const $component = $('.govuk-accordion')
       expect($component.attr('data-attribute')).toEqual('value')
+    })
+
+    it('renders with specified heading level', () => {
+      const $ = render('accordion', examples['custom heading level'])
+      const $componentHeading = $('.govuk-accordion__section-heading')
+
+      expect($componentHeading.get(0).tagName).toEqual('h3')
+    })
+
+    it('renders with heading button html', () => {
+      const $ = render('accordion', examples['heading html'])
+      const $componentHeadingButton = $('.govuk-accordion__section-button')
+
+      expect($componentHeadingButton.html().trim()).toEqual('<span class="myClass">Section A</span>')
     })
 
     it('renders with section expanded class', () => {
@@ -86,6 +80,14 @@ describe('Accordion', () => {
       const $componentSummary = $('.govuk-accordion__section-summary').first()
 
       expect($componentSummary.text().trim()).toEqual('Additional description')
+    })
+
+    it('renders list without falsely values', () => {
+      const $ = render('accordion', examples['with falsey values'])
+      const $component = $('.govuk-accordion')
+      const $items = $component.find('.govuk-accordion__section')
+
+      expect($items.length).toEqual(2)
     })
   })
 })

--- a/src/govuk/components/back-link/back-link.yaml
+++ b/src/govuk/components/back-link/back-link.yaml
@@ -28,3 +28,28 @@ examples:
   data:
     href: '#'
     text: Back to home
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: classes
+  hidden: true
+  data:
+    classes: app-back-link--custom-class
+    href: '#'
+- name: html as text
+  hidden: true
+  data:
+    text: <b>Home</b>
+    href: '#'
+- name: html
+  hidden: true
+  data:
+    html: <b>Back</b>
+    href: '#'
+- name: attributes
+  hidden: true
+  data:
+    href: '#'
+    html: <b>Back to home</b>
+    attributes:
+      data-test: attribute
+      aria-label: Back to home

--- a/src/govuk/components/back-link/template.test.js
+++ b/src/govuk/components/back-link/template.test.js
@@ -26,64 +26,42 @@ describe('back-link component', () => {
   })
 
   it('renders classes correctly', () => {
-    const $ = render('back-link', {
-      classes: 'app-back-link--custom-class',
-      href: '#',
-      html: '<b>Back</b>'
-    })
+    const $ = render('back-link', examples.classes)
 
     const $component = $('.govuk-back-link')
     expect($component.hasClass('app-back-link--custom-class')).toBeTruthy()
   })
 
   it('renders custom text correctly', () => {
-    const $ = render('back-link', {
-      href: '#',
-      text: 'Home'
-    })
+    const $ = render('back-link', examples['with custom text'])
 
     const $component = $('.govuk-back-link')
-    expect($component.html()).toEqual('Home')
+    expect($component.html()).toEqual('Back to home')
   })
 
   it('renders escaped html when passed to text', () => {
-    const $ = render('back-link', {
-      href: '#',
-      text: '<b>Home</b>'
-    })
+    const $ = render('back-link', examples['html as text'])
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('&lt;b&gt;Home&lt;/b&gt;')
   })
 
   it('renders html correctly', () => {
-    const $ = render('back-link', {
-      href: '#',
-      html: '<b>Back</b>'
-    })
+    const $ = render('back-link', examples.html)
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('<b>Back</b>')
   })
 
   it('renders default text correctly', () => {
-    const $ = render('back-link', {
-      href: '#'
-    })
+    const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('Back')
   })
 
   it('renders attributes correctly', () => {
-    const $ = render('back-link', {
-      attributes: {
-        'data-test': 'attribute',
-        'aria-label': 'Back to home'
-      },
-      href: '#',
-      html: 'Back'
-    })
+    const $ = render('back-link', examples.attributes)
 
     const $component = $('.govuk-back-link')
     expect($component.attr('data-test')).toEqual('attribute')

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -97,3 +97,41 @@ examples:
         text: Special educational needs and disability (SEND) and high needs
         href: '/education/special-educational-needs-and-disability-send-and-high-needs'
 
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: classes
+  hidden: true
+  data:
+    classes: app-breadcrumbs--custom-modifier
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      id: my-navigation
+      role: navigation
+- name: item attributes
+  hidden: true
+  data:
+    items:
+      -
+        text: Section 1
+        href: /section
+        attributes:
+          data-attribute: my-attribute
+          data-attribute-2: my-attribute-2
+- name: html as text
+  hidden: true
+  data:
+    items:
+      -
+        text: <span>Section 1</span>
+- name: html
+  hidden: true
+  data:
+    items:
+      -
+        html: <em>Section 1</em>
+      -
+        html: <em>Section 2</em>
+        href: /section-2
+
+

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -10,12 +10,73 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('breadcrumbs')
 
 describe('Breadcrumbs', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('breadcrumbs', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
+    })
+
+    it('renders with items', () => {
+      const $ = render('breadcrumbs', examples.default)
+
+      const $items = $('.govuk-breadcrumbs__list-item')
+      expect($items.length).toEqual(2)
+    })
+
+    it('renders 2 items', () => {
+      const $ = render('breadcrumbs', examples.default)
+      const $items = $('.govuk-breadcrumbs__list-item')
+      expect($items.length).toEqual(2)
+    })
+
+    it('renders item with anchor', () => {
+      const $ = render('breadcrumbs', examples.default)
+
+      const $anchor = $('.govuk-breadcrumbs__list-item a').first()
+      expect($anchor.get(0).tagName).toEqual('a')
+      expect($anchor.attr('class')).toEqual('govuk-breadcrumbs__link')
+      expect($anchor.attr('href')).toEqual('/section')
+      expect($anchor.text()).toEqual('Section')
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders item with text', () => {
+      const $ = render('breadcrumbs', examples['with last breadcrumb as current page'])
+
+      const $item = $('.govuk-breadcrumbs__list-item').last()
+      expect($item.text()).toEqual('Travel abroad')
+    })
+
+    it('renders item with escaped entities in text', () => {
+      const $ = render('breadcrumbs', examples['html as text'])
+
+      const $item = $('.govuk-breadcrumbs__list-item')
+      expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
+    })
+
+    it('renders item with html', () => {
+      const $ = render('breadcrumbs', examples.html)
+
+      const $item = $('.govuk-breadcrumbs__list-item').first()
+      expect($item.html()).toEqual('<em>Section 1</em>')
+    })
+
+    it('renders item with html inside anchor', () => {
+      const $ = render('breadcrumbs', examples.html)
+
+      const $anchor = $('.govuk-breadcrumbs__list-item a').last()
+      expect($anchor.html()).toEqual('<em>Section 2</em>')
+    })
+
+    it('renders item anchor with attributes', () => {
+      const $ = render('breadcrumbs', examples['item attributes'])
+
+      const $breadcrumbLink = $('.govuk-breadcrumbs__link')
+      expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($breadcrumbLink.attr('data-attribute-2')).toEqual('my-attribute-2')
     })
 
     it('renders with classes', () => {
@@ -33,72 +94,11 @@ describe('Breadcrumbs', () => {
       expect($component.attr('role')).toEqual('navigation')
     })
 
-    it('renders with items', () => {
-      const $ = render('breadcrumbs', examples.default)
-
-      const $items = $('.govuk-breadcrumbs__list-item')
-      expect($items.length).toEqual(2)
-    })
-
-    it('renders item with text', () => {
-      const $ = render('breadcrumbs', examples['with last breadcrumb as current page'])
-
-      const $item = $('.govuk-breadcrumbs__list-item').last()
-      expect($item.text()).toEqual('Travel abroad')
-    })
-
-    it('renders item with escaped entities in text', () => {
-      const $ = render('breadcrumbs', examples['html as text'])
-
-      const $item = $('.govuk-breadcrumbs__list-item')
-      expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
-    })
-
-    it('renders item anchor with attributes', () => {
-      const $ = render('breadcrumbs', examples['item attributes'])
-
-      const $breadcrumbLink = $('.govuk-breadcrumbs__link')
-      expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
-      expect($breadcrumbLink.attr('data-attribute-2')).toEqual('my-attribute-2')
-    })
-
-    it('renders item with html', () => {
-      const $ = render('breadcrumbs', examples.html)
-
-      const $item = $('.govuk-breadcrumbs__list-item').first()
-      expect($item.html()).toEqual('<em>Section 1</em>')
-    })
-
-    it('renders item with anchor', () => {
-      const $ = render('breadcrumbs', examples.default)
-
-      const $anchor = $('.govuk-breadcrumbs__list-item a').first()
-      expect($anchor.get(0).tagName).toEqual('a')
-      expect($anchor.attr('class')).toEqual('govuk-breadcrumbs__link')
-      expect($anchor.attr('href')).toEqual('/section')
-      expect($anchor.text()).toEqual('Section')
-    })
-
-    it('renders item with html inside anchor', () => {
-      const $ = render('breadcrumbs', examples.html)
-
-      const $anchor = $('.govuk-breadcrumbs__list-item a').last()
-      expect($anchor.html()).toEqual('<em>Section 2</em>')
-    })
-
     it('renders item as collapse on mobile if specified', () => {
       const $ = render('breadcrumbs', examples['with collapse on mobile'])
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()
-    })
-  })
-
-  describe('default example', () => {
-    it('renders 2 items', () => {
-      const $ = render('breadcrumbs', examples.default)
-      const $items = $('.govuk-breadcrumbs__list-item')
-      expect($items.length).toEqual(2)
     })
   })
 })

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -19,21 +19,14 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('breadcrumbs', {
-        classes: 'app-breadcrumbs--custom-modifier'
-      })
+      const $ = render('breadcrumbs', examples.classes)
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('app-breadcrumbs--custom-modifier')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = render('breadcrumbs', {
-        attributes: {
-          id: 'my-navigation',
-          role: 'navigation'
-        }
-      })
+      const $ = render('breadcrumbs', examples.attributes)
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.attr('id')).toEqual('my-navigation')
@@ -41,60 +34,28 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders with items', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            text: 'Section 1'
-          },
-          {
-            text: 'Sub-section'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples.default)
 
       const $items = $('.govuk-breadcrumbs__list-item')
       expect($items.length).toEqual(2)
     })
 
     it('renders item with text', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            text: 'Section 1'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples['with last breadcrumb as current page'])
 
-      const $item = $('.govuk-breadcrumbs__list-item')
-      expect($item.text()).toEqual('Section 1')
+      const $item = $('.govuk-breadcrumbs__list-item').last()
+      expect($item.text()).toEqual('Travel abroad')
     })
 
     it('renders item with escaped entities in text', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            text: '<span>Section 1</span>'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples['html as text'])
 
       const $item = $('.govuk-breadcrumbs__list-item')
       expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
     })
 
     it('renders item anchor with attributes', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            text: 'Section 1',
-            href: '/section',
-            attributes: {
-              'data-attribute': 'my-attribute',
-              'data-attribute-2': 'my-attribute-2'
-            }
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples['item attributes'])
 
       const $breadcrumbLink = $('.govuk-breadcrumbs__link')
       expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
@@ -102,59 +63,31 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item with html', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            html: '<em>Section 1</em>'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples.html)
 
-      const $item = $('.govuk-breadcrumbs__list-item')
+      const $item = $('.govuk-breadcrumbs__list-item').first()
       expect($item.html()).toEqual('<em>Section 1</em>')
     })
 
     it('renders item with anchor', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            text: 'Section 1',
-            href: '/section'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples.default)
 
-      const $anchor = $('.govuk-breadcrumbs__list-item a')
+      const $anchor = $('.govuk-breadcrumbs__list-item a').first()
       expect($anchor.get(0).tagName).toEqual('a')
       expect($anchor.attr('class')).toEqual('govuk-breadcrumbs__link')
       expect($anchor.attr('href')).toEqual('/section')
-      expect($anchor.text()).toEqual('Section 1')
+      expect($anchor.text()).toEqual('Section')
     })
 
     it('renders item with html inside anchor', () => {
-      const $ = render('breadcrumbs', {
-        items: [
-          {
-            html: '<em>Section 1</em>',
-            href: '/section'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples.html)
 
-      const $anchor = $('.govuk-breadcrumbs__list-item a')
-      expect($anchor.html()).toEqual('<em>Section 1</em>')
+      const $anchor = $('.govuk-breadcrumbs__list-item a').last()
+      expect($anchor.html()).toEqual('<em>Section 2</em>')
     })
 
     it('renders item as collapse on mobile if specified', () => {
-      const $ = render('breadcrumbs', {
-        collapseOnMobile: true,
-        items: [
-          {
-            html: '<em>Section 1</em>',
-            href: '/section'
-          }
-        ]
-      })
+      const $ = render('breadcrumbs', examples['with collapse on mobile'])
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -140,3 +140,84 @@ examples:
     text: Warning button
     href: '/'
     classes: govuk-button--warning
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  hidden: true
+  data:
+    element: button
+    attributes:
+      aria-controls: example-id
+      data-tracking-dimension: 123
+- name: link attributes
+  hidden: true
+  data:
+    element: a
+    attributes:
+      aria-controls: example-id
+      data-tracking-dimension: 123
+- name: input attributes
+  hidden: true
+  data:
+    element: input
+    attributes:
+      aria-controls: example-id
+      data-tracking-dimension: 123
+- name: classes
+  hidden: true
+  data:
+    element: button
+    classes: app-button--custom-modifier
+- name: link classes
+  hidden: true
+  data:
+    element: a
+    classes: app-button--custom-modifier
+- name: input classes
+  hidden: true
+  data:
+    element: input
+    classes: app-button--custom-modifier
+- name: name
+  hidden: true
+  data:
+    element: button
+    name: start-now
+- name: type
+  hidden: true
+  data:
+    element: button
+    type: button
+- name: input type
+  hidden: true
+  data:
+    element: input
+    type: button
+- name: explicit link
+  hidden: true
+  data:
+    element: a
+    href: /
+    text: Continue
+- name: no href
+  hidden: true
+  data:
+    element: a
+- name: value
+  hidden: true
+  data:
+    element: button
+    value: start
+- name: html
+  hidden: true
+  data:
+    element: button
+    html: Start <em>now</em>
+- name: html with no explicit element
+  hidden: true
+  data:
+    html: Start <em>now</em>
+- name: no data
+  hidden: true
+  data: {}
+

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -213,10 +213,6 @@ examples:
   data:
     element: button
     html: Start <em>now</em>
-- name: html with no explicit element
-  hidden: true
-  data:
-    html: Start <em>now</em>
 - name: no data
   hidden: true
   data: {}

--- a/src/govuk/components/button/template.test.js
+++ b/src/govuk/components/button/template.test.js
@@ -10,14 +10,14 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('button')
 
 describe('Button', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('button', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('button', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
 
-  describe('button element', () => {
     it('renders the default example', () => {
       const $ = render('button', examples.default)
 
@@ -25,7 +25,9 @@ describe('Button', () => {
       expect($component.get(0).tagName).toEqual('button')
       expect($component.text()).toContain('Save and continue')
     })
+  })
 
+  describe('custom options', () => {
     it('renders with attributes', () => {
       const $ = render('button', examples.attributes)
 

--- a/src/govuk/components/button/template.test.js
+++ b/src/govuk/components/button/template.test.js
@@ -27,13 +27,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const $ = render('button', {
-        element: 'button',
-        attributes: {
-          'aria-controls': 'example-id',
-          'data-tracking-dimension': '123'
-        }
-      })
+      const $ = render('button', examples.attributes)
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -41,10 +35,7 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('button', {
-        element: 'button',
-        classes: 'app-button--custom-modifier'
-      })
+      const $ = render('button', examples.classes)
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
@@ -60,33 +51,44 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const $ = render('button', {
-        element: 'button',
-        name: 'start-now'
-      })
+      const $ = render('button', examples.name)
 
       const $component = $('.govuk-button')
       expect($component.attr('name')).toEqual('start-now')
     })
 
+    it('renders with value', () => {
+      const $ = render('button', examples.value)
+
+      const $component = $('.govuk-button')
+      expect($component.attr('value')).toEqual('start')
+    })
+
     it('renders with type', () => {
-      const $ = render('button', {
-        element: 'button',
-        type: 'button'
-      })
+      const $ = render('button', examples.type)
 
       const $component = $('.govuk-button')
       expect($component.attr('type')).toEqual('button')
+    })
+
+    it('renders with html', () => {
+      const $ = render('button', examples.html)
+
+      const $component = $('.govuk-button')
+      expect($component.html()).toContain('Start <em>now</em>')
+    })
+
+    it('renders with preventDoubleClick attribute', () => {
+      const $ = render('button', examples['prevent double click'])
+
+      const $component = $('.govuk-button')
+      expect($component.attr('data-prevent-double-click')).toEqual('true')
     })
   })
 
   describe('link', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const $ = render('button', {
-        element: 'a',
-        href: '/',
-        text: 'Continue'
-      })
+      const $ = render('button', examples['explicit link'])
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('a')
@@ -96,42 +98,14 @@ describe('Button', () => {
     })
 
     it('renders with hash href if no href passed', () => {
-      const $ = render('button', {
-        element: 'a'
-      })
+      const $ = render('button', examples['no href'])
 
       const $component = $('.govuk-button')
       expect($component.attr('href')).toEqual('#')
     })
 
-    it('renders with value', () => {
-      const $ = render('button', {
-        element: 'button',
-        value: 'start'
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.attr('value')).toEqual('start')
-    })
-
-    it('renders with html', () => {
-      const $ = render('button', {
-        element: 'button',
-        html: 'Start <em>now</em>'
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.html()).toContain('Start <em>now</em>')
-    })
-
     it('renders with attributes', () => {
-      const $ = render('button', {
-        element: 'a',
-        attributes: {
-          'aria-controls': 'example-id',
-          'data-tracking-dimension': '123'
-        }
-      })
+      const $ = render('button', examples['link attributes'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -139,10 +113,7 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('button', {
-        element: 'a',
-        classes: 'app-button--custom-modifier'
-      })
+      const $ = render('button', examples['link classes'])
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
@@ -166,13 +137,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const $ = render('button', {
-        element: 'input',
-        attributes: {
-          'aria-controls': 'example-id',
-          'data-tracking-dimension': '123'
-        }
-      })
+      const $ = render('button', examples['input attributes'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -180,20 +145,14 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('button', {
-        element: 'input',
-        classes: 'app-button--custom-modifier'
-      })
+      const $ = render('button', examples['input classes'])
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
     })
 
     it('renders with disabled', () => {
-      const $ = render('button', {
-        element: 'input',
-        disabled: true
-      })
+      const $ = render('button', examples['input disabled'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-disabled')).toEqual('true')
@@ -202,57 +161,30 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const $ = render('button', {
-        element: 'input',
-        name: 'start-now'
-      })
+      const $ = render('button', examples.input)
 
       const $component = $('.govuk-button')
       expect($component.attr('name')).toEqual('start-now')
     })
 
     it('renders with type', () => {
-      const $ = render('button', {
-        element: 'input',
-        type: 'button',
-        text: 'Start now'
-      })
+      const $ = render('button', examples['input type'])
 
       const $component = $('.govuk-button')
       expect($component.attr('type')).toEqual('button')
-    })
-
-    it('renders with preventDoubleClick attribute', () => {
-      const $ = render('button', {
-        preventDoubleClick: true
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.attr('data-prevent-double-click')).toEqual('true')
     })
   })
 
   describe('implicitly as no "element" param is set', () => {
     it('renders a link if you pass an href', () => {
-      const $ = render('button', {
-        href: '/'
-      })
+      const $ = render('button', examples.link)
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('a')
     })
 
-    it('renders a button if you pass html', () => {
-      const $ = render('button', {
-        html: 'Start <em>now</em>'
-      })
-
-      const $component = $('.govuk-button')
-      expect($component.get(0).tagName).toEqual('button')
-    })
-
     it('renders a button if you don\'t pass anything', () => {
-      const $ = render('button', {})
+      const $ = render('button', examples['no data'])
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('button')
@@ -261,10 +193,7 @@ describe('Button', () => {
 
   describe('Start button', () => {
     it('renders a svg', () => {
-      const $ = render('button', {
-        href: '/',
-        isStartButton: true
-      })
+      const $ = render('button', examples['start link'])
 
       const $component = $('.govuk-button .govuk-button__start-icon')
       expect($component.get(0).tagName).toEqual('svg')

--- a/src/govuk/components/character-count/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/character-count/__snapshots__/template.test.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Character count when it includes a hint renders with hint 1`] = `
-<div id="character-count-with-hint-hint"
+<div id="with-hint-hint"
      class="govuk-hint"
 >
-  It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+  Don&apos;t include personal or financial information, eg your National Insurance number or credit card details.
 </div>
-<div id="character-count-with-hint-info"
+<div id="with-hint-info"
      class="govuk-hint govuk-character-count__message"
      aria-live="polite"
 >
@@ -15,17 +15,17 @@ exports[`Character count when it includes a hint renders with hint 1`] = `
 `;
 
 exports[`Character count when it includes an error message renders with error message 1`] = `
-<span id="character-count-with-error-error"
+<span id="exceeding-characters-error"
       class="govuk-error-message"
 >
-  Error message
+  Please do not exceed the maximum allowed limit
 </span>
 `;
 
 exports[`Character count with dependant components renders with label 1`] = `
 <label class="govuk-label"
-       for="my-character-count"
+       for="more-detail"
 >
-  Full address
+  Can you provide more detail?
 </label>
 `;

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -153,3 +153,38 @@ examples:
       threshold: 75
       label:
         text: Full address
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: app-character-count--custom-modifier
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value
+  - name: formGroup with classes
+    hidden: true
+    data:
+      formGroup:
+        classes: app-character-count--custom-modifier
+  - name: custom classes on countMessage
+    hidden: true
+    data:
+      countMessage:
+        classes: app-custom-count-message
+  - name: spellcheck enabled
+    hidden: true
+    data:
+      spellcheck: true
+  - name: spellcheck disabled
+    hidden: true
+    data:
+      spellcheck: false
+  - name: custom classes with error message
+    hidden: true
+    data:
+      classes: app-character-count--custom-modifier
+      errorMessage:
+        text: Error message

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -12,19 +12,12 @@ const examples = getExamples('character-count')
 const WORD_BOUNDARY = '\\b'
 
 describe('Character count', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('character-count', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
-    })
-
-    it('renders with classes', () => {
-      const $ = render('character-count', examples.classes)
-
-      const $component = $('.govuk-js-character-count')
-      expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
@@ -41,18 +34,27 @@ describe('Character count', () => {
       expect($component.attr('name')).toEqual('more-detail')
     })
 
-    it('renders with rows', () => {
-      const $ = render('character-count', examples['with custom rows'])
-
-      const $component = $('.govuk-js-character-count')
-      expect($component.attr('rows')).toEqual('8')
-    })
-
     it('renders with default number of rows', () => {
       const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('rows')).toEqual('5')
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('character-count', examples.classes)
+
+      const $component = $('.govuk-js-character-count')
+      expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with rows', () => {
+      const $ = render('character-count', examples['with custom rows'])
+
+      const $component = $('.govuk-js-character-count')
+      expect($component.attr('rows')).toEqual('8')
     })
 
     it('renders with value', () => {

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -7,7 +7,7 @@ const axe = require('../../../../lib/axe-helper')
 
 const { render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
-const examples = getExamples('textarea')
+const examples = getExamples('character-count')
 
 const WORD_BOUNDARY = '\\b'
 
@@ -21,74 +21,56 @@ describe('Character count', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('character-count', {
-        classes: 'app-character-count--custom-modifier'
-      })
+      const $ = render('character-count', examples.classes)
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('character-count', {
-        id: 'my-character-count'
-      })
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('id')).toEqual('my-character-count')
+      expect($component.attr('id')).toEqual('more-detail')
     })
 
     it('renders with name', () => {
-      const $ = render('character-count', {
-        name: 'my-character-count-name'
-      })
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('name')).toEqual('my-character-count-name')
+      expect($component.attr('name')).toEqual('more-detail')
     })
 
     it('renders with rows', () => {
-      const $ = render('character-count', {
-        rows: '4'
-      })
+      const $ = render('character-count', examples['with custom rows'])
 
       const $component = $('.govuk-js-character-count')
-      expect($component.attr('rows')).toEqual('4')
+      expect($component.attr('rows')).toEqual('8')
     })
 
     it('renders with default number of rows', () => {
-      const $ = render('character-count', {})
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('rows')).toEqual('5')
     })
 
     it('renders with value', () => {
-      const $ = render('character-count', {
-        value: '221B Baker Street\nLondon\nNW1 6XE\n'
-      })
+      const $ = render('character-count', examples['with default value'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
     })
 
     it('renders with attributes', () => {
-      const $ = render('character-count', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('character-count', examples.attributes)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with formGroup', () => {
-      const $ = render('character-count', {
-        formGroup: {
-          classes: 'app-character-count--custom-modifier'
-        }
-      })
+      const $ = render('character-count', examples['formGroup with classes'])
 
       const $component = $('.govuk-form-group')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
@@ -97,25 +79,21 @@ describe('Character count', () => {
 
   describe('count message', () => {
     it('renders with the amount of characters expected', () => {
-      const $ = render('character-count', {
-        maxlength: 10
-      })
+      const $ = render('character-count', examples.default)
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.text()).toContain('You can enter up to 10 characters')
     })
+
     it('renders with the amount of words expected', () => {
-      const $ = render('character-count', {
-        maxwords: 10
-      })
+      const $ = render('character-count', examples['with word count'])
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.text()).toContain('You can enter up to 10 words')
     })
+
     it('is associated with the textarea', () => {
-      const $ = render('character-count', {
-        maxlength: 10
-      })
+      const $ = render('character-count', examples.default)
 
       const $textarea = $('.govuk-js-character-count')
       const $countMessage = $('.govuk-character-count__message')
@@ -127,19 +105,16 @@ describe('Character count', () => {
       expect($textarea.attr('aria-describedby'))
         .toMatch(hintId)
     })
+
     it('renders with custom classes', () => {
-      const $ = render('character-count', {
-        countMessage: {
-          classes: 'app-custom-count-message'
-        }
-      })
+      const $ = render('character-count', examples['custom classes on countMessage'])
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.hasClass('app-custom-count-message')).toBeTruthy()
     })
 
     it('renders with aria live set to polite', () => {
-      const $ = render('character-count', {})
+      const $ = render('character-count', examples.default)
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.attr('aria-live')).toEqual('polite')
@@ -148,28 +123,21 @@ describe('Character count', () => {
 
   describe('when it has the spellcheck attribute', () => {
     it('renders the textarea with spellcheck attribute set to true', () => {
-      const $ = render('character-count', {
-        spellcheck: true
-      })
+      const $ = render('character-count', examples['spellcheck enabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders the textarea with spellcheck attribute set to false', () => {
-      const $ = render('character-count', {
-        name: 'my-char-count-name',
-        spellcheck: false
-      })
+      const $ = render('character-count', examples['spellcheck disabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders the textarea without spellcheck attribute by default', () => {
-      const $ = render('character-count', {
-        name: 'my-char-count-name'
-      })
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -178,24 +146,13 @@ describe('Character count', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = render('character-count', {
-        id: 'character-count-with-hint',
-        maxlength: 10,
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('character-count', examples['with hint'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the character count as "described by" the hint', () => {
-      const $ = render('character-count', {
-        id: 'character-count-with-hint',
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('character-count', examples['with hint'])
 
       const $textarea = $('.govuk-js-character-count')
       const $hint = $('.govuk-hint')
@@ -211,23 +168,13 @@ describe('Character count', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = render('character-count', {
-        id: 'character-count-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the character-count as "described by" the error message', () => {
-      const $ = render('character-count', {
-        id: 'character-count-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-js-character-count')
       const $errorMessage = $('.govuk-error-message')
@@ -241,23 +188,14 @@ describe('Character count', () => {
     })
 
     it('adds the error class to the character-count', () => {
-      const $ = render('character-count', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
 
     it('renders with classes', () => {
-      const $ = render('character-count', {
-        errorMessage: {
-          text: 'Error message'
-        },
-        classes: 'app-character-count--custom-modifier'
-      })
+      const $ = render('character-count', examples['custom classes with error message'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
@@ -266,41 +204,32 @@ describe('Character count', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('character-count', {
-        id: 'nested-order',
-        label: {
-          text: 'Full address'
-        },
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-form-group > .govuk-js-character-count')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = render('character-count', {
-        id: 'my-character-count',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('character-count', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the character count "id"', () => {
-      const $ = render('character-count', {
-        id: 'my-character-count',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('character-count', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('my-character-count')
+      expect($label.attr('for')).toEqual('more-detail')
+    })
+  })
+
+  describe('with threshold', () => {
+    it('hides the count to start with', async () => {
+      const $ = render('character-count', examples['with threshold'])
+
+      const $component = $('.govuk-character-count')
+      expect($component.attr('data-threshold')).toEqual('75')
     })
   })
 })

--- a/src/govuk/components/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/checkboxes/__snapshots__/template.test.js.snap
@@ -2,13 +2,10 @@
 
 exports[`Checkboxes nested dependant components passes through fieldset params without breaking 1`] = `
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
-          aria-describedby="example-hint example-error"
+          aria-describedby="example-name-error"
           data-attribute="value"
           data-second-attribute="second-value"
 >
-  <legend class="govuk-fieldset__legend">
-    What is your nationality?
-  </legend>
 </fieldset>
 `;
 
@@ -34,34 +31,28 @@ exports[`Checkboxes nested dependant components passes through label params with
     Option 1
   </b>
 </label>
-<label class="govuk-label govuk-checkboxes__label"
-       for="example-name-2"
->
-  &lt;b&gt;Option 2&lt;/b&gt;
-</label>
 `;
 
 exports[`Checkboxes when they include a hint renders the hint 1`] = `
-<div id="example-hint"
+<div id="example-multiple-hints-hint"
      class="govuk-hint"
 >
   If you have dual nationality, select all options that are relevant to you.
 </div>
-<div id="example-item-hint"
+<div id="example-multiple-hints-item-hint"
      class="govuk-hint govuk-checkboxes__hint"
 >
   Hint for british option here
 </div>
-<div id="example-3-item-hint"
-     class="govuk-hint govuk-checkboxes__hint app-checkboxes__hint-other"
-     data-test-attribute="true"
+<div id="example-multiple-hints-3-item-hint"
+     class="govuk-hint govuk-checkboxes__hint"
 >
   Hint for other option here
 </div>
 `;
 
 exports[`Checkboxes when they include an error message renders the error message 1`] = `
-<span id="example-error"
+<span id="waste-error"
       class="govuk-error-message"
 >
   Please select an option

--- a/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/src/govuk/components/checkboxes/checkboxes.test.js
@@ -69,10 +69,10 @@ describe('Checkboxes with conditional reveals', () => {
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-item-checked')
       const $component = $('.govuk-checkboxes')
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child .govuk-checkboxes__input')
-      const firstInputAriaControls = $firstInput.attr('aria-controls')
+      const $uncheckedInput = $component.find('.govuk-checkboxes__item').last().find('.govuk-checkboxes__input')
+      const uncheckedInputAriaControls = $uncheckedInput.attr('aria-controls')
 
-      const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"].govuk-checkboxes__conditional--hidden`)
+      const isContentHidden = await waitForHiddenSelector(`[id="${uncheckedInputAriaControls}"].govuk-checkboxes__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
     it('indicates when conditional content is collapsed or revealed', async () => {

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -112,13 +112,7 @@ accessibilityCriteria: |
 examples:
 - name: default
   data:
-    idPrefix: nationality
     name: nationality
-    fieldset:
-      legend:
-        text: What is your nationality?
-    hint:
-      text: If you have dual nationality, select all options that are relevant to you.
     items:
       - value: british
         text: British
@@ -547,10 +541,11 @@ examples:
         text: another thing
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
-- name: with minimum name and items
+- name: with idPrefix
   hidden: true
   data:
     name: example-name
+    idPrefix: nationality
     items:
       - value: 1
         text: Option 1

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -144,6 +144,9 @@ examples:
         id: item_irish
         value: irish
         text: Irish
+      - name: custom-name-scottish
+        text: Scottish
+        value: scottish
 
 - name: with hints on items
   data:
@@ -157,13 +160,13 @@ examples:
         value: gov-gateway
         text: Sign in with Government Gateway
         hint:
-          text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+          text: You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.
       - name: verify
         id: govuk-verify
         value: gov-verify
         text: Sign in with GOV.UK Verify
         hint:
-          text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
+          text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
 
 - name: with disabled item
   data:
@@ -374,13 +377,13 @@ examples:
     items:
     - value: email
       text: Email
+      checked: true
       conditional:
         html: |
           <label class="govuk-label" for="context-email">Mobile phone number</label>
           <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
     - value: phone
       text: Phone
-      checked: true
       conditional:
         html: |
           <label class="govuk-label" for="contact-phone">Phone number</label>
@@ -542,3 +545,223 @@ examples:
             <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
       - value: b
         text: another thing
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: with minimum name and items
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: 1
+        text: Option 1
+      - value: 2
+        text: Option 2
+- name: with falsey values
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: 1
+        text: Option 1
+      - false
+      - null
+      - ""
+      - value: 2
+        text: Option 2
+- name: classes
+  hidden: true
+  data:
+    name: example-name
+    classes: app-checkboxes--custom-modifier
+    items:
+      - value: 1
+        text: Option 1
+      - value: 2
+        text: Option 2
+- name: with fieldset describedBy
+  hidden: true
+  data:
+    name: example-name
+    fieldset:
+      describedBy: some-id
+    items:
+      - value: 1
+        text: Option 1
+      - value: 2
+        text: Option 2
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
+- name: attributes
+  hidden: true
+  data:
+    name: example-name
+    attributes:
+      data-attribute: value
+      data-second-attribute: second-value
+    items:
+      - value: 1
+        text: Option 1
+      - value: 2
+        text: Option 2
+- name: with checked item
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: 1
+        text: Option 1
+      - value: 2
+        text: Option 2
+        checked: true
+      - value: 3
+        text: Option 3
+        checked: true
+- name: items with attributes
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: 1
+        text: Option 1
+        attributes:
+          data-attribute: ABC
+          data-second-attribute: DEF
+      - value: 2
+        text: Option 2
+        attributes:
+          data-attribute: GHI
+          data-second-attribute: JKL
+- name: empty conditional
+  hidden: true
+  data:
+    name: example-conditional
+    items:
+      - value: foo
+        text: Foo
+        conditional:
+          html: false
+- name: with label classes
+  hidden: true
+  data:
+    name: example-label-classes
+    items:
+      - value: yes
+        text: Yes
+        label:
+          classes: bold
+- name: multiple hints
+  hidden: true
+  data:
+    name: example-multiple-hints
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
+    items:
+      - value: british
+        text: British
+        hint:
+          text: Hint for british option here
+      - value: irish
+        text: Irish
+      - hint:
+          text: Hint for other option here
+- name: with error message and hint
+  hidden: true
+  data:
+    name: example
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      legend:
+        text: What is your nationality?
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
+- name: with error, hint and fieldset describedBy
+  hidden: true
+  data:
+    name: example
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: What is your nationality?
+    hint:
+      text: If you have dual nationality, select all options that are relevant to you.
+- name: label with attributes
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: 1
+        html: <b>Option 1</b>
+        label:
+          attributes:
+            data-attribute: value
+            data-second-attribute: second-value
+- name: fieldset params
+  hidden: true
+  data:
+    name: example-name
+    errorMessage:
+      text: Please select an option
+    legend:
+      text: What is your nationality?
+    fieldset:
+      classes: app-fieldset--custom-modifier
+      attributes:
+        data-attribute: value
+        data-second-attribute: second-value
+- name: fieldset html params
+  hidden: true
+  data:
+    name: example-name
+    fieldset:
+      legend:
+        html: What is your <b>nationality</b>?
+- name: with single option set 'aria-describedby' on input, and describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+    name: t-and-c
+    errorMessage:
+      text: Please accept the terms and conditions
+    items:
+      - value: yes
+        text: I agree to the terms and conditions
+- name: with single option (and hint) set 'aria-describedby' on input, and describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+    name: t-and-c-with-hint
+    errorMessage:
+      text: Please accept the terms and conditions
+    items:
+      - value: yes
+        text: I agree to the terms and conditions
+        hint:
+          text: Go on, you know you want to!
+- name: with error and idPrefix
+  hidden: true
+  data:
+    name: name-of-checkboxes
+    errorMessage:
+      text: Please select an option
+    idPrefix: id-prefix
+    items:
+      - value: animal
+        text: Waste from animal carcasses
+- name: with error message and fieldset describedBy
+  hidden: true
+  data:
+    name: example
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: What is your nationality?
+
+
+
+
+

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -21,19 +21,7 @@ describe('Checkboxes', () => {
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ]
-    })
+    const $ = render('checkboxes', examples['with minimum name and items'])
 
     const $component = $('.govuk-checkboxes')
 
@@ -51,22 +39,7 @@ describe('Checkboxes', () => {
   })
 
   it('render example without falsely values', () => {
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        undefined,
-        null,
-        false,
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ]
-    })
+    const $ = render('checkboxes', examples['with falsey values'])
 
     const $component = $('.govuk-checkboxes')
     const $items = $component.find('.govuk-checkboxes__item')
@@ -74,21 +47,16 @@ describe('Checkboxes', () => {
     expect($items.length).toEqual(2)
   })
 
+  it('render additional label classes', () => {
+    const $ = render('checkboxes', examples['with label classes'])
+
+    const $component = $('.govuk-checkboxes')
+    const $label = $component.find('.govuk-checkboxes__item label')
+    expect($label.hasClass('bold')).toBeTruthy()
+  })
+
   it('render classes', () => {
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ],
-      classes: 'app-checkboxes--custom-modifier'
-    })
+    const $ = render('checkboxes', examples.classes)
 
     const $component = $('.govuk-checkboxes')
 
@@ -96,47 +64,14 @@ describe('Checkboxes', () => {
   })
 
   it('renders initial aria-describedby on fieldset', () => {
-    const describedById = 'some-id'
-
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      fieldset: {
-        describedBy: describedById
-      },
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ]
-    })
+    const $ = render('checkboxes', examples['with fieldset describedBy'])
 
     const $fieldset = $('.govuk-fieldset')
-    expect($fieldset.attr('aria-describedby')).toMatch(describedById)
+    expect($fieldset.attr('aria-describedby')).toMatch('some-id')
   })
 
   it('render attributes', () => {
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ],
-      attributes: {
-        'data-attribute': 'value',
-        'data-second-attribute': 'second-value'
-      }
-    })
+    const $ = render('checkboxes', examples.attributes)
 
     const $component = $('.govuk-checkboxes')
 
@@ -145,49 +80,22 @@ describe('Checkboxes', () => {
   })
 
   it('renders with a form group wrapper', () => {
-    const $ = render('checkboxes', {})
+    const $ = render('checkboxes', examples.default)
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.length).toBeTruthy()
   })
 
   it('render a custom class on the form group', () => {
-    const $ = render('checkboxes', {
-      name: 'example-name',
-      items: [
-        {
-          value: '1',
-          text: 'Option 1'
-        },
-        {
-          value: '2',
-          text: 'Option 2'
-        }
-      ],
-      formGroup: {
-        classes: 'custom-group-class'
-      }
-    })
+    const $ = render('checkboxes', examples['with optional form-group classes showing group error'])
 
     const $formGroup = $('.govuk-form-group')
-    expect($formGroup.hasClass('custom-group-class')).toBeTruthy()
+    expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
   })
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1'
-          },
-          {
-            value: '2',
-            text: 'Option 2'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with minimum name and items'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -203,129 +111,55 @@ describe('Checkboxes', () => {
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const $ = render('checkboxes', {
-        idPrefix: 'custom',
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1'
-          },
-          {
-            value: '2',
-            text: 'Option 2'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples.default)
 
       const $component = $('.govuk-checkboxes')
 
       const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
       const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('custom')
-      expect($firstLabel.attr('for')).toEqual('custom')
+      expect($firstInput.attr('id')).toEqual('nationality')
+      expect($firstLabel.attr('for')).toEqual('nationality')
 
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
       const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('custom-2')
-      expect($lastLabel.attr('for')).toEqual('custom-2')
+      expect($lastInput.attr('id')).toEqual('nationality-3')
+      expect($lastLabel.attr('for')).toEqual('nationality-3')
     })
 
     it('render explicitly passed item ids', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1'
-          },
-          {
-            id: 'custom_item_id',
-            value: '2',
-            text: 'Option 2'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      expect($firstInput.attr('id')).toBe('example-name')
-
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-      const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
-      expect($lastInput.attr('id')).toBe('custom_item_id')
-      expect($lastLabel.attr('for')).toEqual('custom_item_id')
+      expect($lastInput.attr('id')).toBe('with-id-and-name-3')
+
+      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
+      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+      expect($firstInput.attr('id')).toBe('item_british')
+      expect($firstLabel.attr('for')).toEqual('item_british')
     })
 
     it('render explicitly passed item names', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1',
-            name: 'custom-item-name-1'
-          },
-          {
-            value: '2',
-            text: 'Option 2',
-            name: 'custom-item-name-2'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      expect($firstInput.attr('name')).toBe('custom-item-name-1')
-
       const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-      expect($lastInput.attr('name')).toBe('custom-item-name-2')
+      expect($lastInput.attr('name')).toBe('custom-name-scottish')
     })
 
     it('render disabled', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1',
-            disabled: true
-          },
-          {
-            value: '2',
-            text: 'Option 2'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with disabled item'])
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      expect($firstInput.attr('disabled')).toEqual('disabled')
+      const $disabledInput = $component.find('.govuk-checkboxes__item:last-child input')
+      expect($disabledInput.attr('disabled')).toEqual('disabled')
     })
 
     it('render checked', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1'
-          },
-          {
-            value: '2',
-            text: 'Option 2',
-            checked: true
-          },
-          {
-            value: '3',
-            text: 'Option 3',
-            checked: true
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with checked item'])
 
       const $component = $('.govuk-checkboxes')
       const $secondInput = $component.find('.govuk-checkboxes__item:nth-child(2) input')
@@ -336,27 +170,7 @@ describe('Checkboxes', () => {
 
     describe('when they include attributes', () => {
       it('it renders the attributes', () => {
-        const $ = render('checkboxes', {
-          name: 'example-name',
-          items: [
-            {
-              value: '1',
-              text: 'Option 1',
-              attributes: {
-                'data-attribute': 'ABC',
-                'data-second-attribute': 'DEF'
-              }
-            },
-            {
-              value: '2',
-              text: 'Option 2',
-              attributes: {
-                'data-attribute': 'GHI',
-                'data-second-attribute': 'JKL'
-              }
-            }
-          ]
-        })
+        const $ = render('checkboxes', examples['items with attributes'])
 
         const $component = $('.govuk-checkboxes')
 
@@ -373,217 +187,81 @@ describe('Checkboxes', () => {
 
   describe('when they include a hint', () => {
     it('it renders the hint text', () => {
-      const $ = render('checkboxes', {
-        name: 'gov',
-        items: [
-          {
-            value: 'value',
-            text: 'This is text',
-            hint: {
-              text: 'This is a hint'
-            }
-          }
-        ]
-      })
-      expect($('.govuk-checkboxes__hint').text()).toContain('This is a hint')
+      const $ = render('checkboxes', examples['with hints on items'])
+
+      const $firstHint = $('.govuk-checkboxes__hint').first()
+      expect($firstHint.text().trim()).toContain('You\'ll have a user ID if you\'ve registered for Self Assessment or filed a tax return online before.')
     })
 
     it('it renders the correct id attribute for the hint', () => {
-      const $ = render('checkboxes', {
-        name: 'gov',
-        items: [
-          {
-            value: 'value',
-            text: 'This is text',
-            id: 'item-id',
-            hint: {
-              text: 'This is a hint'
-            }
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with hints on items'])
 
-      expect($('.govuk-checkboxes__hint').attr('id')).toBe('item-id-item-hint')
+      expect($('.govuk-checkboxes__hint').attr('id')).toBe('government-gateway-item-hint')
     })
 
     it('the input describedBy attribute matches the item hint id', () => {
-      const $ = render('checkboxes', {
-        name: 'gov',
-        items: [
-          {
-            value: 'value',
-            text: 'This is text',
-            id: 'item-id',
-            hint: {
-              text: 'This is a hint'
-            }
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with hints on items'])
 
-      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe('item-id-item-hint')
+      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe('government-gateway-item-hint')
     })
   })
 
   describe('render conditionals', () => {
     it('hidden by default when not checked', () => {
-      const $ = render('checkboxes', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes',
-            conditional: {
-              html: 'Conditional content that should be hidden'
-            }
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with conditional items'])
 
       const $component = $('.govuk-checkboxes')
 
       const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
-      expect($firstConditional.html()).toContain('Conditional content that should be hidden')
+      expect($firstConditional.text().trim()).toContain('Mobile phone number')
       expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeTruthy()
     })
     it('visible by default when checked', () => {
-      const $ = render('checkboxes', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes',
-            checked: true,
-            conditional: {
-              html: 'Conditional content that should be visible'
-            }
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with conditional item checked'])
 
       const $component = $('.govuk-checkboxes')
 
       const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
-      expect($firstConditional.html()).toContain('Conditional content that should be visible')
+      expect($firstConditional.text().trim()).toContain('Mobile phone number')
       expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeFalsy()
     })
+
     it('with association to the input they are controlled by', () => {
-      const $ = render('checkboxes', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes',
-            conditional: {
-              html: 'Conditional content that should be hidden'
-            }
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with conditional items'])
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__input').first()
-      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      const $lastInput = $component.find('.govuk-checkboxes__input').last()
+      const $lastConditional = $component.find('.govuk-checkboxes__conditional').last()
 
-      expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional')
-      expect($firstConditional.attr('id')).toBe('conditional-example-conditional')
+      expect($lastInput.attr('data-aria-controls')).toBe('conditional-how-contacted-3')
+      expect($lastConditional.attr('id')).toBe('conditional-how-contacted-3')
     })
 
     it('omits empty conditionals', () => {
-      const $ = render('checkboxes', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'foo',
-            text: 'Foo',
-            conditional: {
-              html: false
-            }
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['empty conditional'])
 
       const $component = $('.govuk-checkboxes')
       expect($component.find('.govuk-checkboxes__conditional').length).toEqual(0)
     })
 
     it('does not associate checkboxes with empty conditionals', () => {
-      const $ = render('checkboxes', {
-        name: 'example-conditional',
-        items: [
-          {
-            value: 'foo',
-            text: 'Foo',
-            conditional: {
-              html: false
-            }
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['empty conditional'])
 
       const $input = $('.govuk-checkboxes__input').first()
       expect($input.attr('data-aria-controls')).toBeFalsy()
     })
   })
 
-  it('render additional label classes', () => {
-    const $ = render('checkboxes', {
-      name: 'example-label-classes',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes',
-          label: {
-            classes: 'bold'
-          }
-        }
-      ]
-    })
-
-    const $component = $('.govuk-checkboxes')
-    const $label = $component.find('.govuk-checkboxes__item label')
-    expect($label.hasClass('bold')).toBeTruthy()
-  })
-
   describe('when they include an error message', () => {
     it('renders the error message', () => {
-      const $ = render('checkboxes', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        }
-      })
+      const $ = render('checkboxes', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the idPrefix for the error message id if provided', () => {
-      const $ = render('checkboxes', {
-        name: 'name-of-checkboxes',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        idPrefix: 'id-prefix',
-        items: [
-          {
-            value: 'animal',
-            text: 'Waste from animal carcasses'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with error and idPrefix'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -591,22 +269,11 @@ describe('Checkboxes', () => {
     })
 
     it('falls back to using the name for the error message id', () => {
-      const $ = render('checkboxes', {
-        name: 'name-of-checkboxes',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        items: [
-          {
-            value: 'animal',
-            text: 'Waste from animal carcasses'
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['with error message'])
 
       const $errorMessage = $('.govuk-error-message')
 
-      expect($errorMessage.attr('id')).toEqual('name-of-checkboxes-error')
+      expect($errorMessage.attr('id')).toEqual('waste-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {
@@ -624,24 +291,17 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples['with fieldset and error message']
-
-      params.fieldset.describedBy = describedById
-
-      const $ = render('checkboxes', params)
+      const $ = render('checkboxes', examples['with error message and fieldset describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby'))
         .toMatch(errorMessageId)
-
-      delete params.fieldset.describedBy
     })
 
     it('does not associate each input as "described by" the error message', () => {
@@ -659,11 +319,7 @@ describe('Checkboxes', () => {
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('checkboxes', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('checkboxes', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -672,50 +328,13 @@ describe('Checkboxes', () => {
 
   describe('when they include a hint', () => {
     it('renders the hint', () => {
-      const $ = render('checkboxes', {
-        name: 'example',
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        },
-        items: [
-          {
-            value: 'british',
-            text: 'British',
-            hint: {
-              text: 'Hint for british option here'
-            }
-          },
-          {
-            value: 'irish',
-            text: 'Irish'
-          },
-          {
-            hint: {
-              text: 'Hint for other option here',
-              classes: 'app-checkboxes__hint-other',
-              attributes: {
-                'data-test-attribute': true
-              }
-            }
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['multiple hints'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('checkboxes', {
-        name: 'example',
-        fieldset: {
-          legend: {
-            text: 'What is your nationality?'
-          }
-        },
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        }
-      })
+      const $ = render('checkboxes', examples.default)
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -728,25 +347,12 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('checkboxes', {
-        name: 'example',
-        fieldset: {
-          describedBy: describedById,
-          legend: {
-            text: 'What is your nationality?'
-          }
-        },
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        }
-      })
+      const $ = render('checkboxes', examples['with fieldset describedBy'])
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(hintId)
@@ -755,20 +361,7 @@ describe('Checkboxes', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = render('checkboxes', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          legend: {
-            text: 'What is your nationality?'
-          }
-        },
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        }
-      })
+      const $ = render('checkboxes', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -783,30 +376,14 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('checkboxes', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          describedBy: describedById,
-          legend: {
-            text: 'What is your nationality?'
-          }
-        },
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        }
-      })
+      const $ = render('checkboxes', examples['with error, hint and fieldset describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
       const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby'))
@@ -816,86 +393,26 @@ describe('Checkboxes', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('checkboxes', {
-        fieldset: {
-          legend: {
-            text: 'What is your nationality?'
-          }
-        }
-      })
+      const $ = render('checkboxes', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
       expect($component.length).toBeTruthy()
     })
 
     it('passes through label params without breaking', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: '1',
-            html: '<b>Option 1</b>',
-            label: {
-              attributes: {
-                'data-attribute': 'value',
-                'data-second-attribute': 'second-value'
-              }
-            }
-          },
-          {
-            value: '2',
-            text: '<b>Option 2</b>',
-            checked: true
-          }
-        ]
-      })
+      const $ = render('checkboxes', examples['label with attributes'])
 
       expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = render('checkboxes', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          classes: 'app-fieldset--custom-modifier',
-          attributes: {
-            'data-attribute': 'value',
-            'data-second-attribute': 'second-value'
-          },
-          legend: {
-            text: 'What is your nationality?'
-          }
-        },
-        hint: {
-          text: 'If you have dual nationality, select all options that are relevant to you.'
-        }
-      })
+      const $ = render('checkboxes', examples['fieldset params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 
     it('passes through html fieldset params without breaking', () => {
-      const $ = render('checkboxes', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'british',
-            text: 'British'
-          },
-          {
-            value: 'irish',
-            text: 'Irish'
-          }
-        ],
-        fieldset: {
-          legend: {
-            html: 'What is your <b>nationality</b>?'
-          }
-        }
-      })
+      const $ = render('checkboxes', examples['fieldset html params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
@@ -909,18 +426,11 @@ describe('Checkboxes', () => {
     })
 
     it('adds aria-describedby to input if there is an error and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples["with single option set 'aria-describedby' on input"]
-
-      params.describedBy = describedById
-
-      const $ = render('checkboxes', params)
+      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input, and describedBy"])
       const $input = $('input')
 
       expect($input.attr('aria-describedby'))
-        .toMatch(`${describedById} t-and-c-error`)
-
-      delete params.describedBy
+        .toMatch('some-id t-and-c-error')
     })
   })
 
@@ -932,16 +442,11 @@ describe('Checkboxes', () => {
     })
 
     it('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples["with single option (and hint) set 'aria-describedby' on input"]
-
-      params.describedBy = describedById
-
-      const $ = render('checkboxes', params)
+      const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input, and describedBy"])
       const $input = $('input')
 
       expect($input.attr('aria-describedby'))
-        .toMatch(`${describedById} t-and-c-with-hint-error t-and-c-with-hint-item-hint`)
+        .toMatch('some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint')
     })
   })
 })

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -21,21 +21,21 @@ describe('Checkboxes', () => {
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = render('checkboxes', examples['with minimum name and items'])
+    const $ = render('checkboxes', examples.default)
 
     const $component = $('.govuk-checkboxes')
 
     const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
     const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
-    expect($firstInput.attr('name')).toEqual('example-name')
-    expect($firstInput.val()).toEqual('1')
-    expect($firstLabel.text()).toContain('Option 1')
+    expect($firstInput.attr('name')).toEqual('nationality')
+    expect($firstInput.val()).toEqual('british')
+    expect($firstLabel.text()).toContain('British')
 
     const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
     const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
-    expect($lastInput.attr('name')).toEqual('example-name')
-    expect($lastInput.val()).toEqual('2')
-    expect($lastLabel.text()).toContain('Option 2')
+    expect($lastInput.attr('name')).toEqual('nationality')
+    expect($lastInput.val()).toEqual('other')
+    expect($lastLabel.text()).toContain('Citizen of another country')
   })
 
   it('render example without falsely values', () => {
@@ -95,22 +95,6 @@ describe('Checkboxes', () => {
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const $ = render('checkboxes', examples['with minimum name and items'])
-
-      const $component = $('.govuk-checkboxes')
-
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('example-name')
-      expect($firstLabel.attr('for')).toEqual('example-name')
-
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-      const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('example-name-2')
-      expect($lastLabel.attr('for')).toEqual('example-name-2')
-    })
-
-    it('render a matching label and input using custom idPrefix', () => {
       const $ = render('checkboxes', examples.default)
 
       const $component = $('.govuk-checkboxes')
@@ -124,6 +108,22 @@ describe('Checkboxes', () => {
       const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
       expect($lastInput.attr('id')).toEqual('nationality-3')
       expect($lastLabel.attr('for')).toEqual('nationality-3')
+    })
+
+    it('render a matching label and input using custom idPrefix', () => {
+      const $ = render('checkboxes', examples['with idPrefix'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
+      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+      expect($firstInput.attr('id')).toEqual('nationality')
+      expect($firstLabel.attr('for')).toEqual('nationality')
+
+      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+      const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
+      expect($lastInput.attr('id')).toEqual('nationality-2')
+      expect($lastLabel.attr('for')).toEqual('nationality-2')
     })
 
     it('render explicitly passed item ids', () => {
@@ -334,7 +334,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('checkboxes', examples.default)
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -393,7 +393,7 @@ describe('Checkboxes', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('checkboxes', examples.default)
+      const $ = render('checkboxes', examples['fieldset params'])
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
       expect($component.length).toBeTruthy()

--- a/src/govuk/components/date-input/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/date-input/__snapshots__/template.test.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Date input nested dependant components passes through fieldset params without breaking 1`] = `
+<fieldset class="govuk-fieldset"
+          role="group"
+          aria-describedby="dob-hint"
+>
+  <legend class="govuk-fieldset__legend">
+    What is your date of birth?
+  </legend>
+</fieldset>
+`;
+
 exports[`Date input nested dependant components passes through label params without breaking 1`] = `
 <label class="govuk-label govuk-date-input__label"
        for="dob-day"
@@ -18,21 +29,9 @@ exports[`Date input nested dependant components passes through label params with
 </label>
 `;
 
-exports[`Date input passes through fieldset params without breaking 1`] = `
-<fieldset class="govuk-fieldset"
-          role="group"
-          aria-describedby="dob-hint"
->
-  <legend class="govuk-fieldset__legend">
-    What is your date of birth?
-  </legend>
-</fieldset>
-`;
-
 exports[`Date input passes through html fieldset params without breaking 1`] = `
 <fieldset class="govuk-fieldset"
           role="group"
-          aria-describedby="dob-error"
 >
   <legend class="govuk-fieldset__legend">
     What is your
@@ -45,7 +44,7 @@ exports[`Date input passes through html fieldset params without breaking 1`] = `
 `;
 
 exports[`Date input when it includes a hint renders the hint 1`] = `
-<div id="dob-errors-hint"
+<div id="dob-hint"
      class="govuk-hint"
 >
   For example, 31 3 1980

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -81,6 +81,9 @@ examples:
 - name: default
   data:
     id: dob
+- name: complete question
+  data:
+    id: dob
     namePrefix: dob
     fieldset:
       legend:

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -265,3 +265,120 @@ examples:
         classes: govuk-input--width-4
         attributes:
           data-example-year: year
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: no data
+  hidden: true
+  data: {}
+- name: classes
+  hidden: true
+  data:
+    classes: app-date-input--custom-modifier
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-attribute: my data value
+- name: with empty items
+  hidden: true
+  data:
+    items: []
+- name: custom pattern
+  hidden: true
+  data:
+    items:
+      -
+        name: day
+        pattern: '[0-8]*'
+- name: with nested name
+  hidden: true
+  data:
+    items:
+      -
+        name: day[dd]
+      -
+        name: month[mm]
+      -
+        name: year[yyyy]
+- name: with id on items
+  hidden: true
+  data:
+    items:
+      -
+        id: day
+      -
+        id: month
+      -
+        year: year
+- name: suffixed id
+  hidden: true
+  data:
+    id: my-date-input
+    items:
+      -
+        name: day
+      -
+        name: month
+      -
+        name: year
+- name: with values
+  hidden: true
+  data:
+    items:
+      -
+        id: day
+      -
+        id: month
+      -
+        id: year
+        value: 2018
+- name: with hint and describedBy
+  hidden: true
+  data:
+    id: dob-errors
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: What is your date of birth?
+    hint:
+      text: For example, 31 3 1980
+- name: with error and describedBy
+  hidden: true
+  data:
+    id: dob-errors
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: What is your date of birth?
+    errorMessage:
+      text: Error message goes here
+- name: fieldset html
+  hidden: true
+  data:
+    fieldset:
+      legend:
+        html: What is your <b>date of birth</b>?
+- name: items with classes
+  hidden: true
+  data:
+    items:
+      -
+        name: day
+        classes: app-date-input__day
+      -
+        name: month
+        classes: app-date-input__month
+      -
+        name: year
+        classes: app-date-input__year
+- name: items without classes
+  hidden: true
+  data:
+    items:
+      -
+        name: day
+      -
+        name: month
+      -
+        name: year
+

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -13,14 +13,14 @@ const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'
 
 describe('Date input', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('date-input', examples.default)
-
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
   describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('date-input', examples.default)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
     it('renders with id', () => {
       const $ = render('date-input', examples.default)
 
@@ -28,28 +28,11 @@ describe('Date input', () => {
       expect($component.attr('id')).toEqual('dob')
     })
 
-    it('renders with items', () => {
+    it('renders default inputs', () => {
       const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
       expect($items.length).toEqual(3)
-    })
-
-    it('renders defaults when an empty item array is provided', () => {
-      const $ = render('date-input', examples['with empty items'])
-
-      const $items = $('.govuk-date-input__item')
-      expect($items.length).toEqual(3)
-    })
-
-    it('renders with default items', () => {
-      const $ = render('date-input', examples['no data'])
-
-      const $items = $('.govuk-date-input__item')
-      const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
-
-      expect($items.length).toEqual(3)
-      expect($firstItemInput.attr('name')).toEqual('day')
     })
 
     it('renders item with capitalised label text', () => {
@@ -94,15 +77,34 @@ describe('Date input', () => {
       expect($firstItems.hasClass('govuk-date-input__input')).toBeTruthy()
     })
 
-    it('renders items with name', () => {
-      const $ = render('date-input', examples['with nested name'])
+    it('renders with a form group wrapper', () => {
+      const $ = render('date-input', examples.default)
 
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('name')).toEqual('day[dd]')
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.length).toBeTruthy()
+    })
+  })
+
+  describe('items', () => {
+    it('renders defaults when an empty item array is provided', () => {
+      const $ = render('date-input', examples['with empty items'])
+
+      const $items = $('.govuk-date-input__item')
+      expect($items.length).toEqual(3)
+    })
+
+    it('renders with default items', () => {
+      const $ = render('date-input', examples['no data'])
+
+      const $items = $('.govuk-date-input__item')
+      const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
+
+      expect($items.length).toEqual(3)
+      expect($firstItemInput.attr('name')).toEqual('day')
     })
 
     it('renders item with suffixed name for input', () => {
-      const $ = render('date-input', examples.default)
+      const $ = render('date-input', examples['complete question'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('name')).toEqual('dob-day')
@@ -127,13 +129,6 @@ describe('Date input', () => {
 
       const $lastItems = $('.govuk-date-input__item:last-child input')
       expect($lastItems.val()).toEqual('2018')
-    })
-
-    it('renders with a form group wrapper', () => {
-      const $ = render('date-input', examples.default)
-
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.length).toBeTruthy()
     })
   })
 
@@ -164,6 +159,13 @@ describe('Date input', () => {
       expect($input3.attr('data-example-year')).toEqual('year')
     })
 
+    it('renders items with name', () => {
+      const $ = render('date-input', examples['with nested name'])
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('day[dd]')
+    })
+
     it('renders inputs with custom pattern attribute', () => {
       const $ = render('date-input', examples['custom pattern'])
 
@@ -181,12 +183,12 @@ describe('Date input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = render('date-input', examples.default)
+      const $ = render('date-input', examples['complete question'])
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('date-input', examples.default)
+      const $ = render('date-input', examples['complete question'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -295,7 +297,7 @@ describe('Date input', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('date-input', examples.default)
+      const $ = render('date-input', examples['complete question'])
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-date-input')
       expect($component.length).toBeTruthy()
@@ -308,7 +310,7 @@ describe('Date input', () => {
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = render('date-input', examples.default)
+      const $ = render('date-input', examples['complete question'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -20,66 +20,30 @@ describe('Date input', () => {
     expect(results).toHaveNoViolations()
   })
 
-  describe('by default', () => {
-    it('renders with classes', () => {
-      const $ = render('date-input', {
-        classes: 'app-date-input--custom-modifier'
-      })
-
-      const $component = $('.govuk-date-input')
-      expect($component.hasClass('app-date-input--custom-modifier')).toBeTruthy()
-    })
-
+  describe('default example', () => {
     it('renders with id', () => {
-      const $ = render('date-input', {
-        id: 'my-date-input'
-      })
+      const $ = render('date-input', examples.default)
 
       const $component = $('.govuk-date-input')
-      expect($component.attr('id')).toEqual('my-date-input')
-    })
-
-    it('renders with attributes', () => {
-      const $ = render('date-input', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
-
-      const $component = $('.govuk-date-input')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('id')).toEqual('dob')
     })
 
     it('renders with items', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
+      const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
       expect($items.length).toEqual(3)
     })
 
     it('renders defaults when an empty item array is provided', () => {
-      const $ = render('date-input', {
-        items: []
-      })
+      const $ = render('date-input', examples['with empty items'])
 
       const $items = $('.govuk-date-input__item')
       expect($items.length).toEqual(3)
     })
 
     it('renders with default items', () => {
-      const $ = render('date-input', {})
+      const $ = render('date-input', examples['no data'])
 
       const $items = $('.govuk-date-input__item')
       const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
@@ -88,29 +52,108 @@ describe('Date input', () => {
       expect($firstItemInput.attr('name')).toEqual('day')
     })
 
+    it('renders item with capitalised label text', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstItems = $('.govuk-date-input__item:first-child')
+      expect($firstItems.text().trim()).toEqual('Day')
+    })
+
+    it('renders inputs with type="text"', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('type')).toEqual('text')
+    })
+
+    it('renders inputs with inputmode="numeric"', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('inputmode')).toEqual('numeric')
+    })
+
+    it('renders inputs with pattern="[0-9]*" to trigger numeric keypad on iOS', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('pattern')).toEqual('[0-9]*')
+    })
+
+    it('renders item with implicit class for label', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstItems = $('.govuk-date-input__item:first-child label')
+      expect($firstItems.hasClass('govuk-date-input__label')).toBeTruthy()
+    })
+
+    it('renders item with implicit class for input', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.hasClass('govuk-date-input__input')).toBeTruthy()
+    })
+
+    it('renders items with name', () => {
+      const $ = render('date-input', examples['with nested name'])
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('day[dd]')
+    })
+
+    it('renders item with suffixed name for input', () => {
+      const $ = render('date-input', examples.default)
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('name')).toEqual('dob-day')
+    })
+
+    it('renders items with id', () => {
+      const $ = render('date-input', examples['with id on items'])
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('id')).toEqual('day')
+    })
+
+    it('renders item with suffixed id for input', () => {
+      const $ = render('date-input', examples['suffixed id'])
+
+      const $firstItems = $('.govuk-date-input__item:first-child input')
+      expect($firstItems.attr('id')).toEqual('my-date-input-day')
+    })
+
+    it('renders items with value', () => {
+      const $ = render('date-input', examples['with values'])
+
+      const $lastItems = $('.govuk-date-input__item:last-child input')
+      expect($lastItems.val()).toEqual('2018')
+    })
+
+    it('renders with a form group wrapper', () => {
+      const $ = render('date-input', examples.default)
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.length).toBeTruthy()
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('date-input', examples.classes)
+
+      const $component = $('.govuk-date-input')
+      expect($component.hasClass('app-date-input--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('date-input', examples.attributes)
+
+      const $component = $('.govuk-date-input')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+
     it('renders with item attributes', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day',
-            attributes: {
-              'data-example-day': 'day'
-            }
-          },
-          {
-            name: 'month',
-            attributes: {
-              'data-example-month': 'month'
-            }
-          },
-          {
-            name: 'year',
-            attributes: {
-              'data-example-year': 'year'
-            }
-          }
-        ]
-      })
+      const $ = render('date-input', examples['with input attributes'])
 
       const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
       const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
@@ -121,235 +164,15 @@ describe('Date input', () => {
       expect($input3.attr('data-example-year')).toEqual('year')
     })
 
-    it('renders item with capitalised label text', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child')
-      expect($firstItems.text().trim()).toEqual('Day')
-    })
-
-    it('renders inputs with type="text"', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          }
-        ]
-      })
-
-      const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('type')).toEqual('text')
-    })
-
-    it('renders inputs with inputmode="numeric"', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          }
-        ]
-      })
-
-      const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('inputmode')).toEqual('numeric')
-    })
-
-    it('renders inputs with pattern="[0-9]*" to trigger numeric keypad on iOS', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          }
-        ]
-      })
-
-      const $firstInput = $('.govuk-date-input__item:first-child input')
-      expect($firstInput.attr('pattern')).toEqual('[0-9]*')
-    })
-
     it('renders inputs with custom pattern attribute', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day',
-            pattern: '[0-8]*'
-          }
-        ]
-      })
+      const $ = render('date-input', examples['custom pattern'])
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('pattern')).toEqual('[0-8]*')
     })
 
-    it('renders item with implicit class for label', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child label')
-      expect($firstItems.hasClass('govuk-date-input__label')).toBeTruthy()
-    })
-
-    it('renders item with implicit class for input', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.hasClass('govuk-date-input__input')).toBeTruthy()
-    })
-
-    it('renders items with name', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            name: 'date[dd]'
-          },
-          {
-            name: 'date[mm]'
-          },
-          {
-            name: 'date[yyy]'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('name')).toEqual('date[dd]')
-    })
-
-    it('renders item with suffixed name for input', () => {
-      const $ = render('date-input', {
-        namePrefix: 'my-date-input',
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('name')).toEqual('my-date-input-day')
-    })
-
-    it('renders items with id', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            id: 'day'
-          },
-          {
-            id: 'month'
-          },
-          {
-            id: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('id')).toEqual('day')
-    })
-
-    it('renders item with suffixed id for input', () => {
-      const $ = render('date-input', {
-        id: 'my-date-input',
-        items: [
-          {
-            name: 'day'
-          },
-          {
-            name: 'month'
-          },
-          {
-            name: 'year'
-          }
-        ]
-      })
-
-      const $firstItems = $('.govuk-date-input__item:first-child input')
-      expect($firstItems.attr('id')).toEqual('my-date-input-day')
-    })
-
-    it('renders items with value', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            id: 'day'
-          },
-          {
-            id: 'month'
-          },
-          {
-            id: 'year',
-            value: '2018'
-          }
-        ]
-      })
-
-      const $lastItems = $('.govuk-date-input__item:last-child input')
-      expect($lastItems.val()).toEqual('2018')
-    })
-
-    it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
-      const $ = render('date-input', examples['with errors and hint'])
-
-      const $fieldset = $('.govuk-fieldset')
-
-      expect($fieldset.attr('role')).toEqual('group')
-    })
-
-    it('renders with a form group wrapper', () => {
-      const $ = render('date-input', {})
-
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.length).toBeTruthy()
-    })
-
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('date-input', {
-        formGroup: {
-          classes: 'extra-class'
-        }
-      })
+      const $ = render('date-input', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -358,12 +181,12 @@ describe('Date input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = render('date-input', examples['with errors and hint'])
+      const $ = render('date-input', examples.default)
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('date-input', examples['with errors and hint'])
+      const $ = render('date-input', examples.default)
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -377,24 +200,17 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples['with errors and hint']
-
-      params.fieldset.describedBy = describedById
-
-      const $ = render('date-input', params)
+      const $ = render('date-input', examples['with hint and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby'))
         .toMatch(hintId)
-
-      delete params.fieldset.describedBy
     })
   })
 
@@ -427,32 +243,16 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples['with errors only']
-
-      params.fieldset.describedBy = describedById
-
-      const $ = render('date-input', params)
+      const $ = render('date-input', examples['with error and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
 
       expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
-
-      delete params.fieldset.describedBy
+        .toMatch('some-id dob-errors-error')
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('date-input', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('date-input', examples['with errors only'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -460,6 +260,14 @@ describe('Date input', () => {
   })
 
   describe('when they include both a hint and an error message', () => {
+    it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
+      const $ = render('date-input', examples['with errors and hint'])
+
+      const $fieldset = $('.govuk-fieldset')
+
+      expect($fieldset.attr('role')).toEqual('group')
+    })
+
     it('associates the fieldset as described by both the hint and the error message', () => {
       const $ = render('date-input', examples['with errors and hint'])
 
@@ -476,23 +284,12 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples['with errors and hint']
-
-      params.fieldset.describedBy = describedById
-
-      const $ = render('date-input', params)
+      const $ = render('date-input', examples['with errors and hint'])
 
       const $fieldset = $('.govuk-fieldset')
-      const errorMessageId = $('.govuk-error-message').attr('id')
-      const hintId = $('.govuk-hint').attr('id')
-
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
-      )
 
       expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+        .toMatch('dob-errors-hint dob-errors-error')
     })
   })
 
@@ -509,59 +306,22 @@ describe('Date input', () => {
 
       expect(htmlWithClassName($, '.govuk-date-input__label')).toMatchSnapshot()
     })
-  })
 
-  it('passes through fieldset params without breaking', () => {
-    const $ = render('date-input', examples.default)
+    it('passes through fieldset params without breaking', () => {
+      const $ = render('date-input', examples.default)
 
-    expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
+      expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
+    })
   })
 
   it('passes through html fieldset params without breaking', () => {
-    const $ = render('date-input', {
-      id: 'dob',
-      name: 'dob',
-      fieldset: {
-        legend: {
-          html: 'What is your <b>date of birth</b>?'
-        }
-      },
-      errorMessage: {
-        text: 'Error message goes here'
-      },
-      items: [
-        {
-          name: 'day'
-        },
-        {
-          name: 'month'
-        },
-        {
-          name: 'year'
-        }
-      ]
-    })
+    const $ = render('date-input', examples['fieldset html'])
 
     expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
   })
 
   it('can have classes for individual items', () => {
-    const $ = render('date-input', {
-      items: [
-        {
-          name: 'day',
-          classes: 'app-date-input__day'
-        },
-        {
-          name: 'month',
-          classes: 'app-date-input__month'
-        },
-        {
-          name: 'year',
-          classes: 'app-date-input__year'
-        }
-      ]
-    })
+    const $ = render('date-input', examples['items with classes'])
 
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
@@ -572,19 +332,7 @@ describe('Date input', () => {
   })
 
   it('does not set classes as undefined if none are defined', () => {
-    const $ = render('date-input', {
-      items: [
-        {
-          name: 'day'
-        },
-        {
-          name: 'month'
-        },
-        {
-          name: 'year'
-        }
-      ]
-    })
+    const $ = render('date-input', examples['items without classes'])
 
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
@@ -596,19 +344,7 @@ describe('Date input', () => {
 
   describe('when it includes autocomplete attributes', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = render('date-input', {
-        items: [
-          {
-            autocomplete: 'bday-day'
-          },
-          {
-            autocomplete: 'bday-month'
-          },
-          {
-            autocomplete: 'bday-year'
-          }
-        ]
-      })
+      const $ = render('date-input', examples['with autocomplete values'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('autocomplete')).toEqual('bday-day')

--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -61,3 +61,35 @@ examples:
         <li>benefits information</li>
         <li>tax return</li>
       </ul>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: id
+  hidden: true
+  data:
+    id: my-details-element
+- name: html as text
+  hidden: true
+  data:
+    text: More about the greater than symbol (>)
+- name: html
+  hidden: true
+  data:
+    html: More about <b>bold text</b>
+- name: summary html as text
+  hidden: true
+  data:
+    summaryText: The greater than symbol (>) is the best
+- name: summary html
+  hidden: true
+  data:
+    summaryHtml: Use <b>bold text</b> sparingly
+- name: classes
+  hidden: true
+  data:
+    classes: some-additional-class
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-some-data-attribute: i-love-data
+      another-attribute: true

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -24,6 +24,27 @@ describe('Details', () => {
     expect($component.get(0).tagName).toEqual('details')
   })
 
+  it('renders with a custom id', () => {
+    const $ = render('details', examples.id)
+
+    const $component = $('.govuk-details')
+    expect($component.attr('id')).toEqual('my-details-element')
+  })
+
+  it('is collapsed by default', () => {
+    const $ = render('details', examples.default)
+
+    const $component = $('.govuk-details')
+    expect($component.attr('open')).toBeFalsy()
+  })
+
+  it('can be opened by default', () => {
+    const $ = render('details', examples.expanded)
+
+    const $component = $('.govuk-details')
+    expect($component.attr('open')).toBeTruthy()
+  })
+
   it('includes a nested summary', () => {
     const $ = render('details', examples.default)
 
@@ -33,57 +54,42 @@ describe('Details', () => {
   })
 
   it('allows text to be passed whilst escaping HTML entities', () => {
-    const $ = render('details', {
-      text: 'More about the greater than symbol (>)'
-    })
+    const $ = render('details', examples['html as text'])
 
     const detailsText = $('.govuk-details__text').html().trim()
     expect(detailsText).toEqual('More about the greater than symbol (&gt;)')
   })
 
   it('allows HTML to be passed un-escaped', () => {
-    const $ = render('details', {
-      html: 'More about <b>bold text</b>'
-    })
+    const $ = render('details', examples.html)
 
     const detailsText = $('.govuk-details__text').html().trim()
     expect(detailsText).toEqual('More about <b>bold text</b>')
   })
 
   it('allows summary text to be passed whilst escaping HTML entities', () => {
-    const $ = render('details', {
-      summaryText: 'The greater than symbol (>) is the best'
-    })
+    const $ = render('details', examples['summary html as text'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
     expect(detailsText).toEqual('The greater than symbol (&gt;) is the best')
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
-    const $ = render('details', {
-      summaryHtml: 'Use <b>bold text</b> sparingly'
-    })
+    const $ = render('details', examples['summary html'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
     expect(detailsText).toEqual('Use <b>bold text</b> sparingly')
   })
 
   it('allows additional classes to be added to the details element', () => {
-    const $ = render('details', {
-      classes: 'some-additional-class'
-    })
+    const $ = render('details', examples.classes)
 
     const $component = $('.govuk-details')
     expect($component.hasClass('some-additional-class')).toBeTruthy()
   })
 
   it('allows additional attributes to be added to the details element', () => {
-    const $ = render('details', {
-      attributes: {
-        'data-some-data-attribute': 'i-love-data',
-        'another-attribute': 'true'
-      }
-    })
+    const $ = render('details', examples.attributes)
 
     const $component = $('.govuk-details')
     expect($component.attr('data-some-data-attribute')).toEqual('i-love-data')

--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -41,3 +41,37 @@ examples:
 - name: default
   data:
     text: Error message about full name goes here
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: id
+  hidden: true
+  data:
+    id: my-error-message-id
+- name: classes
+  hidden: true
+  data:
+    classes: custom-class
+- name: html as text
+  hidden: true
+  data:
+    text: Unexpected > in body
+- name: html
+  hidden: true
+  data:
+    html: Unexpected <b>bold text</b> in body copy
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-test: attribute
+      id: my-error-message
+- name: with visually hidden text
+  hidden: true
+  data:
+    text: Rhowch eich enw llawn
+    visuallyHiddenText: Gwall
+- name: visually hidden text removed
+  hidden: true
+  data:
+    text: There is an error on line 42
+    visuallyHiddenText: false

--- a/src/govuk/components/error-message/template.test.js
+++ b/src/govuk/components/error-message/template.test.js
@@ -17,40 +17,36 @@ describe('Error message', () => {
     expect(results).toHaveNoViolations()
   })
 
+  it('renders with a custom id', () => {
+    const $ = render('error-message', examples.id)
+
+    const $component = $('.govuk-error-message')
+    expect($component.attr('id')).toEqual('my-error-message-id')
+  })
+
   it('allows additional classes to specified', () => {
-    const $ = render('error-message', {
-      classes: 'custom-class'
-    })
+    const $ = render('error-message', examples.classes)
 
     const $component = $('.govuk-error-message')
     expect($component.hasClass('custom-class')).toBeTruthy()
   })
 
   it('allows text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-message', {
-      text: 'Unexpected > in body'
-    })
+    const $ = render('error-message', examples['html as text'])
 
     const content = $('.govuk-error-message').html().trim()
     expect(content).toContain('Unexpected &gt; in body')
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
-    const $ = render('error-message', {
-      html: 'Unexpected <b>bold text</b> in body copy'
-    })
+    const $ = render('error-message', examples.html)
 
     const content = $('.govuk-error-message').html().trim()
     expect(content).toContain('Unexpected <b>bold text</b> in body copy')
   })
 
   it('allows additional attributes to be specified', () => {
-    const $ = render('error-message', {
-      attributes: {
-        'data-test': 'attribute',
-        id: 'my-error-message'
-      }
-    })
+    const $ = render('error-message', examples.attributes)
 
     const $component = $('.govuk-error-message')
     expect($component.attr('data-test')).toEqual('attribute')
@@ -58,29 +54,21 @@ describe('Error message', () => {
   })
 
   it('includes a visually hidden "Error" prefix by default', () => {
-    const $ = render('error-message', {
-      text: 'Enter your full name'
-    })
+    const $ = render('error-message', examples.default)
 
     const $component = $('.govuk-error-message')
-    expect($component.text().trim()).toEqual('Error: Enter your full name')
+    expect($component.text().trim()).toEqual('Error: Error message about full name goes here')
   })
 
   it('allows the visually hidden prefix to be customised', () => {
-    const $ = render('error-message', {
-      text: 'Rhowch eich enw llawn',
-      visuallyHiddenText: 'Gwall'
-    })
+    const $ = render('error-message', examples['with visually hidden text'])
 
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('Gwall: Rhowch eich enw llawn')
   })
 
   it('allows the visually hidden prefix to be removed', () => {
-    const $ = render('error-message', {
-      text: 'There is an error on line 42',
-      visuallyHiddenText: false
-    })
+    const $ = render('error-message', examples['visually hidden text removed'])
 
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('There is an error on line 42')

--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -15,7 +15,6 @@ params:
   type: string
   required: false
   description: HTML to use for the description of the errors. If you set this option, the component will ignore `descriptionText`.
-
 - name: errorList
   type: array
   required: true
@@ -85,3 +84,71 @@ examples:
       -
         text: Agree to the terms of service to log in
         href: '#example-error-1'
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: html as titleText
+  hidden: true
+  data:
+    titleText: Alert, <em>alert</em>
+- name: title html
+  hidden: true
+  data:
+    titleHtml: Alert, <em>alert</em>
+- name: description
+  hidden: true
+  data:
+    descriptionText: Lorem ipsum
+- name: html as descriptionText
+  hidden: true
+  data:
+    descriptionText: See errors below (▼)
+- name: description html
+  hidden: true
+  data:
+    descriptionHtml: See <span>errors</span> below
+- name: classes
+  hidden: true
+  data:
+    classes: extra-class one-more-class
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      first-attribute: 'true'
+      second-attribute: 'false'
+- name: error list with attributes
+  hidden: true
+  data:
+    errorList:
+      -
+        text: Error-1
+        href: '#item'
+        attributes:
+          data-attribute: my-attribute
+          data-attribute-2: my-attribute-2
+- name: error list with html as text
+  hidden: true
+  data:
+    errorList:
+      -
+        text: Descriptive link to the <b>question</b> with an error
+- name: error list with html
+  hidden: true
+  data:
+    errorList:
+      -
+        html: The date your passport was issued <b>must</b> be in the past
+- name: error list with html link
+  hidden: true
+  data:
+    errorList:
+      -
+        html: Descriptive link to the <b>question</b> with an error
+        href: '#error-1'
+- name: error list with html as text link
+  hidden: true
+  data:
+    errorList:
+      -
+        text: Descriptive link to the <b>question</b> with an error
+        href: '#error-1'

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -10,156 +10,160 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('error-summary')
 
 describe('Error-summary', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('error-summary', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('error-summary', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('aria-labelledby attribute matches the title id', () => {
+      const $ = render('error-summary', examples.default)
+      const ariaAttr = $('.govuk-error-summary').attr('aria-labelledby')
+
+      expect(ariaAttr).toEqual('error-summary-title')
+    })
+
+    it('has role=alert attribute', () => {
+      const $ = render('error-summary', examples.default)
+      const roleAttr = $('.govuk-error-summary').attr('role')
+
+      expect(roleAttr).toEqual('alert')
+    })
+
+    it('has the correct tabindex attribute to be focussed', () => {
+      const $ = render('error-summary', examples.default)
+      const tabindexAttr = $('.govuk-error-summary').attr('tabindex')
+
+      expect(tabindexAttr).toEqual('-1')
+    })
+
+    it('renders title text', () => {
+      const $ = render('error-summary', examples.default)
+      const summaryTitle = $('.govuk-error-summary__title').text().trim()
+
+      expect(summaryTitle).toEqual('There is a problem')
+    })
+
+    it('number of error items matches the number of items specified', () => {
+      const $ = render('error-summary', examples.default)
+      const errorList = $('.govuk-error-summary .govuk-error-summary__list li')
+
+      expect(errorList).toHaveLength(2)
+    })
+
+    it('error list item is an anchor tag if href attribute is specified', () => {
+      const $ = render('error-summary', examples.default)
+
+      const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child')
+      expect(errorItem.children().get(0).tagName).toEqual('a')
+    })
+
+    it('render anchor tag href attribute is correctly', () => {
+      const $ = render('error-summary', examples.default)
+
+      const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child a')
+      expect(errorItem.attr('href')).toEqual('#example-error-1')
+    })
   })
 
-  it('aria-labelledby attribute matches the title id', () => {
-    const $ = render('error-summary', examples.default)
-    const ariaAttr = $('.govuk-error-summary').attr('aria-labelledby')
+  describe('custom options', () => {
+    it('allows title text to be passed whilst escaping HTML entities', () => {
+      const $ = render('error-summary', examples['html as titleText'])
 
-    expect(ariaAttr).toEqual('error-summary-title')
-  })
+      const summaryTitle = $('.govuk-error-summary__title').html().trim()
+      expect(summaryTitle).toEqual('Alert, &lt;em&gt;alert&lt;/em&gt;')
+    })
 
-  it('has role=alert attribute', () => {
-    const $ = render('error-summary', examples.default)
-    const roleAttr = $('.govuk-error-summary').attr('role')
+    it('allows title HTML to be passed un-escaped', () => {
+      const $ = render('error-summary', examples['title html'])
 
-    expect(roleAttr).toEqual('alert')
-  })
+      const summaryTitle = $('.govuk-error-summary__title').html().trim()
+      expect(summaryTitle).toEqual('Alert, <em>alert</em>')
+    })
 
-  it('has the correct tabindex attribute to be focussed', () => {
-    const $ = render('error-summary', examples.default)
-    const tabindexAttr = $('.govuk-error-summary').attr('tabindex')
+    it('renders description text', () => {
+      const $ = render('error-summary', examples.description)
+      const summaryDescription = $('.govuk-error-summary__body p').text().trim()
 
-    expect(tabindexAttr).toEqual('-1')
-  })
+      expect(summaryDescription).toEqual('Lorem ipsum')
+    })
 
-  it('renders title text', () => {
-    const $ = render('error-summary', examples.default)
-    const summaryTitle = $('.govuk-error-summary__title').text().trim()
+    it('allows description text to be passed whilst escaping HTML entities', () => {
+      const $ = render('error-summary', examples['html as descriptionText'])
 
-    expect(summaryTitle).toEqual('There is a problem')
-  })
+      const summaryDescription = $('.govuk-error-summary__body p').html().trim()
+      expect(summaryDescription).toEqual('See errors below (&#x25BC;)')
+    })
 
-  it('allows title text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', examples['html as titleText'])
+    it('allows description HTML to be passed un-escaped', () => {
+      const $ = render('error-summary', examples['description html'])
 
-    const summaryTitle = $('.govuk-error-summary__title').html().trim()
-    expect(summaryTitle).toEqual('Alert, &lt;em&gt;alert&lt;/em&gt;')
-  })
+      const summaryDescription = $('.govuk-error-summary__body p').html().trim()
+      expect(summaryDescription).toEqual('See <span>errors</span> below')
+    })
 
-  it('allows title HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', examples['title html'])
+    it('allows additional classes to be added to the error-summary component', () => {
+      const $ = render('error-summary', examples.classes)
 
-    const summaryTitle = $('.govuk-error-summary__title').html().trim()
-    expect(summaryTitle).toEqual('Alert, <em>alert</em>')
-  })
+      const $component = $('.govuk-error-summary')
+      expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
+    })
 
-  it('renders description text', () => {
-    const $ = render('error-summary', examples.description)
-    const summaryDescription = $('.govuk-error-summary__body p').text().trim()
+    it('allows additional attributes to be added to the error-summary component', () => {
+      const $ = render('error-summary', examples.attributes)
 
-    expect(summaryDescription).toEqual('Lorem ipsum')
-  })
+      const $component = $('.govuk-error-summary')
+      expect($component.attr('first-attribute')).toEqual('true')
+      expect($component.attr('second-attribute')).toEqual('false')
+    })
 
-  it('allows description text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', examples['html as descriptionText'])
+    it('renders anchor tag with attributes', () => {
+      const $ = render('error-summary', examples['error list with attributes'])
 
-    const summaryDescription = $('.govuk-error-summary__body p').html().trim()
-    expect(summaryDescription).toEqual('See errors below (&#x25BC;)')
-  })
+      const $component = $('.govuk-error-summary__list a')
+      expect($component.attr('data-attribute')).toEqual('my-attribute')
+      expect($component.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
 
-  it('allows description HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', examples['description html'])
+    it('renders error item text', () => {
+      const $ = render('error-summary', examples['without links'])
+      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()
 
-    const summaryDescription = $('.govuk-error-summary__body p').html().trim()
-    expect(summaryDescription).toEqual('See <span>errors</span> below')
-  })
+      expect(errorItemText).toEqual('Invalid username or password')
+    })
 
-  it('allows additional classes to be added to the error-summary component', () => {
-    const $ = render('error-summary', examples.classes)
+    it('allows error item HTML to be passed un-escaped', () => {
+      const $ = render('error-summary', examples['error list with html'])
 
-    const $component = $('.govuk-error-summary')
-    expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
-  })
+      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
-  it('allows additional attributes to be added to the error-summary component', () => {
-    const $ = render('error-summary', examples.attributes)
+      expect(errorItemText).toEqual('The date your passport was issued <b>must</b> be in the past')
+    })
 
-    const $component = $('.govuk-error-summary')
-    expect($component.attr('first-attribute')).toEqual('true')
-    expect($component.attr('second-attribute')).toEqual('false')
-  })
+    it('allows error item text to be passed whilst escaping HTML entities', () => {
+      const $ = render('error-summary', examples['error list with html as text'])
 
-  it('number of error items matches the number of items specified', () => {
-    const $ = render('error-summary', examples.default)
-    const errorList = $('.govuk-error-summary .govuk-error-summary__list li')
+      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
-    expect(errorList).toHaveLength(2)
-  })
+      expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
+    })
 
-  it('error list item is an anchor tag if href attribute is specified', () => {
-    const $ = render('error-summary', examples.default)
+    it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
+      const $ = render('error-summary', examples['error list with html link'])
 
-    const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child')
-    expect(errorItem.children().get(0).tagName).toEqual('a')
-  })
+      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 
-  it('render anchor tag href attribute is correctly', () => {
-    const $ = render('error-summary', examples.default)
+      expect(errorItemText).toEqual('Descriptive link to the <b>question</b> with an error')
+    })
 
-    const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child a')
-    expect(errorItem.attr('href')).toEqual('#example-error-1')
-  })
+    it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
+      const $ = render('error-summary', examples['error list with html as text link'])
 
-  it('renders anchor tag with attributes', () => {
-    const $ = render('error-summary', examples['error list with attributes'])
+      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 
-    const $component = $('.govuk-error-summary__list a')
-    expect($component.attr('data-attribute')).toEqual('my-attribute')
-    expect($component.attr('data-attribute-2')).toEqual('my-attribute-2')
-  })
-
-  it('renders error item text', () => {
-    const $ = render('error-summary', examples['without links'])
-    const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()
-
-    expect(errorItemText).toEqual('Invalid username or password')
-  })
-
-  it('allows error item HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', examples['error list with html'])
-
-    const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
-
-    expect(errorItemText).toEqual('The date your passport was issued <b>must</b> be in the past')
-  })
-
-  it('allows error item text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', examples['error list with html as text'])
-
-    const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
-
-    expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
-  })
-
-  it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
-    const $ = render('error-summary', examples['error list with html link'])
-
-    const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
-
-    expect(errorItemText).toEqual('Descriptive link to the <b>question</b> with an error')
-  })
-
-  it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', examples['error list with html as text link'])
-
-    const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
-
-    expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
+      expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
+    })
   })
 })

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -46,66 +46,49 @@ describe('Error-summary', () => {
   })
 
   it('allows title text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', {
-      titleText: 'Alert, <em>alert</em>'
-    })
+    const $ = render('error-summary', examples['html as titleText'])
 
     const summaryTitle = $('.govuk-error-summary__title').html().trim()
     expect(summaryTitle).toEqual('Alert, &lt;em&gt;alert&lt;/em&gt;')
   })
 
   it('allows title HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', {
-      titleHtml: 'Alert, <em>alert</em>'
-    })
+    const $ = render('error-summary', examples['title html'])
 
     const summaryTitle = $('.govuk-error-summary__title').html().trim()
     expect(summaryTitle).toEqual('Alert, <em>alert</em>')
   })
 
   it('renders description text', () => {
-    const $ = render('error-summary', {
-      descriptionText: 'Lorem ipsum'
-    })
+    const $ = render('error-summary', examples.description)
     const summaryDescription = $('.govuk-error-summary__body p').text().trim()
 
     expect(summaryDescription).toEqual('Lorem ipsum')
   })
 
   it('allows description text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', {
-      descriptionText: 'See errors below (▼)'
-    })
+    const $ = render('error-summary', examples['html as descriptionText'])
 
     const summaryDescription = $('.govuk-error-summary__body p').html().trim()
     expect(summaryDescription).toEqual('See errors below (&#x25BC;)')
   })
 
   it('allows description HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', {
-      descriptionHtml: 'See <span>errors</span> below'
-    })
+    const $ = render('error-summary', examples['description html'])
 
     const summaryDescription = $('.govuk-error-summary__body p').html().trim()
     expect(summaryDescription).toEqual('See <span>errors</span> below')
   })
 
   it('allows additional classes to be added to the error-summary component', () => {
-    const $ = render('error-summary', {
-      classes: 'extra-class one-more-class'
-    })
+    const $ = render('error-summary', examples.classes)
 
     const $component = $('.govuk-error-summary')
     expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
   })
 
   it('allows additional attributes to be added to the error-summary component', () => {
-    const $ = render('error-summary', {
-      attributes: {
-        'first-attribute': 'true',
-        'second-attribute': 'false'
-      }
-    })
+    const $ = render('error-summary', examples.attributes)
 
     const $component = $('.govuk-error-summary')
     expect($component.attr('first-attribute')).toEqual('true')
@@ -134,18 +117,7 @@ describe('Error-summary', () => {
   })
 
   it('renders anchor tag with attributes', () => {
-    const $ = render('error-summary', {
-      errorList: [
-        {
-          text: 'Error-1',
-          href: '#item',
-          attributes: {
-            'data-attribute': 'my-attribute',
-            'data-attribute-2': 'my-attribute-2'
-          }
-        }
-      ]
-    })
+    const $ = render('error-summary', examples['error list with attributes'])
 
     const $component = $('.govuk-error-summary__list a')
     expect($component.attr('data-attribute')).toEqual('my-attribute')
@@ -153,20 +125,14 @@ describe('Error-summary', () => {
   })
 
   it('renders error item text', () => {
-    const $ = render('error-summary', examples.default)
+    const $ = render('error-summary', examples['without links'])
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()
 
-    expect(errorItemText).toEqual('The date your passport was issued must be in the past')
+    expect(errorItemText).toEqual('Invalid username or password')
   })
 
   it('allows error item HTML to be passed un-escaped', () => {
-    const $ = render('error-summary', {
-      errorList: [
-        {
-          html: 'The date your passport was issued <b>must</b> be in the past'
-        }
-      ]
-    })
+    const $ = render('error-summary', examples['error list with html'])
 
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
@@ -174,13 +140,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item text to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', {
-      errorList: [
-        {
-          text: 'Descriptive link to the <b>question</b> with an error'
-        }
-      ]
-    })
+    const $ = render('error-summary', examples['error list with html as text'])
 
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
@@ -188,14 +148,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
-    const $ = render('error-summary', {
-      errorList: [
-        {
-          html: 'Descriptive link to the <b>question</b> with an error',
-          href: '#error-1'
-        }
-      ]
-    })
+    const $ = render('error-summary', examples['error list with html link'])
 
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 
@@ -203,14 +156,7 @@ describe('Error-summary', () => {
   })
 
   it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
-    const $ = render('error-summary', {
-      errorList: [
-        {
-          text: 'Descriptive link to the <b>question</b> with an error',
-          href: '#error-1'
-        }
-      ]
-    })
+    const $ = render('error-summary', examples['error list with html as text link'])
 
     const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 

--- a/src/govuk/components/fieldset/fieldset.yaml
+++ b/src/govuk/components/fieldset/fieldset.yaml
@@ -36,6 +36,10 @@ params:
   type: object
   required: false
   description: HTML attributes (for example data attributes) to add to the fieldset container.
+- name: html
+  type: string
+  required: false
+  description: HTML to use/render within the fieldset element.
 - name: caller
   type: nunjucks-block
   required: false
@@ -54,6 +58,15 @@ examples:
       isPageHeading: true
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: html fieldset content
+  hidden: true
+  data:
+    legend:
+      text: What is your address?
+    html: |
+      <div class="my-content">
+        <p>This is some content to put inside the fieldset</p>
+      </div>
 - name: with describedBy
   hidden: true
   data:

--- a/src/govuk/components/fieldset/fieldset.yaml
+++ b/src/govuk/components/fieldset/fieldset.yaml
@@ -52,3 +52,38 @@ examples:
       text: What is your address?
       classes: govuk-fieldset__legend--xl
       isPageHeading: true
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: with describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+- name: html as text
+  hidden: true
+  data:
+    legend:
+      text: What is <b>your</b> address?
+- name: html
+  hidden: true
+  data:
+    legend:
+      html: What is <b>your</b> address?
+- name: legend classes
+  hidden: true
+  data:
+    legend:
+      text: What is your address?
+      classes: my-custom-class
+- name: classes
+  hidden: true
+  data:
+    classes: app-fieldset--custom-modifier
+- name: role
+  hidden: true
+  data:
+    role: group
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-attribute: value

--- a/src/govuk/components/fieldset/template.njk
+++ b/src/govuk/components/fieldset/template.njk
@@ -14,5 +14,9 @@
   {% endif %}
   </legend>
   {% endif %}
-{{ caller() if caller }} {#- if statement allows usage of `call` to be optional -#}
+{% if caller %} {#- if statement allows usage of `call` to be optional -#}
+  {{ caller() }}
+{% elseif params.html %}
+  {{ params.html | safe }}
+{% endif %}
 </fieldset>

--- a/src/govuk/components/fieldset/template.test.js
+++ b/src/govuk/components/fieldset/template.test.js
@@ -18,87 +18,56 @@ describe('fieldset', () => {
   })
 
   it('creates a fieldset', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?'
-      }
-    })
+    const $ = render('fieldset', examples.default)
 
     const $component = $('fieldset.govuk-fieldset')
     expect($component.get(0).tagName).toContain('fieldset')
   })
 
   it('includes a legend element which captions the fieldset', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?'
-      }
-    })
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.get(0).tagName).toEqual('legend')
   })
 
   it('nests the legend within the fieldset', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?'
-      }
-    })
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.parent().get(0).tagName).toEqual('fieldset')
   })
 
   it('allows you to set the legend text', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?'
-      }
-    })
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.text().trim()).toEqual('What is your address?')
   })
 
   it('allows you to set the aria-describedby attribute', () => {
-    const $ = render('fieldset', {
-      describedBy: 'some-id'
-    })
+    const $ = render('fieldset', examples['with describedBy'])
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('aria-describedby')).toEqual('some-id')
   })
 
   it('escapes HTML in the text argument', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is <b>your</b> address?'
-      }
-    })
+    const $ = render('fieldset', examples['html as text'])
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.html()).toContain('&lt;b&gt;your&lt;/b&gt;')
   })
 
   it('does not escape HTML in the html argument', () => {
-    const $ = render('fieldset', {
-      legend: {
-        html: 'What is <b>your</b> address?'
-      }
-    })
+    const $ = render('fieldset', examples.html)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.html()).toContain('<b>your</b>')
   })
 
   it('nests the legend text in an H1 if the legend is a page heading', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?',
-        isPageHeading: true
-      }
-    })
+    const $ = render('fieldset', examples['as page heading'])
 
     const $headingInsideLegend = $('.govuk-fieldset__legend > h1')
     expect($headingInsideLegend.text().trim()).toBe('What is your address?')
@@ -111,41 +80,28 @@ describe('fieldset', () => {
   })
 
   it('can have additional classes on the legend', () => {
-    const $ = render('fieldset', {
-      legend: {
-        text: 'What is your address?',
-        classes: 'my-custom-class'
-      }
-    })
+    const $ = render('fieldset', examples['legend classes'])
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.hasClass('my-custom-class')).toBeTruthy()
   })
 
   it('can have additional classes on the fieldset', () => {
-    const $ = render('fieldset', {
-      classes: 'app-fieldset--custom-modifier'
-    })
+    const $ = render('fieldset', examples.classes)
 
     const $component = $('.govuk-fieldset')
     expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
   })
 
   it('can have an explicit role', () => {
-    const $ = render('fieldset', {
-      role: 'group'
-    })
+    const $ = render('fieldset', examples.role)
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('role')).toEqual('group')
   })
 
   it('can have additional attributes', () => {
-    const $ = render('fieldset', {
-      attributes: {
-        'data-attribute': 'value'
-      }
-    })
+    const $ = render('fieldset', examples.attributes)
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('data-attribute')).toEqual('value')

--- a/src/govuk/components/fieldset/template.test.js
+++ b/src/govuk/components/fieldset/template.test.js
@@ -73,6 +73,12 @@ describe('fieldset', () => {
     expect($headingInsideLegend.text().trim()).toBe('What is your address?')
   })
 
+  it('renders html when passed as fieldset content', () => {
+    const $ = render('fieldset', examples['html fieldset content'])
+
+    expect($('.govuk-fieldset .my-content').text().trim()).toEqual('This is some content to put inside the fieldset')
+  })
+
   it('renders nested components using `call`', () => {
     const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
 

--- a/src/govuk/components/file-upload/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/file-upload/__snapshots__/template.test.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`File upload when it includes a hint renders with hint 1`] = `""`;
+exports[`File upload when it includes a hint renders with hint 1`] = `
+<div id="file-upload-2-hint"
+     class="govuk-hint"
+>
+  Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+</div>
+`;
 
 exports[`File upload when it includes an error message renders with error message 1`] = `
 <span id="file-upload-with-error-error"
@@ -12,8 +18,8 @@ exports[`File upload when it includes an error message renders with error messag
 
 exports[`File upload with dependant components renders with label 1`] = `
 <label class="govuk-label"
-       for="my-file-upload"
+       for="file-upload-1"
 >
-  Full address
+  Upload a file
 </label>
 `;

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -63,7 +63,7 @@ examples:
       text: Upload your photo
     hint:
       text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
-- name: with error message
+- name: with error message and hint
   data:
     id: file-upload-3
     name: file-upload-3
@@ -73,15 +73,13 @@ examples:
       text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
     errorMessage:
       text: Error message goes here
-- name: with value and attributes
+- name: with value
   data:
     id: file-upload-4
     name: file-upload-4
     value: C:\fakepath\myphoto.jpg
     label:
       text: Upload a photo
-    attributes:
-      accept: .jpg, .jpeg, .png
 - name: with label as page heading
   data:
     id: file-upload-1
@@ -97,3 +95,44 @@ examples:
       text: Upload a file
     formGroup:
       classes: extra-class
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      accept: .jpg, .jpeg, .png
+- name: classes
+  hidden: true
+  data:
+    classes: app-file-upload--custom-modifier
+- name: with describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+- name: with hint and describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+    hint:
+      text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
+- name: error
+  hidden: true
+  data:
+    id: "file-upload-with-error"
+    errorMessage:
+      text: Error message
+- name: with error and describedBy
+  hidden: true
+  data:
+    describedBy: some-id
+    errorMessage:
+      text: Error message
+- name: with error, describedBy and hint
+  hidden: true
+  data:
+    describedBy: some-id
+    errorMessage:
+      text: Error message
+    hint:
+      text: hint

--- a/src/govuk/components/file-upload/template.test.js
+++ b/src/govuk/components/file-upload/template.test.js
@@ -13,19 +13,12 @@ const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'
 
 describe('File upload', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('file-upload', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
-    })
-
-    it('renders with classes', () => {
-      const $ = render('file-upload', examples.classes)
-
-      const $component = $('.govuk-file-upload')
-      expect($component.hasClass('app-file-upload--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
@@ -40,6 +33,22 @@ describe('File upload', () => {
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('name')).toEqual('file-upload-1')
+    })
+
+    it('renders with a form group wrapper', () => {
+      const $ = render('file-upload', examples.default)
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.length).toBeTruthy()
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('file-upload', examples.classes)
+
+      const $component = $('.govuk-file-upload')
+      expect($component.hasClass('app-file-upload--custom-modifier')).toBeTruthy()
     })
 
     it('renders with value', () => {
@@ -61,13 +70,6 @@ describe('File upload', () => {
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('accept')).toEqual('.jpg, .jpeg, .png')
-    })
-
-    it('renders with a form group wrapper', () => {
-      const $ = render('file-upload', examples.default)
-
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {

--- a/src/govuk/components/file-upload/template.test.js
+++ b/src/govuk/components/file-upload/template.test.js
@@ -22,76 +22,56 @@ describe('File upload', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('file-upload', {
-        classes: 'app-file-upload--custom-modifier'
-      })
+      const $ = render('file-upload', examples.classes)
 
       const $component = $('.govuk-file-upload')
       expect($component.hasClass('app-file-upload--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('file-upload', {
-        id: 'my-file-upload'
-      })
+      const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('id')).toEqual('my-file-upload')
+      expect($component.attr('id')).toEqual('file-upload-1')
     })
 
     it('renders with name', () => {
-      const $ = render('file-upload', {
-        name: 'my-file-upload-name'
-      })
+      const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('name')).toEqual('my-file-upload-name')
+      expect($component.attr('name')).toEqual('file-upload-1')
     })
 
     it('renders with value', () => {
-      const $ = render('file-upload', {
-        value: 'C:/fakepath'
-      })
+      const $ = render('file-upload', examples['with value'])
 
       const $component = $('.govuk-file-upload')
-      expect($component.val()).toEqual('C:/fakepath')
+      expect($component.val()).toEqual('C:\\fakepath\\myphoto.jpg')
     })
 
     it('renders with aria-describedby', () => {
-      const describedById = 'some-id'
-
-      const $ = render('file-upload', {
-        describedBy: describedById
-      })
+      const $ = render('file-upload', examples['with describedBy'])
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('aria-describedby')).toMatch(describedById)
+      expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with attributes', () => {
-      const $ = render('file-upload', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('file-upload', examples.attributes)
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      expect($component.attr('accept')).toEqual('.jpg, .jpeg, .png')
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = render('file-upload', {})
+      const $ = render('file-upload', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('file-upload', {
-        formGroup: {
-          classes: 'extra-class'
-        }
-      })
+      const $ = render('file-upload', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -100,23 +80,13 @@ describe('File upload', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-hint',
-        errorMessage: {
-          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
-        }
-      })
+      const $ = render('file-upload', examples['with hint text'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the hint', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-hint',
-        hint: {
-          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
-        }
-      })
+      const $ = render('file-upload', examples['with hint text'])
 
       const $component = $('.govuk-file-upload')
       const $hint = $('.govuk-hint')
@@ -130,21 +100,13 @@ describe('File upload', () => {
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('file-upload', {
-        id: 'file-upload-with-hint',
-        describedBy: describedById,
-        hint: {
-          text: 'Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.'
-        }
-      })
+      const $ = render('file-upload', examples['with hint and describedBy'])
 
       const $component = $('.govuk-file-upload')
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
       )
 
       expect($component.attr('aria-describedby'))
@@ -154,23 +116,13 @@ describe('File upload', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = render('file-upload', {
-        id: 'file-upload-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples.error)
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the error message', () => {
-      const $ = render('file-upload', {
-        id: 'input-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-file-upload')
       const $errorMessage = $('.govuk-error-message')
@@ -184,21 +136,13 @@ describe('File upload', () => {
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('file-upload', {
-        id: 'input-with-error',
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples['with error and describedBy'])
 
       const $component = $('.govuk-file-upload')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
       expect($component.attr('aria-describedby'))
@@ -206,22 +150,14 @@ describe('File upload', () => {
     })
 
     it('includes the error class on the component', () => {
-      const $ = render('file-upload', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-file-upload')
       expect($component.hasClass('govuk-file-upload--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('file-upload', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples.error)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -230,15 +166,7 @@ describe('File upload', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the input as described by both the hint and the error message', () => {
-      const $ = render('file-upload', {
-        id: 'input-with-error',
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('file-upload', examples['with error message and hint'])
 
       const $component = $('.govuk-file-upload')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -255,16 +183,7 @@ describe('File upload', () => {
     it('associates the input as described by the hint, error message and parent fieldset', () => {
       const describedById = 'some-id'
 
-      const $ = render('file-upload', {
-        id: 'input-with-error',
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('file-upload', examples['with error, describedBy and hint'])
 
       const $component = $('.govuk-file-upload')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -281,37 +200,23 @@ describe('File upload', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('file-upload', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-form-group > .govuk-file-upload')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = render('file-upload', {
-        id: 'my-file-upload',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('file-upload', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the file-upload "id"', () => {
-      const $ = render('file-upload', {
-        id: 'my-file-upload',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('file-upload', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('my-file-upload')
+      expect($label.attr('for')).toEqual('file-upload-1')
     })
   })
 })

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -301,3 +301,53 @@ examples:
             text: Navigation item 5
           - href: '#6'
             text: Navigation item 6
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  data:
+    attributes:
+      data-test-attribute: value
+      data-test-attribute-2: value-2
+- name: classes
+  data:
+    classes: app-footer--custom-modifier
+- name: with container classes
+  data:
+    containerClasses: app-width-container
+- name: with empty meta
+  data:
+    meta: {}
+- name: with empty meta items
+  data:
+    meta:
+      items: []
+- name: meta html as text
+  data:
+    meta:
+      text: GOV.UK Prototype Kit <strong>v7.0.1</strong>
+- name: with meta html
+  data:
+    meta:
+      html: GOV.UK Prototype Kit <strong>v7.0.1</strong>
+- name: with meta item attributes
+  data:
+    meta:
+      items:
+        - href: '#1'
+          text: meta item 1
+          attributes:
+            data-attribute: my-attribute
+            data-attribute-2: my-attribute-2
+- name: with empty navigation
+  data:
+    navigation: []
+- name: with navigation item attributes
+  data:
+    navigation:
+      -
+        items:
+          - href: '#1'
+            text: Navigation item 1
+            attributes:
+              data-attribute: my-attribute
+              data-attribute-2: my-attribute-2

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -18,28 +18,14 @@ describe('footer', () => {
   })
 
   it('entire component must have a role of `contentinfo`', () => {
-    const $ = render('footer', {})
+    const $ = render('footer', examples.default)
 
     const $component = $('.govuk-footer')
     expect($component.attr('role')).toEqual('contentinfo')
   })
 
-  it('no items displayed when no item array is provided', () => {
-    const $ = render('footer', {
-      navigation: []
-    })
-
-    const $component = $('.govuk-footer')
-    expect($component.find('.govuk-footer__navigation').length).toEqual(0)
-  })
-
   it('renders attributes correctly', () => {
-    const $ = render('footer', {
-      attributes: {
-        'data-test-attribute': 'value',
-        'data-test-attribute-2': 'value-2'
-      }
-    })
+    const $ = render('footer', examples.attributes)
 
     const $component = $('.govuk-footer')
     expect($component.attr('data-test-attribute')).toEqual('value')
@@ -47,18 +33,14 @@ describe('footer', () => {
   })
 
   it('renders classes', () => {
-    const $ = render('footer', {
-      classes: 'app-footer--custom-modifier'
-    })
+    const $ = render('footer', examples.classes)
 
     const $component = $('.govuk-footer')
     expect($component.hasClass('app-footer--custom-modifier')).toBeTruthy()
   })
 
   it('renders custom container classes', () => {
-    const $ = render('footer', {
-      containerClasses: 'app-width-container'
-    })
+    const $ = render('footer', examples['with container classes'])
 
     const $component = $('.govuk-footer')
     const $container = $component.find('.govuk-width-container')
@@ -83,9 +65,7 @@ describe('footer', () => {
     })
 
     it('renders default heading when none supplied', () => {
-      const $ = render('footer', {
-        meta: {}
-      })
+      const $ = render('footer', examples['with empty meta'])
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
@@ -93,9 +73,7 @@ describe('footer', () => {
     })
 
     it('doesn\'t render footer link list when no items are provided', () => {
-      const $ = render('footer', {
-        meta: { items: [] }
-      })
+      const $ = render('footer', examples['with empty meta items'])
 
       const $component = $('.govuk-footer')
       expect($component.find('.govuk-footer__inline-list').length).toEqual(0)
@@ -114,11 +92,15 @@ describe('footer', () => {
     })
 
     it('renders custom meta text', () => {
-      const $ = render('footer', {
-        meta: {
-          text: 'GOV.UK Prototype Kit <strong>v7.0.1</strong>'
-        }
-      })
+      const $ = render('footer', examples['with custom meta'])
+
+      const $component = $('.govuk-footer')
+      const $custom = $component.find('.govuk-footer__meta-custom')
+      expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
+    })
+
+    it('renders custom meta html as text', () => {
+      const $ = render('footer', examples['meta html as text'])
 
       const $component = $('.govuk-footer')
       const $custom = $component.find('.govuk-footer__meta-custom')
@@ -126,11 +108,7 @@ describe('footer', () => {
     })
 
     it('renders custom meta html', () => {
-      const $ = render('footer', {
-        meta: {
-          html: 'GOV.UK Prototype Kit <strong>v7.0.1</strong>'
-        }
-      })
+      const $ = render('footer', examples['with meta html'])
 
       const $component = $('.govuk-footer')
       const $custom = $component.find('.govuk-footer__meta-custom')
@@ -138,20 +116,7 @@ describe('footer', () => {
     })
 
     it('renders attributes on meta links', () => {
-      const $ = render('footer', {
-        meta: {
-          items: [
-            {
-              href: '#1',
-              text: 'meta item 1',
-              attributes: {
-                'data-attribute': 'my-attribute',
-                'data-attribute-2': 'my-attribute-2'
-              }
-            }
-          ]
-        }
-      })
+      const $ = render('footer', examples['with meta item attributes'])
 
       const $metaLink = $('.govuk-footer__meta .govuk-footer__link')
       expect($metaLink.attr('data-attribute')).toEqual('my-attribute')
@@ -165,6 +130,13 @@ describe('footer', () => {
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
+    })
+
+    it('no items displayed when no item array is provided', () => {
+      const $ = render('footer', examples['with empty navigation'])
+
+      const $component = $('.govuk-footer')
+      expect($component.find('.govuk-footer__navigation').length).toEqual(0)
     })
 
     it('renders headings', () => {
@@ -192,22 +164,7 @@ describe('footer', () => {
     })
 
     it('renders attributes on links', () => {
-      const $ = render('footer', {
-        navigation: [
-          {
-            items: [
-              {
-                href: '#1',
-                text: 'Navigation item 1',
-                attributes: {
-                  'data-attribute': 'my-attribute',
-                  'data-attribute-2': 'my-attribute-2'
-                }
-              }
-            ]
-          }
-        ]
-      })
+      const $ = render('footer', examples['with navigation item attributes'])
 
       const $navigationLink = $('.govuk-footer__list .govuk-footer__link')
       expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -232,3 +232,28 @@ examples:
         html: <em>Navigation item 2</em>
       - href: '#3'
         html: <em>Navigation item 3</em>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-test-attribute: value
+      data-test-attribute-2: value-2
+- name: classes
+  hidden: true
+  data:
+    classes: app-header--custom-modifier
+- name: custom homepage url
+  hidden: true
+  data:
+    homepageUrl: /
+- name: navigation item with attributes
+  hidden: true
+  data:
+    navigation:
+      - href: /link
+        text: Item
+        attributes:
+          data-attribute: my-attribute
+          data-attribute-2: my-attribute-2

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -10,66 +10,68 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('header')
 
 describe('header', () => {
-  it('passes accessibility tests', async () => {
-    const $ = render('header', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('header', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
-  it('has a role of `banner`', () => {
-    const $ = render('header', {})
-
-    const $component = $('.govuk-header')
-    expect($component.attr('role')).toEqual('banner')
-  })
-
-  it('renders attributes correctly', () => {
-    const $ = render('header', {
-      attributes: {
-        'data-test-attribute': 'value',
-        'data-test-attribute-2': 'value-2'
-      }
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
     })
 
-    const $component = $('.govuk-header')
-    expect($component.attr('data-test-attribute')).toEqual('value')
-    expect($component.attr('data-test-attribute-2')).toEqual('value-2')
+    it('has a role of `banner`', () => {
+      const $ = render('header', examples.default)
+
+      const $component = $('.govuk-header')
+      expect($component.attr('role')).toEqual('banner')
+    })
   })
 
-  it('renders classes', () => {
-    const $ = render('header', {
-      classes: 'app-header--custom-modifier'
+  describe('custom options', () => {
+    it('renders attributes correctly', () => {
+      const $ = render('header', examples.attributes)
+
+      const $component = $('.govuk-header')
+      expect($component.attr('data-test-attribute')).toEqual('value')
+      expect($component.attr('data-test-attribute-2')).toEqual('value-2')
     })
 
-    const $component = $('.govuk-header')
-    expect($component.hasClass('app-header--custom-modifier')).toBeTruthy()
-  })
+    it('renders classes', () => {
+      const $ = render('header', examples.classes)
 
-  it('renders custom container classes', () => {
-    const $ = render('header', {
-      containerClasses: 'app-width-container'
+      const $component = $('.govuk-header')
+      expect($component.hasClass('app-header--custom-modifier')).toBeTruthy()
     })
 
-    const $component = $('.govuk-header')
-    const $container = $component.find('.govuk-header__container')
+    it('renders custom container classes', () => {
+      const $ = render('header', examples['full width'])
 
-    expect($container.hasClass('app-width-container')).toBeTruthy()
-  })
+      const $component = $('.govuk-header')
+      const $container = $component.find('.govuk-header__container')
 
-  it('renders home page URL', () => {
-    const $ = render('header', {
-      homepageUrl: '/'
+      expect($container.hasClass('govuk-header__container--full-width')).toBeTruthy()
     })
 
-    const $component = $('.govuk-header')
-    const $homepageLink = $component.find('.govuk-header__link--homepage')
-    expect($homepageLink.attr('href')).toEqual('/')
+    it('renders custom navigation classes', () => {
+      const $ = render('header', examples['full width with navigation'])
+
+      const $component = $('.govuk-header')
+      const $container = $component.find('.govuk-header__navigation')
+
+      expect($container.hasClass('govuk-header__navigation--end')).toBeTruthy()
+    })
+
+    it('renders home page URL', () => {
+      const $ = render('header', examples['custom homepage url'])
+
+      const $component = $('.govuk-header')
+      const $homepageLink = $component.find('.govuk-header__link--homepage')
+      expect($homepageLink.attr('href')).toEqual('/')
+    })
   })
 
   describe('with product name', () => {
     it('renders product name', () => {
-      const $ = render('header', examples['full width'])
+      const $ = render('header', examples['with product name'])
 
       const $component = $('.govuk-header')
       const $productName = $component.find('.govuk-header__product-name')
@@ -84,6 +86,14 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__link--service-name')
       expect($serviceName.text().trim()).toEqual('Service Name')
+    })
+
+    it('renders with service url', () => {
+      const $ = render('header', examples['with service name'])
+
+      const $component = $('.govuk-header')
+      const $serviceName = $component.find('.govuk-header__link--service-name')
+      expect($serviceName.attr('href')).toEqual('/components/header')
     })
   })
 
@@ -125,38 +135,28 @@ describe('header', () => {
       expect($list.attr('aria-label')).toEqual('Custom navigation label')
     })
 
+    it('renders navigation with active item', () => {
+      const $ = render('header', examples['with navigation'])
+
+      const $activeItem = $('a.govuk-header__navigation-item:first-child')
+      expect($activeItem.hasClass('govuk-header__navigation-item--active'))
+    })
+
     it('renders navigation item with html', () => {
-      const $ = render('header', {
-        navigation: [
-          {
-            href: '#1',
-            html: '<em>Nav item</em>'
-          }
-        ]
-      })
+      const $ = render('header', examples['navigation item with html'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
-      expect($navigationLink.html()).toContain('<em>Nav item</em>')
+      expect($navigationLink.html()).toContain('<em>Navigation item 1</em>')
     })
 
     it('renders navigation item anchor with attributes', () => {
-      const $ = render('header', {
-        navigation: [
-          {
-            text: 'Item',
-            href: '/link',
-            attributes: {
-              'data-attribute': 'my-attribute',
-              'data-attribute-2': 'my-attribute-2'
-            }
-          }
-        ]
-      })
+      const $ = render('header', examples['navigation item with attributes'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
       expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
       expect($navigationLink.attr('data-attribute-2')).toEqual('my-attribute-2')
     })
+
     describe('menu button', () => {
       it('has an explicit type="button" so it does not act as a submit button', () => {
         const $ = render('header', examples['with navigation'])
@@ -183,7 +183,7 @@ describe('header', () => {
   })
 
   describe('SVG logo', () => {
-    const $ = render('header', {})
+    const $ = render('header', examples.default)
     const $svg = $('.govuk-header__logotype-crown')
 
     it('sets focusable="false" so that IE does not treat it as an interactive element', () => {

--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -38,10 +38,29 @@ examples:
 - name: default
   data:
     text: |
-      It’s on your National Insurance card, benefit letter, payslip or P60.
-      For example, ‘QQ 12 34 56 C’.
+      It's on your National Insurance card, benefit letter, payslip or P60.
+      For example, 'QQ 12 34 56 C'.
 - name: with html
   data:
     html: |
-      It’s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.
-      For example, ‘QQ 12 34 56 C’.
+      It's on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.
+      For example, 'QQ 12 34 56 C'.
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: classes
+  hidden: true
+  data:
+    classes: app-hint--custom-modifier
+- name: id
+  hidden: true
+  data:
+    id: my-hint
+- name: html as text
+  hidden: true
+  data:
+    text: Unexpected <strong>bold text</strong> in body
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      data-attribute: my data value

--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -9,7 +9,7 @@ params:
   description: If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.
 - name: id
   type: string
-  required: true
+  required: false
   description: Optional id attribute to add to the hint span tag.
 - name: classes
   type: string
@@ -50,6 +50,7 @@ examples:
 - name: classes
   hidden: true
   data:
+    id: example-hint
     classes: app-hint--custom-modifier
 - name: id
   hidden: true

--- a/src/govuk/components/hint/template.test.js
+++ b/src/govuk/components/hint/template.test.js
@@ -18,48 +18,43 @@ describe('Hint', () => {
       expect(results).toHaveNoViolations()
     })
 
+    it('renders with text', () => {
+      const $ = render('hint', examples.default)
+
+      const content = $('.govuk-hint').text()
+      expect(content).toEqual('\n  It\'s on your National Insurance card, benefit letter, payslip or P60.\nFor example, \'QQ 12 34 56 C\'.\n\n')
+    })
+
     it('renders with classes', () => {
-      const $ = render('hint', {
-        classes: 'app-hint--custom-modifier'
-      })
+      const $ = render('hint', examples.classes)
 
       const $component = $('.govuk-hint')
       expect($component.hasClass('app-hint--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('hint', {
-        id: 'my-hint'
-      })
+      const $ = render('hint', examples.id)
 
       const $component = $('.govuk-hint')
       expect($component.attr('id')).toEqual('my-hint')
     })
 
     it('allows text to be passed whilst escaping HTML entities', () => {
-      const $ = render('hint', {
-        text: 'Unexpected <strong>bold text</strong> in body'
-      })
+      const $ = render('hint', examples['html as text'])
 
       const content = $('.govuk-hint').html().trim()
       expect(content).toEqual('Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body')
     })
 
     it('allows HTML to be passed un-escaped', () => {
-      const $ = render('hint', {
-        html: 'Unexpected <b>bold text</b> in body copy'
-      })
+      const $ = render('hint', examples['with html'])
 
       const content = $('.govuk-hint').html().trim()
-      expect(content).toEqual('Unexpected <b>bold text</b> in body copy')
+      expect(content).toEqual('It&apos;s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.\nFor example, &apos;QQ 12 34 56 C&apos;.')
     })
 
     it('renders with attributes', () => {
-      const $ = render('hint', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('hint', examples.attributes)
 
       const $component = $('.govuk-hint')
       expect($component.attr('data-attribute')).toEqual('my data value')

--- a/src/govuk/components/input/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/input/__snapshots__/template.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Input when it includes a hint renders the hint 1`] = `
-<div id="input-with-hint-hint"
+<div id="input-with-hint-text-hint"
      class="govuk-hint"
 >
   It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
@@ -9,16 +9,16 @@ exports[`Input when it includes a hint renders the hint 1`] = `
 `;
 
 exports[`Input when it includes an error message renders the error message 1`] = `
-<span id="input-with-error-error"
+<span id="input-with-error-message-error"
       class="govuk-error-message"
 >
-  Error message
+  Error message goes here
 </span>
 `;
 
 exports[`Input with dependant components renders with label 1`] = `
 <label class="govuk-label"
-       for="my-input"
+       for="input-example"
 >
   National Insurance number
 </label>

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -202,3 +202,58 @@ examples:
       name: spellcheck
       type: text
       spellcheck: false
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: app-input--custom-modifier
+  - name: custom type
+    hidden: true
+    data:
+      type: number
+  - name: value
+    hidden: true
+    data:
+      value: QQ 12 34 56 C
+  - name: with describedBy
+    hidden: true
+    data:
+      describedBy: some-id
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value
+  - name: hint with describedBy
+    hidden: true
+    data:
+      describedBy: some-id
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+  - name: error with describedBy
+    hidden: true
+    data:
+      describedBy: some-id
+      errorMessage:
+        text: Error message
+  - name: with error and hint
+    hidden: true
+    data:
+      errorMessage:
+        text: Error message
+      hint:
+        text: Hint
+  - name: with error, hint and describedBy
+    hidden: true
+    data:
+      errorMessage:
+        text: Error message
+      hint:
+        text: Hint
+      describedBy: some-id
+  - name: inputmode
+    hidden: true
+    data:
+      inputmode: decimal
+

--- a/src/govuk/components/input/template.test.js
+++ b/src/govuk/components/input/template.test.js
@@ -22,92 +22,77 @@ describe('Input', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('input', {
-        classes: 'app-input--custom-modifier'
-      })
+      const $ = render('input', examples.classes)
 
       const $component = $('.govuk-input')
       expect($component.hasClass('app-input--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('input', {
-        id: 'my-input'
-      })
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('id')).toEqual('my-input')
+      expect($component.attr('id')).toEqual('input-example')
     })
 
     it('renders with name', () => {
-      const $ = render('input', {
-        name: 'my-input-name'
-      })
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
-      expect($component.attr('name')).toEqual('my-input-name')
+      expect($component.attr('name')).toEqual('test-name')
     })
 
     it('renders with type="text" by default', () => {
-      const $ = render('input', {})
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('type')).toEqual('text')
     })
 
     it('allows you to override the type', () => {
-      const $ = render('input', {
-        type: 'number'
-      })
+      const $ = render('input', examples['custom type'])
 
       const $component = $('.govuk-input')
       expect($component.attr('type')).toEqual('number')
     })
 
+    it('renders with pattern attribute', () => {
+      const $ = render('input', examples['with pattern attribute'])
+
+      const $component = $('.govuk-input')
+      expect($component.attr('pattern')).toEqual('[0-9]*')
+    })
+
     it('renders with value', () => {
-      const $ = render('input', {
-        value: 'QQ 12 34 56 C'
-      })
+      const $ = render('input', examples.value)
 
       const $component = $('.govuk-input')
       expect($component.val()).toEqual('QQ 12 34 56 C')
     })
 
     it('renders with aria-describedby', () => {
-      const describedById = 'some-id'
-
-      const $ = render('input', {
-        describedBy: describedById
-      })
+      const $ = render('input', examples['with describedBy'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('aria-describedby')).toMatch(describedById)
+      expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with attributes', () => {
-      const $ = render('input', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('input', examples.attributes)
 
       const $component = $('.govuk-input')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = render('input', {})
+      const $ = render('input', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('input', {
-        formGroup: {
-          classes: 'extra-class'
-        }
-      })
+      const $ = render('input', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -116,23 +101,13 @@ describe('Input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = render('input', {
-        id: 'input-with-hint',
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('input', examples['with hint text'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the hint', () => {
-      const $ = render('input', {
-        id: 'input-with-hint',
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('input', examples['with hint text'])
 
       const $input = $('.govuk-input')
       const $hint = $('.govuk-hint')
@@ -146,21 +121,13 @@ describe('Input', () => {
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('input', {
-        id: 'input-with-hint',
-        describedBy: describedById,
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('input', examples['hint with describedBy'])
 
       const $input = $('.govuk-input')
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
       )
 
       expect($input.attr('aria-describedby'))
@@ -170,23 +137,13 @@ describe('Input', () => {
 
   describe('when it includes an error message', () => {
     it('renders the error message', () => {
-      const $ = render('input', {
-        id: 'input-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('input', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the error message', () => {
-      const $ = render('input', {
-        id: 'input-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('input', examples['with error message'])
 
       const $input = $('.govuk-input')
       const $errorMessage = $('.govuk-error-message')
@@ -200,21 +157,13 @@ describe('Input', () => {
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('input', {
-        id: 'input-with-error',
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('input', examples['error with describedBy'])
 
       const $input = $('.govuk-input')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
       expect($input.attr('aria-describedby'))
@@ -222,22 +171,14 @@ describe('Input', () => {
     })
 
     it('includes the error class on the input', () => {
-      const $ = render('input', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('input', examples['with error message'])
 
       const $component = $('.govuk-input')
       expect($component.hasClass('govuk-input--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('input', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('input', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -246,28 +187,21 @@ describe('Input', () => {
 
   describe('when it has the spellcheck attribute', () => {
     it('renders with spellcheck attribute set to true', () => {
-      const $ = render('input', {
-        spellcheck: true
-      })
+      const $ = render('input', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
-      const $ = render('input', {
-        name: 'my-input-name',
-        spellcheck: false
-      })
+      const $ = render('input', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
-      const $ = render('input', {
-        name: 'my-input-name'
-      })
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -276,14 +210,7 @@ describe('Input', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the input as described by both the hint and the error message', () => {
-      const $ = render('input', {
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('input', examples['with error and hint'])
 
       const $component = $('.govuk-input')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -298,24 +225,14 @@ describe('Input', () => {
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('input', {
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('input', examples['with error, hint and describedBy'])
 
       const $component = $('.govuk-input')
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
       const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
       expect($component.attr('aria-describedby'))
@@ -325,47 +242,29 @@ describe('Input', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('input', {
-        id: 'my-input',
-        label: {
-          text: 'National Insurance number'
-        }
-      })
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-input')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = render('input', {
-        id: 'my-input',
-        label: {
-          text: 'National Insurance number'
-        }
-      })
+      const $ = render('input', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the input "id"', () => {
-      const $ = render('input', {
-        id: 'my-input',
-        label: {
-          text: 'National Insurance number'
-        }
-      })
+      const $ = render('input', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('my-input')
+      expect($label.attr('for')).toEqual('input-example')
     })
   })
 
   describe('when it includes an autocomplete attribute', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = render('input', {
-        id: 'input-with-autocomplete',
-        autocomplete: 'postal-code'
-      })
+      const $ = render('input', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-input')
       expect($component.attr('autocomplete')).toEqual('postal-code')
@@ -374,9 +273,7 @@ describe('Input', () => {
 
   describe('when it includes an inputmode', () => {
     it('renders with an inputmode attached to the input', () => {
-      const $ = render('input', {
-        inputmode: 'decimal'
-      })
+      const $ = render('input', examples.inputmode)
 
       const $component = $('.govuk-form-group > .govuk-input')
       expect($component.attr('inputmode')).toEqual('decimal')

--- a/src/govuk/components/input/template.test.js
+++ b/src/govuk/components/input/template.test.js
@@ -13,19 +13,12 @@ const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'
 
 describe('Input', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('input', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
-    })
-
-    it('renders with classes', () => {
-      const $ = render('input', examples.classes)
-
-      const $component = $('.govuk-input')
-      expect($component.hasClass('app-input--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
@@ -47,6 +40,22 @@ describe('Input', () => {
 
       const $component = $('.govuk-input')
       expect($component.attr('type')).toEqual('text')
+    })
+
+    it('renders with a form group wrapper', () => {
+      const $ = render('input', examples.default)
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.length).toBeTruthy()
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('input', examples.classes)
+
+      const $component = $('.govuk-input')
+      expect($component.hasClass('app-input--custom-modifier')).toBeTruthy()
     })
 
     it('allows you to override the type', () => {
@@ -82,13 +91,6 @@ describe('Input', () => {
 
       const $component = $('.govuk-input')
       expect($component.attr('data-attribute')).toEqual('my data value')
-    })
-
-    it('renders with a form group wrapper', () => {
-      const $ = render('input', examples.default)
-
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -36,3 +36,22 @@ examples:
           </strong>
         </div>
         <p class="govuk-body">It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.</p>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: app-inset-text--custom-modifier
+  - name: id
+    hidden: true
+    data:
+      id: my-inset-text
+  - name: html as text
+    hidden: true
+    data:
+      text: It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value

--- a/src/govuk/components/inset-text/template.test.js
+++ b/src/govuk/components/inset-text/template.test.js
@@ -19,47 +19,37 @@ describe('Inset text', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('inset-text', {
-        classes: 'app-inset-text--custom-modifier'
-      })
+      const $ = render('inset-text', examples.classes)
 
       const $component = $('.govuk-inset-text')
       expect($component.hasClass('app-inset-text--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('inset-text', {
-        id: 'my-inset-text'
-      })
+      const $ = render('inset-text', examples.id)
 
       const $component = $('.govuk-inset-text')
       expect($component.attr('id')).toEqual('my-inset-text')
     })
 
     it('allows text to be passed whilst escaping HTML entities', () => {
-      const $ = render('inset-text', {
-        text: 'It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.'
-      })
+      const $ = render('inset-text', examples['html as text'])
 
       const content = $('.govuk-inset-text').html().trim()
       expect(content).toEqual('It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.')
     })
 
     it('allows HTML to be passed un-escaped', () => {
-      const $ = render('inset-text', {
-        html: 'It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.'
-      })
+      const $ = render('inset-text', examples['with html'])
 
-      const content = $('.govuk-inset-text').html().trim()
-      expect(content).toEqual('It can take <b>up to 8 weeks</b> to register a lasting power of attorney if there are no mistakes in the application.')
+      const mainContent = $('.govuk-inset-text .govuk-body:first-child').text().trim()
+      const warningContent = $('.govuk-inset-text .govuk-warning-text__text').text().trim()
+      expect(mainContent).toEqual('It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.')
+      expect(warningContent).toEqual('Warning\n    You can be fined up to £5,000 if you don’t register.')
     })
 
     it('renders with attributes', () => {
-      const $ = render('inset-text', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('inset-text', examples.attributes)
 
       const $component = $('.govuk-inset-text')
       expect($component.attr('data-attribute')).toEqual('my data value')

--- a/src/govuk/components/label/label.yaml
+++ b/src/govuk/components/label/label.yaml
@@ -37,3 +37,33 @@ examples:
       text: National Insurance number
       classes: govuk-label--xl
       isPageHeading: true
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: empty
+    hidden: true
+    data: {}
+  - name: classes
+    hidden: true
+    data:
+      text: National Insurance number
+      classes: extra-class one-more-class
+  - name: html as text
+    hidden: true
+    data:
+      text: National Insurance number, <em>NINO</em>
+  - name: html
+    hidden: true
+    data:
+      html: National Insurance number <em>NINO</em>
+  - name: for
+    hidden: true
+    data:
+      for: '#dummy-input'
+      text: National Insurance number
+  - name: attributes
+    hidden: true
+    data:
+      text: National Insurance number
+      attributes:
+        first-attribute: 'true'
+        second-attribute: 'false'

--- a/src/govuk/components/label/template.test.js
+++ b/src/govuk/components/label/template.test.js
@@ -26,7 +26,7 @@ describe('Label', () => {
     })
 
     it('does not output anything if no html or text is provided', () => {
-      const $ = render('label', {})
+      const $ = render('label', examples.empty)
 
       const $component = $('.govuk-label')
 
@@ -34,70 +34,49 @@ describe('Label', () => {
     })
 
     it('allows additional classes to be added to the component', () => {
-      const $ = render('label', {
-        text: 'National Insurance number',
-        classes: 'extra-class one-more-class'
-      })
+      const $ = render('label', examples.classes)
 
       const $component = $('.govuk-label')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('renders label text', () => {
-      const $ = render('label', {
-        text: 'National Insurance number'
-      })
+      const $ = render('label', examples.default)
       const labelText = $('.govuk-label').text().trim()
 
       expect(labelText).toEqual('National Insurance number')
     })
 
     it('allows label text to be passed whilst escaping HTML entities', () => {
-      const $ = render('label', {
-        text: 'National Insurance number, <em>NINO</em>'
-      })
+      const $ = render('label', examples['html as text'])
 
       const labelText = $('.govuk-label').html().trim()
       expect(labelText).toEqual('National Insurance number, &lt;em&gt;NINO&lt;/em&gt;')
     })
 
     it('allows label HTML to be passed un-escaped', () => {
-      const $ = render('label', {
-        html: 'National Insurance number <em>NINO</em>'
-      })
+      const $ = render('label', examples.html)
 
       const labelText = $('.govuk-label').html().trim()
       expect(labelText).toEqual('National Insurance number <em>NINO</em>')
     })
 
     it('renders for attribute if specified', () => {
-      const $ = render('label', {
-        text: 'National Insurance number',
-        for: '#dummy-input'
-      })
+      const $ = render('label', examples.for)
 
       const labelForAttr = $('.govuk-label').attr('for')
       expect(labelForAttr).toEqual('#dummy-input')
     })
 
     it('can be nested inside an H1 using isPageHeading', () => {
-      const $ = render('label', {
-        text: 'National Insurance number',
-        isPageHeading: true
-      })
+      const $ = render('label', examples['as page heading'])
 
       const $selector = $('h1 > .govuk-label')
       expect($selector.length).toBeTruthy()
     })
 
     it('allows additional attributes to be added to the component', () => {
-      const $ = render('label', {
-        text: 'National Insurance number',
-        attributes: {
-          'first-attribute': 'true',
-          'second-attribute': 'false'
-        }
-      })
+      const $ = render('label', examples.attributes)
 
       const $component = $('.govuk-label')
       expect($component.attr('first-attribute')).toEqual('true')

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -38,3 +38,35 @@ examples:
     titleText: Application complete
     headingLevel: 2
     text: 'Your reference number: HDJ2123F'
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: title html as text
+  hidden: true
+  data:
+    titleText: Application <strong>not</strong> complete
+- name: title html
+  hidden: true
+  data:
+    titleHtml: Application <strong>not</strong> complete
+- name: body html as text
+  hidden: true
+  data:
+    text: Your reference number<br><strong>HDJ2123F</strong>
+- name: body html
+  hidden: true
+  data:
+    html: Your reference number<br><strong>HDJ2123F</strong>
+- name: classes
+  hidden: true
+  data:
+    classes: extra-class one-more-class
+- name: attributes
+  hidden: true
+  data:
+    attributes:
+      first-attribute: true
+      second-attribute: false
+- name: title with no body text
+  hidden: true
+  data:
+    titleText: Application complete

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -10,107 +10,92 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('panel')
 
 describe('Panel', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('panel', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('panel', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
-  it('renders title text', () => {
-    const $ = render('panel', examples.default)
-    const panelTitle = $('.govuk-panel__title').text().trim()
-
-    expect(panelTitle).toEqual('Application complete')
-  })
-
-  it('allows title text to be passed whilst escaping HTML entities', () => {
-    const $ = render('panel', {
-      titleText: 'Application <strong>not</strong> complete'
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
     })
 
-    const panelTitle = $('.govuk-panel__title').html().trim()
-    expect(panelTitle).toEqual('Application &lt;strong&gt;not&lt;/strong&gt; complete')
-  })
+    it('renders title text', () => {
+      const $ = render('panel', examples.default)
+      const panelTitle = $('.govuk-panel__title').text().trim()
 
-  it('renders title as h1 (as the default heading level)', () => {
-    const $ = render('panel', examples.default)
-    const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
-
-    expect(panelTitleHeadingLevel).toEqual('h1')
-  })
-
-  it('renders title as specified heading level', () => {
-    const $ = render('panel', {
-      headingLevel: 3
-    })
-    const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
-
-    expect(panelTitleHeadingLevel).toEqual('h3')
-  })
-
-  it('allows title HTML to be passed un-escaped', () => {
-    const $ = render('panel', {
-      titleHtml: 'Application <strong>not</strong> complete'
+      expect(panelTitle).toEqual('Application complete')
     })
 
-    const panelTitle = $('.govuk-panel__title').html().trim()
-    expect(panelTitle).toEqual('Application <strong>not</strong> complete')
-  })
+    it('renders title as h1 (as the default heading level)', () => {
+      const $ = render('panel', examples.default)
+      const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
-  it('renders body text', () => {
-    const $ = render('panel', examples.default)
-    const panelBodyText = $('.govuk-panel__body').text().trim()
-
-    expect(panelBodyText).toEqual('Your reference number: HDJ2123F')
-  })
-
-  it('allows body text to be passed whilst escaping HTML entities', () => {
-    const $ = render('panel', {
-      text: 'Your reference number<br><strong>HDJ2123F</strong>'
+      expect(panelTitleHeadingLevel).toEqual('h1')
     })
 
-    const panelBodyText = $('.govuk-panel__body').html().trim()
-    expect(panelBodyText).toEqual('Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;')
-  })
+    it('renders body text', () => {
+      const $ = render('panel', examples.default)
+      const panelBodyText = $('.govuk-panel__body').text().trim()
 
-  it('allows body HTML to be passed un-escaped', () => {
-    const $ = render('panel', {
-      html: 'Your reference number<br><strong>HDJ2123F</strong>'
+      expect(panelBodyText).toEqual('Your reference number: HDJ2123F')
     })
 
-    const panelBodyText = $('.govuk-panel__body').html().trim()
-    expect(panelBodyText).toEqual('Your reference number<br><strong>HDJ2123F</strong>')
+    it('doesnt render panel body if no body text is passed', () => {
+      const $ = render('panel', examples['title with no body text'])
+      const panelBody = $('.govuk-panel__body').length
+
+      expect(panelBody).toBeFalsy()
+    })
   })
 
-  it('allows additional classes to be added to the component', () => {
-    const $ = render('panel', {
-      classes: 'extra-class one-more-class'
+  describe('custom options', () => {
+    it('allows title text to be passed whilst escaping HTML entities', () => {
+      const $ = render('panel', examples['title html as text'])
+
+      const panelTitle = $('.govuk-panel__title').html().trim()
+      expect(panelTitle).toEqual('Application &lt;strong&gt;not&lt;/strong&gt; complete')
     })
 
-    const $component = $('.govuk-panel')
-    expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
-  })
+    it('renders title as specified heading level', () => {
+      const $ = render('panel', examples['custom heading level'])
+      const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
-  it('allows additional attributes to be added to the component', () => {
-    const $ = render('panel', {
-      attributes: {
-        'first-attribute': 'true',
-        'second-attribute': 'false'
-      }
+      expect(panelTitleHeadingLevel).toEqual('h2')
     })
 
-    const $component = $('.govuk-panel')
-    expect($component.attr('first-attribute')).toEqual('true')
-    expect($component.attr('second-attribute')).toEqual('false')
-  })
+    it('allows title HTML to be passed un-escaped', () => {
+      const $ = render('panel', examples['title html'])
 
-  it('doesnt render panel body if no body text is passed', () => {
-    const $ = render('panel', {
-      titleText: 'Application complete'
+      const panelTitle = $('.govuk-panel__title').html().trim()
+      expect(panelTitle).toEqual('Application <strong>not</strong> complete')
     })
-    const panelBody = $('.govuk-panel__body').length
 
-    expect(panelBody).toBeFalsy()
+    it('allows body text to be passed whilst escaping HTML entities', () => {
+      const $ = render('panel', examples['body html as text'])
+
+      const panelBodyText = $('.govuk-panel__body').html().trim()
+      expect(panelBodyText).toEqual('Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;')
+    })
+
+    it('allows body HTML to be passed un-escaped', () => {
+      const $ = render('panel', examples['body html'])
+
+      const panelBodyText = $('.govuk-panel__body').html().trim()
+      expect(panelBodyText).toEqual('Your reference number<br><strong>HDJ2123F</strong>')
+    })
+
+    it('allows additional classes to be added to the component', () => {
+      const $ = render('panel', examples.classes)
+
+      const $component = $('.govuk-panel')
+      expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
+    })
+
+    it('allows additional attributes to be added to the component', () => {
+      const $ = render('panel', examples.attributes)
+
+      const $component = $('.govuk-panel')
+      expect($component.attr('first-attribute')).toEqual('true')
+      expect($component.attr('second-attribute')).toEqual('false')
+    })
   })
 })

--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -27,3 +27,35 @@ examples:
       tag:
         text: alpha
       html: This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: extra-class one-more-class
+  - name: text
+    hidden: true
+    data:
+      text: This is a new service – your feedback will help us to improve it
+  - name: html as text
+    hidden: true
+    data:
+      text: This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        first-attribute: true
+        second-attribute: false
+  - name: tag html
+    hidden: true
+    data:
+      tag:
+        html: <em>alpha</em>
+  - name: tag classes
+    hidden: true
+    data:
+      tag:
+        classes: govuk-tag--inactive
+        text: alpha
+

--- a/src/govuk/components/phase-banner/template.test.js
+++ b/src/govuk/components/phase-banner/template.test.js
@@ -19,27 +19,21 @@ describe('Phase banner', () => {
     })
 
     it('allows additional classes to be added to the component', () => {
-      const $ = render('phase-banner', {
-        classes: 'extra-class one-more-class'
-      })
+      const $ = render('phase-banner', examples.classes)
 
       const $component = $('.govuk-phase-banner')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('renders banner text', () => {
-      const $ = render('phase-banner', {
-        text: 'This is a new service – your feedback will help us to improve it.'
-      })
+      const $ = render('phase-banner', examples.text)
       const phaseBannerText = $('.govuk-phase-banner__text').text().trim()
 
-      expect(phaseBannerText).toEqual('This is a new service – your feedback will help us to improve it.')
+      expect(phaseBannerText).toEqual('This is a new service – your feedback will help us to improve it')
     })
 
     it('allows body text to be passed whilst escaping HTML entities', () => {
-      const $ = render('phase-banner', {
-        text: 'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
-      })
+      const $ = render('phase-banner', examples['html as text'])
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
       expect(phaseBannerText).toEqual('This is a new service - your &lt;a href=&quot;#&quot; class=&quot;govuk-link&quot;&gt;feedback&lt;/a&gt; will help us to improve it.')
@@ -53,18 +47,14 @@ describe('Phase banner', () => {
     })
 
     it('allows additional attributes to be added to the component', () => {
-      const $ = render('phase-banner', {
-        attributes: {
-          'first-attribute': 'true',
-          'second-attribute': 'false'
-        }
-      })
+      const $ = render('phase-banner', examples.attributes)
 
       const $component = $('.govuk-phase-banner')
       expect($component.attr('first-attribute')).toEqual('true')
       expect($component.attr('second-attribute')).toEqual('false')
     })
   })
+
   describe('with dependant components', () => {
     it('renders the tag component text', () => {
       const $ = render('phase-banner', examples.default)
@@ -73,22 +63,13 @@ describe('Phase banner', () => {
     })
 
     it('renders the tag component html', () => {
-      const $ = render('phase-banner', {
-        tag: {
-          html: '<em>alpha</em>'
-        }
-      })
+      const $ = render('phase-banner', examples['tag html'])
 
       expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
     })
 
     it('renders the tag component classes', () => {
-      const $ = render('phase-banner', {
-        tag: {
-          text: 'alpha',
-          classes: 'govuk-tag--inactive'
-        }
-      })
+      const $ = render('phase-banner', examples['tag classes'])
 
       expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
     })

--- a/src/govuk/components/radios/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/radios/__snapshots__/template.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Radios nested dependant components passes through fieldset params without breaking 1`] = `
 <fieldset class="govuk-fieldset app-fieldset--custom-modifier"
-          aria-describedby="example-hint example-error"
+          aria-describedby="example-fieldset-params-hint"
           data-attribute="value"
           data-second-attribute="second-value"
 >
@@ -28,40 +28,31 @@ exports[`Radios nested dependant components passes through label params without 
 <label class="govuk-label govuk-radios__label"
        data-attribute="value"
        data-second-attribute="second-value"
-       for="example-name"
 >
-  <b>
-    Yes
-  </b>
-</label>
-<label class="govuk-label govuk-radios__label"
-       for="example-name-2"
->
-  &lt;b&gt;No&lt;/b&gt;
+  Yes
 </label>
 `;
 
 exports[`Radios when they include a hint renders the hint 1`] = `
-<div id="example-hint"
+<div id="example-multiple-hints-hint"
      class="govuk-hint"
 >
   This includes changing your last name or spelling your name differently.
 </div>
-<div id="example-item-hint"
+<div id="example-multiple-hints-item-hint"
      class="govuk-hint govuk-radios__hint"
 >
   Hint for yes option here
 </div>
-<div id="example-2-item-hint"
-     class="govuk-hint govuk-radios__hint app-radios__hint-no"
-     data-test-attribute="true"
+<div id="example-multiple-hints-2-item-hint"
+     class="govuk-hint govuk-radios__hint"
 >
   Hint for no option here
 </div>
 `;
 
 exports[`Radios when they include an error message renders the error message 1`] = `
-<span id="example-error"
+<span id="example-error-message-error"
       class="govuk-error-message"
 >
   Please select an option

--- a/src/govuk/components/radios/radios.test.js
+++ b/src/govuk/components/radios/radios.test.js
@@ -69,10 +69,10 @@ describe('Radios with conditional reveals', () => {
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-item-checked')
       const $component = $('.govuk-radios')
-      const $firstInput = $component.find('.govuk-radios__item:first-child .govuk-radios__input')
-      const firstInputAriaControls = $firstInput.attr('aria-controls')
+      const $uncheckedInput = $component.find('.govuk-radios__item').last().find('.govuk-radios__input')
+      const uncheckedInputAriaControls = $uncheckedInput.attr('aria-controls')
 
-      const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"].govuk-radios__conditional--hidden`)
+      const isContentHidden = await waitForHiddenSelector(`[id="${uncheckedInputAriaControls}"].govuk-radios__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
     it('indicates when conditional content is collapsed or revealed', async () => {

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -108,7 +108,7 @@ accessibilityCriteria: |
 examples:
 - name: default
   data:
-    idPrefix: example
+    idPrefix: example-default
     name: example
     fieldset:
       legend:
@@ -224,10 +224,12 @@ examples:
     items:
       - value: gateway
         text: Sign in with Government Gateway
+        id: gateway
         hint:
           text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
       - value: verify
         text: Sign in with GOV.UK Verify
+        id: verify
         hint:
           text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
 
@@ -324,7 +326,6 @@ examples:
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
 - name: inline with conditional items
-
   data:
     classes: govuk-radios--inline
     idPrefix: how-contacted
@@ -363,13 +364,13 @@ examples:
     items:
     - value: email
       text: Email
+      checked: true
       conditional:
         html: |
-          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <label class="govuk-label" for="context-email">Email</label>
           <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
     - value: phone
       text: Phone
-      checked: true
       conditional:
         html: |
           <label class="govuk-label" for="contact-phone">Phone number</label>
@@ -601,3 +602,191 @@ examples:
       - divider: or
       - value: create-account
         text: Create an account
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+
+- name: minimal items and name
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+- name: with falsey items
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: yes
+        text: Yes
+      - null
+      - false
+      - value: no
+        text: No
+- name: fieldset with describedBy
+  hidden: true
+  data:
+    name: example-name
+    fieldset:
+      describedBy: some-id
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+- name: attributes
+  hidden: true
+  data:
+    name: example-name
+    attributes:
+      data-attribute: value
+      data-second-attribute: second-value
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+- name: items with attributes
+  hidden: true
+  data:
+    name: example-name
+    items:
+      - value: yes
+        text: Yes
+        attributes:
+          data-attribute: ABC
+          data-second-attribute: DEF
+      - value: no
+        text: No
+        attributes:
+          data-attribute: GHI
+          data-second-attribute: JKL
+- name: with empty conditional
+  hidden: true
+  data:
+    name: example-conditional
+    items:
+      - value: yes
+        text: Yes
+        conditional:
+          html: false
+      - value: no
+        text: No
+- name: label with classes
+  hidden: true
+  data:
+    name: example-label-classes
+    items:
+      - value: yes
+        text: Yes
+        label:
+          classes: bold
+- name: with hints on parent and items
+  hidden: true
+  data:
+    name: example-multiple-hints
+    fieldset:
+      legend:
+        text: Have you changed your name?
+    hint:
+      text: This includes changing your last name or spelling your name differently.
+    items:
+      - hint:
+          text: Hint for yes option here
+      - hint:
+          text: Hint for no option here
+- name: with describedBy and hint
+  hidden: true
+  data:
+    name: example-hint-describedby
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: Have you changed your name?
+    hint:
+      text: This includes changing your last name or spelling your name differently.
+- name: with error message
+  hidden: true
+  data:
+    name: example-error-message
+    errorMessage:
+      text: Please select an option
+- name: with error message and idPrefix
+  hidden: true
+  data:
+    name: example-error-message
+    idPrefix: id-prefix
+    errorMessage:
+      text: Please select an option
+- name: with hint and error message
+  hidden: true
+  data:
+    name: example-error-message-hint
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      legend:
+        text: Have you changed your name?
+    hint:
+      text: This includes changing your last name or spelling your name differently.
+- name: with hint, error message and describedBy
+  hidden: true
+  data:
+    name: example-error-message-hint
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: Have you changed your name?
+    hint:
+      text: This includes changing your last name or spelling your name differently.
+- name: label with attributes
+  hidden: true
+  data:
+    items:
+      - value: yes
+        text: Yes
+        label:
+          attributes:
+            data-attribute: value
+            data-second-attribute: second-value
+- name: fieldset params
+  hidden: true
+  data:
+    name: example-fieldset-params
+    fieldset:
+      classes: app-fieldset--custom-modifier
+      legend:
+        text: Have you changed your name?
+      attributes:
+        data-attribute: value
+        data-second-attribute: second-value
+    hint:
+      text: This includes changing your last name or spelling your name differently.
+- name: fieldset with html
+  hidden: true
+  data:
+    fieldset:
+      legend:
+        html: Have <b>you</b> changed your name?
+- name: with fieldset, error message and describedBy
+  hidden: true
+  data:
+    idPrefix: example
+    name: example
+    errorMessage:
+      text: Please select an option
+    fieldset:
+      describedBy: some-id
+      legend:
+        text: Have you changed your name?
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
+        checked: true
+

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -108,11 +108,7 @@ accessibilityCriteria: |
 examples:
 - name: default
   data:
-    idPrefix: example-default
-    name: example
-    fieldset:
-      legend:
-        text: Have you changed your name?
+    name: example-default
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
@@ -604,7 +600,15 @@ examples:
         text: Create an account
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
-
+- name: with idPrefix
+  data:
+    name: example-radio
+    idPrefix: example-id-prefix
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: minimal items and name
   hidden: true
   data:

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -21,19 +21,19 @@ describe('Radios', () => {
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = render('radios', examples['minimal items and name'])
+    const $ = render('radios', examples.default)
 
     const $component = $('.govuk-radios')
 
     const $firstInput = $component.find('.govuk-radios__item:first-child input')
     const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-    expect($firstInput.attr('name')).toEqual('example-name')
+    expect($firstInput.attr('name')).toEqual('example-default')
     expect($firstInput.val()).toEqual('yes')
     expect($firstLabel.text()).toContain('Yes')
 
     const $lastInput = $component.find('.govuk-radios__item:last-child input')
     const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-    expect($lastInput.attr('name')).toEqual('example-name')
+    expect($lastInput.attr('name')).toEqual('example-default')
     expect($lastInput.val()).toEqual('no')
     expect($lastLabel.text()).toContain('No')
   })
@@ -97,19 +97,19 @@ describe('Radios', () => {
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const $ = render('radios', examples.default)
+      const $ = render('radios', examples['with idPrefix'])
 
       const $component = $('.govuk-radios')
 
       const $firstInput = $component.find('.govuk-radios__item:first-child input')
       const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('example-default')
-      expect($firstLabel.attr('for')).toEqual('example-default')
+      expect($firstInput.attr('id')).toEqual('example-id-prefix')
+      expect($firstLabel.attr('for')).toEqual('example-id-prefix')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('example-default-2')
-      expect($lastLabel.attr('for')).toEqual('example-default-2')
+      expect($lastInput.attr('id')).toEqual('example-id-prefix-2')
+      expect($lastLabel.attr('for')).toEqual('example-id-prefix-2')
     })
 
     it('render disabled', () => {
@@ -356,7 +356,7 @@ describe('Radios', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('radios', examples.default)
+      const $ = render('radios', examples.inline)
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
       expect($component.length).toBeTruthy()

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -21,19 +21,7 @@ describe('Radios', () => {
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = render('radios', {
-      name: 'example-name',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ]
-    })
+    const $ = render('radios', examples['minimal items and name'])
 
     const $component = $('.govuk-radios')
 
@@ -51,21 +39,7 @@ describe('Radios', () => {
   })
 
   it('renders without falsely items', () => {
-    const $ = render('radios', {
-      name: 'example-name',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        undefined,
-        null,
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ]
-    })
+    const $ = render('radios', examples['with falsey items'])
 
     const $component = $('.govuk-radios')
     const $items = $component.find('.govuk-radios__item input')
@@ -73,68 +47,24 @@ describe('Radios', () => {
   })
 
   it('render classes', () => {
-    const $ = render('radios', {
-      name: 'example-name',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ],
-      classes: 'app-radios--custom-modifier'
-    })
+    const $ = render('radios', examples.inline)
 
     const $component = $('.govuk-radios')
 
-    expect($component.hasClass('app-radios--custom-modifier')).toBeTruthy()
+    expect($component.hasClass('govuk-radios--inline')).toBeTruthy()
   })
 
   it('renders initial aria-describedby on fieldset', () => {
     const describedById = 'some-id'
 
-    const $ = render('radios', {
-      name: 'example-name',
-      fieldset: {
-        describedBy: describedById
-      },
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ]
-    })
+    const $ = render('radios', examples['fieldset with describedBy'])
 
     const $fieldset = $('.govuk-fieldset')
     expect($fieldset.attr('aria-describedby')).toMatch(describedById)
   })
 
   it('render attributes', () => {
-    const $ = render('radios', {
-      name: 'example-name',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ],
-      attributes: {
-        'data-attribute': 'value',
-        'data-second-attribute': 'second-value'
-      }
-    })
+    const $ = render('radios', examples.attributes)
 
     const $component = $('.govuk-radios')
 
@@ -143,101 +73,47 @@ describe('Radios', () => {
   })
 
   it('render a custom class on the form group', () => {
-    const $ = render('radios', {
-      name: 'example-name',
-      items: [
-        {
-          value: 'yes',
-          text: 'Yes'
-        },
-        {
-          value: 'no',
-          text: 'No'
-        }
-      ],
-      formGroup: {
-        classes: 'custom-group-class'
-      }
-    })
+    const $ = render('radios', examples['with optional form-group classes showing group error'])
 
     const $formGroup = $('.govuk-form-group')
-    expect($formGroup.hasClass('custom-group-class')).toBeTruthy()
+    expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
   })
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ]
-      })
+      const $ = render('radios', examples.default)
 
       const $component = $('.govuk-radios')
 
       const $firstInput = $component.find('.govuk-radios__item:first-child input')
       const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('example-name')
-      expect($firstLabel.attr('for')).toEqual('example-name')
+      expect($firstInput.attr('id')).toEqual('example-default')
+      expect($firstLabel.attr('for')).toEqual('example-default')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('example-name-2')
-      expect($lastLabel.attr('for')).toEqual('example-name-2')
+      expect($lastInput.attr('id')).toEqual('example-default-2')
+      expect($lastLabel.attr('for')).toEqual('example-default-2')
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const $ = render('radios', {
-        idPrefix: 'custom',
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ]
-      })
+      const $ = render('radios', examples.default)
 
       const $component = $('.govuk-radios')
 
       const $firstInput = $component.find('.govuk-radios__item:first-child input')
       const $firstLabel = $component.find('.govuk-radios__item:first-child label')
-      expect($firstInput.attr('id')).toEqual('custom')
-      expect($firstLabel.attr('for')).toEqual('custom')
+      expect($firstInput.attr('id')).toEqual('example-default')
+      expect($firstLabel.attr('for')).toEqual('example-default')
 
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
       const $lastLabel = $component.find('.govuk-radios__item:last-child label')
-      expect($lastInput.attr('id')).toEqual('custom-2')
-      expect($lastLabel.attr('for')).toEqual('custom-2')
+      expect($lastInput.attr('id')).toEqual('example-default-2')
+      expect($lastLabel.attr('for')).toEqual('example-default-2')
     })
 
     it('render disabled', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes',
-            disabled: true
-          },
-          {
-            value: 'no',
-            text: 'No',
-            disabled: true
-          }
-        ]
-      })
+      const $ = render('radios', examples['with disabled'])
 
       const $component = $('.govuk-radios')
 
@@ -249,20 +125,7 @@ describe('Radios', () => {
     })
 
     it('render checked', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No',
-            checked: true
-          }
-        ]
-      })
+      const $ = render('radios', examples.default)
 
       const $component = $('.govuk-radios')
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
@@ -271,28 +134,7 @@ describe('Radios', () => {
 
     describe('when they include attributes', () => {
       it('it renders the attributes', () => {
-        const $ = render('radios', {
-          name: 'example-name',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              attributes: {
-                'data-attribute': 'ABC',
-                'data-second-attribute': 'DEF'
-              }
-            },
-            {
-              value: 'no',
-              text: 'No',
-              checked: true,
-              attributes: {
-                'data-attribute': 'GHI',
-                'data-second-attribute': 'JKL'
-              }
-            }
-          ]
-        })
+        const $ = render('radios', examples['items with attributes'])
 
         const $component = $('.govuk-radios')
 
@@ -308,171 +150,67 @@ describe('Radios', () => {
 
     describe('when they include a hint', () => {
       it('it renders the hint text', () => {
-        const $ = render('radios', {
-          items: [
-            {
-              value: 'value',
-              text: 'This is text',
-              hint: {
-                text: 'This is a hint'
-              }
-            }
-          ]
-        })
-        expect($('.govuk-radios__hint').text()).toContain('This is a hint')
+        const $ = render('radios', examples['with hints on items'])
+
+        expect($('.govuk-radios__hint').text())
+          .toContain('You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.')
       })
 
       it('it renders the correct id attribute for the hint', () => {
-        const $ = render('radios', {
-          items: [
-            {
-              value: 'value',
-              text: 'This is text',
-              id: 'item-id',
-              hint: {
-                text: 'This is a hint'
-              }
-            }
-          ]
-        })
+        const $ = render('radios', examples['with hints on items'])
 
-        expect($('.govuk-radios__hint').attr('id')).toBe('item-id-item-hint')
+        expect($('.govuk-radios__hint').attr('id')).toBe('gateway-item-hint')
       })
 
       it('the input describedBy attribute matches the item hint id', () => {
-        const $ = render('radios', {
-          items: [
-            {
-              value: 'value',
-              text: 'This is text',
-              id: 'item-id',
-              hint: {
-                text: 'This is a hint'
-              }
-            }
-          ]
-        })
+        const $ = render('radios', examples['with hints on items'])
 
-        expect($('.govuk-radios__input').attr('aria-describedby')).toBe('item-id-item-hint')
+        expect($('.govuk-radios__input').attr('aria-describedby')).toBe('gateway-item-hint')
       })
     })
 
     describe('render conditionals', () => {
       it('hidden by default when not checked', () => {
-        const $ = render('radios', {
-          name: 'example-conditional',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              conditional: {
-                html: 'Conditional content that should be hidden'
-              }
-            },
-            {
-              value: 'no',
-              text: 'No'
-            }
-          ]
-        })
+        const $ = render('radios', examples['with conditional items'])
 
         const $component = $('.govuk-radios')
 
-        const $firstConditional = $component.find('.govuk-radios__conditional').first()
-        expect($firstConditional.html()).toContain('Conditional content that should be hidden')
-        expect($firstConditional.hasClass('govuk-radios__conditional--hidden')).toBeTruthy()
+        const $hiddenConditional = $component.find('.govuk-radios__conditional').first()
+        expect($hiddenConditional.text()).toContain('Mobile phone number')
+        expect($hiddenConditional.hasClass('govuk-radios__conditional--hidden')).toBeTruthy()
       })
+
       it('visible by default when checked', () => {
-        const $ = render('radios', {
-          name: 'example-conditional',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              checked: true,
-              conditional: {
-                html: 'Conditional content that should be visible'
-              }
-            },
-            {
-              value: 'no',
-              text: 'No'
-            }
-          ]
-        })
+        const $ = render('radios', examples['with conditional item checked'])
 
         const $component = $('.govuk-radios')
 
-        const $firstConditional = $component.find('.govuk-radios__conditional').first()
-        expect($firstConditional.html()).toContain('Conditional content that should be visible')
-        expect($firstConditional.hasClass('govuk-radios__conditional--hidden')).toBeFalsy()
+        const $visibleConditional = $component.find('.govuk-radios__conditional').first()
+        expect($visibleConditional.text()).toContain('Email')
+        expect($visibleConditional.hasClass('govuk-radios__conditional--hidden')).toBeFalsy()
       })
+
       it('with association to the input they are controlled by', () => {
-        const $ = render('radios', {
-          name: 'example-conditional',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              conditional: {
-                html: 'Conditional content that should be hidden'
-              }
-            },
-            {
-              value: 'no',
-              text: 'No'
-            }
-          ]
-        })
+        const $ = render('radios', examples['with conditional items'])
 
         const $component = $('.govuk-radios')
 
         const $firstInput = $component.find('.govuk-radios__input').first()
         const $firstConditional = $component.find('.govuk-radios__conditional').first()
 
-        expect($firstInput.attr('data-aria-controls')).toBe('conditional-example-conditional')
-        expect($firstConditional.attr('id')).toBe('conditional-example-conditional')
+        expect($firstInput.attr('data-aria-controls')).toBe('conditional-how-contacted')
+        expect($firstConditional.attr('id')).toBe('conditional-how-contacted')
       })
 
       it('omits empty conditionals', () => {
-        const $ = render('radios', {
-          name: 'example-conditional',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              conditional: {
-                html: false
-              }
-            },
-            {
-              value: 'no',
-              text: 'No'
-            }
-          ]
-        })
+        const $ = render('radios', examples['with empty conditional'])
 
         const $component = $('.govuk-radios')
         expect($component.find('.govuk-radios__conditional').length).toEqual(0)
       })
 
       it('does not associate radios with empty conditionals', () => {
-        const $ = render('radios', {
-          name: 'example-conditional',
-          items: [
-            {
-              value: 'yes',
-              text: 'Yes',
-              conditional: {
-                html: false
-              }
-            },
-            {
-              value: 'no',
-              text: 'No'
-            }
-          ]
-        })
+        const $ = render('radios', examples['with empty conditional'])
 
         const $input = $('.govuk-radios__input').first()
         expect($input.attr('data-aria-controls')).toBeFalsy()
@@ -480,26 +218,7 @@ describe('Radios', () => {
     })
 
     it('render divider', () => {
-      const $ = render('radios', {
-        name: 'example-divider',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No'
-          },
-          {
-            divider: 'or'
-          },
-          {
-            value: 'maybe',
-            text: 'Maybe'
-          }
-        ]
-      })
+      const $ = render('radios', examples['with a divider'])
 
       const $component = $('.govuk-radios')
       const $divider = $component.find('.govuk-radios__divider')
@@ -507,18 +226,7 @@ describe('Radios', () => {
     })
 
     it('render additional label classes', () => {
-      const $ = render('radios', {
-        name: 'example-label-classes',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes',
-            label: {
-              classes: 'bold'
-            }
-          }
-        ]
-      })
+      const $ = render('radios', examples['label with classes'])
 
       const $component = $('.govuk-radios')
       const $label = $component.find('.govuk-radios__item label')
@@ -526,7 +234,7 @@ describe('Radios', () => {
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = render('radios', {})
+      const $ = render('radios', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -535,129 +243,47 @@ describe('Radios', () => {
 
   describe('when they include a hint', () => {
     it('renders the hint', () => {
-      const $ = render('radios', {
-        name: 'example',
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        },
-        items: [
-          {
-            hint: {
-              text: 'Hint for yes option here'
-            }
-          },
-          {
-            hint: {
-              classes: 'app-radios__hint-no',
-              text: 'Hint for no option here',
-              attributes: {
-                'data-test-attribute': true
-              }
-            }
-          }
-        ]
-      })
+      const $ = render('radios', examples['with hints on parent and items'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = render('radios', {
-        name: 'example',
-        fieldset: {
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        },
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        }
-      })
+      const $ = render('radios', examples['with hints on parent and items'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch('example-multiple-hints-hint')
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('radios', {
-        name: 'example',
-        fieldset: {
-          describedBy: describedById,
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        },
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        }
-      })
+      const $ = render('radios', examples['with describedBy and hint'])
       const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch('some-id')
     })
   })
 
   describe('when they include an error message', () => {
     it('renders the error message', () => {
-      const $ = render('radios', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        }
-      })
+      const $ = render('radios', examples['with error message'])
+
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the idPrefix for the error message id if provided', () => {
-      const $ = render('radios', {
-        name: 'name-of-radios',
-        errorMessage: {
-          text: 'Have you changed your name?'
-        },
-        idPrefix: 'id-prefix',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          }
-        ]
-      })
-
+      const $ = render('radios', examples['with error message and idPrefix'])
       const $errorMessage = $('.govuk-error-message')
 
       expect($errorMessage.attr('id')).toEqual('id-prefix-error')
     })
 
     it('falls back to using the name for the error message id', () => {
-      const $ = render('radios', {
-        name: 'name-of-radios',
-        errorMessage: {
-          text: 'Have you changed your name?'
-        },
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          }
-        ]
-      })
+      const $ = render('radios', examples['with error message'])
 
       const $errorMessage = $('.govuk-error-message')
 
-      expect($errorMessage.attr('id')).toEqual('name-of-radios-error')
+      expect($errorMessage.attr('id')).toEqual('example-error-message-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {
@@ -675,32 +301,21 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-      const params = examples['with fieldset and error message']
-
-      params.fieldset.describedBy = describedById
-
-      const $ = render('radios', params)
+      const $ = render('radios', examples['with fieldset, error message and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby'))
         .toMatch(errorMessageId)
-
-      delete params.fieldset.describedBy
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('radios', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('radios', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -709,19 +324,7 @@ describe('Radios', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = render('radios', {
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        },
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        }
-      })
+      const $ = render('radios', examples['with hint and error message'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -736,29 +339,14 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('radios', {
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          describedBy: describedById,
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        },
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        }
-      })
+      const $ = render('radios', examples['with hint, error message and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
       const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
       expect($fieldset.attr('aria-describedby'))
@@ -768,86 +356,26 @@ describe('Radios', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('radios', {
-        fieldset: {
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        }
-      })
+      const $ = render('radios', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
       expect($component.length).toBeTruthy()
     })
 
     it('passes through label params without breaking', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            html: '<b>Yes</b>',
-            label: {
-              attributes: {
-                'data-attribute': 'value',
-                'data-second-attribute': 'second-value'
-              }
-            }
-          },
-          {
-            value: 'no',
-            text: '<b>No</b>',
-            checked: true
-          }
-        ]
-      })
+      const $ = render('radios', examples['label with attributes'])
 
       expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = render('radios', {
-        name: 'example',
-        errorMessage: {
-          text: 'Please select an option'
-        },
-        fieldset: {
-          classes: 'app-fieldset--custom-modifier',
-          attributes: {
-            'data-attribute': 'value',
-            'data-second-attribute': 'second-value'
-          },
-          legend: {
-            text: 'Have you changed your name?'
-          }
-        },
-        hint: {
-          text: 'This includes changing your last name or spelling your name differently.'
-        }
-      })
+      const $ = render('radios', examples['fieldset params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 
     it('passes through html fieldset params without breaking', () => {
-      const $ = render('radios', {
-        name: 'example-name',
-        items: [
-          {
-            value: 'yes',
-            text: 'Yes'
-          },
-          {
-            value: 'no',
-            text: 'No'
-          }
-        ],
-        fieldset: {
-          legend: {
-            html: 'Have <b>you</b> changed your name?'
-          }
-        }
-      })
+      const $ = render('radios', examples['fieldset with html'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })

--- a/src/govuk/components/select/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/select/__snapshots__/template.test.js.snap
@@ -18,8 +18,8 @@ exports[`Select when it includes an error message renders with error message 1`]
 
 exports[`Select with dependant components renders with label 1`] = `
 <label class="govuk-label"
-       for="my-select"
+       for="select-1"
 >
-  National Insurance number
+  Label text goes here
 </label>
 `;

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -70,100 +70,163 @@ params:
   description: HTML attributes (for example data attributes) to add to the select.
 
 examples:
-- name: default
-  data:
-    id: select-1
-    name: select-1
-    label:
-      text: Label text goes here
-    items:
-      -
-        value: 1
-        text: GOV.UK frontend option 1
-      -
-        value: 2
-        text: GOV.UK frontend option 2
-        selected: true
-      -
-        value: 3
-        text: GOV.UK frontend option 3
-        disabled: true
-- name: with hint text and error message
-  data:
-    id: select-2
-    name: select-2
-    label:
-      text: Label text goes here
-    hint:
-      text: Hint text goes here
-    errorMessage:
-      text: Error message goes here
-    items:
-      -
-        value: 1
-        text: GOV.UK frontend option 1
-      -
-        value: 2
-        text: GOV.UK frontend option 2
-      -
-        value: 3
-        text: GOV.UK frontend option 3
-- name: with label as page heading
-  data:
-    id: select-3
-    name: select-3
-    label:
-      text: Label text goes here
-      isPageHeading: true
-    items:
-      -
-        value: 1
-        text: GOV.UK frontend option 1
-      -
-        value: 2
-        text: GOV.UK frontend option 2
-        selected: true
-      -
-        value: 3
-        text: GOV.UK frontend option 3
-        disabled: true
-- name: with full width override
-  data:
-    id: select-1
-    name: select-1
-    classes: govuk-!-width-full
-    label:
-      text: Label text goes here
-    items:
-      -
-        value: 1
-        text: GOV.UK frontend option 1
-      -
-        value: 2
-        text: GOV.UK frontend option 2
-        selected: true
-      -
-        value: 3
-        text: GOV.UK frontend option 3
-        disabled: true
-- name: with optional form-group classes
-  data:
-    id: select-1
-    name: select-1
-    classes: govuk-!-width-full
-    label:
-      text: Label text goes here
-    formGroup:
-      classes: extra-class
-    items:
-      -
-        value: 1
-        text: GOV.UK frontend option 1
-      -
-        value: 2
-        text: GOV.UK frontend option 2
-        selected: true
-      -
-        value: 3
-        text: GOV.UK frontend option 3
-        disabled: true
+  - name: default
+    data:
+      id: select-1
+      name: select-1
+      label:
+        text: Label text goes here
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
+          selected: true
+        -
+          value: 3
+          text: GOV.UK frontend option 3
+          disabled: true
+  - name: with hint text and error message
+    data:
+      id: select-2
+      name: select-2
+      label:
+        text: Label text goes here
+      hint:
+        text: Hint text goes here
+      errorMessage:
+        text: Error message goes here
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
+        -
+          value: 3
+          text: GOV.UK frontend option 3
+  - name: with label as page heading
+    data:
+      id: select-3
+      name: select-3
+      label:
+        text: Label text goes here
+        isPageHeading: true
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
+          selected: true
+        -
+          value: 3
+          text: GOV.UK frontend option 3
+          disabled: true
+  - name: with full width override
+    data:
+      id: select-1
+      name: select-1
+      classes: govuk-!-width-full
+      label:
+        text: Label text goes here
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
+          selected: true
+        -
+          value: 3
+          text: GOV.UK frontend option 3
+          disabled: true
+  - name: with optional form-group classes
+    data:
+      id: select-1
+      name: select-1
+      classes: govuk-!-width-full
+      label:
+        text: Label text goes here
+      formGroup:
+        classes: extra-class
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
+          selected: true
+        -
+          value: 3
+          text: GOV.UK frontend option 3
+          disabled: true
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: with describedBy
+    hidden: true
+    data:
+      describedBy: some-id
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value
+  - name: attributes on items
+    hidden: true
+    data:
+      value: 2
+      items:
+        -
+          text: Option 1
+          attributes:
+            data-attribute: ABC
+            data-second-attribute: DEF
+        -
+          text: Option 2
+          attributes:
+            data-attribute: GHI
+            data-second-attribute: JKL
+  - name: with falsey values
+    hidden: true
+    data:
+      items:
+        -
+          text: Option 1
+        - null
+        - false
+        - ""
+        -
+          text: Options 2
+  - name: hint
+    hidden: true
+    data:
+      id: select-with-hint
+      hint:
+        text: Hint text goes here
+  - name: hint and describedBy
+    hidden: true
+    data:
+      id: select-with-hint
+      describedBy: some-id
+      hint:
+        text: Hint text goes here
+  - name: error
+    hidden: true
+    data:
+      id: select-with-error
+      errorMessage:
+        text: Error message
+  - name: error and describedBy
+    hidden: true
+    data:
+      id: select-with-error
+      describedBy: some-id
+      errorMessage:
+        text: Error message

--- a/src/govuk/components/select/template.test.js
+++ b/src/govuk/components/select/template.test.js
@@ -21,200 +21,100 @@ describe('Select', () => {
       expect(results).toHaveNoViolations()
     })
 
-    it('renders with classes', () => {
-      const $ = render('select', {
-        classes: 'app-select--custom-modifier'
-      })
-
-      const $component = $('.govuk-select')
-      expect($component.hasClass('app-select--custom-modifier')).toBeTruthy()
-    })
-
     it('renders with id', () => {
-      const $ = render('select', {
-        id: 'my-select'
-      })
+      const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
-      expect($component.attr('id')).toEqual('my-select')
+      expect($component.attr('id')).toEqual('select-1')
     })
 
     it('renders with name', () => {
-      const $ = render('select', {
-        name: 'my-select-name'
-      })
+      const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
-      expect($component.attr('name')).toEqual('my-select-name')
+      expect($component.attr('name')).toEqual('select-1')
     })
 
     it('renders with items', () => {
-      const $ = render('select', {
-        items: [
-          {
-            text: 'Option 1'
-          },
-          {
-            text: 'Options 2'
-          }
-        ]
-      })
+      const $ = render('select', examples.default)
       const $items = $('.govuk-select option')
-      expect($items.length).toEqual(2)
-    })
-
-    it('renders without falsely items', () => {
-      const $ = render('select', {
-        items: [
-          {
-            text: 'Option 1'
-          },
-          undefined,
-          null,
-          false,
-          {
-            text: 'Options 2'
-          }
-        ]
-      })
-      const $items = $('.govuk-select option')
-      expect($items.length).toEqual(2)
+      expect($items.length).toEqual(3)
     })
 
     it('renders item with value', () => {
-      const $ = render('select', {
-        value: '2',
-        items: [
-          {
-            value: '1',
-            text: 'Option 1'
-          },
-          {
-            value: '2',
-            text: 'Options 2'
-          }
-        ]
-      })
+      const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
       expect($firstItem.attr('value')).toEqual('1')
     })
 
     it('renders item with text', () => {
-      const $ = render('select', {
-        value: '2',
-        items: [
-          {
-            text: 'Option 1'
-          },
-          {
-            text: 'Options 2'
-          }
-        ]
-      })
+      const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
-      expect($firstItem.text()).toEqual('Option 1')
+      expect($firstItem.text()).toEqual('GOV.UK frontend option 1')
     })
 
     it('renders item with selected', () => {
-      const $ = render('select', {
-        value: '2',
-        items: [
-          {
-            text: 'Option 1',
-            selected: true
-          },
-          {
-            text: 'Options 2'
-          }
-        ]
-      })
+      const $ = render('select', examples.default)
 
-      const $firstItem = $('.govuk-select option:first-child')
-      expect($firstItem.attr('selected')).toBeTruthy()
+      const $selectedItem = $('.govuk-select option:nth-child(2)')
+      expect($selectedItem.attr('selected')).toBeTruthy()
     })
 
     it('renders item with disabled', () => {
-      const $ = render('select', {
-        value: '2',
-        items: [
-          {
-            text: 'Option 1',
-            disabled: true
-          },
-          {
-            text: 'Options 2'
-          }
-        ]
-      })
+      const $ = render('select', examples.default)
 
-      const $firstItem = $('.govuk-select option:first-child')
-      expect($firstItem.attr('disabled')).toBeTruthy()
-    })
-
-    it('renders with aria-describedby', () => {
-      const describedById = 'some-id'
-
-      const $ = render('select', {
-        describedBy: describedById
-      })
-
-      const $component = $('.govuk-select')
-      expect($component.attr('aria-describedby')).toMatch(describedById)
-    })
-
-    it('renders with attributes', () => {
-      const $ = render('select', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
-
-      const $component = $('.govuk-select')
-      expect($component.attr('data-attribute')).toEqual('my data value')
+      const $disabledItem = $('.govuk-select option:last-child')
+      expect($disabledItem.attr('disabled')).toBeTruthy()
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = render('select', {})
+      const $ = render('select', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('select', {
-        formGroup: {
-          classes: 'extra-class'
-        }
-      })
+      const $ = render('select', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
     })
+
+    it('renders without falsely items', () => {
+      const $ = render('select', examples['with falsey values'])
+
+      const $items = $('.govuk-select option')
+      expect($items.length).toEqual(2)
+    })
   })
 
-  describe('when they include option attributes', () => {
-    it('renders the option attributes', () => {
-      const $ = render('select', {
-        value: '2',
-        items: [
-          {
-            text: 'Option 1',
-            attributes: {
-              'data-attribute': 'ABC',
-              'data-second-attribute': 'DEF'
-            }
-          },
-          {
-            text: 'Options 2',
-            attributes: {
-              'data-attribute': 'GHI',
-              'data-second-attribute': 'JKL'
-            }
-          }
-        ]
-      })
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('select', examples['with full width override'])
+
+      const $component = $('.govuk-select')
+      expect($component.hasClass('govuk-!-width-full')).toBeTruthy()
+    })
+
+    it('renders with aria-describedby', () => {
+      const $ = render('select', examples['with describedBy'])
+
+      const $component = $('.govuk-select')
+      expect($component.attr('aria-describedby')).toMatch('some-id')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('select', examples.attributes)
+
+      const $component = $('.govuk-select')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+
+    it('renders with attributes on items', () => {
+      const $ = render('select', examples['attributes on items'])
 
       const $component = $('.govuk-select')
 
@@ -230,23 +130,13 @@ describe('Select', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = render('select', {
-        id: 'select-with-hint',
-        hint: {
-          text: 'Hint text goes here'
-        }
-      })
+      const $ = render('select', examples.hint)
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the select as "described by" the hint', () => {
-      const $ = render('select', {
-        id: 'select-with-hint',
-        hint: {
-          text: 'Hint text goes here'
-        }
-      })
+      const $ = render('select', examples.hint)
 
       const $select = $('.govuk-select')
       const $hint = $('.govuk-hint')
@@ -260,47 +150,24 @@ describe('Select', () => {
     })
 
     it('associates the select as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('select', {
-        id: 'select-with-hint',
-        describedBy: describedById,
-        hint: {
-          text: 'Hint text goes here'
-        }
-      })
+      const $ = render('select', examples['hint and describedBy'])
 
       const $select = $('.govuk-select')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
-      )
 
       expect($select.attr('aria-describedby'))
-        .toMatch(hintId)
+        .toMatch('some-id')
     })
   })
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = render('select', {
-        id: 'select-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples.error)
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the select as "described by" the error message', () => {
-      const $ = render('select', {
-        id: 'select-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples.error)
 
       const $input = $('.govuk-select')
       const $errorMessage = $('.govuk-error-message')
@@ -314,44 +181,23 @@ describe('Select', () => {
     })
 
     it('associates the select as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('select', {
-        id: 'select-with-error',
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples['error and describedBy'])
 
       const $input = $('.govuk-select')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
 
       expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+        .toMatch('some-id')
     })
 
     it('adds the error class to the select', () => {
-      const $ = render('select', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples.error)
 
       const $component = $('.govuk-select')
       expect($component.hasClass('govuk-select--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('select', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples.error)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -360,14 +206,7 @@ describe('Select', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the select as described by both the hint and the error message', () => {
-      const $ = render('select', {
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-select')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -382,68 +221,34 @@ describe('Select', () => {
     })
 
     it('associates the select as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('select', {
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-select')
-      const errorMessageId = $('.govuk-error-message').attr('id')
-      const hintId = $('.govuk-hint').attr('id')
-
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
-      )
 
       expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+        .toMatch('select-2-hint select-2-error')
     })
   })
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('select', {
-        id: 'nesting-order',
-        label: {
-          text: 'National Insurance number'
-        },
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-form-group > .govuk-select')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = render('select', {
-        id: 'my-select',
-        label: {
-          text: 'National Insurance number'
-        }
-      })
+      const $ = render('select', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the select "id"', () => {
-      const $ = render('select', {
-        id: 'my-select',
-        label: {
-          text: 'Label text'
-        }
-      })
+      const $ = render('select', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('my-select')
+      expect($label.attr('for')).toEqual('select-1')
     })
   })
 })

--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -21,14 +21,45 @@ params:
   description: HTML attributes (for example data attributes) to add to the skip link.
 
 examples:
-- name: default
-  data:
-    text: Skip to main content
-    href: '#content'
+  - name: default
+    data:
+      text: Skip to main content
+      href: '#content'
 
-- name: with focus
-  description: Simulate triggering the :focus CSS pseudo-class, not available in the production build.
-  data:
-    classes: :focus
-    text: Skip to main content
-    href: '#content'
+  - name: with focus
+    description: Simulate triggering the :focus CSS pseudo-class, not available in the production build.
+    data:
+      classes: :focus
+      text: Skip to main content
+      href: '#content'
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: default values
+    hidden: true
+    data: {}
+  - name: custom href
+    hidden: true
+    data:
+      href: "#custom"
+  - name: custom text
+    hidden: true
+    data:
+      text: skip
+  - name: html as text
+    hidden: true
+    data:
+      text: <p>skip</p>
+  - name: html
+    hidden: true
+    data:
+      html: <p>skip</p>
+  - name: classes
+    hidden: true
+    data:
+      classes: app-skip-link--custom-class
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-test: attribute
+        aria-label: Skip to content

--- a/src/govuk/components/skip-link/template.test.js
+++ b/src/govuk/components/skip-link/template.test.js
@@ -10,75 +10,71 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('skip-link')
 
 describe('Skip link', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('skip-link', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('skip-link', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
-  it('renders href', () => {
-    const $ = render('skip-link', {
-      href: '#custom'
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.attr('href')).toEqual('#custom')
-  })
+    it('renders text', () => {
+      const $ = render('skip-link', examples.default)
 
-  it('renders default href', () => {
-    const $ = render('skip-link', {})
-
-    const $component = $('.govuk-skip-link')
-    expect($component.attr('href')).toEqual('#content')
-  })
-
-  it('renders text', () => {
-    const $ = render('skip-link', {
-      text: 'skip'
+      const $component = $('.govuk-skip-link')
+      expect($component.html()).toEqual('Skip to main content')
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.html()).toEqual('skip')
+    it('renders default href', () => {
+      const $ = render('skip-link', examples['default values'])
+
+      const $component = $('.govuk-skip-link')
+      expect($component.attr('href')).toEqual('#content')
+    })
   })
 
-  it('renders escaped html in text', () => {
-    const $ = render('skip-link', {
-      text: '<p>skip</p>'
+  describe('custom options', () => {
+    it('renders href', () => {
+      const $ = render('skip-link', examples['custom href'])
+
+      const $component = $('.govuk-skip-link')
+      expect($component.attr('href')).toEqual('#custom')
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.html()).toEqual('&lt;p&gt;skip&lt;/p&gt;')
-  })
+    it('renders text', () => {
+      const $ = render('skip-link', examples['custom text'])
 
-  it('renders html', () => {
-    const $ = render('skip-link', {
-      html: '<p>skip</p>'
+      const $component = $('.govuk-skip-link')
+      expect($component.html()).toEqual('skip')
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.html()).toEqual('<p>skip</p>')
-  })
+    it('renders escaped html in text', () => {
+      const $ = render('skip-link', examples['html as text'])
 
-  it('renders classes', () => {
-    const $ = render('skip-link', {
-      classes: 'app-skip-link--custom-class'
+      const $component = $('.govuk-skip-link')
+      expect($component.html()).toEqual('&lt;p&gt;skip&lt;/p&gt;')
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.hasClass('app-skip-link--custom-class')).toBeTruthy()
-  })
+    it('renders html', () => {
+      const $ = render('skip-link', examples.html)
 
-  it('renders attributes', () => {
-    const $ = render('skip-link', {
-      attributes: {
-        'data-test': 'attribute',
-        'aria-label': 'Skip to content'
-      }
+      const $component = $('.govuk-skip-link')
+      expect($component.html()).toEqual('<p>skip</p>')
     })
 
-    const $component = $('.govuk-skip-link')
-    expect($component.attr('data-test')).toEqual('attribute')
-    expect($component.attr('aria-label')).toEqual('Skip to content')
+    it('renders classes', () => {
+      const $ = render('skip-link', examples.classes)
+
+      const $component = $('.govuk-skip-link')
+      expect($component.hasClass('app-skip-link--custom-class')).toBeTruthy()
+    })
+
+    it('renders attributes', () => {
+      const $ = render('skip-link', examples.attributes)
+
+      const $component = $('.govuk-skip-link')
+      expect($component.attr('data-test')).toEqual('attribute')
+      expect($component.attr('aria-label')).toEqual('Skip to content')
+    })
   })
 })

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -81,6 +81,31 @@ examples:
             text: Name
           value:
             text: Firstname Lastname
+        - key:
+            text: Date of birth
+          value:
+            text: 13/08/1980
+        - key:
+            text: Contact information
+          value:
+            html: |
+              <p class="govuk-body">
+                email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+  - name: with actions
+    data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
           actions:
             items:
               - href: '#'
@@ -120,31 +145,6 @@ examples:
               - href: '#'
                 text: Change
                 visuallyHiddenText: contact information
-  - name: without actions
-    data:
-      rows:
-        - key:
-            text: Name
-          value:
-            text: Firstname Lastname
-        - key:
-            text: Date of birth
-          value:
-            text: 13/08/1980
-        - key:
-            text: Contact information
-          value:
-            html: |
-              <p class="govuk-body">
-                email@email.com
-              </p>
-              <p class="govuk-body">
-                Address line 1<br>
-                Address line 2<br>
-                Address line 3<br>
-                Address line 4<br>
-                Address line 5
-              </p>
   - name: with some actions
     data:
       rows:

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -545,3 +545,106 @@ examples:
                 text: Stop
               - href: '#'
                 text: Format
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute-1: value-1
+        data-attribute-2: value-2
+  - name: with falsey values
+    hidden: true
+    data:
+      rows:
+        - key:
+            text: Name
+        - null
+        - false
+        - ""
+        - key:
+            text: Name 2
+  - name: key with html
+    hidden: true
+    data:
+      rows:
+        - key:
+            html: <b>Name</b>
+  - name: key with classes
+    hidden: true
+    data:
+      rows:
+        - key:
+            text: Name
+            classes: app-custom-class
+  - name: value with html
+    hidden: true
+    data:
+      rows:
+        - key:
+          value:
+            html: <span>email@email.com</span>
+  - name: actions href
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items:
+              - href: https://www.gov.uk
+  - name: actions with html
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items:
+              - html: Edit<span class="visually-hidden"> name</span>
+  - name: actions with classes
+    hidden: true
+    data:
+      rows:
+        - actions:
+            classes: app-custom-class
+            items:
+              - text: Edit
+  - name: actions with attributes
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items:
+              - text: Edit
+                href: '#'
+                attributes:
+                  data-test-attribute: value
+                  data-test-attribute-2: value-2
+  - name: single action with anchor
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items:
+              - text: First action
+                href: '#'
+  - name: classes on items
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items:
+              - text: Edit
+                href: '#'
+                classes: govuk-link--no-visited-state
+  - name: empty items array
+    hidden: true
+    data:
+      rows:
+        - actions:
+            items: []
+  - name: rows with classes
+    hidden: true
+    data:
+      rows:
+        - key:
+            text: Name
+          classes: app-custom-class
+

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -10,7 +10,7 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('summary-list')
 
 describe('Summary list', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('summary-list', examples.default)
 
@@ -24,7 +24,9 @@ describe('Summary list', () => {
       })
       expect(results).toHaveNoViolations()
     })
+  })
 
+  describe('custom options', () => {
     it('renders classes', async () => {
       const $ = render('summary-list', examples['no-border'])
 
@@ -125,7 +127,7 @@ describe('Summary list', () => {
       })
 
       it('renders text', async () => {
-        const $ = render('summary-list', examples.default)
+        const $ = render('summary-list', examples['with actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -143,7 +145,7 @@ describe('Summary list', () => {
       })
 
       it('renders custom accessible name', async () => {
-        const $ = render('summary-list', examples.default)
+        const $ = render('summary-list', examples['with actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -198,7 +200,7 @@ describe('Summary list', () => {
       })
 
       it('skips the action column when no array is provided', async () => {
-        const $ = render('summary-list', examples['without actions'])
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -9,305 +9,158 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 
 const examples = getExamples('summary-list')
 
-describe('Data list', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('summary-list', examples.default)
+describe('Summary list', () => {
+  describe('by default', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('summary-list', examples.default)
 
-    const results = await axe($.html(), {
-      rules: {
-        // In newer versions of the HTML specification wrapper
-        // <div>s are allowed in a definition list
-        dlitem: { enabled: false },
-        'definition-list': { enabled: false }
-      }
-    })
-    expect(results).toHaveNoViolations()
-  })
-  it('renders classes', async () => {
-    const $ = render('summary-list', {
-      classes: 'app-custom-class'
+      const results = await axe($.html(), {
+        rules: {
+          // In newer versions of the HTML specification wrapper
+          // <div>s are allowed in a definition list
+          dlitem: { enabled: false },
+          'definition-list': { enabled: false }
+        }
+      })
+      expect(results).toHaveNoViolations()
     })
 
-    const $component = $('.govuk-summary-list')
-    expect($component.hasClass('app-custom-class')).toBeTruthy()
-  })
-  it('renders with attributes', () => {
-    const $ = render('summary-list', {
-      attributes: {
-        'data-attribute-1': 'value-1',
-        'data-attribute-2': 'value-2'
-      }
+    it('renders classes', async () => {
+      const $ = render('summary-list', examples['no-border'])
+
+      const $component = $('.govuk-summary-list')
+      expect($component.hasClass('govuk-summary-list--no-border')).toBeTruthy()
     })
 
-    const $component = $('.govuk-summary-list')
-    expect($component.attr('data-attribute-1')).toEqual('value-1')
-    expect($component.attr('data-attribute-2')).toEqual('value-2')
+    it('renders with attributes', () => {
+      const $ = render('summary-list', examples.attributes)
+
+      const $component = $('.govuk-summary-list')
+      expect($component.attr('data-attribute-1')).toEqual('value-1')
+      expect($component.attr('data-attribute-2')).toEqual('value-2')
+    })
   })
+
   describe('rows', () => {
     it('renders list without falsely values', async () => {
-      const $ = render('summary-list', {
-        rows: [
-          {
-            key: {
-              text: 'Name'
-            },
-            classes: 'app-custom-class'
-          },
-          null,
-          undefined,
-          false,
-          {
-            key: {
-              text: 'Name 2'
-            },
-            classes: 'app-custom-class'
-          }
-        ]
-      })
+      const $ = render('summary-list', examples['with falsey values'])
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')
       expect($row.length).toBe(2)
     })
+
     it('renders classes', async () => {
-      const $ = render('summary-list', {
-        rows: [
-          {
-            key: {
-              text: 'Name'
-            },
-            classes: 'app-custom-class'
-          }
-        ]
-      })
+      const $ = render('summary-list', examples['rows with classes'])
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')
       expect($row.hasClass('app-custom-class')).toBeTruthy()
     })
+
     describe('keys', () => {
       it('renders text', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                text: 'Name'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
 
         expect($key.html()).toContain('Name')
       })
+
       it('renders html', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                html: '<b>Name</b>'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['key with html'])
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
 
         expect($key.html()).toContain('<b>Name</b>')
       })
+
       it('renders classes', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                classes: 'app-custom-class',
-                text: 'Name'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['key with classes'])
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
         expect($key.hasClass('app-custom-class')).toBeTruthy()
       })
     })
+
     describe('values', () => {
       it('renders text', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              value: {
-                text: 'Firstname Lastname'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
 
         expect($value.html()).toContain('Firstname Lastname')
       })
+
       it('renders html', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              value: {
-                html: '<span>email@email.com</span>'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['value with html'])
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
 
         expect($value.html()).toContain('<span>email@email.com</span>')
       })
+
       it('renders classes', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              value: {
-                classes: 'app-custom-class',
-                text: 'Firstname Lastname'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['overridden-widths'])
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
-        expect($value.hasClass('app-custom-class')).toBeTruthy()
+        expect($value.hasClass('govuk-!-width-one-quarter')).toBeTruthy()
       })
     })
+
     describe('actions', () => {
       it('renders href', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    href: 'https://www.gov.uk'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['actions href'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
         expect($actionLink.attr('href')).toBe('https://www.gov.uk')
       })
+
       it('renders text', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    text: 'Edit'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
-        expect($actionLink.text()).toContain('Edit')
+        expect($actionLink.text().trim()).toContain('Change date of birth')
       })
+
       it('renders html', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    html: 'Edit<span class="visually-hidden"> name</span>'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['actions with html'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
         expect($actionLink.html()).toContain('Edit<span class="visually-hidden"> name</span>')
       })
+
       it('renders custom accessible name', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                text: 'Name'
-              },
-              actions: {
-                items: [
-                  {
-                    text: 'Edit',
-                    visuallyHiddenText: 'Custom Accessible Name'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
-        expect($actionLink.text()).toContain('Edit Custom Accessible Name')
+        expect($actionLink.text().trim()).toContain('Change date of birth')
       })
+
       it('renders classes', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                classes: 'app-custom-class',
-                items: [
-                  {
-                    text: 'Edit'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['actions with classes'])
 
         const $component = $('.govuk-summary-list')
         const $actionList = $component.find('.govuk-summary-list__actions')
 
         expect($actionList.hasClass('app-custom-class')).toBeTruthy()
       })
+
       it('renders attributes', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    text: 'Edit',
-                    attributes: {
-                      'data-test-attribute': 'value',
-                      'data-test-attribute-2': 'value-2'
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['actions with attributes'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -315,155 +168,66 @@ describe('Data list', () => {
         expect($actionLink.attr('data-test-attribute')).toEqual('value')
         expect($actionLink.attr('data-test-attribute-2')).toEqual('value-2')
       })
+
       it('renders a single anchor with one action', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    href: '#',
-                    text: 'First action'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['single action with anchor'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions > a')
 
         expect($action.html().trim()).toBe('First action')
       })
+
       it('renders a list with mutliple actions', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    href: '#',
-                    text: 'First action'
-                  },
-                  {
-                    href: '#',
-                    text: 'Second action'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['with some actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionList = $component.find('.govuk-summary-list__actions')
         const $secondAction = $actionList.find('.govuk-summary-list__actions-list-item:last-child')
 
-        expect($secondAction.text().trim()).toBe('Second action')
+        expect($secondAction.text().trim()).toBe('Delete name')
       })
+
       it('renders classes on actions', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              actions: {
-                items: [
-                  {
-                    text: 'Edit',
-                    classes: 'govuk-link--no-visited-state'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['classes on items'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions > a')
 
         expect($action.hasClass('govuk-link--no-visited-state')).toBeTruthy()
       })
+
       it('skips the action column when no array is provided', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                text: 'Name'
-              },
-              value: {
-                text: 'Firstname Lastname'
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['without actions'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
 
         expect($action.length).toEqual(0)
       })
+
       it('skips the action column when no items are in the array provided', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                text: 'Name'
-              },
-              value: {
-                text: 'Firstname Lastname'
-              },
-              actions: {
-                items: []
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['empty items array'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
 
         expect($action.length).toEqual(0)
       })
+
       it('adds dummy action columns when only some rows have actions', async () => {
-        const $ = render('summary-list', {
-          rows: [
-            {
-              key: {
-                text: 'Name'
-              },
-              value: {
-                text: 'Firstname Lastname'
-              }
-            },
-            {
-              key: {
-                text: 'Name'
-              },
-              value: {
-                text: 'Firstname Lastname'
-              },
-              actions: {
-                items: [
-                  {
-                    href: '#',
-                    text: 'First action'
-                  }
-                ]
-              }
-            }
-          ]
-        })
+        const $ = render('summary-list', examples['with some actions'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
 
-        // First action column is a dummy
-        expect($action[0].tagName).toEqual('span')
-        expect($($action[0]).text()).toEqual('')
+        // First action column contains link text
+        expect($action[0].tagName).toEqual('dd')
+        expect($($action[0]).text()).toContain('Edit')
 
-        // Second action column contains link text
-        expect($action[1].tagName).toEqual('dd')
-        expect($($action[1]).text()).toContain('First action')
+        // Second action column is a dummy
+        expect($action[1].tagName).toEqual('span')
+        expect($($action[1]).text()).toEqual('')
       })
     })
   })

--- a/src/govuk/components/table/table.yaml
+++ b/src/govuk/components/table/table.yaml
@@ -87,8 +87,8 @@ params:
   description: HTML attributes (for example data attributes) to add to the table container.
 
 examples:
- - name: default
-   data:
+  - name: default
+    data:
      rows:
      -
        - text: January
@@ -108,8 +108,8 @@ examples:
          format: numeric
        - text: £125
          format: numeric
- - name: table with head
-   data:
+  - name: table with head
+    data:
      head:
        - text: Month you apply
        - text: Rate for bicycles
@@ -135,8 +135,8 @@ examples:
          format: numeric
        - text: £125
          format: numeric
- - name: table with head and caption
-   data:
+  - name: table with head and caption
+    data:
      caption: 'Caption 1: Months and rates'
      captionClasses: govuk-heading-m
      firstCellIsHeader: true
@@ -165,3 +165,151 @@ examples:
            format: numeric
          - text: £125
            format: numeric
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: custom-class-goes-here
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-foo: bar
+  - name: html as text
+    hidden: true
+    data:
+      head:
+        - text: Foo <script>hacking.do(1337)</script>
+      rows:
+      -
+        - text: Foo <script>hacking.do(1337)</script>
+  - name: html
+    hidden: true
+    data:
+      head:
+        - html: Foo <span>bar</span>
+      rows:
+      -
+        - html: Foo <span>bar</span>
+  - name: head with classes
+    hidden: true
+    data:
+      head:
+        - text: Foo
+          classes: my-custom-class
+  - name: head with rowspan and colspan
+    hidden: true
+    data:
+      head:
+        - text: Foo
+          rowspan: 2
+          colspan: 2
+  - name: head with attributes
+    hidden: true
+    data:
+      head:
+        - attributes:
+            data-fizz: buzz
+  - name: with firstCellIsHeader true
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - text: January
+        - text: £85
+          format: numeric
+        - text: £95
+          format: numeric
+      -
+        - text: February
+        - text: £75
+          format: numeric
+        - text: £55
+          format: numeric
+      -
+        - text: March
+        - text: £165
+          format: numeric
+        - text: £125
+          format: numeric
+  - name: firstCellIsHeader with classes
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - text: Foo
+          classes: my-custom-class
+  - name: firstCellIsHeader with html
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - html: Foo <span>bar</span>
+  - name: firstCellIsHeader with html as text
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - text: Foo <script>hacking.do(1337)</script>
+  - name: firstCellIsHeader with rowspan and colspan
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - text: Foo
+          rowspan: 2
+          colspan: 2
+  - name: firstCellIsHeader with attributes
+    hidden: true
+    data:
+      firstCellIsHeader: true
+      rows:
+      -
+        - text: Foo
+          attributes:
+            data-fizz: buzz
+  - name: with falsey items
+    hidden: true
+    data:
+      rows:
+      -
+        - text: A
+        - text: 1
+      - false
+      - null
+      -
+        - text: B
+        - text: 2
+      -
+        - text: C
+        - text: 3
+  - name: rows with classes
+    hidden: true
+    data:
+      rows:
+      -
+        - text: Foo
+          classes: my-custom-class
+  - name: rows with rowspan and colspan
+    hidden: true
+    data:
+      rows:
+      -
+        - text: Foo
+          rowspan: 2
+          colspan: 2
+  - name: rows with attributes
+    hidden: true
+    data:
+      rows:
+      -
+        - text: Foo
+          attributes:
+            data-fizz: buzz
+

--- a/src/govuk/components/table/template.test.js
+++ b/src/govuk/components/table/template.test.js
@@ -18,19 +18,13 @@ describe('Table', () => {
   })
 
   it('can have additional classes', () => {
-    const $ = render('table', {
-      classes: 'custom-class-goes-here'
-    })
+    const $ = render('table', examples.classes)
 
     expect($('.govuk-table').hasClass('custom-class-goes-here')).toBeTruthy()
   })
 
   it('can have additional attributes', () => {
-    const $ = render('table', {
-      attributes: {
-        'data-foo': 'bar'
-      }
-    })
+    const $ = render('table', examples.attributes)
 
     expect($('.govuk-table').attr('data-foo')).toEqual('bar')
   })
@@ -76,13 +70,7 @@ describe('Table', () => {
     })
 
     it('have HTML escaped when passed as text', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo <script>hacking.do(1337)</script>'
-          }
-        ]
-      })
+      const $ = render('table', examples['html as text'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -90,13 +78,7 @@ describe('Table', () => {
     })
 
     it('allow HTML when passed as HTML', () => {
-      const $ = render('table', {
-        head: [
-          {
-            html: 'Foo <span>bar</span>'
-          }
-        ]
-      })
+      const $ = render('table', examples.html)
 
       const $th = $('.govuk-table thead tr th')
 
@@ -104,14 +86,7 @@ describe('Table', () => {
     })
 
     it('can have a format specified', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo',
-            format: 'numeric'
-          }
-        ]
-      })
+      const $ = render('table', examples['table with head'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -119,14 +94,7 @@ describe('Table', () => {
     })
 
     it('can have additional classes', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo',
-            classes: 'my-custom-class'
-          }
-        ]
-      })
+      const $ = render('table', examples['head with classes'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -134,14 +102,7 @@ describe('Table', () => {
     })
 
     it('can have rowspan specified', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo',
-            rowspan: 2
-          }
-        ]
-      })
+      const $ = render('table', examples['head with rowspan and colspan'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -149,14 +110,7 @@ describe('Table', () => {
     })
 
     it('can have colspan specified', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo',
-            colspan: 2
-          }
-        ]
-      })
+      const $ = render('table', examples['head with rowspan and colspan'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -164,16 +118,7 @@ describe('Table', () => {
     })
 
     it('can have additional attributes', () => {
-      const $ = render('table', {
-        head: [
-          {
-            text: 'Foo',
-            attributes: {
-              'data-fizz': 'buzz'
-            }
-          }
-        ]
-      })
+      const $ = render('table', examples['head with attributes'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -188,69 +133,31 @@ describe('Table', () => {
   describe('row headers', () => {
     describe('when firstCellIsHeader is false', () => {
       it('are not included', () => {
-        const $ = render('table', {
-          rows: [
-            [
-              { text: 'Apples' },
-              { text: 'green' }
-            ],
-            [
-              { text: 'Strawberries' },
-              { text: 'red' }
-            ],
-            [
-              { text: 'Bananas' },
-              { text: 'yellow' }
-            ]
-          ]
-        })
+        const $ = render('table', examples.default)
 
         const cells = $('.govuk-table').find('tbody tr td')
           .map((_, e) => $(e).text())
           .get()
 
         expect(cells).toEqual(
-          ['Apples', 'green', 'Strawberries', 'red', 'Bananas', 'yellow']
+          ['January', '£85', '£95', 'February', '£75', '£55', 'March', '£165', '£125']
         )
       })
     })
 
     describe('when firstCellIsHeader is true', () => {
       it('are included', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Apples' },
-              { text: 'green' }
-            ],
-            [
-              { text: 'Strawberries' },
-              { text: 'red' }
-            ],
-            [
-              { text: 'Bananas' },
-              { text: 'yellow' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const headings = $('.govuk-table').find('tbody tr th')
           .map((_, e) => $(e).text())
           .get()
 
-        expect(headings).toEqual(['Apples', 'Strawberries', 'Bananas'])
+        expect(headings).toEqual(['January', 'February', 'March'])
       })
 
       it('have HTML escaped when passed as text', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo <script>hacking.do(1337)</script>' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with html as text'])
 
         const $th = $('.govuk-table tbody tr th')
 
@@ -258,14 +165,7 @@ describe('Table', () => {
       })
 
       it('allow HTML when passed as HTML', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { html: 'Foo <span>bar</span>' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with html'])
 
         const $th = $('.govuk-table tbody tr th')
 
@@ -273,15 +173,7 @@ describe('Table', () => {
       })
 
       it('are associated with their rows using scope="row"', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo' },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -289,15 +181,7 @@ describe('Table', () => {
       })
 
       it('have the govuk-table__header class', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo' },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -305,15 +189,7 @@ describe('Table', () => {
       })
 
       it('can have additional classes', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo', classes: 'my-custom-class' },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with classes'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -321,15 +197,7 @@ describe('Table', () => {
       })
 
       it('can have rowspan specified', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo', rowspan: 2 },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -337,15 +205,7 @@ describe('Table', () => {
       })
 
       it('can have colspan specified', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo', colspan: 2 },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -353,15 +213,7 @@ describe('Table', () => {
       })
 
       it('can have additional attributes', () => {
-        const $ = render('table', {
-          firstCellIsHeader: true,
-          rows: [
-            [
-              { text: 'Foo', attributes: { 'data-fizz': 'buzz' } },
-              { text: 'bar' }
-            ]
-          ]
-        })
+        const $ = render('table', examples['firstCellIsHeader with attributes'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -376,13 +228,7 @@ describe('Table', () => {
 
   describe('cells', () => {
     it('can be specified', () => {
-      const $ = render('table', {
-        rows: [
-          [{ text: 'A' }, { text: '1' }],
-          [{ text: 'B' }, { text: '2' }],
-          [{ text: 'C' }, { text: '3' }]
-        ]
-      })
+      const $ = render('table', examples.default)
 
       const cells = $('.govuk-table').find('tbody tr')
         .map((_, tr) => {
@@ -391,23 +237,14 @@ describe('Table', () => {
         .get()
 
       expect(cells).toEqual([
-        ['A', '1'],
-        ['B', '2'],
-        ['C', '3']
+        ['January', '£85', '£95'],
+        ['February', '£75', '£55'],
+        ['March', '£165', '£125']
       ])
     })
 
     it('can be skipped when falsely', () => {
-      const $ = render('table', {
-        rows: [
-          [{ text: 'A' }, { text: '1' }],
-          null,
-          undefined,
-          false,
-          [{ text: 'B' }, { text: '2' }],
-          [{ text: 'C' }, { text: '3' }]
-        ]
-      })
+      const $ = render('table', examples['with falsey items'])
 
       const cells = $('.govuk-table').find('tbody tr')
         .map((_, tr) => {
@@ -423,13 +260,7 @@ describe('Table', () => {
     })
 
     it('have HTML escaped when passed as text', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            { text: 'Foo <script>hacking.do(1337)</script>' }
-          ]
-        ]
-      })
+      const $ = render('table', examples['html as text'])
 
       const $td = $('.govuk-table td')
 
@@ -437,13 +268,7 @@ describe('Table', () => {
     })
 
     it('allow HTML when passed as HTML', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            { html: 'Foo <span>bar</span>' }
-          ]
-        ]
-      })
+      const $ = render('table', examples.html)
 
       const $td = $('.govuk-table td')
 
@@ -451,16 +276,7 @@ describe('Table', () => {
     })
 
     it('can have a format specified', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            {
-              text: 'Foo',
-              format: 'numeric'
-            }
-          ]
-        ]
-      })
+      const $ = render('table', examples.default)
 
       const $td = $('.govuk-table td')
 
@@ -468,16 +284,7 @@ describe('Table', () => {
     })
 
     it('can have additional classes', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            {
-              text: 'Foo',
-              classes: 'my-custom-class'
-            }
-          ]
-        ]
-      })
+      const $ = render('table', examples['rows with classes'])
 
       const $td = $('.govuk-table td')
 
@@ -485,16 +292,7 @@ describe('Table', () => {
     })
 
     it('can have rowspan specified', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            {
-              text: 'Foo',
-              rowspan: 2
-            }
-          ]
-        ]
-      })
+      const $ = render('table', examples['rows with rowspan and colspan'])
 
       const $td = $('.govuk-table td')
 
@@ -502,16 +300,7 @@ describe('Table', () => {
     })
 
     it('can have colspan specified', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            {
-              text: 'Foo',
-              colspan: 2
-            }
-          ]
-        ]
-      })
+      const $ = render('table', examples['rows with rowspan and colspan'])
 
       const $td = $('.govuk-table td')
 
@@ -519,18 +308,7 @@ describe('Table', () => {
     })
 
     it('can have additional attributes', () => {
-      const $ = render('table', {
-        rows: [
-          [
-            {
-              text: 'Foo',
-              attributes: {
-                'data-fizz': 'buzz'
-              }
-            }
-          ]
-        ]
-      })
+      const $ = render('table', examples['rows with attributes'])
 
       const $td = $('.govuk-table td')
 

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -55,148 +55,244 @@ params:
   description: HTML attributes (for example data attributes) to add to the tabs component.
 
 examples:
-- name: default
-  data:
-    items:
-      - label: Past day
-        id: past-day
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Past day</h2>
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="col">Case manager</th>
-                  <th class="govuk-table__header" scope="col">Cases opened</th>
-                  <th class="govuk-table__header" scope="col">Cases closed</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">David Francis</td>
-                  <td class="govuk-table__cell">3</td>
-                  <td class="govuk-table__cell">0</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Paul Farmer</td>
-                  <td class="govuk-table__cell">1</td>
-                  <td class="govuk-table__cell">0</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Rita Patel</td>
-                  <td class="govuk-table__cell">2</td>
-                  <td class="govuk-table__cell">0</td>
-                </tr>
-              </tbody>
-            </table>
-      - label: Past week
-        id: past-week
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Past week</h2>
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="col">Case manager</th>
-                  <th class="govuk-table__header" scope="col">Cases opened</th>
-                  <th class="govuk-table__header" scope="col">Cases closed</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">David Francis</td>
-                  <td class="govuk-table__cell">24</td>
-                  <td class="govuk-table__cell">18</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Paul Farmer</td>
-                  <td class="govuk-table__cell">16</td>
-                  <td class="govuk-table__cell">20</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Rita Patel</td>
-                  <td class="govuk-table__cell">24</td>
-                  <td class="govuk-table__cell">27</td>
-                </tr>
-              </tbody>
-            </table>
-      - label: Past month
-        id: past-month
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Past month</h2>
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="col">Case manager</th>
-                  <th class="govuk-table__header" scope="col">Cases opened</th>
-                  <th class="govuk-table__header" scope="col">Cases closed</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">David Francis</td>
-                  <td class="govuk-table__cell">98</td>
-                  <td class="govuk-table__cell">95</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Paul Farmer</td>
-                  <td class="govuk-table__cell">122</td>
-                  <td class="govuk-table__cell">131</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Rita Patel</td>
-                  <td class="govuk-table__cell">126</td>
-                  <td class="govuk-table__cell">142</td>
-                </tr>
-              </tbody>
-            </table>
-      - label: Past year
-        id: past-year
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Past year</h2>
-            <table class="govuk-table">
-              <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                  <th class="govuk-table__header" scope="col">Case manager</th>
-                  <th class="govuk-table__header" scope="col">Cases opened</th>
-                  <th class="govuk-table__header" scope="col">Cases closed</th>
-                </tr>
-              </thead>
-              <tbody class="govuk-table__body">
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">David Francis</td>
-                  <td class="govuk-table__cell">1380</td>
-                  <td class="govuk-table__cell">1472</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Paul Farmer</td>
-                  <td class="govuk-table__cell">1129</td>
-                  <td class="govuk-table__cell">1083</td>
-                </tr>
-                <tr class="govuk-table__row">
-                  <td class="govuk-table__cell">Rita Patel</td>
-                  <td class="govuk-table__cell">1539</td>
-                  <td class="govuk-table__cell">1265</td>
-                </tr>
-              </tbody>
-            </table>
+  - name: default
+    data:
+      items:
+        - label: Past day
+          id: past-day
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Past day</h2>
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Case manager</th>
+                    <th class="govuk-table__header" scope="col">Cases opened</th>
+                    <th class="govuk-table__header" scope="col">Cases closed</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">David Francis</td>
+                    <td class="govuk-table__cell">3</td>
+                    <td class="govuk-table__cell">0</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Paul Farmer</td>
+                    <td class="govuk-table__cell">1</td>
+                    <td class="govuk-table__cell">0</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Rita Patel</td>
+                    <td class="govuk-table__cell">2</td>
+                    <td class="govuk-table__cell">0</td>
+                  </tr>
+                </tbody>
+              </table>
+        - label: Past week
+          id: past-week
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Past week</h2>
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Case manager</th>
+                    <th class="govuk-table__header" scope="col">Cases opened</th>
+                    <th class="govuk-table__header" scope="col">Cases closed</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">David Francis</td>
+                    <td class="govuk-table__cell">24</td>
+                    <td class="govuk-table__cell">18</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Paul Farmer</td>
+                    <td class="govuk-table__cell">16</td>
+                    <td class="govuk-table__cell">20</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Rita Patel</td>
+                    <td class="govuk-table__cell">24</td>
+                    <td class="govuk-table__cell">27</td>
+                  </tr>
+                </tbody>
+              </table>
+        - label: Past month
+          id: past-month
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Past month</h2>
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Case manager</th>
+                    <th class="govuk-table__header" scope="col">Cases opened</th>
+                    <th class="govuk-table__header" scope="col">Cases closed</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">David Francis</td>
+                    <td class="govuk-table__cell">98</td>
+                    <td class="govuk-table__cell">95</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Paul Farmer</td>
+                    <td class="govuk-table__cell">122</td>
+                    <td class="govuk-table__cell">131</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Rita Patel</td>
+                    <td class="govuk-table__cell">126</td>
+                    <td class="govuk-table__cell">142</td>
+                  </tr>
+                </tbody>
+              </table>
+        - label: Past year
+          id: past-year
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Past year</h2>
+              <table class="govuk-table">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Case manager</th>
+                    <th class="govuk-table__header" scope="col">Cases opened</th>
+                    <th class="govuk-table__header" scope="col">Cases closed</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">David Francis</td>
+                    <td class="govuk-table__cell">1380</td>
+                    <td class="govuk-table__cell">1472</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Paul Farmer</td>
+                    <td class="govuk-table__cell">1129</td>
+                    <td class="govuk-table__cell">1083</td>
+                  </tr>
+                  <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">Rita Patel</td>
+                    <td class="govuk-table__cell">1539</td>
+                    <td class="govuk-table__cell">1265</td>
+                  </tr>
+                </tbody>
+              </table>
 
-- name: tabs-with-anchor-in-panel
-  description: Ensure that anchors that are in tab panels work correctly
-  data:
-    items:
-      - label: Tab 1
-        id: tab-1
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Tab 1</h2>
-            <p class="govuk-body">Testing that when you click the anchor it moves to the anchor point successfully</p>
-            <p class="govuk-body"><a class="govuk-link" href="#anchor">Anchor</a></p>
-            <p class="govuk-body"><a id="anchor" tabIndex="0">Anchor Point</a></p>
-      - label: Tab 2
-        id: tab-2
-        panel:
-          html: |
-            <h2 class="govuk-heading-l">Tab 2</h2>
+  - name: tabs-with-anchor-in-panel
+    description: Ensure that anchors that are in tab panels work correctly
+    data:
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Tab 1</h2>
+              <p class="govuk-body">Testing that when you click the anchor it moves to the anchor point successfully</p>
+              <p class="govuk-body"><a class="govuk-link" href="#anchor">Anchor</a></p>
+              <p class="govuk-body"><a id="anchor" tabIndex="0">Anchor Point</a></p>
+        - label: Tab 2
+          id: tab-2
+          panel:
+            html: |
+              <h2 class="govuk-heading-l">Tab 2</h2>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: app-tabs--custom-modifier
+  - name: id
+    hidden: true
+    data:
+      id: my-tabs
+  - name: title
+    hidden: true
+    data:
+      title: Custom title for Contents
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value
+  - name: item with attributes
+    hidden: true
+    data:
+      items:
+        - id: tab-1
+          label: Tab 1
+          attributes:
+            data-attribute: my-attribute
+            data-attribute-2: my-attribute-2
+  - name: panel with attributes
+    hidden: true
+    data:
+      items:
+        - id: tab-1
+          label: Tab 1
+          panel:
+            text: Panel text
+            attributes:
+              data-attribute: my-attribute
+              data-attribute-2: my-attribute-2
+  - name: no item list
+    hidden: true
+    data:
+      id: my-tabs
+      classes: app-tabs--custom-modifier
+  - name: empty item list
+    hidden: true
+    data:
+      items: []
+  - name: with falsey values
+    hidden: true
+    data:
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            text: Panel 1 content
+        - null
+        - false
+        - ""
+        - label: Tab 2
+          id: tab-2
+          panel:
+            text: Panel 2 content
+  - name: idPrefix
+    hidden: true
+    data:
+      idPrefix: custom
+      items:
+        - label: Tab 1
+          panel:
+            text: Panel 1 content
+        - label: Tab 2
+          panel:
+            text: Panel 2 content
+  - name: html as text
+    hidden: true
+    data:
+      items:
+        - label: Tab 1
+          panel:
+            text: <p>Panel 1 content</p>
+        - label: Tab 2
+          panel:
+            text: <p>Panel 2 content</p>
+  - name: html
+    hidden: true
+    data:
+      items:
+        - label: Tab 1
+          panel:
+            html: <p>Panel 1 content</p>
+        - label: Tab 2
+          panel:
+            html: <p>Panel 2 content</p>
+
+

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -10,7 +10,7 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('tabs')
 
 describe('Tabs', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('tabs', examples.default)
 
@@ -18,6 +18,23 @@ describe('Tabs', () => {
       expect(results).toHaveNoViolations()
     })
 
+    it('renders the first tab selected', () => {
+      const $ = render('tabs', examples.default)
+
+      const $tab = $('[href="#past-day"]').parent()
+      expect($tab.hasClass('govuk-tabs__list-item--selected')).toBeTruthy()
+    })
+
+    it('hides all but the first panel', () => {
+      const $ = render('tabs', examples.default)
+
+      expect($('#past-week').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect($('#past-month').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect($('#past-year').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+    })
+  })
+
+  describe('custom options', () => {
     it('renders with classes', () => {
       const $ = render('tabs', examples.classes)
 
@@ -45,110 +62,95 @@ describe('Tabs', () => {
       const $component = $('.govuk-tabs')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
+  })
 
-    describe('items', () => {
-      it('doesn\'t render a list if items is not defined', () => {
-        const $ = render('tabs', examples['no item list'])
+  describe('items', () => {
+    it('doesn\'t render a list if items is not defined', () => {
+      const $ = render('tabs', examples['no item list'])
 
-        const $component = $('.govuk-tabs')
-        expect($component.find('.govuk-tabs__list').length).toEqual(0)
-      })
-
-      it('doesn\'t render a list if items is empty', () => {
-        const $ = render('tabs', examples['empty item list'])
-
-        const $component = $('.govuk-tabs')
-        expect($component.find('.govuk-tabs__list').length).toEqual(0)
-      })
-
-      it('render a matching tab and panel using item id', () => {
-        const $ = render('tabs', examples.default)
-
-        const $component = $('.govuk-tabs')
-
-        const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
-        const $firstPanel = $component.find('.govuk-tabs__panel')
-        expect($firstTab.attr('href')).toEqual('#past-day')
-        expect($firstPanel.attr('id')).toEqual('past-day')
-      })
-
-      it('render without falsey values', () => {
-        const $ = render('tabs', examples['with falsey values'])
-
-        const $component = $('.govuk-tabs')
-
-        const $items = $component.find('.govuk-tabs__list-item')
-        expect($items.length).toEqual(2)
-      })
-
-      it('render a matching tab and panel using custom idPrefix', () => {
-        const $ = render('tabs', examples.idPrefix)
-
-        const $component = $('.govuk-tabs')
-
-        const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
-        const $firstPanel = $component.find('.govuk-tabs__panel')
-        expect($firstTab.attr('href')).toEqual('#custom-1')
-        expect($firstPanel.attr('id')).toEqual('custom-1')
-      })
-
-      it('render the label', () => {
-        const $ = render('tabs', examples.default)
-
-        const $component = $('.govuk-tabs')
-
-        const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
-        expect($firstTab.text().trim()).toEqual('Past day')
-      })
-
-      it('render escaped html when passed to text content', () => {
-        const $ = render('tabs', examples['html as text'])
-
-        const $component = $('.govuk-tabs')
-
-        const $firstPanel = $component.find('.govuk-tabs__panel')
-        expect($firstPanel.html().trim()).toEqual('&lt;p&gt;Panel 1 content&lt;/p&gt;')
-      })
-
-      it('render html when passed to content', () => {
-        const $ = render('tabs', examples.html)
-
-        const $component = $('.govuk-tabs')
-
-        const $firstPanel = $component.find('.govuk-tabs__panel')
-        expect($firstPanel.html().trim()).toEqual('<p>Panel 1 content</p>')
-      })
-
-      it('render a tab anchor with attributes', () => {
-        const $ = render('tabs', examples['item with attributes'])
-
-        const $tabItemLink = $('.govuk-tabs__tab')
-        expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
-        expect($tabItemLink.attr('data-attribute-2')).toEqual('my-attribute-2')
-      })
-
-      it('render a tab panel with attributes', () => {
-        const $ = render('tabs', examples['panel with attributes'])
-
-        const $tabPanelItems = $('.govuk-tabs__panel')
-        expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')
-        expect($tabPanelItems.attr('data-attribute-2')).toEqual('my-attribute-2')
-      })
+      const $component = $('.govuk-tabs')
+      expect($component.find('.govuk-tabs__list').length).toEqual(0)
     })
 
-    it('renders the first tab selected', () => {
-      const $ = render('tabs', examples.default)
+    it('doesn\'t render a list if items is empty', () => {
+      const $ = render('tabs', examples['empty item list'])
 
-      const $tab = $('[href="#past-day"]').parent()
-      expect($tab.hasClass('govuk-tabs__list-item--selected')).toBeTruthy()
+      const $component = $('.govuk-tabs')
+      expect($component.find('.govuk-tabs__list').length).toEqual(0)
     })
 
-    it('hides all but the first panel', () => {
+    it('render a matching tab and panel using item id', () => {
       const $ = render('tabs', examples.default)
 
-      expect($('#past-week').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
-      expect($('#past-month').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
-      expect($('#past-year').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      const $component = $('.govuk-tabs')
+
+      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      const $firstPanel = $component.find('.govuk-tabs__panel')
+      expect($firstTab.attr('href')).toEqual('#past-day')
+      expect($firstPanel.attr('id')).toEqual('past-day')
+    })
+
+    it('render without falsey values', () => {
+      const $ = render('tabs', examples['with falsey values'])
+
+      const $component = $('.govuk-tabs')
+
+      const $items = $component.find('.govuk-tabs__list-item')
+      expect($items.length).toEqual(2)
+    })
+
+    it('render a matching tab and panel using custom idPrefix', () => {
+      const $ = render('tabs', examples.idPrefix)
+
+      const $component = $('.govuk-tabs')
+
+      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      const $firstPanel = $component.find('.govuk-tabs__panel')
+      expect($firstTab.attr('href')).toEqual('#custom-1')
+      expect($firstPanel.attr('id')).toEqual('custom-1')
+    })
+
+    it('render the label', () => {
+      const $ = render('tabs', examples.default)
+
+      const $component = $('.govuk-tabs')
+
+      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      expect($firstTab.text().trim()).toEqual('Past day')
+    })
+
+    it('render escaped html when passed to text content', () => {
+      const $ = render('tabs', examples['html as text'])
+
+      const $component = $('.govuk-tabs')
+
+      const $firstPanel = $component.find('.govuk-tabs__panel')
+      expect($firstPanel.html().trim()).toEqual('&lt;p&gt;Panel 1 content&lt;/p&gt;')
+    })
+
+    it('render html when passed to content', () => {
+      const $ = render('tabs', examples.html)
+
+      const $component = $('.govuk-tabs')
+
+      const $firstPanel = $component.find('.govuk-tabs__panel')
+      expect($firstPanel.html().trim()).toEqual('<p>Panel 1 content</p>')
+    })
+
+    it('render a tab anchor with attributes', () => {
+      const $ = render('tabs', examples['item with attributes'])
+
+      const $tabItemLink = $('.govuk-tabs__tab')
+      expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
+      expect($tabItemLink.attr('data-attribute-2')).toEqual('my-attribute-2')
+    })
+
+    it('render a tab panel with attributes', () => {
+      const $ = render('tabs', examples['panel with attributes'])
+
+      const $tabPanelItems = $('.govuk-tabs__panel')
+      expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')
+      expect($tabPanelItems.attr('data-attribute-2')).toEqual('my-attribute-2')
     })
   })
 })

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -19,38 +19,28 @@ describe('Tabs', () => {
     })
 
     it('renders with classes', () => {
-      const $ = render('tabs', {
-        classes: 'app-tabs--custom-modifier'
-      })
+      const $ = render('tabs', examples.classes)
 
       const $component = $('.govuk-tabs')
       expect($component.hasClass('app-tabs--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = render('tabs', {
-        id: 'my-tabs'
-      })
+      const $ = render('tabs', examples.id)
 
       const $component = $('.govuk-tabs')
       expect($component.attr('id')).toEqual('my-tabs')
     })
 
     it('allows custom title text to be passed', () => {
-      const $ = render('tabs', {
-        title: 'Custom title for Contents'
-      })
+      const $ = render('tabs', examples.title)
 
       const content = $('.govuk-tabs__title').html().trim()
       expect(content).toEqual('Custom title for Contents')
     })
 
     it('renders with attributes', () => {
-      const $ = render('tabs', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
+      const $ = render('tabs', examples.attributes)
 
       const $component = $('.govuk-tabs')
       expect($component.attr('data-attribute')).toEqual('my data value')
@@ -58,61 +48,32 @@ describe('Tabs', () => {
 
     describe('items', () => {
       it('doesn\'t render a list if items is not defined', () => {
-        const $ = render('tabs', {})
+        const $ = render('tabs', examples['no item list'])
 
         const $component = $('.govuk-tabs')
         expect($component.find('.govuk-tabs__list').length).toEqual(0)
       })
 
       it('doesn\'t render a list if items is empty', () => {
-        const $ = render('tabs', { items: [] })
+        const $ = render('tabs', examples['empty item list'])
 
         const $component = $('.govuk-tabs')
         expect($component.find('.govuk-tabs__list').length).toEqual(0)
       })
 
       it('render a matching tab and panel using item id', () => {
-        const $ = render('tabs', {
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              panel: { text: 'Panel 1 content' }
-            },
-            {
-              id: 'tab-2',
-              label: 'Tab 2',
-              panel: { text: 'Panel 2 content' }
-            }
-          ]
-        })
+        const $ = render('tabs', examples.default)
 
         const $component = $('.govuk-tabs')
 
         const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
         const $firstPanel = $component.find('.govuk-tabs__panel')
-        expect($firstTab.attr('href')).toEqual('#tab-1')
-        expect($firstPanel.attr('id')).toEqual('tab-1')
+        expect($firstTab.attr('href')).toEqual('#past-day')
+        expect($firstPanel.attr('id')).toEqual('past-day')
       })
 
-      it('render without falsely values', () => {
-        const $ = render('tabs', {
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              panel: { text: 'Panel 1 content' }
-            },
-            undefined,
-            null,
-            false,
-            {
-              id: 'tab-2',
-              label: 'Tab 2',
-              panel: { text: 'Panel 2 content' }
-            }
-          ]
-        })
+      it('render without falsey values', () => {
+        const $ = render('tabs', examples['with falsey values'])
 
         const $component = $('.govuk-tabs')
 
@@ -121,19 +82,7 @@ describe('Tabs', () => {
       })
 
       it('render a matching tab and panel using custom idPrefix', () => {
-        const $ = render('tabs', {
-          idPrefix: 'custom',
-          items: [
-            {
-              label: 'Tab 1',
-              panel: { text: 'Panel 1 content' }
-            },
-            {
-              label: 'Tab 2',
-              panel: { text: 'Panel 2 content' }
-            }
-          ]
-        })
+        const $ = render('tabs', examples.idPrefix)
 
         const $component = $('.govuk-tabs')
 
@@ -144,40 +93,16 @@ describe('Tabs', () => {
       })
 
       it('render the label', () => {
-        const $ = render('tabs', {
-          idPrefix: 'custom',
-          items: [
-            {
-              label: 'Tab 1'
-            },
-            {
-              label: 'Tab 2'
-            }
-          ]
-        })
+        const $ = render('tabs', examples.default)
 
         const $component = $('.govuk-tabs')
 
         const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
-        expect($firstTab.text().trim()).toEqual('Tab 1')
+        expect($firstTab.text().trim()).toEqual('Past day')
       })
 
       it('render escaped html when passed to text content', () => {
-        const $ = render('tabs', {
-          idPrefix: 'custom',
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              panel: { text: '<p>Panel 1 content</p>' }
-            },
-            {
-              id: 'tab-2',
-              label: 'Tab 2',
-              panel: { text: '<p>Panel 2 content</p>' }
-            }
-          ]
-        })
+        const $ = render('tabs', examples['html as text'])
 
         const $component = $('.govuk-tabs')
 
@@ -186,21 +111,7 @@ describe('Tabs', () => {
       })
 
       it('render html when passed to content', () => {
-        const $ = render('tabs', {
-          idPrefix: 'custom',
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              panel: { html: '<p>Panel 1 content</p>' }
-            },
-            {
-              id: 'tab-2',
-              label: 'Tab 2',
-              panel: { html: '<p>Panel 2 content</p>' }
-            }
-          ]
-        })
+        const $ = render('tabs', examples.html)
 
         const $component = $('.govuk-tabs')
 
@@ -209,18 +120,7 @@ describe('Tabs', () => {
       })
 
       it('render a tab anchor with attributes', () => {
-        const $ = render('tabs', {
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              attributes: {
-                'data-attribute': 'my-attribute',
-                'data-attribute-2': 'my-attribute-2'
-              }
-            }
-          ]
-        })
+        const $ = render('tabs', examples['item with attributes'])
 
         const $tabItemLink = $('.govuk-tabs__tab')
         expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
@@ -228,21 +128,7 @@ describe('Tabs', () => {
       })
 
       it('render a tab panel with attributes', () => {
-        const $ = render('tabs', {
-          items: [
-            {
-              id: 'tab-1',
-              label: 'Tab 1',
-              panel: {
-                text: 'Panel text',
-                attributes: {
-                  'data-attribute': 'my-attribute',
-                  'data-attribute-2': 'my-attribute-2'
-                }
-              }
-            }
-          ]
-        })
+        const $ = render('tabs', examples['panel with attributes'])
 
         const $tabPanelItems = $('.govuk-tabs__panel')
         expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')
@@ -251,50 +137,18 @@ describe('Tabs', () => {
     })
 
     it('renders the first tab selected', () => {
-      const $ = render('tabs', {
-        items: [
-          {
-            id: 'tab-1',
-            label: 'Tab 1',
-            panel: {
-              text: 'Panel text'
-            }
-          },
-          {
-            id: 'tab-2',
-            label: 'Tab 2',
-            panel: {
-              text: 'Panel text 2'
-            }
-          }
-        ]
-      })
+      const $ = render('tabs', examples.default)
 
-      const $tab = $('[href="#tab-1"]').parent()
+      const $tab = $('[href="#past-day"]').parent()
       expect($tab.hasClass('govuk-tabs__list-item--selected')).toBeTruthy()
     })
 
     it('hides all but the first panel', () => {
-      const $ = render('tabs', {
-        items: [
-          {
-            id: 'tab-1',
-            label: 'Tab 1',
-            panel: {
-              text: 'Panel text'
-            }
-          },
-          {
-            id: 'tab-2',
-            label: 'Tab 2',
-            panel: {
-              text: 'Panel text 2'
-            }
-          }
-        ]
-      })
+      const $ = render('tabs', examples.default)
 
-      expect($('#tab-2').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect($('#past-week').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect($('#past-month').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect($('#past-year').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
     })
   })
 })

--- a/src/govuk/components/tag/tag.yaml
+++ b/src/govuk/components/tag/tag.yaml
@@ -17,46 +17,63 @@ params:
   description: HTML attributes (for example data attributes) to add to the tag.
 
 examples:
- - name: default
-   data:
+- name: default
+  data:
     text: alpha
- - name: inactive
-   data:
+- name: inactive
+  data:
     text: alpha
     classes: govuk-tag--inactive
- - name: grey
-   data:
+- name: grey
+  data:
     text: Grey
     classes: govuk-tag--grey
- - name: blue
-   data:
+- name: blue
+  data:
     text: Blue
     classes: govuk-tag--blue
- - name: turquoise
-   data:
+- name: turquoise
+  data:
     text: Turquoise
     classes: govuk-tag--turquoise
- - name: green
-   data:
+- name: green
+  data:
     text: Green
     classes: govuk-tag--green
- - name: purple
-   data:
+- name: purple
+  data:
     text: Purple
     classes: govuk-tag--purple
- - name: pink
-   data:
+- name: pink
+  data:
     text: Pink
     classes: govuk-tag--pink
- - name: red
-   data:
+- name: red
+  data:
     text: Red
     classes: govuk-tag--red
- - name: orange
-   data:
+- name: orange
+  data:
     text: Orange
     classes: govuk-tag--orange
- - name: yellow
-   data:
+- name: yellow
+  data:
     text: Yellow
     classes: govuk-tag--yellow
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+- name: attributes
+  hidden: true
+  data:
+    text: Tag with attributes
+    attributes:
+      data-test: attribute
+      id: my-tag
+- name: html as text
+  hidden: true
+  data:
+    text: <span>alpha</span>
+- name: html
+  hidden: true
+  data:
+    html: <span>alpha</span>

--- a/src/govuk/components/tag/template.test.js
+++ b/src/govuk/components/tag/template.test.js
@@ -10,69 +10,60 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('tag')
 
 describe('Tag', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('tag', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('tag', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
-  it('renders the default example with strong element and text', () => {
-    const $ = render('tag', examples.default)
-
-    const $component = $('.govuk-tag')
-    expect($component.get(0).tagName).toEqual('strong')
-    expect($component.text()).toContain('alpha')
-  })
-
-  it('renders classes', () => {
-    const $ = render('tag', {
-      classes: 'govuk-tag--inactive',
-      text: 'alpha'
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
     })
 
-    const $component = $('.govuk-tag')
-    expect($component.hasClass('govuk-tag--inactive')).toBeTruthy()
-  })
+    it('renders the default example with strong element and text', () => {
+      const $ = render('tag', examples.default)
 
-  it('renders custom text', () => {
-    const $ = render('tag', {
-      text: 'some-custom-text'
+      const $component = $('.govuk-tag')
+      expect($component.get(0).tagName).toEqual('strong')
+      expect($component.text()).toContain('alpha')
     })
 
-    const $component = $('.govuk-tag')
-    expect($component.html()).toContain('some-custom-text')
+    it('renders classes', () => {
+      const $ = render('tag', examples.inactive)
+
+      const $component = $('.govuk-tag')
+      expect($component.hasClass('govuk-tag--inactive')).toBeTruthy()
+    })
   })
 
-  it('renders escaped html when passed to text', () => {
-    const $ = render('tag', {
-      text: '<span>alpha</span>'
+  describe('custom options', () => {
+    it('renders custom text', () => {
+      const $ = render('tag', examples.grey)
+
+      const $component = $('.govuk-tag')
+      expect($component.html()).toContain('Grey')
     })
 
-    const $component = $('.govuk-tag')
-    expect($component.html()).toContain('&lt;span&gt;alpha&lt;/span&gt;')
+    it('renders attributes', () => {
+      const $ = render('tag', examples.attributes)
+
+      const $component = $('.govuk-tag')
+      expect($component.attr('data-test')).toEqual('attribute')
+      expect($component.attr('id')).toEqual('my-tag')
+    })
   })
 
-  it('renders html', () => {
-    const $ = render('tag', {
-      html: '<span>alpha</span>'
+  describe('html', () => {
+    it('renders escaped html when passed to text', () => {
+      const $ = render('tag', examples['html as text'])
+
+      const $component = $('.govuk-tag')
+      expect($component.html()).toContain('&lt;span&gt;alpha&lt;/span&gt;')
     })
 
-    const $component = $('.govuk-tag')
-    expect($component.html()).toContain('<span>alpha</span>')
-  })
+    it('renders html', () => {
+      const $ = render('tag', examples.html)
 
-  it('renders attributes', () => {
-    const $ = render('tag', {
-      attributes: {
-        'data-test': 'attribute',
-        id: 'my-tag'
-      },
-      html: '<span>alpha</span>'
+      const $component = $('.govuk-tag')
+      expect($component.html()).toContain('<span>alpha</span>')
     })
-
-    const $component = $('.govuk-tag')
-    expect($component.attr('data-test')).toEqual('attribute')
-    expect($component.attr('id')).toEqual('my-tag')
   })
 })

--- a/src/govuk/components/textarea/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/textarea/__snapshots__/template.test.js.snap
@@ -4,7 +4,7 @@ exports[`Textarea when it includes a hint renders with hint 1`] = `
 <div id="more-detail-hint"
      class="govuk-hint"
 >
-  Don&#x2019;t include personal or financial information, eg your National Insurance number or credit card details.
+  Don&apos;t include personal or financial information, eg your National Insurance number or credit card details.
 </div>
 `;
 

--- a/src/govuk/components/textarea/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/textarea/__snapshots__/template.test.js.snap
@@ -1,25 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Textarea when it includes a hint renders with hint 1`] = `
-<div id="textarea-with-error-hint"
+<div id="more-detail-hint"
      class="govuk-hint"
 >
-  It&#x2019;s on your National Insurance card, benefit letter, payslip or P60. For example, &#x2018;QQ 12 34 56 C&#x2019;.
+  Don&#x2019;t include personal or financial information, eg your National Insurance number or credit card details.
 </div>
 `;
 
 exports[`Textarea when it includes an error message renders with error message 1`] = `
-<span id="textarea-with-error-error"
+<span id="no-ni-reason-error"
       class="govuk-error-message"
 >
-  Error message
+  You must provide an explanation
 </span>
 `;
 
 exports[`Textarea with dependant components renders with label 1`] = `
 <label class="govuk-label"
-       for="my-textarea"
+       for="more-detail"
 >
-  Full address
+  Can you provide more detail?
 </label>
 `;

--- a/src/govuk/components/textarea/template.test.js
+++ b/src/govuk/components/textarea/template.test.js
@@ -119,13 +119,13 @@ describe('Textarea', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = render('textarea', examples.default)
+      const $ = render('textarea', examples['with hint'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the textarea as "described by" the hint', () => {
-      const $ = render('textarea', examples['with hint and described by'])
+      const $ = render('textarea', examples['with hint'])
 
       const $textarea = $('.govuk-textarea')
       const $hint = $('.govuk-hint')

--- a/src/govuk/components/textarea/template.test.js
+++ b/src/govuk/components/textarea/template.test.js
@@ -13,7 +13,7 @@ const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'
 
 describe('Textarea', () => {
-  describe('by default', () => {
+  describe('default example', () => {
     it('passes accessibility tests', async () => {
       const $ = render('textarea', examples.default)
 
@@ -21,112 +21,96 @@ describe('Textarea', () => {
       expect(results).toHaveNoViolations()
     })
 
-    it('renders with classes', () => {
-      const $ = render('textarea', {
-        classes: 'app-textarea--custom-modifier'
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.hasClass('app-textarea--custom-modifier')).toBeTruthy()
-    })
-
     it('renders with id', () => {
-      const $ = render('textarea', {
-        id: 'my-textarea'
-      })
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('id')).toEqual('my-textarea')
+      expect($component.attr('id')).toEqual('more-detail')
     })
 
     it('renders with name', () => {
-      const $ = render('textarea', {
-        name: 'my-textarea-name'
-      })
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('name')).toEqual('my-textarea-name')
-    })
-
-    it('renders with aria-describedby', () => {
-      const describedById = 'some-id'
-
-      const $ = render('textarea', {
-        describedBy: describedById
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.attr('aria-describedby')).toMatch(describedById)
-    })
-
-    it('renders with rows', () => {
-      const $ = render('textarea', {
-        rows: '4'
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.attr('rows')).toEqual('4')
+      expect($component.attr('name')).toEqual('more-detail')
     })
 
     it('renders with default number of rows', () => {
-      const $ = render('textarea', {})
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('rows')).toEqual('5')
     })
 
-    it('renders with value', () => {
-      const $ = render('textarea', {
-        value: '221B Baker Street\nLondon\nNW1 6XE\n'
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
-    })
-
-    it('renders with attributes', () => {
-      const $ = render('textarea', {
-        attributes: {
-          'data-attribute': 'my data value'
-        }
-      })
-
-      const $component = $('.govuk-textarea')
-      expect($component.attr('data-attribute')).toEqual('my data value')
-    })
-
     it('renders with a form group wrapper', () => {
-      const $ = render('textarea', {})
+      const $ = render('textarea', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
     })
   })
 
+  describe('custom options', () => {
+    it('renders with classes', () => {
+      const $ = render('textarea', examples.classes)
+
+      const $component = $('.govuk-textarea')
+      expect($component.hasClass('app-textarea--custom-modifier')).toBeTruthy()
+    })
+
+    it('renders with value', () => {
+      const $ = render('textarea', examples['with default value'])
+
+      const $component = $('.govuk-textarea')
+      expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
+    })
+
+    it('renders with attributes', () => {
+      const $ = render('textarea', examples.attributes)
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('data-attribute')).toEqual('my data value')
+    })
+
+    it('renders with aria-describedby', () => {
+      const $ = render('textarea', examples['with describedBy'])
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('aria-describedby')).toMatch('some-id')
+    })
+
+    it('renders with rows', () => {
+      const $ = render('textarea', examples['with custom rows'])
+
+      const $component = $('.govuk-textarea')
+      expect($component.attr('rows')).toEqual('8')
+    })
+
+    it('renders with a form group wrapper that has extra classes', () => {
+      const $ = render('textarea', examples['with optional form-group classes'])
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('extra-class')).toBeTruthy()
+    })
+  })
+
   describe('when it has the spellcheck attribute', () => {
     it('renders with spellcheck attribute set to true', () => {
-      const $ = render('textarea', {
-        spellcheck: true
-      })
+      const $ = render('textarea', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
-      const $ = render('textarea', {
-        name: 'my-textarea-name',
-        spellcheck: false
-      })
+      const $ = render('textarea', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
-      const $ = render('textarea', {
-        name: 'my-textarea-name'
-      })
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -135,23 +119,13 @@ describe('Textarea', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('textarea', examples.default)
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the textarea as "described by" the hint', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('textarea', examples['with hint and described by'])
 
       const $textarea = $('.govuk-textarea')
       const $hint = $('.govuk-hint')
@@ -165,21 +139,13 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as "described by" the hint and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        describedBy: describedById,
-        hint: {
-          text: 'It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.'
-        }
-      })
+      const $ = render('textarea', examples['with hint and described by'])
 
       const $textarea = $('.govuk-textarea')
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $hint.attr('id') + WORD_BOUNDARY
       )
 
       expect($textarea.attr('aria-describedby'))
@@ -189,23 +155,13 @@ describe('Textarea', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the textarea as "described by" the error message', () => {
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples['with error message'])
 
       const $component = $('.govuk-textarea')
       const $errorMessage = $('.govuk-error-message')
@@ -219,21 +175,13 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as "described by" the error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('textarea', {
-        id: 'textarea-with-error',
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples['with error message and described by'])
 
       const $component = $('.govuk-textarea')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
       expect($component.attr('aria-describedby'))
@@ -241,33 +189,14 @@ describe('Textarea', () => {
     })
 
     it('adds the error class to the textarea', () => {
-      const $ = render('textarea', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples['with error message'])
 
       const $component = $('.govuk-textarea')
       expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
 
-    it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('textarea', {
-        formGroup: {
-          classes: 'extra-class'
-        }
-      })
-
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.hasClass('extra-class')).toBeTruthy()
-    })
-
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = render('textarea', {
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -276,14 +205,7 @@ describe('Textarea', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the textarea as described by both the hint and the error message', () => {
-      const $ = render('textarea', {
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('textarea', examples['with hint and error message'])
 
       const $component = $('.govuk-textarea')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -298,24 +220,14 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
-
-      const $ = render('textarea', {
-        describedBy: describedById,
-        errorMessage: {
-          text: 'Error message'
-        },
-        hint: {
-          text: 'Hint'
-        }
-      })
+      const $ = render('textarea', examples['with hint, error message and described by'])
 
       const $component = $('.govuk-textarea')
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
       const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+        WORD_BOUNDARY + 'some-id' + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
       expect($component.attr('aria-describedby'))
@@ -325,51 +237,37 @@ describe('Textarea', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('textarea', {
-        id: 'nested-order',
-        label: {
-          text: 'Full address'
-        },
-        errorMessage: {
-          text: 'Error message'
-        }
-      })
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-textarea')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = render('textarea', {
-        id: 'my-textarea',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('textarea', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the textarea "id"', () => {
-      const $ = render('textarea', {
-        id: 'my-textarea',
-        label: {
-          text: 'Full address'
-        }
-      })
+      const $ = render('textarea', examples.default)
 
       const $label = $('.govuk-label')
-      expect($label.attr('for')).toEqual('my-textarea')
+      expect($label.attr('for')).toEqual('more-detail')
+    })
+
+    it('renders label as page heading', () => {
+      const $ = render('textarea', examples['with label as page heading'])
+
+      const $label = $('.govuk-label')
+      expect($('.govuk-label-wrapper')).toBeTruthy()
+      expect($label.attr('for')).toEqual('textarea-with-page-heading')
     })
   })
 
   describe('when it includes an autocomplete attribute', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = render('textarea', {
-        attributes: {
-          autocomplete: 'street-address'
-        }
-      })
+      const $ = render('textarea', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('autocomplete')).toEqual('street-address')

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -67,9 +67,14 @@ examples:
       id: more-detail
       label:
         text: Can you provide more detail?
+  - name: with hint
+    data:
+      name: more-detail
+      id: more-detail
+      label:
+        text: Can you provide more detail?
       hint:
-        text: Don’t include personal or financial information, eg your
-              National Insurance number or credit card details.
+        text: Don't include personal or financial information, eg your National Insurance number or credit card details.
 
   - name: with error message
     data:

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -139,3 +139,47 @@ examples:
       id: textarea-with-spellcheck-disabled
       name: spellcheck
       spellcheck: false
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: classes
+    hidden: true
+    data:
+      classes: app-textarea--custom-modifier
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        data-attribute: my data value
+  - name: with describedBy
+    hidden: true
+    data:
+      describedBy: some-id
+  - name: with hint and described by
+    hidden: true
+    data:
+      describedBy: some-id
+      hint:
+        text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
+  - name: with error message and described by
+    hidden: true
+    data:
+      describedBy: some-id
+      id: textarea-with-error
+      errorMessage:
+        text: Error message
+  - name: with hint and error message
+    hidden: true
+    data:
+      errorMessage:
+        text: Error message
+      hint:
+        text: Hint
+  - name: with hint, error message and described by
+    hidden: true
+    data:
+      describedBy: some-id
+      errorMessage:
+        text: Error message
+      hint:
+        text: Hint
+

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -10,88 +10,80 @@ const { render, getExamples } = require('../../../../lib/jest-helpers')
 const examples = getExamples('warning-text')
 
 describe('Warning text', () => {
-  it('default example passes accessibility tests', async () => {
-    const $ = render('warning-text', examples.default)
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('warning-text', examples.default)
 
-    const results = await axe($.html())
-    expect(results).toHaveNoViolations()
-  })
-
-  it('renders the default example with text', () => {
-    const $ = render('warning-text', examples.default)
-
-    const $component = $('.govuk-warning-text')
-    expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
-  })
-
-  it('renders the default example with assistive text', () => {
-    const $ = render('warning-text', examples.default)
-
-    const $assistiveText = $('.govuk-warning-text__assistive')
-    expect($assistiveText.text()).toEqual('Warning')
-  })
-
-  it('hides the icon from screen readers using the aria-hidden attribute', () => {
-    const $ = render('warning-text', examples.default)
-
-    const $icon = $('.govuk-warning-text__icon')
-    expect($icon.attr('aria-hidden')).toEqual('true')
-  })
-
-  it('renders classes', () => {
-    const $ = render('warning-text', {
-      classes: 'govuk-warning-text--custom-class',
-      text: 'Warning text'
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
     })
 
-    const $component = $('.govuk-warning-text')
-    expect($component.hasClass('govuk-warning-text--custom-class')).toBeTruthy()
-  })
+    it('renders with text', () => {
+      const $ = render('warning-text', examples.default)
 
-  it('renders custom text', () => {
-    const $ = render('warning-text', {
-      text: 'Some custom warning text'
-    })
-    const $component = $('.govuk-warning-text')
-    expect($component.html()).toContain('Some custom warning text')
-  })
-
-  it('renders custom assistive text', () => {
-    const $ = render('warning-text', {
-      iconFallbackText: 'Some custom fallback text'
-    })
-    const $assistiveText = $('.govuk-warning-text__assistive')
-    expect($assistiveText.html()).toContain('Some custom fallback text')
-  })
-
-  it('renders escaped html when passed to text', () => {
-    const $ = render('warning-text', {
-      text: '<span>Some custom warning text</span>'
+      const $component = $('.govuk-warning-text')
+      expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
     })
 
-    const $component = $('.govuk-warning-text')
-    expect($component.html()).toContain('&lt;span&gt;Some custom warning text&lt;/span&gt;')
-  })
+    it('renders with assistive text', () => {
+      const $ = render('warning-text', examples.default)
 
-  it('renders html', () => {
-    const $ = render('warning-text', {
-      html: '<span>Some custom warning text</span>'
+      const $assistiveText = $('.govuk-warning-text__assistive')
+      expect($assistiveText.text()).toEqual('Warning')
     })
 
-    const $component = $('.govuk-warning-text')
-    expect($component.html()).toContain('<span>Some custom warning text</span>')
+    it('hides the icon from screen readers using the aria-hidden attribute', () => {
+      const $ = render('warning-text', examples.default)
+
+      const $icon = $('.govuk-warning-text__icon')
+      expect($icon.attr('aria-hidden')).toEqual('true')
+    })
   })
 
-  it('renders attributes', () => {
-    const $ = render('warning-text', {
-      attributes: {
-        'data-test': 'attribute',
-        id: 'my-warning-text'
-      }
+  describe('custom options', () => {
+    it('renders classes', () => {
+      const $ = render('warning-text', examples.classes)
+
+      const $component = $('.govuk-warning-text')
+      expect($component.hasClass('govuk-warning-text--custom-class')).toBeTruthy()
     })
 
-    const $component = $('.govuk-warning-text')
-    expect($component.attr('data-test')).toEqual('attribute')
-    expect($component.attr('id')).toEqual('my-warning-text')
+    it('renders with text option only', () => {
+      const $ = render('warning-text', examples['text only'])
+
+      const $component = $('.govuk-warning-text')
+      expect($component.html()).toContain('Some custom warning text')
+    })
+
+    it('renders custom assistive text', () => {
+      const $ = render('warning-text', examples['icon fallback text only'])
+
+      const $assistiveText = $('.govuk-warning-text__assistive')
+      expect($assistiveText.html()).toContain('Some custom fallback text')
+    })
+
+    it('renders attributes', () => {
+      const $ = render('warning-text', examples.attributes)
+
+      const $component = $('.govuk-warning-text')
+      expect($component.attr('data-test')).toEqual('attribute')
+      expect($component.attr('id')).toEqual('my-warning-text')
+    })
+  })
+
+  describe('html', () => {
+    it('renders escaped html when passed to text', () => {
+      const $ = render('warning-text', examples['html as text'])
+
+      const $component = $('.govuk-warning-text')
+      expect($component.html()).toContain('&lt;span&gt;Some custom warning text&lt;/span&gt;')
+    })
+
+    it('renders html', () => {
+      const $ = render('warning-text', examples.html)
+
+      const $component = $('.govuk-warning-text')
+      expect($component.html()).toContain('<span>Some custom warning text</span>')
+    })
   })
 })

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -29,3 +29,33 @@ examples:
     data:
       text: "If you are not covered by this License), You must: (a) comply with the terms stated above for the purpose of this license. It explains, for example, the production of a Source form, including but not limited to, the implied warranties or conditions of this License, without any additional file created by such Respondent to you under Sections 2.1 and 2.2 above. Larger Works. You may choose to distribute such a notice and a brief idea of what it does."
       iconFallbackText: Warning
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: attributes
+    hidden: true
+    data:
+      attributes:
+        id: my-warning-text
+        data-test: attribute
+  - name: classes
+    hidden: true
+    data:
+      text: Warning text
+      iconFallbackText: Warning
+      classes: govuk-warning-text--custom-class
+  - name: html
+    hidden: true
+    data:
+      html: <span>Some custom warning text</span>
+  - name: html as text
+    hidden: true
+    data:
+      text: <span>Some custom warning text</span>
+  - name: icon fallback text only
+    hidden: true
+    data:
+      iconFallbackText: Some custom fallback text
+  - name: text only
+    hidden: true
+    data:
+      text: Some custom warning text


### PR DESCRIPTION
Resolves https://github.com/alphagov/govuk-frontend/issues/1894

## What

-  Updates component tests to consistently use the examples in the YAML files, and adds any tests for untested params
- Adds a flag to hide examples that we don't want shown in the GOVUK Frontend review app
- Adds a html param and example to the fieldset component as an alternative to `caller`

## Why
Prep work for https://github.com/alphagov/govuk-frontend/issues/1895 

**Note: I've left any examples that were previously visible in the review app as-is for now as I'm not sure what the reasoning was behind adding those particular examples as something to check. It's possible some of those examples could also be hidden with the new flag.**