### PR TITLE
Fix typo: checkbox -> radio

### DIFF
--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -26,7 +26,7 @@ params:
 - name: idPrefix
   type: string
   required: false
-  description: String to prefix id for each checkbox item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
+  description: String to prefix id for each radio item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
 - name: name
   type: string
   required: true
@@ -60,7 +60,7 @@ params:
   - name: hint
     type: object
     required: false
-    description: Provide hint to each checkbox item.
+    description: Provide hint to each radio item.
     isComponent: true
   - name: divider
     type: string


### PR DESCRIPTION
Fixes a typo in the documentation for the radios component; references to checkbox items which should be radio items.