### PR TITLE
Set aria-expanded and aria-hidden attributes on header menu button and menu when page loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ This was added in [pull request #1905: Set navigation and mobile menu labels of 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#1943: Change header menu button label](https://github.com/alphagov/govuk-frontend/pull/1943)
-
+- [#1942: Set aria-expanded and aria-hidden attributes on header menu button and menu when page loads](https://github.com/alphagov/govuk-frontend/pull/1942)
 
 ## 3.8.1 (Fix release)
 

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -34,11 +34,12 @@ Header.prototype.handleClick = function (event) {
 
   // If a button with aria-controls, handle click
   if ($toggleButton && $target) {
-    $target.classList.toggle('govuk-header__navigation--open')
-    $toggleButton.classList.toggle('govuk-header__menu-button--open')
+    var isVisible = $target.classList.toggle('govuk-header__navigation--open')
 
-    $toggleButton.setAttribute('aria-expanded', $toggleButton.getAttribute('aria-expanded') !== 'true')
-    $target.setAttribute('aria-hidden', $target.getAttribute('aria-hidden') === 'false')
+    $toggleButton.classList.toggle('govuk-header__menu-button--open', isVisible)
+
+    $toggleButton.setAttribute('aria-expanded', isVisible)
+    $target.setAttribute('aria-hidden', !isVisible)
   }
 }
 

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -1,46 +1,53 @@
-import '../../vendor/polyfills/Function/prototype/bind'
-import '../../vendor/polyfills/Event' // addEventListener and event.target normalization
+import '../../vendor/polyfills/Event'
 import '../../vendor/polyfills/Element/prototype/classList'
+import '../../vendor/polyfills/Function/prototype/bind'
 
 function Header ($module) {
   this.$module = $module
-}
-
-Header.prototype.init = function () {
-  // Check for module
-  var $module = this.$module
-  if (!$module) {
-    return
-  }
-
-  // Check for button
-  var $toggleButton = $module.querySelector('.govuk-js-header-toggle')
-  if (!$toggleButton) {
-    return
-  }
-
-  // Handle $toggleButton click events
-  $toggleButton.addEventListener('click', this.handleClick.bind(this))
+  this.$menuButton = $module && $module.querySelector('.govuk-js-header-toggle')
+  this.$menu = this.$menuButton && $module.querySelector(
+    '#' + this.$menuButton.getAttribute('aria-controls')
+  )
 }
 
 /**
-* An event handler for click event on $toggleButton
-* @param {object} event event
-*/
-Header.prototype.handleClick = function (event) {
-  var $module = this.$module
-  var $toggleButton = event.target || event.srcElement
-  var $target = $module.querySelector('#' + $toggleButton.getAttribute('aria-controls'))
-
-  // If a button with aria-controls, handle click
-  if ($toggleButton && $target) {
-    var isVisible = $target.classList.toggle('govuk-header__navigation--open')
-
-    $toggleButton.classList.toggle('govuk-header__menu-button--open', isVisible)
-
-    $toggleButton.setAttribute('aria-expanded', isVisible)
-    $target.setAttribute('aria-hidden', !isVisible)
+ * Initialise header
+ *
+ * Check for the presence of the header, menu and menu button – if any are
+ * missing then there's nothing to do so return early.
+ */
+Header.prototype.init = function () {
+  if (!this.$module || !this.$menuButton || !this.$menu) {
+    return
   }
+
+  this.syncState(this.$menu.classList.contains('govuk-header__navigation--open'))
+  this.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind(this))
+}
+
+/**
+ * Sync menu state
+ *
+ * Sync the menu button class and the accessible state of the menu and the menu
+ * button with the visible state of the menu
+ *
+ * @param {boolean} isVisible Whether the menu is currently visible
+ */
+Header.prototype.syncState = function (isVisible) {
+  this.$menuButton.classList.toggle('govuk-header__menu-button--open', isVisible)
+  this.$menuButton.setAttribute('aria-expanded', isVisible)
+  this.$menu.setAttribute('aria-hidden', !isVisible)
+}
+
+/**
+ * Handle menu button click
+ *
+ * When the menu button is clicked, change the visibility of the menu and then
+ * sync the accessibility state and menu button state
+ */
+Header.prototype.handleMenuButtonClick = function () {
+  var isVisible = this.$menu.classList.toggle('govuk-header__navigation--open')
+  this.syncState(isVisible)
 }
 
 export default Header

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -1,5 +1,5 @@
 import '../../vendor/polyfills/Function/prototype/bind'
-import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
+import '../../vendor/polyfills/Event' // addEventListener and event.target normalization
 import '../../vendor/polyfills/Element/prototype/classList'
 
 function Header ($module) {

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -1,5 +1,6 @@
 import '../../vendor/polyfills/Function/prototype/bind'
 import '../../vendor/polyfills/Event' // addEventListener and event.target normaliziation
+import '../../vendor/polyfills/Element/prototype/classList'
 
 function Header ($module) {
   this.$module = $module
@@ -23,19 +24,6 @@ Header.prototype.init = function () {
 }
 
 /**
-* Toggle class
-* @param {object} node element
-* @param {string} className to toggle
-*/
-Header.prototype.toggleClass = function (node, className) {
-  if (node.className.indexOf(className) > 0) {
-    node.className = node.className.replace(' ' + className, '')
-  } else {
-    node.className += ' ' + className
-  }
-}
-
-/**
 * An event handler for click event on $toggleButton
 * @param {object} event event
 */
@@ -46,8 +34,8 @@ Header.prototype.handleClick = function (event) {
 
   // If a button with aria-controls, handle click
   if ($toggleButton && $target) {
-    this.toggleClass($target, 'govuk-header__navigation--open')
-    this.toggleClass($toggleButton, 'govuk-header__menu-button--open')
+    $target.classList.toggle('govuk-header__navigation--open')
+    $toggleButton.classList.toggle('govuk-header__menu-button--open')
 
     $toggleButton.setAttribute('aria-expanded', $toggleButton.getAttribute('aria-expanded') !== 'true')
     $target.setAttribute('aria-hidden', $target.getAttribute('aria-hidden') === 'false')

--- a/src/govuk/components/header/header.test.js
+++ b/src/govuk/components/header/header.test.js
@@ -7,133 +7,146 @@ const PORT = configPaths.ports.test
 
 const baseUrl = 'http://localhost:' + PORT
 
-beforeAll(async (done) => {
-  await page.emulate(iPhone)
-  done()
-})
+describe('Header navigation', () => {
+  beforeAll(async (done) => {
+    await page.emulate(iPhone)
+    done()
+  })
 
-describe('/components/header', () => {
-  describe('/components/header/with-navigation/preview', () => {
-    describe('when JavaScript is unavailable or fails', () => {
-      beforeAll(async () => {
-        await page.setJavaScriptEnabled(false)
-      })
-
-      afterAll(async () => {
-        await page.setJavaScriptEnabled(true)
-      })
-
-      it('falls back to making the navigation visible', async () => {
-        await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
-        const isContentVisible = await page.waitForSelector('.govuk-header__navigation', { visible: true, timeout: 1000 })
-        expect(isContentVisible).toBeTruthy()
+  describe('when JavaScript is unavailable or fails', () => {
+    beforeAll(async () => {
+      await page.setJavaScriptEnabled(false)
+      await page.goto(`${baseUrl}/components/header/with-navigation/preview`, {
+        waitUntil: 'load'
       })
     })
 
-    describe('when JavaScript is available', () => {
-      describe('when no navigation is present', () => {
-        it('exits gracefully with no errors', async () => {
-          // Errors logged to the console will cause this test to fail
-          await page.goto(baseUrl + '/components/header/preview', { waitUntil: 'load' })
+    afterAll(async () => {
+      await page.setJavaScriptEnabled(true)
+    })
+
+    it('shows the navigation', async () => {
+      await expect(page).toMatchElement('.govuk-header__navigation', {
+        visible: true,
+        timeout: 1000
+      })
+    })
+  })
+
+  describe('when JavaScript is available', () => {
+    describe('when no navigation is present', () => {
+      it('exits gracefully with no errors', async () => {
+        // Errors logged to the console will cause this test to fail
+        await page.goto(`${baseUrl}/components/header/preview`, {
+          waitUntil: 'load'
+        })
+      })
+    })
+
+    describe('on page load', () => {
+      beforeAll(async () => {
+        await page.goto(`${baseUrl}/components/header/with-navigation/preview`, {
+          waitUntil: 'load'
         })
       })
 
-      describe('on page load', () => {
-        beforeAll(async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
-        })
+      it('exposes the hidden state of the menu using aria-hidden', async () => {
+        const ariaHidden = await page.$eval('.govuk-header__navigation',
+          el => el.getAttribute('aria-hidden')
+        )
 
-        it('exposes the hidden state of the menu using aria-hidden', async () => {
-          const ariaHidden = await page.$eval('.govuk-header__navigation', el => el.getAttribute('aria-hidden'))
-
-          expect(ariaHidden).toBe('true')
-        })
-
-        it('exposes the collapsed state of the menu button using aria-expanded', async () => {
-          const ariaExpanded = await page.$eval('.govuk-header__menu-button', el => el.getAttribute('aria-expanded'))
-
-          expect(ariaExpanded).toBe('false')
-        })
+        expect(ariaHidden).toBe('true')
       })
 
-      describe('when menu button is pressed', () => {
-        it('should indicate the open state of the toggle button', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+      it('exposes the collapsed state of the menu button using aria-expanded', async () => {
+        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
+          el => el.getAttribute('aria-expanded')
+        )
 
-          await page.click('.govuk-js-header-toggle')
+        expect(ariaExpanded).toBe('false')
+      })
+    })
 
-          const toggleButtonIsOpen = await page.evaluate(() => document.body.querySelector('.govuk-header__menu-button').classList.contains('govuk-header__menu-button--open'))
-          expect(toggleButtonIsOpen).toBeTruthy()
+    describe('when menu button is pressed', () => {
+      beforeAll(async () => {
+        await page.goto(`${baseUrl}/components/header/with-navigation/preview`, {
+          waitUntil: 'load'
         })
-
-        it('should indicate the expanded state of the toggle button using aria-expanded', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
-
-          await page.click('.govuk-js-header-toggle')
-
-          const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.govuk-header__menu-button').getAttribute('aria-expanded'))
-          expect(toggleButtonAriaExpanded).toBe('true')
-        })
-
-        it('should indicate the open state of the navigation', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
-
-          await page.click('.govuk-js-header-toggle')
-
-          const navigationIsOpen = await page.evaluate(() => document.body.querySelector('.govuk-header__navigation').classList.contains('govuk-header__navigation--open'))
-          expect(navigationIsOpen).toBeTruthy()
-        })
-
-        it('should indicate the visible state of the navigation using aria-hidden', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
-
-          await page.click('.govuk-js-header-toggle')
-
-          const navigationAriaHidden = await page.evaluate(() => document.body.querySelector('.govuk-header__navigation').getAttribute('aria-hidden'))
-          expect(navigationAriaHidden).toBe('false')
-        })
+        await page.click('.govuk-js-header-toggle')
       })
 
-      describe('when menu button is pressed twice', () => {
-        it('should indicate the open state of the toggle button', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+      it('adds the --open modifier class to the menu, making it visible', async () => {
+        const hasOpenClass = await page.$eval('.govuk-header__navigation',
+          el => el.classList.contains('govuk-header__navigation--open')
+        )
 
-          await page.click('.govuk-js-header-toggle')
-          await page.click('.govuk-js-header-toggle')
+        expect(hasOpenClass).toBeTruthy()
+      })
 
-          const toggleButtonIsOpen = await page.evaluate(() => document.body.querySelector('.govuk-header__menu-button').classList.contains('govuk-header__menu-button--open'))
-          expect(toggleButtonIsOpen).toBeFalsy()
+      it('adds the --open modifier class to the menu button', async () => {
+        const hasOpenClass = await page.$eval('.govuk-header__menu-button',
+          el => el.classList.contains('govuk-header__menu-button--open')
+        )
+
+        expect(hasOpenClass).toBeTruthy()
+      })
+
+      it('exposes the visible state of the menu using aria-hidden', async () => {
+        const ariaHidden = await page.$eval('.govuk-header__navigation',
+          el => el.getAttribute('aria-hidden')
+        )
+
+        expect(ariaHidden).toBe('false')
+      })
+
+      it('exposes the expanded state of the menu button using aria-expanded', async () => {
+        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
+          el => el.getAttribute('aria-expanded')
+        )
+
+        expect(ariaExpanded).toBe('true')
+      })
+    })
+
+    describe('when menu button is pressed twice', () => {
+      beforeAll(async () => {
+        await page.goto(`${baseUrl}/components/header/with-navigation/preview`, {
+          waitUntil: 'load'
         })
+        await page.click('.govuk-js-header-toggle')
+        await page.click('.govuk-js-header-toggle')
+      })
 
-        it('should indicate the expanded state of the toggle button using aria-expanded', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+      it('removes the --open modifier class from the menu, hiding it', async () => {
+        const hasOpenClass = await page.$eval('.govuk-header__navigation',
+          el => el.classList.contains('govuk-header__navigation--open')
+        )
 
-          await page.click('.govuk-js-header-toggle')
-          await page.click('.govuk-js-header-toggle')
+        expect(hasOpenClass).toBeFalsy()
+      })
 
-          const toggleButtonAriaExpanded = await page.evaluate(() => document.body.querySelector('.govuk-header__menu-button').getAttribute('aria-expanded'))
-          expect(toggleButtonAriaExpanded).toBe('false')
-        })
+      it('removes the --open modifier class from the menu button', async () => {
+        const hasOpenClass = await page.$eval('.govuk-header__menu-button',
+          el => el.classList.contains('govuk-header__menu-button--open')
+        )
 
-        it('should indicate the open state of the navigation', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+        expect(hasOpenClass).toBeFalsy()
+      })
 
-          await page.click('.govuk-js-header-toggle')
-          await page.click('.govuk-js-header-toggle')
+      it('exposes the hidden state of the menu using aria-hidden', async () => {
+        const ariaHidden = await page.$eval('.govuk-header__navigation',
+          el => el.getAttribute('aria-hidden')
+        )
 
-          const navigationIsOpen = await page.evaluate(() => document.body.querySelector('.govuk-header__navigation').classList.contains('govuk-header__navigation--open'))
-          expect(navigationIsOpen).toBeFalsy()
-        })
+        expect(ariaHidden).toBe('true')
+      })
 
-        it('should indicate the visible state of the navigation using aria-hidden', async () => {
-          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+      it('exposes the collapsed state of the menu button using aria-expanded', async () => {
+        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
+          el => el.getAttribute('aria-expanded')
+        )
 
-          await page.click('.govuk-js-header-toggle')
-          await page.click('.govuk-js-header-toggle')
-
-          const navigationAriaHidden = await page.evaluate(() => document.body.querySelector('.govuk-header__navigation').getAttribute('aria-hidden'))
-          expect(navigationAriaHidden).toBe('true')
-        })
+        expect(ariaExpanded).toBe('false')
       })
     })
   })

--- a/src/govuk/components/header/header.test.js
+++ b/src/govuk/components/header/header.test.js
@@ -31,6 +31,31 @@ describe('/components/header', () => {
     })
 
     describe('when JavaScript is available', () => {
+      describe('when no navigation is present', () => {
+        it('exits gracefully with no errors', async () => {
+          // Errors logged to the console will cause this test to fail
+          await page.goto(baseUrl + '/components/header/preview', { waitUntil: 'load' })
+        })
+      })
+
+      describe('on page load', () => {
+        beforeAll(async () => {
+          await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })
+        })
+
+        it('exposes the hidden state of the menu using aria-hidden', async () => {
+          const ariaHidden = await page.$eval('.govuk-header__navigation', el => el.getAttribute('aria-hidden'))
+
+          expect(ariaHidden).toBe('true')
+        })
+
+        it('exposes the collapsed state of the menu button using aria-expanded', async () => {
+          const ariaExpanded = await page.$eval('.govuk-header__menu-button', el => el.getAttribute('aria-expanded'))
+
+          expect(ariaExpanded).toBe('false')
+        })
+      })
+
       describe('when menu button is pressed', () => {
         it('should indicate the open state of the toggle button', async () => {
           await page.goto(baseUrl + '/components/header/with-navigation/preview', { waitUntil: 'load' })


### PR DESCRIPTION
Expose the hidden / collapsed state of the navigation on page load, rather than only after the menu button to be interacted with for the first time.

I've ended up re-writing most of the component to try and simplify it, and to avoid duplicating any logic that sets the aria attributes.

I've also updated the tests to use `page.$eval` and to avoid unnecessary navigations, by navigating and interacting with the menu button in a single `beforeAll` block and then making the assertions in individual tests.

Fixes #1932 