### PR TITLE
Add print styles for the panel component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#1943: Change header menu button label](https://github.com/alphagov/govuk-frontend/pull/1943)
 - [#1942: Set aria-expanded and aria-hidden attributes on header menu button and menu when page loads](https://github.com/alphagov/govuk-frontend/pull/1942)
+- [#1947 Add print styles for the panel component](https://github.com/alphagov/govuk-frontend/pull/1947)
 
 ## 3.8.1 (Fix release)
 

--- a/src/govuk/components/panel/_index.scss
+++ b/src/govuk/components/panel/_index.scss
@@ -20,6 +20,12 @@
   .govuk-panel--confirmation {
     color: govuk-colour("white");
     background: govuk-colour("green", $legacy: "turquoise");
+
+    @include govuk-media-query($media-type: print) {
+      border-color: currentColor;
+      color: $govuk-print-text-colour;
+      background: none;
+    }
   }
 
   .govuk-panel__title {


### PR DESCRIPTION
Because the panel component is currently white text on a green background, it prints without the background with with light grey text (at least in Chrome).

![Screenshot 2020-09-07 at 15 40 46](https://user-images.githubusercontent.com/121939/92398680-f3d08d00-f120-11ea-93d9-9f0917fc5e21.png)

Add print styles to remove the background, set the text colour to black and add a border (like we do when colours are overridden).

![Screenshot 2020-09-07 at 15 40 36](https://user-images.githubusercontent.com/121939/92398693-f9c66e00-f120-11ea-8de3-3a17dd273155.png)

Fixes #1946 