### PR TITLE
Remove duplicate $_govuk-colour-palette-legacy

### DIFF
--- a/src/govuk/settings/_colours-palette.scss
+++ b/src/govuk/settings/_colours-palette.scss
@@ -26,39 +26,6 @@ $govuk-use-legacy-palette: if(
   false
 ) !default;
 
-/// Legacy colour palette
-///
-/// This exists only because you cannot easily set a !default variable
-/// conditionally (thanks to the way scope works in Sass) so we set
-/// `$govuk-colour-palette` using the `if` function.
-///
-/// @access private
-
-$_govuk-colour-palette-legacy: (
-  "purple": #2e358b,
-  "light-purple": #6f72af,
-  "bright-purple": #912b88,
-  "pink": #d53880,
-  "light-pink": #f499be,
-  "red": #b10e1e,
-  "bright-red": #df3034,
-  "orange": #f47738,
-  "brown": #b58840,
-  "yellow": #ffbf47,
-  "light-green": #85994b,
-  "green": #006435,
-  "turquoise": #28a197,
-  "light-blue": #2b8cc4,
-  "blue": #005ea5,
-
-  "black": #0b0c0c,
-  "grey-1": #6f777b,
-  "grey-2": #bfc1c3,
-  "grey-3": #dee0e2,
-  "grey-4": #f8f8f8,
-  "white": #ffffff
-);
-
 /// Modern colour palette
 ///
 /// This exists only because you cannot easily set a !default variable


### PR DESCRIPTION
We ended up with two `$_govuk-colour-palette-legacy` as a result of a messy rebase when switching from sass-lint to stylelint. This removes the duplicate definition.