### PR TITLE
Remove deprecated `$govuk-border-width-form-element-error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+### Breaking changes
+You must make the following changes when you migrate to this release, or your service may break.
+
+#### Remove deprecated $govuk-border-width-form-element-error
+To make sure the border width of form elements in their error state is the same as form elements in their normal state, we've deprecated the `$govuk-border-width-form-element-error` setting.
+
+You must remove this setting. Otherwise, you would have to conditionally add overrides if users changed the `$govuk-border-width-form-element` to maintain a consistent focus state.
+
+This was added in [pull request 1963: Remove deprecated `$govuk-border-width-form-element-error` setting](https://github.com/alphagov/govuk-frontend/pull/1963).
+
+
 ## 3.14.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -52,7 +52,7 @@
   }
 
   .govuk-input--error {
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+    border-color: $govuk-error-colour;
 
     &:focus {
       border-color: $govuk-input-border-colour;

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -40,7 +40,7 @@
   }
 
   .govuk-select--error {
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+    border-color: $govuk-error-colour;
 
     &:focus {
       border-color: $govuk-input-border-colour;

--- a/src/govuk/components/textarea/_index.scss
+++ b/src/govuk/components/textarea/_index.scss
@@ -38,7 +38,7 @@
   }
 
   .govuk-textarea--error {
-    border: $govuk-border-width-form-element-error solid $govuk-error-colour;
+    border-color: $govuk-error-colour;
 
     &:focus {
       border-color: $govuk-input-border-colour;

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -73,16 +73,6 @@ $govuk-border-width-narrow: 4px !default;
 
 $govuk-border-width-form-element: 2px !default;
 
-/// Form control border width when in error state
-///
-/// @type Number
-/// @access public
-/// @deprecated Use $govuk-border-width-form-element instead. There should be no
-///   difference in thickness for inputs in the error state, in order to
-///   maintain a distinct focus state.
-
-$govuk-border-width-form-element-error: 2px !default;
-
 /// Form group border width when in error state
 ///
 /// @type Number


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1871

Depends on https://github.com/alphagov/govuk-frontend/issues/1958 being decided first. 