### PR TITLE
Fix navigation links in the header not being announced by screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#1967: Fix navigation links in the header not being announced by screen readers](https://github.com/alphagov/govuk-frontend/pull/1967)
+
 ## 3.9.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -36,7 +36,6 @@ Header.prototype.init = function () {
 Header.prototype.syncState = function (isVisible) {
   this.$menuButton.classList.toggle('govuk-header__menu-button--open', isVisible)
   this.$menuButton.setAttribute('aria-expanded', isVisible)
-  this.$menu.setAttribute('aria-hidden', !isVisible)
 }
 
 /**

--- a/src/govuk/components/header/header.test.js
+++ b/src/govuk/components/header/header.test.js
@@ -50,14 +50,6 @@ describe('Header navigation', () => {
         })
       })
 
-      it('exposes the hidden state of the menu using aria-hidden', async () => {
-        const ariaHidden = await page.$eval('.govuk-header__navigation',
-          el => el.getAttribute('aria-hidden')
-        )
-
-        expect(ariaHidden).toBe('true')
-      })
-
       it('exposes the collapsed state of the menu button using aria-expanded', async () => {
         const ariaExpanded = await page.$eval('.govuk-header__menu-button',
           el => el.getAttribute('aria-expanded')
@@ -89,14 +81,6 @@ describe('Header navigation', () => {
         )
 
         expect(hasOpenClass).toBeTruthy()
-      })
-
-      it('exposes the visible state of the menu using aria-hidden', async () => {
-        const ariaHidden = await page.$eval('.govuk-header__navigation',
-          el => el.getAttribute('aria-hidden')
-        )
-
-        expect(ariaHidden).toBe('false')
       })
 
       it('exposes the expanded state of the menu button using aria-expanded', async () => {
@@ -131,14 +115,6 @@ describe('Header navigation', () => {
         )
 
         expect(hasOpenClass).toBeFalsy()
-      })
-
-      it('exposes the hidden state of the menu using aria-hidden', async () => {
-        const ariaHidden = await page.$eval('.govuk-header__navigation',
-          el => el.getAttribute('aria-hidden')
-        )
-
-        expect(ariaHidden).toBe('true')
       })
 
       it('exposes the collapsed state of the menu button using aria-expanded', async () => {


### PR DESCRIPTION
In 18771ce (released as part of v3.9.0) we changed the logic of the header javascript to set the aria-expanded and aria-hidden attributes on the menu button and navigation respectively.

However, the logic is applied at all breakpoints, not just the mobile breakpoint where the navigation is hidden, and so the navigation is currently not visible to screen reader users.

As noted by @adamsilver, in this instance when the navigation is hidden it is already removed from the accessibility tree through the use of `display: none;`. As such, the `aria-hidden` attribute is redundant and can be removed:

> If an interactive element is hidden using display:none or visibility:hidden (either on the element itself, or any of the element's ancestors), it won't be focusable, and it will also be removed from the accessibility tree. This makes the addition of aria-hidden="true" or explicitly setting tabindex="-1" unnecessary.
>
> https://www.w3.org/TR/using-aria/#4thrule

This means that the only aria attribute we need to keep in sync is the `aria-expanded` attribute – which is applied to the menu control which is hidden when the menu is not collapsible, so it being ‘out of sync’ on the desktop breakpoint is not an issue.

Fixes #1966.