### PR TITLE
Enable custom inputmode for date input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New features
+
+#### Customise input mode in the date component
+
+You can now customise the input mode of each input in the date component to trigger a keyboard of your choice to appear on mobiles.
+
+This was added in [#1975 Enable custom inputmode for date input component](https://github.com/alphagov/govuk-frontend/pull/1975) – thanks to [@foaly-nr1](https://github.com/foaly-nr1) for contributing this.
+
 ## 3.9.1 (Fix release)
 
 ### Fixes

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -293,6 +293,14 @@ examples:
       -
         name: day
         pattern: '[0-8]*'
+- name: custom inputmode
+  hidden: true
+  data:
+    items:
+      -
+        name: day
+        pattern: '[0-9X]*'
+        inputmode: 'text'
 - name: with nested name
   hidden: true
   data:

--- a/src/govuk/components/date-input/template.njk
+++ b/src/govuk/components/date-input/template.njk
@@ -66,7 +66,7 @@
         name: (params.namePrefix + "-" + item.name) if params.namePrefix else item.name,
         value: item.value,
         type: "text",
-        inputmode: "numeric",
+        inputmode: item.inputmode if item.inputmode else "numeric",
         autocomplete: item.autocomplete,
         pattern: item.pattern if item.pattern else "[0-9]*",
         attributes: item.attributes

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -173,6 +173,13 @@ describe('Date input', () => {
       expect($firstInput.attr('pattern')).toEqual('[0-8]*')
     })
 
+    it('renders inputs with custom inputmode="text"', () => {
+      const $ = render('date-input', examples['custom inputmode'])
+
+      const $firstInput = $('.govuk-date-input__item:first-child input')
+      expect($firstInput.attr('inputmode')).toEqual('text')
+    })
+
     it('renders with a form group wrapper that has extra classes', () => {
       const $ = render('date-input', examples['with optional form-group classes'])
 


### PR DESCRIPTION
Some government websites allow the input of `X` characters in the day and month fields of a date when the values are unknown. In this case the `pattern` would need to be changed to `[0-9X]*` along with changing the `inputmode` to `text`.