### PR TITLE
Add notifications banner template macro and tests

### DIFF
--- a/src/govuk/components/notification-banner/README.md
+++ b/src/govuk/components/notification-banner/README.md
@@ -1,0 +1,15 @@
+# Notification banner
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the notification banner component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/notification-banner).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/notification-banner/#options-notification-banner-example) for details.

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -1,0 +1,3 @@
+.govuk-notification-banner {
+  display: block;
+}

--- a/src/govuk/components/notification-banner/_notification-banner.scss
+++ b/src/govuk/components/notification-banner/_notification-banner.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/src/govuk/components/notification-banner/macro.njk
+++ b/src/govuk/components/notification-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukNotificationBanner(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -1,0 +1,177 @@
+params:
+- name: text
+  type: string
+  required: true
+  description: If `html` is set, this is not required. Text to use within the notification banner. If `html` is provided, the `text` argument will be ignored.
+- name: html
+  type: string
+  required: true
+  description: If `text` is set, this is not required. HTML to use within the notification banner. If `html` is provided, the `text` argument will be ignored.
+- name: title
+  type: string
+  required: false
+  description: Title text to use within the notification banner. Defaults to 'Important' ('Success' for success type and 'Error' for error type). If `titleHtml` is supplied, the `title` argument will be ignored.
+- name: titleHtml
+  type: string
+  required: false
+  description: Title HTML to use within the notification banner. If `titleHtml` is provided, the `title` argument will be ignored.
+- name: titleHeadingLevel
+  type: string
+  required: false
+  description: Heading level, from 1 to 6. Default is `2`.
+- name: type
+  type: string
+  required: false
+  description: If `type` is set to `success` or `error`, the notification banner sets `role` to `alert` and `tabindex` to `-1`, and JavaScript moves the keyboard focus moves to the notification banner when the page loads. If `type` is not set, the notification banner defaults to setting `role` to `region` and using `aria-labelledby` to provide information for users of assistive technologies.
+- name: role
+  type: string
+  required: false
+  description: Overrides the value of the `role` attribute for the notification banner. Defaults to `region`. If `type` is set to `success` or `error`, defaults to `alert`.
+- name: tabindex
+  type: string/boolean
+  required: false
+  description: Overrides the value of the `tabindex` attribute for the notification banner. Not set by default.  If `type` is set to `success` or `error`, defaults to `-1`; the attribute can be removed by setting `tabindex` to `false`;
+- name: titleId
+  type: string
+  required: false
+  description: Overrides the value of the `id` attribute for the title. `id` used by the `aria-labelledby` attribute on the notification banner to provide information to users of assistive technologies. `id` defaults to `govuk-notification-banner-title` if `role` is set to `region`. If `type` is set to `success` or `error`, `id` is not rendered by default.
+- name: autoFocus
+  type: boolean
+  required: false
+  description: Moves keyboard focus to the notification banner when the page loads. Defaults to `false`. If `type` is set to `success` or `error`, defaults to `true`.
+- name: classes
+  type: string
+  required: false
+  description: Classes to add to the notification banner.
+- name: attributes
+  type: object
+  required: false
+  description: HTML attributes (for example data attributes) to add to the notification banner.
+
+examples:
+- name: default
+  data:
+    text: This publication was withdrawn on 7 March 2014.
+- name: with text as html
+  data:
+    html: |
+      <h3 class="govuk-heading-m">This publication was withdrawn on 7 March 2014</h3><p>Archived and replaced by the <a href="#">new planning guidance</a> launched 6 March 2014 on an external website</p>
+- name: with type as success
+  data:
+    type: success
+    text: Email sent to example@email.com
+- name: with type as error
+  data:
+    type: error
+    text: There was a problem uploading your file. Please try again.
+- name: with a list
+  data:
+    html: |
+      <h3 class="govuk-heading-m">4 files uploaded</h3>
+      <ul class="govuk-list govuk-list--bullet">
+          <li><a href="#">government-strategy.pdf</a></li>
+          <li><a href="#">government-strategy-v2.pdf</a></li>
+          <li><a href="#">government-strategy-v3-FINAL.pdf</a></li>
+          <li><a href="#">government-strategy-v4-FINAL-v2.pdf</a></li>
+      </ul>
+
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+
+- name: custom title
+  hidden: true
+  data:
+    title: Important information
+    text: This publication was withdrawn on 7 March 2014.
+- name: title as html
+  hidden: true
+  data:
+    titleHtml: <span>Important information</span>
+    text: This publication was withdrawn on 7 March 2014.
+- name: title html as text
+  hidden: true
+  data:
+    title: <span>Important information</span>
+    text: This publication was withdrawn on 7 March 2014.
+- name: custom title heading level
+  hidden: true
+  data:
+    titleHeadingLevel: 3
+    text: This publication was withdrawn on 7 March 2014.
+- name: custom title id
+  hidden: true
+  data:
+    titleId: my-id
+    text: This publication was withdrawn on 7 March 2014.
+- name: custom title id with type as success
+  hidden: true
+  data:
+    type: success
+    titleId: my-id
+    text: Email sent to example@email.com
+- name: custom title id with type as error
+  hidden: true
+  data:
+    type: error
+    titleId: my-id
+    text: There was a problem uploading your file. Please try again.
+
+- name: custom text
+  hidden: true
+  data:
+    text: This publication was withdrawn on 7 March 2014.
+- name: html as text
+  hidden: true
+  data:
+    text: <span>This publication was withdrawn on 7 March 2014.</span>
+
+- name:  custom role
+  hidden: true
+  data:
+    role: banner
+    text: This publication was withdrawn on 7 March 2014.
+- name:  role overridden to region
+  hidden: true
+  data:
+    type: success
+    role: region
+    text: Email sent to example@email.com-
+- name: custom tabindex
+  hidden: true
+  data:
+    tabindex: 0
+    text: This publication was withdrawn on 7 March 2014.
+- name: tabindex as false and type as success
+  hidden: true
+  data:
+    type: success
+    tabindex: false
+    text: Email sent to example@email.com
+- name: autoFocus as true
+  hidden: true
+  data:
+    autoFocus: true
+    text: This publication was withdrawn on 7 March 2014.
+- name: autoFocus as false and type as success
+  hidden: true
+  data:
+    type: success
+    autoFocus: false
+    text: Email sent to example@email.com
+
+- name: classes
+  hidden: true
+  data:
+    text: This publication was withdrawn on 7 March 2014.
+    classes: app-my-class
+- name: attributes
+  hidden: true
+  data:
+    text: This publication was withdrawn on 7 March 2014.
+    attributes:
+      my-attribute: value
+
+- name: with invalid type
+  hidden: true
+  data:
+    type: some-type
+    text: This publication was withdrawn on 7 March 2014.

--- a/src/govuk/components/notification-banner/template.njk
+++ b/src/govuk/components/notification-banner/template.njk
@@ -1,0 +1,65 @@
+{%- if params.type == "success" or params.type == "error" %}
+  {% set successOrError = true %}
+{% endif %}
+
+{%- if successOrError %}
+  {% set typeClass = "govuk-notification-banner--" + params.type %}
+{% endif %}
+
+{% if params.role %}
+  {% set role = params.role %}
+{% elif successOrError %}
+  {# If type is success or error, add `role="alert"` to prioritise the information in the notification banner to users of assistive technologies #}
+  {% set role = "alert" %}
+{% else %}
+  {# Otherwise add `role="region"` to make the notification banner a landmark to help users of assistive technologies to navigate to the banner #}
+  {% set role = "region" %}
+{% endif %}
+
+{# Check whether to add `data-auto-focus="true"` which focuses the notification banner on page load #}
+{% if params.autoFocus is defined %}
+  {% set autoFocus = params.autoFocus %}
+{% elif successOrError %}
+  {% set autoFocus = true %}
+{% endif %}
+
+{% if params.tabindex is defined %}
+  {% set tabindex = params.tabindex %}
+{# Make sure that success or error banner should be focused on page load #}
+{% elif successOrError and autoFocus %}
+  {# Make the notification banner focusable #}
+  {% set tabindex = "-1" %}
+{% endif %}
+
+{%- if params.titleHtml %}
+  {% set title = params.titleHtml | safe %}
+{%- elif params.title %}
+  {% set title = params.title %}
+{%- elif params.type == "success" %}
+  {% set title = "Success" %}
+{%- elif params.type == "error" %}
+  {% set title = "Error" %}
+{%- else %}
+  {% set title = "Important" %}
+{%- endif -%}
+
+<div class="govuk-notification-banner {{ typeClass }} {%- if params.classes %} {{ params.classes }}{% endif -%}" role="{{ role }}"
+  {%- if tabindex or tabindex === 0 %} tabindex="{{ tabindex }}" {% endif %}
+  {%- if (role == "region") %} aria-labelledby="{{ params.titleId | default('govuk-notification-banner-title') }}" {%- endif -%}
+  data-module="govuk-notification-banner"
+  {%- if autoFocus -%} data-auto-focus="true"{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  <div class="govuk-notification-banner__header">
+    <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title"{% if (role == "region" or params.titleId) %} id="{{ params.titleId | default('govuk-notification-banner-title') }}" {%- endif %}>
+      {{ title }}
+    </h{{ params.titleHeadingLevel | default(2) }}>
+  </div>
+  <div class="govuk-notification-banner__content">
+    {%- if params.html -%}
+      {{ params.html | safe }}
+    {%- elif params.text -%}
+      {# Set default style for single line content #}
+      <p class="govuk-notification-banner__heading">{{ params.text }}</p>
+    {%- endif -%}
+  </div>
+</div>

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -1,0 +1,348 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('notification-banner')
+
+describe('Notification-banner', () => {
+  describe('default example', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('notification-banner', examples.default)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('aria-labelledby attribute matches the title id', () => {
+      const $ = render('notification-banner', examples.default)
+      const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
+      const titleId = $('.govuk-notification-banner__title').attr('id')
+
+      expect(ariaAttr).toEqual(titleId)
+    })
+
+    it('has role=region attribute', () => {
+      const $ = render('notification-banner', examples.default)
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('role')).toEqual('region')
+    })
+
+    it('does not have tabindex set', () => {
+      const $ = render('notification-banner', examples.default)
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('tabindex')).toBeUndefined()
+    })
+
+    it('has data-module attribute to initialise JavaScript', () => {
+      const $ = render('notification-banner', examples.default)
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('data-module')).toEqual('govuk-notification-banner')
+    })
+
+    it('does not have data-auto-focus attribute to focus component on page load', () => {
+      const $ = render('notification-banner', examples.default)
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('data-auto-focus')).not.toEqual('govuk-auto-focus')
+    })
+
+    it('renders header container', () => {
+      const $ = render('notification-banner', examples.default)
+      const $header = $('.govuk-notification-banner__header')
+
+      expect($header.length).toBeTruthy()
+    })
+
+    it('renders default heading level', () => {
+      const $ = render('notification-banner', examples.default)
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.get(0).tagName).toEqual('h2')
+    })
+
+    it('renders default title text', () => {
+      const $ = render('notification-banner', examples.default)
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('Important')
+    })
+
+    it('renders content', () => {
+      const $ = render('notification-banner', examples.default)
+      const $content = $('.govuk-notification-banner__content')
+
+      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014.</p>')
+    })
+  })
+
+  describe('custom options', () => {
+    it('renders custom title', () => {
+      const $ = render('notification-banner', examples['custom title'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('Important information')
+    })
+
+    it('renders custom content', () => {
+      const $ = render('notification-banner', examples['custom text'])
+      const $content = $('.govuk-notification-banner__content')
+
+      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014.</p>')
+    })
+
+    it('renders custom heading level', () => {
+      const $ = render('notification-banner', examples['custom title heading level'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.get(0).tagName).toEqual('h3')
+    })
+
+    it('renders custom role', () => {
+      const $ = render('notification-banner', examples['custom role'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('role')).toEqual('banner')
+    })
+
+    it('renders aria-labelledby attribute matching the title id when role overridden to region', () => {
+      const $ = render('notification-banner', examples['role overridden to region'])
+      const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
+      const titleId = $('.govuk-notification-banner__title').attr('id')
+
+      expect(ariaAttr).toEqual(titleId)
+    })
+
+    it('renders custom tabindex', () => {
+      const $ = render('notification-banner', examples['custom tabindex'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('tabindex')).toEqual('0')
+    })
+
+    it('renders custom title id', () => {
+      const $ = render('notification-banner', examples['custom title id'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.attr('id')).toEqual('my-id')
+    })
+
+    it('has an aria-labelledby attribute matching the title id', () => {
+      const $ = render('notification-banner', examples['custom title id'])
+      const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
+
+      expect(ariaAttr).toEqual('my-id')
+    })
+
+    it('renders data-auto-focus attribute to focus component on page load', () => {
+      const $ = render('notification-banner', examples['autoFocus as true'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('data-auto-focus')).toEqual('true')
+    })
+
+    it('removes tabindex attribute so component is not focusable', () => {
+      const $ = render('notification-banner', examples['tabindex as false and type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('tabindex')).toBeUndefined()
+    })
+
+    it('removes data-auto-focus attribute so component is not focused on page load', () => {
+      const $ = render('notification-banner', examples['autoFocus as false and type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('data-auto-focus')).toBeUndefined()
+    })
+
+    it('renders classes', () => {
+      const $ = render('notification-banner', examples.classes)
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.hasClass('app-my-class')).toBeTruthy()
+    })
+
+    it('renders attributes', () => {
+      const $ = render('notification-banner', examples.attributes)
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('my-attribute')).toEqual('value')
+    })
+  })
+
+  describe('html', () => {
+    it('renders title as escaped html when passed as text', () => {
+      const $ = render('notification-banner', examples['title html as text'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('&lt;span&gt;Important information&lt;/span&gt;')
+    })
+
+    it('renders title as html', () => {
+      const $ = render('notification-banner', examples['title as html'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('<span>Important information</span>')
+    })
+
+    it(' as escaped html when passed as text', () => {
+      const $ = render('notification-banner', examples['html as text'])
+      const $content = $('.govuk-notification-banner__content')
+
+      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>')
+    })
+
+    it('renders content as html', () => {
+      const $ = render('notification-banner', examples['with text as html'])
+      const $contentHtml = $('.govuk-notification-banner__content')
+
+      expect($contentHtml.html().trim()).toEqual('<h3 class="govuk-heading-m">This publication was withdrawn on 7 March 2014</h3><p>Archived and replaced by the <a href="#">new planning guidance</a> launched 6 March 2014 on an external website</p>')
+    })
+  })
+
+  describe('when success type is passed', () => {
+    it('renders with appropriate class', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.hasClass('govuk-notification-banner--success')).toBeTruthy()
+    })
+
+    it('has role=alert attribute', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('role')).toEqual('alert')
+    })
+
+    it('does not render aria-labelledby', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('aria-labelledby')).toBeUndefined()
+    })
+
+    it('does not render a title id for aria-labelledby', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('id')).toBeUndefined()
+    })
+
+    it('renders custom title id', () => {
+      const $ = render('notification-banner', examples['custom title id with type as success'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.attr('id')).toEqual('my-id')
+    })
+
+    it('has the correct tabindex attribute to be focused', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('tabindex')).toEqual('-1')
+    })
+
+    it('renders data-auto-focus attribute to focus component on page load', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('data-auto-focus')).toEqual('true')
+    })
+
+    it('renders default success title text', () => {
+      const $ = render('notification-banner', examples['with type as success'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('Success')
+    })
+  })
+
+  describe('when error type is passed', () => {
+    it('renders with appropriate class', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.hasClass('govuk-notification-banner--error')).toBeTruthy()
+    })
+
+    it('has role=alert attribute', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('role')).toEqual('alert')
+    })
+
+    it('does not render aria-labbelledby', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('aria-labbelledby')).toBeUndefined()
+    })
+
+    it('does not render a title id for aria-labelledby', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('id')).toBeUndefined()
+    })
+
+    it('renders custom title id', () => {
+      const $ = render('notification-banner', examples['custom title id with type as error'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.attr('id')).toEqual('my-id')
+    })
+
+    it('has the correct tabindex attribute to be focused', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('tabindex')).toEqual('-1')
+    })
+
+    it('renders data-auto-focus attribute to focus component on page load', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('data-auto-focus')).toEqual('true')
+    })
+
+    it('renders default error title text', () => {
+      const $ = render('notification-banner', examples['with type as error'])
+      const $title = $('.govuk-notification-banner__title')
+
+      expect($title.html().trim()).toEqual('Error')
+    })
+  })
+
+  describe('when type that is invalid is passed', () => {
+    it('has role=region attribute', () => {
+      const $ = render('notification-banner', examples['with invalid type'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('role')).toEqual('region')
+    })
+
+    it('does not have tabindex set', () => {
+      const $ = render('notification-banner', examples['with invalid type'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('tabindex')).toBeUndefined()
+    })
+
+    it('does not have data-auto-focus attribute to focus component on page load', () => {
+      const $ = render('notification-banner', examples['with invalid type'])
+      const $component = $('.govuk-notification-banner')
+
+      expect($component.attr('data-auto-focus')).not.toEqual('govuk-auto-focus')
+    })
+  })
+})


### PR DESCRIPTION
This PR adds
- a template macro for the notification banner component
- tests for the template logic
- examples of the component

Please don't review the stylesheets for now, they are from the demo version and need to be worked on separately; this could be done as part of https://github.com/alphagov/govuk-frontend/issues/1934.

Addresses parts of https://github.com/alphagov/govuk-frontend/issues/1935
 

