### PR TITLE
Update required options for components

### DIFF
--- a/src/govuk/components/back-link/back-link.yaml
+++ b/src/govuk/components/back-link/back-link.yaml
@@ -1,12 +1,12 @@
 params:
 - name: text
   type: string
-  required: true
-  description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+  required: false
+  description: Text to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to "Back".
 - name: html
   type: string
-  required: true
-  description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+  required: false
+  description: HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to "Back".
 - name: href
   type: string
   required: true

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -25,7 +25,7 @@ params:
   description: If `maxlength` is set, this is not required. The maximum number of words. If `maxwords` is provided, the `maxlength` argument will be ignored.
 - name: threshold
   type: string
-  required: true
+  required: false
   description: The percentage value of the limit at which point the count message is displayed. If this attribute is set, the count message will be hidden by default.
 - name: label
   type: object

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -51,7 +51,7 @@ params:
   - name: id
     type: string
     required: false
-    description: Specific id attribute for the checkbox item. If omitted, then idPrefix option will be applied.
+    description: Specific id attribute for the checkbox item. If omitted, then component global `idPrefix` option will be applied.
   - name: name
     type: string
     required: false

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -54,7 +54,7 @@ params:
     description: Specific id attribute for the checkbox item. If omitted, then idPrefix option will be applied.
   - name: name
     type: string
-    required: true
+    required: false
     description: Specific name for the checkbox item. If omitted, then component global `name` string will be applied.
   - name: value
     type: string

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -22,7 +22,7 @@ params:
     description: Item-specific name attribute.
   - name: label
     type: string
-    required: true
+    required: false
     description: Item-specific label text. If provided, this will be used instead of `name` for item label text.
   - name: value
     type: string

--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -21,6 +21,7 @@ params:
   description: HTML attributes (for example data attributes) to add to the error message span tag
 - name: visuallyHiddenText
   type: string
+  required: false
   description: A visually hidden prefix used before the error message. Defaults to "Error".
 
 accessibilityCriteria: |

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -6,12 +6,15 @@ params:
   params:
   - name: visuallyHiddenTitle
     type: string
+    required: false
     description: Title for a meta item section, which defaults to Support links
   - name: html
     type: string
+    required: false
     description: HTML to add to the meta section of the footer, which will appear below any links specified using meta.items.
   - name: text
     type: string
+    required: false
     description: Text to add to the meta section of the footer, which will appear below any links specified using meta.items. If meta.html is specified, this option is ignored.
   - name: items
     type: array

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -53,11 +53,11 @@ params:
     params:
     - name: text
       type: string
-      required: false
+      required: true
       description: List item text in the navigation section of the footer.
     - name: href
       type: string
-      required: false
+      required: true
       description: List item href attribute in the navigation section of the footer. Both `text` and `href` attributes need to be present to create a link.
     - name: attributes
       type: object

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -40,7 +40,7 @@ params:
   params:
   - name: title
     type: string
-    required: false
+    required: true
     description: Title for a section
   - name: columns
     type: integer

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -23,11 +23,11 @@ params:
     params:
     - name: text
       type: string
-      required: false
+      required: true
       description: List item text in the meta section of the footer.
     - name: href
       type: string
-      required: false
+      required: true
       description: List item href attribute in the meta section of the footer.
     - name: attributes
       type: object

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -26,11 +26,11 @@ params:
   params:
   - name: text
     type: string
-    required: false
+    required: true
     description: Text for the navigation item. If `html` is provided, the `text` argument will be ignored.
   - name: html
     type: string
-    required: false
+    required: true
     description: HTML for the navigation item. If `html` is provided, the `text` argument will be ignored.
   - name: href
     type: string

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -13,7 +13,7 @@ params:
   description: Type of input control to render. Defaults to "text".
 - name: inputmode
   type: string
-  require: false
+  required: false
   description: Optional value for [inputmode](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode).
 - name: value
   type: string

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -19,7 +19,7 @@ params:
   - name: id
     type: string
     required: true
-    description: Specific id attribute for the tab item. If omitted, then `idPrefix` string will be applied.
+    description: Specific id attribute for the tab item. If omitted, then `idPrefix` string is required instead.
   - name: label
     type: string
     required: true

--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -107,17 +107,19 @@ describe('package/', () => {
       return readFile(filePath, 'utf8')
         .then((data) => {
           var parsedData = JSON.parse(data)
+
           // We expect the component JSON to contain "name", "type", "required", "description"
-          expect(parsedData).toEqual(
-            expect.arrayContaining([
+          expect(parsedData).toBeInstanceOf(Array)
+          parsedData.forEach((option) => {
+            expect(option).toEqual(
               expect.objectContaining({
                 name: expect.any(String),
                 type: expect.any(String),
                 required: expect.any(Boolean),
                 description: expect.any(String)
               })
-            ])
-          )
+            )
+          })
         })
         .catch(error => {
           throw error
@@ -135,15 +137,19 @@ describe('package/', () => {
           expect(parsedData).toEqual(
             expect.objectContaining({
               component: name,
-              fixtures: expect.arrayContaining([
-                expect.objectContaining({
-                  name: expect.any(String),
-                  options: expect.any(Object),
-                  html: expect.any(String)
-                })
-              ])
+              fixtures: expect.any(Object)
             })
           )
+
+          parsedData.fixtures.forEach((fixture) => {
+            expect(fixture).toEqual(
+              expect.objectContaining({
+                name: expect.any(String),
+                options: expect.any(Object),
+                html: expect.any(String)
+              })
+            )
+          })
         })
         .catch(error => {
           throw error


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/1965

## What

- Updates some component yaml files to mark certain options as `required: false`
- Add any missing `required` attributes to options 
- Attempt to clarify option descriptions where certain options depend on/override the other

Not included:

- Phase banner - tag is marked as `required: false` but failing to pass a tag means that a blank tag (with background colour) is rendered. See [issue here](https://github.com/alphagov/govuk-frontend/issues/1930).