### PR TITLE
Style notification banner

### DIFF
--- a/src/govuk/components/_all.scss
+++ b/src/govuk/components/_all.scss
@@ -19,6 +19,7 @@
 @import "input/index";
 @import "inset-text/index";
 @import "label/index";
+@import "notification-banner/index";
 @import "panel/index";
 @import "phase-banner/index";
 @import "tabs/index";

--- a/src/govuk/components/error-summary/_index.scss
+++ b/src/govuk/components/error-summary/_index.scss
@@ -37,17 +37,7 @@
 
   .govuk-error-summary__list a {
     @include govuk-typography-weight-bold;
-
-    // Override default link styling to use error colour
-    &:link,
-    &:visited,
-    &:hover,
-    &:active {
-      color: $govuk-error-colour;
-    }
-
-    &:focus {
-      @include govuk-focused-text;
-    }
+    @include govuk-link-common;
+    @include govuk-link-style-error;
   }
 }

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -1,3 +1,75 @@
-.govuk-notification-banner {
-  display: block;
+@include govuk-exports("govuk/component/notification-banner") {
+  .govuk-notification-banner {
+    @include govuk-font($size: 19);
+    @include govuk-responsive-margin(8, "bottom");
+
+    border: $govuk-border-width solid $govuk-brand-colour;
+
+    &:focus {
+      outline: $govuk-focus-width solid $govuk-focus-colour;
+    }
+  }
+
+  .govuk-notification-banner--success {
+    border-color: $govuk-success-colour;
+  }
+
+  .govuk-notification-banner--error {
+    border-color: $govuk-error-colour;
+  }
+
+  .govuk-notification-banner__header {
+    padding: 2px govuk-spacing(3) govuk-spacing(1);
+
+    // Ensures the notification header appears separate to the notification body text in high contrast mode
+    border-bottom: 1px solid transparent;
+
+    background-color: $govuk-brand-colour;
+
+    @include govuk-media-query($from: tablet) {
+      padding: 2px govuk-spacing(4) govuk-spacing(1);
+    }
+  }
+
+  .govuk-notification-banner--success .govuk-notification-banner__header {
+    background-color: $govuk-success-colour;
+  }
+
+  .govuk-notification-banner--error .govuk-notification-banner__header {
+    background-color: $govuk-error-colour;
+  }
+
+  .govuk-notification-banner__title {
+    @include govuk-font($size: 19, $weight: bold);
+
+    margin: 0;
+
+    padding: 0;
+
+    color: govuk-colour("white");
+  }
+
+  .govuk-notification-banner__content {
+    @include govuk-font($size: 24, $weight: bold);
+
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      padding: govuk-spacing(4);
+    }
+  }
+
+  .govuk-notification-banner__link {
+    @include govuk-typography-weight-bold;
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+  }
+
+  .govuk-notification-banner__link--success {
+    @include govuk-link-style-success;
+  }
+
+  .govuk-notification-banner__link--error {
+    @include govuk-link-style-error;
+  }
 }

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -10,14 +10,6 @@
     }
   }
 
-  .govuk-notification-banner--success {
-    border-color: $govuk-success-colour;
-  }
-
-  .govuk-notification-banner--error {
-    border-color: $govuk-error-colour;
-  }
-
   .govuk-notification-banner__header {
     padding: 2px govuk-spacing(3) govuk-spacing(1);
 
@@ -29,14 +21,6 @@
     @include govuk-media-query($from: tablet) {
       padding: 2px govuk-spacing(4) govuk-spacing(1);
     }
-  }
-
-  .govuk-notification-banner--success .govuk-notification-banner__header {
-    background-color: $govuk-success-colour;
-  }
-
-  .govuk-notification-banner--error .govuk-notification-banner__header {
-    background-color: $govuk-error-colour;
   }
 
   .govuk-notification-banner__title {
@@ -60,16 +44,31 @@
   }
 
   .govuk-notification-banner__link {
-    @include govuk-typography-weight-bold;
     @include govuk-link-common;
     @include govuk-link-style-default;
   }
 
-  .govuk-notification-banner__link--success {
-    @include govuk-link-style-success;
+  .govuk-notification-banner--success {
+    border-color: $govuk-success-colour;
+
+    .govuk-notification-banner__header {
+      background-color: $govuk-success-colour;
+    }
+
+    .govuk-notification-banner__link {
+      @include govuk-link-style-success;
+    }
   }
 
-  .govuk-notification-banner__link--error {
-    @include govuk-link-style-error;
+  .govuk-notification-banner--error {
+    border-color: $govuk-error-colour;
+
+    .govuk-notification-banner__header {
+      background-color: $govuk-error-colour;
+    }
+
+    .govuk-notification-banner__link {
+      @include govuk-link-style-error;
+    }
   }
 }

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -34,13 +34,19 @@
   }
 
   .govuk-notification-banner__content {
-    @include govuk-font($size: 24, $weight: bold);
-
-    padding: govuk-spacing(3);
+    margin: govuk-spacing(3);
 
     @include govuk-media-query($from: tablet) {
-      padding: govuk-spacing(4);
+      margin: govuk-spacing(4);
     }
+  }
+
+  .govuk-notification-banner__heading {
+    @include govuk-font($size: 24, $weight: bold);
+
+    margin: 0 0 govuk-spacing(3) 0;
+
+    padding: 0;
   }
 
   .govuk-notification-banner__link {

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -60,19 +60,29 @@ examples:
   data:
     type: success
     text: Email sent to example@email.com
+- name: success with custom html
+  data:
+    type: success
+    html: |
+      <h3 class="govuk-heading-m">4 files uploaded</h3><ul class="govuk-!-margin-0 govuk-list"><li><a href="link-1" class="govuk-notification-banner__link govuk-notification-banner__link--success">government-strategy.pdf</a></li><li><a href="link-2" class="govuk-notification-banner__link govuk-notification-banner__link--success">government-strategy-v1.pdf</a></li></ul>
 - name: with type as error
   data:
     type: error
     text: There was a problem uploading your file. Please try again.
+- name: error with custom html
+  data:
+    type: error
+    html: |
+      <p class="govuk-!-margin-0 govuk-heading-m">There was a problem uploading your file. <a href="#" class="govuk-notification-banner__link govuk-notification-banner__link--error">Please try again.</a></p>
 - name: with a list
   data:
     html: |
       <h3 class="govuk-heading-m">4 files uploaded</h3>
       <ul class="govuk-list govuk-list--bullet">
-          <li><a href="#">government-strategy.pdf</a></li>
-          <li><a href="#">government-strategy-v2.pdf</a></li>
-          <li><a href="#">government-strategy-v3-FINAL.pdf</a></li>
-          <li><a href="#">government-strategy-v4-FINAL-v2.pdf</a></li>
+          <li><a href="#" class="govuk-notification-banner__link">government-strategy.pdf</a></li>
+          <li><a href="#" class="govuk-notification-banner__link">government-strategy-v2.pdf</a></li>
+          <li><a href="#" class="govuk-notification-banner__link">government-strategy-v3-FINAL.pdf</a></li>
+          <li><a href="#" class="govuk-notification-banner__link">government-strategy-v4-FINAL-v2.pdf</a></li>
       </ul>
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -52,10 +52,13 @@ examples:
 - name: default
   data:
     text: This publication was withdrawn on 7 March 2014.
+- name: paragraph as html heading
+  data:
+    html: <p class="govuk-notification-banner__heading">You have 9 days to send a response.</p>
 - name: with text as html
   data:
     html: |
-      <h3 class="govuk-heading-m">This publication was withdrawn on 7 March 2014</h3><p>Archived and replaced by the <a href="#">new planning guidance</a> launched 6 March 2014 on an external website</p>
+      <h3 class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014</h3><p class="govuk-body">Archived and replaced by the <a href="#" class="govuk-notification-banner__link">new planning guidance</a> launched 6 March 2014 on an external website</p>
 - name: with type as success
   data:
     type: success
@@ -64,7 +67,7 @@ examples:
   data:
     type: success
     html: |
-      <h3 class="govuk-heading-m">4 files uploaded</h3><ul class="govuk-!-margin-0 govuk-list"><li><a href="link-1" class="govuk-notification-banner__link">government-strategy.pdf</a></li><li><a href="link-2" class="govuk-notification-banner__link">government-strategy-v1.pdf</a></li></ul>
+      <h3 class="govuk-notification-banner__heading">4 files uploaded</h3><ul class="govuk-!-margin-0 govuk-list"><li><a href="link-1" class="govuk-notification-banner__link">government-strategy.pdf</a></li><li><a href="link-2" class="govuk-notification-banner__link">government-strategy-v1.pdf</a></li></ul>
 - name: with type as error
   data:
     type: error
@@ -73,12 +76,12 @@ examples:
   data:
     type: error
     html: |
-      <p class="govuk-!-margin-0 govuk-heading-m">There was a problem uploading your file. <a href="#" class="govuk-notification-banner__link">Please try again.</a></p>
+      <p class="govuk-notification-banner__heading">There was a problem uploading your file. <a href="#" class="govuk-notification-banner__link">Please try again.</a></p>
 - name: with a list
   data:
     html: |
-      <h3 class="govuk-heading-m">4 files uploaded</h3>
-      <ul class="govuk-list govuk-list--bullet">
+      <h3 class="govuk-notification-banner__heading">4 files uploaded</h3>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
           <li><a href="#" class="govuk-notification-banner__link">government-strategy.pdf</a></li>
           <li><a href="#" class="govuk-notification-banner__link">government-strategy-v2.pdf</a></li>
           <li><a href="#" class="govuk-notification-banner__link">government-strategy-v3-FINAL.pdf</a></li>

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -64,7 +64,7 @@ examples:
   data:
     type: success
     html: |
-      <h3 class="govuk-heading-m">4 files uploaded</h3><ul class="govuk-!-margin-0 govuk-list"><li><a href="link-1" class="govuk-notification-banner__link govuk-notification-banner__link--success">government-strategy.pdf</a></li><li><a href="link-2" class="govuk-notification-banner__link govuk-notification-banner__link--success">government-strategy-v1.pdf</a></li></ul>
+      <h3 class="govuk-heading-m">4 files uploaded</h3><ul class="govuk-!-margin-0 govuk-list"><li><a href="link-1" class="govuk-notification-banner__link">government-strategy.pdf</a></li><li><a href="link-2" class="govuk-notification-banner__link">government-strategy-v1.pdf</a></li></ul>
 - name: with type as error
   data:
     type: error
@@ -73,7 +73,7 @@ examples:
   data:
     type: error
     html: |
-      <p class="govuk-!-margin-0 govuk-heading-m">There was a problem uploading your file. <a href="#" class="govuk-notification-banner__link govuk-notification-banner__link--error">Please try again.</a></p>
+      <p class="govuk-!-margin-0 govuk-heading-m">There was a problem uploading your file. <a href="#" class="govuk-notification-banner__link">Please try again.</a></p>
 - name: with a list
   data:
     html: |

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -77,9 +77,9 @@ describe('Notification-banner', () => {
 
     it('renders content', () => {
       const $ = render('notification-banner', examples.default)
-      const $content = $('.govuk-notification-banner__content')
+      const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014.</p>')
+      expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
     })
   })
 
@@ -93,9 +93,9 @@ describe('Notification-banner', () => {
 
     it('renders custom content', () => {
       const $ = render('notification-banner', examples['custom text'])
-      const $content = $('.govuk-notification-banner__content')
+      const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014.</p>')
+      expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
     })
 
     it('renders custom heading level', () => {
@@ -194,16 +194,16 @@ describe('Notification-banner', () => {
 
     it(' as escaped html when passed as text', () => {
       const $ = render('notification-banner', examples['html as text'])
-      const $content = $('.govuk-notification-banner__content')
+      const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>')
+      expect($content.html().trim()).toEqual('&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;')
     })
 
     it('renders content as html', () => {
       const $ = render('notification-banner', examples['with text as html'])
       const $contentHtml = $('.govuk-notification-banner__content')
 
-      expect($contentHtml.html().trim()).toEqual('<h3 class="govuk-heading-m">This publication was withdrawn on 7 March 2014</h3><p>Archived and replaced by the <a href="#">new planning guidance</a> launched 6 March 2014 on an external website</p>')
+      expect($contentHtml.html().trim()).toEqual('<h3 class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014</h3><p class="govuk-body">Archived and replaced by the <a href="#" class="govuk-notification-banner__link">new planning guidance</a> launched 6 March 2014 on an external website</p>')
     })
   })
 

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -66,6 +66,106 @@
   }
 }
 
+/// Error link style mixin
+///
+/// Provides the error unvisited, visited, hover and active states for links.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-error;
+///   }
+///
+/// @access public
+
+@mixin govuk-link-style-error {
+  &:link {
+    color: $govuk-error-colour;
+  }
+
+  &:visited {
+    color: $govuk-link-visited-colour;
+  }
+
+  &:hover {
+    color: scale-color($govuk-error-colour, $lightness: -30%);
+  }
+
+  &:active {
+    color: $govuk-error-colour;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector
+  // designed to make unvisited link  s a slightly darker blue when focussed, so
+  // we need to override the text colour for that combination of selectors so
+  // so that unvisited links styled as buttons do not end up with dark blue
+  // text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}
+
+/// Success link style mixin
+///
+/// Provides the success unvisited, visited, hover and active states for links.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-success;
+///   }
+///
+/// @access public
+
+@mixin govuk-link-style-success {
+  &:link {
+    color: $govuk-success-colour;
+  }
+
+  &:visited {
+    color: $govuk-link-visited-colour;
+  }
+
+  &:hover {
+    color: scale-color($govuk-success-colour, $lightness: -30%);
+  }
+
+  &:active {
+    color: $govuk-success-colour;
+  }
+
+  // When focussed, the text colour needs to be darker to ensure that colour
+  // contrast is still acceptable
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector
+  // designed to make unvisited link  s a slightly darker blue when focussed, so
+  // we need to override the text colour for that combination of selectors so
+  // so that unvisited links styled as buttons do not end up with dark blue
+  // text when focussed.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $govuk-focus-text-colour;
+    }
+  }
+}
+
 /// Muted style link mixin
 ///
 /// Used for secondary links on a page - the link will appear in muted colours

--- a/src/govuk/settings/_colours-applied.scss
+++ b/src/govuk/settings/_colours-applied.scss
@@ -86,6 +86,15 @@ $govuk-focus-text-colour: govuk-colour("black") !default;
 
 $govuk-error-colour: govuk-colour("red") !default;
 
+/// Success colour
+///
+/// Used to highlight success messages and banners
+///
+/// @type Colour
+/// @access public
+
+$govuk-success-colour: govuk-colour("green") !default;
+
 /// Border colour
 ///
 /// Used in for example borders, separators, rules and keylines.


### PR DESCRIPTION
Temporarily cherrypicks commits from https://github.com/alphagov/govuk-frontend/pull/1977.
**Please only review commits solely authored by me - others will be removed before merging into feature branch**

## Why
Following on from https://github.com/alphagov/govuk-frontend/issues/1934 and https://github.com/alphagov/govuk-frontend/pull/1977, add the styling for the notification banner component.

Full designs can be found here: https://design-system-mess.herokuapp.com/notification-banner-colour-heading

## What
- Styling added for notification banner component
- Links within the notification banner use a `govuk-notification-banner__link` class
- Added additional examples to show links within error and success notification banners
- Added success and error link style mixins, and applied them to the error summary component too