### PR TITLE
Update examples for conditional reveals on radios and checkboxes

### DIFF
--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -346,7 +346,7 @@ examples:
         text: Email
         conditional:
           html: |
-            <label class="govuk-label" for="context-email">Mobile phone number</label>
+            <label class="govuk-label" for="context-email">Email address</label>
             <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
       - value: phone
         text: Phone
@@ -374,7 +374,7 @@ examples:
       checked: true
       conditional:
         html: |
-          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <label class="govuk-label" for="context-email">Email address</label>
           <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
     - value: phone
       text: Phone
@@ -403,7 +403,7 @@ examples:
       text: Email
       conditional:
         html: |
-          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <label class="govuk-label" for="context-email">Email address</label>
           <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
     - value: phone
       text: Phone

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -213,7 +213,7 @@ describe('Checkboxes', () => {
       const $component = $('.govuk-checkboxes')
 
       const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
-      expect($firstConditional.text().trim()).toContain('Mobile phone number')
+      expect($firstConditional.text().trim()).toContain('Email address')
       expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeTruthy()
     })
     it('visible by default when checked', () => {
@@ -222,7 +222,7 @@ describe('Checkboxes', () => {
       const $component = $('.govuk-checkboxes')
 
       const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
-      expect($firstConditional.text().trim()).toContain('Mobile phone number')
+      expect($firstConditional.text().trim()).toContain('Email address')
       expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeFalsy()
     })
 

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -306,7 +306,7 @@ examples:
         text: Email
         conditional:
           html: |
-            <label class="govuk-label" for="context-email">Mobile phone number</label>
+            <label class="govuk-label" for="context-email">Email address</label>
             <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
       - value: phone
         text: Phone
@@ -392,7 +392,7 @@ examples:
       text: Email
       conditional:
         html: |
-          <label class="govuk-label" for="context-email">Mobile phone number</label>
+          <label class="govuk-label" for="context-email">Email address</label>
           <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
     - value: phone
       text: Phone

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -176,7 +176,7 @@ describe('Radios', () => {
         const $component = $('.govuk-radios')
 
         const $hiddenConditional = $component.find('.govuk-radios__conditional').first()
-        expect($hiddenConditional.text()).toContain('Mobile phone number')
+        expect($hiddenConditional.text()).toContain('Email address')
         expect($hiddenConditional.hasClass('govuk-radios__conditional--hidden')).toBeTruthy()
       })
 


### PR DESCRIPTION
Correctly label the conditionally revealed email address field ‘email address’ rather than ‘mobile phone number’ in the conditional reveals example for checkboxes and radios.