### PR TITLE
Add required fields to examples

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -150,6 +150,7 @@ examples:
 - name: classes
   hidden: true
   data:
+    id: accordion-classes
     classes: myClass
     items:
       - heading:
@@ -159,6 +160,7 @@ examples:
 - name: attributes
   hidden: true
   data:
+    id: accordion-attributes
     attributes:
       data-attribute: value
     items:
@@ -169,6 +171,7 @@ examples:
 - name: custom heading level
   hidden: true
   data:
+    id: accordion-heading
     headingLevel: 3
     items:
       - heading:
@@ -178,6 +181,7 @@ examples:
 - name: heading html
   hidden: true
   data:
+    id: accordion-heading-html
     items:
       - heading:
           html: <span class="myClass">Section A</span>
@@ -186,6 +190,7 @@ examples:
 - name: with falsey values
   hidden: true
   data:
+    id: accordion-falsey
     items:
       - heading:
           text: Section A

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -103,12 +103,18 @@ examples:
   hidden: true
   data:
     classes: app-breadcrumbs--custom-modifier
+    items:
+      -
+        text: Home
 - name: attributes
   hidden: true
   data:
     attributes:
       id: my-navigation
       role: navigation
+    items:
+      -
+        text: Home
 - name: item attributes
   hidden: true
   data:

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -18,6 +18,7 @@ params:
     description: Link for the breadcrumbs item. If not specified, breadcrumbs item is a normal list item.
   - name: attributes
     type: object
+    required: false
     description: HTML attributes (for example data attributes) to add to the individual crumb.
 - name: classes
   type: string

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -146,6 +146,7 @@ examples:
   hidden: true
   data:
     element: button
+    text: Submit
     attributes:
       aria-controls: example-id
       data-tracking-dimension: 123
@@ -153,6 +154,7 @@ examples:
   hidden: true
   data:
     element: a
+    text: Submit
     attributes:
       aria-controls: example-id
       data-tracking-dimension: 123
@@ -160,37 +162,44 @@ examples:
   hidden: true
   data:
     element: input
+    text: Submit
     attributes:
       aria-controls: example-id
       data-tracking-dimension: 123
 - name: classes
   hidden: true
   data:
+    text: Submit
     element: button
     classes: app-button--custom-modifier
 - name: link classes
   hidden: true
   data:
+    text: Submit
     element: a
     classes: app-button--custom-modifier
 - name: input classes
   hidden: true
   data:
+    text: Submit
     element: input
     classes: app-button--custom-modifier
 - name: name
   hidden: true
   data:
+    text: Submit
     element: button
     name: start-now
 - name: type
   hidden: true
   data:
+    text: Submit
     element: button
     type: button
 - name: input type
   hidden: true
   data:
+    text: Submit
     element: input
     type: button
 - name: explicit link
@@ -202,15 +211,18 @@ examples:
 - name: no href
   hidden: true
   data:
+    text: Submit
     element: a
 - name: value
   hidden: true
   data:
+    text: Submit
     element: button
     value: start
 - name: html
   hidden: true
   data:
+    text: Submit
     element: button
     html: Start <em>now</em>
 - name: no data

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -158,33 +158,68 @@ examples:
   - name: classes
     hidden: true
     data:
+      id: with-classes
+      name: with-classes
+      maxlength: 10
+      label:
+        text: With classes
       classes: app-character-count--custom-modifier
   - name: attributes
     hidden: true
     data:
+      id: with-attributes
+      name: with-attributes
+      maxlength: 10
+      label:
+        text: With attributes
       attributes:
         data-attribute: my data value
   - name: formGroup with classes
     hidden: true
     data:
+      id: with-formgroup
+      name: with-formgroup
+      maxlength: 10
+      label:
+        text: With formgroup
       formGroup:
         classes: app-character-count--custom-modifier
   - name: custom classes on countMessage
     hidden: true
     data:
+      id: with-custom-countmessage-class
+      name: with-custom-countmessage-class
+      maxlength: 10
+      label:
+        text: With custom countMessage class
       countMessage:
         classes: app-custom-count-message
   - name: spellcheck enabled
     hidden: true
     data:
+      id: with-spellcheck
+      name: with-spellcheck
+      maxlength: 10
+      label:
+        text: With spellcheck
       spellcheck: true
   - name: spellcheck disabled
     hidden: true
     data:
+      id: without-spellcheck
+      name: without-spellcheck
+      maxlength: 10
+      label:
+        text: Without spellcheck
       spellcheck: false
   - name: custom classes with error message
     hidden: true
     data:
+      id: with-custom-error-class
+      name: with-custom-error-class
+      maxlength: 10
+      label:
+        text: With custom error class
       classes: app-character-count--custom-modifier
       errorMessage:
         text: Error message

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -144,6 +144,7 @@ examples:
 
 - name: with hints on items
   data:
+    name: with-hints-on-items
     fieldset:
       legend:
         text: How do you want to sign in?
@@ -244,7 +245,7 @@ examples:
 
 - name: with fieldset and error message
   data:
-    name: colours
+    name: nationality
     errorMessage:
       text: Please accept the terms and conditions
     fieldset:
@@ -663,6 +664,11 @@ examples:
   hidden: true
   data:
     name: example
+    items:
+      - value: british
+        text: British
+      - value: irish
+        text: Irish
     errorMessage:
       text: Please select an option
     fieldset:
@@ -682,6 +688,11 @@ examples:
         text: What is your nationality?
     hint:
       text: If you have dual nationality, select all options that are relevant to you.
+    items:
+      - value: british
+        text: British
+      - value: irish
+        text: Irish
 - name: label with attributes
   hidden: true
   data:
@@ -706,6 +717,11 @@ examples:
       attributes:
         data-attribute: value
         data-second-attribute: second-value
+    items:
+      - value: british
+        text: British
+      - value: irish
+        text: Irish
 - name: fieldset html params
   hidden: true
   data:
@@ -713,6 +729,11 @@ examples:
     fieldset:
       legend:
         html: What is your <b>nationality</b>?
+    items:
+      - value: british
+        text: British
+      - value: irish
+        text: Irish
 - name: with single option set 'aria-describedby' on input, and describedBy
   hidden: true
   data:
@@ -755,6 +776,11 @@ examples:
       describedBy: some-id
       legend:
         text: What is your nationality?
+    items:
+      - value: british
+        text: British
+      - value: irish
+        text: Irish
 
 
 

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -270,9 +270,6 @@ examples:
           data-example-year: year
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
-- name: no data
-  hidden: true
-  data: {}
 - name: classes
   hidden: true
   data:

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -276,19 +276,23 @@ examples:
 - name: classes
   hidden: true
   data:
+    id: with-classes
     classes: app-date-input--custom-modifier
 - name: attributes
   hidden: true
   data:
+    id: with-attributes
     attributes:
       data-attribute: my data value
 - name: with empty items
   hidden: true
   data:
+    id: with-empty-items
     items: []
 - name: custom pattern
   hidden: true
   data:
+    id: with-custom-pattern
     items:
       -
         name: day
@@ -296,6 +300,7 @@ examples:
 - name: custom inputmode
   hidden: true
   data:
+    id: with-custom-inputmode
     items:
       -
         name: day
@@ -304,6 +309,7 @@ examples:
 - name: with nested name
   hidden: true
   data:
+    id: with-nested-name
     items:
       -
         name: day[dd]
@@ -314,13 +320,17 @@ examples:
 - name: with id on items
   hidden: true
   data:
+    id: with-item-id
     items:
       -
         id: day
+        name: day
       -
         id: month
+        name: month
       -
-        year: year
+        id: year
+        name: year
 - name: suffixed id
   hidden: true
   data:
@@ -335,13 +345,17 @@ examples:
 - name: with values
   hidden: true
   data:
+    id: with-values
     items:
       -
         id: day
+        name: day
       -
         id: month
+        name: month
       -
         id: year
+        name: year
         value: 2018
 - name: with hint and describedBy
   hidden: true
@@ -366,12 +380,14 @@ examples:
 - name: fieldset html
   hidden: true
   data:
+    id: with-fieldset-html
     fieldset:
       legend:
         html: What is your <b>date of birth</b>?
 - name: items with classes
   hidden: true
   data:
+    id: with-item-classes
     items:
       -
         name: day
@@ -385,6 +401,7 @@ examples:
 - name: items without classes
   hidden: true
   data:
+    id: without-item-classes
     items:
       -
         name: day

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -94,7 +94,7 @@ describe('Date input', () => {
     })
 
     it('renders with default items', () => {
-      const $ = render('date-input', examples['no data'])
+      const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
       const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')

--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -67,29 +67,39 @@ examples:
   hidden: true
   data:
     id: my-details-element
+    summaryText: Expand this section
+    text: Here are some more details
 - name: html as text
   hidden: true
   data:
+    summaryText: Expand this section
     text: More about the greater than symbol (>)
 - name: html
   hidden: true
   data:
+    summaryText: Expand this section
     html: More about <b>bold text</b>
 - name: summary html as text
   hidden: true
   data:
     summaryText: The greater than symbol (>) is the best
+    text: Here are some more details
 - name: summary html
   hidden: true
   data:
     summaryHtml: Use <b>bold text</b> sparingly
+    text: Here are some more details
 - name: classes
   hidden: true
   data:
     classes: some-additional-class
+    text: Here are some more details
+    summaryText: Expand me
 - name: attributes
   hidden: true
   data:
+    text: Here are some more details
+    summaryText: Expand me
     attributes:
       data-some-data-attribute: i-love-data
       another-attribute: true

--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -48,10 +48,12 @@ examples:
   hidden: true
   data:
     id: my-error-message-id
+    text: This is an error message
 - name: classes
   hidden: true
   data:
     classes: custom-class
+    text: This is an error message
 - name: html as text
   hidden: true
   data:
@@ -63,6 +65,7 @@ examples:
 - name: attributes
   hidden: true
   data:
+    text: This is an error message
     attributes:
       data-test: attribute
       id: my-error-message

--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -90,35 +90,62 @@ examples:
   hidden: true
   data:
     titleText: Alert, <em>alert</em>
+    errorList:
+      -
+        text: Invalid username or password
 - name: title html
   hidden: true
   data:
     titleHtml: Alert, <em>alert</em>
+    errorList:
+      -
+        text: Invalid username or password
 - name: description
   hidden: true
   data:
+    titleText: There is a problem
     descriptionText: Lorem ipsum
+    errorList:
+      -
+        text: Invalid username or password
 - name: html as descriptionText
   hidden: true
   data:
+    titleText: There is a problem
     descriptionText: See errors below (▼)
+    errorList:
+      -
+        text: Invalid username or password
 - name: description html
   hidden: true
   data:
+    titleText: There is a problem
     descriptionHtml: See <span>errors</span> below
+    errorList:
+      -
+        text: Invalid username or password
 - name: classes
   hidden: true
   data:
+    titleText: There is a problem
     classes: extra-class one-more-class
+    errorList:
+      -
+        text: Invalid username or password
 - name: attributes
   hidden: true
   data:
+    titleText: There is a problem
     attributes:
       first-attribute: 'true'
       second-attribute: 'false'
+    errorList:
+      -
+        text: Invalid username or password
 - name: error list with attributes
   hidden: true
   data:
+    titleText: There is a problem
     errorList:
       -
         text: Error-1
@@ -129,18 +156,21 @@ examples:
 - name: error list with html as text
   hidden: true
   data:
+    titleText: There is a problem
     errorList:
       -
         text: Descriptive link to the <b>question</b> with an error
 - name: error list with html
   hidden: true
   data:
+    titleText: There is a problem
     errorList:
       -
         html: The date your passport was issued <b>must</b> be in the past
 - name: error list with html link
   hidden: true
   data:
+    titleText: There is a problem
     errorList:
       -
         html: Descriptive link to the <b>question</b> with an error
@@ -148,6 +178,7 @@ examples:
 - name: error list with html as text link
   hidden: true
   data:
+    titleText: There is a problem
     errorList:
       -
         text: Descriptive link to the <b>question</b> with an error

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -100,37 +100,64 @@ examples:
 - name: attributes
   hidden: true
   data:
+    id: file-upload-attributes
+    name: file-upload-attributes
+    label:
+      text: Upload a file
     attributes:
       accept: .jpg, .jpeg, .png
 - name: classes
   hidden: true
   data:
+    id: file-upload-classes
+    name: file-upload-classes
+    label:
+      text: Upload a file
     classes: app-file-upload--custom-modifier
 - name: with describedBy
   hidden: true
   data:
+    id: file-upload-describedby
+    name: file-upload-describedby
+    label:
+      text: Upload a file
     describedBy: some-id
 - name: with hint and describedBy
   hidden: true
   data:
+    id: file-upload-hint-describedby
+    name: file-upload-hint-describedby
+    label:
+      text: Upload a file
     describedBy: some-id
     hint:
       text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
 - name: error
   hidden: true
   data:
-    id: "file-upload-with-error"
+    id: file-upload-with-error
+    name: file-upload-with-error
+    label:
+      text: Upload a file
     errorMessage:
       text: Error message
 - name: with error and describedBy
   hidden: true
   data:
+    id: file-upload-error-describedby
+    name: file-upload-error-describedby
+    label:
+      text: Upload a file
     describedBy: some-id
     errorMessage:
       text: Error message
 - name: with error, describedBy and hint
   hidden: true
   data:
+    id: file-upload-error-describedby-hint
+    name: file-upload-error-describedby-hint
+    label:
+      text: Upload a file
     describedBy: some-id
     errorMessage:
       text: Error message

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -347,7 +347,7 @@ examples:
 - name: with navigation item attributes
   data:
     navigation:
-      -
+      - title: Single column list 1
         items:
           - href: '#1'
             text: Navigation item 1

--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -52,10 +52,12 @@ examples:
   data:
     id: example-hint
     classes: app-hint--custom-modifier
+    text: It's on your National Insurance card, benefit letter, payslip or P60.
 - name: id
   hidden: true
   data:
     id: my-hint
+    text: It's on your National Insurance card, benefit letter, payslip or P60.
 - name: html as text
   hidden: true
   data:
@@ -63,5 +65,6 @@ examples:
 - name: attributes
   hidden: true
   data:
+    text: It's on your National Insurance card, benefit letter, payslip or P60.
     attributes:
       data-attribute: my data value

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -311,39 +311,71 @@ examples:
   - name: classes
     hidden: true
     data:
+      id: with-classes
+      name: with-classes
+      label:
+        text: With classes
       classes: app-input--custom-modifier
   - name: custom type
     hidden: true
     data:
+      id: with-custom-type
+      name: with-custom-type
+      label:
+        text: With custom type
       type: number
   - name: value
     hidden: true
     data:
+      id: with-value
+      name: with-value
+      label:
+        text: With value
       value: QQ 12 34 56 C
   - name: with describedBy
     hidden: true
     data:
+      id: with-describedby
+      name: with-describedby
+      label:
+        text: With describedBy
       describedBy: some-id
   - name: attributes
     hidden: true
     data:
+      id: with-attributes
+      name: with-attributes
+      label:
+        text: With attributes
       attributes:
         data-attribute: my data value
   - name: hint with describedBy
     hidden: true
     data:
+      id: with-hint-describedby
+      name: with-hint-describedby
+      label:
+        text: With hint describedBy
       describedBy: some-id
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
   - name: error with describedBy
     hidden: true
     data:
+      id: with-error-describedby
+      name: with-error-describedby
+      label:
+        text: With error describedBy
       describedBy: some-id
       errorMessage:
         text: Error message
   - name: with error and hint
     hidden: true
     data:
+      id: with-error-hint
+      name: with-error-hint
+      label:
+        text: With error and hint
       errorMessage:
         text: Error message
       hint:
@@ -351,6 +383,10 @@ examples:
   - name: with error, hint and describedBy
     hidden: true
     data:
+      id: with-error-hint-describedby
+      name: with-error-hint-describedby
+      label:
+        text: With error, hint and describedBy
       errorMessage:
         text: Error message
       hint:
@@ -359,6 +395,10 @@ examples:
   - name: inputmode
     hidden: true
     data:
+      id: with-inputmode
+      name: with-inputmode
+      label:
+        text: With inputmode
       inputmode: decimal
 
   - name: with prefix with html as text

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -42,10 +42,12 @@ examples:
     hidden: true
     data:
       classes: app-inset-text--custom-modifier
+      text: It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
   - name: id
     hidden: true
     data:
       id: my-inset-text
+      text: It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
   - name: html as text
     hidden: true
     data:
@@ -53,5 +55,6 @@ examples:
   - name: attributes
     hidden: true
     data:
+      text: It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
       attributes:
         data-attribute: my data value

--- a/src/govuk/components/label/label.yaml
+++ b/src/govuk/components/label/label.yaml
@@ -9,7 +9,7 @@ params:
   description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
 - name: for
   type: string
-  required: true
+  required: false
   description: The value of the for attribute, the id of the input the label is associated with.
 - name: isPageHeading
   type: boolean

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -44,25 +44,33 @@ examples:
   hidden: true
   data:
     titleText: Application <strong>not</strong> complete
+    text: Please complete form 1
 - name: title html
   hidden: true
   data:
     titleHtml: Application <strong>not</strong> complete
+    html: Please complete <strong>form 1</strong>
 - name: body html as text
   hidden: true
   data:
+    titleText: Application complete
     text: Your reference number<br><strong>HDJ2123F</strong>
 - name: body html
   hidden: true
   data:
+    titleText: Application complete
     html: Your reference number<br><strong>HDJ2123F</strong>
 - name: classes
   hidden: true
   data:
+    titleText: Application complete
+    text: Your reference number is HDJ2123F
     classes: extra-class one-more-class
 - name: attributes
   hidden: true
   data:
+    titleText: Application complete
+    text: Your reference number is HDJ2123F
     attributes:
       first-attribute: true
       second-attribute: false

--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -32,6 +32,7 @@ examples:
   - name: classes
     hidden: true
     data:
+      text: This is a new service – your feedback will help us to improve it
       classes: extra-class one-more-class
   - name: text
     hidden: true
@@ -44,17 +45,20 @@ examples:
   - name: attributes
     hidden: true
     data:
+      text: This is a new service – your feedback will help us to improve it
       attributes:
         first-attribute: true
         second-attribute: false
   - name: tag html
     hidden: true
     data:
+      text: This is a new service – your feedback will help us to improve it
       tag:
         html: <em>alpha</em>
   - name: tag classes
     hidden: true
     data:
+      text: This is a new service – your feedback will help us to improve it
       tag:
         classes: govuk-tag--inactive
         text: alpha

--- a/src/govuk/components/radios/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/radios/__snapshots__/template.test.js.snap
@@ -28,6 +28,7 @@ exports[`Radios nested dependant components passes through label params without 
 <label class="govuk-label govuk-radios__label"
        data-attribute="value"
        data-second-attribute="second-value"
+       for="with-label-attributes"
 >
   Yes
 </label>

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -697,9 +697,13 @@ examples:
     hint:
       text: This includes changing your last name or spelling your name differently.
     items:
-      - hint:
+      - value: yes
+        text: Yes
+        hint:
           text: Hint for yes option here
-      - hint:
+      - value: no
+        text: No
+        hint:
           text: Hint for no option here
 - name: with describedBy and hint
   hidden: true
@@ -711,12 +715,22 @@ examples:
         text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: with error message
   hidden: true
   data:
     name: example-error-message
     errorMessage:
       text: Please select an option
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: with error message and idPrefix
   hidden: true
   data:
@@ -724,6 +738,11 @@ examples:
     idPrefix: id-prefix
     errorMessage:
       text: Please select an option
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: with hint and error message
   hidden: true
   data:
@@ -735,6 +754,11 @@ examples:
         text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: with hint, error message and describedBy
   hidden: true
   data:
@@ -747,9 +771,15 @@ examples:
         text: Have you changed your name?
     hint:
       text: This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: label with attributes
   hidden: true
   data:
+    name: with-label-attributes
     items:
       - value: yes
         text: Yes
@@ -770,12 +800,23 @@ examples:
         data-second-attribute: second-value
     hint:
       text: This includes changing your last name or spelling your name differently.
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: fieldset with html
   hidden: true
   data:
+    name: with-fieldset-html
     fieldset:
       legend:
         html: Have <b>you</b> changed your name?
+    items:
+      - value: yes
+        text: Yes
+      - value: no
+        text: No
 - name: with fieldset, error message and describedBy
   hidden: true
   data:

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -172,15 +172,35 @@ examples:
   - name: with describedBy
     hidden: true
     data:
+      id: with-describedby
+      name: with-describedby
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
       describedBy: some-id
   - name: attributes
     hidden: true
     data:
+      id: with-attributes
+      name: with-attributes
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
       attributes:
         data-attribute: my data value
   - name: attributes on items
     hidden: true
     data:
+      id: with-item-attributes
+      name: with-item-attributes
       value: 2
       items:
         -
@@ -196,6 +216,8 @@ examples:
   - name: with falsey values
     hidden: true
     data:
+      id: with-falsey-values
+      name: with-falsey-values
       items:
         -
           text: Option 1
@@ -208,25 +230,50 @@ examples:
     hidden: true
     data:
       id: select-with-hint
+      name: select-with-hint
       hint:
         text: Hint text goes here
   - name: hint and describedBy
     hidden: true
     data:
       id: select-with-hint
+      name: select-with-hint
       describedBy: some-id
       hint:
         text: Hint text goes here
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
   - name: error
     hidden: true
     data:
       id: select-with-error
+      name: select-with-error
       errorMessage:
         text: Error message
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2
   - name: error and describedBy
     hidden: true
     data:
       id: select-with-error
+      name: select-with-error
       describedBy: some-id
       errorMessage:
         text: Error message
+      items:
+        -
+          value: 1
+          text: GOV.UK frontend option 1
+        -
+          value: 2
+          text: GOV.UK frontend option 2

--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -40,6 +40,7 @@ examples:
   - name: custom href
     hidden: true
     data:
+      text: Skip to custom content
       href: "#custom"
   - name: custom text
     hidden: true
@@ -56,10 +57,12 @@ examples:
   - name: classes
     hidden: true
     data:
+      text: Skip link
       classes: app-skip-link--custom-class
   - name: attributes
     hidden: true
     data:
+      text: Skip link
       attributes:
         data-test: attribute
         aria-label: Skip to content

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -550,6 +550,11 @@ examples:
   - name: attributes
     hidden: true
     data:
+      rows:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
       attributes:
         data-attribute-1: value-1
         data-attribute-2: value-2
@@ -559,17 +564,23 @@ examples:
       rows:
         - key:
             text: Name
+          value:
+            text: Firstname Lastname
         - null
         - false
         - ""
         - key:
             text: Name 2
+          value:
+            text: Firstname2 Lastname2
   - name: key with html
     hidden: true
     data:
       rows:
         - key:
             html: <b>Name</b>
+          value:
+            html: <strong>Firstname Lastname</strong>
   - name: key with classes
     hidden: true
     data:
@@ -577,40 +588,62 @@ examples:
         - key:
             text: Name
             classes: app-custom-class
+          value:
+            text: Firstname Lastname
   - name: value with html
     hidden: true
     data:
       rows:
         - key:
+            text: Name
           value:
             html: <span>email@email.com</span>
   - name: actions href
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items:
               - href: https://www.gov.uk
+                text: Go to GOV.UK
   - name: actions with html
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items:
               - html: Edit<span class="visually-hidden"> name</span>
+                href: "#"
   - name: actions with classes
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             classes: app-custom-class
             items:
               - text: Edit
+                href: "/edit"
   - name: actions with attributes
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items:
               - text: Edit
                 href: '#'
@@ -621,7 +654,11 @@ examples:
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items:
               - text: First action
                 href: '#'
@@ -629,7 +666,11 @@ examples:
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items:
               - text: Edit
                 href: '#'
@@ -638,7 +679,11 @@ examples:
     hidden: true
     data:
       rows:
-        - actions:
+        - key:
+            text: Name
+          value:
+            text: Firstname Lastname
+          actions:
             items: []
   - name: rows with classes
     hidden: true
@@ -646,5 +691,7 @@ examples:
       rows:
         - key:
             text: Name
+          value:
+            text: Firstname Lastname
           classes: app-custom-class
 

--- a/src/govuk/components/table/table.yaml
+++ b/src/govuk/components/table/table.yaml
@@ -171,33 +171,45 @@ examples:
     hidden: true
     data:
       classes: custom-class-goes-here
+      rows:
+        -
+          - text: Jan
+          - text: Feb
   - name: attributes
     hidden: true
     data:
       attributes:
         data-foo: bar
+      rows:
+        -
+          - text: Jan
+          - text: Feb
   - name: html as text
     hidden: true
     data:
       head:
         - text: Foo <script>hacking.do(1337)</script>
       rows:
-      -
-        - text: Foo <script>hacking.do(1337)</script>
+        -
+          - text: Foo <script>hacking.do(1337)</script>
   - name: html
     hidden: true
     data:
       head:
         - html: Foo <span>bar</span>
       rows:
-      -
-        - html: Foo <span>bar</span>
+        -
+          - html: Foo <span>bar</span>
   - name: head with classes
     hidden: true
     data:
       head:
         - text: Foo
           classes: my-custom-class
+      rows:
+        -
+          - text: Jan
+          - text: Feb
   - name: head with rowspan and colspan
     hidden: true
     data:
@@ -205,12 +217,20 @@ examples:
         - text: Foo
           rowspan: 2
           colspan: 2
+      rows:
+        -
+          - text: Jan
+          - text: Feb
   - name: head with attributes
     hidden: true
     data:
       head:
         - attributes:
             data-fizz: buzz
+      rows:
+        -
+          - text: Jan
+          - text: Feb
   - name: with firstCellIsHeader true
     hidden: true
     data:

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -206,25 +206,47 @@ examples:
     hidden: true
     data:
       classes: app-tabs--custom-modifier
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            text: Information about tabs
   - name: id
     hidden: true
     data:
       id: my-tabs
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            text: Information about tabs
   - name: title
     hidden: true
     data:
       title: Custom title for Contents
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            text: Information about tabs
   - name: attributes
     hidden: true
     data:
       attributes:
         data-attribute: my data value
+      items:
+        - label: Tab 1
+          id: tab-1
+          panel:
+            text: Information about tabs
   - name: item with attributes
     hidden: true
     data:
       items:
         - id: tab-1
           label: Tab 1
+          panel:
+            text: Information about tabs
           attributes:
             data-attribute: my-attribute
             data-attribute-2: my-attribute-2
@@ -279,9 +301,11 @@ examples:
     data:
       items:
         - label: Tab 1
+          id: tab-1
           panel:
             text: <p>Panel 1 content</p>
         - label: Tab 2
+          id: tab-2
           panel:
             text: <p>Panel 2 content</p>
   - name: html
@@ -289,9 +313,11 @@ examples:
     data:
       items:
         - label: Tab 1
+          id: tab-1
           panel:
             html: <p>Panel 1 content</p>
         - label: Tab 2
+          id: tab-2
           panel:
             html: <p>Panel 2 content</p>
 

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -149,25 +149,44 @@ examples:
   - name: classes
     hidden: true
     data:
+      id: with-classes
+      name: with-classes
+      label:
+        text: With classes
       classes: app-textarea--custom-modifier
   - name: attributes
     hidden: true
     data:
+      id: with-attributes
+      name: with-attributes
+      label:
+        text: With attributes
       attributes:
         data-attribute: my data value
   - name: with describedBy
     hidden: true
     data:
+      id: with-describedby
+      name: with-describedby
+      label:
+        text: With describedBy
       describedBy: some-id
   - name: with hint and described by
     hidden: true
     data:
+      id: with-hint-describedby
+      name: with-hint-describedby
+      label:
+        text: With hint and describedBy
       describedBy: some-id
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
   - name: with error message and described by
     hidden: true
     data:
+      name: textarea-with-error
+      label:
+        text: Textarea with error
       describedBy: some-id
       id: textarea-with-error
       errorMessage:
@@ -175,6 +194,10 @@ examples:
   - name: with hint and error message
     hidden: true
     data:
+      id: with-hint-error
+      name: with-hint-error
+      label:
+        text: With hint and error
       errorMessage:
         text: Error message
       hint:
@@ -182,6 +205,10 @@ examples:
   - name: with hint, error message and described by
     hidden: true
     data:
+      id: with-hint-error-describedby
+      name: with-hint-error-describedby
+      label:
+        text: With hint, error and describedBy
       describedBy: some-id
       errorMessage:
         text: Error message

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -48,13 +48,6 @@ describe('Warning text', () => {
       expect($component.hasClass('govuk-warning-text--custom-class')).toBeTruthy()
     })
 
-    it('renders with text option only', () => {
-      const $ = render('warning-text', examples['text only'])
-
-      const $component = $('.govuk-warning-text')
-      expect($component.html()).toContain('Some custom warning text')
-    })
-
     it('renders custom assistive text', () => {
       const $ = render('warning-text', examples['icon fallback text only'])
 

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -60,7 +60,3 @@ examples:
     hidden: true
     data:
       iconFallbackText: Some custom fallback text
-  - name: text only
-    hidden: true
-    data:
-      text: Some custom warning text

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -34,6 +34,8 @@ examples:
   - name: attributes
     hidden: true
     data:
+      text: You can be fined up to £5,000 if you don’t register.
+      iconFallbackText: Warning
       attributes:
         id: my-warning-text
         data-test: attribute
@@ -46,10 +48,13 @@ examples:
   - name: html
     hidden: true
     data:
+      text: You can be fined up to £5,000 if you don’t register.
+      iconFallbackText: Warning
       html: <span>Some custom warning text</span>
   - name: html as text
     hidden: true
     data:
+      iconFallbackText: Warning
       text: <span>Some custom warning text</span>
   - name: icon fallback text only
     hidden: true


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/1965

## What

- Update component YAML examples to include required attributes for all examples
- The only exception to the above is when we want to intentionally test how a component behaves with invalid data/in certain extremes, e.g: when no data is passed in at all, or when falsey values are provided.


## Why
In a previous PR we reviewed the `required` attributes on all our component options to double check that they're correct (https://github.com/alphagov/govuk-frontend/pull/1979). Following on from that work, we want to make sure the examples in the YAML files (used for tests and to generate `macro-options.json` and `fixtures.json`) properly reflect the required attributes.