### PR TITLE
Allow certain (header) component variables to be overridden.

### DIFF
--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -1,13 +1,13 @@
 @include govuk-exports("govuk/component/header") {
 
-  $govuk-header-background: govuk-colour("black");
-  $govuk-header-border-color: $govuk-brand-colour;
-  $govuk-header-border-width: govuk-spacing(2);
-  $govuk-header-text: govuk-colour("white");
-  $govuk-header-link: govuk-colour("white");
-  $govuk-header-link-hover: govuk-colour("white");
-  $govuk-header-link-active: #1d8feb;
-  $govuk-header-nav-item-border-color: #2e3133;
+  $govuk-header-background: govuk-colour("black") !default !global;
+  $govuk-header-border-color: $govuk-brand-colour !default !global;
+  $govuk-header-border-width: govuk-spacing(2) !default !global;
+  $govuk-header-text: govuk-colour("white") !default !global;
+  $govuk-header-link: govuk-colour("white") !default !global;
+  $govuk-header-link-hover: govuk-colour("white") !default !global;
+  $govuk-header-link-active: #1d8feb !default !global;
+  $govuk-header-nav-item-border-color: #2e3133 !default !global;
 
   .govuk-header {
     @include govuk-font($size: 16);


### PR DESCRIPTION
This issue also affects other components which might need certain variables to be overridden.

Unsure about the use of the `!global` flag as that assigns the variable globally if it's not already defined.

This quick regex `^\h+\$[\w-]+:` may be used to find locally defined component variables that can potentially be made to be overridden as needed.

