### PR TITLE
Auto-focus the notification banner, add tests

### DIFF
--- a/src/govuk/all.js
+++ b/src/govuk/all.js
@@ -5,6 +5,7 @@ import Details from './components/details/details'
 import CharacterCount from './components/character-count/character-count'
 import Checkboxes from './components/checkboxes/checkboxes'
 import ErrorSummary from './components/error-summary/error-summary'
+import NotificationBanner from './components/notification-banner/notification-banner'
 import Header from './components/header/header'
 import Radios from './components/radios/radios'
 import Tabs from './components/tabs/tabs'
@@ -49,6 +50,11 @@ function initAll (options) {
   // Find first header module to enhance.
   var $toggleButton = scope.querySelector('[data-module="govuk-header"]')
   new Header($toggleButton).init()
+
+  var $notificationBanners = scope.querySelectorAll('[data-module="govuk-notification-banner"]')
+  nodeListForEach($notificationBanners, function ($notificationBanner) {
+    new NotificationBanner($notificationBanner).init()
+  })
 
   var $radios = scope.querySelectorAll('[data-module="govuk-radios"]')
   nodeListForEach($radios, function ($radio) {

--- a/src/govuk/components/notification-banner/notification-banner.js
+++ b/src/govuk/components/notification-banner/notification-banner.js
@@ -1,0 +1,47 @@
+function NotificationBanner ($module) {
+  this.$module = $module
+}
+
+/**
+ * Initialise the component
+ */
+NotificationBanner.prototype.init = function () {
+  var $module = this.$module
+  // Check for module
+  if (!$module) {
+    return
+  }
+
+  this.setFocus()
+}
+
+/**
+ * Focus the element
+ *
+ * If `role="alert"` is set, focus the element to help some assistive technologies
+ * prioritise announcing it.
+ *
+ * You can turn off the auto-focus functionality by setting `data-disable-auto-focus="true"` in the
+ * component HTML. You might wish to do this based on user research findings, or to avoid a clash
+ * with another element which should be focused when the page loads.
+ */
+NotificationBanner.prototype.setFocus = function () {
+  var $module = this.$module
+
+  if ($module.getAttribute('data-disable-auto-focus') === 'true') {
+    return
+  }
+
+  if ($module.getAttribute('role') !== 'alert') {
+    return
+  }
+
+  // Set tabindex to -1 to make the element focusable with JavaScript.
+  if (!$module.getAttribute('tabindex')) {
+    $module.setAttribute('tabindex', '-1')
+  }
+
+  $module.focus()
+}
+
+export default NotificationBanner

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -1,0 +1,64 @@
+/* eslint-env jest */
+
+const configPaths = require('../../../../config/paths.json')
+const PORT = configPaths.ports.test
+
+const baseUrl = 'http://localhost:' + PORT
+
+describe('/components/notification-banner/with-type-as-success', () => {
+  it('has the correct tabindex to be focused with JavaScript', async () => {
+    await page.goto(baseUrl + '/components/notification-banner/with-type-as-success/preview', { waitUntil: 'load' })
+
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+    expect(tabindex).toEqual('-1')
+  })
+
+  it('is automatically focused when the page loads', async () => {
+    await page.goto(baseUrl + '/components/notification-banner/with-type-as-success/preview', { waitUntil: 'load' })
+
+    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+    expect(activeElement).toBe('govuk-notification-banner')
+  })
+})
+
+describe('components/notification-banner/auto-focus-disabled,-with-type-as-success/', () => {
+  describe('when auto-focus is disabled', () => {
+    it('does not have a tabindex attribute', async () => {
+      await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toBeFalsy()
+    })
+
+    it('does not focus the notification banner', async () => {
+      await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+      expect(activeElement).not.toBe('govuk-notification-banner')
+    })
+  })
+})
+
+describe('components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success', () => {
+  describe('when role is not alert', () => {
+    it('does not have a tabindex attribute', async () => {
+      await page.goto(`${baseUrl}/components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success/preview`, { waitUntil: 'load' })
+
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toBeFalsy()
+    })
+
+    it('does not focus the notification banner', async () => {
+      await page.goto(`${baseUrl}/components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success/preview`, { waitUntil: 'load' })
+
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+      expect(activeElement).not.toBe('govuk-notification-banner')
+    })
+  })
+})

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -27,18 +27,14 @@ params:
   type: string
   required: false
   description: Overrides the value of the `role` attribute for the notification banner. Defaults to `region`. If `type` is set to `success` or `error`, defaults to `alert`.
-- name: tabindex
-  type: string/boolean
-  required: false
-  description: Overrides the value of the `tabindex` attribute for the notification banner. Not set by default.  If `type` is set to `success` or `error`, defaults to `-1`; the attribute can be removed by setting `tabindex` to `false`;
 - name: titleId
   type: string
   required: false
   description: Overrides the value of the `id` attribute for the title. `id` used by the `aria-labelledby` attribute on the notification banner to provide information to users of assistive technologies. `id` defaults to `govuk-notification-banner-title` if `role` is set to `region`. If `type` is set to `success` or `error`, `id` is not rendered by default.
-- name: autoFocus
+- name: disableAutoFocus
   type: boolean
   required: false
-  description: Moves keyboard focus to the notification banner when the page loads. Defaults to `false`. If `type` is set to `success` or `error`, defaults to `true`.
+  description: If you set 'type' to 'success' or 'error', or 'role' to 'alert', JavaScript moves the keyboard focus to the notification banner when the page loads. To disable this behaviour, set 'disableAutoFocus' to 'true'.
 - name: classes
   type: string
   required: false
@@ -87,6 +83,16 @@ examples:
           <li><a href="#" class="govuk-notification-banner__link">government-strategy-v3-FINAL.pdf</a></li>
           <li><a href="#" class="govuk-notification-banner__link">government-strategy-v4-FINAL-v2.pdf</a></li>
       </ul>
+- name: auto-focus disabled, with type as success
+  data:
+    type: success
+    disableAutoFocus: true
+    text: Email sent to example@email.com
+- name:  role=alert overridden to role=region, with type as success
+  data:
+    type: success
+    role: region
+    text: Email sent to example@email.com-
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 
@@ -142,34 +148,6 @@ examples:
   data:
     role: banner
     text: This publication was withdrawn on 7 March 2014.
-- name:  role overridden to region
-  hidden: true
-  data:
-    type: success
-    role: region
-    text: Email sent to example@email.com-
-- name: custom tabindex
-  hidden: true
-  data:
-    tabindex: 0
-    text: This publication was withdrawn on 7 March 2014.
-- name: tabindex as false and type as success
-  hidden: true
-  data:
-    type: success
-    tabindex: false
-    text: Email sent to example@email.com
-- name: autoFocus as true
-  hidden: true
-  data:
-    autoFocus: true
-    text: This publication was withdrawn on 7 March 2014.
-- name: autoFocus as false and type as success
-  hidden: true
-  data:
-    type: success
-    autoFocus: false
-    text: Email sent to example@email.com
 
 - name: classes
   hidden: true

--- a/src/govuk/components/notification-banner/template.njk
+++ b/src/govuk/components/notification-banner/template.njk
@@ -16,21 +16,6 @@
   {% set role = "region" %}
 {% endif %}
 
-{# Check whether to add `data-auto-focus="true"` which focuses the notification banner on page load #}
-{% if params.autoFocus is defined %}
-  {% set autoFocus = params.autoFocus %}
-{% elif successOrError %}
-  {% set autoFocus = true %}
-{% endif %}
-
-{% if params.tabindex is defined %}
-  {% set tabindex = params.tabindex %}
-{# Make sure that success or error banner should be focused on page load #}
-{% elif successOrError and autoFocus %}
-  {# Make the notification banner focusable #}
-  {% set tabindex = "-1" %}
-{% endif %}
-
 {%- if params.titleHtml %}
   {% set title = params.titleHtml | safe %}
 {%- elif params.title %}
@@ -43,11 +28,10 @@
   {% set title = "Important" %}
 {%- endif -%}
 
-<div class="govuk-notification-banner {{ typeClass }} {%- if params.classes %} {{ params.classes }}{% endif -%}" role="{{ role }}"
-  {%- if tabindex or tabindex === 0 %} tabindex="{{ tabindex }}" {% endif %}
-  {%- if (role == "region") %} aria-labelledby="{{ params.titleId | default('govuk-notification-banner-title') }}" {%- endif -%}
+<div class="govuk-notification-banner{% if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}"
+  {%- if (role == "region") %} aria-labelledby="{{ params.titleId | default('govuk-notification-banner-title')}}" {% endif -%}
   data-module="govuk-notification-banner"
-  {%- if autoFocus -%} data-auto-focus="true"{% endif %}
+  {%- if params.disableAutoFocus %} data-disable-auto-focus="true"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-notification-banner__header">
     <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title"{% if (role == "region" or params.titleId) %} id="{{ params.titleId | default('govuk-notification-banner-title') }}" {%- endif %}>

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -33,25 +33,11 @@ describe('Notification-banner', () => {
       expect($component.attr('role')).toEqual('region')
     })
 
-    it('does not have tabindex set', () => {
-      const $ = render('notification-banner', examples.default)
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('tabindex')).toBeUndefined()
-    })
-
     it('has data-module attribute to initialise JavaScript', () => {
       const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('data-module')).toEqual('govuk-notification-banner')
-    })
-
-    it('does not have data-auto-focus attribute to focus component on page load', () => {
-      const $ = render('notification-banner', examples.default)
-      const $component = $('.govuk-notification-banner')
-
-      expect($component.attr('data-auto-focus')).not.toEqual('govuk-auto-focus')
     })
 
     it('renders header container', () => {
@@ -113,18 +99,11 @@ describe('Notification-banner', () => {
     })
 
     it('renders aria-labelledby attribute matching the title id when role overridden to region', () => {
-      const $ = render('notification-banner', examples['role overridden to region'])
+      const $ = render('notification-banner', examples['role=alert overridden to role=region, with type as success'])
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
       const titleId = $('.govuk-notification-banner__title').attr('id')
 
       expect(ariaAttr).toEqual(titleId)
-    })
-
-    it('renders custom tabindex', () => {
-      const $ = render('notification-banner', examples['custom tabindex'])
-      const $component = $('.govuk-notification-banner')
-
-      expect($component.attr('tabindex')).toEqual('0')
     })
 
     it('renders custom title id', () => {
@@ -141,25 +120,11 @@ describe('Notification-banner', () => {
       expect(ariaAttr).toEqual('my-id')
     })
 
-    it('renders data-auto-focus attribute to focus component on page load', () => {
-      const $ = render('notification-banner', examples['autoFocus as true'])
+    it('adds the data-disable-auto-focus attribute so component is not focused on page load', () => {
+      const $ = render('notification-banner', examples['auto-focus disabled, with type as success'])
 
       const $component = $('.govuk-notification-banner')
-      expect($component.attr('data-auto-focus')).toEqual('true')
-    })
-
-    it('removes tabindex attribute so component is not focusable', () => {
-      const $ = render('notification-banner', examples['tabindex as false and type as success'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('tabindex')).toBeUndefined()
-    })
-
-    it('removes data-auto-focus attribute so component is not focused on page load', () => {
-      const $ = render('notification-banner', examples['autoFocus as false and type as success'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('data-auto-focus')).toBeUndefined()
+      expect($component.attr('data-disable-auto-focus')).toBeTruthy()
     })
 
     it('renders classes', () => {
@@ -192,11 +157,11 @@ describe('Notification-banner', () => {
       expect($title.html().trim()).toEqual('<span>Important information</span>')
     })
 
-    it(' as escaped html when passed as text', () => {
+    it('renders content as escaped html when passed as text', () => {
       const $ = render('notification-banner', examples['html as text'])
-      const $content = $('.govuk-notification-banner__heading')
+      const $content = $('.govuk-notification-banner__content')
 
-      expect($content.html().trim()).toEqual('&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;')
+      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>')
     })
 
     it('renders content as html', () => {
@@ -234,27 +199,6 @@ describe('Notification-banner', () => {
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('id')).toBeUndefined()
-    })
-
-    it('renders custom title id', () => {
-      const $ = render('notification-banner', examples['custom title id with type as success'])
-      const $title = $('.govuk-notification-banner__title')
-
-      expect($title.attr('id')).toEqual('my-id')
-    })
-
-    it('has the correct tabindex attribute to be focused', () => {
-      const $ = render('notification-banner', examples['with type as success'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('tabindex')).toEqual('-1')
-    })
-
-    it('renders data-auto-focus attribute to focus component on page load', () => {
-      const $ = render('notification-banner', examples['with type as success'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('data-auto-focus')).toEqual('true')
     })
 
     it('renders default success title text', () => {
@@ -301,20 +245,6 @@ describe('Notification-banner', () => {
       expect($title.attr('id')).toEqual('my-id')
     })
 
-    it('has the correct tabindex attribute to be focused', () => {
-      const $ = render('notification-banner', examples['with type as error'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('tabindex')).toEqual('-1')
-    })
-
-    it('renders data-auto-focus attribute to focus component on page load', () => {
-      const $ = render('notification-banner', examples['with type as error'])
-
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('data-auto-focus')).toEqual('true')
-    })
-
     it('renders default error title text', () => {
       const $ = render('notification-banner', examples['with type as error'])
       const $title = $('.govuk-notification-banner__title')
@@ -331,18 +261,12 @@ describe('Notification-banner', () => {
       expect($component.attr('role')).toEqual('region')
     })
 
-    it('does not have tabindex set', () => {
+    it('aria-labelledby attribute matches the title id', () => {
       const $ = render('notification-banner', examples['with invalid type'])
+      const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
+      const titleId = $('.govuk-notification-banner__title').attr('id')
 
-      const $component = $('.govuk-notification-banner')
-      expect($component.attr('tabindex')).toBeUndefined()
-    })
-
-    it('does not have data-auto-focus attribute to focus component on page load', () => {
-      const $ = render('notification-banner', examples['with invalid type'])
-      const $component = $('.govuk-notification-banner')
-
-      expect($component.attr('data-auto-focus')).not.toEqual('govuk-auto-focus')
+      expect(ariaAttr).toEqual(titleId)
     })
   })
 })


### PR DESCRIPTION
This PR:
- Auto-focuses the notification banner when the page loads if it has `role="alert"` and adds `tabindex="1"` so it can be fosused.
- Tests the auto-focus behaviour:
  - If a notification banner has `role=alert`, it should receive `tabindex="1"` so it can be focused with JavaScript and the keyboard focus should move to it on page load
  - If a notification banner has the `data-disable-auto-focus` attribute, or it doesn't have `role="alert"` it should not have a tabindex or be focused 

Tested in:
✅ Chrome 86 (Mac)
✅ Firefox 81 (Mac)
✅ Safari 14 (Mac)
✅ Galaxy S20 (Android 10)
✅ Galaxy Note 10 (Android 9)
✅ iPhone XS 12 
✅ IE11
✅ IE10 
✅ IE9
✅ IE8

Addresses part of https://github.com/alphagov/govuk-frontend/issues/1935