### PR TITLE
Adding guidance for use of sans-serif print styles

### DIFF
--- a/src/govuk/settings/_typography-font.scss
+++ b/src/govuk/settings/_typography-font.scss
@@ -52,6 +52,8 @@ $govuk-font-family-tabular: if(
 
 /// Font families to use for print media
 ///
+/// This option avoids font-related issues that occur with some printer drivers and operating systems.
+///
 /// @type List
 /// @access public
 

--- a/src/govuk/settings/_typography-font.scss
+++ b/src/govuk/settings/_typography-font.scss
@@ -52,7 +52,8 @@ $govuk-font-family-tabular: if(
 
 /// Font families to use for print media
 ///
-/// This option avoids font-related issues that occur with some printer drivers and operating systems.
+/// We recommend that you use system fonts when printing. This will avoid issues
+/// with some printer drivers and operating systems.
 ///
 /// @type List
 /// @access public


### PR DESCRIPTION
Added comment line [line 55] with guidance as to why sans-serif font is set as default and why we don't use govuk-font-family in print styles.