### PR TITLE
Remove tabindex attribute from notification alert banner on blur

### DIFF
--- a/src/govuk/components/notification-banner/notification-banner.js
+++ b/src/govuk/components/notification-banner/notification-banner.js
@@ -37,8 +37,14 @@ NotificationBanner.prototype.setFocus = function () {
   }
 
   // Set tabindex to -1 to make the element focusable with JavaScript.
+  // Remove the tabindex on blur as the component doesn't need to be focusable after the page has
+  // loaded.
   if (!$module.getAttribute('tabindex')) {
     $module.setAttribute('tabindex', '-1')
+
+    $module.addEventListener('blur', function () {
+      $module.removeAttribute('tabindex')
+    })
   }
 
   $module.focus()

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -6,7 +6,7 @@ const PORT = configPaths.ports.test
 const baseUrl = 'http://localhost:' + PORT
 
 describe('/components/notification-banner/with-type-as-success', () => {
-  it('has the correct tabindex to be focused with JavaScript', async () => {
+  it('has the correct tabindex attribute to be focused with JavaScript', async () => {
     await page.goto(baseUrl + '/components/notification-banner/with-type-as-success/preview', { waitUntil: 'load' })
 
     const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
@@ -21,6 +21,15 @@ describe('/components/notification-banner/with-type-as-success', () => {
 
     expect(activeElement).toBe('govuk-notification-banner')
   })
+
+  it('removes the tabindex attribute on blur', async () => {
+    await page.goto(baseUrl + '/components/notification-banner/with-type-as-success/preview', { waitUntil: 'load' })
+
+    await page.$eval('.govuk-notification-banner', el => el.blur())
+
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+    expect(tabindex).toBeNull()
+  })
 })
 
 describe('components/notification-banner/auto-focus-disabled,-with-type-as-success/', () => {
@@ -30,7 +39,7 @@ describe('components/notification-banner/auto-focus-disabled,-with-type-as-succe
 
       const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      expect(tabindex).toBeFalsy()
+      expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
@@ -50,7 +59,7 @@ describe('components/notification-banner/role=alert-overridden-to-role=region,-w
 
       const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      expect(tabindex).toBeFalsy()
+      expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
@@ -59,6 +68,19 @@ describe('components/notification-banner/role=alert-overridden-to-role=region,-w
       const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
       expect(activeElement).not.toBe('govuk-notification-banner')
+    })
+  })
+})
+
+describe('/components/notification-banner/custom-tabindex', () => {
+  describe('when custom tabindex set', () => {
+    it('it does not remove the tabindex attribute on blur', async () => {
+      await page.goto(baseUrl + '/components/notification-banner/custom-tabindex/preview', { waitUntil: 'load' })
+
+      await page.$eval('.govuk-notification-banner', el => el.blur())
+
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      expect(tabindex).toEqual('2')
     })
   })
 })

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -93,6 +93,12 @@ examples:
     type: success
     role: region
     text: Email sent to example@email.com-
+- name:  custom tabindex
+  data:
+    type: success
+    text: Email sent to example@email.com-
+    attributes:
+      tabindex: 2
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 


### PR DESCRIPTION
There is no need for the notification banner component to remain focusable after the page has loaded and the focus has moved away from it. This is following some feedback from the GDS Accessibility clinic: https://github.com/alphagov/govuk-frontend/issues/1999#issuecomment-723020026. 

This PR:
- Removes the tabindex attribute from the notification alert banner on blur 
- Tests that the attribute gets removed correctly
- Also tests that if the tabindex has been set as an attribute in the HTML, it doesn't get removed by the script.

Partially addresses https://github.com/alphagov/govuk-frontend/issues/2011