### PR TITLE
Change ‘title’ to ‘titleText’ in notification banner

### DIFF
--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -7,7 +7,7 @@ params:
   type: string
   required: true
   description: If `text` is set, this is not required. HTML to use within the notification banner. If `html` is provided, the `text` argument will be ignored.
-- name: title
+- name: titleText
   type: string
   required: false
   description: Title text to use within the notification banner. Defaults to 'Important' ('Success' for success type and 'Error' for error type). If `titleHtml` is supplied, the `title` argument will be ignored.
@@ -99,7 +99,7 @@ examples:
 - name: custom title
   hidden: true
   data:
-    title: Important information
+    titleText: Important information
     text: This publication was withdrawn on 7 March 2014.
 - name: title as html
   hidden: true
@@ -109,7 +109,7 @@ examples:
 - name: title html as text
   hidden: true
   data:
-    title: <span>Important information</span>
+    titleText: <span>Important information</span>
     text: This publication was withdrawn on 7 March 2014.
 - name: custom title heading level
   hidden: true

--- a/src/govuk/components/notification-banner/template.njk
+++ b/src/govuk/components/notification-banner/template.njk
@@ -18,8 +18,8 @@
 
 {%- if params.titleHtml %}
   {% set title = params.titleHtml | safe %}
-{%- elif params.title %}
-  {% set title = params.title %}
+{%- elif params.titleText %}
+  {% set title = params.titleText %}
 {%- elif params.type == "success" %}
   {% set title = "Success" %}
 {%- elif params.type == "error" %}


### PR DESCRIPTION
To be consistent with the options we use elsewhere, where we use text / html suffixes together, update the Nunjucks template for the notification banner to accept `titleText` rather than `title`.

Part of #2015