### PR TITLE
Change visited state for error summary and notification banner

### DIFF
--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -51,7 +51,7 @@
 
   .govuk-notification-banner__link {
     @include govuk-link-common;
-    @include govuk-link-style-default;
+    @include govuk-link-style-no-visited-state;
   }
 
   .govuk-notification-banner--success {

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -82,12 +82,9 @@
 /// @access public
 
 @mixin govuk-link-style-error {
-  &:link {
-    color: $govuk-error-colour;
-  }
-
+  &:link,
   &:visited {
-    color: $govuk-link-visited-colour;
+    color: $govuk-error-colour;
   }
 
   &:hover {
@@ -132,12 +129,9 @@
 /// @access public
 
 @mixin govuk-link-style-success {
-  &:link {
-    color: $govuk-success-colour;
-  }
-
+  &:link,
   &:visited {
-    color: $govuk-link-visited-colour;
+    color: $govuk-success-colour;
   }
 
   &:hover {


### PR DESCRIPTION
We recommend not having a different visited link state where it is not helpful to distinguish between visited and unvisited states, for example when linking to pages with frequently-changing content such as the dashboard for an admin interface.

It doesn't seem useful to highlight visited links in the notification banner, and the previous behaviour for the error summary also matches this.

Therefore this commit updates the error and success link style mixins so that the visited colour is the same as the original link colour.