### PR TITLE
Remove stray dash from banner nunjucks examples

### DIFF
--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -97,11 +97,11 @@ examples:
   data:
     type: success
     role: region
-    text: Email sent to example@email.com-
+    text: Email sent to example@email.com
 - name:  custom tabindex
   data:
     type: success
-    text: Email sent to example@email.com-
+    text: Email sent to example@email.com
     attributes:
       tabindex: 2
 


### PR DESCRIPTION
There was a stray dash after some of the email addresses in the notification banner examples