### PR TITLE
Check for unstaged changes before building release

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 set -e
 
+# Check if there are files that need to be commited
+if [[ -n $(git status --porcelain) ]]; then
+  echo "⚠️ You have unstaged files, please commit these and then try again."
+  exit 1
+fi
+
 echo "Starting to build release..."
 echo " "
 echo "This will:"


### PR DESCRIPTION
Avoid situations where unrelated changes are included in the release commit by exiting at the start of the script if there are any unstaged or uncommitted changes in the working directory.

This is important because the script runs `git add .` followed by `git commit`, so any unrelated changes (staged or not) would otherwise end up in the release commit.