### PR TITLE
Include hidden status of the component examples in published fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2031: Expose hidden status of component examples in packaged fixtures](https://github.com/alphagov/govuk-frontend/pull/2031)
 ## 3.10.1 (Patch release)
 
 ### Fixes

--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -142,13 +142,12 @@ describe('package/', () => {
           )
 
           parsedData.fixtures.forEach((fixture) => {
-            expect(fixture).toEqual(
-              expect.objectContaining({
-                name: expect.any(String),
-                options: expect.any(Object),
-                html: expect.any(String)
-              })
-            )
+            expect(fixture).toEqual({
+              name: expect.any(String),
+              options: expect.any(Object),
+              html: expect.any(String),
+              hidden: expect.any(Boolean)
+            })
           })
         })
         .catch(error => {

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -70,7 +70,8 @@ function generateFixtures (file) {
         const fixture = {
           name: example.name,
           options: example.data,
-          html: nunjucks.render(componentTemplatePath, { params: example.data }).trim()
+          html: nunjucks.render(componentTemplatePath, { params: example.data }).trim(),
+          hidden: example.hidden
         }
 
         fixtures.fixtures.push(fixture)

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -71,7 +71,7 @@ function generateFixtures (file) {
           name: example.name,
           options: example.data,
           html: nunjucks.render(componentTemplatePath, { params: example.data }).trim(),
-          hidden: example.hidden
+          hidden: Boolean(example.hidden)
         }
 
         fixtures.fixtures.push(fixture)


### PR DESCRIPTION
In order for downstream projects to use the component examples for rendering as well as for tests, it is useful to know which examples should be hidden from display since they were designed for tests only.

I have therefore modified the gulp script slightly to include that `hidden` field when packaging up the fixtures.

To give some context - I used to use the example yaml files directly in govuk-react-jsx to render the demonstration app. I am working on the 3.9.0 update which added the fixtures.json files and so am switching across to those, but these now contain additional hidden examples which were not there before, and don't make a lot of sense when rendered on screen since they are often so minimal. I would therefore like to hide these from display.