### PR TITLE
Fix hairline gap between notification banner header and outer border on high resolution screens in Chrome/Edge (Blink)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2035: Fix hairline gap between notification banner header and outer border on high resolution screens in Chrome/Edge (Blink)](https://github.com/alphagov/govuk-frontend/pull/2035)
+
 ## 3.10.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -5,6 +5,8 @@
 
     border: $govuk-border-width solid $govuk-brand-colour;
 
+    background-color: $govuk-brand-colour;
+
     &:focus {
       outline: $govuk-focus-width solid $govuk-focus-colour;
     }
@@ -15,8 +17,6 @@
 
     // Ensures the notification header appears separate to the notification body text in high contrast mode
     border-bottom: 1px solid transparent;
-
-    background-color: $govuk-brand-colour;
 
     @include govuk-media-query($from: tablet) {
       padding: 2px govuk-spacing(4) govuk-spacing(1);
@@ -34,10 +34,16 @@
   }
 
   .govuk-notification-banner__content {
-    margin: govuk-spacing(3);
+    padding: govuk-spacing(3);
+
+    background-color: $govuk-body-background-colour;
 
     @include govuk-media-query($from: tablet) {
-      margin: govuk-spacing(4);
+      padding: govuk-spacing(4);
+    }
+
+    > :last-child {
+      margin-bottom: 0;
     }
   }
 
@@ -57,9 +63,7 @@
   .govuk-notification-banner--success {
     border-color: $govuk-success-colour;
 
-    .govuk-notification-banner__header {
-      background-color: $govuk-success-colour;
-    }
+    background-color: $govuk-success-colour;
 
     .govuk-notification-banner__link {
       @include govuk-link-style-success;


### PR DESCRIPTION
To fix #2034 (White line around notification banner heading on high DPI screens in chrome) I have flipped the colouring of the notification banner around. This means the background colour of the entire notification banner is now blue/green, but the content container inside it is white - meaning there is no gap between the two any more.

I had to remove bottom margin from the last child inside the content div - reason being I had to switch the content container to padding instead of margins but that causes it to contain the bottom margin of the last child.