### PR TITLE
Explicitly set the text colour for notification banner content, rather than using the user-agent default text colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2035: Fix hairline gap between notification banner header and outer border on high resolution screens in Chrome/Edge (Blink)](https://github.com/alphagov/govuk-frontend/pull/2035)
+- [#2036: Explicitly set the text colour for notification banner content, rather than using the user-agent default text colour](https://github.com/alphagov/govuk-frontend/pull/2036)
 
 ## 3.10.0 (Feature release)
 

--- a/src/govuk/components/notification-banner/_index.scss
+++ b/src/govuk/components/notification-banner/_index.scss
@@ -34,6 +34,7 @@
   }
 
   .govuk-notification-banner__content {
+    @include govuk-text-colour;
     padding: govuk-spacing(3);
 
     background-color: $govuk-body-background-colour;


### PR DESCRIPTION
The notification banner content currently uses the user agent default text colour.

This means that for users who have not changed their user agent default text colour, the text will be true black (`#000000`) rather than the ‘GOV.UK’ black we specify in the colour palette (`#0b0c0c`).

It also means that if a user has changed their default text colour, but has not chosen to override colours, depending on the user’s prefered colour scheme the text may have low contrast or be invisible.

For example, my Firefox instance is configured to use white text on a blue background:

![Firefox colour preferences, with 'Text' set to white, 'Background' set to blue, and Unvisited/Visited links set to yellow, and 'Override the colors specified by the page with your selections above' set to 'Never'](https://user-images.githubusercontent.com/121939/100221111-231cbc00-2f10-11eb-9f44-f9ff0009031b.png)

The notification banner is therefore white-on-white, and thus invisible:

![The notification banner showing invisible text](https://user-images.githubusercontent.com/121939/100221138-2a43ca00-2f10-11eb-81bf-6c563a49ea2b.png)

As I understand it, this is as a [‘failure of Success Criterion 1.4.3, 1.4.6 and 1.4.8 due to specifying foreground colors without specifying background colors or vice versa’][1].

Set the text colour of the `govuk-notification-banner__content` element using the `govuk-text-colour` mixin to fix this:

![The fixed notification banner with visible text](https://user-images.githubusercontent.com/121939/100221274-5a8b6880-2f10-11eb-815c-d04e6d31c6da.png)

[1]: https://www.w3.org/TR/WCAG20-TECHS/F24.html

Fixes #2037