### PR TITLE
Expand git tag error in build-release script

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -32,7 +32,7 @@ TAG="v$ALL_PACKAGE_VERSION"
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 
 if [ $(git tag -l "$TAG") ]; then
-    echo "⚠️ Git tag already exists."
+    echo "⚠️ Git tag $TAG already exists. Check you have updated the version in package/package.json correctly."
     exit 1;
 else
     git add .


### PR DESCRIPTION
## What
Expands the git tag error message in the build-release script to include:

- The name of the tag which already exists
- A suggestion for what might be causing the error

## Why
This tripped me up when I was doing the release - I had forgotten to update the package.json file, but thought the error was about the new release tag already existing. Hopefully adding the tag itself to the error message and suggesting the package.json check will help if anyone else gets this error in the future.