### PR TITLE
Clarifying committing work step in publishing steps

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -26,7 +26,7 @@
 
 7. Update [`package/package.json`](../../package/package.json) version with the new version number.
 
-8. Save the changes. Do not commit.
+8. Save and commit your changes.
 
 9. Run `npm run build-release`, you will be prompted to continue or cancel.
 


### PR DESCRIPTION
## What
Update `Save the changes. Do not commit.` to `Save and commit your changes.`

## Why
The build-release script now [checks for uncommitted changes](https://github.com/alphagov/govuk-frontend/blob/master/bin/build-release.sh#L6) and errors if there are any. We therefore *have* to commit our changes before we run `npm run build-release`. This updates the docs accordingly.