### PR TITLE
Ignore changes in package.json and CHANGELOG.md

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 set -e
 
-# Check if there are files that need to be commited
-if [[ -n $(git status --porcelain) ]]; then
-  echo "⚠️ You have unstaged files, please commit these and then try again."
+# Check if there are unexpected changes. Changes to CHANGELOG.md and the
+# package.json file are expected as part of the normal release process.
+changes="$(git status --porcelain -- ':!CHANGELOG.md' ':!package/package.json')"
+if [[ -n $changes ]]; then
+  echo "⚠ Unexpected changes in your working directory:"
+  echo "$changes"
   exit 1
 fi
 


### PR DESCRIPTION
Our release process involves updating [`CHANGELOG.md`][1] and [`package/package.json`][2] and then running the build-release script WITHOUT committing those changes, so we expect both of those files to be modified at the point the build-release script runs.

Ignore changes in both of those files by [excluding them in the pathspec][3] passed to git status.

Store the output of running git status so that we can include it in the output when there are unstaged changes.

[1]: https://github.com/alphagov/govuk-frontend/blob/9fc38d58e356c9188a16071ae0e3580a94bbd608/docs/releasing/publishing.md#:~:text=Update%20CHANGELOG.md%20%22Unreleased%22%20heading%20with%20the%20new%20version%20number.
[2]: https://github.com/alphagov/govuk-frontend/blob/9fc38d58e356c9188a16071ae0e3580a94bbd608/docs/releasing/publishing.md#:~:text=Update%20package%2Fpackage.json%20version
[3]: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-exclude