### PR TITLE
Fixes for a couple of component examples / fixtures

### DIFF
--- a/src/govuk/components/checkboxes/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/checkboxes/__snapshots__/template.test.js.snap
@@ -6,6 +6,9 @@ exports[`Checkboxes nested dependant components passes through fieldset params w
           data-attribute="value"
           data-second-attribute="second-value"
 >
+  <legend class="govuk-fieldset__legend">
+    What is your nationality?
+  </legend>
 </fieldset>
 `;
 

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -710,9 +710,9 @@ examples:
     name: example-name
     errorMessage:
       text: Please select an option
-    legend:
-      text: What is your nationality?
     fieldset:
+      legend:
+        text: What is your nationality?
       classes: app-fieldset--custom-modifier
       attributes:
         data-attribute: value

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -658,7 +658,8 @@ examples:
           text: Hint for british option here
       - value: irish
         text: Irish
-      - hint:
+      - value: other
+        hint:
           text: Hint for other option here
 - name: with error message and hint
   hidden: true

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -14,7 +14,7 @@ params:
   params:
   - name: value
     type: string
-    required: false
+    required: true
     description: Value for the option item.
   - name: text
     type: string
@@ -205,11 +205,13 @@ examples:
       items:
         -
           text: Option 1
+          value: 1
           attributes:
             data-attribute: ABC
             data-second-attribute: DEF
         -
           text: Option 2
+          value: 2
           attributes:
             data-attribute: GHI
             data-second-attribute: JKL
@@ -221,11 +223,13 @@ examples:
       items:
         -
           text: Option 1
+          value: 1
         - null
         - false
         - ""
         -
           text: Options 2
+          value: 2
   - name: hint
     hidden: true
     data:

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -14,7 +14,7 @@ params:
   params:
   - name: value
     type: string
-    required: true
+    required: false
     description: Value for the option item.
   - name: text
     type: string


### PR DESCRIPTION
I have spotted a couple of issues with the current fixtures whilst using them in govuk-react-jsx. This PR is to fix them...

1) on the `fieldset params` example in the checkboxes component, the `legend` param was not nested underneath the `fieldset` param.

2) On the select component, `value` is not marked as required underneath the items / individual options. If not supplied, the component will render every option with an empty value which I think doesn't make much sense. I have therefore marked it as required, and fixed two of the hidden examples to match (All the other examples already had `value` specified. This was causing problems in my react port since React cannot have two `<option>` elements with the same underlying `value`, even if that value is blank.