### PR TITLE
Stop same-site cookies from being wiped when printing in Internet Explorer 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2080: Fix JavaScript error when character count ID starts with a number](https://github.com/alphagov/govuk-frontend/pull/2080) - thanks to [@josef-vlach](https://github.com/josef-vlach) for reporting this issue.
 - [#2092: Use tabular numbers for character count message](https://github.com/alphagov/govuk-frontend/pull/2092)
+- [#2045: Stop same-site cookies from being wiped when printing in Internet Explorer 11](https://github.com/alphagov/govuk-frontend/pull/2045) – thanks to [@gunjam](https://github.com/gunjam) for contributing this
 
 ## 3.10.2 (Patch release)
 

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -33,9 +33,9 @@
 
             The <image> element is a valid SVG element. In SVG, you would specify
             the URL of the image file with the xlink:href – as we don't reference an
-            image it has no effect. It's important to include the empty xlink:href
-            attribute as this prevents versions of IE which support SVG from
-            downloading the fallback image when they don't need to.
+            image it has no effect. It's important to include an empty data URI
+            as the xlink:href attribute as this prevents versions of IE which
+            support SVG from downloading the fallback image when they don't need to.
 
             In other browsers <image> is synonymous for the <img> tag and will be
             interpreted as such, displaying the fallback image. #}

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -39,7 +39,7 @@
 
             In other browsers <image> is synonymous for the <img> tag and will be
             interpreted as such, displaying the fallback image. #}
-            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
+            <image src="{{ params.assetsPath | default('/assets/images') }}/govuk-logotype-crown.png" xlink:href="data:," display="none" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
           </svg>
           <span class="govuk-header__logotype-text">
             GOV.UK

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -222,9 +222,9 @@ describe('header', () => {
         expect($fallbackImage[0].tagName).toEqual('image')
       })
 
-      it('sets a blank xlink:href to prevent IE from downloading both the SVG and the PNG', () => {
+      it('sets an empty data URI xlink:href to prevent IE from downloading both the SVG and the PNG', () => {
         // Cheerio converts xhref to href - https://github.com/cheeriojs/cheerio/issues/1101
-        expect($fallbackImage.attr('href')).toEqual('')
+        expect($fallbackImage.attr('href')).toEqual('data:,')
       })
     })
   })

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -226,6 +226,10 @@ describe('header', () => {
         // Cheerio converts xhref to href - https://github.com/cheeriojs/cheerio/issues/1101
         expect($fallbackImage.attr('href')).toEqual('data:,')
       })
+
+      it('hides the image when SVG is supported by using the SVG display attribute', () => {
+        expect($fallbackImage.attr('display')).toEqual('none')
+      })
     })
   })
 })


### PR DESCRIPTION
**tl;dr** this fixes an issue where a service with `SameSite: Strict` set on its session cookies will have them wiped in IE when opening the print dialog if they serve a page on the root of their domain.

We were experiencing an odd issue in our service where some users were unexpectantly getting sent back to the beginning of the service from the Check Your Answers page. After some research with users this appeared to only happen after they attempted to print their answers. A lot of head scratching later I figured out what was going on: when a user in IE11 (and presumably lower) opens the print dialog, the browser re-requests all uncached assets and in doing will make a GET request for `xlink:href` value in the crown SVG image tag, even though it's blank. It'll resolve this to the root of the domain which for us is the first page of our service. The problem is that if you have `SameSite: Strict` set on your cookies, IE won't send them when making the image request to `/` so our service will act as if this is a new session and send a new session cookie with the response, which IE will then propagate back into the page resetting the session cookie. On submission, the user is now trying to access a page at the end of the service with a blank session, so gets sent back to the start.

A pretty odd issue, typical of IE, but will affect any service with a session based page being served on `/`, unless you set `SameSite` to something other than `Strict`, which we don't really want to do.

The simplest solution to this I've come up with, is to set the empty `xlink:href` value to a blank data URI so that the browser will not initiate a network request. I've also set the SVG `display` attribute to `none` so browsers do no render a small blank SVG in place.
