### PR TITLE
Clarify default value for 'value' option in select component

### DIFF
--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -15,7 +15,7 @@ params:
   - name: value
     type: string
     required: false
-    description: Value for the option item.
+    description: Value for the option item. Defaults to an empty string.
   - name: text
     type: string
     required: true


### PR DESCRIPTION
Prompted by https://github.com/alphagov/govuk-frontend/pull/2043, this commit adds a line to the docs for the value option to explain that it defaults to an empty string.