### PR TITLE
Use non-bool type strings for attributes in test fixtures

### DIFF
--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -137,8 +137,8 @@ examples:
   data:
     titleText: There is a problem
     attributes:
-      first-attribute: 'true'
-      second-attribute: 'false'
+      first-attribute: 'foo'
+      second-attribute: 'bar'
     errorList:
       -
         text: Invalid username or password

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -115,8 +115,8 @@ describe('Error-summary', () => {
       const $ = render('error-summary', examples.attributes)
 
       const $component = $('.govuk-error-summary')
-      expect($component.attr('first-attribute')).toEqual('true')
-      expect($component.attr('second-attribute')).toEqual('false')
+      expect($component.attr('first-attribute')).toEqual('foo')
+      expect($component.attr('second-attribute')).toEqual('bar')
     })
 
     it('renders anchor tag with attributes', () => {

--- a/src/govuk/components/label/label.yaml
+++ b/src/govuk/components/label/label.yaml
@@ -65,5 +65,5 @@ examples:
     data:
       text: National Insurance number
       attributes:
-        first-attribute: 'true'
-        second-attribute: 'false'
+        first-attribute: 'foo'
+        second-attribute: 'bar'

--- a/src/govuk/components/label/template.test.js
+++ b/src/govuk/components/label/template.test.js
@@ -79,8 +79,8 @@ describe('Label', () => {
       const $ = render('label', examples.attributes)
 
       const $component = $('.govuk-label')
-      expect($component.attr('first-attribute')).toEqual('true')
-      expect($component.attr('second-attribute')).toEqual('false')
+      expect($component.attr('first-attribute')).toEqual('foo')
+      expect($component.attr('second-attribute')).toEqual('bar')
     })
   })
 })

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -72,8 +72,8 @@ examples:
     titleText: Application complete
     text: Your reference number is HDJ2123F
     attributes:
-      first-attribute: true
-      second-attribute: false
+      first-attribute: foo
+      second-attribute: bar
 - name: title with no body text
   hidden: true
   data:

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -94,8 +94,8 @@ describe('Panel', () => {
       const $ = render('panel', examples.attributes)
 
       const $component = $('.govuk-panel')
-      expect($component.attr('first-attribute')).toEqual('true')
-      expect($component.attr('second-attribute')).toEqual('false')
+      expect($component.attr('first-attribute')).toEqual('foo')
+      expect($component.attr('second-attribute')).toEqual('bar')
     })
   })
 })

--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -47,8 +47,8 @@ examples:
     data:
       text: This is a new service – your feedback will help us to improve it
       attributes:
-        first-attribute: true
-        second-attribute: false
+        first-attribute: foo
+        second-attribute: bar
   - name: tag html
     hidden: true
     data:

--- a/src/govuk/components/phase-banner/template.test.js
+++ b/src/govuk/components/phase-banner/template.test.js
@@ -50,8 +50,8 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples.attributes)
 
       const $component = $('.govuk-phase-banner')
-      expect($component.attr('first-attribute')).toEqual('true')
-      expect($component.attr('second-attribute')).toEqual('false')
+      expect($component.attr('first-attribute')).toEqual('foo')
+      expect($component.attr('second-attribute')).toEqual('bar')
     })
   })
 


### PR DESCRIPTION
Follow on from #2064:

> When using boolean cast-able string values in test fixtures, these can be interpreted as actual boolean types by ports of govuk-frontend, such as the govuk-frontend-jinja Python port. For example, three tests fail due to casing differences between the expected string values of "true" and "false" and their boolean equivalents True and False: https://github.com/LandRegistry/govuk-frontend-jinja/pull/10/checks?check_run_id=1538392387#step:6:1365
>
> Other options:
>
> - I could code around this in my port by type-checking all param values and lower casing only bool cast-able values as strings. However, it seems better to improve the upstream test fixtures to use more explicit string type values instead.
> - I could blanket lower case all attribute values, but this could break things with unexpected behaviour and would deviate from how the upstream original behaves.
> 
> Changing these test fixture params to non-bool type strings will make maintaining ports of govuk-frontend in other frameworks and languages easier.