### PR TITLE
Remove bool type strings from details component test fixture attribute

### DIFF
--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -102,4 +102,4 @@ examples:
     summaryText: Expand me
     attributes:
       data-some-data-attribute: i-love-data
-      another-attribute: true
+      another-attribute: foo

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -93,6 +93,6 @@ describe('Details', () => {
 
     const $component = $('.govuk-details')
     expect($component.attr('data-some-data-attribute')).toEqual('i-love-data')
-    expect($component.attr('another-attribute')).toEqual('true')
+    expect($component.attr('another-attribute')).toEqual('foo')
   })
 })


### PR DESCRIPTION
Follow on from #2064 and #2071 

After recreating the PR I must have neglected to re-run my tests and subsequently missed one final instance of this issue.