### PR TITLE
Fix JavaScript error when character count ID starts with a number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2080: Fix JavaScript error when character count ID starts with a number](https://github.com/alphagov/govuk-frontend/pull/2080) - thanks to [@josef-vlach](https://github.com/josef-vlach) for reporting this issue.
+
 ## 3.10.2 (Patch release)
 
 ### Fixes

--- a/app/views/macros/showExamples.njk
+++ b/app/views/macros/showExamples.njk
@@ -2,7 +2,7 @@
 
 {% macro showExamples(componentSlug, componentName, data, legacyQuery) %}
 
-{% for example in data.examples %}
+{% for example in data.examples | rejectattr('hidden') %}
   {% set exampleSlug = (example.name | replace(" ", "-")) %}
   {% set iframePathQuery = legacyQuery + '&iframe=true' if legacyQuery != '' else '?iframe=true' %}
 

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -26,13 +26,9 @@ exports.readFileContents = readFileContents
 const getComponentData = componentName => {
   try {
     const yamlPath = path.join(configPaths.components, componentName, `${componentName}.yaml`)
-    const yamlObj = yaml.safeLoad(
+    return yaml.safeLoad(
       fs.readFileSync(yamlPath, 'utf8'), { json: true }
     )
-
-    yamlObj.examples = yamlObj.examples.filter(function (example) { return !example.hidden })
-
-    return yamlObj
   } catch (error) {
     return new Error(error)
   }

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -6,7 +6,7 @@ function CharacterCount ($module) {
   this.$module = $module
   this.$textarea = $module.querySelector('.govuk-js-character-count')
   if (this.$textarea) {
-    this.$countMessage = $module.querySelector('[id=' + this.$textarea.id + '-info]')
+    this.$countMessage = $module.querySelector('[id="' + this.$textarea.id + '-info"]')
   }
 }
 

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -141,6 +141,16 @@ describe('Character count', () => {
           expect(ariaHidden).toBeFalsy()
         })
       })
+
+      describe('when the ID starts with a number', () => {
+        it('still works correctly', async () => {
+          await goToExample('with-id-starting-with-number')
+
+          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+          expect(message).toEqual('You have 10 characters remaining')
+        })
+      })
     })
 
     describe('when counting words', () => {

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -223,3 +223,11 @@ examples:
       classes: app-character-count--custom-modifier
       errorMessage:
         text: Error message
+  - name: with id starting with number
+    hidden: true
+    data:
+      name: more-detail
+      id: 1_more-detail
+      maxlength: 10
+      label:
+        text: Can you provide more detail?


### PR DESCRIPTION
As reported in #2058, the call to `querySelector` in `character-count.js` errors when the id starts with a number:

> DOMException: Failed to execute 'querySelector' on 'Element': '[id=1_more-detail-info]' is not a valid selector.

Although it’s valid to start an ID with a number, the lack of quotes makes this an invalid CSS selector when interpolated with an ID that starts with a number, hence the error.

https://github.com/alphagov/govuk-frontend/blob/9b320cece2177f3a9749d8150e250fe8978e7eef/src/govuk/components/character-count/character-count.js#L8-L10

This is because [attribute values are either `ident-tokens` or `string-tokens`][1]. Omitting the quotes means that the atrribute value is treated as [an ident-token, which may not start with a number][2].

Quoting the value means it’s treated instead as [a string-token, which can start with a number][3].

Ideally we’d be using `document.getElementById` to get the count message, but we’ve [previously decided that would be a breaking change as it means the lookup is no longer scoped to the `$module`][4].

This also changes the way that we exclude hidden examples from the list of examples shown for each component, so that we still make their data available to the review app so that they can be viewed if you know the URL. This allows us to write JavaScript tests (which rely on examples in the review app) that target ‘edge cases’ without having to make the examples ‘visible’ in the review app.

Closes #2058

[1]: https://www.w3.org/TR/selectors/#attribute-representation
[2]: https://www.w3.org/TR/css-syntax-3/#ident-token-diagram
[3]: https://www.w3.org/TR/css-syntax-3/#string-token-diagram
[4]: #1843 (comment)