### PR TITLE
Add GitHub Action to diff changes to dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.min.js diff=minjs
+*.min.css diff=mincss

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -8,6 +8,8 @@ jobs:
   generate-diff:
     name: Generate Diff
     runs-on: ubuntu-latest
+    # Abort if run from a fork, as token won't have write access to post comment
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -1,0 +1,47 @@
+name: Diff changes to dist
+
+on:
+  pull_request:
+    paths: ['dist/**']
+
+jobs:
+  generate-diff:
+    name: Generate Diff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Need to also checkout the base branch to compare
+      - uses: actions/setup-node@v1
+      - name: Set up diff drivers
+        run: |
+          npm install -g js-beautify
+          git config diff.minjs.textconv js-beautify
+          git config diff.mincss.textconv js-beautify
+      - name: Generate diff
+        id: diff
+        run: |
+          diff=$(git diff -M1 origin/$GITHUB_BASE_REF -- dist)
+          # Escape new lines
+          diff="${diff//'%'/'%25'}"
+          diff="${diff//$'\n'/'%0A'}"
+          diff="${diff//$'\r'/'%0D'}"
+          echo "::set-output name=diff::$diff"
+      - name: Add comment to PR
+        uses: actions/github-script@v3
+        env:
+          DIFF: ${{ steps.diff.outputs.diff }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const commentText = '## Changes to dist\n' + 
+              '```diff\n' +
+              process.env.DIFF +
+              '\n```'
+
+            github.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentText
+            })


### PR DESCRIPTION
When a pull request makes changes to files in the `dist` directory, automatically post a prettified git diff of the changes made, which we can use to ensure that the changes are what we expect (versus trying to review the minified change on GitHub).

This broadly follows the same steps that we've been doing manually, as outlined in https://scripter.co/git-diff-minified-js-and-css/:

1. Install js-beautify
2. Define two new [diff drivers][1] using `git config` for minified JS and CSS
3. Configure Git to use the diff driver for minified CSS and JS in .gitattributes - if the driver is not defined (for example, because it's not in a contributor's local Git config) it seems to be ignored.
4. Run git diff against the base branch for the PR for the dist folder, whilst [allowing for renames using `-M`][2] with a similarity index of 10% which has worked well previously.

The diff is then added to the PR as a comment using a GitHub Script action.

There is an [example comment below](https://github.com/alphagov/govuk-frontend/pull/2082#issuecomment-749046038) based on some test changes made in d1f449be460ea9c0ad4a5a3cc1cf7b10d423d1c4 – that commit has since been rebased out of this branch.

[1]: https://git-scm.com/docs/gitattributes#_defining_an_external_diff_driver
[2]: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--Mltngt

Closes #2054 