### PR TITLE
Run review apps on Heroku 20 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "NPM_CONFIG_PRODUCTION": "false",
     "NODE_MODULES_CACHE": "false"
   },
+  "stack": "heroku-20",
   "formation": {
   },
   "addons": [


### PR DESCRIPTION
The current Heroku-16 stack will be end-of-life (EOL) from May 1st 2021. From June 1st 2021, builds will no longer be allowed for Heroku-16 apps.

Updating to the latest Heroku stack now means we won’t get an email every time a review app is deployed.

Changing the stack definition in app.json only changes the stack for new review apps. Once this has been tested, we’ll also need to change the stack for the current running ‘production’ app using the Heroku CLI or the Heroku Dashboard.

https://devcenter.heroku.com/articles/upgrading-to-the-latest-stack

Part of #2074 