### PR TITLE
[WIP] Make links and hover states clearer

### DIFF
--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -58,7 +58,39 @@
         </p>
       {% endfor %}
       </section>
+
     {% endfor %}
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-half">
+
+      <h2 class="govuk-heading-l govuk-!-margin-top-6">Multi-line links</h2>
+
+      <p class="govuk-heading-xl">
+        <a class="govuk-link" href="#">Research your family history using the General Register Office</a>
+      </p>
+
+      <p class="govuk-heading-l">
+        <a class="govuk-link" href="#">Research your family history using the General Register Office</a>
+      </p>
+
+      <p class="govuk-heading-m">
+        <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+      </p>
+
+      <p class="govuk-heading-s">
+        <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+      </p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+      </p>
+
+      <p class="govuk-body-s">
+        <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+      </p>
 
     </div>
   </div>

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -223,12 +223,6 @@
       <section class="govuk-!-margin-top-8">
         <h2 class="govuk-heading-l govuk-!-padding-bottom-2" style="border-bottom: 4px solid;">Links</h2>
         <div>
-          <h2 class="govuk-heading-xl"><a href="#" class="govuk-link">A heading with a link</h2>
-          <h2 class="govuk-heading-l"><a href="#" class="govuk-link">A heading with a link</h2>
-          <h2 class="govuk-heading-m"><a href="#" class="govuk-link">A heading with a link</h2>
-          <h2 class="govuk-heading-s"><a href="#" class="govuk-link">A heading with a link</h2>
-        </div>
-        <div>
           <p class="govuk-body">
             <a href="#" class="govuk-link">govuk-link</a>
           </p>
@@ -236,11 +230,6 @@
         <div>
           <p class="govuk-body">
             <a href="#" class="govuk-link govuk-link--muted">govuk-link govuk-link--muted</a>
-          </p>
-        </div>
-        <div>
-          <p class="govuk-body-s">
-            <a href="#" class="govuk-link">govuk-link govuk-link--muted</a>
           </p>
         </div>
       </section>

--- a/app/views/examples/typography/index.njk
+++ b/app/views/examples/typography/index.njk
@@ -223,6 +223,12 @@
       <section class="govuk-!-margin-top-8">
         <h2 class="govuk-heading-l govuk-!-padding-bottom-2" style="border-bottom: 4px solid;">Links</h2>
         <div>
+          <h2 class="govuk-heading-xl"><a href="#" class="govuk-link">A heading with a link</h2>
+          <h2 class="govuk-heading-l"><a href="#" class="govuk-link">A heading with a link</h2>
+          <h2 class="govuk-heading-m"><a href="#" class="govuk-link">A heading with a link</h2>
+          <h2 class="govuk-heading-s"><a href="#" class="govuk-link">A heading with a link</h2>
+        </div>
+        <div>
           <p class="govuk-body">
             <a href="#" class="govuk-link">govuk-link</a>
           </p>
@@ -230,6 +236,11 @@
         <div>
           <p class="govuk-body">
             <a href="#" class="govuk-link govuk-link--muted">govuk-link govuk-link--muted</a>
+          </p>
+        </div>
+        <div>
+          <p class="govuk-body-s">
+            <a href="#" class="govuk-link">govuk-link govuk-link--muted</a>
           </p>
         </div>
       </section>

--- a/app/views/full-page-examples/coronavirus-campaign/index.njk
+++ b/app/views/full-page-examples/coronavirus-campaign/index.njk
@@ -1,0 +1,195 @@
+---
+
+---
+
+{# This example is based off the coronavirus home page, to explore complex campaign-type pages, original available at https://www.gov.uk/coronavirus #}
+{% extends "_generic.njk" %}
+
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "radios/macro.njk" import govukRadios %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "button/macro.njk" import govukButton %}
+{% from "input/macro.njk" import govukInput %}
+
+{% set pageTitle = "Coronavirus (COVID‑19)" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block head %}
+    {{ super() }}
+    <style>
+
+        .govuk-header {
+          padding-bottom: 10px;
+          border-bottom: 10px solid #fff500;
+        }
+
+        .govuk-header__container {
+          border-bottom: none;
+        }
+
+        .app-covid-banner-top {
+          background-color: #0b0c0c;
+          padding-bottom: 20px;     
+        }
+
+        .app-covid-banner-top .govuk-heading-xl{
+          color: #fff;
+          padding-top: 10px;
+        }
+
+        .app-covid-banner-bottom {
+          background-color: #272828;
+          padding: 15px 0 5px;
+          margin-bottom: 30px;
+        }
+
+        .app-covid-banner-bottom .govuk-body,
+        .app-covid-banner-bottom .govuk-heading-m {
+          color: #fff;
+        }
+
+        .app-covid-banner-bottom .govuk-link,
+        .app-covid-banner-top .govuk-breadcrumbs__link {
+          color: #fff;
+          text-decoration-color: #fff;
+        }
+
+        .app-section {
+          border-top: 2px solid #0b0c0c;
+          padding: 15px 0;
+        }
+
+        section .govuk-heading-m {
+          font-size: 27px
+        }
+
+        .app-updates {
+          background-color: #f3f2f1;
+          border: 1px solid #b1b4b6;
+          padding: 20px 20px 10px;
+          margin-bottom: 50px;
+        }
+
+        .app-nhs-box {
+          border: 5px solid #0b0c0c;
+          padding: 20px;
+          margin-bottom: 20px;
+        }
+
+        .app-danger-box {
+          color: #fff;
+          background-color: #272828;
+          padding: 30px 25px;
+          border-left: solid #fff500;
+          border-width: 0 0 0 10px;
+          border-image: repeating-linear-gradient(25deg, transparent 0, #fff500 1px, #fff500 10px, transparent 11px, transparent 20px) 25;
+        }
+
+        .app-danger-box .govuk-body,
+        .app-danger-box .govuk-heading-m,
+        .app-danger-box .govuk-link {
+          color: #fff;
+        }
+
+        .app-danger-box .govuk-link {
+          text-decoration-color: #fff;
+        }
+
+    </style>
+{% endblock %}
+
+{% block main %}
+
+  <div class="app-covid-banner-top">
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row">  
+        <div class="govuk-grid-column-two-thirds">
+          {{ govukBreadcrumbs({
+              items: [
+                  {
+                      text: "Home",
+                      href: "#"
+                  }
+              ]
+          }) }}
+          <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">{{ pageTitle }}</h1>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="app-covid-banner-bottom">
+    <div class="govuk-width-container">
+      <div class="govuk-grid-row app-covid-banner-bottom">  
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-m">National lockdown: stay at home</h2>
+          <p class="govuk-body">Coronavirus (COVID‑19) is spreading fast.</p>
+          <p class="govuk-body">Do not leave your home unless necessary.</p>
+          <p class="govuk-body">1 in 3 people who have the virus have no symptoms, so you could be spreading it without knowing it.</p>
+          <a class="govuk-link govuk-heading-s" href="">Find out what the rules are</a>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-width-container">  
+    <div class="govuk-grid-row">  
+      <div class="govuk-grid-column-one-third">
+        <div class="app-nhs-box">
+          <h2 class="govuk-heading-m">If you have any coronavirus symptoms:</h2>
+          <ul class="govuk-list govuk-list--bullet">
+            <li>a high temperature</li>
+            <li>a new, continuous cough</li>
+            <li>a loss of, or change to, your sense of smell or taste</li>
+          </ul>
+          <p class="govuk-body govuk-!-font-weight-bold"><a class="govuk-link" href="#">Get a test</a> and stay at home</p>
+        </div>
+        <div class="app-danger-box">
+          <h2 class="govuk-heading-m">Find out what support you can get</h2>
+          <p class="govuk-body">For example, if you’re out of work, need to get food, or want to take care of your mental health.</p>
+          <p class="govuk-body govuk-!-font-weight-bold"><a class="govuk-link" href="#">Find support</a></p>
+        </div>
+      </div>
+      <div class="govuk-grid-column-two-thirds">
+        <section class="govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m">Recent and upcoming changes</h2>
+          <h3 class="govuk-heading-s">27 January</h3>
+          <p class="govuk-body">The Prime Minister has announced that <a class="govuk-link" href="#">it’ll not be possible to resume face-to-face learning</a> for the majority of pupils and students until 8 March at the earliest.</p>
+          <p class="govuk-body">The Prime Minister has also announced <a class="govuk-link" href="#">further measures at the border</a>, including the strengthening of requirements for some arrivals through hotel isolation. We’ll set out more details in due course.</p>
+          <h3 class="govuk-heading-s">5 January</h3>
+          <p class="govuk-body"><a class="govuk-link" href="#">National lockdown rules apply in England</a>. Stay at home. Find out what the rules are in <a class="govuk-link" href="#">Scotland</a>, <a class="govuk-link" href="#">Wales</a> and <a class="govuk-link" href="#">Northern Ireland</a>.</p>
+          <p class="govuk-body"><a class="govuk-link" href="#">Shielding has resumed in England</a>. If you’re shielding, do not attend work, school, college or university. You can get <a class="govuk-link" href="#">support if you’re clinically extremely vulnerable</a>, for example priority access to supermarket deliveries.</p>
+        </section>
+        <section class="app-section">
+          <h2 class="govuk-heading-m">Announcements</h2>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Schools and colleges will not return to full face-to-face education after February half-term</a></h3>
+          <p class="govuk-body">Published 27 January 2021</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">New rules for people travelling in to and out of the UK</a></h3>
+          <p class="govuk-body">Published 27 January 2021</p>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">New hard-hitting national TV ad urges the nation to stay at home</a></h3>
+          <p class="govuk-body">Published 27 January 2021</p>
+          <p class="govuk-body"><a class="govuk-link" href="#">See all announcements</a></p>
+        </section>
+        <section class="app-section govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m">Announcements</h2>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Daily summary of coronavirus testing, cases and vaccinatons</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">All data and analysis on coronavirus</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Coronavirus cases by local authority</a></h3>
+        </section>
+        <section class="app-section govuk-!-margin-bottom-8">
+          <h2 class="govuk-heading-m">All coronavirus information on GOV.UK</h2>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Guidance</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">News</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Legislation (legislation.gov.uk)</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Press conferences (YouTube)</a></h3>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Press conference statements</a></h3>
+        </section>
+        <div class="app-updates">
+          <h3 class="govuk-heading-s">Stay up to date with GOV.UK</h3>
+          <p class="govuk-body"><a class="govuk-link" href="#">Sign up to get emails when we change any coronavirus information on the GOV.UK website</a></p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+{% endblock %}

--- a/app/views/full-page-examples/search-results/index.njk
+++ b/app/views/full-page-examples/search-results/index.njk
@@ -1,0 +1,292 @@
+---
+
+---
+
+{# This example is based of the live search results page on GOV.UK, with a query of 'tax': https://www.gov.uk/search/all?keywords=tax&order=relevance #}
+{% extends "_generic.njk" %}
+
+{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "radios/macro.njk" import govukRadios %}
+{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "button/macro.njk" import govukButton %}
+{% from "input/macro.njk" import govukInput %}
+
+{% set pageTitle = "Search" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block head %}
+    {{ super() }}
+    <style>
+        .app-document-list {
+            list-style: none;
+            padding: 0;
+            margin-top: 0;
+            margin-bottom: 30px;
+        }
+        .app-document-list > li {
+            border-bottom: 1px solid #b1b4b6;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+        }
+        .app-metadata-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+            margin-left: -5px;
+            margin-right: -5px;
+        }
+        .app-metadata-list > li {
+            display: inline-block;
+            margin-left: 5px;
+            margin-right: 5px;
+        }
+        .app-filter li {
+          border-bottom: 1px solid #b1b4b6;
+          padding-bottom: 20px;
+        }
+
+        .app-search-result-list__children {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          column-gap: 15px;
+          list-style: none;
+        }
+
+        .app-search-results-summary {
+          position: relative;
+        }
+
+        .app-search-results-summary .subscribe-link {
+          position: absolute;
+          top: 5px;
+          right: 0;
+        }
+
+        .app-search-result-sort {
+          font-size: 16px;
+          line-height: 20px;
+        }
+
+        .app-search-result-sort label {
+          display: inline;
+          margin-right: 5px;
+          font-size: 16px;
+          line-height: 20px;  
+        }
+    </style>
+{% endblock %}
+
+{% block beforeContent %}
+    {{ govukBreadcrumbs({
+        items: [
+            {
+                text: "Home",
+                href: "#"
+            }
+        ]
+    }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-5">{{ pageTitle }}</h1>
+  
+
+  {{ govukInput({
+    label: {
+      text: "Search GOV.UK",
+      classes: "govuk-label--l, govuk-visually-hidden"
+    },
+    id: "search",
+    name: "search",
+    classes: "govuk-!-width-two-thirds",
+    value: "tax"
+  }) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      <ul class="govuk-list govuk-list--spaced app-filter">
+        <li><a class="govuk-link" href="#">Topic</a></li>
+        <li><a class="govuk-link" href="#">Content type</a></li>
+        <li><a class="govuk-link" href="#">Updated</a></li>
+      </ul>
+    </div>
+    <div class="govuk-grid-column-two-thirds">
+      <div class="app-search-results-summary">
+        <h2 class="govuk-heading-s">58,779 results</h2>
+        <span class="subscribe-link"><a href="#" class="govuk-link govuk-body-s">Subscribe to feed</a></span>
+      </div>
+      <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible govuk-!-margin-bottom-3">
+      <div class="app-search-result-sort">
+        {{ govukSelect({
+          id: "sort",
+          name: "sort",
+          classes: "app-search-result-sort",
+          label: {
+            text: "Sort by"
+          },
+          items: [
+            {
+              value: "relevance",
+              text: "Relevance"
+            },
+            {
+              value: "updated-new",
+              text: "Updated (newest)",
+              selected: true
+            },
+            {
+              value: "updated-old",
+              text: "Updated (oldest)"
+            }
+          ]
+        }) }}
+      </div>
+      <ul class="app-document-list">
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Tax your vehicle
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Renew or <strong>tax</strong> your vehicle for the first time using a reminder letter, your log book or the green 'new keeper' slip - and how to <strong>tax</strong> if you do not have any documents
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Income Tax
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Income <strong>tax</strong> is a <strong>tax</strong> you pay on your earnings - find out about what it is, how you pay and how to check you're paying the right amount using HMRC's <strong>tax</strong> calculator
+          </p>
+          <ul class="app-search-result-list__children">
+            <li>
+              <h4 class="govuk-heading-xs govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+                <a class="govuk-link" href="#">
+                  Overview
+                </a>
+              </h4>
+              <p class="govuk-body-s">
+                Income Tax is a tax you pay on your income. You do not have to pay tax on…
+              </p>
+            </li>
+            <li>
+              <h4 class="govuk-heading-xs govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+                <a class="govuk-link" href="#">
+                  How you pay Income Tax
+                </a>
+              </h4>
+              <p class="govuk-body-s">      
+                Pay As You Earn (PAYE) Most people pay Income Tax through PAYE. This is…
+              </p>
+            </li>
+            <li>
+              <h4 class="govuk-heading-xs govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+                <a class="govuk-link" href="#">
+                  Tax-free and taxable state benefits
+                </a>
+              </h4>
+              <p class="govuk-body-s">      
+                State benefits that are taxable The most common benefits that you pay…
+              </p>
+            </li>
+            <li>
+              <h4 class="govuk-heading-xs govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+                <a class="govuk-link" href="#">
+                  Work out if you need to pay Income Tax
+                </a>
+              </h4>
+              <p class="govuk-body-s">                   
+                To work out if you should be paying Income Tax, follow these steps. Add up…
+              </p>
+            </li>
+            <li>
+              <h4 class="govuk-heading-xs govuk-!-margin-bottom-1 govuk-!-margin-top-1">
+                <a class="govuk-link" href="#">
+                  Check you're paying the right amount
+                </a>
+              </h4>
+              <p class="govuk-body-s">                   
+                You can see if you’re paying the right amount of Income Tax online. For…
+              </p>
+            </li>
+          </ul>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Check if you need to send a Self Assessment tax return
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Use this tool to find out if you need to send a tax return for the 2019 to 2020 tax year (6 April 2019 to 5 April 2020).
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              HMRC services: sign in or register
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Sign in or register for your personal or business tax account, Self Assessment, Corporation Tax, PAYE for employers, VAT and other services
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Check if a vehicle is taxed
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Check and report if a vehicle has up-to-date vehicle tax or is 'off road' (SORN)
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Apply for a Test and Trace Support Payment
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Find out if you can get a Test and Trace Support Payment from your local council
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              HM Revenue & Customs
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            …We help the honest majority to get their tax right and make it hard for the dishonest minority to cheat the system.
+          </p>
+        </li>
+        <li>
+          <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
+            <a class="govuk-link" href="#">
+              Check your Income Tax for the current year
+            </a>
+          </h3>
+          <p class="govuk-body-s">
+            Check your Income Tax, Personal Allowance and tax code for the current tax year. Change your tax code if it's wrong.
+          </p>
+        </li>
+
+      </ul>
+
+      <div class="govuk-!-margin-left-5">
+        <p class="govuk-body">
+          <a class="govuk-link " href="#">
+            <span class="govuk-!-font-weight-bold">Next page</span><br>
+            <span class="govuk-!-font-size-16">2 of 2939</span>
+          </a>
+        </p>
+      </div>
+
+    </div>
+  </div>
+{% endblock %}

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -26,7 +26,8 @@
 
   // Only underline if the component is linkable
   .govuk-back-link[href] {
-    text-decoration: underline;
+    // Removing this so that the back link uses same approach as other links
+    // text-decoration: underline;
 
     // When the back link is focused, hide the bottom link border as the
     // focus styles has a bottom border.

--- a/src/govuk/components/details/_index.scss
+++ b/src/govuk/components/details/_index.scss
@@ -23,10 +23,6 @@
     color: $govuk-link-colour;
     cursor: pointer;
 
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
-
     &:focus {
       @include govuk-focused-text;
     }
@@ -34,6 +30,7 @@
 
   // ...but only underline the text, not the arrow
   .govuk-details__summary-text {
+    @include govuk-link-common;
     text-decoration: underline;
   }
 

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -37,6 +37,7 @@
   }
 
   .govuk-footer__link {
+    @include govuk-link-common;
     @if ($govuk-use-legacy-palette) {
       &:link,
       &:visited {

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -70,6 +70,8 @@
 
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: 3px;
+      text-underline-offset: .1em;
     }
 
     &:focus {
@@ -103,10 +105,10 @@
     &:hover,
     &:active {
       // Negate the added border
-      margin-bottom: -1px;
+      margin-bottom: -3px;
       // Omitting colour will use default value of currentColor – if we
       // specified currentColor explicitly IE8 would ignore this rule.
-      border-bottom: 1px solid;
+      border-bottom: 3px solid;
     }
 
     // Remove any borders that show when focused and hovered.
@@ -161,6 +163,8 @@
 
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: 3px;
+      text-underline-offset: .1em;
     }
 
     &:focus {

--- a/src/govuk/components/tabs/_index.scss
+++ b/src/govuk/components/tabs/_index.scss
@@ -102,9 +102,9 @@
       }
 
       .govuk-tabs__tab {
-        @include govuk-link-style-text;
-
+        @include govuk-link-common;
         margin-bottom: 0;
+        color: $govuk-text-colour;
 
         &:after {
           content: "";

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -98,10 +98,11 @@
     @include govuk-link-colour($govuk-error-colour);
   }
 
-  &:hover {
-    $hover-color: scale-color($govuk-error-colour, $lightness: -30%);
-    color: $hover-color;
-  }
+  // Removing this for working group review
+  // &:hover {
+  //   $hover-color: scale-color($govuk-error-colour, $lightness: -30%);
+  //   color: $hover-color;
+  // }
 
   &:active {
     color: $govuk-error-colour;
@@ -146,10 +147,11 @@
     @include govuk-link-colour($govuk-success-colour);
   }
 
-  &:hover {
-    $hover-color: scale-color($govuk-success-colour, $lightness: -30%);
-    color: $hover-color;
-  }
+  // Removing this for the working group review
+  // &:hover {
+  //   $hover-color: scale-color($govuk-success-colour, $lightness: -30%);
+  //   color: $hover-color;
+  // }
 
   &:active {
     color: $govuk-success-colour;

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -11,6 +11,10 @@
 @mixin govuk-link-common {
   @include govuk-typography-common;
 
+  &:hover {
+    text-decoration-thickness: unquote("max(2px, .15em)");
+  }
+
   &:focus {
     @include govuk-focused-text;
   }

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -25,7 +25,6 @@
 
 @mixin govuk-link-colour($colour) {
   color: $colour;
-  text-decoration-color: lighten(desaturate($colour, 20.52), 14.71);
 }
 
 /// Default link style mixin
@@ -54,12 +53,10 @@
 
   &:hover {
     color: $govuk-link-colour;
-    text-decoration-color: $govuk-link-colour;
   }
 
   &:active {
     color: $govuk-link-active-colour;
-    text-decoration-color: $govuk-link-active-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -104,12 +101,10 @@
   &:hover {
     $hover-color: scale-color($govuk-error-colour, $lightness: -30%);
     color: $hover-color;
-    text-decoration-color: $hover-color;
   }
 
   &:active {
     color: $govuk-error-colour;
-    text-decoration-color: $govuk-error-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -154,12 +149,10 @@
   &:hover {
     $hover-color: scale-color($govuk-success-colour, $lightness: -30%);
     color: $hover-color;
-    text-decoration-color: $hover-color;
   }
 
   &:active {
     color: $govuk-success-colour;
-    text-decoration-color: $govuk-success-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -283,7 +276,6 @@
 
   &:visited {
     color: $govuk-link-colour;
-    text-decoration-color: govuk-colour("light-blue");
   }
 
   &:hover {

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -10,9 +10,12 @@
 
 @mixin govuk-link-common {
   @include govuk-typography-common;
+  text-decoration-thickness: 1px;
+  text-underline-offset: .1em;
 
   &:hover {
-    text-decoration-thickness: unquote("max(2px, .15em)");
+    // text-decoration-thickness: 3px;
+    text-decoration-thickness: unquote("max(2px, .18em)");
   }
 
   &:focus {
@@ -38,18 +41,22 @@
 @mixin govuk-link-style-default {
   &:link {
     color: $govuk-link-colour;
+    text-decoration-color: govuk-colour("light-blue");
   }
 
   &:visited {
     color: $govuk-link-visited-colour;
+    text-decoration-color: $govuk-link-visited-colour;
   }
 
   &:hover {
-    color: $govuk-link-hover-colour;
+    color: $govuk-link-colour;
+    text-decoration-color: $govuk-link-colour;
   }
 
   &:active {
     color: $govuk-link-active-colour;
+    text-decoration-color: $govuk-link-active-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -186,6 +193,7 @@
   &:hover,
   &:active {
     color: $govuk-secondary-text-colour;
+    text-decoration-color: $govuk-secondary-text-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -228,6 +236,7 @@
   &:active,
   &:focus {
     @include govuk-text-colour;
+    text-decoration-color: $govuk-text-colour;
   }
 
   // alphagov/govuk_template includes a specific a:link:focus selector designed
@@ -267,10 +276,11 @@
 
   &:visited {
     color: $govuk-link-colour;
+    text-decoration-color: govuk-colour("light-blue");
   }
 
   &:hover {
-    color: $govuk-link-hover-colour;
+    color: $govuk-link-colour;
   }
 
   &:active {

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -14,8 +14,7 @@
   text-underline-offset: .1em;
 
   &:hover {
-    // text-decoration-thickness: 3px;
-    text-decoration-thickness: unquote("max(2px, .18em)");
+    text-decoration-thickness: unquote("max(3px, .12em)");
   }
 
   &:focus {
@@ -51,9 +50,9 @@
     @include govuk-link-colour($govuk-link-visited-colour);
   }
 
-  &:hover {
-    color: $govuk-link-colour;
-  }
+  // &:hover {
+  //   color: inherit;
+  // }
 
   &:active {
     color: $govuk-link-active-colour;


### PR DESCRIPTION
(not actually Ollie's words – added by @christopherthomasdesign  later)

Some changes to link styles and hover states, put together for the working group review in February 2021.

There are 2 problems we're trying to solve here:

- link hover states are not clear (outlined in https://github.com/alphagov/govuk-frontend/issues/1417)
- link text could be easier to read – especially when used in long lists or at larger sizes (a problem raised by designers on the GOV.UK team)

The change adds some extra CSS to links to make underlines lighter and a bit further away from the text:

```
text-decoration-thickness: 1px;
text-underline-offset: .1em;
```

Browser support for this is about to improve massively when it's adopted by Chrome around April this year. We see it as an enhancement – for browsers that don't support these properties, the normal underline will still work.

On hover the underlines become thicker, to make the hover state clearer:

```
text-decoration-thickness: unquote("max(2px, .18em)");
```

Some of the rationale for this is included in a [comment around the time of the previous working group review](https://github.com/alphagov/govuk-frontend/issues/1417#issuecomment-590970918). The broad intention is that the thicker underline is a state change that can work across any combination of text colour and background colour, as long as the link has enough contrast in its default state.
