### PR TITLE
Use tabular numbers for character count message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2080: Fix JavaScript error when character count ID starts with a number](https://github.com/alphagov/govuk-frontend/pull/2080) - thanks to [@josef-vlach](https://github.com/josef-vlach) for reporting this issue.
+- [#2092: Use tabular numbers for character count message](https://github.com/alphagov/govuk-frontend/pull/2092)
 
 ## 3.10.2 (Patch release)
 

--- a/src/govuk/components/character-count/_index.scss
+++ b/src/govuk/components/character-count/_index.scss
@@ -14,6 +14,7 @@
   }
 
   .govuk-character-count__message {
+    @include govuk-font($size: false, $tabular: true);
     margin-top: 0;
     margin-bottom: 0;
   }


### PR DESCRIPTION
By default different numbers take up different amounts of horizontal space, for example ‘1’ is narrower than ‘0’, just like an ‘i’ is narrower than an ‘m’.

In the character count component the amount of space take up by the message changes as the user types. This causes the words after the count (‘characters remaining’) to jump around in a distracting way.

Tabular numbers take up a fixed amount of space, which means the words after the count do not change position as long as the count maintains the same number of digits (which will be true for most keystrokes).

# Before 

![cc-lining](https://user-images.githubusercontent.com/355079/103925722-dc75d080-510f-11eb-881f-09869c96bc97.gif)

# After 

![cc-tabular](https://user-images.githubusercontent.com/355079/103925735-e0095780-510f-11eb-92a0-b94ca66eb958.gif)
