### PR TITLE
Only output space after breadcrumbs class if there's an additional class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2080: Fix JavaScript error when character count ID starts with a number](https://github.com/alphagov/govuk-frontend/pull/2080) - thanks to [@josef-vlach](https://github.com/josef-vlach) for reporting this issue.
 - [#2092: Use tabular numbers for character count message](https://github.com/alphagov/govuk-frontend/pull/2092)
 - [#2045: Stop same-site cookies from being wiped when printing in Internet Explorer 11](https://github.com/alphagov/govuk-frontend/pull/2045) – thanks to [@gunjam](https://github.com/gunjam) for contributing this
+- [#2093: Only output space after breadcrumbs class if there’s an additional class](https://github.com/alphagov/govuk-frontend/pull/2093) – thanks to [@frankieroberto](https://github.com/frankieroberto) for contributing this.
 
 ## 3.10.2 (Patch release)
 

--- a/src/govuk/components/breadcrumbs/template.njk
+++ b/src/govuk/components/breadcrumbs/template.njk
@@ -1,8 +1,8 @@
 {# Set classes for this component #}
-{%- set classNames = "govuk-breadcrumbs " -%}
+{%- set classNames = "govuk-breadcrumbs" -%}
 
 {% if params.classes %}
-  {% set classNames = classNames + params.classes %}
+  {% set classNames = classNames + " " + params.classes %}
 {% endif -%}
 
 {% if params.collapseOnMobile %}


### PR DESCRIPTION
This change prevents the breadcrumb component from outputting a space after the html class if there are no custom classes to include. This has no impact on end users, but improves consistency with other components, and makes it easier to port the macros to other languages using the test fixtures. 

## Before

```html
<div class="govuk-breadcrumbs ">
```

## After

```html
<div class="govuk-breadcrumbs">
```