### PR TITLE
Add button groups for use in cookie banner

### DIFF
--- a/app/views/examples/button-groups/index.njk
+++ b/app/views/examples/button-groups/index.njk
@@ -1,0 +1,111 @@
+{% extends "layout.njk" %}
+
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    "href": "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      "text": "Accept analytics cookies"
+    }) }}
+
+    {{ govukButton({
+      "text": "Reject analytics cookies"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--align-button">View cookies</a>
+  </div>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      "text": "Derbyn cwcis dadansoddeg"
+    }) }}
+
+    {{ govukButton({
+      "text": "Gwrthod cwcis dadansoddeg"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--align-button">Gweld cwcis</a>
+  </div>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      "text": "Accept really important analytics cookies"
+    }) }}
+
+    {{ govukButton({
+      "text": "Reject really important analytics cookies but not essential cookies"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--align-button">View cookies and set preferences to do with whether we can set cookies</a>
+  </div>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      "text": "Delete account",
+      "classes": "govuk-button--warning"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--muted govuk-link--align-button">Cancel</a>
+    <a href="#" class="govuk-link govuk-link--muted govuk-link--align-button">Cancel and go back</a>
+  </div>
+
+  <div class="govuk-button-group">
+    <a href="#" class="govuk-link govuk-link--align-button">Buy it</a>
+
+    {{ govukButton({
+      "text": "Use it"
+    }) }}
+
+    {{ govukButton({
+      "text": "Break it"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--align-button">Fix it</a>
+    <a href="#" class="govuk-link govuk-link--align-button">Trash it</a>
+    <a href="#" class="govuk-link govuk-link--align-button">Change it</a>
+
+    {{ govukButton({
+      "text": "Mail it"
+    }) }}
+
+    <a href="#" class="govuk-link govuk-link--align-button">Upgrade it</a>
+    
+    <a href="#" class="govuk-link govuk-link--align-button">Charge it</a>
+
+    {{ govukButton({
+      "text": "Point it"
+    }) }}
+
+    {{ govukButton({
+      "text": "Zoom it"
+    }) }}
+
+    {{ govukButton({
+      "text": "Press it"
+    }) }}
+  </div>
+
+  <div class="govuk-button-group">
+    {{ govukButton({
+      text: "Start now",
+      href: "#",
+      isStartButton: true
+    }) }}
+
+    <a href="#" class="govuk-link">Back</a>
+  </div>
+
+  </div>
+</div>
+{% endblock %}

--- a/app/views/full-page-examples/confirm-delete/index.njk
+++ b/app/views/full-page-examples/confirm-delete/index.njk
@@ -26,17 +26,17 @@
       }) }}
 
       <form method="post" novalidate>
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Delete account",
+            classes: "govuk-button--warning"
+          }) }}
 
-        {{ govukButton({
-          text: "Delete account",
-          classes: "govuk-button--warning govuk-!-margin-right-3"
-        }) }}
-
-        {{ govukButton({
-          text: "Cancel",
-          classes: "govuk-button--secondary"
-        }) }}
-
+          {{ govukButton({
+            text: "Cancel",
+            classes: "govuk-button--secondary"
+          }) }}
+        </div>
       </form>
 
     </div>

--- a/src/govuk/objects/_all.scss
+++ b/src/govuk/objects/_all.scss
@@ -1,3 +1,4 @@
+@import "button-group";
 @import "form-group";
 @import "grid";
 @import "main-wrapper";

--- a/src/govuk/objects/_button-group.scss
+++ b/src/govuk/objects/_button-group.scss
@@ -1,0 +1,75 @@
+@import "../base";
+
+@include govuk-exports("govuk/objects/button-group") {
+  // Button groups can be used to group buttons and links together as a group.
+  //
+  // Within a button group:
+  //
+  // - links are styled to line up visually with the buttons, including being
+  //   centre-aligned on mobile
+  // - spacing between the buttons and links is handled automatically, including
+  //   when they wrap across multiple lines
+  .govuk-button-group {
+    $horizontal-gap: govuk-spacing(3);
+    $vertical-gap: govuk-spacing(3);
+
+    // These need to be kept in sync with the button component's styles
+    $button-padding: govuk-spacing(2);
+    $button-shadow-size: $govuk-border-width-form-element;
+
+    $link-spacing: govuk-spacing(1);
+
+    @include govuk-responsive-margin(6, "bottom", $adjustment: $vertical-gap * -1);
+
+    // Flexbox is used to center-align links on mobile, align everything along
+    // the baseline on tablet and above, and to removes extra whitespace that
+    // we'd get between the buttons and links because they're inline-blocks.
+    //
+    // Ideally we'd use `gap` with flexbox rather than having to do it all with
+    // margins, but unfortunately the support isn't there (yet) and @supports
+    // doesn't play nicely with it
+    // (https://github.com/w3c/csswg-drafts/issues/3559)
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    // Give links within the button group the same font-size and line-height
+    // as buttons.
+    //
+    // Because we want the focus state to be tight around the link text, we use
+    // margins where the buttons would use padding.
+    .govuk-link {
+      @include govuk-font($size: 19, $line-height: 19px);
+      display: inline-block;
+      margin-top: $link-spacing;
+      margin-bottom: $link-spacing + $vertical-gap;
+      text-align: center;
+    }
+
+    // Reduce the bottom margin to the size of the vertical gap (accommodating
+    // the button shadow) – the 'lost' margin is moved to the button-group.
+    .govuk-button {
+      margin-bottom: $vertical-gap + $button-shadow-size;
+    }
+
+    // On tablet and above, we also introduce a 'column gap' between the
+    // buttons and links in each row and left align links
+    @include govuk-media-query($from: tablet) {
+      // Cancel out the column gap for the last item in each row
+      margin-right: ($horizontal-gap * -1);
+
+      flex-direction: row;
+      flex-wrap: wrap;
+      align-items: baseline;
+
+      .govuk-button,
+      .govuk-link {
+        margin-right: $horizontal-gap;
+      }
+
+      .govuk-link {
+        text-align: left;
+      }
+    }
+  }
+}

--- a/src/govuk/objects/_button-group.scss
+++ b/src/govuk/objects/_button-group.scss
@@ -41,6 +41,9 @@
     .govuk-link {
       @include govuk-font($size: 19, $line-height: 19px);
       display: inline-block;
+      // Prevent links overflowing their container in IE10/11 because of bug
+      // with align-items: center
+      max-width: 100%;
       margin-top: $link-spacing;
       margin-bottom: $link-spacing + $vertical-gap;
       text-align: center;


### PR DESCRIPTION
Add a new button groups object which can be used to group buttons and links together.

Within a button group:
 - links are styled to line up visually with the buttons, including being centre-aligned on mobile
 - spacing between the buttons and links is handled automatically, including when they wrap across multiple lines

The button group object will then be used to group the 'Accept cookies', 'Reject cookies' and 'View cookies' buttons and links in the cookie banner component.

The button group object uses flexbox and align-items to align the buttons and links along the 'cross axis' – centre-aligning on mobile and aligning rows along the baseline on tablet and above.

`align-items` is in theory supported in IE11 and above, but our use of autoprefixer means that IE10-compatible flexbox properties are also included, and in testing it works as well in IE10 as it does in IE11.

In browsers that do not support [flexbox][1] or [align-items][2] the spacing between buttons and links is different (as whitespace between inline blocks is not handled) and they are not aligned along the cross-axis, but the general layout is still applied (see screenshots for IE9, IE8 and iOS 7 for examples).

There's a corresponding PR to add guidance to the Design System here: https://github.com/alphagov/govuk-design-system/pull/1472

Closes #2107 

[1]: https://caniuse.com/flexbox
[2]: https://caniuse.com/mdn-css_properties_align-items_flex_context

## Screenshots

### Firefox 84 (macOS)
![Firefox 84](https://user-images.githubusercontent.com/121939/105829845-c3e53180-5fbc-11eb-9c82-f5245c836a10.png)

### Safari 14 (macOS)
![Safari 14](https://user-images.githubusercontent.com/121939/105829848-c5165e80-5fbc-11eb-85ea-b763243c615d.png)

### Chrome 88 (macOS)
![Chrome 88](https://user-images.githubusercontent.com/121939/105829852-c5165e80-5fbc-11eb-8160-70d8298c055b.png)

### Android 11
![Android 11](https://user-images.githubusercontent.com/121939/105829861-c6478b80-5fbc-11eb-8620-d1387962fbf1.png)

### Edge 87
![Edge](https://user-images.githubusercontent.com/121939/105829863-c6478b80-5fbc-11eb-923e-71ab954832a6.png)

### IE11
![IE11](https://user-images.githubusercontent.com/121939/105829864-c6e02200-5fbc-11eb-9a56-aacacc1bf466.png)

### IE10
![IE10](https://user-images.githubusercontent.com/121939/105829868-c778b880-5fbc-11eb-891c-fc76c219e195.png)

### IE10 ('mobile')
![IE10 mobile](https://user-images.githubusercontent.com/121939/105829865-c6e02200-5fbc-11eb-9c58-de7c901308b1.png)

### IE9
![IE9](https://user-images.githubusercontent.com/121939/105829871-c8114f00-5fbc-11eb-9b8f-6c12cc90f4d9.png)

### IE8
![IE8](https://user-images.githubusercontent.com/121939/105829874-c8114f00-5fbc-11eb-80d9-34c36e60f7e4.png)

### iOS 7 (Simulated iPhone 5S)
![iOS 7 (Simulated iPhone 5S)](https://user-images.githubusercontent.com/121939/105829855-c5165e80-5fbc-11eb-94bf-052e50ba0424.png)

### Android 4.4 (Simulated Galaxy S4)
![Android 4 4 (Simulated Galaxy S4)](https://user-images.githubusercontent.com/121939/105829858-c5aef500-5fbc-11eb-932e-91aab9ea630f.png)

## Example of use in the cookie banner

https://user-images.githubusercontent.com/121939/105830147-0e66ae00-5fbd-11eb-8d5b-0b498e427d0a.mov
