### PR TITLE
Add Nunjucks macro template, tests and examples for cookie banner 

### DIFF
--- a/src/govuk/components/_all.scss
+++ b/src/govuk/components/_all.scss
@@ -6,6 +6,7 @@
 @import "button/index";
 @import "checkboxes/index";
 @import "character-count/index";
+@import "cookie-banner/index";
 @import "summary-list/index";
 @import "date-input/index";
 @import "details/index";

--- a/src/govuk/components/cookie-banner/_cookie-banner.scss
+++ b/src/govuk/components/cookie-banner/_cookie-banner.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -1,5 +1,6 @@
 @include govuk-exports("govuk/component/cookie-banner") {
-  .govuk-cookie-banner__container--hidden {
+  // For supporting older browsers which don't hide elements with the `hidden` attribute
+  .govuk-cookie-banner__container[hidden] {
     display: none;
   }
 }

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -1,6 +1,6 @@
 @include govuk-exports("govuk/component/cookie-banner") {
   // For supporting older browsers which don't hide elements with the `hidden` attribute
-  .govuk-cookie-banner__container[hidden] {
+  .govuk-cookie-banner__message[hidden] {
     display: none;
   }
 }

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -1,0 +1,5 @@
+@include govuk-exports("govuk/component/cookie-banner") {
+  .govuk-cookie-banner__container--hidden {
+    display: none;
+  }
+}

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -100,8 +100,6 @@ examples:
           actions:
             - text: Hide this message
               type: button
-              attributes:
-                "data-hide-button": "true"
 
   - name: rejected confirmation banner
     data:
@@ -111,8 +109,36 @@ examples:
           actions:
             - text: Hide this message
               type: button
-              attributes:
-                "data-hide-button": "true"
+
+  - name: client-side implementation
+    data:
+      banners:
+        - headingText: Cookies on this service
+          text: We use cookies to help understand how users use our service.
+          actions:
+            - text: Accept analytics cookies
+              type: submit
+              name: cookies
+              value: accept
+            - text: Reject analytics cookies
+              type: submit
+              name: cookies
+              value: reject
+            - text: View cookie preferences
+              href: /cookie-preferences
+        - text: Your cookie preferences have been saved. You have accepted cookies.
+          role: alert
+          hidden: true
+          actions:
+            - text: Hide this message
+              type: button
+        - text: Your cookie preferences have been saved. You have rejected cookies.
+          role: alert
+          hidden: true
+          actions:
+            - text: Hide this message
+              type: button
+
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: heading html

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -114,3 +114,107 @@ examples:
               attributes:
                 "data-hide-button": "true"
 
+# Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: heading html
+    hidden: true
+    data:
+      banners:
+        - headingHtml: Cookies on <span>my service</span>
+  - name: heading html as text
+    hidden: true
+    data:
+      banners:
+        - headingText: Cookies on <span>my service</span>
+  - name: html
+    hidden: true
+    data:
+      banners:
+        - html: <p class="govuk-body">We use cookies in <span>our service</span>.</p>
+  - name: classes
+    hidden: true
+    data:
+      banners:
+        - classes: "app-my-class"
+  - name: attributes
+    hidden: true
+    data:
+      banners:
+        - attributes:
+            "data-attribute": "my-value"
+  - name: custom aria label
+    hidden: true
+    data:
+      ariaLabel: "Cookies on GOV.UK"
+      banners:
+        - text: "We use cookies on GOV.UK"
+  - name: hidden
+    hidden: true
+    data:
+      banners:
+        - hidden: true
+  - name: hidden false
+    hidden: true
+    data:
+      banners:
+        - hidden: false
+  - name: default action
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: This is a button
+  - name: link
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: This is a link
+            href: /link
+  - name: link with button options
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: This is a link
+            href: /link
+            value: cookies
+            name: link
+  - name: type
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: Button
+            type: button
+  - name: button classes
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: Button with custom classes
+            classes: "my-button-class app-button-class"
+  - name: button attributes
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: Button with attributes
+            attributes:
+              "data-button-attribute": "my-value"
+  - name: link classes
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: Link with custom classes
+            href: /my-link
+            classes: "my-link-class app-link-class"
+  - name: link attributes
+    hidden: true
+    data:
+      banners:
+        - actions:
+          - text: Link with attributes
+            href: /link
+            attributes:
+              "data-link-attribute": "my-value"

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -1,0 +1,75 @@
+params:
+- name: ariaLabel
+  type: string
+  required: false
+  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all banners that the cookie banner includes. For example, the question banner and the replacement banner. Defaults to "Cookie banner".
+- name: banners
+  type: array
+  required: true
+  description: Required. The different kinds of banners you can pass into the cookie banner. For example, the question banner and the replacement banner.
+  params:
+    - name: headingText
+      type: string
+      required: false
+      description: The heading text that displays in the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.
+    - name: headingHtml
+      type: string
+      required: false
+      description: The heading HTML to use within the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.If you are not passing HTML, use `headingText`.
+    - name: text
+      type: string
+      required: false
+      description: Required. The text for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
+    - name: html
+      type: string
+      required: false
+      description: Required. The HTML for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `Text`.
+    - name: hidden
+      type: boolean
+      required: false
+      description: Defaults to false. If you set it to `true`, the banner is hidden. You can use `hidden` for client-side implementations where the replacement banner HTML is present, but hidden on the page.
+    - name: role
+      type: string
+      required: false
+      description: Set `role` to ’alert` on replacement banners to allow assistive tech to automatically read the message. You will also need to move focus to the replacement banner using JavaScript you have written yourself
+    - name: classes
+      type: string
+      required: false
+      description: The additional classes that you want to add to the cookie banner.
+    - name: attributes
+      type: object
+      required: false
+      description: The additional attributes that you want to add to the cookie banner. For example, data attributes.
+    - name: actions
+      type: array
+      required: false
+      description: The buttons and links that you want to display in the cookie banner. `actions` defaults to `button` unless you set `href`, which renders the action as a link.
+      params:
+        - name: text
+          type: string
+          required: false
+          description: Required. The button or link text that you want to add to the cookie banner.
+        - name: type
+          type: string
+          required: false
+          description: The type of button. Does not apply if you set `href`, which renders a link. You can choose `button` or `submit`.
+        - name: href
+          type: string
+          required: false
+          description: The `href` for a link. If you set `href`, users will see a link instead of a button.
+        - name: name
+          type: string
+          required: false
+          description: The name attribute for the button. Does not apply if you set `href`, which makes a link.
+        - name: value
+          type: string
+          required: false
+          description: The value attribute for the button. Does not apply if you set `href`, which makes a link.
+        - name: classes
+          type: string
+          required: false
+          description: The additional classes that you want to add to the button or link.
+        - name: attributes
+          type: object
+          required: false
+          description: The additional attributes that you want to add to the button or link. For example, data attributes.

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -73,3 +73,44 @@ params:
           type: object
           required: false
           description: The additional attributes that you want to add to the button or link. For example, data attributes.
+
+examples:
+  - name: default
+    data:
+      banners:
+        - headingText: Cookies on this government service
+          text: We use analytics cookies to help understand how users use our service.
+          actions:
+            - text: Accept analytics cookies
+              type: submit
+              name: cookies
+              value: accept
+            - text: Reject analytics cookies
+              type: submit
+              name: cookies
+              value: reject
+            - text: View cookie preferences
+              href: /cookie-preferences
+
+  - name: accepted confirmation banner
+    data:
+      banners:
+        - text: Your cookie preferences have been saved. You have accepted cookies.
+          role: alert
+          actions:
+            - text: Hide this message
+              type: button
+              attributes:
+                "data-hide-button": "true"
+
+  - name: rejected confirmation banner
+    data:
+      banners:
+        - text: Your cookie preferences have been saved. You have rejected cookies.
+          role: alert
+          actions:
+            - text: Hide this message
+              type: button
+              attributes:
+                "data-hide-button": "true"
+

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -2,11 +2,11 @@ params:
 - name: ariaLabel
   type: string
   required: false
-  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all banners that the cookie banner includes. For example, the question banner and the replacement banner. Defaults to "Cookie banner".
+  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all banners that the cookie banner includes. For example, the question banner and the replacement message. Defaults to "Cookie banner".
 - name: banners
   type: array
   required: true
-  description: Required. The different kinds of banners you can pass into the cookie banner. For example, the question banner and the replacement banner.
+  description: Required. The different kinds of banners you can pass into the cookie banner. For example, the question banner and the replacement message.
   params:
     - name: headingText
       type: string
@@ -15,7 +15,7 @@ params:
     - name: headingHtml
       type: string
       required: false
-      description: The heading HTML to use within the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.If you are not passing HTML, use `headingText`.
+      description: The heading HTML to use within the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored. If you are not passing HTML, use `headingText`.
     - name: text
       type: string
       required: false
@@ -23,15 +23,15 @@ params:
     - name: html
       type: string
       required: false
-      description: Required. The HTML for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `Text`.
+      description: Required. The HTML for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
     - name: hidden
       type: boolean
       required: false
-      description: Defaults to false. If you set it to `true`, the banner is hidden. You can use `hidden` for client-side implementations where the replacement banner HTML is present, but hidden on the page.
+      description: Defaults to false. If you set it to `true`, the banner is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
     - name: role
       type: string
       required: false
-      description: Set `role` to ’alert` on replacement banners to allow assistive tech to automatically read the message. You will also need to move focus to the replacement banner using JavaScript you have written yourself
+      description: Set `role` to ’alert` on replacement messages to allow assistive tech to automatically read the message. You will also need to move focus to the replacement message using JavaScript you have written yourself.
     - name: classes
       type: string
       required: false
@@ -47,7 +47,7 @@ params:
       params:
         - name: text
           type: string
-          required: false
+          required: true
           description: Required. The button or link text that you want to add to the cookie banner.
         - name: type
           type: string

--- a/src/govuk/components/cookie-banner/macro.njk
+++ b/src/govuk/components/cookie-banner/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukCookieBanner(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -8,7 +8,7 @@
     {% endif -%}
 
     <div class="{{classNames}}" {% if banner.role %}role="{{banner.role}}"{% endif %}
-    {%- for attribute, value in banner.attributes %}{{attribute}}="{{value}}"{% endfor %}
+    {%- for attribute, value in banner.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {% if banner.hidden %} hidden {% endif %}>
 
       {% if banner.headingHtml or banner.headingText %}
@@ -33,7 +33,7 @@
       <div class="govuk-button-group">
         {% for action in banner.actions %}
             {% if action.href %}
-              {% set linkClasses = "govuk-link govuk-link--align-button" %}
+              {% set linkClasses = "govuk-link" %}
               {% if action.classes %}
                 {% set linkClasses = linkClasses + " " + action.classes %}
               {% endif %}

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -2,7 +2,7 @@
 
 <div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}">
   {%- for banner in params.banners %}
-    {% set classNames = "govuk-cookie-banner__container govuk-width-container" %}
+    {% set classNames = "govuk-cookie-banner__message govuk-width-container" %}
     {% if banner.classes %}
       {% set classNames = classNames + " " + banner.classes %}
     {% endif %}

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -6,12 +6,10 @@
     {% if banner.classes %}
       {%- set classNames = classNames + " " + banner.classes -%}
     {% endif -%}
-    {% if banner.hidden %}
-      {%- set classNames = classNames + " " + "govuk-cookie-banner__container--hidden" %}
-    {% endif %}
 
     <div class="{{classNames}}" {% if banner.role %}role="{{banner.role}}"{% endif %}
-    {%- for attribute, value in banner.attributes %}{{attribute}}="{{value}}"{% endfor %}>
+    {%- for attribute, value in banner.attributes %}{{attribute}}="{{value}}"{% endfor %}
+    {% if banner.hidden %} hidden {% endif %}>
 
       {% if banner.headingHtml or banner.headingText %}
         <h2 class="govuk-cookie-banner__heading govuk-heading-m">

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -1,24 +1,24 @@
-{% from "../button/macro.njk" import govukButton %}
+{% from "../button/macro.njk" import govukButton -%}
 
 <div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}">
-  {% for banner in params.banners %}
-    {%- set classNames = "govuk-cookie-banner__container govuk-width-container" -%}
+  {%- for banner in params.banners %}
+    {% set classNames = "govuk-cookie-banner__container govuk-width-container" %}
     {% if banner.classes %}
-      {%- set classNames = classNames + " " + banner.classes -%}
-    {% endif -%}
+      {% set classNames = classNames + " " + banner.classes %}
+    {% endif %}
 
-    <div class="{{classNames}}" {% if banner.role %}role="{{banner.role}}"{% endif %}
+    <div class="{{classNames}}" {%- if banner.role %} role="{{banner.role}}"{% endif %}
     {%- for attribute, value in banner.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {% if banner.hidden %} hidden {% endif %}>
+    {% if banner.hidden %} hidden{% endif %}>
 
       {% if banner.headingHtml or banner.headingText %}
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          {%- if banner.headingHtml -%}
-            {{ banner.headingHtml | safe }}
-          {%- else -%}
-            {{ banner.headingText }}
-          {%- endif -%}
-        </h2>
+      <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+        {%- if banner.headingHtml -%}
+          {{ banner.headingHtml | safe }}
+        {%- else -%}
+          {{ banner.headingText }}
+        {%- endif -%}
+      </h2>
       {% endif %}
 
       <div class="govuk-cookie-banner__content">
@@ -32,26 +32,25 @@
       {% if banner.actions %}
       <div class="govuk-button-group">
         {% for action in banner.actions %}
-            {% if action.href %}
-              {% set linkClasses = "govuk-link" %}
-              {% if action.classes %}
-                {% set linkClasses = linkClasses + " " + action.classes %}
-              {% endif %}
-              <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
-            {% else %}
-              {{ govukButton({
-                "text": action.text,
-                "value": action.value,
-                "name": action.name,
-                "type": action.type,
-                "classes": action.classes,
-                "attributes": action.attributes
-              }) }}
+          {% if action.href %}
+            {% set linkClasses = "govuk-link" %}
+            {% if action.classes %}
+              {% set linkClasses = linkClasses + " " + action.classes %}
             {% endif %}
+            <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
+          {% else %}
+            {{ govukButton({
+              "text": action.text,
+              "value": action.value,
+              "name": action.name,
+              "type": action.type,
+              "classes": action.classes,
+              "attributes": action.attributes
+            }) | indent(12) | trim }}
+          {% endif %}
         {% endfor %}
       </div>
       {% endif %}
-
     </div>
   {% endfor %}
 </div>

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -1,0 +1,59 @@
+{% from "../button/macro.njk" import govukButton %}
+
+<div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}">
+  {% for banner in params.banners %}
+    {%- set classNames = "govuk-cookie-banner__container govuk-width-container" -%}
+    {% if banner.classes %}
+      {%- set classNames = classNames + " " + banner.classes -%}
+    {% endif -%}
+    {% if banner.hidden %}
+      {%- set classNames = classNames + " " + "govuk-cookie-banner__container--hidden" %}
+    {% endif %}
+
+    <div class="{{classNames}}" {% if banner.role %}role="{{banner.role}}"{% endif %}
+    {%- for attribute, value in banner.attributes %}{{attribute}}="{{value}}"{% endfor %}>
+
+      {% if banner.headingHtml or banner.headingText %}
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          {%- if banner.headingHtml -%}
+            {{ banner.headingHtml | safe }}
+          {%- else -%}
+            {{ banner.headingText }}
+          {%- endif -%}
+        </h2>
+      {% endif %}
+
+      <div class="govuk-cookie-banner__content">
+        {%- if banner.html -%}
+          {{ banner.html | safe }}
+        {%- elif banner.text -%}
+          <p class="govuk-body">{{ banner.text }}</p>
+        {%- endif -%}
+      </div>
+
+      {% if banner.actions %}
+      <div class="govuk-button-group">
+        {% for action in banner.actions %}
+            {% if action.href %}
+              {% set linkClasses = "govuk-link govuk-link--align-button" %}
+              {% if action.classes %}
+                {% set linkClasses = linkClasses + " " + action.classes %}
+              {% endif %}
+              <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
+            {% else %}
+              {{ govukButton({
+                "text": action.text,
+                "value": action.value,
+                "name": action.name,
+                "type": action.type,
+                "classes": action.classes,
+                "attributes": action.attributes
+              }) }}
+            {% endif %}
+        {% endfor %}
+      </div>
+      {% endif %}
+
+    </div>
+  {% endfor %}
+</div>

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -89,8 +89,6 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['custom aria label'])
 
       const $component = $('.govuk-cookie-banner')
-
-      // expect($component.attr('role')).toEqual('region')
       expect($component.attr('aria-label')).toEqual('Cookies on GOV.UK')
     })
   })
@@ -103,20 +101,20 @@ describe('Cookie Banner', () => {
       expect(results).toHaveNoViolations()
     })
 
-    it('set role attribute to alert', () => {
-      const $ = render('cookie-banner', examples['accepted confirmation banner'])
-
-      const $component = $('.govuk-cookie-banner')
-      const $banner = $component.find('.govuk-cookie-banner__container')
-      expect($banner.attr('role')).toEqual('alert')
-    })
-
     it('role alert not set by default', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
       const $banner = $component.find('.govuk-cookie-banner__container')
       expect($banner.attr('role')).toBeUndefined()
+    })
+
+    it('sets role attribute when role provided', () => {
+      const $ = render('cookie-banner', examples['accepted confirmation banner'])
+
+      const $component = $('.govuk-cookie-banner')
+      const $banner = $component.find('.govuk-cookie-banner__container')
+      expect($banner.attr('role')).toEqual('alert')
     })
 
     it('hides banner if hidden option set to true', () => {
@@ -140,7 +138,6 @@ describe('Cookie Banner', () => {
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.get(0).tagName).toEqual('button')
-      expect($actions.text().trim()).toEqual('This is a button')
     })
 
     it('renders as a link if href provided', () => {
@@ -148,8 +145,6 @@ describe('Cookie Banner', () => {
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.get(0).tagName).toEqual('a')
-      expect($actions.text()).toEqual('This is a link')
-      expect($actions.attr('href')).toEqual('/link')
     })
 
     it('ignores other button options if href provided', () => {
@@ -164,11 +159,17 @@ describe('Cookie Banner', () => {
       expect($actions.attr('name')).toBeUndefined()
     })
 
+    it('renders button text', () => {
+      const $ = render('cookie-banner', examples['default action'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.text().trim()).toEqual('This is a button')
+    })
+
     it('renders button with custom type', () => {
       const $ = render('cookie-banner', examples.type)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.get(0).tagName).toEqual('button')
       expect($actions.attr('type')).toEqual('button')
     })
 
@@ -176,7 +177,6 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.get(0).tagName).toEqual('button')
       expect($actions.attr('name')).toEqual('cookies')
     })
 
@@ -184,7 +184,6 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.get(0).tagName).toEqual('button')
       expect($actions.attr('value')).toEqual('accept')
     })
 
@@ -202,11 +201,19 @@ describe('Cookie Banner', () => {
       expect($actions.attr('data-button-attribute')).toEqual('my-value')
     })
 
+    it('renders link text and href', () => {
+      const $ = render('cookie-banner', examples.link)
+
+      const $actions = $('.govuk-cookie-banner .govuk-link')
+      expect($actions.text()).toEqual('This is a link')
+      expect($actions.attr('href')).toEqual('/link')
+    })
+
     it('renders link with additional classes', () => {
       const $ = render('cookie-banner', examples['link classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.attr('class')).toEqual('govuk-link govuk-link--align-button my-link-class app-link-class')
+      expect($actions.attr('class')).toEqual('govuk-link my-link-class app-link-class')
     })
 
     it('renders link with custom attributes', () => {
@@ -214,6 +221,22 @@ describe('Cookie Banner', () => {
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.attr('data-link-attribute')).toEqual('my-value')
+    })
+  })
+
+  describe('client-side implementation example', () => {
+    it('renders 3 banners', () => {
+      const $ = render('cookie-banner', examples['client-side implementation'])
+
+      const $actions = $('.govuk-cookie-banner__container')
+      expect($actions.length).toEqual(3)
+    })
+
+    it('2 banners are hidden', () => {
+      const $ = render('cookie-banner', examples['client-side implementation'])
+
+      const $actions = $('.govuk-cookie-banner__container[hidden]')
+      expect($actions.length).toEqual(2)
     })
   })
 })

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -123,14 +123,14 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.hidden)
 
       const $component = $('.govuk-cookie-banner__container')
-      expect($component.attr('class')).toContain('govuk-cookie-banner__container--hidden')
+      expect($component.attr('hidden')).toBeTruthy()
     })
 
     it('does not hide banner if hidden option set to false', () => {
       const $ = render('cookie-banner', examples['hidden false'])
 
       const $component = $('.govuk-cookie-banner__container')
-      expect($component.attr('class')).not.toContain('govuk-cookie-banner__container--hidden')
+      expect($component.attr('hidden')).toBeUndefined()
     })
   })
 

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -1,0 +1,219 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('cookie-banner')
+
+describe('Cookie Banner', () => {
+  describe('question banner', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('renders a heading', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $heading = $('.govuk-cookie-banner__heading')
+      expect($heading.text()).toEqual('Cookies on this government service')
+    })
+
+    it('renders heading as escaped html when passed as text', () => {
+      const $ = render('cookie-banner', examples['heading html as text'])
+
+      const $heading = $('.govuk-cookie-banner__heading')
+      expect($heading.html().trim()).toEqual('Cookies on &lt;span&gt;my service&lt;/span&gt;')
+    })
+
+    it('renders heading html', () => {
+      const $ = render('cookie-banner', examples['heading html'])
+
+      const $heading = $('.govuk-cookie-banner__heading')
+      expect($heading.html().trim()).toEqual('Cookies on <span>my service</span>')
+    })
+
+    it('renders main content text', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $content = $('.govuk-cookie-banner__content')
+      expect($content.text()).toEqual('We use analytics cookies to help understand how users use our service.')
+    })
+
+    it('renders main content html', () => {
+      const $ = render('cookie-banner', examples.html)
+
+      const $content = $('.govuk-cookie-banner__content')
+      expect($content.html().trim()).toEqual('<p class="govuk-body">We use cookies in <span>our service</span>.</p>')
+    })
+
+    it('renders classes', () => {
+      const $ = render('cookie-banner', examples.classes)
+
+      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__container')
+
+      expect($banner.hasClass('app-my-class')).toBeTruthy()
+    })
+
+    it('renders attributes', () => {
+      const $ = render('cookie-banner', examples.attributes)
+
+      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__container')
+
+      expect($banner.attr('data-attribute')).toEqual('my-value')
+    })
+  })
+
+  describe('role and aria attributes', () => {
+    it('has role=region by default', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $component = $('.govuk-cookie-banner')
+      expect($component.attr('role')).toEqual('region')
+    })
+
+    it('has a default aria-label', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $component = $('.govuk-cookie-banner')
+      expect($component.attr('aria-label')).toEqual('Cookie banner')
+    })
+
+    it('renders a custom aria label', () => {
+      const $ = render('cookie-banner', examples['custom aria label'])
+
+      const $component = $('.govuk-cookie-banner')
+
+      // expect($component.attr('role')).toEqual('region')
+      expect($component.attr('aria-label')).toEqual('Cookies on GOV.UK')
+    })
+  })
+
+  describe('confirmation banner', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('cookie-banner', examples['accepted confirmation banner'])
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+
+    it('set role attribute to alert', () => {
+      const $ = render('cookie-banner', examples['accepted confirmation banner'])
+
+      const $component = $('.govuk-cookie-banner')
+      const $banner = $component.find('.govuk-cookie-banner__container')
+      expect($banner.attr('role')).toEqual('alert')
+    })
+
+    it('role alert not set by default', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $component = $('.govuk-cookie-banner')
+      const $banner = $component.find('.govuk-cookie-banner__container')
+      expect($banner.attr('role')).toBeUndefined()
+    })
+
+    it('hides banner if hidden option set to true', () => {
+      const $ = render('cookie-banner', examples.hidden)
+
+      const $component = $('.govuk-cookie-banner__container')
+      expect($component.attr('class')).toContain('govuk-cookie-banner__container--hidden')
+    })
+
+    it('does not hide banner if hidden option set to false', () => {
+      const $ = render('cookie-banner', examples['hidden false'])
+
+      const $component = $('.govuk-cookie-banner__container')
+      expect($component.attr('class')).not.toContain('govuk-cookie-banner__container--hidden')
+    })
+  })
+
+  describe('action', () => {
+    it('renders as button by default', () => {
+      const $ = render('cookie-banner', examples['default action'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.get(0).tagName).toEqual('button')
+      expect($actions.text().trim()).toEqual('This is a button')
+    })
+
+    it('renders as a link if href provided', () => {
+      const $ = render('cookie-banner', examples.link)
+
+      const $actions = $('.govuk-cookie-banner .govuk-link')
+      expect($actions.get(0).tagName).toEqual('a')
+      expect($actions.text()).toEqual('This is a link')
+      expect($actions.attr('href')).toEqual('/link')
+    })
+
+    it('ignores other button options if href provided', () => {
+      const $ = render('cookie-banner', examples['link with button options'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-link')
+      expect($actions.get(0).tagName).toEqual('a')
+      expect($actions.text()).toEqual('This is a link')
+      expect($actions.attr('href')).toEqual('/link')
+
+      expect($actions.attr('value')).toBeUndefined()
+      expect($actions.attr('name')).toBeUndefined()
+    })
+
+    it('renders button with custom type', () => {
+      const $ = render('cookie-banner', examples.type)
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.get(0).tagName).toEqual('button')
+      expect($actions.attr('type')).toEqual('button')
+    })
+
+    it('renders button with name', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.get(0).tagName).toEqual('button')
+      expect($actions.attr('name')).toEqual('cookies')
+    })
+
+    it('renders button with value', () => {
+      const $ = render('cookie-banner', examples.default)
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.get(0).tagName).toEqual('button')
+      expect($actions.attr('value')).toEqual('accept')
+    })
+
+    it('renders button with additional classes', () => {
+      const $ = render('cookie-banner', examples['button classes'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.attr('class')).toEqual('govuk-button my-button-class app-button-class')
+    })
+
+    it('renders button with custom attributes', () => {
+      const $ = render('cookie-banner', examples['button attributes'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.attr('data-button-attribute')).toEqual('my-value')
+    })
+
+    it('renders link with additional classes', () => {
+      const $ = render('cookie-banner', examples['link classes'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-link')
+      expect($actions.attr('class')).toEqual('govuk-link govuk-link--align-button my-link-class app-link-class')
+    })
+
+    it('renders link with custom attributes', () => {
+      const $ = render('cookie-banner', examples['link attributes'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-link')
+      expect($actions.attr('data-link-attribute')).toEqual('my-value')
+    })
+  })
+})

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -71,7 +71,7 @@ describe('Cookie Banner', () => {
   })
 
   describe('role and aria attributes', () => {
-    it('has role=region by default', () => {
+    it('has a role of region', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -56,7 +56,7 @@ describe('Cookie Banner', () => {
     it('renders classes', () => {
       const $ = render('cookie-banner', examples.classes)
 
-      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__container')
+      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__message')
 
       expect($banner.hasClass('app-my-class')).toBeTruthy()
     })
@@ -64,7 +64,7 @@ describe('Cookie Banner', () => {
     it('renders attributes', () => {
       const $ = render('cookie-banner', examples.attributes)
 
-      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__container')
+      const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__message')
 
       expect($banner.attr('data-attribute')).toEqual('my-value')
     })
@@ -105,7 +105,7 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
-      const $banner = $component.find('.govuk-cookie-banner__container')
+      const $banner = $component.find('.govuk-cookie-banner__message')
       expect($banner.attr('role')).toBeUndefined()
     })
 
@@ -113,21 +113,21 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['accepted confirmation banner'])
 
       const $component = $('.govuk-cookie-banner')
-      const $banner = $component.find('.govuk-cookie-banner__container')
+      const $banner = $component.find('.govuk-cookie-banner__message')
       expect($banner.attr('role')).toEqual('alert')
     })
 
     it('hides banner if hidden option set to true', () => {
       const $ = render('cookie-banner', examples.hidden)
 
-      const $component = $('.govuk-cookie-banner__container')
+      const $component = $('.govuk-cookie-banner__message')
       expect($component.attr('hidden')).toBeTruthy()
     })
 
     it('does not hide banner if hidden option set to false', () => {
       const $ = render('cookie-banner', examples['hidden false'])
 
-      const $component = $('.govuk-cookie-banner__container')
+      const $component = $('.govuk-cookie-banner__message')
       expect($component.attr('hidden')).toBeUndefined()
     })
   })
@@ -228,14 +228,14 @@ describe('Cookie Banner', () => {
     it('renders 3 banners', () => {
       const $ = render('cookie-banner', examples['client-side implementation'])
 
-      const $actions = $('.govuk-cookie-banner__container')
+      const $actions = $('.govuk-cookie-banner__message')
       expect($actions.length).toEqual(3)
     })
 
     it('2 banners are hidden', () => {
       const $ = render('cookie-banner', examples['client-side implementation'])
 
-      const $actions = $('.govuk-cookie-banner__container[hidden]')
+      const $actions = $('.govuk-cookie-banner__message[hidden]')
       expect($actions.length).toEqual(2)
     })
   })


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/2099

Adds the macro, YAML examples and tests for the cookie banner component.

Depends on https://github.com/alphagov/govuk-frontend/pull/2114/files for the button grouping to work.