### PR TITLE
Remove redundant align-button modifiers in example

### DIFF
--- a/app/views/examples/button-groups/index.njk
+++ b/app/views/examples/button-groups/index.njk
@@ -23,7 +23,7 @@
       "text": "Reject analytics cookies"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--align-button">View cookies</a>
+    <a href="#" class="govuk-link">View cookies</a>
   </div>
 
   <div class="govuk-button-group">
@@ -35,7 +35,7 @@
       "text": "Gwrthod cwcis dadansoddeg"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--align-button">Gweld cwcis</a>
+    <a href="#" class="govuk-link">Gweld cwcis</a>
   </div>
 
   <div class="govuk-button-group">
@@ -47,7 +47,7 @@
       "text": "Reject really important analytics cookies but not essential cookies"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--align-button">View cookies and set preferences to do with whether we can set cookies</a>
+    <a href="#" class="govuk-link">View cookies and set preferences to do with whether we can set cookies</a>
   </div>
 
   <div class="govuk-button-group">
@@ -56,12 +56,12 @@
       "classes": "govuk-button--warning"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--muted govuk-link--align-button">Cancel</a>
-    <a href="#" class="govuk-link govuk-link--muted govuk-link--align-button">Cancel and go back</a>
+    <a href="#" class="govuk-link govuk-link--muted">Cancel</a>
+    <a href="#" class="govuk-link govuk-link--muted">Cancel and go back</a>
   </div>
 
   <div class="govuk-button-group">
-    <a href="#" class="govuk-link govuk-link--align-button">Buy it</a>
+    <a href="#" class="govuk-link">Buy it</a>
 
     {{ govukButton({
       "text": "Use it"
@@ -71,17 +71,17 @@
       "text": "Break it"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--align-button">Fix it</a>
-    <a href="#" class="govuk-link govuk-link--align-button">Trash it</a>
-    <a href="#" class="govuk-link govuk-link--align-button">Change it</a>
+    <a href="#" class="govuk-link">Fix it</a>
+    <a href="#" class="govuk-link">Trash it</a>
+    <a href="#" class="govuk-link">Change it</a>
 
     {{ govukButton({
       "text": "Mail it"
     }) }}
 
-    <a href="#" class="govuk-link govuk-link--align-button">Upgrade it</a>
+    <a href="#" class="govuk-link">Upgrade it</a>
     
-    <a href="#" class="govuk-link govuk-link--align-button">Charge it</a>
+    <a href="#" class="govuk-link">Charge it</a>
 
     {{ govukButton({
       "text": "Point it"


### PR DESCRIPTION
The original intent was to use a modifier on links to align them with buttons, but we ended up finding another approach that used flexbox and didn’t require the modifier. However, the classes were never removed from the example page in the review app, as spotted by @vanitabarrett 👀 .

Remove the redundant classes as they are not doing anything and will only cause confusion.