### PR TITLE
Add styling for the cookie banner component

### DIFF
--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -1,10 +1,37 @@
 @include govuk-exports("govuk/component/cookie-banner") {
-  // For supporting older browsers which don't hide elements with the `hidden` attribute
+
+  // This needs to be kept in sync with the header component's styles
+  $border-bottom-width: govuk-spacing(2);
+
+  .govuk-cookie-banner {
+    @include govuk-font($size: 19);
+
+    padding-top: govuk-spacing(4);
+    // The component does not set bottom spacing.
+    // The bottom spacing should be created by the items inside the component.
+
+    // Visually separate the cookie banner from content underneath
+    // when user changes colours in their browser.
+    border-bottom: $border-bottom-width solid transparent;
+
+    background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  }
+
+  // Support older browsers which don't hide elements with the `hidden` attribute
+  // when user hides the whole cookie banner with a 'Hide' button.
   .govuk-cookie-banner[hidden] {
     display: none;
   }
 
-  .govuk-cookie-banner__message[hidden] {
-    display: none;
+  .govuk-cookie-banner__message {
+    // Remove the extra height added by the separator border.
+    margin-bottom: -$border-bottom-width;
+
+    &[hidden] {
+      // Support older browsers which don't hide elements with the `hidden` attribute
+      // when the visibility of cookie and replacement messages is toggled.
+      display: none;
+    }
+
   }
 }

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -33,5 +33,19 @@
       display: none;
     }
 
+    &:focus {
+      // Remove the native visible focus indicator when the element is programmatically focused.
+      //
+      // The focused cookie banner is the first element on the page and the last thing the user
+      // interacted with prior to it gaining focus.
+      // We therefore assume that moving focus to it is not going to surprise users, and that giving
+      // it a visible focus indicator could be more confusing than helpful, especially as the
+      // element is not normally keyboard operable.
+      //
+      // We have flagged this in the research section of the guidance as something to monitor.
+      //
+      // A related discussion: https://github.com/w3c/wcag/issues/1001
+      outline: none;
+    }
   }
 }

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -14,23 +14,27 @@
     {%- for attribute, value in message.attributes %} {{attribute}}="{{value}}"{% endfor %}
     {% if message.hidden %} hidden{% endif %}>
 
-      {% if message.headingHtml or message.headingText %}
-      <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-        {%- if message.headingHtml -%}
-          {{ message.headingHtml | safe }}
-        {%- else -%}
-          {{ message.headingText }}
-        {%- endif -%}
-      </h2>
-      {% endif %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {% if message.headingHtml or message.headingText %}
+        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+          {%- if message.headingHtml -%}
+            {{ message.headingHtml | safe }}
+          {%- else -%}
+            {{ message.headingText }}
+          {%- endif -%}
+        </h2>
+        {% endif %}
 
-      <div class="govuk-cookie-banner__content">
-        {%- if message.html -%}
-          {{ message.html | safe }}
-        {%- elif message.text -%}
-          <p class="govuk-body">{{ message.text }}</p>
-        {%- endif -%}
+        <div class="govuk-cookie-banner__content">
+          {%- if message.html -%}
+            {{ message.html | safe }}
+          {%- elif message.text -%}
+            <p class="govuk-body">{{ message.text }}</p>
+          {%- endif -%}
+        </div>
       </div>
+    </div>
 
       {% if message.actions %}
       <div class="govuk-button-group">


### PR DESCRIPTION
## What
Following on from https://github.com/alphagov/govuk-frontend/pull/2114 and https://github.com/alphagov/govuk-frontend/pull/2114, add the styling for the cookie banner component.

The designs are shown here: https://github.com/alphagov/govuk-frontend/issues/2107#issuecomment-763595873 Additionally, the heading and content should be constrained to 2/3 grid column, whilst the button group should be full width on desktop.

### Spacing
The component does not set bottom spacing. The bottom spacing should be created by the items inside the component. 

### Hiding sections
 We're going to use the `hidden` attribute to hide sections as this will hide the content even if CSS fails to load.

`display: none;` will act as a fallback for legacy browsers (IE 8-10) that don't support the `hidden` attribute. Unfortunately it looks like Lynx doesn't support `hidden` but that's a vendor implementation issue. It also appears that Lynx hasn't been in active development for some time. Using the `hidden` attribute seems like the semantically correct thing to do here and it makes the component usable when CSS fails to load.

(The alternative would be to insert text into the DOM at relevant points which could also be a suitable solution in some contexts. We decided against it as the Design System components need to be really flexible so we're trying to avoid patterns where HTML markup needs to be maintained inside JavaScript which will also simplify localisation etc. where relevant.)

### Border
Visually separate the cookie banner from content underneath with a transparent bottom border when user changes colours in their browser.

### Remove visible focus indicator from cookie banner 

when the element is programmatically focused.

The focused cookie banner is the first element on the page and the last thing the user interacted with prior to it gaining focus. We therefore assume that moving focus to it is not going to surprise users, and that giving it a visible focus indicator could be more confusing than helpful, especially as the element is not normally keyboard operable.

We will flag this in the research section of the guidance as something to monitor.

A related discussion: https://github.com/w3c/wcag/issues/1001

(It's also worth noting that this is different to what we do with the notification banner which does have a visible focus indicator. However, the notification banner is further down the page and the user might not have interacted with it prior to it gaining focus. It is therefore helpful to indicate to users that the focus has moved to it, even though the element, like the cookie banner, isn’t normally keyboard operable.)

Fixes https://github.com/alphagov/govuk-frontend/issues/2098 and https://github.com/alphagov/govuk-frontend/issues/2112

## Tested on
✅ Chrome 88 (Mac)
✅ Firefox 84 (Mac)
✅ Safari 14 (Mac)

✅ Chrome 85 (Windows)
✅ Firefox 85 (Windows)
✅ Edge 88 (Windows)

✅ Chrome (Android 10)
✅ Firefox (Android 9)
✅ Samsung Internet (Android 10)

✅ Safari (iPhone 12 , iOS 14)
✅ Chrome (iPhone 8, iOS 13)

✅ IE11 (Windows 10)
✅ IE10 (Windows 7)
✅ IE9 (Windows 7)
✅ IE8 (Windows 7)

### When users change colours in their browser (Firefox 84)

![Screenshot 2021-02-02 at 14 55 18](https://user-images.githubusercontent.com/5007934/106617628-b6085100-6566-11eb-9136-3a6204a50244.png)