### PR TITLE
Rename banners to messages

### DIFF
--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -28,7 +28,7 @@ notes: >-
 {% block bodyStart %}
     {{ govukCookieBanner({
     "classes": "js-cookies-banner",
-    "banners": [
+    "messages": [
         {
             "headingText": "Cookies on this government service",
             "text": "We use analytics cookies to help understand how users use our service.",

--- a/app/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -7,7 +7,7 @@ notes: >-
   For this example, when the user makes a choice to accept or reject cookies the
   form is submitted and a page navigation occurs, with the confirmation banner
   shown on the next page.
-  
+
   The choice to accept or reject cookies will not be remembered.
 
   The content of the page is not important for this scenario.
@@ -33,7 +33,7 @@ notes: >-
     {% endif %}
 
     {{ govukCookieBanner({
-    "banners": [
+    "messages": [
         {
             "text": "Your cookie preferences have been saved. " + outcome,
             "role": "alert",
@@ -51,7 +51,7 @@ notes: >-
 {% else %}
 <form action="" method="POST">
     {{ govukCookieBanner({
-    "banners": [
+    "messages": [
         {
         "headingText": "Cookies on this government service",
         "text": "We use analytics cookies to help understand how users use our service.",
@@ -187,12 +187,12 @@ notes: >-
     var hideButton = document.querySelector('.js-hide')
     var cookieBanner = document.querySelector(".govuk-cookie-banner")
     var confirmationBanner = document.querySelector('.js-confirmation-banner')
-    
+
     if (confirmationBanner) {
       // Shift focus to the confirmation banner
       confirmationBanner.setAttribute('tabindex', '-1')
       confirmationBanner.focus()
-      
+
       confirmationBanner.addEventListener('blur', function () {
           confirmationBanner.removeAttribute('tabindex')
       })

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -15,10 +15,10 @@ params:
   type: object
   required: false
   description: The additional attributes that you want to add to the button or link. For example, data attributes.
-- name: banners
+- name: messages
   type: array
   required: true
-  description: Required. The different kinds of banners you can pass into the cookie banner. For example, the question banner and the replacement message.
+  description: Required. The different messages you can pass into the cookie banner. For example, the question message and the replacement message.
   params:
     - name: headingText
       type: string
@@ -31,15 +31,15 @@ params:
     - name: text
       type: string
       required: false
-      description: Required. The text for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
+      description: Required. The text for the main content within the cookie banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
     - name: html
       type: string
       required: false
-      description: Required. The HTML for the main content within the banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
+      description: Required. The HTML for the main content within the cookie banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
     - name: hidden
       type: boolean
       required: false
-      description: Defaults to false. If you set it to `true`, the banner is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
+      description: Defaults to false. If you set it to `true`, the message is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
     - name: role
       type: string
       required: false
@@ -47,11 +47,11 @@ params:
     - name: classes
       type: string
       required: false
-      description: The additional classes that you want to add to the cookie banner.
+      description: The additional classes that you want to add to the message.
     - name: attributes
       type: object
       required: false
-      description: The additional attributes that you want to add to the cookie banner. For example, data attributes.
+      description: The additional attributes that you want to add to the message. For example, data attributes.
     - name: actions
       type: array
       required: false
@@ -89,7 +89,7 @@ params:
 examples:
   - name: default
     data:
-      banners:
+      messages:
         - headingText: Cookies on this government service
           text: We use analytics cookies to help understand how users use our service.
           actions:
@@ -106,7 +106,7 @@ examples:
 
   - name: accepted confirmation banner
     data:
-      banners:
+      messages:
         - text: Your cookie preferences have been saved. You have accepted cookies.
           role: alert
           actions:
@@ -115,7 +115,7 @@ examples:
 
   - name: rejected confirmation banner
     data:
-      banners:
+      messages:
         - text: Your cookie preferences have been saved. You have rejected cookies.
           role: alert
           actions:
@@ -124,7 +124,7 @@ examples:
 
   - name: client-side implementation
     data:
-      banners:
+      messages:
         - headingText: Cookies on this service
           text: We use cookies to help understand how users use our service.
           actions:
@@ -156,62 +156,62 @@ examples:
   - name: heading html
     hidden: true
     data:
-      banners:
+      messages:
         - headingHtml: Cookies on <span>my service</span>
   - name: heading html as text
     hidden: true
     data:
-      banners:
+      messages:
         - headingText: Cookies on <span>my service</span>
   - name: html
     hidden: true
     data:
-      banners:
+      messages:
         - html: <p class="govuk-body">We use cookies in <span>our service</span>.</p>
   - name: classes
     hidden: true
     data:
-      banners:
+      messages:
         - classes: "app-my-class"
   - name: attributes
     hidden: true
     data:
-      banners:
+      messages:
         - attributes:
             "data-attribute": "my-value"
   - name: custom aria label
     hidden: true
     data:
       ariaLabel: "Cookies on GOV.UK"
-      banners:
+      messages:
         - text: "We use cookies on GOV.UK"
   - name: hidden
     hidden: true
     data:
-      banners:
+      messages:
         - hidden: true
   - name: hidden false
     hidden: true
     data:
-      banners:
+      messages:
         - hidden: false
   - name: default action
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: This is a button
   - name: link
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: This is a link
             href: /link
   - name: link with button options
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: This is a link
             href: /link
@@ -220,21 +220,21 @@ examples:
   - name: type
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: Button
             type: button
   - name: button classes
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: Button with custom classes
             classes: "my-button-class app-button-class"
   - name: button attributes
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: Button with attributes
             attributes:
@@ -242,7 +242,7 @@ examples:
   - name: link classes
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: Link with custom classes
             href: /my-link
@@ -250,7 +250,7 @@ examples:
   - name: link attributes
     hidden: true
     data:
-      banners:
+      messages:
         - actions:
           - text: Link with attributes
             href: /link
@@ -263,7 +263,7 @@ examples:
       classes: hide-cookie-banner
       attributes:
         "data-hide-cookie-banner": "true"
-      banners:
+      messages:
         - headingText: Cookies on this service
           text: We use cookies to help understand how users use our service.
           actions:

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -23,19 +23,19 @@ params:
     - name: headingText
       type: string
       required: false
-      description: The heading text that displays in the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.
+      description: The heading text that displays in the cookie message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.
     - name: headingHtml
       type: string
       required: false
-      description: The heading HTML to use within the cookie banner. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored. If you are not passing HTML, use `headingText`.
+      description: The heading HTML to use within the cookie message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored. If you are not passing HTML, use `headingText`.
     - name: text
       type: string
       required: false
-      description: Required. The text for the main content within the cookie banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
+      description: Required. The text for the main content within the cookie message. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
     - name: html
       type: string
       required: false
-      description: Required. The HTML for the main content within the cookie banner. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
+      description: Required. The HTML for the main content within the cookie message. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
     - name: hidden
       type: boolean
       required: false
@@ -55,12 +55,12 @@ params:
     - name: actions
       type: array
       required: false
-      description: The buttons and links that you want to display in the cookie banner. `actions` defaults to `button` unless you set `href`, which renders the action as a link.
+      description: The buttons and links that you want to display in the cookie message. `actions` defaults to `button` unless you set `href`, which renders the action as a link.
       params:
         - name: text
           type: string
           required: true
-          description: Required. The button or link text that you want to add to the cookie banner.
+          description: Required. The button or link text.
         - name: type
           type: string
           required: false

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -36,22 +36,6 @@ params:
       type: string
       required: false
       description: Required. The HTML for the main content within the message. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
-    - name: hidden
-      type: boolean
-      required: false
-      description: Defaults to false. If you set it to `true`, the message is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
-    - name: role
-      type: string
-      required: false
-      description: Set `role` to ’alert` on replacement messages to allow assistive tech to automatically read the message. You will also need to move focus to the replacement message using JavaScript you have written yourself.
-    - name: classes
-      type: string
-      required: false
-      description: The additional classes that you want to add to the message.
-    - name: attributes
-      type: object
-      required: false
-      description: The additional attributes that you want to add to the message. For example, data attributes.
     - name: actions
       type: array
       required: false
@@ -85,6 +69,22 @@ params:
           type: object
           required: false
           description: The additional attributes that you want to add to the button or link. For example, data attributes.
+    - name: hidden
+      type: boolean
+      required: false
+      description: Defaults to false. If you set it to `true`, the message is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
+    - name: role
+      type: string
+      required: false
+      description: Set `role` to ’alert` on replacement messages to allow assistive tech to automatically read the message. You will also need to move focus to the replacement message using JavaScript you have written yourself.
+    - name: classes
+      type: string
+      required: false
+      description: The additional classes that you want to add to the message.
+    - name: attributes
+      type: object
+      required: false
+      description: The additional attributes that you want to add to the message. For example, data attributes.
 
 examples:
   - name: default

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -2,7 +2,7 @@ params:
 - name: ariaLabel
   type: string
   required: false
-  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all banners that the cookie banner includes. For example, the question banner and the replacement message. Defaults to "Cookie banner".
+  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all messages that the cookie banner includes. For example, the cookie message and the replacement message. Defaults to "Cookie banner".
 - name: hidden
   type: boolean
   required: false
@@ -14,28 +14,28 @@ params:
 - name: attributes
   type: object
   required: false
-  description: The additional attributes that you want to add to the button or link. For example, data attributes.
+  description: The additional attributes that you want to add to the cookie banner. For example, data attributes.
 - name: messages
   type: array
   required: true
-  description: Required. The different messages you can pass into the cookie banner. For example, the question message and the replacement message.
+  description: Required. The different messages you can pass into the cookie banner. For example, the cookie message and the replacement message.
   params:
     - name: headingText
       type: string
       required: false
-      description: The heading text that displays in the cookie message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.
+      description: The heading text that displays in the message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored.
     - name: headingHtml
       type: string
       required: false
-      description: The heading HTML to use within the cookie message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored. If you are not passing HTML, use `headingText`.
+      description: The heading HTML to use within the message. You can use any string with this option. If you set `headingHtml`, `headingText` is ignored. If you are not passing HTML, use `headingText`.
     - name: text
       type: string
       required: false
-      description: Required. The text for the main content within the cookie message. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
+      description: Required. The text for the main content within the message. You can use any string with this option. If you set `html`, `text` is not required and is ignored.
     - name: html
       type: string
       required: false
-      description: Required. The HTML for the main content within the cookie message. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
+      description: Required. The HTML for the main content within the message. You can use any string with this option. If you set `html`, `text` is not required and is ignored. If you are not passing HTML, use `text`.
     - name: hidden
       type: boolean
       required: false
@@ -55,7 +55,7 @@ params:
     - name: actions
       type: array
       required: false
-      description: The buttons and links that you want to display in the cookie message. `actions` defaults to `button` unless you set `href`, which renders the action as a link.
+      description: The buttons and links that you want to display in the message. `actions` defaults to `button` unless you set `href`, which renders the action as a link.
       params:
         - name: text
           type: string

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -4,37 +4,37 @@
   {%- if params.hidden %} hidden{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 
-  {%- for banner in params.banners %}
+  {%- for message in params.messages %}
     {% set classNames = "govuk-cookie-banner__message govuk-width-container" %}
-    {% if banner.classes %}
-      {% set classNames = classNames + " " + banner.classes %}
+    {% if message.classes %}
+      {% set classNames = classNames + " " + message.classes %}
     {% endif %}
 
-    <div class="{{classNames}}" {%- if banner.role %} role="{{banner.role}}"{% endif %}
-    {%- for attribute, value in banner.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {% if banner.hidden %} hidden{% endif %}>
+    <div class="{{classNames}}" {%- if message.role %} role="{{message.role}}"{% endif %}
+    {%- for attribute, value in message.attributes %} {{attribute}}="{{value}}"{% endfor %}
+    {% if message.hidden %} hidden{% endif %}>
 
-      {% if banner.headingHtml or banner.headingText %}
+      {% if message.headingHtml or message.headingText %}
       <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-        {%- if banner.headingHtml -%}
-          {{ banner.headingHtml | safe }}
+        {%- if message.headingHtml -%}
+          {{ message.headingHtml | safe }}
         {%- else -%}
-          {{ banner.headingText }}
+          {{ message.headingText }}
         {%- endif -%}
       </h2>
       {% endif %}
 
       <div class="govuk-cookie-banner__content">
-        {%- if banner.html -%}
-          {{ banner.html | safe }}
-        {%- elif banner.text -%}
-          <p class="govuk-body">{{ banner.text }}</p>
+        {%- if message.html -%}
+          {{ message.html | safe }}
+        {%- elif message.text -%}
+          <p class="govuk-body">{{ message.text }}</p>
         {%- endif -%}
       </div>
 
-      {% if banner.actions %}
+      {% if message.actions %}
       <div class="govuk-button-group">
-        {% for action in banner.actions %}
+        {% for action in message.actions %}
           {% if action.href %}
             {% set linkClasses = "govuk-link" %}
             {% if action.classes %}


### PR DESCRIPTION
We've decided to change the naming of the sections inside the cookie banner component.

Cookie Banner - the whole component
Cookie Message - a message that a user may see at any one time, e.g: the question message; replacement message