### PR TITLE
Allow the whole cookie banner component to be hidden

### DIFF
--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -8,7 +8,7 @@ notes: >-
   their preference is handled entirely on the client side with no page
   navigation, and JavaScript is used to swap out the cookie banner for the
   'confirmation' banner.
-  
+
   The choice to accept or reject cookies will not be remembered.
 
   The content of the page is not important for this scenario.
@@ -27,6 +27,7 @@ notes: >-
 
 {% block bodyStart %}
     {{ govukCookieBanner({
+    "classes": "js-cookies-banner",
     "banners": [
         {
             "headingText": "Cookies on this government service",
@@ -47,7 +48,7 @@ notes: >-
                     "href": "#"
                 }
             ],
-            "classes": "js-cookies-banner"
+            "classes": "js-question-banner"
         },
         {
             "text": "Your cookie preferences have been saved. You have accepted cookies.",
@@ -186,16 +187,17 @@ notes: >-
 
     var acceptedBanner = document.querySelector('.js-cookies-accepted')
     var rejectedBanner = document.querySelector('.js-cookies-rejected')
+    var questionBanner = document.querySelector('.js-question-banner')
     var cookieBanner = document.querySelector('.js-cookies-banner')
 
     function showBanner(banner) {
-        cookieBanner.setAttribute('hidden', 'hidden')
+        questionBanner.setAttribute('hidden', 'hidden')
         banner.removeAttribute('hidden')
 
         // Shift focus to the banner
         banner.setAttribute('tabindex', '-1')
         banner.focus()
-        
+
         banner.addEventListener('blur', function () {
             banner.removeAttribute('tabindex')
         })
@@ -212,11 +214,11 @@ notes: >-
     })
 
     acceptedBanner.querySelector('.js-hide').addEventListener('click', function() {
-      acceptedBanner.setAttribute('hidden', 'hidden')
+      cookieBanner.setAttribute('hidden', 'hidden')
     })
 
     rejectedBanner.querySelector('.js-hide').addEventListener('click', function() {
-      rejectedBanner.setAttribute('hidden', 'hidden')
+      cookieBanner.setAttribute('hidden', 'hidden')
     })
   </script>
 {% endblock %}

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -1,5 +1,9 @@
 @include govuk-exports("govuk/component/cookie-banner") {
   // For supporting older browsers which don't hide elements with the `hidden` attribute
+  .govuk-cookie-banner[hidden] {
+    display: none;
+  }
+
   .govuk-cookie-banner__message[hidden] {
     display: none;
   }

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -7,6 +7,14 @@ params:
   type: boolean
   required: false
   description: Defaults to false. If you set it to `true`, the whole cookie banner (including all messages within) is hidden. You can use `hidden` for client-side implementations where the cookie banner HTML is present, but hidden until it is shown using JavaScript.
+- name: classes
+  type: string
+  required: false
+  description: The additional classes that you want to add to the cookie banner.
+- name: attributes
+  type: object
+  required: false
+  description: The additional attributes that you want to add to the button or link. For example, data attributes.
 - name: banners
   type: array
   required: true
@@ -252,6 +260,9 @@ examples:
     hidden: true
     data:
       hidden: true
+      classes: hide-cookie-banner
+      attributes:
+        "data-hide-cookie-banner": "true"
       banners:
         - headingText: Cookies on this service
           text: We use cookies to help understand how users use our service.

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -3,6 +3,10 @@ params:
   type: string
   required: false
   description: The text for the `aria-label` which labels the cookie banner region. This region applies to all banners that the cookie banner includes. For example, the question banner and the replacement message. Defaults to "Cookie banner".
+- name: hidden
+  type: boolean
+  required: false
+  description: Defaults to false. If you set it to `true`, the whole cookie banner (including all messages within) is hidden. You can use `hidden` for client-side implementations where the cookie banner HTML is present, but hidden until it is shown using JavaScript.
 - name: banners
   type: array
   required: true
@@ -244,3 +248,32 @@ examples:
             href: /link
             attributes:
               "data-link-attribute": "my-value"
+  - name: full banner hidden
+    hidden: true
+    data:
+      hidden: true
+      banners:
+        - headingText: Cookies on this service
+          text: We use cookies to help understand how users use our service.
+          actions:
+            - text: Accept analytics cookies
+              type: submit
+              name: cookies
+              value: accept
+            - text: Reject analytics cookies
+              type: submit
+              name: cookies
+              value: reject
+            - text: View cookie preferences
+              href: /cookie-preferences
+        - text: Your cookie preferences have been saved. You have accepted cookies.
+          role: alert
+          actions:
+            - text: Hide this message
+              type: button
+        - text: Your cookie preferences have been saved. You have rejected cookies.
+          role: alert
+          actions:
+            - text: Hide this message
+              type: button
+

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -1,6 +1,7 @@
 {% from "../button/macro.njk" import govukButton -%}
 
-<div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}">
+<div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}"
+  {%- if params.hidden %} hidden{% endif %}>
   {%- for banner in params.banners %}
     {% set classNames = "govuk-cookie-banner__message govuk-width-container" %}
     {% if banner.classes %}

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -1,7 +1,9 @@
 {% from "../button/macro.njk" import govukButton -%}
 
-<div class="govuk-cookie-banner" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}"
-  {%- if params.hidden %} hidden{% endif %}>
+<div class="govuk-cookie-banner {{ params.classes if params.classes }}" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}"
+  {%- if params.hidden %} hidden{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+
   {%- for banner in params.banners %}
     {% set classNames = "govuk-cookie-banner__message govuk-width-container" %}
     {% if banner.classes %}

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -239,4 +239,20 @@ describe('Cookie Banner', () => {
       expect($actions.length).toEqual(2)
     })
   })
+
+  describe('full cookie banner hidden', () => {
+    it('HTML for 3 banners is present', () => {
+      const $ = render('cookie-banner', examples['full banner hidden'])
+
+      const $actions = $('.govuk-cookie-banner__message')
+      expect($actions.length).toEqual(3)
+    })
+
+    it('parent banner is hidden', () => {
+      const $ = render('cookie-banner', examples['full banner hidden'])
+
+      const $actions = $('.govuk-cookie-banner[hidden]')
+      expect($actions.length).toEqual(1)
+    })
+  })
 })

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -244,15 +244,29 @@ describe('Cookie Banner', () => {
     it('HTML for 3 banners is present', () => {
       const $ = render('cookie-banner', examples['full banner hidden'])
 
-      const $actions = $('.govuk-cookie-banner__message')
-      expect($actions.length).toEqual(3)
+      const $messages = $('.govuk-cookie-banner__message')
+      expect($messages.length).toEqual(3)
     })
 
     it('parent banner is hidden', () => {
       const $ = render('cookie-banner', examples['full banner hidden'])
 
-      const $actions = $('.govuk-cookie-banner[hidden]')
-      expect($actions.length).toEqual(1)
+      const $cookieBanner = $('.govuk-cookie-banner[hidden]')
+      expect($cookieBanner.length).toEqual(1)
+    })
+
+    it('adds classes to parent container when provided', () => {
+      const $ = render('cookie-banner', examples['full banner hidden'])
+
+      const $cookieBanner = $('.govuk-cookie-banner')
+      expect($cookieBanner.hasClass('hide-cookie-banner')).toBeTruthy()
+    })
+
+    it('adds attributes to parent container when provided', () => {
+      const $ = render('cookie-banner', examples['full banner hidden'])
+
+      const $cookieBanner = $('.govuk-cookie-banner')
+      expect($cookieBanner.attr('data-hide-cookie-banner')).toEqual('true')
     })
   })
 })


### PR DESCRIPTION
## What
Allows a user to pass `hidden: true` to the cookie banner component and for the whole component to be hidden. This is separate to the `hidden` flag which allows each individual cookie message to be hidden.

## Why
For a client-side implementation, when a user selects Accept/Reject and then hides the replacement message, the page is still left with a cookie banner region with nothing visible inside. In some AT we tested, this is listed as 'Cookie banner empty region', which at least tells the user there is no visible content, but isn't great. Ideally service teams would completely hide the whole banner when a user chooses to hide the replacement message. This gives them the ability to do that.

We also need to allow service teams to pass classes/attributes to the cookie banner so they can hook in and toggle the `hidden` attribute.