### PR TITLE
Improve vertical alignment of phase banner tag on mobile devices

### DIFF
--- a/src/govuk/components/phase-banner/_index.scss
+++ b/src/govuk/components/phase-banner/_index.scss
@@ -16,11 +16,6 @@
     margin: 0;
   }
 
-  .govuk-phase-banner__phase {
-    display: table-cell;
-    vertical-align: top;
-  }
-
   .govuk-phase-banner__content__tag {
     margin-right: govuk-spacing(2);
   }

--- a/src/govuk/components/phase-banner/_index.scss
+++ b/src/govuk/components/phase-banner/_index.scss
@@ -16,12 +16,17 @@
     margin: 0;
   }
 
+  .govuk-phase-banner__phase {
+    display: table-cell;
+    vertical-align: top;
+  }
+
   .govuk-phase-banner__content__tag {
     margin-right: govuk-spacing(2);
   }
 
   .govuk-phase-banner__text {
     display: table-cell;
-    vertical-align: baseline;
+    vertical-align: middle;
   }
 }

--- a/src/govuk/components/phase-banner/template.njk
+++ b/src/govuk/components/phase-banner/template.njk
@@ -3,13 +3,11 @@
 <div class="govuk-phase-banner
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <p class="govuk-phase-banner__content">
-    <span class="govuk-phase-banner__phase">
-      {{ govukTag({
-        text: params.tag.text,
-        html: params.tag.html,
-        classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
-      }) | indent(4) | trim }}
-    </span>
+    {{ govukTag({
+      text: params.tag.text,
+      html: params.tag.html,
+      classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
+    }) | indent(4) | trim }}
     <span class="govuk-phase-banner__text">
       {{ params.html | safe if params.html else params.text }}
     </span>

--- a/src/govuk/components/phase-banner/template.njk
+++ b/src/govuk/components/phase-banner/template.njk
@@ -3,11 +3,13 @@
 <div class="govuk-phase-banner
   {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   <p class="govuk-phase-banner__content">
-    {{ govukTag({
-      text: params.tag.text,
-      html: params.tag.html,
-      classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
-    }) | indent(4) | trim }}
+    <span class="govuk-phase-banner__phase">
+      {{ govukTag({
+        text: params.tag.text,
+        html: params.tag.html,
+        classes: "govuk-phase-banner__content__tag" + (" " + params.tag.classes if params.tag.classes)
+      }) | indent(4) | trim }}
+    </span>
     <span class="govuk-phase-banner__text">
       {{ params.html | safe if params.html else params.text }}
     </span>


### PR DESCRIPTION
This PR is designed to improve the vertical alignment of the phase banner tag when viewed on mobile devices. Following consultation with @timpaul and @christopherthomasdesign it was agreed that the desired behaviour should be:
- single line of text = centre-aligned
- multiple lines of text = top-aligned

In order to fix this problem, it was necessary to wrap the tag element in a SPAN with `display: table-cell`, allowing the vertical alignment of the tag to be controlled.

**Before:**
![image](https://user-images.githubusercontent.com/27346863/106484340-6f9fed00-64a7-11eb-9f49-d71fca6468c7.png)

**After:**
![image](https://user-images.githubusercontent.com/27346863/106484385-7c244580-64a7-11eb-92bb-486cecc03640.png)
![image](https://user-images.githubusercontent.com/27346863/106484420-83e3ea00-64a7-11eb-8dcc-a2e55654e2db.png)

**Tested on:**
Windows 7, IE8
Windows 7, IE9
Windows 7, IE10
Windows 10, IE11
Windows 10, Firefox 84
Windows 10, Chrome 88
Windows 10, Edge 88
Galaxy S8, Android 7, Chrome
Galaxy S8, Android 7, Samsung Internet
iPhone 8, iOS 13, Safari
iPhone 8, iOS 13, Chrome
macOS Catalina, Firefox 85
macOS Catalina, Safari 14
macOS Catalina, Chrome 88
