### PR TITLE
Remove user-agent default 2px horizontal margins on buttons in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2092: Use tabular numbers for character count message](https://github.com/alphagov/govuk-frontend/pull/2092)
 - [#2045: Stop same-site cookies from being wiped when printing in Internet Explorer 11](https://github.com/alphagov/govuk-frontend/pull/2045) – thanks to [@gunjam](https://github.com/gunjam) for contributing this
 - [#2093: Only output space after breadcrumbs class if there’s an additional class](https://github.com/alphagov/govuk-frontend/pull/2093) – thanks to [@frankieroberto](https://github.com/frankieroberto) for contributing this.
+- [#2133: Remove user-agent default 2px horizontal margins on buttons in Safari](https://github.com/alphagov/govuk-frontend/pull/2133)
 
 ## 3.10.2 (Patch release)
 

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -29,6 +29,8 @@
     position: relative;
     width: 100%;
     margin-top: 0;
+    margin-right: 0;
+    margin-left: 0;
     @include govuk-responsive-margin(6, "bottom", $adjustment: $button-shadow-size); // s2
     padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2) (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2)); // s1
     border: $govuk-border-width-form-element solid transparent;


### PR DESCRIPTION
Safari’s default user-agent styles for buttons include a 2px margin on the left and right. Explicitly set the left and right margin to 0 rather than relying on the default user-agent styles having a margin of 0 to ensure consistent alignment and spacing across browsers.

## Before

![Screenshot 2021-02-02 at 09 44 18](https://user-images.githubusercontent.com/121939/106581916-4f217280-653b-11eb-89e4-2803dfce6589.png)

## After

![Screenshot 2021-02-02 at 09 44 35](https://user-images.githubusercontent.com/121939/106581929-521c6300-653b-11eb-913b-0be50f6d5ece.png)
