### PR TITLE
Use display: none instead of hidden attribute

### DIFF
--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -191,8 +191,8 @@ notes: >-
     var cookieBanner = document.querySelector('.js-cookies-banner')
 
     function showBanner(banner) {
-        questionBanner.setAttribute('hidden', 'hidden')
-        banner.removeAttribute('hidden')
+        questionBanner.style.display = 'none';
+        banner.style.display = 'block';
 
         // Shift focus to the banner
         banner.setAttribute('tabindex', '-1')
@@ -214,11 +214,11 @@ notes: >-
     })
 
     acceptedBanner.querySelector('.js-hide').addEventListener('click', function() {
-      cookieBanner.setAttribute('hidden', 'hidden')
+      cookieBanner.style.display = 'none';
     })
 
     rejectedBanner.querySelector('.js-hide').addEventListener('click', function() {
-      cookieBanner.setAttribute('hidden', 'hidden')
+      cookieBanner.style.display = 'none';
     })
   </script>
 {% endblock %}

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -1,7 +1,7 @@
 {% from "../button/macro.njk" import govukButton -%}
 
 <div class="govuk-cookie-banner {{ params.classes if params.classes }}" role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}"
-  {%- if params.hidden %} hidden{% endif %}
+  {%- if params.hidden %} style="display: none;"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 
   {%- for message in params.messages %}
@@ -12,7 +12,7 @@
 
     <div class="{{classNames}}" {%- if message.role %} role="{{message.role}}"{% endif %}
     {%- for attribute, value in message.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {% if message.hidden %} hidden{% endif %}>
+    {% if message.hidden %} style="display: none;"{% endif %}>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## Pros

- Fixes confirmation banner alert being announced when using JAWS 2021 with IE11
- Still keeps confirmation banner hidden even if CSS fails to load

## Cons

- Less semantically correct / clear? `hidden` attribute better separates content from presentation.
- Although it's an inline style (so should persist if e.g. stylesheet fails to load or user stylesheet) it still relies on CSS being parsed, so hidden state not communicated to e.g. text based browsers (although e.g. Lynx doesn't appear to support `hidden` anyway), and _possibly_ things like Reader view?
- `hidden` nunjucks option no longer maps directly to `hidden` HTML attribute (minor)
- `[element].style.display = 'block'` in JS carries less intent than `[element].removeAttribute('hidden')`?

We're not 100% sure how big an issue it really is that it doesn’t read it out. The user's focus is still in the approximate area of the cookie banner, it is still listed as a landmark and in user research most users dismissed the cookie banner almost immediately and paid no further attention to it.

Although, ["If we have to sacrifice elegance - so be it."](https://www.gov.uk/guidance/government-design-principles#this-is-for-everyone)