### PR TITLE
Fix client-side cookie banner hide button in IE 11

### DIFF
--- a/app/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -199,7 +199,7 @@ notes: >-
     }
 
     hideButton.addEventListener('click', function() {
-      cookieBanner.remove()
+      cookieBanner.setAttribute('hidden', 'hidden')
     })
   </script>
 {% endblock %}


### PR DESCRIPTION
`ChildNode.remove` is not supported in IE11, so use the hidden attribute like we do with the client side example.