### PR TITLE
Silence deprecation warning for iff in tests and add test

### DIFF
--- a/src/govuk/tools/iff.test.js
+++ b/src/govuk/tools/iff.test.js
@@ -1,9 +1,18 @@
 /* eslint-env jest */
+const sass = require('node-sass')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 
+// Create a mock warn function that we can use to override the native @warn
+// function, that we can make assertions about post-render.
+const mockWarnFunction = jest.fn()
+  .mockReturnValue(sass.NULL)
+
 const sassConfig = {
-  outputStyle: 'compressed'
+  outputStyle: 'compressed',
+  functions: {
+    '@warn': mockWarnFunction
+  }
 }
 
 describe('@function iff', () => {
@@ -31,5 +40,24 @@ describe('@function iff', () => {
     const results = await renderSass({ data: sass, ...sassConfig })
 
     expect(results.css.toString().trim()).toBe('.foo{color:red}')
+  })
+
+  it('outputs a deprecation warning when called', () => {
+    const sass = `
+      @import 'tools/iff';
+
+      .foo {
+        color: red iff(true, !important);
+      }`
+
+    return renderSass({ data: sass, ...sassConfig }).then(() => {
+      // Expect our mocked @warn function to have been called once with a single
+      // argument, which should be the deprecation notice
+      return expect(mockWarnFunction.mock.calls[0][0].getValue())
+        .toEqual(
+          'The `iff` function will be removed in a future release, ' +
+          'use `if($condition, $if-true, null);` instead.'
+        )
+    })
   })
 })


### PR DESCRIPTION
The deprecation warning for the `iff` function currently appears in the middle of the test output:

```
PASS src/govuk/objects/objects.test.js
PASS src/govuk/overrides/overrides.test.js
PASS src/govuk/core/core.test.js
WARNING: The `iff` function will be removed in a future release, use `if($condition, $if-true, null);` instead.
         on line 15 of src/govuk/tools/_iff.scss, in function `iff`
         from line 5 of stdin

WARNING: The `iff` function will be removed in a future release, use `if($condition, $if-true, null);` instead.
         on line 15 of src/govuk/tools/_iff.scss, in function `iff`
         from line 5 of stdin

PASS src/govuk/tools/iff.test.js
```

Silence it by mocking the `@warn` function in Sass render calls from its tests, and add a new test for the deprecation warning.

This it consistent with the approach used for the import deprecation warnings from the overrides and core layers.