### PR TITLE
Use pointer cursor for 'Menu' button in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- [#2157 Use pointer cursor for 'Menu' button in header](https://github.com/alphagov/govuk-frontend/pull/2157) – thanks to [@MalcolmVonMoJ](https://github.com/MalcolmVonMoJ) for contributing this.
+
 ## 3.11.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -158,6 +158,7 @@
     border: 0;
     color: $govuk-header-link;
     background: none;
+    cursor: pointer;
 
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
Currently, the cursor is `default` when hovering over the menu button in the header.   An edge case perhaps because this will presumably mostly be for mobile.  But users on desktops with a narrow window, or when heavily zoomed in, will have an inconsistent experience.

This change adds one line of CSS to change the cursor to `pointer` when hovered over, as per any other link, including other links in the header.