### PR TITLE
Replace e.g. in Character count macros

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -50,7 +50,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false


### PR DESCRIPTION
Style guide says to avoid 'e.g' - screen readers can misread it.