### PR TITLE
Fix inaccessible text in components macros

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -50,7 +50,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -6,12 +6,12 @@ params:
 - name: fieldset
   type: object
   required: false
-  description: Options for the fieldset component (e.g. legend).
+  description: Options for the fieldset component (for example legend).
   isComponent: true
 - name: hint
   type: object
   required: false
-  description: Options for the hint component (e.g. text).
+  description: Options for the hint component (for example text).
   isComponent: true
 - name: errorMessage
   type: object
@@ -26,7 +26,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: idPrefix
   type: string
   required: false
@@ -782,8 +782,3 @@ examples:
         text: British
       - value: irish
         text: Irish
-
-
-
-
-

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -62,11 +62,11 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: fieldset
   type: object
   required: false
-  description: Options for the fieldset component (e.g. legend).
+  description: Options for the fieldset component (for example legend).
   isComponent: true
 - name: classes
   type: string
@@ -406,4 +406,3 @@ examples:
         name: month
       -
         name: year
-

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -38,7 +38,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -2,12 +2,12 @@ params:
 - name: fieldset
   type: object
   required: false
-  description: Options for the fieldset component (e.g. legend).
+  description: Options for the fieldset component (for example legend).
   isComponent: true
 - name: hint
   type: object
   required: false
-  description: Options for the hint component (e.g. text).
+  description: Options for the hint component (for example text).
   isComponent: true
 - name: errorMessage
   type: object
@@ -22,7 +22,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: idPrefix
   type: string
   required: false
@@ -834,4 +834,3 @@ examples:
       - value: no
         text: No
         checked: true
-

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -59,7 +59,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -46,7 +46,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false
@@ -214,4 +214,3 @@ examples:
         text: Error message
       hint:
         text: Hint
-


### PR DESCRIPTION
Style guide says to avoid 'e.g' - screen readers can misread it.