### PR TITLE
Enable cookie banner to set link styled as a button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## New features
+
+- [#2164: Enable cookie banner to set link styled as a button](https://github.com/alphagov/govuk-frontend/pull/2164)
+
 ### Fixes
 
 - [#2132 Improve vertical alignment of phase banner tag on mobile devices](https://github.com/alphagov/govuk-frontend/pull/2132) – thanks to [@matthewmascord](https://github.com/matthewmascord) for contributing this.

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -217,6 +217,14 @@ examples:
             href: /link
             value: cookies
             name: link
+  - name: link as a button
+    hidden: true
+    data:
+      messages:
+        - actions:
+          - text: This is a link
+            href: /link
+            type: button
   - name: type
     hidden: true
     data:

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -208,7 +208,7 @@ examples:
         - actions:
           - text: This is a link
             href: /link
-  - name: link with button options
+  - name: link with false button options
     hidden: true
     data:
       messages:

--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -40,11 +40,21 @@
       <div class="govuk-button-group">
         {% for action in message.actions %}
           {% if action.href %}
-            {% set linkClasses = "govuk-link" %}
-            {% if action.classes %}
-              {% set linkClasses = linkClasses + " " + action.classes %}
+            {% if action.type == "button" %}
+              {{ govukButton({
+                "text": action.text,
+                "type": "button",
+                "classes": action.classes,
+                "href": action.href,
+                "attributes": action.attributes
+              }) | indent(12) | trim }}
+            {% else %}
+              {% set linkClasses = "govuk-link" %}
+              {% if action.classes %}
+                {% set linkClasses = linkClasses + " " + action.classes %}
+              {% endif %}
+              <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
             {% endif %}
-            <a class="{{ linkClasses }}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ action.text }}</a>
           {% else %}
             {{ govukButton({
               "text": action.text,

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -159,6 +159,16 @@ describe('Cookie Banner', () => {
       expect($actions.attr('name')).toBeUndefined()
     })
 
+    it('renders as a link button if href and type=button provided', () => {
+      const $ = render('cookie-banner', examples['link as a button'])
+
+      const $actions = $('.govuk-cookie-banner .govuk-button')
+      expect($actions.get(0).tagName).toEqual('a')
+      expect($actions.text().trim()).toEqual('This is a link')
+      expect($actions.attr('href')).toEqual('/link')
+      expect($actions.attr('role')).toEqual('button')
+    })
+
     it('renders button text', () => {
       const $ = render('cookie-banner', examples['default action'])
 

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -148,7 +148,7 @@ describe('Cookie Banner', () => {
     })
 
     it('ignores other button options if href provided', () => {
-      const $ = render('cookie-banner', examples['link with button options'])
+      const $ = render('cookie-banner', examples['link with false button options'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.get(0).tagName).toEqual('a')


### PR DESCRIPTION
It should be possible to render a link styled as a button in the cookie banner. This is an edge case but could be useful for rendering the 'Hide' button if: 
- The cookie banner needs to work without JavaScript.
- The user has already accepted/rejected cookies. This means that when the user presses 'Hide' and the page reloads, the banner will be hidden.
 
This PR:
- Enables an action in the cookie banner to be a link styled as a button, with `role="button"` and `draggable="false"`, if both `href` and `type="button"` are provided. The resulting markup matches [Start buttons](https://design-system.service.gov.uk/components/button/#start-buttons).
- Add a test.
- Rename another example that renders a link but also sets additional button attributes to test that they aren't rendered, to distinguish it from this new example. 
 
We need to add some extra documentation to the macro options for this change. There are a few concepts mixed up in this change so I've started a [doc](https://docs.google.com/document/d/1BhH2VGCUkbltc5k9hAjSPBCxG7emdX12xxeNinJwOiU/edit) for @EoinShaughnessy to help us finalise the wording. 