### PR TITLE
Fix padding on GOV.UK logo affecting hover and focus states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ This was added in [pull request #2164: Enable cookie banner to set link styled a
 
 ### Fixes
 
-- [#2132 Improve vertical alignment of phase banner tag on mobile devices](https://github.com/alphagov/govuk-frontend/pull/2132) – thanks to [@matthewmascord](https://github.com/matthewmascord) for contributing this.
-- [#2157 Use pointer cursor for 'Menu' button in header](https://github.com/alphagov/govuk-frontend/pull/2157) – thanks to [@MalcolmVonMoJ](https://github.com/MalcolmVonMoJ) for contributing this.
+- [#2132: Improve vertical alignment of phase banner tag on mobile devices](https://github.com/alphagov/govuk-frontend/pull/2132) – thanks to [@matthewmascord](https://github.com/matthewmascord) for contributing this.
+- [#2157: Use pointer cursor for 'Menu' button in header](https://github.com/alphagov/govuk-frontend/pull/2157) – thanks to [@MalcolmVonMoJ](https://github.com/MalcolmVonMoJ) for contributing this.
+- [#2171: Fix padding on GOV.UK logo affecting hover and focus states](https://github.com/alphagov/govuk-frontend/pull/2171)
 
 ## 3.11.0 (Feature release)
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -57,7 +57,6 @@
   .govuk-header__product-name {
     @include govuk-font($size: 24, $line-height: 1);
     display: inline-table;
-    padding-right: govuk-spacing(2);
   }
 
   .govuk-header__link {
@@ -92,6 +91,7 @@
     @include govuk-font($size: false, $weight: bold);
 
     display: inline-block;
+    margin-right: govuk-spacing(2);
     font-size: 30px; // We don't have a mixin that produces 30px font size
     line-height: 1;
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -36,7 +36,15 @@
 
   .govuk-header__logotype {
     display: inline-block;
+
+    // Add a gap between logo and any product name
     margin-right: govuk-spacing(1);
+
+    // But remove it if there's nothing after the logo to keep hover and focus
+    // states neat
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   .govuk-header__logotype-crown {


### PR DESCRIPTION
Address two minor issues with the hover and focus states for the GOV.UK logo (including product name, when present):

## 1. With product name

When the header includes a product name, the homepage link’s underline (on hover) and the focus state take up an additional 10px on the right hand side, because of the 10px right padding on `govuk-header__product-name`.

| Before | After |
| --- | --- |
| ![Screenshot 2021-03-23 at 17 20 09](https://user-images.githubusercontent.com/121939/112189682-285af080-8bfc-11eb-9a4f-f3d110a6926d.png) | ![Screenshot 2021-03-23 at 17 20 19](https://user-images.githubusercontent.com/121939/112189724-31e45880-8bfc-11eb-848d-2d43bdd612f6.png) |
| ![Screenshot 2021-03-23 at 17 20 13](https://user-images.githubusercontent.com/121939/112189771-40327480-8bfc-11eb-9128-9c30591fb2ae.png) | ![Screenshot 2021-03-23 at 17 20 22](https://user-images.githubusercontent.com/121939/112189772-40cb0b00-8bfc-11eb-8c9f-aa59ff7d277d.png) |

This [padding is there to ensure there is a gap left between the product name and the menu button][1]. Remove it, and add a 10px margin to `govuk-header__link--homepage` instead which achieves the same result but without adding an additional 10px to the hover and focus states.

## 2. Without product name

When the header does not include a product name, the homepage link’s underline (on hover) and the focus state take up an additional 5px on the right hand side, because of a 5px margin on `govuk-header__logotype`.

| Before | After |
| --- | --- |
| ![Screenshot 2021-03-23 at 17 19 17](https://user-images.githubusercontent.com/121939/112189862-59d3bc00-8bfc-11eb-982d-ef567c7f70ca.png) | ![Screenshot 2021-03-23 at 17 19 33](https://user-images.githubusercontent.com/121939/112189861-593b2580-8bfc-11eb-9f91-710ce72154ab.png) |
| ![Screenshot 2021-03-23 at 17 19 42](https://user-images.githubusercontent.com/121939/112189858-58a28f00-8bfc-11eb-9443-5e68446fccd8.png) | ![Screenshot 2021-03-23 at 17 19 37](https://user-images.githubusercontent.com/121939/112189860-593b2580-8bfc-11eb-9bc1-099aabfd87d9.png) |

This margin has been present since the component was added to GOV.UK Frontend, and I believe it’s to ensure there’s a gap between GOV.UK and a product name. Remove this margin when the `__logotype` element is the last child of its descendent, so that the margin is only included when there is a product name to show.

[1]: https://github.com/alphagov/govuk-frontend/commit/df413cf6363b537fe37b1b0db5bc40b97424422f