### PR TITLE
Replace inaccessible text in text input macros

### DIFF
--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -88,7 +88,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (e.g. to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group)
 - name: classes
   type: string
   required: false


### PR DESCRIPTION
This PR replaces 'e.g.' with 'for example.'

GOV.UK style guide advises us not to use 'e.g.' - screen readers can misread it.