### PR TITLE
Updates to link styles and link hover states

### DIFF
--- a/app/assets/scss/app.scss
+++ b/app/assets/scss/app.scss
@@ -1,4 +1,5 @@
 $govuk-show-breakpoints: true;
+$govuk-new-link-styles: true;
 
 @import "../../../src/govuk/all";
 @import "partials/app";

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -63,6 +63,34 @@
       </section>
     {% endfor %}
 
+      <section class="govuk-!-margin-top-8">
+        <h2 class="govuk-heading-l govuk-!-margin-top-6">Multi-line links</h2>
+
+        <p class="govuk-heading-xl">
+          <a class="govuk-link" href="#">Research your family history using the General Register Office</a>
+        </p>
+
+        <p class="govuk-heading-l">
+          <a class="govuk-link" href="#">Research your family history using the General Register Office</a>
+        </p>
+
+        <p class="govuk-heading-m">
+          <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+        </p>
+
+        <p class="govuk-heading-s">
+          <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+        </p>
+
+        <p class="govuk-body">
+          <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+        </p>
+
+        <p class="govuk-body-s">
+          <a class="govuk-link" href="#">Consultation on amendments to the Attorney General’s Code of Practice issued under Section 377A of the Proceeds of Crime Act 2002</a>
+        </p>
+      </section>
+
     </div>
   </div>
 {% endblock %}

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -47,7 +47,7 @@
 /// Provides the default unvisited, visited, hover and active states for links.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -97,7 +97,7 @@
 /// Provides the error unvisited, visited, hover and active states for links.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -144,7 +144,7 @@
 /// Provides the success unvisited, visited, hover and active states for links.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -192,7 +192,7 @@
 /// regardless of visited state.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -232,7 +232,7 @@
 /// navigation components, such as breadcrumbs or the back link.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -266,7 +266,7 @@
 /// Overrides the colour of links to work on a dark background.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {
@@ -308,7 +308,7 @@
 /// that you’ve visited it before is not important.
 ///
 /// If you use this mixin in a component you must also include the
-/// govuk-link-common mixin in order to get the focus state.
+/// govuk-link-common mixin in order to get the correct focus and hover states.
 ///
 /// @example scss
 ///   .govuk-component__link {

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -25,17 +25,19 @@
 @mixin govuk-link-decoration {
   text-decoration: underline;
 
-  @if ($govuk-link-underline-thickness) {
-    text-decoration-thickness: $govuk-link-underline-thickness;
-  }
+  @if ($govuk-new-link-styles) {
+    @if ($govuk-link-underline-thickness) {
+      text-decoration-thickness: $govuk-link-underline-thickness;
+    }
 
-  @if ($govuk-link-underline-offset) {
-    text-underline-offset: $govuk-link-underline-offset;
-  }
+    @if ($govuk-link-underline-offset) {
+      text-underline-offset: $govuk-link-underline-offset;
+    }
 
-  @if ($govuk-link-hover-underline-thickness) {
-    &:hover {
-      text-decoration-thickness: $govuk-link-hover-underline-thickness;
+    @if ($govuk-link-hover-underline-thickness) {
+      &:hover {
+        text-decoration-thickness: $govuk-link-hover-underline-thickness;
+      }
     }
   }
 }

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -202,10 +202,13 @@
 
 @mixin govuk-link-style-muted {
   &:link,
-  &:visited,
+  &:visited {
+    color: $govuk-secondary-text-colour;
+  }
+
   &:hover,
   &:active {
-    color: $govuk-secondary-text-colour;
+    color: $govuk-text-colour;
   }
 
   // When focussed, the text colour needs to be darker to ensure that colour
@@ -242,8 +245,16 @@
 
 @mixin govuk-link-style-text {
   &:link,
-  &:visited,
-  &:hover,
+  &:visited {
+    @include govuk-text-colour;
+  }
+
+  // Force a colour change on hover to work around a bug in Safari
+  // https://bugs.webkit.org/show_bug.cgi?id=224483
+  &:hover {
+    color: rgba($govuk-text-colour, .99);
+  }
+
   &:active,
   &:focus {
     @include govuk-text-colour;
@@ -276,10 +287,15 @@
 
 @mixin govuk-link-style-inverse {
   &:link,
-  &:visited,
+  &:visited {
+    color: govuk-colour("white");
+  }
+
+  // Force a colour change on hover to work around a bug in Safari
+  // https://bugs.webkit.org/show_bug.cgi?id=224483
   &:hover,
   &:active {
-    color: govuk-colour("white");
+    color: rgba(govuk-colour("white"), .99);
   }
 
   &:focus {

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -10,9 +10,29 @@
 
 @mixin govuk-link-common {
   @include govuk-typography-common;
+  @include govuk-link-decoration;
 
   &:focus {
     @include govuk-focused-text;
+  }
+}
+
+/// Link decoration mixin
+///
+/// Provides the text decoration for links, including any underline offset
+///
+/// @access public
+@mixin govuk-link-decoration {
+  $thickness: if(
+    $govuk-link-underline-thickness,
+    $govuk-link-underline-thickness,
+    auto
+  );
+
+  text-decoration: solid underline $thickness;
+
+  @if ($govuk-link-underline-offset) {
+    text-underline-offset: $govuk-link-underline-offset;
   }
 }
 

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -34,6 +34,12 @@
   @if ($govuk-link-underline-offset) {
     text-underline-offset: $govuk-link-underline-offset;
   }
+
+  @if ($govuk-link-hover-underline-thickness) {
+    &:hover {
+      text-decoration-thickness: $govuk-link-hover-underline-thickness;
+    }
+  }
 }
 
 /// Default link style mixin

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -23,13 +23,11 @@
 ///
 /// @access public
 @mixin govuk-link-decoration {
-  $thickness: if(
-    $govuk-link-underline-thickness,
-    $govuk-link-underline-thickness,
-    auto
-  );
+  text-decoration: underline;
 
-  text-decoration: solid underline $thickness;
+  @if ($govuk-link-underline-thickness) {
+    text-decoration-thickness: $govuk-link-underline-thickness;
+  }
 
   @if ($govuk-link-underline-offset) {
     text-underline-offset: $govuk-link-underline-offset;

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -18,7 +18,7 @@ describe('@mixin govuk-link-decoration', () => {
 
     const results = await renderSass({ data: sass, ...sassConfig })
 
-    expect(results.css.toString()).toContain('text-decoration: solid underline 1px;')
+    expect(results.css.toString()).toContain('text-decoration-thickness: 1px;')
   })
 
   describe('when $govuk-link-underline-thickness is falsey', () => {
@@ -33,7 +33,7 @@ describe('@mixin govuk-link-decoration', () => {
 
       const results = await renderSass({ data: sass, ...sassConfig })
 
-      expect(results.css.toString()).toContain('text-decoration: solid underline auto;')
+      expect(results.css.toString()).not.toContain('text-decoration-thickness;')
     })
   })
 

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -7,24 +7,9 @@ const sassConfig = {
 }
 
 describe('@mixin govuk-link-decoration', () => {
-  it('sets text-decoration with a thickness of 1px', async () => {
-    const sass = `
-      $govuk-link-underline-thickness: 1px;
-      @import "base";
-
-      .foo {
-        @include govuk-link-decoration;
-      }`
-
-    const results = await renderSass({ data: sass, ...sassConfig })
-
-    expect(results.css.toString()).toContain('text-decoration-thickness: 1px;')
-  })
-
-  describe('when $govuk-link-underline-thickness is falsey', () => {
-    it('sets text-decoration with a thickness of auto', async () => {
+  describe('by default', () => {
+    it('does not set text-decoration-thickness', async () => {
       const sass = `
-        $govuk-link-underline-thickness: false;
         @import "base";
 
         .foo {
@@ -33,60 +18,26 @@ describe('@mixin govuk-link-decoration', () => {
 
       const results = await renderSass({ data: sass, ...sassConfig })
 
-      expect(results.css.toString()).not.toContain('text-decoration-thickness;')
+      expect(results.css.toString()).not.toContain('text-decoration-thickness')
     })
-  })
 
-  it('sets text-underline-offset', async () => {
-    const sass = `
-      $govuk-link-underline-offset: .1em;
-      @import "base";
-
-      .foo {
-        @include govuk-link-decoration;
-      }`
-
-    const results = await renderSass({ data: sass, ...sassConfig })
-
-    expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
-  })
-
-  describe('when $govuk-link-underline-offset is falsey', () => {
-    it('does not set text-decoration-offset ', async () => {
+    it('does not set text-underline-offset', async () => {
       const sass = `
-      $govuk-link-underline-offset: false;
-      @import "base";
+        @import "base";
 
-      .foo {
+        .foo {
           @include govuk-link-decoration;
-      }`
+        }`
 
       const results = await renderSass({ data: sass, ...sassConfig })
 
       expect(results.css.toString()).not.toContain('text-underline-offset')
     })
-  })
 
-  it('sets text-decoration-thickness on hover', async () => {
-    const sass = `
-    $govuk-link-hover-underline-thickness: 10px;
-      @import "base";
-
-      .foo {
-        @include govuk-link-decoration;
-      }`
-
-    const results = await renderSass({ data: sass, ...sassConfig })
-
-    expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
-  })
-
-  describe('when $govuk-link-hover-underline-thickness is falsey', () => {
     it('does not set a hover state', async () => {
       const sass = `
-      $govuk-link-hover-underline-thickness: false;
       @import "base";
-
+  
       .foo {
           @include govuk-link-decoration;
       }`
@@ -94,6 +45,104 @@ describe('@mixin govuk-link-decoration', () => {
       const results = await renderSass({ data: sass, ...sassConfig })
 
       expect(results.css.toString()).not.toContain(':hover')
+    })
+  })
+
+  describe('when $govuk-new-link-styles are enabled', () => {
+    it('sets text-decoration-thickness', async () => {
+      const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-underline-thickness: 1px;
+        @import "base";
+  
+        .foo {
+          @include govuk-link-decoration;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain('text-decoration-thickness: 1px;')
+    })
+
+    it('sets text-underline-offset', async () => {
+      const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-underline-offset: .1em;
+        @import "base";
+  
+        .foo {
+          @include govuk-link-decoration;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
+    })
+
+    it('sets text-decoration-thickness on hover', async () => {
+      const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-hover-underline-thickness: 10px;
+        @import "base";
+  
+        .foo {
+          @include govuk-link-decoration;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
+    })
+
+    describe('when $govuk-link-underline-thickness is falsey', () => {
+      it('does not set text-decoration-thickness', async () => {
+        const sass = `
+          $govuk-new-link-styles: true;
+          $govuk-link-underline-thickness: false;
+          @import "base";
+  
+          .foo {
+            @include govuk-link-decoration;
+          }`
+
+        const results = await renderSass({ data: sass, ...sassConfig })
+
+        expect(results.css.toString()).not.toMatch(/\.foo {.*text-decoration-thickness.*}/)
+      })
+    })
+
+    describe('when $govuk-link-underline-offset is falsey', () => {
+      it('does not set text-decoration-offset ', async () => {
+        const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-underline-offset: false;
+        @import "base";
+  
+        .foo {
+            @include govuk-link-decoration;
+        }`
+
+        const results = await renderSass({ data: sass, ...sassConfig })
+
+        expect(results.css.toString()).not.toContain('text-underline-offset')
+      })
+    })
+
+    describe('when $govuk-link-hover-underline-thickness is falsey', () => {
+      it('does not set a hover state', async () => {
+        const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-hover-underline-thickness: false;
+        @import "base";
+    
+        .foo {
+            @include govuk-link-decoration;
+        }`
+
+        const results = await renderSass({ data: sass, ...sassConfig })
+
+        expect(results.css.toString()).not.toContain('.foo:hover')
+      })
     })
   })
 })

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -1,0 +1,69 @@
+/* eslint-env jest */
+
+const { renderSass } = require('../../../lib/jest-helpers')
+
+const sassConfig = {
+  outputStyle: 'nested'
+}
+
+describe('@mixin govuk-link-decoration', () => {
+  it('sets text-decoration with a thickness of 1px', async () => {
+    const sass = `
+      $govuk-link-underline-thickness: 1px;
+      @import "base";
+
+      .foo {
+        @include govuk-link-decoration;
+      }`
+
+    const results = await renderSass({ data: sass, ...sassConfig })
+
+    expect(results.css.toString()).toContain('text-decoration: solid underline 1px;')
+  })
+
+  describe('when $govuk-link-underline-thickness is falsey', () => {
+    it('sets text-decoration with a thickness of auto', async () => {
+      const sass = `
+        $govuk-link-underline-thickness: false;
+        @import "base";
+
+        .foo {
+          @include govuk-link-decoration;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain('text-decoration: solid underline auto;')
+    })
+  })
+
+  it('sets text-underline-offset', async () => {
+    const sass = `
+      $govuk-link-underline-offset: .1em;
+      @import "base";
+
+      .foo {
+        @include govuk-link-decoration;
+      }`
+
+    const results = await renderSass({ data: sass, ...sassConfig })
+
+    expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
+  })
+
+  describe('when $govuk-link-underline-offset is falsey', () => {
+    it('does not set text-decoration-offset ', async () => {
+      const sass = `
+      $govuk-link-underline-offset: false;
+      @import "base";
+
+      .foo {
+          @include govuk-link-decoration;
+      }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).not.toContain('text-underline-offset')
+    })
+  })
+})

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -3,7 +3,7 @@
 const { renderSass } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
-  outputStyle: 'nested'
+  outputStyle: 'compact'
 }
 
 describe('@mixin govuk-link-decoration', () => {
@@ -64,6 +64,36 @@ describe('@mixin govuk-link-decoration', () => {
       const results = await renderSass({ data: sass, ...sassConfig })
 
       expect(results.css.toString()).not.toContain('text-underline-offset')
+    })
+  })
+
+  it('sets text-decoration-thickness on hover', async () => {
+    const sass = `
+    $govuk-link-hover-underline-thickness: 10px;
+      @import "base";
+
+      .foo {
+        @include govuk-link-decoration;
+      }`
+
+    const results = await renderSass({ data: sass, ...sassConfig })
+
+    expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
+  })
+
+  describe('when $govuk-link-hover-underline-thickness is falsey', () => {
+    it('does not set a hover state', async () => {
+      const sass = `
+      $govuk-link-hover-underline-thickness: false;
+      @import "base";
+
+      .foo {
+          @include govuk-link-decoration;
+      }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).not.toContain(':hover')
     })
   })
 })

--- a/src/govuk/settings/_all.scss
+++ b/src/govuk/settings/_all.scss
@@ -19,3 +19,5 @@
 @import "typography-font-families";
 @import "typography-font";
 @import "typography-responsive";
+
+@import "links";

--- a/src/govuk/settings/_links.scss
+++ b/src/govuk/settings/_links.scss
@@ -1,0 +1,38 @@
+////
+/// @group settings/links
+////
+
+/// Link underline thickness
+///
+/// Default is a 1px underline for all links regardless of size, but is defined
+/// in rem so that it scales accordingly if the user has a different root font
+/// size ('zoom text only')
+///
+/// Set to false to disable setting a thickness
+///
+/// @type Number
+/// @access public
+
+$govuk-link-underline-thickness: .0625rem !default;
+
+/// Link underline offset.
+///
+/// Set to false to disable setting an offset
+///
+/// @type Number
+/// @access public
+
+$govuk-link-underline-offset: .1em !default;
+
+/// Link hover state underline thickness
+///
+/// Default is, for a given link, whichever is the thicker:
+///  - a 3px underline (defined in rem to scale with the root font size)
+///  - .12em relative to the link's text size
+///
+/// Set to false to disable setting a thickness
+///
+/// @type Number
+/// @access public
+
+$govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;

--- a/src/govuk/settings/_links.scss
+++ b/src/govuk/settings/_links.scss
@@ -2,6 +2,13 @@
 /// @group settings/links
 ////
 
+/// Enable new link styles
+///
+/// @type Boolean
+/// @access public
+
+$govuk-new-link-styles: false !default;
+
 /// Link underline thickness
 ///
 /// Default is a 1px underline for all links regardless of size, but is defined

--- a/src/govuk/settings/_links.scss
+++ b/src/govuk/settings/_links.scss
@@ -11,16 +11,17 @@ $govuk-new-link-styles: false !default;
 
 /// Link underline thickness
 ///
-/// Default is a 1px underline for all links regardless of size, but is defined
-/// in rem so that it scales accordingly if the user has a different root font
-/// size ('zoom text only')
+/// The default is, for a given link, whichever is thicker:
+///  - an absolute 1px underline
+///  - .0625rem, equivalent to 1px but adjusts with the root font size if the
+///.   user has zoomed in 'text only'
 ///
 /// Set to false to disable setting a thickness
 ///
 /// @type Number
 /// @access public
 
-$govuk-link-underline-thickness: .0625rem !default;
+$govuk-link-underline-thickness: unquote("max(1px, .0625rem)") !default;
 
 /// Link underline offset.
 ///
@@ -33,8 +34,10 @@ $govuk-link-underline-offset: .1em !default;
 
 /// Link hover state underline thickness
 ///
-/// Default is, for a given link, whichever is the thicker:
-///  - a 3px underline (defined in rem to scale with the root font size)
+/// The default is, for a given link, whichever is the thicker of:
+///  - an absolute 3px underline
+///  - .1875rem, which equivalent to 3px (at 16px root font size) but adjusts
+///    with the root font size if the user has zoomed in 'text only'
 ///  - .12em relative to the link's text size
 ///
 /// Set to false to disable setting a thickness
@@ -42,4 +45,4 @@ $govuk-link-underline-offset: .1em !default;
 /// @type Number
 /// @access public
 
-$govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;
+$govuk-link-hover-underline-thickness: unquote("max(3px, .1875rem, .12em)") !default;

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -112,6 +112,14 @@ $govuk-hover-width: 10px !default;
 /// @access public
 $govuk-link-underline-thickness: 1px !default;
 
+/// Link hover state underline thickness
+///
+/// Set to false to disable setting a thickness
+///
+/// @type Number
+/// @access public
+$govuk-link-hover-underline-thickness: unquote("max(3px, .12em)") !default;
+
 /// Link underline offset.
 ///
 /// Set to false to disable setting an offset

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -103,35 +103,3 @@ $govuk-focus-width: 3px !default;
 /// @access public
 
 $govuk-hover-width: 10px !default;
-
-/// Link underline thickness
-///
-/// Default is a 1px underline for all links regardless of size, but is defined
-/// in rem so that it scales accordingly if the user has a different root font
-/// size ('zoom text only')
-///
-/// Set to false to disable setting a thickness
-///
-/// @type Number
-/// @access public
-$govuk-link-underline-thickness: .0625rem !default;
-
-/// Link hover state underline thickness
-///
-/// Default is, for a given link, whichever is the thicker:
-///  - a 3px underline (defined in rem to scale with the root font size)
-///  - .12em relative to the link's text size
-///
-/// Set to false to disable setting a thickness
-///
-/// @type Number
-/// @access public
-$govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;
-
-/// Link underline offset.
-///
-/// Set to false to disable setting an offset
-///
-/// @type Number
-/// @access public
-$govuk-link-underline-offset: .1em !default;

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -106,19 +106,27 @@ $govuk-hover-width: 10px !default;
 
 /// Link underline thickness
 ///
+/// Default is a 1px underline for all links regardless of size, but is defined
+/// in rem so that it scales accordingly if the user has a different root font
+/// size ('zoom text only')
+///
 /// Set to false to disable setting a thickness
 ///
 /// @type Number
 /// @access public
-$govuk-link-underline-thickness: 1px !default;
+$govuk-link-underline-thickness: .0625rem !default;
 
 /// Link hover state underline thickness
 ///
+/// Default is, for a given link, whichever is the thicker:
+///  - a 3px underline (defined in rem to scale with the root font size)
+///  - .12em relative to the link's text size
+///
 /// Set to false to disable setting a thickness
 ///
 /// @type Number
 /// @access public
-$govuk-link-hover-underline-thickness: unquote("max(3px, .12em)") !default;
+$govuk-link-hover-underline-thickness: unquote("max(.1875rem, .12em)") !default;
 
 /// Link underline offset.
 ///

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -103,3 +103,19 @@ $govuk-focus-width: 3px !default;
 /// @access public
 
 $govuk-hover-width: 10px !default;
+
+/// Link underline thickness
+///
+/// Set to false to disable setting a thickness
+///
+/// @type Number
+/// @access public
+$govuk-link-underline-thickness: 1px !default;
+
+/// Link underline offset.
+///
+/// Set to false to disable setting an offset
+///
+/// @type Number
+/// @access public
+$govuk-link-underline-offset: .1em !default;


### PR DESCRIPTION
This is a tidied up version of #2089.

We're making changes to link styles in order to improve their readability and to make the hover state clearer.

These changes will be behind a feature flag and 'opt-in' for their initial release. This is because:

- there's a a rendering bug in Chromium that affects links inside CSS columns (see 'known issues')
- users that have implemented their own link styles will likely need to make changes to their CSS in order for their links behave consistently.

In a future major version, we'll flip the feature flag so that this behaviour is opt-out, and then deprecate and remove the feature flag.

## Improve readability of links

Reduce the thickness of link underlines and offset them from the text in order to improve readability. This should help especially when multiple links are included in long lists (for example, search results pages) or at larger sizes.

| Before | After |
|----|----|
![Screenshot before changes](https://user-images.githubusercontent.com/121939/114198701-85b8a680-994b-11eb-83a2-721e3a4d7ad7.png) | ![Screenshot after changes](https://user-images.githubusercontent.com/121939/114198691-83564c80-994b-11eb-8eb9-e24aae37033c.png) |

Allow the thickness and offset to be overridden, so that anyone using GOV.UK Frontend outside of GOV.UK can opt out of these changes.

## Make link hover state clearer with thick underline

We have a long-standing issue (#1417) from an audit in May 2019 about the link hover state not being clear:

> The colour change when a user hovers over a link is not clear and this was especially difficult for low vision users to determine.
>
> Ensuring that the state change is distinctive would benefit low vision users in particular, while benefiting all mouse users in general.

This was raised as a usability issue rather than a WCAG failure.

We’ve been keeping an eye on browser support for the `text-decoration-thickness` property, and its introduction into Chrome 87 means that all evergreen browsers now support it. We can therefore use `text-decoration-thickess` as a way to differentiate the link on hover.

| Before | After |
|----|----|
| ![Screenshot before changes](https://user-images.githubusercontent.com/121939/114198869-b6004500-994b-11eb-85bb-0dc562b5cb3c.png) | ![Screenshot after changes](https://user-images.githubusercontent.com/121939/114198866-b567ae80-994b-11eb-968b-c159ea418b53.png) |

https://user-images.githubusercontent.com/121939/114198950-c9abab80-994b-11eb-8f4a-7ecb8d3a8938.mov

Some of the rationale for this is included in [a comment around the time of the previous working group review][2]. The broad intention is that the thicker underline is a state change that can work across any combination of text colour and background colour, as long as the link has enough contrast in its default state.

We set the underline to a minimum width to 3px with a max to 0.12em. The aim is to make the state change clear whilst avoiding the underline crashing into the text below at larger sizes. A minimum 3px width ensures at least a 2px change from the default 1px thickness. It’s a bit close with 16px body-s text, but if you set the minimum width too low, the hover thickness at 19px stays too thin ([original comment][3]).

We're retaining the existing colour change on hover, as without the colour change there would be no state change in browsers that don't support `text-decoration-thickness`, including IE11. We can revisit this decision as and when our browser support requirements change ([original comment][4]).

[2]: #1417 (comment)
[3]: alphagov/govuk-design-system#1578 (comment)
[4]: alphagov/govuk-design-system#1578 (comment)

## Browser testing
- [x] IE 11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)
- [x] Edge (Windows High Contrast Mode)
- [x] Firefox (Forced colours)
- [x] Firefox (Zoomed to 400%, zoom text only)

## Known issues

- In Safari, [links above 19px which do not have a colour change do not show the underline thickness change on hover](https://bugs.webkit.org/show_bug.cgi?id=224483). All of the link styles in GOV.UK Frontend have a colour change (even if imperceptible) to force the hover state to render correctly, but this could affect custom link styles.
- In Chrome, there's [a rendering bug that affects links inside CSS columns](https://bugs.chromium.org/p/chromium/issues/detail?id=1190987). This would affect the multi-column lists of links in the footer, except we've disabled the hover style for those links as we don't think they're really used outside of GOV.UK, and GOV.UK have their own implementation that does not use CSS columns. We think the risk here is relatively low, and will flag this issue in the release notes and advise anyone using CSS columns to opt out of the new hover state.