### PR TITLE
Fix display of warning text in Edge when Windows High Contrast Mode is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This was added in [pull request #2164: Enable cookie banner to set link styled a
 - [#2132: Improve vertical alignment of phase banner tag on mobile devices](https://github.com/alphagov/govuk-frontend/pull/2132) – thanks to [@matthewmascord](https://github.com/matthewmascord) for contributing this.
 - [#2157: Use pointer cursor for 'Menu' button in header](https://github.com/alphagov/govuk-frontend/pull/2157) – thanks to [@MalcolmVonMoJ](https://github.com/MalcolmVonMoJ) for contributing this.
 - [#2171: Fix padding on GOV.UK logo affecting hover and focus states](https://github.com/alphagov/govuk-frontend/pull/2171)
+- [#2186: Fix display of warning text in Edge when Windows High Contrast Mode is enabled](https://github.com/alphagov/govuk-frontend/pull/2186)
 
 ## 3.11.0 (Feature release)
 

--- a/src/govuk/components/warning-text/_index.scss
+++ b/src/govuk/components/warning-text/_index.scss
@@ -43,6 +43,16 @@
     // Prevent the exclamation mark from being included when the warning text
     // is copied, for example.
     user-select: none;
+
+    // Improve rendering in Windows High Contrast Mode (Edge), where a
+    // readability backplate behind the exclamation mark obscures the circle
+    forced-color-adjust: none;
+
+    @media screen and (forced-colors: active) {
+      border-color: windowText;
+      color: windowText;
+      background: transparent;
+    }
   }
 
   .govuk-warning-text__text {


### PR DESCRIPTION
When Windows High Contrast Mode (HCM) is enabled for Edge, the warning text icon is affected by the [readability backplate][1] which draws a box around the exclamation mark, obscuring parts of the circle.

Opt out of the readability backplate by setting `forced-color:adjust: none` and handle it ourselves, by overriding the colors to system colours in a media query which detects if forced colors are active.

Use `forced-color-adjust` and `forced-colors` over the MS specific `-ms-high-contrast-adjust: none;` and `-ms-high-contrast: active` to allow for future support from other browsers (e.g. Firefox, which allows users to set their own colour scheme for pages).

HCM with IE11 does not seem to be affected by the same issue – I don’t think it implements a readability backplate.

| Theme | Before | After |
| --- | --- | --- |
| High Contrast Black | ![Screenshot 2021-04-13 at 09 12 00](https://user-images.githubusercontent.com/121939/114522978-c827ff00-9c3b-11eb-91c5-0158e45415e8.png)|  ![Screenshot 2021-04-13 at 09 12 04](https://user-images.githubusercontent.com/121939/114522973-c6f6d200-9c3b-11eb-898b-de9420265af5.png) |
| High Contrast White | ![Screenshot 2021-04-13 at 09 12 12](https://user-images.githubusercontent.com/121939/114523114-ea218180-9c3b-11eb-9234-c27021561616.png) | ![Screenshot 2021-04-13 at 09 12 17](https://user-images.githubusercontent.com/121939/114523111-e988eb00-9c3b-11eb-9234-70c12d46eb26.png) |
| High Contrast # 1 |  ![Screenshot 2021-04-13 at 09 12 26](https://user-images.githubusercontent.com/121939/114523209-01606f00-9c3c-11eb-9637-136f1ae07309.png) | ![Screenshot 2021-04-13 at 09 12 30](https://user-images.githubusercontent.com/121939/114523204-00c7d880-9c3c-11eb-9f1a-c80bdbc95b59.png) |
| High Contrast # 2 | ![Screenshot 2021-04-13 at 09 12 40](https://user-images.githubusercontent.com/121939/114523277-0e7d5e00-9c3c-11eb-9bfb-0508755f58ef.png) | ![Screenshot 2021-04-13 at 09 12 43](https://user-images.githubusercontent.com/121939/114523275-0de4c780-9c3c-11eb-897b-9f953f86c970.png) |

[1]: https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/6208eaffa0362ca107644c99b902c0b06bd5a0c8/Accessibility/HighContrast/explainer.md#ensuring-readability