### PR TITLE
Explicitly round line height calculations to 5 decimal places to achieve consistent rendering across node-sass and dart-sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This was added in [pull request #2164: Enable cookie banner to set link styled a
 - [#2171: Fix padding on GOV.UK logo affecting hover and focus states](https://github.com/alphagov/govuk-frontend/pull/2171)
 - [#2186: Fix display of warning text in Edge when Windows High Contrast Mode is enabled](https://github.com/alphagov/govuk-frontend/pull/2186)
 - [#2192: Add data-nosnippet to prevent cookie banner text appearing in Google Search snippets](https://github.com/alphagov/govuk-frontend/pull/2192)
+- [#2200: Explicitly round line height calculations to 5 decimal places to achieve consistent rendering across node-sass and dart-sass](https://github.com/alphagov/govuk-frontend/pull/2200)
 
 ## 3.11.0 (Feature release)
 

--- a/src/govuk/helpers/_typography.scss
+++ b/src/govuk/helpers/_typography.scss
@@ -78,7 +78,11 @@
 
 @function _govuk-line-height($line-height, $font-size) {
   @if not unitless($line-height) and unit($line-height) == unit($font-size) {
-    $line-height: $line-height / $font-size;
+    // Explicitly rounding to 5 decimal places to match the node-sass/libsass default precision.
+    // This is expanded to 10 in dart-sass and results in significant line height differences
+    // Therefore by rounding it here we achieve consistent rendering across node-sass and dart-sass
+    $ten-to-the-power-five: 100000;
+    $line-height: round(($line-height / $font-size) * $ten-to-the-power-five) / $ten-to-the-power-five;
   }
 
   @return $line-height;


### PR DESCRIPTION
This achieves consistent rendering of line heights across node-sass and dart-sass which have different default precisions of 5 and 10 respectively.

Fixes #2199

This is the approach we have taken over on nhsuk-frontend (See https://github.com/nhsuk/nhsuk-frontend/pull/731), but very happy to discuss other options.