### PR TITLE
Set `-webkit-appearance: button` on file upload so text is aligned in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This was added in [pull request #2164: Enable cookie banner to set link styled a
 - [#2171: Fix padding on GOV.UK logo affecting hover and focus states](https://github.com/alphagov/govuk-frontend/pull/2171)
 - [#2186: Fix display of warning text in Edge when Windows High Contrast Mode is enabled](https://github.com/alphagov/govuk-frontend/pull/2186)
 - [#2192: Add data-nosnippet to prevent cookie banner text appearing in Google Search snippets](https://github.com/alphagov/govuk-frontend/pull/2192)
+- [#2201: Set -webkit-appearance: button on file upload so text is aligned in Safari](https://github.com/alphagov/govuk-frontend/pull/2201)
 
 ## 3.11.0 (Feature release)
 

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -11,6 +11,17 @@
     padding-top: $component-padding;
     padding-bottom: $component-padding;
 
+    // The default file upload button in Safari does not
+    // support setting a custom font-size. Set `-webkit-appearance`
+    // to `button` to drop out of the native appearance so the
+    // font-size is set to 19px
+    // https://bugs.webkit.org/show_bug.cgi?id=224746
+    &::-webkit-file-upload-button {
+      -webkit-appearance: button;
+      color: inherit;
+      font: inherit;
+    }
+
     &:focus {
       // "Yank" the padding with negative margin to avoid a jump
       // when element is focused


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2194

<img width="236" alt="Screenshot 2021-04-23 at 10 36 29" src="https://user-images.githubusercontent.com/29889908/115852254-c7ebe880-a41f-11eb-9710-f445d0b5f560.png">

## What
In Safari, the text of the file upload component was mis-aligned with the upload button on desktop, due to the font-size not being properly applied to the button. Safari say:

> We've had this behavior for a long time, since the native rounded button style does not support variable sizes. It works when you specify a "background-color", since that drops us out of the native appearance. A workaround, if you do not require a native appearance, would be to specify "-webkit-appearance: none".

## Setting -webkit-appearance: none
Setting `-webkit-appearance: none` fixes the alignment issue as the font-size can now be set correctly. However, setting appearance to none suggests the element has no "special" appearance - "No special styling is applied. This is the default." (https://developer.mozilla.org/en-US/docs/Web/CSS/appearance).

<img width="278" alt="Screenshot 2021-04-23 at 10 35 16" src="https://user-images.githubusercontent.com/29889908/115852109-9f63ee80-a41f-11eb-8375-00d27ea985be.png">

## Setting -webkit-appearance: button
Setting appearance to `button` means that "the element is drawn like a button", which is more appropriate for our use case.

<img width="287" alt="Screenshot 2021-04-23 at 10 48 23" src="https://user-images.githubusercontent.com/29889908/115853774-70e71300-a421-11eb-800f-87e0b1ad0fe7.png">

However, the button goes grey with white text when pressed, which fails colour contrast recommendations (2.09:1 instead of 4.5:1). So we need to also set the text colour for the button.

<img width="381" alt="Screenshot 2021-04-23 at 10 51 31" src="https://user-images.githubusercontent.com/29889908/115854540-3df14f00-a422-11eb-96b1-c3956fa0baf8.png">

## Cross-browser testing
Because we're nesting `-webkit-appearance` within a `::-webkit-file-upload-button` selector, this doesn't have any effect in the majority of browsers. The only change I observed was in Safari (Mac). Full selection of screenshots [here](https://docs.google.com/presentation/d/1V1b0rwgjyTH6EwfkYn1NLwLzwnTFymcuAgsr0VJF73w/edit#slide=id.p)

- [x] IE11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)
- [x] Windows High Contrast Mode (Edge)

