### PR TITLE
Add consistent terminology to cookie banner macros

### DIFF
--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -2,7 +2,7 @@ params:
 - name: ariaLabel
   type: string
   required: false
-  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all messages that the cookie banner includes. For example, the cookie message and the replacement message. Defaults to "Cookie banner".
+  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all messages that the cookie banner includes. For example, the cookie message and the confirmation message. Defaults to "Cookie banner".
 - name: hidden
   type: boolean
   required: false
@@ -18,7 +18,7 @@ params:
 - name: messages
   type: array
   required: true
-  description: The different messages you can pass into the cookie banner. For example, the cookie message and the replacement message.
+  description: The different messages you can pass into the cookie banner. For example, the cookie message and the confirmation message.
   params:
     - name: headingText
       type: string
@@ -72,11 +72,11 @@ params:
     - name: hidden
       type: boolean
       required: false
-      description: Defaults to `false`. If you set it to `true`, the message is hidden. You can use `hidden` for client-side implementations where the replacement message HTML is present, but hidden on the page.
+      description: Defaults to `false`. If you set it to `true`, the message is hidden. You can use `hidden` for client-side implementations where the confirmation message HTML is present, but hidden on the page.
     - name: role
       type: string
       required: false
-      description: Set `role` to `alert` on replacement messages to allow assistive tech to automatically read the message. You will also need to move focus to the replacement message using JavaScript you have written yourself.
+      description: Set `role` to `alert` on confirmation messages to allow assistive tech to automatically read the message. You will also need to move focus to the confirmation message using JavaScript you have written yourself.
     - name: classes
       type: string
       required: false


### PR DESCRIPTION
This PR replaces instances of "replacement message" with "confirmation message."

This is to mirror a commit in [#1600: Improve cookie banner guidance](https://github.com/alphagov/govuk-design-system/pull/1600), which similarly updates the cookie banner guidance to also use the term 'confirmation message.'