### PR TITLE
Stop file upload component 'jumping' on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This was added in [pull request #2164: Enable cookie banner to set link styled a
 - [#2186: Fix display of warning text in Edge when Windows High Contrast Mode is enabled](https://github.com/alphagov/govuk-frontend/pull/2186)
 - [#2192: Add data-nosnippet to prevent cookie banner text appearing in Google Search snippets](https://github.com/alphagov/govuk-frontend/pull/2192)
 - [#2201: Set -webkit-appearance: button on file upload so text is aligned in Safari](https://github.com/alphagov/govuk-frontend/pull/2201)
+- [#2205: Stop file upload component 'jumping' on focus](https://github.com/alphagov/govuk-frontend/pull/2205)
 
 ## 3.11.0 (Feature release)
 

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -8,8 +8,8 @@
   .govuk-file-upload {
     @include govuk-font($size: 19);
     @include govuk-text-colour;
-    padding-top: $component-padding;
-    padding-bottom: $component-padding;
+    margin-left: -$component-padding;
+    padding: $component-padding;
 
     // The default file upload button in Safari does not
     // support setting a custom font-size. Set `-webkit-appearance`
@@ -23,13 +23,6 @@
     }
 
     &:focus {
-      // "Yank" the padding with negative margin to avoid a jump
-      // when element is focused
-      margin-right: -$component-padding;
-      margin-left: -$component-padding;
-      padding-right: $component-padding;
-      padding-left: $component-padding;
-
       outline: $govuk-focus-width solid $govuk-focus-colour;
       // Use `box-shadow` to add border instead of changing `border-width`
       // (which changes element size) and since `outline` is already used for the
@@ -48,11 +41,6 @@
     // to recognise `focus-within` and don't set any styles from the block
     // when it's a selector.
     &:focus-within {
-      margin-right: -$component-padding;
-      margin-left: -$component-padding;
-      padding-right: $component-padding;
-      padding-left: $component-padding;
-
       outline: $govuk-focus-width solid $govuk-focus-colour;
 
       box-shadow: inset 0 0 0 4px $govuk-input-border-colour;


### PR DESCRIPTION
## What
Stop file upload component 'jumping' on focus.

## Why
While working on https://github.com/alphagov/govuk-frontend/issues/2194 , we noticed that the file upload component 'jumps' slightly to the left on focus. Example (in Safari, but this affects other browsers too):

https://user-images.githubusercontent.com/29889908/116105923-b0279500-a6a9-11eb-8ad7-d6b041652d67.mov

This is related to some CSS and a comment in the code, which is applied on focus:

```scss
// Yank the padding with negative margin to avoid a jump
// when element is focused
margin-right: -$component-padding;
margin-left: -$component-padding;
padding-right: $component-padding;
padding-left: $component-padding;
```

We can understand why this code was added by observing the effect of removing it:

https://user-images.githubusercontent.com/29889908/116106552-1d3b2a80-a6aa-11eb-89ee-6b8d8f6f96b8.mov

When this CSS is removed, the focus state and the file upload button overlap on the left-hand side.

### So... we need to add some padding-left?
The component has bottom and top padding applied by default, but left and right padding is only added on focus (see the code above). What happens if we add padding by default instead of waiting for focus, to prevent anything moving around on focus?

<img width="879" alt="Screenshot 2021-04-26 at 16 07 03" src="https://user-images.githubusercontent.com/29889908/116106871-64c1b680-a6aa-11eb-9b03-9c8d78841f28.png">
<img width="847" alt="Screenshot 2021-04-26 at 16 07 09" src="https://user-images.githubusercontent.com/29889908/116106902-6ee3b500-a6aa-11eb-8f23-132172b6de15.png">

This initially looks good on focus, but we can see that when the focus state is removed the file upload button is out of line with the text above it. This explains why we were initially adding a negative margin.

### Setting padding and negative margin by default
Instead of waiting until focus, we can add padding and a negative left margin by default:

https://user-images.githubusercontent.com/29889908/116108031-72c40700-a6ab-11eb-93a6-b30bfe11f035.mov

## Cross Browser testing
- [x] IE11
- [x] Edge
- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)
- [x] Windows High Contrast Mode (Edge)