### PR TITLE
Simplify back link styles

### DIFF
--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -24,21 +24,6 @@
     padding-left: 14px;
   }
 
-  // Only underline if the component is linkable
-  .govuk-back-link[href] {
-    text-decoration: underline;
-
-    // When the back link is focused, hide the bottom link border as the
-    // focus styles has a bottom border.
-    &:focus {
-      text-decoration: none;
-
-      &:before {
-        border-color: $govuk-text-colour;
-      }
-    }
-  }
-
   // Prepend left pointing chevron
   .govuk-back-link:before {
     content: "";
@@ -82,6 +67,10 @@
       // so fall back to using another sans-serif font to render the chevron.
       font-family: Arial, sans-serif;
     }
+  }
+
+  .govuk-back-link:focus:before {
+    border-color: $govuk-focus-text-colour;
   }
 
   .govuk-back-link:after {


### PR DESCRIPTION
We used to use a bottom border to create the underline so that the ‘triangle’ and the link were both underlined.

This was changed in ad141f4 to make it consistent with breadcrumbs, which means the special link treatment isn’t required any more.

Remove it, in preparation for the new link styles which it will otherwise override.

There should be no visual change to the component.

Split out from #2183.