### PR TITLE
Update tabs to use core link mixin

### DIFF
--- a/src/govuk/components/tabs/_index.scss
+++ b/src/govuk/components/tabs/_index.scss
@@ -30,16 +30,11 @@
   }
 
   .govuk-tabs__tab {
+    @include govuk-link-common;
     @include govuk-link-style-default;
 
     display: inline-block;
     margin-bottom: govuk-spacing(2);
-
-    // Focus state for mobile and when JavaScript is disabled
-    // It is removed for JS-enabled desktop styles
-    &:focus {
-      @include govuk-focused-text;
-    }
   }
 
   .govuk-tabs__panel {


### PR DESCRIPTION
Tabs are progressively enhanced from a set of links, which is what users see if JavaScript is not enabled.

Apply the common link styles mixin, which includes the new link style treatments, to the tabs. The common link styles mixin also includes the focus state, so we no longer need to apply that separately.

When we progressively enhance the tabs, the only thing we then need to change about the links is the link colour, which is already handled by the inclusion of the `govuk-link-style-text` mixin.

Using the text link style mixin for this component prepares us for the new link styles which will now be inherited from the mixins.

There should be no visual change to the component.

Split out from #2183.