### PR TITLE
Tidy up redundant code in accordion

### DIFF
--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -2,7 +2,6 @@
 
   $govuk-accordion-link-colour: $govuk-link-colour;
   $govuk-accordion-link-hover-colour: govuk-colour("light-blue");
-  $govuk-accordion-border-width: 3px;
 
   .govuk-accordion {
     @include govuk-responsive-margin(6, "bottom");
@@ -100,15 +99,6 @@
       border-top: 1px solid $govuk-border-colour;
       color: $govuk-accordion-link-colour;
       cursor: pointer;
-    }
-
-    // For devices that can't hover such as touch devices,
-    // remove hover state as it can be stuck in that state (iOS).
-    @media (hover: none) {
-      .govuk-accordion__section-header:hover {
-        border-top-color: $govuk-accordion-link-colour;
-        box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-accordion-link-colour;
-      }
     }
 
     // Buttons within the headers don’t need default styling


### PR DESCRIPTION
The CSS within the `hover: none` block is there to ‘undo’ the hover state for the `govuk-accordion__section-header` class on devices that don’t support hover (like touch screen devices) in order to prevent the hover state being applied on touch and getting ‘stuck’.

However, the hover state on `govuk-accordion__section-header` was removed in 9bfbc80 in favour of applying the hover state directly to `govuk-accordion__section-button`, so there’s nothing to ‘undo’ any more and this block can be removed.

This is the only place where `$govuk-accordion-border-width` gets used, so we can remove that as well.

There should be no visual change to the component.

Split out from #2183.