### PR TITLE
Add underline to crown copyright link in footer

### DIFF
--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -124,7 +124,6 @@
     background-position: 50% 0%;
     background-size: $govuk-footer-crest-image-width $govuk-footer-crest-image-height;
     text-align: center;
-    text-decoration: none;
     white-space: nowrap;
   }
 


### PR DESCRIPTION
To be consistent with all of the other links in the footer.

## Before

![Screenshot 2021-04-29 at 17 52 36](https://user-images.githubusercontent.com/121939/116588627-b0c36400-a913-11eb-83ba-9d6240dd9406.png)

## After

![Screenshot 2021-04-29 at 17 52 27](https://user-images.githubusercontent.com/121939/116588651-b751db80-a913-11eb-946e-f4e16623c0d5.png)
