### PR TITLE
Add inverse link mixin and modifier class

### DIFF
--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -14,7 +14,8 @@
   'Link': '',
   'Link with no visited state': 'govuk-link--no-visited-state',
   'Text link': 'govuk-link--text-colour',
-  'Muted link': 'govuk-link--muted'
+  'Muted link': 'govuk-link--muted',
+  'Inverse': 'govuk-link--inverse'
 } %}
 
 {% set states = {
@@ -49,8 +50,8 @@
 
     {% for variant_description, variant_class in variants %}
 
-      <section class="govuk-!-margin-top-8">
-        <h2 class="govuk-heading-l">{{ variant_description }}</h2>
+      <section class="govuk-!-margin-top-8"{% if variant_class == "govuk-link--inverse"%} style="background: #1d70b8; padding: 15px; margin: -15px;"{% endif %}>
+        <h2 class="govuk-heading-l"{% if variant_class == "govuk-link--inverse"%} style="color: #fff;"{% endif %}>{{ variant_description }}</h2>
 
       {% for state_description, state_class in states %}
         <p class="govuk-body">

--- a/src/govuk/core/_links.scss
+++ b/src/govuk/core/_links.scss
@@ -27,6 +27,10 @@
     @include govuk-link-style-text;
   }
 
+  .govuk-link--inverse {
+    @include govuk-link-style-inverse;
+  }
+
   .govuk-link--no-underline {
     @include govuk-link-style-no-underline;
   }

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -217,7 +217,6 @@
 /// @access public
 
 @mixin govuk-link-style-text {
-  // Override link colour to use text colour
   &:link,
   &:visited,
   &:hover,
@@ -232,6 +231,43 @@
   @include govuk-compatibility(govuk_template) {
     &:link:focus {
       @include govuk-text-colour;
+    }
+  }
+}
+
+/// Inverse style link mixin
+///
+/// Overrides the colour of links to work on a dark background.
+///
+/// If you use this mixin in a component you must also include the
+/// govuk-link-common mixin in order to get the focus state.
+///
+/// @example scss
+///   .govuk-component__link {
+///     @include govuk-link-common;
+///     @include govuk-link-style-inverse;
+///   }
+///
+/// @access public
+
+@mixin govuk-link-style-inverse {
+  &:link,
+  &:visited,
+  &:hover,
+  &:active {
+    color: govuk-colour("white");
+  }
+
+  &:focus {
+    color: $govuk-focus-text-colour;
+  }
+
+  // alphagov/govuk_template includes a specific a:link:focus selector designed
+  // to make unvisited links a slightly darker blue when focussed, so we need to
+  // override the text colour for that combination of selectors.
+  @include govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $govuk-focus-text-colour;
     }
   }
 }


### PR DESCRIPTION
Inverse links are a fairly common thing for service teams to need to implement, and we often see issues with the focus state being implemented incorrectly.

The upcoming changes to link styles will add even more nuance, so providing a reusable mixin and modifier class will save users time and help to make it more likely that link styles are implemented well.

We can also use this new mixin when we update the header component.

Closes #1916 

![Screenshot 2021-04-30 at 09 21 43](https://user-images.githubusercontent.com/121939/116668612-7dc1b480-a995-11eb-87d1-f2d1f6298dd8.png)
