### PR TITLE
Add no-underline mixin and modifier class

### DIFF
--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -17,6 +17,10 @@
   'Muted link': 'govuk-link--muted'
 } %}
 
+{% set modifiers = {
+  'with no underline': 'govuk-link--no-underline'
+} %}
+
 {% set states = {
   'Link': ':link',
   'Visited link': ':visited',
@@ -54,6 +58,18 @@
             {{ state_description}}
           </a>
         </p>
+      {% endfor %}
+
+        {% for modifier_description, modifier_class in modifiers %}
+        <h3 class="govuk-heading-m">{{ modifier_description }}</h2>
+
+        {% for state_description, state_class in states %}
+          <p class="govuk-body">
+            <a href="/#{{ randomPageHash }}" class="govuk-link {{ variant_class }} {{ modifier_class }} {{ state_class }}">
+              {{ state_description}}
+            </a>
+          </p>
+        {% endfor %}
       {% endfor %}
       </section>
     {% endfor %}

--- a/app/views/examples/links/index.njk
+++ b/app/views/examples/links/index.njk
@@ -17,10 +17,6 @@
   'Muted link': 'govuk-link--muted'
 } %}
 
-{% set modifiers = {
-  'with no underline': 'govuk-link--no-underline'
-} %}
-
 {% set states = {
   'Link': ':link',
   'Visited link': ':visited',
@@ -47,6 +43,10 @@
         (<a class="govuk-link" href="#">Link with surrounding brackets</a>) test that the focus style does not overlap.
       </p>
 
+      <p class="govuk-body">
+        <a class="govuk-link govuk-link--no-underline" href="#">Link with no underline</a>
+      </p>
+
     {% for variant_description, variant_class in variants %}
 
       <section class="govuk-!-margin-top-8">
@@ -58,18 +58,6 @@
             {{ state_description}}
           </a>
         </p>
-      {% endfor %}
-
-        {% for modifier_description, modifier_class in modifiers %}
-        <h3 class="govuk-heading-m">{{ modifier_description }}</h2>
-
-        {% for state_description, state_class in states %}
-          <p class="govuk-body">
-            <a href="/#{{ randomPageHash }}" class="govuk-link {{ variant_class }} {{ modifier_class }} {{ state_class }}">
-              {{ state_description}}
-            </a>
-          </p>
-        {% endfor %}
       {% endfor %}
       </section>
     {% endfor %}

--- a/src/govuk/core/_links.scss
+++ b/src/govuk/core/_links.scss
@@ -27,6 +27,10 @@
     @include govuk-link-style-text;
   }
 
+  .govuk-link--no-underline {
+    @include govuk-link-style-no-underline;
+  }
+
   .govuk-link--no-visited-state {
     @include govuk-link-style-no-visited-state;
   }

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -280,6 +280,28 @@
   }
 }
 
+/// No underline link mixin
+///
+/// Removes underlines from links (except on hover, or when the link is active).
+/// This does not work in IE8, because IE8 does not support `:not`.
+///
+/// @access public
+
+@mixin govuk-link-style-no-underline {
+  &:link {
+    text-decoration-line: none;
+  }
+
+  &:hover,
+  &:active {
+    text-decoration-line: underline;
+  }
+
+  &:focus {
+    text-decoration: none;
+  }
+}
+
 /// Print friendly link mixin
 ///
 /// When printing, append the the destination URL to the link text, as long

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -288,16 +288,7 @@
 /// @access public
 
 @mixin govuk-link-style-no-underline {
-  &:link {
-    text-decoration-line: none;
-  }
-
-  &:hover,
-  &:active {
-    text-decoration-line: underline;
-  }
-
-  &:focus {
+  &:not(:hover):not(:active) {
     text-decoration: none;
   }
 }


### PR DESCRIPTION
This is a fairly common thing for service teams to need to implement, and they’ll often do it using `text-decoration` which, as a shorthand property, results in the `text-decoration-thickness` being reset to auto for the hover state.

Provide a mixin and class which includes the correct behaviour. Add it to the ‘links’ examples page.

The underlying styles make use of `:not`, which means that the `no-underline` mixin / modifier will have no effect in IE8 which does not support `:not`.

## Screenshot

### Link without underline
![Screenshot 2021-04-30 at 11 58 00](https://user-images.githubusercontent.com/121939/116686176-5970d280-a9ab-11eb-975a-eaa6ea62b5d2.png)

### Link without underline (hovered / active)
![Screenshot 2021-04-30 at 11 58 04](https://user-images.githubusercontent.com/121939/116686171-58d83c00-a9ab-11eb-8bcb-5ba6b8cc077f.png)

Split out from #2183.

Closes #2189 