### PR TITLE
Update components to use new link styles

### DIFF
--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -1,8 +1,4 @@
 @include govuk-exports("govuk/component/accordion") {
-
-  $govuk-accordion-link-colour: $govuk-link-colour;
-  $govuk-accordion-link-hover-colour: govuk-colour("light-blue");
-
   .govuk-accordion {
     @include govuk-responsive-margin(6, "bottom");
   }
@@ -97,7 +93,6 @@
       // Safe area on the right to avoid clashing with icon
       padding-right: 40px;
       border-top: 1px solid $govuk-border-colour;
-      color: $govuk-accordion-link-colour;
       cursor: pointer;
     }
 
@@ -109,7 +104,7 @@
       margin-left: 0;
       padding: 0;
       border-width: 0;
-      color: inherit;
+      color: $govuk-link-colour;
       background: none;
       text-align: left;
       cursor: pointer;
@@ -137,7 +132,13 @@
     }
 
     .govuk-accordion__section-button:hover:not(:focus) {
+      color: $govuk-link-hover-colour;
       text-decoration: underline;
+
+      // This needs to come after the text-decoration property otherwise
+      // text-decoration, as a shorthand property, resets it to auto
+      @include govuk-link-hover-decoration;
+      text-underline-offset: $govuk-link-underline-offset;
     }
 
     // For devices that can't hover such as touch devices,

--- a/src/govuk/components/details/_index.scss
+++ b/src/govuk/components/details/_index.scss
@@ -34,7 +34,11 @@
 
   // ...but only underline the text, not the arrow
   .govuk-details__summary-text {
-    text-decoration: underline;
+    @include govuk-link-decoration;
+  }
+
+  .govuk-details__summary:hover .govuk-details__summary-text {
+    @include govuk-link-hover-decoration;
   }
 
   // Remove the underline when focussed to avoid duplicate borders

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -178,6 +178,13 @@
     padding: 0;
     list-style: none;
     column-gap: $govuk-gutter; // Support: Columns
+
+    // Disable thicker underlines on hover because of a bug in Chromium
+    // affecting links within columns
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1190987
+    .govuk-footer__link:hover {
+      text-decoration-thickness: auto;
+    }
   }
 
   @include govuk-media-query ($from: desktop) {

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -4,10 +4,9 @@
   $govuk-header-border-color: $govuk-brand-colour;
   $govuk-header-border-width: govuk-spacing(2);
   $govuk-header-text: govuk-colour("white");
-  $govuk-header-link: govuk-colour("white");
-  $govuk-header-link-hover: govuk-colour("white");
   $govuk-header-link-active: #1d8feb;
   $govuk-header-nav-item-border-color: #2e3133;
+  $govuk-header-link-underline-thickness: 3px;
 
   .govuk-header {
     @include govuk-font($size: 16);
@@ -40,6 +39,10 @@
     // Add a gap between logo and any product name
     margin-right: govuk-spacing(1);
 
+    // Prevent readability backplate from obscuring underline in Windows
+    // High Contrast Mode
+    forced-color-adjust: none;
+
     // But remove it if there's nothing after the logo to keep hover and focus
     // states neat
     &:last-child {
@@ -68,28 +71,29 @@
   }
 
   .govuk-header__link {
-    text-decoration: none;
+    // Avoid using the `govuk-link-common` mixin because the links in the header
+    // get a special treatment, because:
+    //
+    // - underlines are only visible on hover
+    // - all links get a 3px underline regardless of text size, as there are
+    //   multiple grouped elements close to one another and having slightly
+    //   different underline widths looks unbalanced
+    @include govuk-typography-common;
+    @include govuk-link-style-inverse;
 
-    &:link,
-    &:visited {
-      color: $govuk-header-link;
-    }
+    text-decoration: none;
 
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: $govuk-header-link-underline-thickness;
+
+      @if ($govuk-link-underline-offset) {
+        text-underline-offset: $govuk-link-underline-offset;
+      }
     }
 
     &:focus {
       @include govuk-focused-text;
-    }
-
-    // alphagov/govuk_template includes a specific a:link:focus selector
-    // designed to make unvisited links a slightly darker blue when focussed, so
-    // we need to override the text colour for that combination of selectors.
-    @include govuk-compatibility(govuk_template) {
-      &:link:focus {
-        @include govuk-text-colour;
-      }
     }
   }
 
@@ -111,10 +115,10 @@
     &:hover,
     &:active {
       // Negate the added border
-      margin-bottom: -1px;
+      margin-bottom: $govuk-header-link-underline-thickness * -1;
       // Omitting colour will use default value of currentColor – if we
       // specified currentColor explicitly IE8 would ignore this rule.
-      border-bottom: 1px solid;
+      border-bottom: $govuk-header-link-underline-thickness solid;
     }
 
     // Remove any borders that show when focused and hovered.
@@ -164,12 +168,16 @@
     margin: 0;
     padding: 0;
     border: 0;
-    color: $govuk-header-link;
+    color: govuk-colour("white");
     background: none;
     cursor: pointer;
 
     &:hover {
-      text-decoration: underline;
+      text-decoration: solid underline $govuk-header-link-underline-thickness;
+
+      @if ($govuk-link-underline-offset) {
+        text-underline-offset: $govuk-link-underline-offset;
+      }
     }
 
     &:focus {

--- a/src/govuk/components/skip-link/_index.scss
+++ b/src/govuk/components/skip-link/_index.scss
@@ -2,6 +2,7 @@
   .govuk-skip-link {
     @include govuk-visually-hidden-focusable;
     @include govuk-typography-common;
+    @include govuk-link-decoration;
     @include govuk-link-style-text;
     @include govuk-typography-responsive($size: 16);
 
@@ -27,7 +28,6 @@
       // Undo unwanted changes when global styles are enabled
       @if ($govuk-global-styles) {
         box-shadow: none;
-        text-decoration: underline;
       }
     }
   }

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -12,6 +12,10 @@
   @include govuk-typography-common;
   @include govuk-link-decoration;
 
+  &:hover {
+    @include govuk-link-hover-decoration;
+  }
+
   &:focus {
     @include govuk-focused-text;
   }
@@ -33,12 +37,19 @@
     @if ($govuk-link-underline-offset) {
       text-underline-offset: $govuk-link-underline-offset;
     }
+  }
+}
 
-    @if ($govuk-link-hover-underline-thickness) {
-      &:hover {
-        text-decoration-thickness: $govuk-link-hover-underline-thickness;
-      }
-    }
+/// Link hover decoration mixin
+///
+/// Provides the text decoration for links in their hover state, intended to
+/// be used within a `:hover` pseudo-selector
+///
+/// @access public
+
+@mixin govuk-link-hover-decoration {
+  @if ($govuk-new-link-styles and $govuk-link-hover-underline-thickness) {
+    text-decoration-thickness: $govuk-link-hover-underline-thickness;
   }
 }
 

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -33,19 +33,6 @@ describe('@mixin govuk-link-decoration', () => {
 
       expect(results.css.toString()).not.toContain('text-underline-offset')
     })
-
-    it('does not set a hover state', async () => {
-      const sass = `
-      @import "base";
-  
-      .foo {
-          @include govuk-link-decoration;
-      }`
-
-      const results = await renderSass({ data: sass, ...sassConfig })
-
-      expect(results.css.toString()).not.toContain(':hover')
-    })
   })
 
   describe('when $govuk-new-link-styles are enabled', () => {
@@ -79,21 +66,6 @@ describe('@mixin govuk-link-decoration', () => {
       expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
     })
 
-    it('sets text-decoration-thickness on hover', async () => {
-      const sass = `
-        $govuk-new-link-styles: true;
-        $govuk-link-hover-underline-thickness: 10px;
-        @import "base";
-  
-        .foo {
-          @include govuk-link-decoration;
-        }`
-
-      const results = await renderSass({ data: sass, ...sassConfig })
-
-      expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
-    })
-
     describe('when $govuk-link-underline-thickness is falsey', () => {
       it('does not set text-decoration-thickness', async () => {
         const sass = `
@@ -107,7 +79,7 @@ describe('@mixin govuk-link-decoration', () => {
 
         const results = await renderSass({ data: sass, ...sassConfig })
 
-        expect(results.css.toString()).not.toMatch(/\.foo {.*text-decoration-thickness.*}/)
+        expect(results.css.toString()).not.toContain('text-decoration-thickness')
       })
     })
 
@@ -127,6 +99,42 @@ describe('@mixin govuk-link-decoration', () => {
         expect(results.css.toString()).not.toContain('text-underline-offset')
       })
     })
+  })
+})
+
+describe('@mixin govuk-link-hover-decoration', () => {
+  describe('by default', () => {
+    it('does not set a hover state', async () => {
+      const sass = `
+      @import "base";
+  
+      // The mixin shouldn't return anything, so this selector ends up empty and
+      // is omitted from the CSS
+      .foo:hover {
+          @include govuk-link-hover-decoration;
+      }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).not.toContain('.foo:hover')
+    })
+  })
+
+  describe('when $govuk-new-link-styles are enabled', () => {
+    it('sets text-decoration-thickness on hover', async () => {
+      const sass = `
+        $govuk-new-link-styles: true;
+        $govuk-link-hover-underline-thickness: 10px;
+        @import "base";
+
+        .foo:hover {
+          @include govuk-link-hover-decoration;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
+    })
 
     describe('when $govuk-link-hover-underline-thickness is falsey', () => {
       it('does not set a hover state', async () => {
@@ -135,8 +143,10 @@ describe('@mixin govuk-link-decoration', () => {
         $govuk-link-hover-underline-thickness: false;
         @import "base";
     
-        .foo {
-            @include govuk-link-decoration;
+        // The mixin shouldn't return anything, so this selector ends up empty and
+        // is omitted from the CSS
+        .foo:hover {
+            @include govuk-link-hover-decoration;
         }`
 
         const results = await renderSass({ data: sass, ...sassConfig })


### PR DESCRIPTION
Most components that use the link mixins will automatically benefit from the new link styles introduced in #2183, but some components need special treatment.

Update those components to use the new link styles.

## Accordion

Updated to use new link styles, including the colour change which was missing previously.

### Before

![Accordion before](https://user-images.githubusercontent.com/121939/115521685-4a8b7100-a283-11eb-98a8-c84d4eeecd38.png)

### After (new link styles disabled)

![Accordion after off](https://user-images.githubusercontent.com/121939/115521681-49f2da80-a283-11eb-9d58-d5ea925ab132.png)

### After (new link styles enabled)

![Accordion after on](https://user-images.githubusercontent.com/121939/115521683-49f2da80-a283-11eb-8a67-3e1978fb479c.png)

## Details

Updated to use new link styles

## Before

![govuk-frontend-pr-2183 herokuapp com_components_details_preview (1)](https://user-images.githubusercontent.com/121939/116725956-8be5f400-a9da-11eb-8369-1c137b5356eb.png)
![govuk-frontend-pr-2183 herokuapp com_components_details_preview](https://user-images.githubusercontent.com/121939/116725957-8be5f400-a9da-11eb-873a-43e2c7797e99.png)

## After

![govuk-frontend-pr-2215 herokuapp com_components_details_preview](https://user-images.githubusercontent.com/121939/116725953-8be5f400-a9da-11eb-94f5-81c0ddb7f748.png)
![govuk-frontend-pr-2215 herokuapp com_components_details_preview (1)](https://user-images.githubusercontent.com/121939/116725950-8b4d5d80-a9da-11eb-848c-e57d4ccf9432.png)

## Footer

Remove the hover state from links in the multi-column lists due to a bug in Chromium browsers affecting links within columns.

## Header

Updated to use new link styles, with a consistent 3px underline on all links on hover. These changes are applied whether `$govuk-new-link-styles` is enabled or not.

### Before

![Header before](https://user-images.githubusercontent.com/121939/115521615-39426480-a283-11eb-940c-6629f3d11eb8.png)

### After

![Header after](https://user-images.githubusercontent.com/121939/115521596-35aedd80-a283-11eb-9be6-05c781c31987.png)

### Known issues

- In Firefox, when colours are overridden, the underline on the 'GOV.UK' logo in the header when hovered is partially obscured by the readability backplate, and is only visible below the crown.

## Skip link

Updated to use underline offset

### Before

![govuk-frontend-pr-2183 herokuapp com_components_skip-link_with-focus_preview](https://user-images.githubusercontent.com/121939/116725800-58a36500-a9da-11eb-9fde-79485f13404f.png)

### After

![govuk-frontend-pr-2215 herokuapp com_components_skip-link_with-focus_preview](https://user-images.githubusercontent.com/121939/116725798-580ace80-a9da-11eb-8580-f52f9487f427.png)