### PR TITLE
Rename default branch to `main`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Code of Conduct
 
-This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/.github/blob/master/CODE_OF_CONDUCT.md).
+This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Your contribution needs to work with certain assistive technology as set out in 
 
 ## Commit hygiene
 
-Please see our [git style guide](https://github.com/alphagov/styleguides/blob/master/git.md)
+Please see our [git style guide](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages)
 which describes how we prefer git history and commit messages to read.
 
 ## Updating Changelog

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 GOV.UK Frontend ·
-[![Build Status](https://github.com/alphagov/govuk-frontend/workflows/Tests/badge.svg)](https://github.com/alphagov/govuk-frontend/actions?query=workflow%3ATests+branch%3Amaster)
+[![Build Status](https://github.com/alphagov/govuk-frontend/workflows/Tests/badge.svg)](https://github.com/alphagov/govuk-frontend/actions?query=workflow%3ATests+branch%3Amain)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 =====================
 

--- a/docs/contributing/coding-standards/components.md
+++ b/docs/contributing/coding-standards/components.md
@@ -27,4 +27,4 @@ If your component uses JavaScript, you must also create the following files in t
 
 If you need help building a component, [contact the Design System team](https://design-system.service.gov.uk/get-in-touch/) and we'll support you.
 
-Learn more about styling components in our [CSS style guide](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/css.md). Our [JavaScript style guide](https://github.com/alphagov/govuk-frontend/blob/master/docs/contributing/coding-standards/js.md) has more information on coding components.
+Learn more about styling components in our [CSS style guide](./css.md). Our [JavaScript style guide](./js.md) has more information on coding components.

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -120,6 +120,6 @@ GOV.UK Frontend uses [standardjs](http://standardjs.com/), an opinionated JavaSc
 
 The standard docs have a [complete list of rules and some reasoning behind them](http://standardjs.com/rules.html).
 
-Read more about [running standard manually or in your editor](https://github.com/alphagov/styleguides/blob/master/js.md#linting).
+Read more about [running standard manually or in your editor](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
 
 See also [testing and linting](/docs/releasing/testing-and-linting.md).

--- a/docs/contributing/coding-standards/nunjucks-api.md
+++ b/docs/contributing/coding-standards/nunjucks-api.md
@@ -6,7 +6,7 @@ To provide a level of consistency for developers we have standardised option nam
 
 The options (arguments) accepted by the component macro are specified in a `[component-name].yaml` file as `params`. Each option should have the following attributes: `name`, `type`, `required`, `description`.
 
-An option can additionally contain `params` that denotes nested items in the option (see [breadcrumbs component](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/breadcrumbs/breadcrumbs.yaml#L6)) and `isComponent: true` where the option is another component (see [checkboxes component](https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/components/checkboxes/checkboxes.yaml#L11)).
+An option can additionally contain `params` that denotes nested items in the option (see [breadcrumbs component](/src/govuk/components/breadcrumbs/breadcrumbs.yaml#L6)) and `isComponent: true` where the option is another component (see [checkboxes component](/src/govuk/components/checkboxes/checkboxes.yaml#L11)).
 
 Component macro options are shipped as  `macro-options.json` in `package`.
 

--- a/docs/contributing/versioning.md
+++ b/docs/contributing/versioning.md
@@ -91,7 +91,7 @@ This includes:
 - SCSS - for example [colours variables](https://design-system.service.gov.uk/styles/colour/)
 
 ### npm package
-The other primary way is through what is [published to npm](https://github.com/alphagov/govuk-frontend/tree/master/package).
+The other primary way is through what is [published to npm](/package).
 
 This includes:
 

--- a/docs/contributing/versioning.md
+++ b/docs/contributing/versioning.md
@@ -35,7 +35,7 @@ Whenever we decide to make a breaking change we must ensure we do our best to tr
 
 ## Proposal
 
-Some breaking changes that need discussion may first be proposed in the [GOV.UK Design System architecture repository](https://github.com/alphagov/govuk-design-system-architecture/blob/master/proposals/README.md).
+Some breaking changes that need discussion may first be proposed in the [GOV.UK Design System architecture repository](https://github.com/alphagov/govuk-design-system-architecture/blob/main/proposals/README.md).
 
 This is to ensure the community can get involved with the decision.
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -36,7 +36,7 @@
 
 Developers should pair on releases. When remote working, it can be useful to be on a call together.
 
-1. Checkout the **master** branch and pull the latest changes.
+1. Checkout the **main** branch and pull the latest changes.
 
 2. Run `nvm use` to make sure you are using the right version of Node.js and npm.
 
@@ -60,7 +60,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
   ```bash
   cd ../govuk-design-system
-  git checkout master
+  git checkout main
   git pull
   npm install # note running `npm install` after `npm link` will destroy the link.
   npm link ../govuk-frontend/package/
@@ -75,9 +75,9 @@ Developers should pair on releases. When remote working, it can be useful to be 
 10. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version-numbers have been updated and that the compiled assets use this version-number.
 
-11. Once a reviewer approves the pull request, merge it to **master**.
+11. Once a reviewer approves the pull request, merge it to **main**.
 
-12. Checkout the **master** branch and pull the latest changes.
+12. Checkout the **main** branch and pull the latest changes.
 
 13. Log into npm (`npm login`), using team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -79,7 +79,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 12. Checkout the **master** branch and pull the latest changes.
 
-13. Log into npm (`npm login`), using team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/master/npm/govuk-patterns-and-tools).
+13. Log into npm (`npm login`), using team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
 
 14. Run `npm run publish-release`. You will now be prompted to continue or cancel.
 


### PR DESCRIPTION
Part of #2149 

## What

Replace instances of "master" with "main" in preparation for the default branch renaming work

## Why

Many communities on GitHub are considering renaming the default branch name of their repository from master, as this terminology can be offensive. Statements and guidance have been published by Git [here](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) and GitHub [here](https://github.com/github/renaming).

New GitHub repositories use `main` as the name for the default branch, so it makes sense that we should follow this convention, as well as matching what other teams within GDS are doing so we are consistent.
We are renaming the default branch to `main`, we need to update documentation and tooling to reflect this.