### PR TITLE
Fix link text for anchor links to GDS Way pages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,7 @@ Your contribution needs to work with certain assistive technology as set out in 
 
 ## Commit hygiene
 
-Please see our [git style guide](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages)
-which describes how we prefer git history and commit messages to read.
+Please see our [Git style guide in the 'How to store source code' page of the GDS Way](https://gds-way.cloudapps.digital/standards/source-code.html#commit-messages), which describes how we prefer Git history and commit messages to read.
 
 ## Updating Changelog
 

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -120,6 +120,6 @@ GOV.UK Frontend uses [standardjs](http://standardjs.com/), an opinionated JavaSc
 
 The standard docs have a [complete list of rules and some reasoning behind them](http://standardjs.com/rules.html).
 
-Read more about [running standard manually or in your editor](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
+Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
 
 See also [testing and linting](/docs/releasing/testing-and-linting.md).


### PR DESCRIPTION
Commit a4c057 updated the URL for links to style guides that had been moved to the GDS Way. In doing so the links now violate the rule that anchor links should not be used without explaining that the link goes into a page [1].

This commit updates the link text so that it is clear that the links take you to a place within a page.

[1]: https://docs.google.com/document/d/1XY8RG2uQjQNo7PFhtjvqIcHqGqSgGDRuQGkpOFpc6iM/preview