### PR TITLE
Remove link to not-yet published cookie banner guidance from release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ This was added in [pull request #2213: Add inverse link mixin and modifier class
 
 #### Add links styled as buttons to cookie banners
 
-You can now add links styled as buttons to cookie banners. For example, you can set the **Hide** button to be a link styled as a button that reloads the page. Use this feature if you set non-essential cookies on the server and want to [help users keep their place using progressive enhancement](https://design-system.service.gov.uk/components/cookie-banner/#help-users-keep-their-place-using-progressive-enhancement).
+You can now add links styled as buttons to cookie banners. For example, you can set the **Hide** button to be a link styled as a button that reloads the page. Use this feature if you set non-essential cookies on the server and want to help users keep their place using progressive enhancement.
 
 This feature is enabled by default.
 


### PR DESCRIPTION
We haven't published the [improved cookie banner guidance][1] yet, so remove the deep link to a currently non-existent section until we have.

[1]: https://github.com/alphagov/govuk-design-system/pull/1600