### PR TITLE
Fix display of checkboxes in Internet Explorer 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2228: Fix display of checkboxes in Internet Explorer 8](https://github.com/alphagov/govuk-frontend/pull/2228)
+
 ## 3.12.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -72,43 +72,45 @@
     touch-action: manipulation;
   }
 
-  // [ ] Check box
-  .govuk-checkboxes__label:before {
-    content: "";
-    box-sizing: border-box;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: $govuk-checkboxes-size;
-    height: $govuk-checkboxes-size;
-    border: $govuk-border-width-form-element solid currentColor;
-    background: transparent;
-  }
+  @include govuk-not-ie8 {
+    // [ ] Check box
+    .govuk-checkboxes__label:before {
+      content: "";
+      box-sizing: border-box;
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: $govuk-checkboxes-size;
+      height: $govuk-checkboxes-size;
+      border: $govuk-border-width-form-element solid currentColor;
+      background: transparent;
+    }
 
-  // ✔ Check mark
-  //
-  // The check mark is a box with a border on the left and bottom side (└──),
-  // rotated 45 degrees
-  .govuk-checkboxes__label:after {
-    content: "";
-    box-sizing: border-box;
+    // ✔ Check mark
+    //
+    // The check mark is a box with a border on the left and bottom side (└──),
+    // rotated 45 degrees
+    .govuk-checkboxes__label:after {
+      content: "";
+      box-sizing: border-box;
 
-    position: absolute;
-    top: 11px;
-    left: 9px;
-    width: 23px;
-    height: 12px;
+      position: absolute;
+      top: 11px;
+      left: 9px;
+      width: 23px;
+      height: 12px;
 
-    transform: rotate(-45deg);
-    border: solid;
-    border-width: 0 0 5px 5px;
-    // Fix bug in IE11 caused by transform rotate (-45deg).
-    // See: alphagov/govuk_elements/issues/518
-    border-top-color: transparent;
+      transform: rotate(-45deg);
+      border: solid;
+      border-width: 0 0 5px 5px;
+      // Fix bug in IE11 caused by transform rotate (-45deg).
+      // See: alphagov/govuk_elements/issues/518
+      border-top-color: transparent;
 
-    opacity: 0;
+      opacity: 0;
 
-    background: transparent;
+      background: transparent;
+    }
   }
 
   .govuk-checkboxes__hint {


### PR DESCRIPTION
We use the `before` and `after` pseudo-elements on the label for checkboxes to provide stylised checkboxes in modern browsers.

Internet Explorer 8 (IE8) does not support some of the features we use to do this, so we ‘fall back’ to the native HTML inputs instead.

In 09ef79d2e4ed5ea824d1f09526f902a4c8edc643 we updated the before and after pseudo-elements in the checkboxes sass to use a single colon, which was newly enforced as part of a switch to stylelint.

IE8 [only supports the single-colon syntax][1], and it looks like we were actually relying on the double-colon syntax _not_ being interpreted by IE8 in order to prevent them being displayed in that browser.

As a result, changing to a single-colon means that IE8 now interprets the pseudo-selectors, and as a result ends up with a malformed checkmark visible next to the native HTML input.

Wrap the before and after pseduo-elements with the `@govuk-not-ie8 mixin` to exclude these rules from being included in the IE8 specific stylesheet.

## Before

![Screenshot 2021-05-14 at 11 00 42](https://user-images.githubusercontent.com/121939/118255033-a8d2fa80-b4a3-11eb-8fb7-dcfaf3fbfa27.png)

## After

![Screenshot 2021-05-14 at 11 00 46](https://user-images.githubusercontent.com/121939/118255023-a53f7380-b4a3-11eb-870d-06b089eb06c3.png)

[1]: https://caniuse.com/css-gencontent

Fixes #2227 