### PR TITLE
Add extra letter spacing modifier for inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,9 +53,10 @@ The [Button](https://design-system.service.gov.uk/components/button/) Nunjucks m
 ```
 
 This was added in [pull request #3344: Adding optional id attribute to button component](https://github.com/alphagov/govuk-frontend/pull/3344). Thanks to [Tom Billington](https://github.com/TomBillingtonUK) for this contribution.
+
 ### Added a modifier for text input styles that accept sequences of digits
 
-A new `.govuk-input--extra-letter-spacing` class for [Text Input](https://design-system.service.gov.uk/components/text-input/) was added to increase readability of text inputs meant to receive sequences of digits (like security codes, references or phone numbers).
+We've added a new `.govuk-input--extra-letter-spacing` class for [Text Input](https://design-system.service.gov.uk/components/text-input/). This increases readability of text inputs that receive sequences of digits (like security codes, references or phone numbers).
 
 You can add it through the `classes` option when using Nunjucks, or directly in the `class` attribute of the `<input>` when using HTML.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ The [Button](https://design-system.service.gov.uk/components/button/) Nunjucks m
 ```
 
 This was added in [pull request #3344: Adding optional id attribute to button component](https://github.com/alphagov/govuk-frontend/pull/3344). Thanks to [Tom Billington](https://github.com/TomBillingtonUK) for this contribution.
+### Added a modifier for text input styles that accept sequences of digits
+
+A new `.govuk-input--extra-letter-spacing` class for [Text Input](https://design-system.service.gov.uk/components/text-input/) was added to increase readability of text inputs meant to receive sequences of digits (like security codes, references or phone numbers).
+
+You can add it through the `classes` option when using Nunjucks, or directly in the `class` attribute of the `<input>` when using HTML.
+
+This was added in [pull request #2230: Add extra letter spacing modifier for inputs](https://github.com/alphagov/govuk-frontend/pull/2230)
 
 ### Deprecated features
 

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -66,6 +66,11 @@
     }
   }
 
+  .govuk-input--extra-letter-spacing {
+    @include govuk-font(false, $tabular: true);
+    letter-spacing: .05em;
+  }
+
   // em measurements are based on the point size of the typeface
   // Extra space is added on the right hand side to allow for the Safari prefill icon
 

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -311,6 +311,13 @@ examples:
         text: £
       suffix:
         text: per item
+  - name: with extra letter spacing
+    data:
+      id: input-with-extra-letter-spacing
+      label:
+        text: National insurance number
+      classes: govuk-input--width-30 govuk-input--extra-letter-spacing
+      value: QQ 12 34 56 C
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes


### PR DESCRIPTION
This is a re-implementation of the changes in #1222.

---

Add an `--extra-letter-spacing` modifier for inputs which increases the spacing between letters and turns on [tabular numbers](https://www.fonts.com/content/learning/fontology/level-3/numbers/proportional-vs-tabular-figures).

The idea is that this modifier would be used for inputs asking for things like security codes, reference or phone numbers, where the user would be checking back one character at a time.

This was inspired by https://github.com/alphagov/notifications-admin/pull/1545

## Without modifier

![localhost_3000_components_input_extra-tracking-reference_preview 1](https://user-images.githubusercontent.com/121939/53399747-744af500-39a4-11e9-9be3-321166f44753.png)

## With modifier

![localhost_3000_components_input_extra-tracking-reference_preview 2](https://user-images.githubusercontent.com/121939/53399802-87f65b80-39a4-11e9-9e84-572ed6595365.png)