### PR TITLE
Update robots.txt to ensure review app isn’t indexed

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -54,6 +54,16 @@ module.exports = (options) => {
     next()
   })
 
+  // Ensure robots are still able to crawl the pages.
+  //
+  // This might seem like a mistake, but it's not. If a page is blocked by
+  // robots.txt, the crawler will never see the noindex directive, and so the
+  // page can still appear in search results.
+  app.get('/robots.txt', function (req, res) {
+    res.type('text/plain')
+    res.send('User-agent: *\nAllow: /')
+  })
+
   // Set up middleware to serve static assets
   app.use('/public', express.static(configPaths.public))
 
@@ -194,11 +204,6 @@ module.exports = (options) => {
 
   // Full page example views
   require('./full-page-examples.js')(app)
-
-  app.get('/robots.txt', function (req, res) {
-    res.type('text/plain')
-    res.send('User-agent: *\nDisallow: /')
-  })
 
   return app
 }

--- a/app/app.test.js
+++ b/app/app.test.js
@@ -66,6 +66,15 @@ describe(`http://localhost:${PORT}`, () => {
     })
   })
 
+  describe('/robots.txt', () => {
+    it('should allow crawling by robots', done => {
+      requestPath('/robots.txt', (err, res) => {
+        expect(res.body).toMatch(/^Allow: \/$/m)
+        done(err)
+      })
+    })
+  })
+
   describe('/examples/template-custom', () => {
     const templatePath = '/examples/template-custom'
 


### PR DESCRIPTION
The review app does two things to prevent pages from being indexed – it adds a `X-Robots-Tag` header to responses, and it also serves a `/robots.txt` file which disallows all robots from crawling the site.

However, the `robots.txt` disallow statement actually prevents robots from ever seeing the `X-Robots-Tag`, which means that although pages from the review app can't be crawled they can still appear in search indexes.

From Google's own documentation:

> Important: For the noindex directive to be effective, the page must not be blocked by a robots.txt file. If the page is blocked by a robots.txt file, the crawler will never see the noindex directive, and the page can still appear in search results, for example if other pages link to it.
>
> – https://developers.google.com/search/docs/advanced/crawling/block-indexing

> While Google won't crawl or index the content blocked by robots.txt, we might still find and index a disallowed URL if it is linked from other places on the web. As a result, the URL address and, potentially, other publicly available information such as anchor text in links to the page can still appear in Google search results. To properly prevent your URL from appearing in Google Search results, you should password-protect the files on your server or use the noindex meta tag or response header (or remove the page entirely).
>
> – https://developers.google.com/search/docs/advanced/robots/intro#understand-the-limitations-of-robots.txt


Update the robots.txt to allow crawling by all user agents, move the route so that it’s closer to the code that sets the `X-Robots-Tag` header and add a test to check that the robots.txt file matches the expected contents.
