### PR TITLE
Fix GOV.UK logo disappearing on light background in Windows High Contrast Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [#2228: Fix display of checkboxes in Internet Explorer 8](https://github.com/alphagov/govuk-frontend/pull/2228)
 - [#2229: Change approach to fallback PNG in the header to fix blank data URI from triggering Content Security Policy errors](https://github.com/alphagov/govuk-frontend/pull/2229)
 - [#2229: Fix alignment of fallback PNG in the header](https://github.com/alphagov/govuk-frontend/pull/2229)
+- [#2237: Fix GOV.UK logo disappearing on light background in Windows High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/2237)
 
 ## 3.12.0 (Feature release)
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -39,9 +39,12 @@
     // Add a gap between logo and any product name
     margin-right: govuk-spacing(1);
 
-    // Prevent readability backplate from obscuring underline in Windows
-    // High Contrast Mode
-    forced-color-adjust: none;
+    // Prevent readability backplate from obscuring underline in Windows High
+    // Contrast Mode
+    @media (forced-colors: active) {
+      forced-color-adjust: none;
+      color: linktext;
+    }
 
     // But remove it if there's nothing after the logo to keep hover and focus
     // states neat

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -36,7 +36,8 @@
   .govuk-header__logotype {
     display: inline-block;
 
-    // Add a gap between logo and any product name
+    // Add a gap after the logo in case it's followed by a product name. This
+    // gets removed later if the logotype is a :last-child.
     margin-right: govuk-spacing(1);
 
     // Prevent readability backplate from obscuring underline in Windows High
@@ -46,8 +47,8 @@
       color: linktext;
     }
 
-    // But remove it if there's nothing after the logo to keep hover and focus
-    // states neat
+    // Remove the gap after the logo if there's no product name to keep hover
+    // and focus states neat
     &:last-child {
       margin-right: 0;
     }


### PR DESCRIPTION
In 6f90027 I updated the logo in the header to use `forced-color-adjust: none;` in order to fix an issue where the readability backplate obscured the underline on the link.

However, I neglected to then handle the color adjustment correctly – the logo is now always white in high contrast mode, regardless of the user’s colour preferences. This means that the logo can be invisible or hard to perceive when the user’s colour scheme has a lighter background.

To fix this, set the colour of the logo to the system color `linktext` when forced colors are active, which means it will appear in the user’s preferred colour for unvisited links, matching the appearance of the other links in the header.

This only affects Chrome and Edge (and presumably Opera as that's also built on Chromium, but that's not available to test with in Assistiv Labs) – as Firefox doesn't support `forced-color-adjust`.

| Browser / Theme | Before | After
| -- | -- | -- |
| Chrome / #1 | ![Chrome Before 1](https://user-images.githubusercontent.com/121939/119797740-6a413500-bed2-11eb-9657-addc48d41632.png) | ![Chrome After 1](https://user-images.githubusercontent.com/121939/119797750-6c0af880-bed2-11eb-950d-70dbbdb46cb2.png) |
| Chrome / #2 | ![Chrome Before 2](https://user-images.githubusercontent.com/121939/119797754-6c0af880-bed2-11eb-9192-25beca517c03.png) | ![Chrome After 2](https://user-images.githubusercontent.com/121939/119797744-6ad9cb80-bed2-11eb-97b2-c7f41b8bf1f9.png) |
| Chrome / Dark | ![Chrome Before Dark](https://user-images.githubusercontent.com/121939/119797756-6ca38f00-bed2-11eb-824c-b904a652ab7e.png) | ![Chrome After Dark](https://user-images.githubusercontent.com/121939/119797745-6b726200-bed2-11eb-82b3-d2ec24eaf1d8.png) |
| Chrome / White | ![Chrome Before White](https://user-images.githubusercontent.com/121939/119797758-6ca38f00-bed2-11eb-9f77-7e8e418dabd1.png) | ![Chrome After White](https://user-images.githubusercontent.com/121939/119797748-6b726200-bed2-11eb-974b-7f76f27aabb1.png) |
| Edge / #1 | ![Edge Before 1](https://user-images.githubusercontent.com/121939/119798034-b3918480-bed2-11eb-8d49-67c61ae21954.png) | ![Edge After 1](https://user-images.githubusercontent.com/121939/119798032-b2f8ee00-bed2-11eb-88e3-307274a9aef7.png) |
| Edge / #2 | ![Edge Before 2](https://user-images.githubusercontent.com/121939/119798083-bb512900-bed2-11eb-8380-dcece93dc5bf.png) | ![Edge After 2](https://user-images.githubusercontent.com/121939/119798076-ba1ffc00-bed2-11eb-9019-8017a826e4e5.png) |
| Edge / Dark | ![Edge Before Dark](https://user-images.githubusercontent.com/121939/119798149-c6a45480-bed2-11eb-95ca-cbaafa4bcb50.png) | ![Edge After Dark](https://user-images.githubusercontent.com/121939/119798140-c60bbe00-bed2-11eb-9c18-3994e4299d73.png) |
| Edge / White | ![Edge Before White](https://user-images.githubusercontent.com/121939/119798152-c73ceb00-bed2-11eb-9bba-71cd180ef0ff.png) | ![Edge After White](https://user-images.githubusercontent.com/121939/119798148-c6a45480-bed2-11eb-90bd-fbeb51ab89ad.png) |