### PR TITLE
Fix diff changes to dist GitHub Action

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -23,22 +23,21 @@ jobs:
       - name: Generate diff
         id: diff
         run: |
-          diff=$(git diff -M1 origin/$GITHUB_BASE_REF -- dist)
-          # Escape new lines
-          diff="${diff//'%'/'%25'}"
-          diff="${diff//$'\n'/'%0A'}"
-          diff="${diff//$'\r'/'%0D'}"
-          echo "::set-output name=diff::$diff"
+          git diff -M1 origin/$GITHUB_BASE_REF -- dist \
+            > $GITHUB_WORKSPACE/dist.diff
       - name: Add comment to PR
         uses: actions/github-script@v3
-        env:
-          DIFF: ${{ steps.diff.outputs.diff }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const commentText = '## Changes to dist\n' + 
+            const fs = require('fs').promises
+            const diff = await fs.readFile(
+              process.env.GITHUB_WORKSPACE + '/dist.diff', 'utf8'
+            )
+
+            const commentText = '## Changes to dist\n' +
               '```diff\n' +
-              process.env.DIFF +
+              diff +
               '\n```'
 
             github.issues.createComment({

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate diff
         id: diff
         run: |
-          git diff -M1 origin/$GITHUB_BASE_REF -- dist \
+          git diff -M05 origin/$GITHUB_BASE_REF -- dist \
             > $GITHUB_WORKSPACE/dist.diff
       - name: Add comment to PR
         uses: actions/github-script@v3


### PR DESCRIPTION
Fixes #2225.

Following a suggestion from another person who had the same issue [[1]], this commit saves the diff text to a file in the GITHUB_WORKSPACE folder instead. The GitHub Actions states actions can modify this directory and have subsequent actions access those changes [[2]].

This also has the advantage of removing the need to percent-encode the diff text, so the script to generate the diff can now be simpler.

---

I tested this by temporarily adding a commit to change a file in the `dist` folder; you can see the comment(s) from the GitHub action below. Once I was happy that the new action works I deleted the commit changing the dist folder.

[1]: https://github.community/t/maximum-length-for-the-comment-body-in-issues-and-pr/148867/5
[2]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#file-systems

---

This PR also tweaks the [git diff detect renames similarity index threshold](https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--Mltngt) to make sure the diff is always showing the changes to the generated CSS as a rename.