### PR TITLE
Allow the CSP `nonce` attribute to be set on the inline script in the page template

### DIFF
--- a/src/govuk/template.njk
+++ b/src/govuk/template.njk
@@ -28,7 +28,7 @@
     <meta property="og:image" content="{{ assetUrl | default('/assets') }}/images/govuk-opengraph-image.png">
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     {% block bodyStart %}{% endblock %}
 
     {% block skipLink %}

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -165,6 +165,18 @@ describe('Template', () => {
         // updating the hash published in https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-isn-t-working-properly
         expect('sha256-' + hash).toEqual('sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=')
       })
+      it('should not have a nonce attribute by default', () => {
+        const $ = renderTemplate()
+        const scriptTag = $('body > script').first()
+
+        expect(scriptTag.attr('nonce')).toEqual(undefined)
+      })
+      it('should have a nonce attribute when nonce is provided', () => {
+        const $ = renderTemplate({ cspNonce: 'abcdef' })
+        const scriptTag = $('body > script').first()
+
+        expect(scriptTag.attr('nonce')).toEqual('abcdef')
+      })
     })
 
     describe('skip link', () => {


### PR DESCRIPTION
This relates the issue [Support nonce attribute on js-enabled script](https://github.com/alphagov/govuk-frontend/issues/2246).