### PR TITLE
Disable ink skipping for underlines in hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#2229: Change approach to fallback PNG in the header to fix blank data URI from triggering Content Security Policy errors](https://github.com/alphagov/govuk-frontend/pull/2229)
 - [#2229: Fix alignment of fallback PNG in the header](https://github.com/alphagov/govuk-frontend/pull/2229)
 - [#2237: Fix GOV.UK logo disappearing on light background in Windows High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/2237)
+- [#2251: Disable ink skipping for underlines in hover state](https://github.com/alphagov/govuk-frontend/pull/2251)
 
 ## 3.12.0 (Feature release)
 

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -52,6 +52,10 @@
 @mixin govuk-link-hover-decoration {
   @if ($govuk-new-link-styles and $govuk-link-hover-underline-thickness) {
     text-decoration-thickness: $govuk-link-hover-underline-thickness;
+    // Disable ink skipping on underlines on hover. Browsers haven't
+    // standardised on this part of the spec yet, so set both properties
+    text-decoration-skip-ink: none; // Chromium, Firefox
+    text-decoration-skip: none; // Safari
   }
 }
 

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -121,7 +121,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
   })
 
   describe('when $govuk-new-link-styles are enabled', () => {
-    it('sets text-decoration-thickness on hover', async () => {
+    it('sets a hover state', async () => {
       const sass = `
         $govuk-new-link-styles: true;
         $govuk-link-hover-underline-thickness: 10px;
@@ -133,7 +133,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
 
       const results = await renderSass({ data: sass, ...sassConfig })
 
-      expect(results.css.toString()).toContain('.foo:hover { text-decoration-thickness: 10px; }')
+      expect(results.css.toString()).toContain('.foo:hover')
     })
 
     describe('when $govuk-link-hover-underline-thickness is falsey', () => {


### PR DESCRIPTION
Solves #2250

Uses both `text-decoration-skip-ink: none;` and `text-decoration-skip: none;` to stop the thick hover underlines from skipping the descenders. We have to use both because Safari supports `text-decoration-skip` and the other browsers support `text-decoration-skip-ink`. Fun!

## Before (Safari)

![Screenshot 2021-06-14 at 16 27 27](https://user-images.githubusercontent.com/121939/121917990-898eed80-cd2d-11eb-85c7-c37421af0542.png)

## After (Safari)

![Screenshot 2021-06-14 at 16 27 49](https://user-images.githubusercontent.com/121939/121917988-88f65700-cd2d-11eb-85f3-ac6d16287b74.png)

## Before (Firefox)

<img width="418" alt="Screenshot 2021-06-14 at 16 30 07" src="https://user-images.githubusercontent.com/121939/121918376-e5597680-cd2d-11eb-9735-3fb4994001c0.png">

## After (Firefox)

<img width="418" alt="Screenshot 2021-06-14 at 16 30 36" src="https://user-images.githubusercontent.com/121939/121918371-e4c0e000-cd2d-11eb-8bf2-828427e00905.png">

## Before (Chrome)

![Screenshot 2021-06-14 at 16 32 03](https://user-images.githubusercontent.com/121939/121918565-133ebb00-cd2e-11eb-8df4-568faab237fe.png)

## After (Chrome)

![Screenshot 2021-06-14 at 16 31 41](https://user-images.githubusercontent.com/121939/121918569-13d75180-cd2e-11eb-8104-06b88ba0020a.png)
