### PR TITLE
Fix bugs with radios and checkboxes where multiple modules have the same name

### DIFF
--- a/app/views/examples/conditional-reveals/index.njk
+++ b/app/views/examples/conditional-reveals/index.njk
@@ -2,6 +2,7 @@
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "fieldset/macro.njk" import govukFieldset %}
 {% from "radios/macro.njk" import govukRadios %}
 {% from "input/macro.njk" import govukInput %}
 
@@ -170,6 +171,166 @@
       ]
     }) }}
 
-    {% endblock %}
+    <hr class="govuk-section-break govuk-section-break--l">
+
+    {% call govukFieldset({
+      legend: {
+        text: "Which colours do you like?",
+        classes: "govuk-fieldset__legend--l"
+      }
+    })%}
+
+      <h2 class="govuk-heading-m">Primary colours</h2>
+
+      {{ govukCheckboxes({
+        idPrefix: "colour-primary",
+        name: "colour",
+        items: [
+          {
+            value: "red",
+            text: "Red"
+          },
+          {
+            value: "yellow",
+            text: "Yellow",
+            conditional: {
+              html: '<p class="govuk-body">Orange is much nicer than yellow!</p>'
+            }
+          },
+          {
+            value: "blue",
+            text: "Blue"
+          }
+        ]
+      }) }}
+
+      <h2 class="govuk-heading-m">Secondary colours</h2>
+
+      {{ govukCheckboxes({
+        idPrefix: "colour-secondary",
+        name: "colour",
+        items: [
+          {
+            value: "green",
+            text: "Green"
+          },
+          {
+            value: "purple",
+            text: "Purple"
+          },
+          {
+            value: "orange",
+            text: "Orange",
+            conditional: {
+              html: '<p class="govuk-body">I like orange too!</p>'
+            }
+          }
+        ]
+      }) }}
+
+      <h2 class="govuk-heading-m">Other colours</h2>
+
+      {{ govukCheckboxes({
+        idPrefix: "colour-other",
+        name: "colour",
+        items: [
+          {
+            value: "imaginary",
+            text: "An imaginary colour"
+          },
+          {
+            divider: "or"
+          },
+          {
+            value: "none",
+            text: "None of the above",
+            behaviour: "exclusive"
+          }
+        ]
+      }) }}
+
+    {% endcall %}
+
+    <hr class="govuk-section-break govuk-section-break--l">
+
+    {% call govukFieldset({
+      legend: {
+        text: "Which colour is your favourite?",
+        classes: "govuk-fieldset__legend--l"
+      }
+    })%}
+
+      <h2 class="govuk-heading-m">Primary colours</h2>
+
+      {{ govukRadios({
+        idPrefix: "fave-primary",
+        name: "fave",
+        items: [
+          {
+            value: "red",
+            text: "Red"
+          },
+          {
+            value: "yellow",
+            text: "Yellow",
+            conditional: {
+              html: '<p class="govuk-body">Orange is much nicer than yellow!</p>'
+            }
+          },
+          {
+            value: "blue",
+            text: "Blue"
+          }
+        ]
+      }) }}
+
+      <h2 class="govuk-heading-m">Secondary colours</h2>
+
+      {{ govukRadios({
+        idPrefix: "fave-secondary",
+        name: "fave",
+        items: [
+          {
+            value: "green",
+            text: "Green"
+          },
+          {
+            value: "purple",
+            text: "Purple"
+          },
+          {
+            value: "orange",
+            text: "Orange",
+            conditional: {
+              html: '<p class="govuk-body">Orange is my favourite colour!</p>'
+            }
+          }
+        ]
+      }) }}
+
+      <h2 class="govuk-heading-m">Other colours</h2>
+
+      {{ govukRadios({
+        idPrefix: "fave-other",
+        name: "fave",
+        items: [
+          {
+            value: "imaginary",
+            text: "An imaginary colour"
+          },
+          {
+            divider: "or"
+          },
+          {
+            value: "none",
+            text: "None of the above",
+            behaviour: "exclusive"
+          }
+        ]
+      }) }}
+
+    {% endcall %}
+
   </div>
 </div>
+{% endblock %}

--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -76,7 +76,7 @@ Checkboxes.prototype.syncAllConditionalReveals = function () {
  * @param {HTMLInputElement} $input Checkbox input
  */
 Checkboxes.prototype.syncConditionalRevealWithInputState = function ($input) {
-  var $target = this.$module.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $target = document.getElementById($input.getAttribute('aria-controls'))
 
   if ($target && $target.classList.contains('govuk-checkboxes__conditional')) {
     var inputIsChecked = $input.checked
@@ -99,10 +99,9 @@ Checkboxes.prototype.unCheckAllInputsExcept = function ($input) {
     var hasSameFormOwner = ($input.form === $inputWithSameName.form)
     if (hasSameFormOwner && $inputWithSameName !== $input) {
       $inputWithSameName.checked = false
+      this.syncConditionalRevealWithInputState($inputWithSameName)
     }
-  })
-
-  this.syncAllConditionalReveals()
+  }.bind(this))
 }
 
 /**
@@ -121,10 +120,9 @@ Checkboxes.prototype.unCheckExclusiveInputs = function ($input) {
     var hasSameFormOwner = ($input.form === $exclusiveInput.form)
     if (hasSameFormOwner) {
       $exclusiveInput.checked = false
+      this.syncConditionalRevealWithInputState($exclusiveInput)
     }
-  })
-
-  this.syncAllConditionalReveals()
+  }.bind(this))
 }
 
 /**

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -77,7 +77,7 @@ Radios.prototype.syncAllConditionalReveals = function () {
  * @param {HTMLInputElement} $input Radio input
  */
 Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
-  var $target = document.querySelector('#' + $input.getAttribute('aria-controls'))
+  var $target = document.getElementById($input.getAttribute('aria-controls'))
 
   if ($target && $target.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked

--- a/src/govuk/components/radios/template.njk
+++ b/src/govuk/components/radios/template.njk
@@ -11,13 +11,6 @@
    aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.fieldset.describedBy if params.fieldset.describedBy else "" %}
 
-{% set isConditional = false %}
-{% for item in params.items %}
-  {% if item.conditional.html %}
-    {% set isConditional = true %}
-  {% endif %}
-{% endfor %}
-
 {#- Capture the HTML so we can optionally nest it in a fieldset -#}
 {% set innerHtml %}
 {% if params.hint %}
@@ -45,7 +38,7 @@
 {% endif %}
   <div class="govuk-radios {%- if params.classes %} {{ params.classes }}{% endif %}{%- if isConditional %} govuk-radios--conditional{% endif -%}"
     {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}
-    {%- if isConditional %} data-module="govuk-radios"{% endif -%}>
+    data-module="govuk-radios">
     {% for item in params.items %}
       {% if item %}
         {#- If the user explicitly sets an id, use this instead of the regular idPrefix -#}


### PR DESCRIPTION
We have an [open issue to provide examples of grouping radios and checkboxes under headings](https://github.com/alphagov/govuk-frontend/issues/1079).

Whilst we don’t provide any guidance on this at the minute, we’ve previously suggested that users can achieve this by making multiple calls to the `govukCheckboxes` macro and grouping them together inside a single call to `govukFieldset`. However, this means that each ‘set’ of checkboxes is inside its own module, which can cause issues with things like conditional reveals.

Add an example of this to the review app, so that we can test that everything works as expected, and fix a few issues identified that can leave conditional reveals 'out of sync' with their controls in this context.

See individual commits for details.