### PR TITLE
Update Accordion design

### DIFF
--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -75,7 +75,7 @@ notes: >-
         </div>
         <div class="app-danger-box">
           <h2 class="govuk-heading-m">Find out what support you can get</h2>
-          <p class="govuk-body">For example, if you're out of work, need to get food, or want to take care of your mental health.</p>
+          <p class="govuk-body">For example, if you’re out of work, need to get food, or want to take care of your mental health.</p>
           <p class="govuk-body govuk-!-font-weight-bold"><a class="govuk-link govuk-link--inverse" href="#">Find support</a></p>
         </div>
       </div>
@@ -83,11 +83,11 @@ notes: >-
         <section class="govuk-!-margin-bottom-8">
           <h2 class="govuk-heading-m">Recent and upcoming changes</h2>
           <h3 class="govuk-heading-s">27 January</h3>
-          <p class="govuk-body">The Prime Minister has announced that <a class="govuk-link" href="#">it'll not be possible to resume face-to-face learning</a> for the majority of pupils and students until 8 March at the earliest.</p>
-          <p class="govuk-body">The Prime Minister has also announced <a class="govuk-link" href="#">further measures at the border</a>, including the strengthening of requirements for some arrivals through hotel isolation. We'll set out more details in due course.</p>
+          <p class="govuk-body">The Prime Minister has announced that <a class="govuk-link" href="#">it’ll not be possible to resume face-to-face learning</a> for the majority of pupils and students until 8 March at the earliest.</p>
+          <p class="govuk-body">The Prime Minister has also announced <a class="govuk-link" href="#">further measures at the border</a>, including the strengthening of requirements for some arrivals through hotel isolation. We’ll set out more details in due course.</p>
           <h3 class="govuk-heading-s">5 January</h3>
           <p class="govuk-body"><a class="govuk-link" href="#">National lockdown rules apply in England</a>. Stay at home. Find out what the rules are in <a class="govuk-link" href="#">Scotland</a>, <a class="govuk-link" href="#">Wales</a> and <a class="govuk-link" href="#">Northern Ireland</a>.</p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Shielding has resumed in England</a>. If you're shielding, do not attend work, school, college or university. You can get <a class="govuk-link" href="#">support if you're clinically extremely vulnerable</a>, for example priority access to supermarket deliveries.</p>
+          <p class="govuk-body"><a class="govuk-link" href="#">Shielding has resumed in England</a>. If you’re shielding, do not attend work, school, college or university. You can get <a class="govuk-link" href="#">support if you’re clinically extremely vulnerable</a>, for example priority access to supermarket deliveries.</p>
         </section>
         <section class="app-section">
           <h2 class="govuk-heading-m">Announcements</h2>

--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -109,7 +109,7 @@ notes: >-
               },
               expanded: true,
               content: {
-                html: "<p class='govuk-body'>This is the content for Staying for the<sup>1</sup> web.</p>"
+                html: "<p class='govuk-body'>This is the content for Staying for the web.</p>"
               }
             },
             {
@@ -165,7 +165,7 @@ notes: >-
                 text: "Providing assisted digital support"
               },
               summary: {
-                html: "<span class='govuk-!-font-weight-regular'>Helping people who don't have the skills or access to use a service.<sup>1</sup></span>"
+                html: "<span class='govuk-!-font-weight-regular'>Helping people who don't have the skills or access to use a service.</span>"
               },
               content: {
                 html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
@@ -193,6 +193,35 @@ notes: >-
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Press conferences (YouTube)</a></h3>
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Press conference statements</a></h3>
         </section>
+
+        {{ govukAccordion({
+          id: "accordion-summaries-short",
+          items: [
+            {
+              heading: {
+                text: "Accessibility requirements"
+              },
+              summary: {
+                text: "Assessments"
+              },
+              content: {
+                html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
+              }
+            },
+            {
+              heading: {
+                text: "User support"
+              },
+              summary: {
+                text: "Estimating demand"
+              },
+              content: {
+                html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
+              }
+            }
+          ]
+        }) }}
+
         <div class="app-updates">
           <h3 class="govuk-heading-s">Stay up to date with GOV.UK</h3>
           <p class="govuk-body"><a class="govuk-link" href="#">Sign up to get emails when we change any coronavirus information on the GOV.UK website</a></p>

--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -12,6 +12,7 @@ notes: >-
 
 {% from "header/macro.njk" import govukHeader %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "accordion/macro.njk" import govukAccordion %}
 
 {% set pageTitle = "Coronavirus (COVID‑19)" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
@@ -74,7 +75,7 @@ notes: >-
         </div>
         <div class="app-danger-box">
           <h2 class="govuk-heading-m">Find out what support you can get</h2>
-          <p class="govuk-body">For example, if you’re out of work, need to get food, or want to take care of your mental health.</p>
+          <p class="govuk-body">For example, if you're out of work, need to get food, or want to take care of your mental health.</p>
           <p class="govuk-body govuk-!-font-weight-bold"><a class="govuk-link govuk-link--inverse" href="#">Find support</a></p>
         </div>
       </div>
@@ -82,11 +83,11 @@ notes: >-
         <section class="govuk-!-margin-bottom-8">
           <h2 class="govuk-heading-m">Recent and upcoming changes</h2>
           <h3 class="govuk-heading-s">27 January</h3>
-          <p class="govuk-body">The Prime Minister has announced that <a class="govuk-link" href="#">it’ll not be possible to resume face-to-face learning</a> for the majority of pupils and students until 8 March at the earliest.</p>
-          <p class="govuk-body">The Prime Minister has also announced <a class="govuk-link" href="#">further measures at the border</a>, including the strengthening of requirements for some arrivals through hotel isolation. We’ll set out more details in due course.</p>
+          <p class="govuk-body">The Prime Minister has announced that <a class="govuk-link" href="#">it'll not be possible to resume face-to-face learning</a> for the majority of pupils and students until 8 March at the earliest.</p>
+          <p class="govuk-body">The Prime Minister has also announced <a class="govuk-link" href="#">further measures at the border</a>, including the strengthening of requirements for some arrivals through hotel isolation. We'll set out more details in due course.</p>
           <h3 class="govuk-heading-s">5 January</h3>
           <p class="govuk-body"><a class="govuk-link" href="#">National lockdown rules apply in England</a>. Stay at home. Find out what the rules are in <a class="govuk-link" href="#">Scotland</a>, <a class="govuk-link" href="#">Wales</a> and <a class="govuk-link" href="#">Northern Ireland</a>.</p>
-          <p class="govuk-body"><a class="govuk-link" href="#">Shielding has resumed in England</a>. If you’re shielding, do not attend work, school, college or university. You can get <a class="govuk-link" href="#">support if you’re clinically extremely vulnerable</a>, for example priority access to supermarket deliveries.</p>
+          <p class="govuk-body"><a class="govuk-link" href="#">Shielding has resumed in England</a>. If you're shielding, do not attend work, school, college or university. You can get <a class="govuk-link" href="#">support if you're clinically extremely vulnerable</a>, for example priority access to supermarket deliveries.</p>
         </section>
         <section class="app-section">
           <h2 class="govuk-heading-m">Announcements</h2>
@@ -98,12 +99,92 @@ notes: >-
           <p class="govuk-body">Published 27 January 2021</p>
           <p class="govuk-body"><a class="govuk-link" href="#">See all announcements</a></p>
         </section>
+        <section class="app-section">
+        {{ govukAccordion({
+          id: "accordion-default",
+          items: [
+            {
+              heading: {
+                text: "Staying safe"
+              },
+              expanded: true,
+              content: {
+                html: "<p class='govuk-body'>This is the content for Staying for the<sup>1</sup> web.</p>"
+              }
+            },
+            {
+              heading: {
+                text: "International travel"
+              },
+              content: {
+                html: "<p class='govuk-body'>This is the content for Writing well for specialists.</p>"
+              }
+            },
+              {
+              heading: {
+                text: "Vaccination"
+              },
+              content: {
+                html: "<ul class='govuk-list govuk-list--bullet'><li>Example item 2</li></ul>"
+              }
+            },
+              {
+              heading: {
+                text: "Self-employment and businesses"
+              },
+              content: {
+                html: "<p class='govuk-body'>This is the content for How people read.</p>"
+              }
+            }
+          ]
+        }) }}
+        </section>
         <section class="app-section govuk-!-margin-bottom-8">
           <h2 class="govuk-heading-m">Announcements</h2>
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Daily summary of coronavirus testing, cases and vaccinatons</a></h3>
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">All data and analysis on coronavirus</a></h3>
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Coronavirus cases by local authority</a></h3>
         </section>
+
+        {{ govukAccordion({
+          id: "accordion-summaries",
+          items: [
+            {
+              heading: {
+                text: "Meeting accessibility requirements"
+              },
+              summary: {
+                text: "Getting an audit, understanding WCAG 2.1, preparing for assessment"
+              },
+              content: {
+                html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
+              }
+            },
+            {
+              heading: {
+                text: "Providing assisted digital support"
+              },
+              summary: {
+                html: "<span class='govuk-!-font-weight-regular'>Helping people who don't have the skills or access to use a service.<sup>1</sup></span>"
+              },
+              content: {
+                html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
+              }
+            },
+              {
+              heading: {
+                text: "Managing user support"
+              },
+              summary: {
+                text: "Estimating demand, setting target levels, measuring support performance"
+              },
+              content: {
+                html: "<ul class='govuk-list'><li><a class='govuk-link' href='#'>Making your service accessible: an introduction</a></li><li><a class='govuk-link' href='#'>Understanding WCAG 2.1</a></li><li><a class='govuk-link' href='#'>Getting an accessibility audit</a></li><li><a class='govuk-link' href='#'>Testing for accessibility</a></li><li><a class='govuk-link' href='#'>Publishing information about your service's accessibility</a></li></ul>"
+              }
+            }
+          ]
+        }) }}
+
         <section class="app-section govuk-!-margin-bottom-8">
           <h2 class="govuk-heading-m">All coronavirus information on GOV.UK</h2>
           <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><a class="govuk-link" href="#">Guidance</a></h3>

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -84,12 +84,12 @@
         }
 
         .govuk-accordion-nav__chevron {
-          border-color: $govuk-accordion-base-colour;
+          color: $govuk-accordion-base-colour;
           background: $govuk-accordion-base-colour;
         }
 
         .govuk-accordion-nav__chevron:after {
-          border-color: $govuk-accordion-hover-colour;
+          color: $govuk-accordion-hover-colour;
         }
       }
 
@@ -101,7 +101,7 @@
         }
 
         .govuk-accordion-nav__chevron:after {
-          border-color: $govuk-accordion-icon-focus-colour;
+          color: $govuk-accordion-icon-focus-colour;
         }
       }
     }
@@ -218,7 +218,7 @@
         }
 
         .govuk-accordion-nav__chevron:after {
-          border-color: $govuk-accordion-hover-colour;
+          color: $govuk-accordion-hover-colour;
         }
       }
 
@@ -234,12 +234,12 @@
         }
 
         .govuk-accordion-nav__chevron {
-          border-color: $govuk-accordion-base-colour;
+          color: $govuk-accordion-base-colour;
           background: $govuk-accordion-base-colour;
         }
 
         .govuk-accordion-nav__chevron:after {
-          border-color: $govuk-accordion-icon-focus-colour;
+          color: $govuk-accordion-icon-focus-colour;
         }
       }
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -118,10 +118,10 @@
 
       position: relative;
 
-      width: 20px;
-      height: 20px;
+      width: govuk-em(20, 19);
+      height: govuk-em(20, 19);
 
-      border: 1px solid;
+      border: govuk-em(1, 16) solid;
       border-radius: 50%;
 
       vertical-align: text-top;
@@ -140,16 +140,16 @@
         display: block;
 
         position: absolute;
-        bottom: 5px;
-        left: 6px;
+        bottom: govuk-em(5, 19);
+        left: govuk-em(6, 19);
 
-        width: 6px;
-        height: 6px;
+        width: govuk-em(6, 19);
+        height: govuk-em(6, 19);
 
         transform: rotate(-45deg);
 
-        border-top: 2px solid $govuk-link-colour;
-        border-right: 2px solid $govuk-link-colour;
+        border-top: govuk-em(2, 16) solid;
+        border-right: govuk-em(2, 16) solid;
 
         // IE8 fallback of icon with HTML symbol
         @include govuk-if-ie8 {

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -256,6 +256,16 @@
       }
     }
 
+    // As Chevron icon is vertically aligned it overlaps with the focus state bottom border
+    // Styling adds some spacing
+    .govuk-accordion__section-button:focus .govuk-accordion__section-toggle {
+      padding-bottom: 3px;
+
+      @include govuk-media-query ($from: desktop) {
+        padding-bottom: 2px;
+      }
+    }
+
     // NVDA fix
     //
     // NVDA treats any form of line break as a different announcement landmark and will therefore announce it separately.

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -275,4 +275,36 @@
     .govuk-accordion__section-toggle-text {
       margin-left: 5px;
     }
+
+    // High contrast / user colour adjustments
+    // When adjustments are active the inner button content is not visible.
+    // On hover add underline to toggle text to add extra affordance as icon colour changes on pseudo element are not respected.
+    // On focus add transparency to background so content is visible
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+      .govuk-accordion__section-button:hover,
+      .govuk-accordion__show-all:hover {
+        background: transparent;
+
+        .govuk-accordion-nav__chevron {
+          background-color: transparent;
+        }
+
+        .govuk-accordion__show-all-text,
+        .govuk-accordion__section-toggle {
+          text-decoration: underline;
+          text-decoration-thickness: $govuk-header-link-underline-thickness;
+        }
+      }
+
+      .govuk-accordion__show-all:focus,
+      .govuk-accordion__section-button:focus {
+        .govuk-accordion__section-heading-focus-wrapper,
+        .govuk-accordion__section-summary,
+        .govuk-accordion__section-toggle,
+        .govuk-accordion-nav__chevron {
+          background: transparent;
+          background-color: transparent;
+        }
+      }
+    }
 }

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -125,7 +125,6 @@
 
     .govuk-accordion__section-heading {
       padding: 0;
-      border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
     }
 
     // Create Chevron icon aligned with text
@@ -198,9 +197,14 @@
     .govuk-accordion__section-button {
       width: 100%;
 
-      padding: govuk-spacing(2) 0 govuk-spacing(3);
+      padding: govuk-spacing(2) 0 govuk-spacing(1) 0;
 
-      border-width: 0;
+      border: 0;
+
+      border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
+      // Visually separate the section from the one underneath when user changes colours in their
+      // browser.
+      border-bottom: govuk-spacing(2) solid transparent;
 
       color: $govuk-text-colour;
       background: none;
@@ -259,6 +263,14 @@
         padding: 0;
         border: 0;
       }
+    }
+
+    // Remove the transparent border when the section is expanded to make it clear that the heading
+    // relates to the content below. Adjust padding to maintain the height of the element.
+    // See https://github.com/alphagov/govuk-frontend/pull/2257#issuecomment-951920798
+    .govuk-accordion__section--expanded .govuk-accordion__section-button {
+      padding-bottom: govuk-spacing(4);
+      border-bottom: 0;
     }
 
     // As Chevron icon is vertically aligned it overlaps with the focus state bottom border

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -1,5 +1,10 @@
 @include govuk-exports("govuk/component/accordion") {
+  $govuk-accordion-base-colour: govuk-colour("black");
+  $govuk-accordion-hover-colour: govuk-colour("light-grey", $legacy: "grey-3");
   $govuk-accordion-icon-focus-colour: govuk-colour("yellow");
+  $govuk-accordion-border-width: 3px;
+  $govuk-accordion-bottom-border-width: 1px;
+  $govuk-header-link-underline-thickness: 3px;
 
   .govuk-accordion {
     @include govuk-responsive-margin(6, "bottom");
@@ -10,11 +15,6 @@
     padding-top: govuk-spacing(3);
   }
 
-  .govuk-accordion__section-header {
-    padding-top: govuk-spacing(3);
-    padding-bottom: govuk-spacing(3);
-  }
-
   .govuk-accordion__section-heading {
     // Override browser defaults to ensure consistent element height
     // Font size is set in .govuk-accordion__section-button
@@ -22,19 +22,18 @@
 
     margin-top: 0; // Override browser default
     margin-bottom: 0; // Override browser default
+
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(3);
   }
 
   // Buttons within the sections don’t need default styling
   .govuk-accordion__section-button {
-    @include govuk-font($size: 24, $weight: bold);
-    display: inline-block;
+    @include govuk-text-colour;
+    @include govuk-font($size: 24, $weight: bold, $line-height: 1.25);
+    display: block;
     margin-bottom: 0;
     padding-top: govuk-spacing(3);
-  }
-
-  .govuk-accordion__section-summary {
-    margin-top: govuk-spacing(2);
-    margin-bottom: 0;
   }
 
   // Remove the bottom margin from the last item inside the content
@@ -46,47 +45,70 @@
   .js-enabled {
     .govuk-accordion {
       // Border at the bottom of the whole accordion
-      border-bottom: 1px solid $govuk-border-colour;
+      border-bottom: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
     }
 
     // Borders between accordion sections
     .govuk-accordion__section {
-      padding-top: 0;
+      padding: 0;
     }
 
-    // Hide the body of collapsed sections
-    .govuk-accordion__section-content {
-      display: none;
-      @include govuk-responsive-padding(3, "top");
-      @include govuk-responsive-padding(3, "bottom");
-    }
-
-    // Show the body of expanded sections
-    .govuk-accordion__section--expanded .govuk-accordion__section-content {
-      display: block;
-    }
-
-    // This is styled to look like a link not a button
-    .govuk-accordion__open-all {
-      @include govuk-font($size: 16);
+    .govuk-accordion__show-all {
+      @include govuk-font($size: 19);
       position: relative;
       z-index: 1;
-      margin: 0;
-      padding: 0;
+
+      margin: 0 0 govuk-spacing(2) 0;
+      padding: 7px 2px 7px 0;
+
       border-width: 0;
+
       color: $govuk-link-colour;
       background: none;
+
       cursor: pointer;
       -webkit-appearance: none;
-
-      @include govuk-link-common;
-      @include govuk-link-style-default;
 
       // Remove default button focus outline in Firefox
       &::-moz-focus-inner {
         padding: 0;
         border: 0;
       }
+
+      &:hover {
+        color: $govuk-accordion-base-colour;
+        background: $govuk-accordion-hover-colour;
+
+        .govuk-accordion__section-toggle-text {
+          color: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron {
+          border-color: $govuk-accordion-base-colour;
+          background: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron:after {
+          border-color: $govuk-accordion-hover-colour;
+        }
+      }
+
+      &:focus {
+        @include govuk-focused-text;
+
+        .govuk-accordion-nav__chevron {
+          background: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron:after {
+          border-color: $govuk-accordion-icon-focus-colour;
+        }
+      }
+    }
+
+    // Removing padding from once JavaScript loaded
+    .govuk-accordion__section-heading {
+      padding: 0;
     }
 
     // Create Chervon icon aligned with text
@@ -154,31 +176,71 @@
       }
     }
 
-    // Section headers have a pointer cursor as an additional affordance
     .govuk-accordion__section-header {
-      position: relative;
-      // Safe area on the right to avoid clashing with icon
-      padding-right: 40px;
-      border-top: 1px solid $govuk-border-colour;
-      cursor: pointer;
+      padding: 0;
     }
 
     // Buttons within the headers don’t need default styling
     .govuk-accordion__section-button {
-      @include govuk-typography-common;
-      margin-top: 0;
-      margin-bottom: 0;
-      margin-left: 0;
-      padding: 0;
-      border-width: 0;
-      color: $govuk-link-colour;
+      position: relative;
+
+      width: 100%;
+
+      padding: govuk-spacing(2) 0 govuk-spacing(3);
+
+      border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
+      border-width: $govuk-accordion-bottom-border-width 0 0 0;
+
+      color: $govuk-text-colour;
       background: none;
+
       text-align: left;
+      // Section headers have a pointer cursor as an additional affordance
       cursor: pointer;
       -webkit-appearance: none;
 
+      &:active {
+        color: $govuk-link-active-colour;
+        background: none;
+      }
+
+      &:hover {
+        color: $govuk-accordion-base-colour;
+        background: $govuk-accordion-hover-colour;
+
+        .govuk-accordion__section-toggle-text {
+          color: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron {
+          color: $govuk-accordion-base-colour;
+          background: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron:after {
+          border-color: $govuk-accordion-hover-colour;
+        }
+      }
+
       &:focus {
-        @include govuk-focused-text;
+        // Remove default focus border around button as
+        // styling is being applied to inner text elements that receive focus
+        outline: 0;
+
+        .govuk-accordion__section-heading-focus-wrapper,
+        .govuk-accordion__section-summary,
+        .govuk-accordion__section-toggle {
+          @include govuk-focused-text;
+        }
+
+        .govuk-accordion-nav__chevron {
+          border-color: $govuk-accordion-base-colour;
+          background: $govuk-accordion-base-colour;
+        }
+
+        .govuk-accordion-nav__chevron:after {
+          border-color: $govuk-accordion-icon-focus-colour;
+        }
       }
 
       // Remove default button focus outline in Firefox
@@ -188,77 +250,29 @@
       }
     }
 
-    // Extend the touch area of the button to span the section header
-    .govuk-accordion__section-button:after {
-      content: "";
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+    // Add toggle link with Chevron icon on left.
+    .govuk-accordion__section-toggle {
+      @include govuk-font($size: 19, $line-height: 1);
+
+      color: $govuk-link-colour;
     }
 
-    .govuk-accordion__section-button:hover:not(:focus) {
-      color: $govuk-link-hover-colour;
-      text-decoration: underline;
-
-      // This needs to come after the text-decoration property otherwise
-      // text-decoration, as a shorthand property, resets it to auto
-      @include govuk-link-hover-decoration;
-      text-underline-offset: $govuk-link-underline-offset;
-    }
-
-    // For devices that can't hover such as touch devices,
-    // remove hover state as it can be stuck in that state (iOS).
-    @media (hover: none) {
-      .govuk-accordion__section-button:hover {
-        text-decoration: none;
-      }
-    }
-
-    .govuk-accordion__controls {
-      text-align: right;
-    }
-
-    // Display an icon to the right of each header to indicate open/closed status,
-    // and as an additional affordance.
-    .govuk-accordion__icon {
-      position: absolute;
-      top: 50%;
-      right: 15px;
-      width: 16px;
-      height: 16px;
-      margin-top: -8px;
-    }
-
-    .govuk-accordion__icon:after,
-    .govuk-accordion__icon:before {
-      content: "";
-      box-sizing: border-box;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      width: 25%;
-      height: 25%;
-      margin: auto;
-      border: 2px solid transparent;
-      background-color: govuk-colour("black");
-    }
-
-    .govuk-accordion__icon:before {
-      width: 100%;
-    }
-
-    .govuk-accordion__icon:after {
-      height: 100%;
-    }
-
-    // Vertical bar should be hidden when section is open, to display a '-' icon
-    .govuk-accordion__section--expanded .govuk-accordion__icon:after {
-      content: " ";
+    // Hide body of expanded sections
+    .govuk-accordion__section-content {
       display: none;
+      @include govuk-responsive-padding(0, "top");
+      @include govuk-responsive-padding(8, "bottom");
     }
-  }
+
+    // Show the body of expanded sections
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
+      display: block;
+    }
+
+    // Space between icon and text,
+    // Avoid placing on icon due to transform altering placement of margin
+    .govuk-accordion__show-all-text,
+    .govuk-accordion__section-toggle-text {
+      margin-left: 5px;
+    }
 }

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -287,37 +287,11 @@
       }
     }
 
-    // 1. A fix to improve NVDA announcements.
-    //
-    // NVDA treats any form of line break as a different announcement landmark and will therefore announce it separately.
-    // As you move through NVDA using arrow keys, this announces each element in turn (rather than a whole block) which could cause confusion for users
-    // This line break can come from both the semantics via br tags or two block-level tags, or via CSS using display: block or display: table
-    // In this case it was the span(s) within the button being styled using display: block.
-    // This fix forces a visual break but bypasses NVDA's line break interpreter, thus causing the accordion title and the inner Content to be read as a single sentence
-    //
-    // Consider NVDA output before:
-    // clickable  heading    level 2  button  collapsed    [Heading copy],Show
-    // heading    level 2  button  collapsed    this section
-    //
-    // After:
-    // clickable  heading    level 2  button  collapsed    [Heading copy] , Showthis section
-    //
-    // Additional details and testing videos can be found here:
-    // (https://github.com/alphagov/govuk-design-system/issues/1706#issuecomment-862451506)
-    //
-    // 2. Limit the width of the focus state.
-    //
-    // This fix also has the unrelated but desirable effect of limiting the width of the focus
-    // state to only span the width of the contained text, rather than the width of the whole
-    // component. This impacts section-toggle, section-heading-focus-wrapper and section-summary.
     .govuk-accordion__section-toggle,
     .govuk-accordion__section-heading-focus-wrapper,
     .govuk-accordion__section-summary {
-      display: inline;
-
-      &:before {
-        content: "";
-        display: block;
+      display: block;
+      margin-top: 13px;
       }
     }
 
@@ -325,13 +299,6 @@
     .govuk-accordion__section-toggle {
       @include govuk-font($size: 19);
       color: $govuk-link-colour;
-    }
-
-    // The NVDA fix means a display:inline element cannot receive box model spacing styling such as margin.
-    // As a result this is applied to the pseudo element that has a display:block property to maintain Design
-    .govuk-accordion__section-summary:before,
-    .govuk-accordion__section-toggle:before {
-      margin-top: 13px;
     }
 
     // Space between icon and text,

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -58,7 +58,7 @@
       position: relative;
       z-index: 1;
 
-      margin-bottom: 14px;
+      margin-bottom: 9px;
       padding: 5px 2px 3px 0;
 
       border-width: 0;
@@ -68,6 +68,10 @@
 
       cursor: pointer;
       -webkit-appearance: none;
+
+      @include govuk-media-query ($from: desktop) {
+        margin-bottom: 14px;
+      }
 
       // Remove default button focus outline in Firefox
       &::-moz-focus-inner {

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -58,8 +58,8 @@
       position: relative;
       z-index: 1;
 
-      margin: 0 0 govuk-spacing(2) 0;
-      padding: 7px 2px 7px 0;
+      margin-bottom: 14px;
+      padding: 5px 2px 3px 0;
 
       border-width: 0;
 
@@ -78,6 +78,8 @@
       &:hover {
         color: $govuk-accordion-base-colour;
         background: $govuk-accordion-hover-colour;
+        // Mimic the focus styles so the height is the same changing from hover to focused
+        box-shadow: 0 -2px $govuk-accordion-hover-colour, 0 4px $govuk-accordion-hover-colour;
 
         .govuk-accordion__section-toggle-text {
           color: $govuk-accordion-base-colour;

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -1,4 +1,6 @@
 @include govuk-exports("govuk/component/accordion") {
+  $govuk-accordion-icon-focus-colour: govuk-colour("yellow");
+
   .govuk-accordion {
     @include govuk-responsive-margin(6, "bottom");
   }
@@ -84,6 +86,71 @@
       &::-moz-focus-inner {
         padding: 0;
         border: 0;
+      }
+    }
+
+    // Create Chervon icon aligned with text
+    .govuk-accordion-nav__chevron {
+      box-sizing: border-box;
+      display: inline-block;
+
+      position: relative;
+
+      width: 20px;
+      height: 20px;
+
+      border: 1px solid;
+      border-radius: 50%;
+
+      vertical-align: text-top;
+
+      // IE8 fallback of icon
+      @include govuk-if-ie8 {
+        display: inline-block;
+        max-height: 20px;
+        line-height: 1;
+      }
+
+      // Create inner Chervon arrow
+      &:after {
+        content: "";
+        box-sizing: border-box;
+        display: block;
+
+        position: absolute;
+        bottom: 5px;
+        left: 6px;
+
+        width: 6px;
+        height: 6px;
+
+        transform: rotate(-45deg);
+
+        border-top: 2px solid $govuk-link-colour;
+        border-right: 2px solid $govuk-link-colour;
+
+        // IE8 fallback of icon with HTML symbol
+        @include govuk-if-ie8 {
+          content: "\25B2"; // "▲"
+
+          top: 0;
+          left: 0;
+
+          border: 0;
+        }
+      }
+    }
+
+    // Rotate icon to create "Down" version
+    .govuk-accordion-nav__chevron--down {
+      transform: rotate(180deg);
+
+      // IE8 fallback of arrow icon
+      @include govuk-if-ie8 {
+        &:after {
+          content: "\25BC"; // "▼"
+          transform: none;
+        }
       }
     }
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -281,14 +281,14 @@
     // Add toggle link with Chevron icon on left.
     .govuk-accordion__section-toggle {
       @include govuk-font($size: 19, $line-height: 1);
-
       color: $govuk-link-colour;
+    }
 
-      // The NVDA fix means a display:inline element cannot receive box model spacing styling such as margin.
-      // As a result this is applied to the pseudo element that has a display:block property to maintain Design
-      &:before {
-        @include govuk-responsive-margin(1, "top");
-      }
+    // The NVDA fix means a display:inline element cannot receive box model spacing styling such as margin.
+    // As a result this is applied to the pseudo element that has a display:block property to maintain Design
+    .govuk-accordion__section-summary:before,
+    .govuk-accordion__section-toggle:before {
+      @include govuk-responsive-margin(1, "top");
     }
 
     // Hide body of expanded sections

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -32,7 +32,7 @@
     padding-top: govuk-spacing(3);
   }
 
-  .govuk-accordion__section-heading-focus-wrapper {
+  .govuk-accordion__section-heading-text {
     @include govuk-font($size: 24, $weight: bold);
   }
 
@@ -196,7 +196,7 @@
     .govuk-accordion__section-button {
       width: 100%;
 
-      padding: govuk-spacing(2) 0 govuk-spacing(3) 0;
+      padding: govuk-spacing(2) 0 0 0;
 
       border: 0;
 
@@ -246,9 +246,9 @@
         // styling is being applied to inner text elements that receive focus
         outline: 0;
 
-        .govuk-accordion__section-heading-focus-wrapper,
-        .govuk-accordion__section-summary,
-        .govuk-accordion__section-toggle {
+        .govuk-accordion__section-heading-text-focus,
+        .govuk-accordion__section-summary-focus,
+        .govuk-accordion__section-toggle-focus {
           @include govuk-focused-text;
         }
 
@@ -279,7 +279,7 @@
 
     // As Chevron icon is vertically aligned it overlaps with the focus state bottom border
     // Styling adds some spacing
-    .govuk-accordion__section-button:focus .govuk-accordion__section-toggle {
+    .govuk-accordion__section-button:focus .govuk-accordion__section-toggle-focus {
       padding-bottom: 3px;
 
       @include govuk-media-query ($from: desktop) {
@@ -288,10 +288,15 @@
     }
 
     .govuk-accordion__section-toggle,
-    .govuk-accordion__section-heading-focus-wrapper,
+    .govuk-accordion__section-heading-text,
     .govuk-accordion__section-summary {
       display: block;
-      margin-top: 13px;
+      margin-bottom: 13px;
+
+      .govuk-accordion__section-heading-text-focus,
+      .govuk-accordion__section-summary-focus,
+      .govuk-accordion__section-toggle-focus {
+        display: inline;
       }
     }
 
@@ -321,19 +326,13 @@
         .govuk-accordion-nav__chevron {
           background-color: transparent;
         }
-
-        .govuk-accordion__show-all-text,
-        .govuk-accordion__section-toggle {
-          text-decoration: underline;
-          text-decoration-thickness: 3px;
-        }
       }
 
       .govuk-accordion__show-all:focus,
       .govuk-accordion__section-button:focus {
-        .govuk-accordion__section-heading-focus-wrapper,
-        .govuk-accordion__section-summary,
-        .govuk-accordion__section-toggle,
+        .govuk-accordion__section-heading-text-focus,
+        .govuk-accordion__section-summary-focus,
+        .govuk-accordion__section-toggle-focus,
         .govuk-accordion-nav__chevron {
           background: transparent;
           background-color: transparent;

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -15,8 +15,6 @@
 
   .govuk-accordion__section-heading {
     // Override browser defaults to ensure consistent element height
-    // Font size is set in .govuk-accordion__section-button
-    @include govuk-font(24);
 
     margin-top: 0; // Override browser default
     margin-bottom: 0; // Override browser default
@@ -28,10 +26,14 @@
   // Buttons within the sections don’t need default styling
   .govuk-accordion__section-button {
     @include govuk-text-colour;
-    @include govuk-font($size: 24, $weight: bold);
+
     display: block;
     margin-bottom: 0;
     padding-top: govuk-spacing(3);
+  }
+
+  .govuk-accordion__section-heading-focus-wrapper {
+    @include govuk-font($size: 24, $weight: bold);
   }
 
   // Remove the bottom margin from the last item inside the content
@@ -329,11 +331,7 @@
     // As a result this is applied to the pseudo element that has a display:block property to maintain Design
     .govuk-accordion__section-summary:before,
     .govuk-accordion__section-toggle:before {
-      margin-top: govuk-spacing(2);
-
-      @include govuk-media-query ($from: desktop) {
-        margin-top: 8px;
-      }
+      margin-top: 13px;
     }
 
     // Space between icon and text,

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -341,4 +341,19 @@
         }
       }
     }
+
+    // For devices that can't hover such as touch devices,
+    // remove hover state as it can be stuck in that state (iOS).
+    @media (hover: none) {
+      .govuk-accordion__section-header:hover {
+        border-top-color: $govuk-border-colour;
+
+        box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-link-colour;
+
+        .govuk-accordion__section-button {
+          border-top-color: $govuk-border-colour;
+        }
+      }
+    }
+  }
 }

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -8,22 +8,19 @@
     @include govuk-responsive-margin(6, "bottom");
   }
 
-  // Borders between accordion sections
   .govuk-accordion__section {
     padding-top: govuk-spacing(3);
   }
 
   .govuk-accordion__section-heading {
     // Override browser defaults to ensure consistent element height
-
-    margin-top: 0; // Override browser default
-    margin-bottom: 0; // Override browser default
+    margin-top: 0;
+    margin-bottom: 0;
 
     padding-top: govuk-spacing(3);
     padding-bottom: govuk-spacing(3);
   }
 
-  // Buttons within the sections don’t need default styling
   .govuk-accordion__section-button {
     @include govuk-text-colour;
 
@@ -48,7 +45,6 @@
       border-bottom: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
     }
 
-    // Borders between accordion sections
     .govuk-accordion__section {
       padding-top: 0;
     }
@@ -93,9 +89,9 @@
       &:hover {
         color: $govuk-accordion-base-colour;
         background: $govuk-accordion-hover-colour;
-        // The GOV.UK focus state adds a box-shadow to the top and bottom of the button. We add a
-        // grey box-shadow on hover too, to make the height of the hover state match the height of
-        // the focus state.
+        // The GOV.UK Design System focus state adds a box-shadow to the top and bottom of the
+        // button. We add a grey box-shadow on hover too, to make the height of the hover state
+        // match the height of the focus state.
         box-shadow: 0 -2px $govuk-accordion-hover-colour, 0 4px $govuk-accordion-hover-colour;
 
         .govuk-accordion__section-toggle-text {
@@ -192,7 +188,6 @@
       }
     }
 
-    // Buttons within the headers don’t need default styling
     .govuk-accordion__section-button {
       width: 100%;
 
@@ -203,7 +198,7 @@
       border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
 
       // Visually separate the section from the one underneath when user changes colours in their
-      // browser.
+      // browser. See https://github.com/alphagov/govuk-frontend/issues/2321#issuecomment-924201488
       border-bottom: govuk-spacing(2) solid transparent;
 
       color: $govuk-text-colour;
@@ -306,8 +301,9 @@
       color: $govuk-link-colour;
     }
 
-    // Space between icon and text,
-    // Avoid placing on icon due to transform altering placement of margin
+    // Add space between the icon and text.
+    // Avoid applying spacing directly to the icon as the use of `transform` will change the
+    // placement of any margins.
     .govuk-accordion__show-all-text,
     .govuk-accordion__section-toggle-text {
       margin-left: govuk-spacing(1);

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -310,15 +310,28 @@
       vertical-align: middle;
     }
 
-    // High contrast / user colour adjustments
-    // When adjustments are active the inner button content is not visible.
-    // On hover add underline to toggle text to add extra affordance as icon colour changes on pseudo element are not respected.
-    // On focus add transparency to background so content is visible
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
-      .govuk-accordion__section-button:hover,
-      .govuk-accordion__show-all:hover {
-        background: transparent;
-
+    // Background colour adjustment when user changes colours in Firefox
+    //
+    // When user changes colours in Firefox, text colour inside <button> is always black
+    // (regardless of the custom colours the user has set). This is fine when the text in the
+    // button is not nested inside another element because when user changes colours in Firefox,
+    // the immediate background colour of buttons is always white (again, regardless of user's
+    // custom colours).
+    //
+    // However, when the text inside <button> is wrapped inside another element AND that element
+    // sets a background colour, the text colour is still black but the background of that nested
+    // element gets the user's custom background colour. When the custom background is a lighter
+    // hue, the contrast might be sufficient. But if the user's custom background colour is a
+    // darker colour, the contrast with the text might not be sufficient.
+    //
+    // To ensure sufficient contrast, override the background colour set by the focus state on the
+    // nested elements to be transparent.
+    //
+    // Also override the background colour of the Show/Hide chevrons which set a background colour
+    // on hover.
+    @media screen and (forced-colors: active) {
+      .govuk-accordion__show-all:hover,
+      .govuk-accordion__section-button:hover {
         .govuk-accordion-nav__chevron {
           background-color: transparent;
         }

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -2,9 +2,7 @@
   $govuk-accordion-base-colour: govuk-colour("black");
   $govuk-accordion-hover-colour: govuk-colour("light-grey", $legacy: "grey-3");
   $govuk-accordion-icon-focus-colour: govuk-colour("yellow");
-  $govuk-accordion-border-width: 3px;
   $govuk-accordion-bottom-border-width: 1px;
-  $govuk-header-link-underline-thickness: 3px;
 
   .govuk-accordion {
     @include govuk-responsive-margin(6, "bottom");
@@ -50,7 +48,18 @@
 
     // Borders between accordion sections
     .govuk-accordion__section {
-      padding: 0;
+      padding-top: 0;
+    }
+
+    // Hide the body of collapsed sections
+    .govuk-accordion__section-content {
+      display: none;
+      @include govuk-responsive-padding(8, "bottom");
+    }
+
+    // Show the body of expanded sections
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
+      display: block;
     }
 
     .govuk-accordion__show-all {
@@ -82,7 +91,9 @@
       &:hover {
         color: $govuk-accordion-base-colour;
         background: $govuk-accordion-hover-colour;
-        // Mimic the focus styles so the height is the same changing from hover to focused
+        // The GOV.UK focus state adds a box-shadow to the top and bottom of the button. We add a
+        // grey box-shadow on hover too, to make the height of the hover state match the height of
+        // the focus state.
         box-shadow: 0 -2px $govuk-accordion-hover-colour, 0 4px $govuk-accordion-hover-colour;
 
         .govuk-accordion__section-toggle-text {
@@ -112,18 +123,19 @@
       }
     }
 
-    // Removing padding from once JavaScript loaded
     .govuk-accordion__section-heading {
       padding: 0;
+      border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
     }
 
-    // Create Chervon icon aligned with text
+    // Create Chevron icon aligned with text
     .govuk-accordion-nav__chevron {
       box-sizing: border-box;
       display: inline-block;
 
       position: relative;
 
+      // Set size using rems to make the icon scale with text if user resizes text in their browser
       width: govuk-px-to-rem(20px);
       height: govuk-px-to-rem(20px);
 
@@ -139,7 +151,7 @@
         line-height: 1;
       }
 
-      // Create inner Chervon arrow
+      // Create inner chevron arrow
       &:after {
         content: "";
         box-sizing: border-box;
@@ -182,20 +194,13 @@
       }
     }
 
-    .govuk-accordion__section-header {
-      padding: 0;
-    }
-
     // Buttons within the headers don’t need default styling
     .govuk-accordion__section-button {
-      position: relative;
-
       width: 100%;
 
       padding: govuk-spacing(2) 0 govuk-spacing(3);
 
-      border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
-      border-width: $govuk-accordion-bottom-border-width 0 0 0;
+      border-width: 0;
 
       color: $govuk-text-colour;
       background: none;
@@ -266,7 +271,7 @@
       }
     }
 
-    // NVDA fix
+    // 1. A fix to improve NVDA announcements.
     //
     // NVDA treats any form of line break as a different announcement landmark and will therefore announce it separately.
     // As you move through NVDA using arrow keys, this announces each element in turn (rather than a whole block) which could cause confusion for users
@@ -283,6 +288,12 @@
     //
     // Additional details and testing videos can be found here:
     // (https://github.com/alphagov/govuk-design-system/issues/1706#issuecomment-862451506)
+    //
+    // 2. Limit the width of the focus state.
+    //
+    // This fix also has the unrelated but desirable effect of limiting the width of the focus
+    // state to only span the width of the contained text, rather than the width of the whole
+    // component. This impacts section-toggle, section-heading-focus-wrapper and section-summary.
     .govuk-accordion__section-toggle,
     .govuk-accordion__section-heading-focus-wrapper,
     .govuk-accordion__section-summary {
@@ -307,23 +318,11 @@
       @include govuk-responsive-margin(1, "top");
     }
 
-    // Hide body of expanded sections
-    .govuk-accordion__section-content {
-      display: none;
-      @include govuk-responsive-padding(0, "top");
-      @include govuk-responsive-padding(8, "bottom");
-    }
-
-    // Show the body of expanded sections
-    .govuk-accordion__section--expanded .govuk-accordion__section-content {
-      display: block;
-    }
-
     // Space between icon and text,
     // Avoid placing on icon due to transform altering placement of margin
     .govuk-accordion__show-all-text,
     .govuk-accordion__section-toggle-text {
-      margin-left: govuk-em(5, 19);
+      margin-left: govuk-spacing(1);
       vertical-align: middle;
     }
 
@@ -343,7 +342,7 @@
         .govuk-accordion__show-all-text,
         .govuk-accordion__section-toggle {
           text-decoration: underline;
-          text-decoration-thickness: $govuk-header-link-underline-thickness;
+          text-decoration-thickness: 3px;
         }
       }
 
@@ -365,7 +364,7 @@
       .govuk-accordion__section-header:hover {
         border-top-color: $govuk-border-colour;
 
-        box-shadow: inset 0 $govuk-accordion-border-width 0 0 $govuk-link-colour;
+        box-shadow: inset 0 3px 0 0 $govuk-link-colour;
 
         .govuk-accordion__section-button {
           border-top-color: $govuk-border-colour;

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -250,11 +250,45 @@
       }
     }
 
+    // NVDA fix
+    //
+    // NVDA treats any form of line break as a different announcement landmark and will therefore announce it separately.
+    // As you move through NVDA using arrow keys, this announces each element in turn (rather than a whole block) which could cause confusion for users
+    // This line break can come from both the semantics via br tags or two block-level tags, or via CSS using display: block or display: table
+    // In this case it was the span(s) within the button being styled using display: block.
+    // This fix forces a visual break but bypasses NVDA's line break interpreter, thus causing the accordion title and the inner Content to be read as a single sentence
+    //
+    // Consider NVDA output before:
+    // clickable  heading    level 2  button  collapsed    [Heading copy],Show
+    // heading    level 2  button  collapsed    this section
+    //
+    // After:
+    // clickable  heading    level 2  button  collapsed    [Heading copy] , Showthis section
+    //
+    // Additional details and testing videos can be found here:
+    // (https://github.com/alphagov/govuk-design-system/issues/1706#issuecomment-862451506)
+    .govuk-accordion__section-toggle,
+    .govuk-accordion__section-heading-focus-wrapper,
+    .govuk-accordion__section-summary {
+      display: inline;
+
+      &:before {
+        content: "";
+        display: block;
+      }
+    }
+
     // Add toggle link with Chevron icon on left.
     .govuk-accordion__section-toggle {
       @include govuk-font($size: 19, $line-height: 1);
 
       color: $govuk-link-colour;
+
+      // The NVDA fix means a display:inline element cannot receive box model spacing styling such as margin.
+      // As a result this is applied to the pseudo element that has a display:block property to maintain Design
+      &:before {
+        @include govuk-responsive-margin(1, "top");
+      }
     }
 
     // Hide body of expanded sections

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -28,7 +28,7 @@
   // Buttons within the sections don’t need default styling
   .govuk-accordion__section-button {
     @include govuk-text-colour;
-    @include govuk-font($size: 24, $weight: bold, $line-height: 1.25);
+    @include govuk-font($size: 24, $weight: bold);
     display: block;
     margin-bottom: 0;
     padding-top: govuk-spacing(3);
@@ -202,6 +202,7 @@
       border: 0;
 
       border-top: $govuk-accordion-bottom-border-width solid $govuk-border-colour;
+
       // Visually separate the section from the one underneath when user changes colours in their
       // browser.
       border-bottom: govuk-spacing(2) solid transparent;
@@ -319,7 +320,7 @@
 
     // Add toggle link with Chevron icon on left.
     .govuk-accordion__section-toggle {
-      @include govuk-font($size: 19, $line-height: 1);
+      @include govuk-font($size: 19);
       color: $govuk-link-colour;
     }
 
@@ -327,7 +328,7 @@
     // As a result this is applied to the pseudo element that has a display:block property to maintain Design
     .govuk-accordion__section-summary:before,
     .govuk-accordion__section-toggle:before {
-      @include govuk-responsive-margin(1, "top");
+      margin-top: 8px;
     }
 
     // Space between icon and text,

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -59,7 +59,7 @@
       z-index: 1;
 
       margin-bottom: 9px;
-      padding: 5px 2px 3px 0;
+      padding: govuk-spacing(1) 2px govuk-spacing(1) 0;
 
       border-width: 0;
 
@@ -124,13 +124,13 @@
 
       position: relative;
 
-      width: govuk-em(20, 19);
-      height: govuk-em(20, 19);
+      width: govuk-px-to-rem(20px);
+      height: govuk-px-to-rem(20px);
 
-      border: govuk-em(1, 16) solid;
+      border: govuk-px-to-rem(1px) solid;
       border-radius: 50%;
 
-      vertical-align: text-top;
+      vertical-align: middle;
 
       // IE8 fallback of icon
       @include govuk-if-ie8 {
@@ -146,16 +146,16 @@
         display: block;
 
         position: absolute;
-        bottom: govuk-em(5, 19);
-        left: govuk-em(6, 19);
+        bottom: govuk-px-to-rem(5px);
+        left: govuk-px-to-rem(6px);
 
-        width: govuk-em(6, 19);
-        height: govuk-em(6, 19);
+        width: govuk-px-to-rem(6px);
+        height: govuk-px-to-rem(6px);
 
         transform: rotate(-45deg);
 
-        border-top: govuk-em(2, 16) solid;
-        border-right: govuk-em(2, 16) solid;
+        border-top: govuk-px-to-rem(2px) solid;
+        border-right: govuk-px-to-rem(2px) solid;
 
         // IE8 fallback of icon with HTML symbol
         @include govuk-if-ie8 {
@@ -313,7 +313,8 @@
     // Avoid placing on icon due to transform altering placement of margin
     .govuk-accordion__show-all-text,
     .govuk-accordion__section-toggle-text {
-      margin-left: 5px;
+      margin-left: govuk-em(5, 19);
+      vertical-align: middle;
     }
 
     // High contrast / user colour adjustments

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -171,10 +171,7 @@
         // IE8 fallback of icon with HTML symbol
         @include govuk-if-ie8 {
           content: "\25B2"; // "▲"
-
-          top: 0;
-          left: 0;
-
+          position: relative;
           border: 0;
         }
       }
@@ -197,7 +194,7 @@
     .govuk-accordion__section-button {
       width: 100%;
 
-      padding: govuk-spacing(2) 0 govuk-spacing(1) 0;
+      padding: govuk-spacing(2) 0 govuk-spacing(3) 0;
 
       border: 0;
 
@@ -214,6 +211,10 @@
       // Section headers have a pointer cursor as an additional affordance
       cursor: pointer;
       -webkit-appearance: none;
+
+      @include govuk-media-query ($from: tablet) {
+        padding-bottom: govuk-spacing(2);
+      }
 
       &:active {
         color: $govuk-link-active-colour;
@@ -328,7 +329,11 @@
     // As a result this is applied to the pseudo element that has a display:block property to maintain Design
     .govuk-accordion__section-summary:before,
     .govuk-accordion__section-toggle:before {
-      margin-top: 8px;
+      margin-top: govuk-spacing(2);
+
+      @include govuk-media-query ($from: desktop) {
+        margin-top: 8px;
+      }
     }
 
     // Space between icon and text,

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -32,14 +32,17 @@ function Accordion ($module) {
 
   this.sectionHeaderClass = 'govuk-accordion__section-header'
   this.sectionHeadingClass = 'govuk-accordion__section-heading'
-  this.sectionHeadingClassFocusWrapper = 'govuk-accordion__section-heading-focus-wrapper'
+  this.sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
+  this.sectionHeadingTextFocusClass = 'govuk-accordion__section-heading-text-focus'
   this.sectionSummaryClass = 'govuk-accordion__section-summary'
   this.sectionButtonClass = 'govuk-accordion__section-button'
   this.sectionExpandedClass = 'govuk-accordion__section--expanded'
   this.sectionShowHideToggleClass = 'govuk-accordion__section-toggle'
+  this.sectionShowHideToggleFocusClass = 'govuk-accordion__section-toggle-focus'
   this.sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
   this.upChevronIconClass = 'govuk-accordion-nav__chevron'
   this.downChevronIconClass = 'govuk-accordion-nav__chevron--down'
+  this.sectionSummaryFocusClass = 'govuk-accordion__section-summary-focus'
 }
 
 // Initialize component
@@ -117,25 +120,33 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   // Create show / hide icons with text.
   var $showIcons = document.createElement('span')
   $showIcons.classList.add(this.sectionShowHideToggleClass)
+  // Create an inner container to limit the width of the show/hide focus state
+  var $showIconsFocus = document.createElement('span')
+  $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
+  $showIcons.appendChild($showIconsFocus)
 
   // Wrapper of heading to receive focus state design
   // ID set to allow the heading alone to be referenced without "this section"
-  var $wrapperFocusHeading = document.createElement('span')
-  $wrapperFocusHeading.classList.add(this.sectionHeadingClassFocusWrapper)
-  $wrapperFocusHeading.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
+  var $wrapperHeadingText = document.createElement('span')
+  $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
+  $wrapperHeadingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
+  // Create an inner heading container to limit the width of the heading text focus state
+  var $wrapperHeadingTextFocus = document.createElement('span')
+  $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
+  $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
 
   // Build additional wrapper for toggle text, place icon before wrapped text.
   var $wrapperToggleText = document.createElement('span')
   var $icon = document.createElement('span')
   $icon.classList.add(this.upChevronIconClass)
-  $showIcons.appendChild($icon)
+  $showIconsFocus.appendChild($icon)
   $wrapperToggleText.classList.add(this.sectionShowHideTextClass)
-  $showIcons.appendChild($wrapperToggleText)
+  $showIconsFocus.appendChild($wrapperToggleText)
 
   // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
   for (var i = 0; i < $span.attributes.length; i++) {
     var attr = $span.attributes.item(i)
-    // Add all attributes but not ID as this is being add directly on $wrapperFocusHeading
+    // Add all attributes but not ID as this is being added directly on $wrapperHeadingText
     if (attr.nodeName !== 'id') {
       $button.setAttribute(attr.nodeName, attr.nodeValue)
     }
@@ -143,15 +154,20 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
 
   $heading.removeChild($span)
   $heading.appendChild($button)
-  $button.appendChild($wrapperFocusHeading)
+  $button.appendChild($wrapperHeadingText)
+
   $button.appendChild(this.getButtonPunctuationEl())
   // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
-  $wrapperFocusHeading.innerHTML = $span.innerHTML
+  $wrapperHeadingTextFocus.innerHTML = $span.innerHTML
 
   // If summary content exists add to DOM in correct order
   if (typeof ($summary) !== 'undefined' && $summary !== null) {
     // Create new element, in order to swap the summary from div to span as the summary element is with a button
     var $summarySpan = document.createElement('span')
+    // Create an inner summary container to limit the width of the summary focus state
+    var $summarySpanFocus = document.createElement('span')
+    $summarySpanFocus.classList.add(this.sectionSummaryFocusClass)
+    $summarySpan.appendChild($summarySpanFocus)
 
     // Get original attributes, and pass them to the replacement
     for (var j = 0, l = $summary.attributes.length; j < l; ++j) {
@@ -161,7 +177,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
     }
 
     // Persist contents
-    $summarySpan.innerHTML = $summary.innerHTML
+    $summarySpanFocus.innerHTML = $summary.innerHTML
 
     // Switch summary from div to span
     $summary.parentNode.replaceChild($summarySpan, $summary)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -23,12 +23,12 @@ function Accordion ($module) {
   this.$module = $module
   this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
-  this.$openAllButton = ''
+  this.$showAllButton = ''
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 
   this.controlsClass = 'govuk-accordion__controls'
-  this.openAllClass = 'govuk-accordion__show-all'
-  this.openAllTextClass = 'govuk-accordion__show-all-text'
+  this.showAllClass = 'govuk-accordion__show-all'
+  this.showAllTextClass = 'govuk-accordion__show-all-text'
 
   this.sectionHeaderClass = 'govuk-accordion__section-header'
   this.sectionHeadingClass = 'govuk-accordion__section-heading'
@@ -57,35 +57,35 @@ Accordion.prototype.init = function () {
 
   // See if "Show all sections" button text should be updated
   var areAllSectionsOpen = this.checkIfAllSectionsOpen()
-  this.updateOpenAllButton(areAllSectionsOpen)
+  this.updateShowAllButton(areAllSectionsOpen)
 }
 
 // Initialise controls and set attributes
 Accordion.prototype.initControls = function () {
   // Create "Show all" button and set attributes
-  this.$openAllButton = document.createElement('button')
-  this.$openAllButton.setAttribute('type', 'button')
-  this.$openAllButton.setAttribute('class', this.openAllClass)
-  this.$openAllButton.setAttribute('aria-expanded', 'false')
+  this.$showAllButton = document.createElement('button')
+  this.$showAllButton.setAttribute('type', 'button')
+  this.$showAllButton.setAttribute('class', this.showAllClass)
+  this.$showAllButton.setAttribute('aria-expanded', 'false')
 
   // Create icon, add to element
   var $icon = document.createElement('span')
   $icon.classList.add(this.upChevronIconClass)
-  this.$openAllButton.appendChild($icon)
+  this.$showAllButton.appendChild($icon)
 
   // Create control wrapper and add controls to it
   var $accordionControls = document.createElement('div')
   $accordionControls.setAttribute('class', this.controlsClass)
-  $accordionControls.appendChild(this.$openAllButton)
+  $accordionControls.appendChild(this.$showAllButton)
   this.$module.insertBefore($accordionControls, this.$module.firstChild)
 
-  // Build additional wrapper for open all toggle text, place icon before wrapped text.
-  var $wrapperOpenAllText = document.createElement('span')
-  $wrapperOpenAllText.classList.add(this.openAllTextClass)
-  this.$openAllButton.appendChild($wrapperOpenAllText)
+  // Build additional wrapper for Show all toggle text and place after icon
+  var $wrappershowAllText = document.createElement('span')
+  $wrappershowAllText.classList.add(this.showAllTextClass)
+  this.$showAllButton.appendChild($wrappershowAllText)
 
-  // Handle events for the controls
-  this.$openAllButton.addEventListener('click', this.onOpenOrCloseAllToggle.bind(this))
+  // Handle click events on the show/hide all button
+  this.$showAllButton.addEventListener('click', this.onShowOrHideAllToggle.bind(this))
 }
 
 // Initialise section headers
@@ -112,12 +112,12 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   var $heading = $headerWrapper.querySelector('.' + this.sectionHeadingClass)
   var $summary = $headerWrapper.querySelector('.' + this.sectionSummaryClass)
 
-  // Copy existing span element to an actual button element, for improved accessibility.
+  // Create a button element that will replace the '.govuk-accordion__section-button' span
   var $button = document.createElement('button')
   $button.setAttribute('type', 'button')
   $button.setAttribute('aria-controls', this.moduleId + '-content-' + (index + 1))
 
-  // Create show / hide icons with text.
+  // Create span for show / hide icons with text.
   var $showIcons = document.createElement('span')
   $showIcons.classList.add(this.sectionShowHideToggleClass)
   // Create an inner container to limit the width of the show/hide focus state
@@ -125,7 +125,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
   $showIcons.appendChild($showIconsFocus)
 
-  // Wrapper of heading to receive focus state design
+  // Wrapper of heading
   // ID set to allow the heading alone to be referenced without "this section"
   var $wrapperHeadingText = document.createElement('span')
   $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
@@ -135,7 +135,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
   $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
 
-  // Build additional wrapper for toggle text, place icon before wrapped text.
+  // Build an additional wrapper for the show/hide text. Append text after the show/hide icon
   var $wrapperToggleText = document.createElement('span')
   var $icon = document.createElement('span')
   $icon.classList.add(this.upChevronIconClass)
@@ -146,7 +146,8 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
   for (var i = 0; i < $span.attributes.length; i++) {
     var attr = $span.attributes.item(i)
-    // Add all attributes but not ID as this is being added directly on $wrapperHeadingText
+    // Add all attributes but not ID as this is being added to
+    // the section heading ($wrapperHeadingText)
     if (attr.nodeName !== 'id') {
       $button.setAttribute(attr.nodeName, attr.nodeValue)
     }
@@ -162,7 +163,10 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
 
   // If summary content exists add to DOM in correct order
   if (typeof ($summary) !== 'undefined' && $summary !== null) {
-    // Create new element, in order to swap the summary from div to span as the summary element is with a button
+    // Create a new `span` element and copy the summary line content from the original `div` to the
+    // new `span`
+    // This is because the summary line text is now inside a button element, which can only contain
+    // phrasing content
     var $summarySpan = document.createElement('span')
     // Create an inner summary container to limit the width of the summary focus state
     var $summarySpanFocus = document.createElement('span')
@@ -176,10 +180,10 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
       $summarySpan.setAttribute(nodeName, nodeValue)
     }
 
-    // Persist contents
+    // Copy original contents of summary to the new summary span
     $summarySpanFocus.innerHTML = $summary.innerHTML
 
-    // Switch summary from div to span
+    // Replace the original summary `div` with the new summary `span`
     $summary.parentNode.replaceChild($summarySpan, $summary)
 
     $button.appendChild($summarySpan)
@@ -199,7 +203,7 @@ Accordion.prototype.onSectionToggle = function ($section) {
 }
 
 // When Open/Close All toggled, set and store state
-Accordion.prototype.onOpenOrCloseAllToggle = function () {
+Accordion.prototype.onShowOrHideAllToggle = function () {
   var $module = this
   var $sections = this.$sections
   var nowExpanded = !this.checkIfAllSectionsOpen()
@@ -210,7 +214,7 @@ Accordion.prototype.onOpenOrCloseAllToggle = function () {
     $module.storeState($section)
   })
 
-  $module.updateOpenAllButton(nowExpanded)
+  $module.updateShowAllButton(nowExpanded)
 }
 
 // Set section attributes when opened/closed
@@ -221,12 +225,12 @@ Accordion.prototype.setExpanded = function (expanded, $section) {
   var $newButtonText = expanded ? 'Hide' : 'Show'
 
   // Build additional copy of "this section" for assistive technology and place inside toggle link
-  var $srAdditionalCopy = document.createElement('span')
-  $srAdditionalCopy.classList.add('govuk-visually-hidden')
-  $srAdditionalCopy.innerHTML = ' this section'
+  var $visuallyHiddenText = document.createElement('span')
+  $visuallyHiddenText.classList.add('govuk-visually-hidden')
+  $visuallyHiddenText.innerHTML = ' this section'
 
   $showHideText.innerHTML = $newButtonText
-  $showHideText.appendChild($srAdditionalCopy)
+  $showHideText.appendChild($visuallyHiddenText)
   $button.setAttribute('aria-expanded', expanded)
 
   // Swap icon, change class
@@ -240,7 +244,7 @@ Accordion.prototype.setExpanded = function (expanded, $section) {
 
   // See if "Show all sections" button text should be updated
   var areAllSectionsOpen = this.checkIfAllSectionsOpen()
-  this.updateOpenAllButton(areAllSectionsOpen)
+  this.updateShowAllButton(areAllSectionsOpen)
 }
 
 // Get state of section
@@ -260,18 +264,18 @@ Accordion.prototype.checkIfAllSectionsOpen = function () {
 }
 
 // Update "Show all sections" button
-Accordion.prototype.updateOpenAllButton = function (expanded) {
-  var $icon = this.$openAllButton.querySelector('.' + this.upChevronIconClass)
-  var $openAllCopy = this.$openAllButton.querySelector('.' + this.openAllTextClass)
+Accordion.prototype.updateShowAllButton = function (expanded) {
+  var $showAllIcon = this.$showAllButton.querySelector('.' + this.upChevronIconClass)
+  var $showAllText = this.$showAllButton.querySelector('.' + this.showAllTextClass)
   var newButtonText = expanded ? 'Hide all sections' : 'Show all sections'
-  this.$openAllButton.setAttribute('aria-expanded', expanded)
-  $openAllCopy.innerHTML = newButtonText
+  this.$showAllButton.setAttribute('aria-expanded', expanded)
+  $showAllText.innerHTML = newButtonText
 
   // Swap icon, toggle class
   if (expanded) {
-    $icon.classList.remove(this.downChevronIconClass)
+    $showAllIcon.classList.remove(this.downChevronIconClass)
   } else {
-    $icon.classList.add(this.downChevronIconClass)
+    $showAllIcon.classList.add(this.downChevronIconClass)
   }
 }
 

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -157,7 +157,23 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
 
   // If summary content exists add to DOM in correct order
   if (typeof ($summary) !== 'undefined' && $summary !== null) {
-    $button.setAttribute('aria-describedby', this.moduleId + '-summary-' + (index + 1))
+    // Create new element, in order to swap the summary from div to span as the summary element is with a button
+    var $summarySpan = document.createElement('span')
+
+    // Get original attributes, and pass them to the replacement
+    for (var j = 0, l = $summary.attributes.length; j < l; ++j) {
+      var nodeName = $summary.attributes.item(j).nodeName
+      var nodeValue = $summary.attributes.item(j).nodeValue
+      $summarySpan.setAttribute(nodeName, nodeValue)
+    }
+
+    // Persist contents
+    $summarySpan.innerHTML = $summary.innerHTML
+
+    // Switch summary from div to span
+    $summary.parentNode.replaceChild($summarySpan, $summary)
+
+    $button.appendChild($summarySpan)
   }
 
   $button.appendChild($showIcons)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -11,6 +11,8 @@
   The state of each section is saved to the DOM via the `aria-expanded`
   attribute, which also provides accessibility.
 
+  A Chevron icon has been addded for extra affordance that this is an interactive element.
+
 */
 
 import { nodeListForEach } from '../../common'
@@ -34,6 +36,8 @@ function Accordion ($module) {
   this.sectionSummaryClass = 'govuk-accordion__section-summary'
   this.sectionButtonClass = 'govuk-accordion__section-button'
   this.sectionExpandedClass = 'govuk-accordion__section--expanded'
+  this.upChevronIconClass = 'govuk-accordion-nav__chevron'
+  this.downChevronIconClass = 'govuk-accordion-nav__chevron--down'
 }
 
 // Initialize component
@@ -61,6 +65,17 @@ Accordion.prototype.initControls = function () {
   this.$openAllButton.setAttribute('class', this.openAllClass)
   this.$openAllButton.setAttribute('aria-expanded', 'false')
   this.$openAllButton.setAttribute('type', 'button')
+
+  // Create icon, add to element
+  var $icon = document.createElement('span')
+  $icon.classList.add(this.upChevronIconClass)
+  this.$openAllButton.appendChild($icon)
+
+  // Create control wrapper and add controls to it
+  var $accordionControls = document.createElement('div')
+  $accordionControls.setAttribute('class', this.controlsClass)
+  $accordionControls.appendChild(this.$openAllButton)
+  this.$module.insertBefore($accordionControls, this.$module.firstChild)
 
   // Create control wrapper and add controls to it
   var accordionControls = document.createElement('div')
@@ -104,6 +119,18 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   $button.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
   $button.setAttribute('aria-controls', this.moduleId + '-content-' + (index + 1))
 
+  // Create show / hide icons with text.
+  var $showIcons = document.createElement('span')
+  $showIcons.classList.add(this.sectionShowHideToggleClass)
+
+  // Build additional wrapper for toggle text, place icon before wrapped text.
+  var $wrapperShowHideIcon = document.createElement('span')
+  var $icon = document.createElement('span')
+  $icon.classList.add(this.upChevronIconClass)
+  $showIcons.appendChild($icon)
+  $wrapperShowHideIcon.classList.add(this.sectionShowHideTextClass)
+  $showIcons.appendChild($wrapperShowHideIcon)
+
   // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
   for (var i = 0; i < $span.attributes.length; i++) {
     var attr = $span.attributes.item(i)
@@ -135,7 +162,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   icon.className = this.iconClass
   icon.setAttribute('aria-hidden', 'true')
 
-  $button.appendChild(icon)
+  $button.appendChild($showIcons)
 }
 
 // When section toggled, set and store state
@@ -165,13 +192,17 @@ Accordion.prototype.onOpenOrCloseAllToggle = function () {
 
 // Set section attributes when opened/closed
 Accordion.prototype.setExpanded = function (expanded, $section) {
+  var $icon = $section.querySelector('.' + this.upChevronIconClass)
   var $button = $section.querySelector('.' + this.sectionButtonClass)
   $button.setAttribute('aria-expanded', expanded)
 
+  // Swap icon, change class
   if (expanded) {
     $section.classList.add(this.sectionExpandedClass)
+    $icon.classList.remove(this.downChevronIconClass)
   } else {
     $section.classList.remove(this.sectionExpandedClass)
+    $icon.classList.add(this.downChevronIconClass)
   }
 
   // See if "Open all" button text should be updated

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -27,15 +27,18 @@ function Accordion ($module) {
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 
   this.controlsClass = 'govuk-accordion__controls'
-  this.openAllClass = 'govuk-accordion__open-all'
-  this.iconClass = 'govuk-accordion__icon'
+  this.openAllClass = 'govuk-accordion__show-all'
+  this.openAllTextClass = 'govuk-accordion__show-all-text'
 
   this.sectionHeaderClass = 'govuk-accordion__section-header'
-  this.sectionHeaderFocusedClass = 'govuk-accordion__section-header--focused'
   this.sectionHeadingClass = 'govuk-accordion__section-heading'
+  this.sectionHeadingClassFocusWrapper = 'govuk-accordion__section-heading-focus-wrapper'
   this.sectionSummaryClass = 'govuk-accordion__section-summary'
   this.sectionButtonClass = 'govuk-accordion__section-button'
   this.sectionExpandedClass = 'govuk-accordion__section--expanded'
+  this.sectionInnerContent = 'govuk-accordion__section-content'
+  this.sectionShowHideToggleClass = 'govuk-accordion__section-toggle'
+  this.sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
   this.upChevronIconClass = 'govuk-accordion-nav__chevron'
   this.downChevronIconClass = 'govuk-accordion-nav__chevron--down'
 }

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -30,18 +30,20 @@ function Accordion ($module) {
   this.showAllClass = 'govuk-accordion__show-all'
   this.showAllTextClass = 'govuk-accordion__show-all-text'
 
+  this.sectionExpandedClass = 'govuk-accordion__section--expanded'
+  this.sectionButtonClass = 'govuk-accordion__section-button'
   this.sectionHeaderClass = 'govuk-accordion__section-header'
   this.sectionHeadingClass = 'govuk-accordion__section-heading'
   this.sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
   this.sectionHeadingTextFocusClass = 'govuk-accordion__section-heading-text-focus'
-  this.sectionSummaryClass = 'govuk-accordion__section-summary'
-  this.sectionButtonClass = 'govuk-accordion__section-button'
-  this.sectionExpandedClass = 'govuk-accordion__section--expanded'
+
   this.sectionShowHideToggleClass = 'govuk-accordion__section-toggle'
   this.sectionShowHideToggleFocusClass = 'govuk-accordion__section-toggle-focus'
   this.sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
   this.upChevronIconClass = 'govuk-accordion-nav__chevron'
   this.downChevronIconClass = 'govuk-accordion-nav__chevron--down'
+
+  this.sectionSummaryClass = 'govuk-accordion__section-summary'
   this.sectionSummaryFocusClass = 'govuk-accordion__section-summary-focus'
 }
 

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -118,6 +118,13 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   var $showIcons = document.createElement('span')
   $showIcons.classList.add(this.sectionShowHideToggleClass)
 
+  // Add pause (with a comma) after heading for assistive technology.
+  // Example: [heading]Section A ,[pause] Show this section.
+  // https://accessibility.blog.gov.uk/2017/12/18/what-working-on-gov-uk-navigation-taught-us-about-accessibility/
+  var $srPause = document.createElement('span')
+  $srPause.classList.add('govuk-visually-hidden')
+  $srPause.innerHTML = ', '
+
   // Wrapper of heading to receive focus state design
   // ID set to allow the heading alone to be referenced without "this section"
   var $wrapperFocusHeading = document.createElement('span')
@@ -144,6 +151,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   $heading.removeChild($span)
   $heading.appendChild($button)
   $button.appendChild($wrapperFocusHeading)
+  $button.appendChild($srPause)
   // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
   $wrapperFocusHeading.innerHTML = $span.innerHTML
 

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -11,7 +11,7 @@
   The state of each section is saved to the DOM via the `aria-expanded`
   attribute, which also provides accessibility.
 
-  A Chevron icon has been addded for extra affordance that this is an interactive element.
+  A Chevron icon has been added for extra affordance that this is an interactive element.
 
 */
 

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -129,10 +129,12 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   }
 
   // Create container for heading text so it can be styled
-  // ID set to allow the heading alone to be referenced without "this section"
   var $headingText = document.createElement('span')
   $headingText.classList.add(this.sectionHeadingTextClass)
-  $headingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
+  // Copy the span ID to the heading text to allow it to be referenced by `aria-labelledby` on the
+  // hidden content area without "Show this section"
+  $headingText.id = $span.id
+
   // Create an inner heading text container to limit the width of the focus state
   var $headingTextFocus = document.createElement('span')
   $headingTextFocus.classList.add(this.sectionHeadingTextFocusClass)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -126,26 +126,26 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
     }
   }
 
-  // Wrapper of heading
+  // Create container for heading text so it can be styled
   // ID set to allow the heading alone to be referenced without "this section"
   var $wrapperHeadingText = document.createElement('span')
   $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
   $wrapperHeadingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
-  // Create an inner heading container to limit the width of the heading text focus state
+  // Create an inner heading text container to limit the width of the focus state
   var $wrapperHeadingTextFocus = document.createElement('span')
   $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
   $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
   // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
   $wrapperHeadingTextFocus.innerHTML = $span.innerHTML
 
-  // Build an additional wrapper for the show/hide text. Append text after the show/hide icon
-  // Create span for show / hide icons with text.
+  // Create container for show / hide icons and text.
   var $showIcons = document.createElement('span')
   $showIcons.classList.add(this.sectionShowHideToggleClass)
   // Create an inner container to limit the width of the focus state
   var $showIconsFocus = document.createElement('span')
   $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
   $showIcons.appendChild($showIconsFocus)
+  // Create wrapper for the show / hide text. Append text after the show/hide icon
   var $wrapperToggleText = document.createElement('span')
   var $icon = document.createElement('span')
   $icon.classList.add(this.upChevronIconClass)
@@ -153,8 +153,12 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   $wrapperToggleText.classList.add(this.sectionShowHideTextClass)
   $showIconsFocus.appendChild($wrapperToggleText)
 
+  // Append elements to the button:
+  // 1. Heading text
+  // 2. Punctuation
+  // 3. (Optional: Summary line followed by punctuation)
+  // 4. Show / hide toggle
   $button.appendChild($wrapperHeadingText)
-
   $button.appendChild(this.getButtonPunctuationEl())
 
   // If summary content exists add to DOM in correct order

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -118,13 +118,6 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   var $showIcons = document.createElement('span')
   $showIcons.classList.add(this.sectionShowHideToggleClass)
 
-  // Add pause (with a comma) after heading for assistive technology.
-  // Example: [heading]Section A ,[pause] Show this section.
-  // https://accessibility.blog.gov.uk/2017/12/18/what-working-on-gov-uk-navigation-taught-us-about-accessibility/
-  var $srPause = document.createElement('span')
-  $srPause.classList.add('govuk-visually-hidden')
-  $srPause.innerHTML = ', '
-
   // Wrapper of heading to receive focus state design
   // ID set to allow the heading alone to be referenced without "this section"
   var $wrapperFocusHeading = document.createElement('span')
@@ -151,7 +144,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
   $heading.removeChild($span)
   $heading.appendChild($button)
   $button.appendChild($wrapperFocusHeading)
-  $button.appendChild($srPause)
+  $button.appendChild(this.getButtonPunctuationEl())
   // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
   $wrapperFocusHeading.innerHTML = $span.innerHTML
 
@@ -174,6 +167,7 @@ Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
     $summary.parentNode.replaceChild($summarySpan, $summary)
 
     $button.appendChild($summarySpan)
+    $button.appendChild(this.getButtonPunctuationEl())
   }
 
   $button.appendChild($showIcons)
@@ -325,6 +319,25 @@ Accordion.prototype.setInitialState = function ($section) {
       }
     }
   }
+}
+
+/**
+* Create an element to improve semantics of the section button with punctuation
+* @return {object} DOM element
+*
+* Used to add pause (with a comma) for assistive technology.
+* Example: [heading]Section A ,[pause] Show this section.
+* https://accessibility.blog.gov.uk/2017/12/18/what-working-on-gov-uk-navigation-taught-us-about-accessibility/
+*
+* Adding punctuation to the button can also improve its general semantics by dividing its contents
+* into thematic chunks.
+* See https://github.com/alphagov/govuk-frontend/issues/2327#issuecomment-922957442
+*/
+Accordion.prototype.getButtonPunctuationEl = function () {
+  var $punctuationEl = document.createElement('span')
+  $punctuationEl.classList.add('govuk-visually-hidden', 'govuk-accordion__section-heading-divider')
+  $punctuationEl.innerHTML = ', '
+  return $punctuationEl
 }
 
 export default Accordion

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -116,32 +116,6 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   $button.setAttribute('type', 'button')
   $button.setAttribute('aria-controls', this.moduleId + '-content-' + (index + 1))
 
-  // Create span for show / hide icons with text.
-  var $showIcons = document.createElement('span')
-  $showIcons.classList.add(this.sectionShowHideToggleClass)
-  // Create an inner container to limit the width of the show/hide focus state
-  var $showIconsFocus = document.createElement('span')
-  $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
-  $showIcons.appendChild($showIconsFocus)
-
-  // Wrapper of heading
-  // ID set to allow the heading alone to be referenced without "this section"
-  var $wrapperHeadingText = document.createElement('span')
-  $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
-  $wrapperHeadingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
-  // Create an inner heading container to limit the width of the heading text focus state
-  var $wrapperHeadingTextFocus = document.createElement('span')
-  $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
-  $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
-
-  // Build an additional wrapper for the show/hide text. Append text after the show/hide icon
-  var $wrapperToggleText = document.createElement('span')
-  var $icon = document.createElement('span')
-  $icon.classList.add(this.upChevronIconClass)
-  $showIconsFocus.appendChild($icon)
-  $wrapperToggleText.classList.add(this.sectionShowHideTextClass)
-  $showIconsFocus.appendChild($wrapperToggleText)
-
   // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
   for (var i = 0; i < $span.attributes.length; i++) {
     var attr = $span.attributes.item(i)
@@ -152,13 +126,36 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
     }
   }
 
-  $heading.removeChild($span)
-  $heading.appendChild($button)
+  // Wrapper of heading
+  // ID set to allow the heading alone to be referenced without "this section"
+  var $wrapperHeadingText = document.createElement('span')
+  $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
+  $wrapperHeadingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
+  // Create an inner heading container to limit the width of the heading text focus state
+  var $wrapperHeadingTextFocus = document.createElement('span')
+  $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
+  $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
+  // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
+  $wrapperHeadingTextFocus.innerHTML = $span.innerHTML
+
+  // Build an additional wrapper for the show/hide text. Append text after the show/hide icon
+  // Create span for show / hide icons with text.
+  var $showIcons = document.createElement('span')
+  $showIcons.classList.add(this.sectionShowHideToggleClass)
+  // Create an inner container to limit the width of the focus state
+  var $showIconsFocus = document.createElement('span')
+  $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
+  $showIcons.appendChild($showIconsFocus)
+  var $wrapperToggleText = document.createElement('span')
+  var $icon = document.createElement('span')
+  $icon.classList.add(this.upChevronIconClass)
+  $showIconsFocus.appendChild($icon)
+  $wrapperToggleText.classList.add(this.sectionShowHideTextClass)
+  $showIconsFocus.appendChild($wrapperToggleText)
+
   $button.appendChild($wrapperHeadingText)
 
   $button.appendChild(this.getButtonPunctuationEl())
-  // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
-  $wrapperHeadingTextFocus.innerHTML = $span.innerHTML
 
   // If summary content exists add to DOM in correct order
   if (typeof ($summary) !== 'undefined' && $summary !== null) {
@@ -190,6 +187,9 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   }
 
   $button.appendChild($showIcons)
+
+  $heading.removeChild($span)
+  $heading.appendChild($button)
 }
 
 // When section toggled, set and store state

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -94,7 +94,7 @@ Accordion.prototype.initSectionHeaders = function () {
   nodeListForEach(this.$sections, function ($section, i) {
     // Set header attributes
     var $header = $section.querySelector('.' + this.sectionHeaderClass)
-    this.initHeaderAttributes($header, i)
+    this.constructHeaderMarkup($header, i)
     this.setExpanded(this.isExpanded($section), $section)
 
     // Handle events
@@ -106,8 +106,7 @@ Accordion.prototype.initSectionHeaders = function () {
   }.bind(this))
 }
 
-// Set individual header attributes
-Accordion.prototype.initHeaderAttributes = function ($headerWrapper, index) {
+Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   var $span = $headerWrapper.querySelector('.' + this.sectionButtonClass)
   var $heading = $headerWrapper.querySelector('.' + this.sectionHeadingClass)
   var $summary = $headerWrapper.querySelector('.' + this.sectionSummaryClass)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -143,6 +143,10 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   // Create container for show / hide icons and text.
   var $showToggle = document.createElement('span')
   $showToggle.classList.add(this.sectionShowHideToggleClass)
+  // Tell Google not to index the 'show' text as part of the heading
+  // For the snippet to work with JavaScript, it must be added before adding the page element to the
+  // page's DOM. See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
+  $showToggle.setAttribute('data-nosnippet', '')
   // Create an inner container to limit the width of the focus state
   var $showToggleFocus = document.createElement('span')
   $showToggleFocus.classList.add(this.sectionShowHideToggleFocusClass)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -120,7 +120,7 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   for (var i = 0; i < $span.attributes.length; i++) {
     var attr = $span.attributes.item(i)
     // Add all attributes but not ID as this is being added to
-    // the section heading ($wrapperHeadingText)
+    // the section heading ($headingText)
     if (attr.nodeName !== 'id') {
       $button.setAttribute(attr.nodeName, attr.nodeValue)
     }
@@ -128,37 +128,37 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
 
   // Create container for heading text so it can be styled
   // ID set to allow the heading alone to be referenced without "this section"
-  var $wrapperHeadingText = document.createElement('span')
-  $wrapperHeadingText.classList.add(this.sectionHeadingTextClass)
-  $wrapperHeadingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
+  var $headingText = document.createElement('span')
+  $headingText.classList.add(this.sectionHeadingTextClass)
+  $headingText.setAttribute('id', this.moduleId + '-heading-' + (index + 1))
   // Create an inner heading text container to limit the width of the focus state
-  var $wrapperHeadingTextFocus = document.createElement('span')
-  $wrapperHeadingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
-  $wrapperHeadingText.appendChild($wrapperHeadingTextFocus)
+  var $headingTextFocus = document.createElement('span')
+  $headingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
+  $headingText.appendChild($headingTextFocus)
   // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
-  $wrapperHeadingTextFocus.innerHTML = $span.innerHTML
+  $headingTextFocus.innerHTML = $span.innerHTML
 
   // Create container for show / hide icons and text.
-  var $showIcons = document.createElement('span')
-  $showIcons.classList.add(this.sectionShowHideToggleClass)
+  var $showToggle = document.createElement('span')
+  $showToggle.classList.add(this.sectionShowHideToggleClass)
   // Create an inner container to limit the width of the focus state
-  var $showIconsFocus = document.createElement('span')
-  $showIconsFocus.classList.add(this.sectionShowHideToggleFocusClass)
-  $showIcons.appendChild($showIconsFocus)
+  var $showToggleFocus = document.createElement('span')
+  $showToggleFocus.classList.add(this.sectionShowHideToggleFocusClass)
+  $showToggle.appendChild($showToggleFocus)
   // Create wrapper for the show / hide text. Append text after the show/hide icon
-  var $wrapperToggleText = document.createElement('span')
+  var $showToggleText = document.createElement('span')
   var $icon = document.createElement('span')
   $icon.classList.add(this.upChevronIconClass)
-  $showIconsFocus.appendChild($icon)
-  $wrapperToggleText.classList.add(this.sectionShowHideTextClass)
-  $showIconsFocus.appendChild($wrapperToggleText)
+  $showToggleFocus.appendChild($icon)
+  $showToggleText.classList.add(this.sectionShowHideTextClass)
+  $showToggleFocus.appendChild($showToggleText)
 
   // Append elements to the button:
   // 1. Heading text
   // 2. Punctuation
   // 3. (Optional: Summary line followed by punctuation)
   // 4. Show / hide toggle
-  $button.appendChild($wrapperHeadingText)
+  $button.appendChild($headingText)
   $button.appendChild(this.getButtonPunctuationEl())
 
   // If summary content exists add to DOM in correct order
@@ -190,7 +190,7 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
     $button.appendChild(this.getButtonPunctuationEl())
   }
 
-  $button.appendChild($showIcons)
+  $button.appendChild($showToggle)
 
   $heading.removeChild($span)
   $heading.appendChild($button)

--- a/src/govuk/components/accordion/accordion.js
+++ b/src/govuk/components/accordion/accordion.js
@@ -3,9 +3,9 @@
   Accordion
 
   This allows a collection of sections to be collapsed by default,
-  showing only their headers. Sections can be exanded or collapsed
-  individually by clicking their headers. An "Open all" button is
-  also added to the top of the accordion, which switches to "Close all"
+  showing only their headers. Sections can be expanded or collapsed
+  individually by clicking their headers. An "Show all sections" button is
+  also added to the top of the accordion, which switches to "Hide all sections"
   when all the sections are expanded.
 
   The state of each section is saved to the DOM via the `aria-expanded`
@@ -54,14 +54,14 @@ Accordion.prototype.init = function () {
 
   this.initSectionHeaders()
 
-  // See if "Open all" button text should be updated
+  // See if "Show all sections" button text should be updated
   var areAllSectionsOpen = this.checkIfAllSectionsOpen()
   this.updateOpenAllButton(areAllSectionsOpen)
 }
 
 // Initialise controls and set attributes
 Accordion.prototype.initControls = function () {
-  // Create "Open all" button and set attributes
+  // Create "Show all" button and set attributes
   this.$openAllButton = document.createElement('button')
   this.$openAllButton.setAttribute('type', 'button')
   this.$openAllButton.innerHTML = 'Open all <span class="govuk-visually-hidden">sections</span>'
@@ -199,7 +199,7 @@ Accordion.prototype.setExpanded = function (expanded, $section) {
   var $button = $section.querySelector('.' + this.sectionButtonClass)
   $button.setAttribute('aria-expanded', expanded)
 
-  // Swap icon, change class
+  // Swap icon, toggle class
   if (expanded) {
     $section.classList.add(this.sectionExpandedClass)
     $icon.classList.remove(this.downChevronIconClass)
@@ -229,7 +229,7 @@ Accordion.prototype.checkIfAllSectionsOpen = function () {
   return areAllSectionsOpen
 }
 
-// Update "Open all" button
+// Update "Show all sections" button
 Accordion.prototype.updateOpenAllButton = function (expanded) {
   var newButtonText = expanded ? 'Close all' : 'Open all'
   newButtonText += '<span class="govuk-visually-hidden"> sections</span>'
@@ -258,7 +258,7 @@ var helper = {
 // Set the state of the accordions in sessionStorage
 Accordion.prototype.storeState = function ($section) {
   if (this.browserSupportsSessionStorage) {
-    // We need a unique way of identifying each content in the accordion. Since
+    // We need a unique way of identifying each content in the Accordion. Since
     // an `#id` should be unique and an `id` is required for `aria-` attributes
     // `id` can be safely used.
     var $button = $section.querySelector('.' + this.sectionButtonClass)

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -29,10 +29,10 @@ describe('/components/accordion', () => {
         }
       })
 
-      it('does not display "+/-" in the section headings', async () => {
+      it('does not display "↓/↑" in the section headings', async () => {
         await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 
-        const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion__icon').length)
+        const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron').length)
         expect(numberOfIcons).toEqual(0)
       })
     })
@@ -57,22 +57,22 @@ describe('/components/accordion', () => {
         }
       })
 
-      it('should change the Open all button to Close all when both sections are opened', async () => {
+      it('should change the Show all sections button to Hide all sections when both sections are opened', async () => {
         await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 
         await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
-
         await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
 
-        var openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__open-all').textContent)
+        const openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all').textContent)
+        await page.click('.govuk-accordion__show-all')
 
-        expect(openOrCloseAllButtonText).toEqual('Close all sections')
+        expect(openOrCloseAllButtonText).toEqual('Hide all sections')
       })
 
-      it('should open both sections when the Open all button is clicked', async () => {
+      it('should open both sections when the Show all sections button is clicked', async () => {
         await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 
-        await page.click('.govuk-accordion__open-all')
+        await page.click('.govuk-accordion__show-all')
 
         const firstSectionHeaderButtonExpanded = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section').item(0).querySelector('.govuk-accordion__section-button').getAttribute('aria-expanded'))
 
@@ -96,16 +96,15 @@ describe('/components/accordion', () => {
           expect(sectionHeaderButtonExpanded).toEqual('true')
         }
 
-        const openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__open-all').textContent)
+        const openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all').textContent)
 
-        expect(openOrCloseAllButtonText).toEqual('Close all sections')
+        expect(openOrCloseAllButtonText).toEqual('Hide all sections')
       })
 
       it('should maintain the expanded state after a page refresh', async () => {
         const sectionHeaderButton = '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
 
         await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
-
         await page.click(sectionHeaderButton)
 
         const expandedState = await page.evaluate((sectionHeaderButton) => {
@@ -123,14 +122,70 @@ describe('/components/accordion', () => {
         expect(expandedState).toEqual(expandedStateAfterRefresh)
       })
 
-      describe('"+/-" icon', () => {
-        it('should display "+/-" in the section headings', async () => {
+      describe('"↓/↑" icon', () => {
+        it('should display "↓/↑" in the section headings', async () => {
           await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 
           const numberOfExampleSections = 2
+          const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron').length)
 
-          const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion__icon').length)
           expect(numberOfIcons).toEqual(numberOfExampleSections)
+        })
+      })
+
+      describe('hidden comma', () => {
+        it('should contain hidden comma " ," for assistive technology', async () => {
+          await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+          const numberOfExampleSections = 2
+          const numberOfCommas = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden:first-child').length)
+          const firstComma = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden')[0].innerHTML)
+          const secondComma = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden')[2].innerHTML)
+
+          expect(numberOfCommas).toEqual(numberOfExampleSections)
+          expect(firstComma).toMatch(/, /)
+          expect(secondComma).toMatch(/, /)
+        })
+      })
+
+      describe('location of summary', () => {
+        it('should move the additional description to the button text in the correct order', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+
+          const summaryClass = 'govuk-accordion__section-summary govuk-body'
+          const firstSummaryElement = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section-button > span')[2].className)
+          expect(firstSummaryElement).toMatch(summaryClass)
+        })
+      })
+
+      describe('div to span', () => {
+        it('should have converted the div to a span tag', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+
+          const firstSummaryElement = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section .govuk-accordion__section-summary').outerHTML)
+
+          expect(firstSummaryElement).toMatch(/<span[^>]*>/)
+        })
+      })
+
+      it('should change the (combined) Show[ this section] text to Hide[ this section ] when sections are opened', async () => {
+        await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+
+        const ShowOrHideButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').textContent)
+
+        expect(ShowOrHideButtonText).toEqual('Hide this section')
+      })
+
+      describe('hidden text', () => {
+        it('should contain hidden text " this section" for assistive technology', async () => {
+          await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+          const numberOfExampleSections = 2
+          const hiddenText = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion__section-toggle-text .govuk-visually-hidden').length)
+
+          expect(hiddenText).toEqual(numberOfExampleSections)
         })
       })
     })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -231,6 +231,14 @@ describe('/components/accordion', () => {
         expect(ShowOrHideButtonText).toEqual('Hide this section')
       })
 
+      it('should have a data-nosnippet attribute on the "Show / hide this section" container to hide it from search result snippets', async () => {
+        await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+        const dataNoSnippetAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle').getAttribute('data-nosnippet'))
+
+        expect(dataNoSnippetAttribute).toEqual('')
+      })
+
       describe('hidden text', () => {
         it('should contain hidden text " this section" for assistive technology', async () => {
           await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -249,6 +249,18 @@ describe('/components/accordion', () => {
           expect(hiddenText).toEqual(numberOfExampleSections)
         })
       })
+
+      describe('expandable content', () => {
+        it('should have an aria-labelledby that matches the heading text ID', async () => {
+          await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+          const ariaLabelledByValue = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-content').getAttribute('aria-labelledby'))
+
+          const headingTextId = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').getAttribute('id'))
+
+          expect(ariaLabelledByValue).toEqual(headingTextId)
+        })
+      })
     })
   })
 })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -122,6 +122,46 @@ describe('/components/accordion', () => {
         expect(expandedState).toEqual(expandedStateAfterRefresh)
       })
 
+      it('should transform the button span to <button>', async () => {
+        await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+        const buttonTag = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button').tagName)
+
+        expect(buttonTag).toEqual('BUTTON')
+      })
+
+      it('should contain a heading text container', async () => {
+        await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+        const headingTextContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-heading-text'))
+
+        expect(headingTextContainer).toBeTruthy()
+      })
+
+      describe('focus containers', () => {
+        it('should contain a heading text focus container', async () => {
+          await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+          const headingTextFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-heading-text > .govuk-accordion__section-heading-text-focus'))
+
+          expect(headingTextFocusContainer).toBeTruthy()
+        })
+        it('should contain a summary focus container', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+
+          const summaryFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-summary > .govuk-accordion__section-summary-focus'))
+
+          expect(summaryFocusContainer).toBeTruthy()
+        })
+        it('should contain a show/hide focus container', async () => {
+          await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
+
+          const headingTextFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-toggle > .govuk-accordion__section-toggle-focus'))
+
+          expect(headingTextFocusContainer).toBeTruthy()
+        })
+      })
+
       describe('"↓/↑" icon', () => {
         it('should display "↓/↑" in the section headings', async () => {
           await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
@@ -134,37 +174,50 @@ describe('/components/accordion', () => {
       })
 
       describe('hidden comma', () => {
-        it('should contain hidden comma " ," for assistive technology', async () => {
+        it('should contain hidden comma " ," after the heading text for assistive technology', async () => {
           await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 
-          const numberOfExampleSections = 2
-          const numberOfCommas = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden:first-child').length)
-          const firstComma = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden')[0].innerHTML)
-          const secondComma = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-visually-hidden')[2].innerHTML)
+          const commaAfterHeadingTextClassName = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').nextElementSibling.className)
 
-          expect(numberOfCommas).toEqual(numberOfExampleSections)
-          expect(firstComma).toMatch(/, /)
-          expect(secondComma).toMatch(/, /)
+          const commaAfterHeadingTextContent = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').nextElementSibling.innerHTML)
+
+          expect(commaAfterHeadingTextClassName).toEqual('govuk-visually-hidden govuk-accordion__section-heading-divider')
+
+          expect(commaAfterHeadingTextContent).toEqual(', ')
+        })
+
+        it('should contain hidden comma " ," after the summary line for assistive technology', async () => {
+          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+
+          const commaAfterHeadingTextClassName = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-summary').nextElementSibling.className)
+
+          const commaAfterHeadingTextContent = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-summary').nextElementSibling.innerHTML)
+
+          expect(commaAfterHeadingTextClassName).toEqual('govuk-visually-hidden govuk-accordion__section-heading-divider')
+
+          expect(commaAfterHeadingTextContent).toEqual(', ')
         })
       })
 
-      describe('location of summary', () => {
-        it('should move the additional description to the button text in the correct order', async () => {
-          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+      describe('summary line', () => {
+        describe('location of summary', () => {
+          it('should move the additional description to the button text in the correct order', async () => {
+            await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
 
-          const summaryClass = 'govuk-accordion__section-summary govuk-body'
-          const firstSummaryElement = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section-button > span')[2].className)
-          expect(firstSummaryElement).toMatch(summaryClass)
+            const summaryClass = 'govuk-accordion__section-summary govuk-body'
+            const firstSummaryElement = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section-button > span')[2].className)
+            expect(firstSummaryElement).toMatch(summaryClass)
+          })
         })
-      })
 
-      describe('div to span', () => {
-        it('should have converted the div to a span tag', async () => {
-          await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
+        describe('div to span', () => {
+          it('should have converted the div to a span tag', async () => {
+            await page.goto(baseUrl + '/components/accordion/with-additional-descriptions/preview', { waitUntil: 'load' })
 
-          const firstSummaryElement = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section .govuk-accordion__section-summary').outerHTML)
+            const firstSummaryElement = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section .govuk-accordion__section-summary').outerHTML)
 
-          expect(firstSummaryElement).toMatch(/<span[^>]*>/)
+            expect(firstSummaryElement).toMatch(/<span[^>]*>/)
+          })
         })
       })
 

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -58,9 +58,9 @@ examples:
           text: Section A
         content:
           html: |
-            <ul class="govuk-list govuk-list--bullet">
-              <li>Example item 1</li>
-            </ul>
+            <p class="govuk-body">
+              We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
+            </p>
       - heading:
           text: Section B
         content:
@@ -79,6 +79,9 @@ examples:
           text: Additional description
         content:
           html: |
+            <p class="govuk-body">
+              We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.
+            </p>
             <ul class="govuk-list govuk-list--bullet">
               <li>Example item 1</li>
             </ul>
@@ -106,9 +109,9 @@ examples:
               <li>Example item 1</li>
             </ul>
       - heading:
-         text: Praesent faucibus leo feugiat libero pharetra lacinia. Aliquam aliquet ante vitae mollis vestibulum. 
+         text: Praesent faucibus leo feugiat libero pharetra lacinia. Aliquam aliquet ante vitae mollis vestibulum.
         summary:
-          html: <span class="govuk-!-font-weight-regular">Maecenas nec <abbr>est</abbr> sapien<sup>1</sup>. Etiam varius luctus mauris non porttitor. </span>
+          html: <span class="govuk-!-font-weight-regular">Maecenas nec <abbr>est</abbr> sapien. Etiam varius luctus mauris non porttitor. </span>
         content:
           html: |
             <ul class="govuk-list govuk-list--bullet">

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -85,7 +85,30 @@ examples:
       - heading:
          text: Test 2
         summary:
-          html: <span class="govuk-!-font-weight-regular">Additional description</span>
+          html: <span class="govuk-!-font-weight-regular">Additional description (wrapped in span)</span>
+        content:
+          html: |
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Example item 2</li>
+            </ul>
+
+- name: with additional Content & descriptions
+  data:
+    id: with-descriptions-and-longer-content
+    items:
+      - heading:
+          text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc quis tortor porttitor.
+        summary:
+          text: Etiam diam dui, tempus ut pharetra in, aliquet non dui. Nunc pulvinar maximus tortor, ac finibus augue congue vitae. Donec sed cursus lorem.
+        content:
+          html: |
+            <ul class="govuk-list govuk-list--bullet">
+              <li>Example item 1</li>
+            </ul>
+      - heading:
+         text: Praesent faucibus leo feugiat libero pharetra lacinia. Aliquam aliquet ante vitae mollis vestibulum. 
+        summary:
+          html: <span class="govuk-!-font-weight-regular">Maecenas nec <abbr>est</abbr> sapien<sup>1</sup>. Etiam varius luctus mauris non porttitor. </span>
         content:
           html: |
             <ul class="govuk-list govuk-list--bullet">

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -92,9 +92,9 @@ examples:
               <li>Example item 2</li>
             </ul>
 
-- name: with additional Content & descriptions
+- name: with long content and description
   data:
-    id: with-descriptions-and-longer-content
+    id: with-long-content-and-description
     items:
       - heading:
           text: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc quis tortor porttitor.

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -13,7 +13,7 @@
             </span>
           </h{{ headingLevel }}>
           {% if item.summary.html or item.summary.text %}
-            <div class="govuk-accordion__section-summary govuk-body">
+            <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
               {{ item.summary.html | safe if item.summary.html else item.summary.text }}
             </div>
           {% endif %}

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -13,7 +13,7 @@
             </span>
           </h{{ headingLevel }}>
           {% if item.summary.html or item.summary.text %}
-            <div class="govuk-accordion__section-summary govuk-body" id="{{ id }}-summary-{{ loop.index }}">
+            <div class="govuk-accordion__section-summary govuk-body">
               {{ item.summary.html | safe if item.summary.html else item.summary.text }}
             </div>
           {% endif %}

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -29,7 +29,7 @@ describe('Accordion', () => {
       const $ = render('accordion', examples.default)
       const $componentContent = $('.govuk-accordion__section-content').first()
 
-      expect($componentContent.text().trim()).toEqual('Example item 1')
+      expect($componentContent.text().trim()).toEqual('We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.')
     })
 
     it('renders with id', () => {


### PR DESCRIPTION
## What

Update the Design of the Accordion component to improve accessibility.
 
## Why

The existing iteration of the Accordion: the section headings in accordions can be mistaken for links, but are treated as buttons - this fails [WCAG 2.1 success criterion 1.3.1 Info and Relationships
](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html) this update addresses this.

Also, there was initially 3 different Accordion Designs on different parts of GOV.UK Publishing. This impacted [WCAG 3.2.4](https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification.html) as the differences were not consistent they were ultimately confusing for users.

(This iterative update within the Design System (GOV.UK Frontend) will also be updated on [GOV.UK Publishing Gem](https://components.publishing.service.gov.uk/component-guide/accordion))

## Visuals 
(Before: Left, After: Right)

https://github.com/alphagov/govuk-design-system/issues/1706

## Browser testing
- [x]  IE8
- [x]  IE9
- [x]  IE10
- [x]  IE11
- [x] Edge
- [x] Chrome
- [x] Chrome 400% zoom
- [x] Firefox
- [x] Firefox 300% zoom text only 
- [x] Safari
- [x] Safari (iOS)
- [x] Chrome (iOS)
- [x] Chrome (Android)
- [x] Samsung Internet (Android)

<details>
  <summary>Selected Results:</summary>

(Trigger warning: GIFs to follow [do not pause after 3 loops](https://www.w3.org/TR/WCAG20-TECHS/G152.html))

IE8
![IE8](https://user-images.githubusercontent.com/71266765/128702424-0c8b1e72-109a-40da-b613-fd31d769fcc8.gif)

IE9
![IE9](https://user-images.githubusercontent.com/71266765/128702430-5f8353bd-27a0-4e46-ba66-314856b290f5.gif)

IE10
![IE10](https://user-images.githubusercontent.com/71266765/128702434-d37ef672-fdc9-45a1-84e4-513ed66cb21f.gif)

IE11
![IE11](https://user-images.githubusercontent.com/71266765/128702438-8635cbe8-bb71-4e79-9d6c-e900eeb4713a.gif)

Edge

![Edge](https://user-images.githubusercontent.com/71266765/128703032-58402769-c9cc-4923-87f6-f4d5837a3b3a.gif)

Chrome zoom

https://user-images.githubusercontent.com/71266765/128702962-93db59b9-5a33-4675-9a95-5bacc5748d58.mov

Firefox Zoom-text only

https://user-images.githubusercontent.com/71266765/128702994-06028a6b-2f78-499b-a170-6f4e97f305dc.mov

Android Pixel 5 Chrome

![pixel-chrome](https://user-images.githubusercontent.com/71266765/128709525-38f52349-08a1-4c9f-9747-110bd5b700a0.gif)

Android Samsung 20 Chrome

![samsung-20-chrome](https://user-images.githubusercontent.com/71266765/128709613-37b2246f-249a-4470-aa5b-16d1f310ba8b.gif)

Android Samsung 20 Samsung Internet

![samsung-20-samsung](https://user-images.githubusercontent.com/71266765/128709652-409cd3bc-8086-4617-9fde-4f27199312b0.gif)

Safari macOS Catalina

![safari-13 1-macOS-catalina](https://user-images.githubusercontent.com/71266765/128703210-c8dac43a-0903-4ad5-9d2c-b1c5eb45da2e.gif)

Safari macOS BigSur

![safari-macOS-bigSur](https://user-images.githubusercontent.com/71266765/128703216-48ec07c2-afa8-4653-baca-2c5f6ad6e74c.gif)

iPadPro
![iOS-iPadPro11-2020](https://user-images.githubusercontent.com/71266765/128702539-899ac391-374b-4e35-8af9-00d29b23afd2.gif)

iPhone 11 Pro Max
![iOS-iPhone11ProMax](https://user-images.githubusercontent.com/71266765/128702544-c8fe9495-088c-4da6-9dce-d2b010ba8d88.gif)

iPhone 12
![iOS-iPhone12](https://user-images.githubusercontent.com/71266765/128702551-eb67fcbe-de49-4eb3-8d16-6a184a59d830.gif)

iPhone SE 2020
![iOS-iPhoneSE2020](https://user-images.githubusercontent.com/71266765/128702558-3903fb68-573e-487c-ae27-dd696f478649.gif)

Chrome - iPhone 12
![chrome-ios](https://user-images.githubusercontent.com/71266765/128718159-3376ea1f-3564-494a-a603-6318bc2a11d4.gif)


</details>

## Assistive Technology testing
- [x] JavaScript Disabled
- [x] CSS Disabled
- [x] CSS + JS Disabled
- [x] Voiceover / Safari (macOS Big Sur)
- [x] Voiceover / Safari (iOS 14.6)
- [x] NVDA 2020.3 / Firefox 88
- [x] NVDA 2020.3 / Chrome
- [x] JAWS 2020 / Chrome
- [x] JAWS 2020 / IE11
- [x] Windows Magnifier
- [x] Firefox (User preferred colours)
- [x] Chrome - Blurred vision, protanopia, deuteranopia, tritanopia and achromatopsia
- [x] Chrome (User preferred Colours (Increase contrast, Greyscale, Inverted colour, Inverted Greyscale, Yellow on black))
- [x] Windows High Contrast Modes - Chrome, IE, Edge

## Known issues

Untested
- [x] Talkback / Chrome 86 (Android 10)  
- [x] Dragon (speech recognition) \| 15 or later \| Internet Explorer 11*
- [x] Voiceover / Safari (iOS 12.1)

<details>
  <summary>Results:</summary>
  
JavaScript Disabled

![no-JS](https://user-images.githubusercontent.com/71266765/128702817-ff0e4e59-c05c-4fef-b24d-a938286f261d.png)

CSS Disabled

![no-CSS](https://user-images.githubusercontent.com/71266765/128702775-c94b1c22-d6a1-4d59-809a-aeeec60f098c.png)

CSS + JS  Disabled

![no-CSS-no-JS](https://user-images.githubusercontent.com/71266765/128702798-53bfd42b-b0fa-4aaa-b16b-7f08a49bc62f.png)

VoiceOver Safari

https://user-images.githubusercontent.com/71266765/128705909-0bc64625-b261-4c31-9c99-c021017fd49e.mov

VoiceOver iOS (14.6)*
*`main` landmark present in testing environment

https://user-images.githubusercontent.com/71266765/128704394-1677774e-ce8f-465d-8507-09a5a8be04d7.mp4

NVDA 2020.4 / Firefox 88

https://user-images.githubusercontent.com/71266765/128702866-fca26121-1966-4c1a-8a97-988c366d5696.mov

NVDA 2020.4 / Chrome

https://user-images.githubusercontent.com/71266765/128702849-3773d32e-2bc1-4f6e-b254-c70352cd5b4a.mov

JAWs / Chrome  

https://user-images.githubusercontent.com/71266765/128719445-c18b226a-8819-4f37-8e79-39761c8fec09.mov

JAWs / IE  

https://user-images.githubusercontent.com/71266765/128702743-7bba985d-1290-49de-8030-e41079e0717c.mov

Chrome (Blurred vision, protanopia, deuteranopia, tritanopia and achromatopsia)

https://user-images.githubusercontent.com/71266765/128707921-d4182bad-0597-4509-a2aa-5770f520a654.mov

Chrome (Increase contrast, Greyscale, Inverted colour, Inverted Greyscale, Yellow on black)

https://user-images.githubusercontent.com/71266765/128708277-2eb79045-8b67-4c05-9b8c-9273338138df.mov

Windows Magnifier

![Windows-magnifier](https://user-images.githubusercontent.com/71266765/128721094-6cf6e86f-423a-4aa3-bf02-97703d1928d3.gif)

Chrome (Windows High Contrast Modes)

https://user-images.githubusercontent.com/71266765/128722205-50df7a61-5660-4d8e-a024-a1e2458d2a7d.mov

Edge (Windows High Contrast Mode)

https://user-images.githubusercontent.com/71266765/128721473-748f30a9-20ce-48c8-87bd-c16cce52e439.mov

IE11 (Windows High Contrast Mode)

![Windows-high-contrast](https://user-images.githubusercontent.com/71266765/128703219-10857df0-ee31-449e-8915-166561eb7aed.gif)


</details>

## Anything else

**Breaking Change** as the [ID has now been removed from the summary element within the markup](https://github.com/alphagov/govuk-frontend/pull/2257/commits/fa572d331f030685df53923951cc5e0286b9c863)

### User preferred colours

[User's may adjust their colour schemes](https://accessibility.blog.gov.uk/2017/03/27/how-users-change-colours-on-websites/).  Testing with different colour schemes revealed some problems, having nested elements within a button [required additional adjustments](https://github.com/alphagov/govuk-frontend/commit/f258ce4e3cddc653e502193bedd32dab9a44787a) in order to improve the experience. 

There is further conversation about this use and [an opinion piece can be found here](https://kilianvalkhof.com/2021/css-html/prefers-contrast-forced-is-a-mistake/)
https://github.com/w3c/csswg-drafts/issues/5433#issuecomment-785251576

### NVDA fix

<details>
  <summary>Testing videos of NVDA</summary>

Before - the sections are broken up as user navigates.
Within reader-mode the user requires multiple keypresses to navigate, also the audio is heard in an disjointed manner.

![128227998-ea003a53-9492-4a86-863c-5303950a8783](https://user-images.githubusercontent.com/71266765/128982685-9d650c0f-ba5b-432a-be22-e8b389d942dd.gif)

After - read out as one whole block.

https://user-images.githubusercontent.com/71266765/128356759-b3be940f-bfd2-4aff-85cf-807a4e3a8807.mov

</details>

<details>
  <summary>Additional Details and screenshots:</summary>

The issue before:
![before](https://user-images.githubusercontent.com/71266765/123416396-662a3500-d5ae-11eb-94bf-fba1dbcbbf37.gif)

After:

![firefox-color2](https://user-images.githubusercontent.com/71266765/128706575-87caa406-86cf-43a7-8fad-3678d045750a.gif)

![firefox-color1](https://user-images.githubusercontent.com/71266765/128706587-2c704e37-2322-479c-8c11-6f8b0b918de7.gif)

---

To replicate:

`Firefox > preferences > Language and appearance > Colours`:
  
Update to high contrast scheme
![Screenshot 2021-06-22 at 11 02 43](https://user-images.githubusercontent.com/71266765/123416612-b1dcde80-d5ae-11eb-90e3-4da2f86bdd83.png)

Update to reduced contrast scheme

![image](https://user-images.githubusercontent.com/71266765/123416668-c6b97200-d5ae-11eb-8e59-6912788ba13d.png)

</details>

## Details of breaking change

- which users are affected: TBC
- the change that’s been made: TBC
- changes users will have to make: TBC
- impact of users not making those changes: TBC
