### PR TITLE
Clarify which npm user to login with for releases

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -79,7 +79,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 12. Checkout the **main** branch and pull the latest changes.
 
-13. Log into npm (`npm login`), using team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
+13. Log into npm (`npm login`), using the npm/govuk-patterns-and-tools team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
 
 14. Run `npm run publish-release`. You will now be prompted to continue or cancel.
 


### PR DESCRIPTION
## What
Make it clearer in the release docs which npm user we should be logging in as.

## Why
The original documentation linked to the relevant user/folder in the team credentials repo, but it's easy to miss and choose a different user (e.g: alphagov) by mistake.