### PR TITLE
Improve focus state for radio and checkbox controls in forced color mode (for example Windows High Contrast Mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2264: Improve focus state for radio and checkbox controls in forced color mode (for example Windows High Contrast Mode)](https://github.com/alphagov/govuk-frontend/pull/2264) – thanks to [@adamliptrot-oc](https://github.com/adamliptrot-oc) for reporting this issue.
+
 ## 3.13.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -122,6 +122,20 @@
   // Focused state
   .govuk-checkboxes__input:focus + .govuk-checkboxes__label:before {
     border-width: 4px;
+
+    // When colours are overridden, the yellow box-shadow becomes invisible
+    // which means the focus state is less obvious. By adding a transparent
+    // outline, which becomes solid (text-coloured) in that context, we ensure
+    // the focus remains clearly visible.
+    outline: $govuk-focus-width solid transparent;
+    outline-offset: 1px;
+
+    // When in an explicit forced-color mode, we can use the Highlight system
+    // color for the outline to better match focus states of native controls
+    @media screen and (forced-colors: active) {
+      outline-color: Highlight;
+    }
+
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -120,6 +120,20 @@
   // Focused state
   .govuk-radios__input:focus + .govuk-radios__label:before {
     border-width: 4px;
+
+    // When colours are overridden, the yellow box-shadow becomes invisible
+    // which means the focus state is less obvious. By adding a transparent
+    // outline, which becomes solid (text-coloured) in that context, we ensure
+    // the focus remains clearly visible.
+    outline: $govuk-focus-width solid transparent;
+    outline-offset: 1px;
+
+    // When in an explicit forced-color mode, we can use the Highlight system
+    // color for the outline to better match focus states of native controls
+    @media screen and (forced-colors: active) {
+      outline-color: Highlight;
+    }
+
     box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
   }
 


### PR DESCRIPTION
The focus state for radios and checkboxes is currently not very visible in high contrast mode or when colours are overridden in Firefox – the only visible change is that the outer border of the radio or checkbox control thickens from 2px to 4px. This is the same as the part of the focus state change that meets contrast, but omits the yellow ‘ring’ created by the box shadow.

Add an additional transparent outline to the control. In forced colors mode, transparent borders become solid (matching the text / foreground color) and so we get an additional outline around the focused control making it clearly visible.

When explicitly in forced-color mode, we can enhance the outline further by using the Highlight system color, which matches the color used by the focus state of native controls – at least in in Edge / Chrome / Opera which are the only other browsers to support forced color mode.

Fixes #2258

| Browser | Before | After |
|--|--|--|
| Internet Explorer 11 | ![ie-before](https://user-images.githubusercontent.com/121939/124159657-4f467f80-da93-11eb-84b6-1fb9c8792607.png) | ![ie-after](https://user-images.githubusercontent.com/121939/124159659-5077ac80-da93-11eb-9b57-b5f02f27a845.png) |
| Chrome | ![chrome-before](https://user-images.githubusercontent.com/121939/124159663-51a8d980-da93-11eb-9d10-5a4c1ec26635.png) | ![chrome-after](https://user-images.githubusercontent.com/121939/124159664-51a8d980-da93-11eb-8d7b-5acb3a634ade.png) |
| Edge | ![edge-before](https://user-images.githubusercontent.com/121939/124159669-52417000-da93-11eb-8b6f-ace9f5f31b98.png) | ![edge-after](https://user-images.githubusercontent.com/121939/124159668-52417000-da93-11eb-8ed2-d9ef247fc1b1.png)
| Firefox (High Contrast Mode) | ![ff-hcm-before](https://user-images.githubusercontent.com/121939/124159662-51104300-da93-11eb-8975-352a15e16c89.png) | ![ff-hcm-after](https://user-images.githubusercontent.com/121939/124159660-51104300-da93-11eb-9987-3be116e29148.png)
| Firefox ([Custom Colours](https://support.mozilla.org/en-US/kb/change-fonts-and-colors-websites-use)) | ![ff-custom-before](https://user-images.githubusercontent.com/121939/124159672-52da0680-da93-11eb-9acf-331f8e10b8c7.png) | ![ff-custom-after](https://user-images.githubusercontent.com/121939/124159670-52da0680-da93-11eb-98fb-ae313c269fa5.png) |

A native focused text input in Edge in High Contrast Mode, for comparison:

![Screenshot 2021-07-01 at 17 45 05](https://user-images.githubusercontent.com/121939/124160345-13f88080-da94-11eb-83dc-7d64ae7a0e23.png)