### PR TITLE
Don’t remove focus outline from disabled link buttons in forced color mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2264: Improve focus state for radio and checkbox controls in forced color mode (for example Windows High Contrast Mode)](https://github.com/alphagov/govuk-frontend/pull/2264) – thanks to [@adamliptrot-oc](https://github.com/adamliptrot-oc) for reporting this issue.
+- [#2265: Don’t remove focus outline from disabled link buttons in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2265)
 
 ## 3.13.0 (Feature release)
 

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -158,10 +158,6 @@
       cursor: default;
     }
 
-    &:focus {
-      outline: none;
-    }
-
     &:active {
       top: 0;
       box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0


### PR DESCRIPTION
SortSite flags this as a potential issue, referencing [WCAG 2.0 F78][1]:

> The CSS outline or border style on this element makes it difficult or impossible to see the dotted link focus outline.

We apply a 3px transparent outline to focused buttons, which becomes the visible focus indicator in forced color mode when the other focus state changes to the background and box shadow are not visible.

Adding the `--disabled` modifier to link buttons (`<a>` elements styled as buttons) does not remove them from the tab index or make them non-interactive. They are still focusable and outside of forced color mode retain the rest of the focus state. Removing the outline means that users in High Contrast Mode who focus the 'disabled' link button will not have a visible focus indicator.

This change should not affect buttons, as disabled buttons are not focusable and so the `:focus` pseudo-selector should never apply to them.

Outside of forced color mode there should be no visible change, as the outline is transparent.

## Before

![Screenshot 2021-07-09 at 10 15 45](https://user-images.githubusercontent.com/121939/125055369-05672600-e09f-11eb-8869-d17e3721e20c.png)

http://govuk-frontend-review.herokuapp.com/components/button/link-disabled/preview

## After

![Screenshot 2021-07-09 at 10 16 06](https://user-images.githubusercontent.com/121939/125055371-05ffbc80-e09f-11eb-845c-7321c5353edb.png)

https://govuk-frontend-pr-2265.herokuapp.com/components/button/link-disabled/preview

Fixes #2127

[1]: https://www.w3.org/TR/WCAG20-TECHS/F78.html