### PR TITLE
Fix style guide issues across macros content

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -2,11 +2,11 @@ params:
 - name: id
   type: string
   required: true
-  description: Must be **unique** across the domain of your service (as the expanded state of individual instances of the component persists across page loads using [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-labelledby` and `aria-control` attributes.
+  description: Must be unique across the domain of your service (as the expanded state of individual instances of the component persists across page loads using [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-labelledby` and `aria-control` attributes.
 - name: headingLevel
   type: integer
   required: false
-  description: Heading level, from 1 to 6. Default is `2`.
+  description: Heading level, from `1` to `6`. Default is `2`.
 - name: classes
   type: string
   required: false
@@ -203,4 +203,3 @@ examples:
           text: Section B
         content:
           text: Some content
-

--- a/src/govuk/components/back-link/back-link.yaml
+++ b/src/govuk/components/back-link/back-link.yaml
@@ -2,15 +2,15 @@ params:
 - name: text
   type: string
   required: false
-  description: Text to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to "Back".
+  description: Text to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to 'Back'.
 - name: html
   type: string
   required: false
-  description: HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to "Back".
+  description: HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to 'Back'.
 - name: href
   type: string
   required: true
-  description: The value of the link href attribute.
+  description: The value of the link's `href` attribute.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -2,7 +2,7 @@ params:
 - name: id
   type: string
   required: true
-  description: The id of the textarea.
+  description: The ID of the textarea.
 - name: name
   type: string
   required: true
@@ -45,12 +45,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: classes
   type: string
   required: false
@@ -62,16 +62,16 @@ params:
 - name: spellcheck
   type: boolean
   required: false
-  description: Optional field to enable or disable the spellcheck attribute on the character count.
+  description: Optional field to enable or disable the `spellcheck` attribute on the character count.
 - name: countMessage
   type: object
   required: false
-  description: Options for the count message
+  description: Options for the count message.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the count message
+    description: Classes to add to the count message.
 
 examples:
   - name: default

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -21,12 +21,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: idPrefix
   type: string
   required: false
@@ -51,7 +51,7 @@ params:
   - name: id
     type: string
     required: false
-    description: Specific id attribute for the checkbox item. If omitted, then component global `idPrefix` option will be applied.
+    description: Specific ID attribute for the checkbox item. If omitted, then component global `idPrefix` option will be applied.
   - name: name
     type: string
     required: false
@@ -73,15 +73,15 @@ params:
   - name: divider
     type: string
     required: false
-    description: Divider text to separate checkbox items, for example the text "or".
+    description: Divider text to separate checkbox items, for example the text 'or'.
   - name: checked
     type: boolean
     required: false
-    description: If true, checkbox will be checked.
+    description: If `true`, checkbox will be checked.
   - name: conditional
     type: boolean
     required: false
-    description: If true, content provided will be revealed when the item is checked.
+    description: If `true`, content provided will be revealed when the item is checked.
   - name: conditional.html
     type: string
     required: false
@@ -89,11 +89,11 @@ params:
   - name: behaviour
     type: string
     required: false
-    description: If set to `exclusive`, implements a "None of these" type behaviour via javascript when checkboxes are clicked
+    description: If set to `exclusive`, implements a 'None of these' type behaviour via JavaScript when checkboxes are clicked.
   - name: disabled
     type: boolean
     required: false
-    description: If true, checkbox will be disabled.
+    description: If `true`, checkbox will be disabled.
   - name: attributes
     type: object
     required: false

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -2,7 +2,7 @@ params:
 - name: ariaLabel
   type: string
   required: false
-  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all messages that the cookie banner includes. For example, the cookie message and the confirmation message. Defaults to "Cookie banner".
+  description: The text for the `aria-label` which labels the cookie banner region. This region applies to all messages that the cookie banner includes. For example, the cookie message and the confirmation message. Defaults to 'Cookie banner'.
 - name: hidden
   type: boolean
   required: false

--- a/src/govuk/components/date-input/date-input.yaml
+++ b/src/govuk/components/date-input/date-input.yaml
@@ -2,7 +2,7 @@ params:
 - name: id
   type: string
   required: true
-  description: This is used for the main component and to compose id attribute for each item.
+  description: This is used for the main component and to compose the ID attribute for each item.
 - name: namePrefix
   type: string
   required: false
@@ -15,7 +15,7 @@ params:
   - name: id
     type: string
     required: false
-    description: Item-specific id. If provided, it will be used instead of the generated id.
+    description: Item-specific ID. If provided, it will be used instead of the generated ID.
   - name: name
     type: string
     required: true
@@ -31,7 +31,7 @@ params:
   - name: autocomplete
     type: string
     required: false
-    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "bday-day". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance `bday-day`. See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
   - name: pattern
     type: string
     required: false
@@ -57,12 +57,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: fieldset
   type: object
   required: false

--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -18,11 +18,11 @@ params:
 - name: id
   type: string
   required: false
-  description: Id to add to the details element.
+  description: ID to add to the details element.
 - name: open
   type: boolean
   required: false
-  description: If true, details element will be expanded.
+  description: If `true`, details element will be expanded.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -10,7 +10,7 @@ params:
 - name: id
   type: string
   required: false
-  description: Id attribute to add to the error message span tag.
+  description: ID attribute to add to the error message span tag.
 - name: classes
   type: string
   required: false
@@ -18,11 +18,11 @@ params:
 - name: attributes
   type: object
   required: false
-  description: HTML attributes (for example data attributes) to add to the error message span tag
+  description: HTML attributes (for example data attributes) to add to the error message span tag.
 - name: visuallyHiddenText
   type: string
   required: false
-  description: A visually hidden prefix used before the error message. Defaults to "Error".
+  description: A visually hidden prefix used before the error message. Defaults to 'Error'.
 
 accessibilityCriteria: |
   When used with a single input, the error message MUST:

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -6,11 +6,11 @@ params:
 - name: id
   type: string
   required: true
-  description: The id of the input
+  description: The ID of the input.
 - name: value
   type: string
   required: false
-  description: Optional initial value of the input
+  description: Optional initial value of the input.
 - name: describedBy
   type: string
   required: false
@@ -33,12 +33,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -7,7 +7,7 @@ params:
   - name: visuallyHiddenTitle
     type: string
     required: false
-    description: Title for a meta item section, which defaults to Support links
+    description: Title for a meta item section. Defaults to 'Support links'.
   - name: html
     type: string
     required: false
@@ -41,7 +41,7 @@ params:
   - name: title
     type: string
     required: true
-    description: Title for a section
+    description: Title for a section.
   - name: columns
     type: integer
     required: false

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -2,7 +2,7 @@ params:
 - name: homepageUrl
   type: string
   required: false
-  description: The url of the homepage. Defaults to /
+  description: The URL of the homepage. Defaults to `/`
 - name: assetsPath
   type: string
   required: false
@@ -10,7 +10,7 @@ params:
 - name: productName
   type: string
   required: false
-  description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use serviceName.
+  description: Product name, used when the product name follows on directly from ‘GOV.UK’. For example, GOV.UK Pay or GOV.UK Design System. In most circumstances, you should use `serviceName`.
 - name: serviceName
   type: string
   required: false
@@ -18,7 +18,7 @@ params:
 - name: serviceUrl
   type: string
   required: false
-  description: Url for the service name anchor.
+  description: URL for the service name anchor.
 - name: navigation
   type: array
   required: false
@@ -35,7 +35,7 @@ params:
   - name: href
     type: string
     required: false
-    description: Url of the navigation item anchor.
+    description: URL of the navigation item anchor.
   - name: active
     type: boolean
     required: false
@@ -51,11 +51,11 @@ params:
 - name: navigationLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the navigation. Defaults to "Navigation menu".
+  description: Text for the `aria-label` attribute of the navigation. Defaults to 'Navigation menu'.
 - name: menuButtonLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to "Show or hide navigation menu".
+  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide navigation menu'.
 - name: containerClasses
   type: string
   required: false

--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -10,7 +10,7 @@ params:
 - name: id
   type: string
   required: false
-  description: Optional id attribute to add to the hint span tag.
+  description: Optional ID attribute to add to the hint span tag.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -2,7 +2,7 @@ params:
 - name: id
   type: string
   required: true
-  description: The id of the input.
+  description: The ID of the input.
 - name: name
   type: string
   required: true
@@ -10,7 +10,7 @@ params:
 - name: type
   type: string
   required: false
-  description: Type of input control to render. Defaults to "text".
+  description: Type of input control to render. Defaults to `text`.
 - name: inputmode
   type: string
   required: false
@@ -67,11 +67,11 @@ params:
     - name: text
       type: string
       required: true
-      description: Required. If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
     - name: html
       type: string
       required: true
-      description: Required. If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
     - name: classes
       type: string
       required: false
@@ -83,12 +83,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: classes
   type: string
   required: false
@@ -104,7 +104,7 @@ params:
 - name: spellcheck
   type: boolean
   required: false
-  description: Optional field to enable or disable the spellcheck attribute on the input.
+  description: Optional field to enable or disable the `spellcheck` attribute on the input.
 - name: attributes
   type: object
   required: false

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -10,7 +10,7 @@ params:
 - name: id
   type: string
   required: false
-  description: Id attribute to add to the inset text container.
+  description: ID attribute to add to the inset text container.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/label/label.yaml
+++ b/src/govuk/components/label/label.yaml
@@ -10,7 +10,7 @@ params:
 - name: for
   type: string
   required: false
-  description: The value of the for attribute, the id of the input the label is associated with.
+  description: The value of the `for` attribute, the ID of the input the label is associated with.
 - name: isPageHeading
   type: boolean
   required: false

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -10,7 +10,7 @@ params:
 - name: headingLevel
   type: integer
   required: false
-  description: Heading level, from 1 to 6. Default is 1.
+  description: Heading level, from `1` to `6`. Default is `1`.
 - name: text
   type: string
   required: true

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -17,16 +17,16 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: idPrefix
   type: string
   required: false
-  description: String to prefix id for each radio item if no id is specified on each item. If `idPrefix` is not passed, fallback to using the name attribute instead.
+  description: String to prefix ID for each radio item if no ID is specified on each item. If `idPrefix` is not passed, fallback to using the `name` attribute instead.
 - name: name
   type: string
   required: true
@@ -47,7 +47,7 @@ params:
   - name: id
     type: string
     required: false
-    description: Specific id attribute for the radio item. If omitted, then `idPrefix` string will be applied.
+    description: Specific ID attribute for the radio item. If omitted, then `idPrefix` string will be applied.
   - name: value
     type: string
     required: true
@@ -65,15 +65,15 @@ params:
   - name: divider
     type: string
     required: false
-    description: Divider text to separate radio items, for example the text "or".
+    description: Divider text to separate radio items, for example the text 'or'.
   - name: checked
     type: boolean
     required: false
-    description: If true, radio will be checked.
+    description: If `true`, radio will be checked.
   - name: conditional
     type: string
     required: false
-    description: If true, content provided will be revealed when the item is checked.
+    description: If `true`, content provided will be revealed when the item is checked.
   - name: conditional.html
     type: html
     required: false
@@ -81,7 +81,7 @@ params:
   - name: disabled
     type: boolean
     required: false
-    description: If true, radio will be disabled.
+    description: If `true`, radio will be disabled.
   - name: attributes
     type: object
     required: false

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -2,7 +2,7 @@ params:
 - name: id
   type: string
   required: true
-  description: Id for each select box.
+  description: ID for each select box.
 - name: name
   type: string
   required: true
@@ -54,12 +54,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -7,7 +7,7 @@ params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the row `div`
+    description: Classes to add to the row `div`.
   - name: key.text
     type: string
     required: true
@@ -18,7 +18,7 @@ params:
   - name: key.classes
     type: string
     required: false
-    description: Classes to add to the key wrapper
+    description: Classes to add to the key wrapper.
   - name: value.text
     type: string
     required: true
@@ -30,20 +30,20 @@ params:
   - name: value.classes
     type: string
     required: false
-    description: Classes to add to the value wrapper
+    description: Classes to add to the value wrapper.
   - name: actions.classes
     type: string
     required: false
-    description: Classes to add to the actions wrapper
+    description: Classes to add to the actions wrapper.
   - name: actions.items
     type: array
     required: false
-    description: Array of action item objects
+    description: Array of action item objects.
     params:
     - name: href
       type: string
       required: true
-      description: The value of the link href attribute for an action item
+      description: The value of the link's `href` attribute for an action item.
     - name: text
       type: string
       required: true
@@ -55,7 +55,7 @@ params:
     - name: visuallyHiddenText
       type: string
       required: false
-      description: Actions rely on context from the surrounding content so may require additional accessible text, text supplied to this option is appended to the end, use `html` for more complicated scenarios.
+      description: Actions rely on context from the surrounding content so may require additional accessible text. Text supplied to this option is appended to the end. Use `html` for more complicated scenarios.
     - name: classes
       type: string
       required: false
@@ -694,4 +694,3 @@ examples:
           value:
             text: Firstname Lastname
           classes: app-custom-class
-

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -2,15 +2,15 @@ params:
 - name: id
   type: string
   required: false
-  description: This is used for the main component and to compose id attribute for each item.
+  description: This is used for the main component and to compose the ID attribute for each item.
 - name: idPrefix
   type: string
   required: false
-  description: String to prefix id for each tab item if no id is specified on each item
+  description: String to prefix id for each tab item if no id is specified on each item.
 - name: title
   type: string
   required: false
-  description: Title for the tabs table of contents
+  description: Title for the tabs table of contents.
 - name: items
   type: array
   required: true
@@ -19,7 +19,7 @@ params:
   - name: id
     type: string
     required: true
-    description: Specific id attribute for the tab item. If omitted, then `idPrefix` string is required instead.
+    description: Specific ID attribute for the tab item. If omitted, then `idPrefix` string is required instead.
   - name: label
     type: string
     required: true
@@ -320,5 +320,3 @@ examples:
           id: tab-2
           panel:
             html: <p>Panel 2 content</p>
-
-

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -2,7 +2,7 @@ params:
 - name: id
   type: string
   required: true
-  description: The id of the textarea.
+  description: The ID of the textarea.
 - name: name
   type: string
   required: true
@@ -10,7 +10,7 @@ params:
 - name: spellcheck
   type: boolean
   required: false
-  description: Optional field to enable or disable the spellcheck attribute on the textarea.
+  description: Optional field to enable or disable the `spellcheck` attribute on the textarea.
 - name: rows
   type: string
   required: false
@@ -41,12 +41,12 @@ params:
 - name: formGroup
   type: object
   required: false
-  description: Options for the form-group wrapper
+  description: Options for the form-group wrapper.
   params:
   - name: classes
     type: string
     required: false
-    description: Classes to add to the form group (for example to show error state for the whole group)
+    description: Classes to add to the form group (for example to show error state for the whole group).
 - name: classes
   type: string
   required: false
@@ -54,7 +54,7 @@ params:
 - name: autocomplete
   type: string
   required: false
-  description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for instance "postal-code" or "username". See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+  description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for example `postal-code` or `username`. See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
 - name: attributes
   type: object
   required: false


### PR DESCRIPTION
This PR fixes various style guide issues that occur across our macros content:

- some tables display 'id' instead of 'ID'
- some sentences need full stops
- double quotes sometimes display where single quotes should display
- mentions of attributes need to display in code format
- bolding should not be used for emphasis, only for mentions of UI text