### PR TITLE
Fix invisible footer OGL logo in forced color mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2264: Improve focus state for radio and checkbox controls in forced color mode (for example Windows High Contrast Mode)](https://github.com/alphagov/govuk-frontend/pull/2264) – thanks to [@adamliptrot-oc](https://github.com/adamliptrot-oc) for reporting this issue.
 - [#2265: Don’t remove focus outline from disabled link buttons in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2265)
+- [#2273: Fix invisible footer OGL logo in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2273) – thanks to [@oscarduignan](https://github.com/oscarduignan) for reporting this issue.
 
 ## 3.13.0 (Feature release)
 

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -95,6 +95,9 @@
       margin-bottom: govuk-spacing(3);
     }
     vertical-align: top;
+    // Work around SVGs not inheriting color from parent in forced color mode
+    // (https://github.com/w3c/csswg-drafts/issues/6310)
+    forced-color-adjust: auto;
   }
 
   .govuk-footer__licence-description {


### PR DESCRIPTION
When forced color mode was introduced in Chrome 89, the default user agent styles for SVGs were set to `forced-color-adjust: none` in line with [the CSS Color Adjustment specification at the time][1]. Unfortunately, this means that using currentColor for stroke and fill in SVGs no longer works as expected in forced color mode.

As per the comment in [Chromium bug #1164162][2]:

> This is the result of one of the recent spec changes. The spec was updated to force colors at used value time rather than computed value time, which means elements that have "forced-color-adjust: none" set (like svg elements) will inherit their non-forced color values, resulting in a different currentcolor used for stroke and fill in this case than you would get if forcing was done at computed value time.
>
> See spec issue resolution for more details: https://github.com/w3c/csswg-drafts/issues/4915

It looks like this has since been [flagged as an issue with the CSS working group][3] and [the spec has been updated to resolve it][4] but it’s going to take a while before that change is reflected in browsers.

In the meantime, we can [explicitly set `forced-color-adjust: auto` on the OGL logo in order for it to correctly inherit the color from the parent][5].

|  Theme | Before | After |
| -- | -- | -- |
| Black | ![hcm-dark-before](https://user-images.githubusercontent.com/121939/125050743-2a0ccf00-e09a-11eb-86a9-74bcd56ededb.png) | ![hcm-dark-after](https://user-images.githubusercontent.com/121939/125050750-2c6f2900-e09a-11eb-8e57-3aae3bd57db7.png) |
| White | ![hcm-light-before](https://user-images.githubusercontent.com/121939/125050748-2aa56580-e09a-11eb-87fb-0cc83bca45ef.png) | ![hcm-light-after](https://user-images.githubusercontent.com/121939/125050752-2c6f2900-e09a-11eb-8e6a-751f357b6bdd.png) |
| # 1 | ![hcm-1-before](https://user-images.githubusercontent.com/121939/125051198-a0a9cc80-e09a-11eb-8cbb-9f6a5c87588b.png) | ![hcm-1-after](https://user-images.githubusercontent.com/121939/125051196-a0113600-e09a-11eb-8950-561362e573b6.png) |
| # 2 | ![hcm-2-before](https://user-images.githubusercontent.com/121939/125051224-a8697100-e09a-11eb-8a3b-f5100d82d8a0.png) | ![hcm-2-after](https://user-images.githubusercontent.com/121939/125051223-a8697100-e09a-11eb-887b-49454dbfe412.png) |


Once Chromium has been updated so that the default UA styles for SVGs use the new `forced-color-adjust: preserve-parent-color` keyword, and traffic to older versions has dropped off, we can then consider removing this.

Fixes #2272 

[1]: https://www.w3.org/TR/2021/WD-css-color-adjust-1-20210520/#forced-color-adjust-prop
[2]: https://bugs.chromium.org/p/chromium/issues/detail?id=1164162#c4
[3]: https://github.com/w3c/csswg-drafts/issues/6310
[4]: https://www.w3.org/TR/2021/WD-css-color-adjust-1-20210616/#forced-color-adjust-prop
[5]: https://github.com/w3c/csswg-drafts/issues/6310#issuecomment-852526453