### PR TITLE
Fix invisible start button chevron in forced color mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2264: Improve focus state for radio and checkbox controls in forced color mode (for example Windows High Contrast Mode)](https://github.com/alphagov/govuk-frontend/pull/2264) – thanks to [@adamliptrot-oc](https://github.com/adamliptrot-oc) for reporting this issue.
 - [#2265: Don’t remove focus outline from disabled link buttons in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2265)
 - [#2273: Fix invisible footer OGL logo in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2273) – thanks to [@oscarduignan](https://github.com/oscarduignan) for reporting this issue.
+- [#2275: Fix invisible start button chevron in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2275)
 
 ## 3.13.0 (Feature release)
 

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -250,6 +250,9 @@
     vertical-align: middle;
     flex-shrink: 0;
     align-self: center;
+    // Work around SVGs not inheriting color from parent in forced color mode
+    // (https://github.com/w3c/csswg-drafts/issues/6310)
+    forced-color-adjust: auto;
   }
 
   @if $govuk-use-legacy-font {


### PR DESCRIPTION
When forced color mode was introduced in Chrome 89, the default user agent styles for SVGs were set to `forced-color-adjust: none` in line with [the CSS Color Adjustment specification at the time][1]. Unfortunately, this means that using currentColor for stroke and fill in SVGs no longer works as expected in forced color mode.

As per the comment in [Chromium bug #1164162][2]:

> This is the result of one of the recent spec changes. The spec was updated to force colors at used value time rather than computed value time, which means elements that have "forced-color-adjust: none" set (like svg elements) will inherit their non-forced color values, resulting in a different currentcolor used for stroke and fill in this case than you would get if forcing was done at computed value time.
>
> See spec issue resolution for more details: https://github.com/w3c/csswg-drafts/issues/4915

It looks like this has since been [flagged as an issue with the CSS working group][3] and the [spec has been updated to resolve it][4] but it’s going to take a while before that change is reflected in browsers.

In the meantime, we can [explicitly set `forced-color-adjust: auto` on the chevron SVG in order for it to correctly inherit the color from the parent][5]. This mimics the fix for the OGL logo in the footer made in 850c0b7 (#2273).

## Start link buttons

|  Theme | Before | After |
| -- | -- | -- |
| Black |  ![b before](https://user-images.githubusercontent.com/121939/125807048-79fecb6d-cf04-4da9-8590-2110913fcd5e.png) | ![b after](https://user-images.githubusercontent.com/121939/125807047-ddcdde38-dcde-4552-a1cb-832bdb078533.png) |
| White | ![w before](https://user-images.githubusercontent.com/121939/125807052-3204bee9-4ad4-4602-972b-0bb0b3283d6a.png) | ![w after](https://user-images.githubusercontent.com/121939/125807051-b5fdc33a-32cd-44d8-a5c1-cdf9bcbf5995.png) |
| # 1 | ![1 before](https://user-images.githubusercontent.com/121939/125807043-124a881b-93e2-4679-9071-762af1c417b1.png) | ![1 after](https://user-images.githubusercontent.com/121939/125807040-4efc3b9e-c01f-4340-8158-5d4adf48c4a3.png) |
| # 2 | ![2 before](https://user-images.githubusercontent.com/121939/125807046-279de89b-9054-4e5a-b939-5a4da98585fe.png) | ![2 after](https://user-images.githubusercontent.com/121939/125807045-05b4c54c-04b4-42d8-859d-9b1ecaed2d13.png) |

## Start Buttons

|  Theme | Before | After |
| -- | -- | -- |
| Black | ![b before](https://user-images.githubusercontent.com/121939/125806847-55eddad4-d2e0-4709-9e55-b3b10675643e.png) | ![b after](https://user-images.githubusercontent.com/121939/125806846-7edb2f5d-9b47-496d-9a50-ce91c25512a2.png) |
| White | ![w before](https://user-images.githubusercontent.com/121939/125806851-c80ca081-db88-4708-9a0e-1d6eaa37b438.png) | ![w after](https://user-images.githubusercontent.com/121939/125806850-f80cea70-7667-422d-b4db-451a5810172d.png) |
| # 1 | ![1 before](https://user-images.githubusercontent.com/121939/125806839-103a93e2-c350-4a83-87a8-216fbdf9c036.png) | ![1 after](https://user-images.githubusercontent.com/121939/125806836-d6c66c8f-fe10-4200-8d32-cbb37cd953c3.png) |
| # 2 | ![2 before](https://user-images.githubusercontent.com/121939/125806843-21c75b64-ef7b-4163-9156-26ece01950b1.png) | ![2 after](https://user-images.githubusercontent.com/121939/125806840-e1f80e3a-e4b1-4f25-bfd2-65afcefdf4d1.png) |



Once Chromium has been updated so that the default UA styles for SVGs use the new `forced-color-adjust: preserve-parent-color` keyword, and traffic to older versions has dropped off, we can then consider removing this.

[1]: https://www.w3.org/TR/2021/WD-css-color-adjust-1-20210520/#forced-color-adjust-prop
[2]: https://bugs.chromium.org/p/chromium/issues/detail?id=1164162#c4
[3]: https://github.com/w3c/csswg-drafts/issues/6310
[4]: https://www.w3.org/TR/2021/WD-css-color-adjust-1-20210616/#forced-color-adjust-prop
[5]: https://github.com/w3c/csswg-drafts/issues/6310#issuecomment-852526453