### PR TITLE
Add example of non-link start now button

### DIFF
--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -65,6 +65,10 @@ examples:
     text: Disabled link button
     href: '/'
     disabled: true
+- name: start
+  data:
+    text: Start now button
+    isStartButton: true
 - name: start link
   data:
     text: Start now link button


### PR DESCRIPTION
This is unlikely to be used in many contexts – as start buttons are normally used on GOV.UK as links in the context of a start page. Howver, this is a possible combination that should probably be included in the review app. For example, when testing changes to high contrast mode it’s important to see how the inline SVG appears against a button control.