### PR TITLE
Update link to GitHub help on watching repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If you get a warning from a linter or accessibility checker, check our list of [
 
 To be notified when there’s a new release, you can either:
 
-- [watch the govuk-frontend Github repository](https://help.github.com/en/articles/watching-and-unwatching-repositories)
+- [watch the govuk-frontend Github repository](https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/setting-up-notifications/configuring-notifications#configuring-your-watch-settings-for-an-individual-repository)
 - join the [#govuk-design-system channel on cross-government Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
 
 Find out how to [update with npm](https://frontend.design-system.service.gov.uk/updating-with-npm/).


### PR DESCRIPTION
The link to 'watch the govuk-frontend Github repository' used to take you to [a page in GitHub help that told you how to watch a repository][1].

However, GitHub has since restructured their help and the same link currently redirects you to [a page that's focused on reviewing your existing subscriptions, for example if you're getting too many notifications][2].

This isn't the right place to take people when we want to help them watch our repo, so update the link to take them to the latest documentation on setting up notifications instead.

[1]: http://web.archive.org/web/20190616163345/https://help.github.com/en/articles/watching-and-unwatching-repositories
[2]: https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/managing-subscriptions-for-activity-on-github/viewing-your-subscriptions