### PR TITLE
Fix typo in summary list example

### DIFF
--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -396,7 +396,7 @@ examples:
               - href: '#'
                 text: Point
               - href: '#'
-                text: Coom
+                text: Zoom
               - href: '#'
                 text: Press
               - href: '#'


### PR DESCRIPTION
Coom -> Zoom [[1]]

[1]: https://genius.com/Daft-punk-technologic-lyrics

Thanks to @joelanman for spotting this.