### PR TITLE
Fix font-size when Chrome autofills text inputs

### DIFF
--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -39,6 +39,10 @@
         border-width: $govuk-border-width-form-element * 2;
       }
     }
+
+    &::-webkit-autofill::first-line {
+      @include govuk-font($size: 19);
+    }
   }
 
   .govuk-input::-webkit-outer-spin-button,


### PR DESCRIPTION
For some reason Chrome decides that using its own font declaration is preferable to keeping the input looking as it would without autofill.

This overrides that with GOV.UK Frontend’s bigger, better, default font.

Before | After
---|---
![image](https://user-images.githubusercontent.com/355079/91546162-ef82c380-e919-11ea-80ca-cccc2e6ade6a.png) | ![image](https://user-images.githubusercontent.com/355079/91546232-09240b00-e91a-11ea-8c37-fa4372f2f731.png)

Copied from https://github.com/alphagov/notifications-admin/pull/3602
