### PR TITLE
Improve support for IE11 with Windows High Contrast Mode 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2265: Don’t remove focus outline from disabled link buttons in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2265)
 - [#2273: Fix invisible footer OGL logo in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2273) – thanks to [@oscarduignan](https://github.com/oscarduignan) for reporting this issue.
 - [#2277: Fix invisible start button chevron in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2277)
+- [#2290: Improve support for IE11 with Windows High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/2290)
 
 ## 3.13.0 (Feature release)
 

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -132,7 +132,7 @@
 
     // When in an explicit forced-color mode, we can use the Highlight system
     // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active) {
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
       outline-color: Highlight;
     }
 

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -130,7 +130,7 @@
 
     // When in an explicit forced-color mode, we can use the Highlight system
     // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active) {
+    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
       outline-color: Highlight;
     }
 


### PR DESCRIPTION
This PR adds support for IE11 to the previous Windows High Contrast Mode fixes in PR https://github.com/alphagov/govuk-frontend/pull/2264.

Internet Explorer 11 doesn't support the [`forced-colors` media feature](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/forced-colors) or the [`forced-color-adjust` property](https://developer.mozilla.org/en-US/docs/Web/CSS/forced-color-adjust), but it has equivalents in [`-ms-high-contrast`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/-ms-high-contrast) and [`-ms-high-contrast-adjust`](https://docs.microsoft.com/en-us/previous-versions/hh771863(v=vs.85)). We can use those CSS features to extend fixes to high contrast mode that previously only worked on more modern browsers.

| Fix | Before | After |
|--|--|--|
| [Form control focus states](https://github.com/alphagov/govuk-frontend/pull/2264) | <img width="998" alt="Screenshot of focus controls in Internet Explorer 11 before change" src="https://user-images.githubusercontent.com/503614/130039633-0dacc620-baad-408c-aec1-6d9c290618f2.png"> | <img width="1001" alt="Screenshot of focus controls in Internet Explorer 11 before change" src="https://user-images.githubusercontent.com/503614/130039913-b916eebe-ea02-4402-a341-17895cecfcb1.png"> |

---

There are a couple of other places in our codebase where we have fixes for forced color mode (see PRs https://github.com/alphagov/govuk-frontend/pull/2186, https://github.com/alphagov/govuk-frontend/pull/2237), but the problems they fix don't seem to be present in IE11 (I think because it doesn't have a readability backplate), so I left those lines alone.