### PR TITLE
Fix test isolation of accordion component tests

### DIFF
--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -38,6 +38,11 @@ describe('/components/accordion', () => {
     })
 
     describe('when JavaScript is available', () => {
+      afterEach(async () => {
+        // clear accordion state
+        await page.evaluate(() => window.sessionStorage.clear())
+      })
+
       it('should indicate that the sections are not expanded', async () => {
         await page.goto(baseUrl + '/components/accordion/preview', { waitUntil: 'load' })
 


### PR DESCRIPTION
The unit tests for the accordion component can interfere with each other, because within a test suite Puppeteer browser instances are shared, and the accordion component has state stored in the browser session storage. This is especially a problem for any tests after `it('should maintain the expanded state after a page refresh')`, which leaves all the accordion sections opened.

This PR adds a simple teardown function to clear the session storage after each test. It just so happens that our current tests behave the same and still pass with the teardown function, but we should fix this problem now, to prevent any future tests from being affected by the state of our current tests, such as for the accordion design refresh in PR #2257 (which is how this problem was discovered in the first place).

---

We should look at test isolation in general for this repo, but that is a bigger task for a different day; this PR is just to make sure we fix the thing we know to be an active issue.