### PR TITLE
Create resize-text-in-browsers.md

### DIFF
--- a/docs/contributing/resize-text-in-browsers.md
+++ b/docs/contributing/resize-text-in-browsers.md
@@ -1,0 +1,71 @@
+# Resize text in browsers
+
+When building components, you should check that the text:
+
+- resizes with the page and does not stay a fixed size
+- stays within its containers (for example, a box or banner)
+
+If text spills outside of its container, your component:
+
+- will look wrong
+- may not work, if the text blocks out an interactive element
+- may make some text hard for users to read
+
+Follow these instructions to test the effect of resizing text within different browsers and devices. Please note some browsers may work slightly differently, depending on their version.
+
+## Resize text in Firefox
+
+You can resize text in Firefox in 2 ways.
+
+### Use Zoom text only to resize text
+
+1. On the menu bar, select **Firefox**.
+2. Select **Preferences**.
+3. Under **Language and appearance - Zoom**, select **Zoom text only**. This option lets you zoom in or out only on the webpage text. It does not affect images or any other page elements.
+4. Press **Command** (Mac) or **Ctrl** (other operating systems), then **+** or **-** to increase or decrease the text size.
+
+### Use the Size dropdown to resize text
+
+1. On the menu bar, select **Firefox**.
+2. Select **Preferences**.
+3. Under **Language and appearance - Fonts and Colors**, select the **Size** dropdown to display font size options.
+
+## Resize text in Google Chrome
+
+1. On the URL bar, select the 3 dots icon.
+2. Select **Settings**.
+3. Select **Appearance**.
+4. Select **Customise fonts**. The screen displays the options for you to change the font size.
+
+## Resize text in Chrome or Firefox for Android
+
+1. Select **Settings**. 
+2. Select **Accessibility**.
+3. Drag the **Text scaling** slider until you're happy with the size of the example text.
+
+## Resize text in Internet Explorer versions 8 to 11
+
+1. Press **Alt** to display the menu bar. 
+2. On the menu bar, select **View**.
+3. Select **Text size** to display resizing options.
+
+## Resize text in Microsoft Edge
+
+1. On the URL bar, select the 3 dots icon.
+2. Select **Settings**.
+3. Select **Appearance**.
+4. Scroll down to **Fonts** and select the **Font size** dropdown to display font size options.
+
+## Resize text in Safari
+
+1. Press **Option**.
+2. While still pressing **Option**, select the **View** menu.
+3. Select **Make Text Bigger** or **Make Text Smaller**. To display the text in its original size again, select **Actual Size**.
+
+## Known issue: no text resizing in iOS
+
+You cannot resize the text for GOV.UK Design System styles in iOS. 
+
+Due to iOS constraints, our styles do not support adjusting the base font size on iOS devices.
+
+For more details, see our [GitHub issue #882: Investigate Dynamic Type to improve accessibility for iOS users](https://github.com/alphagov/govuk-frontend/issues/882).


### PR DESCRIPTION
## What we're adding

This PR fixes [#2294](https://github.com/alphagov/govuk-frontend/issues/2294) and adds a new document ('Resize text in browsers') to the ['Contributing' folder in our Frontend repo](https://github.com/alphagov/govuk-frontend/tree/main/docs/contributing).

## Why we're adding it

Before users can successfully submit a component to the GOV.UK Design System, they need to make sure the component's text displays correctly when resized in different browsers. So, we created this doc to tell them the necessary steps in Chrome, Firefox, Internet Explorer, etc.

## Origin of browser instructions

In the future, we may need to update the doc's content because of changes in browser functionality. If so, then we can adapt content from these links:

- [Firefox](https://support.mozilla.org/en-US/kb/font-size-and-zoom-increase-size-of-web-pages#w_how-to-only-change-the-size-of-the-text)
- [Google Chrome](https://support.google.com/chrome/answer/96810?hl=en-GB&co=GENIE.Platform%3DDesktop)
- [Internet Explorer](https://support.microsoft.com/en-us/windows/internet-explorer-ease-of-access-options-037270c1-db10-7ca8-ccba-ebd83ea6ace9#:~:text=Open%20Internet%20Explorer%20and%20press,the%20size%20on%20the%20screen.)
- [Microsoft Edge](https://support.microsoft.com/en-us/microsoft-edge/increase-default-text-size-in-microsoft-edge-c62f80af-381d-0716-25a3-c4856dd3806c)
- [Safari](https://support.apple.com/en-gb/HT207209)