### PR TITLE
Add link from testing doc to resize-text doc

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -59,7 +59,7 @@ If you've created a new component, create a new `src/govuk/<COMPONENT>/<COMPONEN
 You should test that your contribution works:
 
 - in [Internet Explorer 8](https://frontend.design-system.service.gov.uk/supporting-ie8/), 9 and 10 - components do not need to look perfect
-- in [recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in)
+- in [recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in), including when you [resize text](/docs/contributing/resize-text-in-browsers.md)
 - when your users [override colours in Windows, Firefox and Chrome](https://accessibility.blog.gov.uk/2018/08/01/supporting-users-who-change-colours-on-gov-uk/)
 - with [recommended assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#what-to-test)
 


### PR DESCRIPTION
## What we've changed

This PR adds a link from our [Frontend testing doc](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/testing.md) to our [doc about resizing text in browsers](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/resize-text-in-browsers.md).

Fixes [#2296](https://github.com/alphagov/govuk-frontend/issues/2296).

## Why we've changed it

We recently created the text-resize doc to help users test their contributions. See [#2294](https://github.com/alphagov/govuk-frontend/issues/2294) for more details. We thought navigation between the 2 docs could help users to quickly find information they need.