### PR TITLE
Fix American English in Sass docs Colour section

### DIFF
--- a/src/govuk/helpers/_colour.scss
+++ b/src/govuk/helpers/_colour.scss
@@ -75,7 +75,7 @@
 /// Make a colour darker by mixing it with black
 ///
 /// @param {Colour} $colour - colour to shade
-/// @param {Number} $percentage - percentage of `$colour` in returned color
+/// @param {Number} $percentage - percentage of `$colour` in returned colour
 /// @return {Colour}
 /// @access public
 
@@ -86,7 +86,7 @@
 /// Make a colour lighter by mixing it with white
 ///
 /// @param {Colour} $colour - colour to tint
-/// @param {Number} $percentage - percentage of `$colour` in returned color
+/// @param {Number} $percentage - percentage of `$colour` in returned colour
 /// @return {Colour}
 /// @access public
 


### PR DESCRIPTION
This PR fixes 2 instances of American English spelling in the ['Colour' section of our Sass docs](https://frontend.design-system.service.gov.uk/sass-api-reference/#colour).

Both occur in ordinary text within tables. They stand out from the British English spellings beside them.