### PR TITLE
Remove padding-right from details element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2273: Fix invisible footer OGL logo in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2273) – thanks to [@oscarduignan](https://github.com/oscarduignan) for reporting this issue.
 - [#2277: Fix invisible start button chevron in forced color mode](https://github.com/alphagov/govuk-frontend/pull/2277)
 - [#2290: Improve support for IE11 with Windows High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/2290)
+- [#2312: Remove padding-right from details element](https://github.com/alphagov/govuk-frontend/pull/2312)
 
 ## 3.13.0 (Feature release)
 

--- a/src/govuk/components/details/_index.scss
+++ b/src/govuk/components/details/_index.scss
@@ -71,7 +71,8 @@
   }
 
   .govuk-details__text {
-    padding: govuk-spacing(3);
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(3);
     padding-left: govuk-spacing(4);
     border-left: $govuk-border-width solid $govuk-border-colour;
   }


### PR DESCRIPTION
The details element doesn't need `padding-right` - having it will mean contents don't line up nicely with the rest of the page.

| Browser | Before |	After |
|---|---|---|
| Chrome | ![govuk-frontend-review herokuapp com_full-page-examples_what-is-your-nationality(Chrome)](https://user-images.githubusercontent.com/503614/130572535-d07ee3f3-b3d6-493f-8969-e49bb2216402.png) | ![govuk-frontend-pr-2312 herokuapp com_full-page-examples_what-is-your-nationality(Chrome)](https://user-images.githubusercontent.com/503614/130572577-8534ddb3-5b38-4d39-b535-5f1acc0f770a.png) |
| Safari mobile | ![govuk-frontend-review herokuapp com_full-page-examples_what-is-your-nationality(iPhone 6_7_8)](https://user-images.githubusercontent.com/121939/129896143-01e33877-c22e-4db1-8527-3e08f1fdbfba.png) | ![govuk-frontend-pr-2312 herokuapp com_full-page-examples_what-is-your-nationality(iPhone 6_7_8)](https://user-images.githubusercontent.com/121939/129896148-c0810ff9-d9d3-40c4-8be0-494798661f3b.png)|

