### PR TITLE
Add wording and Get started link to Heroku banner

### DIFF
--- a/app/views/full-page-examples/announcements/index.njk
+++ b/app/views/full-page-examples/announcements/index.njk
@@ -2,7 +2,7 @@
 scenario: You want to read this article about '2018’s oddest requests from Brits abroad'.
 notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausages-2018s-oddest-requests-from-brits-abroad
 ---
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "inset-text/macro.njk" import govukInsetText %}
@@ -11,7 +11,6 @@ notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausage
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-{% include "../../partials/banner.njk" %}
 {{ govukHeader({
   navigation: [
     {

--- a/app/views/full-page-examples/applicant-details/confirm.njk
+++ b/app/views/full-page-examples/applicant-details/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "legacy.njk" %}
+{% extends "full-page-example-legacy.njk" %}
 
 {% set page_title = "Applicant details submitted" %}
 

--- a/app/views/full-page-examples/applicant-details/index.njk
+++ b/app/views/full-page-examples/applicant-details/index.njk
@@ -8,7 +8,7 @@ notes: >-
   known accessibility issues.
 ---
 
-{% extends "legacy.njk" %}
+{% extends "full-page-example-legacy.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "date-input/macro.njk" import govukDateInput %}

--- a/app/views/full-page-examples/bank-holidays/index.njk
+++ b/app/views/full-page-examples/bank-holidays/index.njk
@@ -13,7 +13,7 @@ notes: >-
   This example is based on https://www.gov.uk/bank-holidays.
   The data is not 'live' and so the answer is unlikely to be correct.
 ---
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "tabs/macro.njk" import govukTabs %}

--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -8,7 +8,7 @@ notes: >-
   Based on https://www.gov.uk/coronavirus
 ---
 
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "header/macro.njk" import govukHeader %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
@@ -22,7 +22,6 @@ notes: >-
 {% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     homepageUrl: "#",
     classes: "app-header--campaign"

--- a/app/views/full-page-examples/check-your-answers/index.njk
+++ b/app/views/full-page-examples/check-your-answers/index.njk
@@ -12,7 +12,7 @@ notes: The links to change your answers are not functional.
 ---
 
 {# This example is based of the  "Check your answers before sending your application" example: https://design-system.service.gov.uk/patterns/check-answers/default/index.html #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "summary-list/macro.njk" import govukSummaryList %}
@@ -24,7 +24,6 @@ notes: The links to change your answers are not functional.
 {% block pageTitle %}{{ pageTitle }} - {{ serviceName }} - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     serviceName: serviceName
   }) }}

--- a/app/views/full-page-examples/confirm-delete/index.njk
+++ b/app/views/full-page-examples/confirm-delete/index.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "warning-text/macro.njk" import govukWarningText %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -15,7 +15,7 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/app/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -13,7 +13,7 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -17,7 +17,7 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/feedback/confirm.njk
+++ b/app/views/full-page-examples/feedback/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 
@@ -6,7 +6,6 @@
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     productName: "Verify"
   }) }}

--- a/app/views/full-page-examples/feedback/index.njk
+++ b/app/views/full-page-examples/feedback/index.njk
@@ -19,7 +19,7 @@ scenario: >-
 
 notes: Based on https://www.signin.service.gov.uk/feedback
 ---
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "warning-text/macro.njk" import govukWarningText %}
 {% from "radios/macro.njk" import govukRadios %}
@@ -32,7 +32,6 @@ notes: Based on https://www.signin.service.gov.uk/feedback
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - Verify - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     productName: "Verify"
   }) }}

--- a/app/views/full-page-examples/have-you-changed-your-name/confirm.njk
+++ b/app/views/full-page-examples/have-you-changed-your-name/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/app/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -11,7 +11,7 @@ scenario: >-
 ---
 
 {# This example is based of the "Radios" example: https://design-system.service.gov.uk/components/radios #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/app/views/full-page-examples/how-do-you-want-to-sign-in/confirm.njk
+++ b/app/views/full-page-examples/how-do-you-want-to-sign-in/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/app/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -10,7 +10,7 @@ scenario: >-
 notes: Based on https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
 ---
 
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}

--- a/app/views/full-page-examples/passport-details/confirm.njk
+++ b/app/views/full-page-examples/passport-details/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/passport-details/index.njk
+++ b/app/views/full-page-examples/passport-details/index.njk
@@ -11,7 +11,7 @@ scenario: >-
 ---
 
 {# This example is based of the "Passport details" pattern: https://design-system.service.gov.uk/patterns/question-pages/ #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/app/views/full-page-examples/renew-driving-licence/index.njk
+++ b/app/views/full-page-examples/renew-driving-licence/index.njk
@@ -8,7 +8,7 @@ notes: >-
 
 {# This example is based on the "Renew driving licence"
 example: https://www.gov.uk/renew-driving-licence #}
-{% extends "legacy.njk" %}
+{% extends "full-page-example-legacy.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "inset-text/macro.njk" import govukInsetText %}

--- a/app/views/full-page-examples/search/index.njk
+++ b/app/views/full-page-examples/search/index.njk
@@ -18,7 +18,7 @@ notes: >-
   This example merges features seen on GOV.UK news and communication finders and search pages.
 ---
 
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "input/macro.njk" import govukInput %}

--- a/app/views/full-page-examples/service-manual-topic/index.njk
+++ b/app/views/full-page-examples/service-manual-topic/index.njk
@@ -8,7 +8,7 @@ notes: The links within each section are not functional.
 ---
 
 {# This example is based of the live "Service Manual - Technology" page: https://www.gov.uk/service-manual/technology #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "accordion/macro.njk" import govukAccordion %}

--- a/app/views/full-page-examples/start-page/index.njk
+++ b/app/views/full-page-examples/start-page/index.njk
@@ -11,7 +11,7 @@ notes: The buttons and links on this page are not functional.
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/update-your-account-details/confirm.njk
+++ b/app/views/full-page-examples/update-your-account-details/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/update-your-account-details/index.njk
+++ b/app/views/full-page-examples/update-your-account-details/index.njk
@@ -8,7 +8,7 @@ scenario: >-
   1. Intentionally avoid answering the questions before continuing to the next page.
 ---
 
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/app/views/full-page-examples/upload-your-photo-success/confirm.njk
+++ b/app/views/full-page-examples/upload-your-photo-success/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 
@@ -6,7 +6,6 @@
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     serviceName: "Apply for a passport",
     navigation: [

--- a/app/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/app/views/full-page-examples/upload-your-photo-success/index.njk
@@ -6,7 +6,7 @@ scenario: >-
 ---
 
 {# This example is based of the live "Passport" service: https://www.passport.service.gov.uk/photo/upload #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "button/macro.njk" import govukButton %}
@@ -19,7 +19,6 @@ scenario: >-
 {% block pageTitle %}Upload your photo - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     serviceName: "Apply for a passport"
   }) }}

--- a/app/views/full-page-examples/upload-your-photo/confirm.njk
+++ b/app/views/full-page-examples/upload-your-photo/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 
@@ -6,7 +6,6 @@
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     serviceName: "Apply for a passport",
     navigation: [

--- a/app/views/full-page-examples/upload-your-photo/index.njk
+++ b/app/views/full-page-examples/upload-your-photo/index.njk
@@ -9,7 +9,7 @@ scenario: >-
 ---
 
 {# This example is based of the live "Passport" service: https://www.passport.service.gov.uk/photo/upload #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "phase-banner/macro.njk" import govukPhaseBanner %}
 {% from "back-link/macro.njk" import govukBackLink %}
@@ -23,7 +23,6 @@ scenario: >-
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block header %}
-  {% include "../../partials/banner.njk" %}
   {{ govukHeader({
     serviceName: "Apply for a passport",
     navigation: [

--- a/app/views/full-page-examples/what-is-your-address/confirm.njk
+++ b/app/views/full-page-examples/what-is-your-address/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/what-is-your-address/index.njk
+++ b/app/views/full-page-examples/what-is-your-address/index.njk
@@ -10,7 +10,7 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home address?" example: https://design-system.service.gov.uk/patterns/addresses/multiple/index.html #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "error-summary/macro.njk" import govukErrorSummary %}

--- a/app/views/full-page-examples/what-is-your-nationality/confirm.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/app/views/full-page-examples/what-is-your-nationality/index.njk
@@ -19,7 +19,7 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your nationality?" example: https://www.registertovote.service.gov.uk/register-to-vote/nationality #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "checkboxes/macro.njk" import govukCheckboxes %}

--- a/app/views/full-page-examples/what-is-your-postcode/confirm.njk
+++ b/app/views/full-page-examples/what-is-your-postcode/confirm.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/what-is-your-postcode/index.njk
+++ b/app/views/full-page-examples/what-is-your-postcode/index.njk
@@ -9,7 +9,7 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home postcode?" example: https://design-system.service.gov.uk/patterns/question-pages/postcode/index.html #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/full-page-examples/what-was-the-last-country-you-visited/confirm.njk
+++ b/app/views/full-page-examples/what-was-the-last-country-you-visited/confirm.njk
@@ -1,5 +1,5 @@
 {# This example is not based on a live example #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "panel/macro.njk" import govukPanel %}
 

--- a/app/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
+++ b/app/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
@@ -9,7 +9,7 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home postcode?" example: https://design-system.service.gov.uk/patterns/question-pages/postcode/index.html #}
-{% extends "_generic.njk" %}
+{% extends "full-page-example.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "button/macro.njk" import govukButton %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -37,9 +37,10 @@
   {% block styles %}{% endblock %}
 {% endblock %}
 
-{% block header %}
-  {% include "../partials/banner.njk" %}
-  {{ super() }}
+{% block bodyStart %}
+  {% block banner %}
+    {% include "../partials/banner.njk" %}
+  {% endblock %}
 {% endblock %}
 
 {% set mainClasses = 'govuk-main-wrapper--auto-spacing' %}

--- a/app/views/layouts/component-preview.njk
+++ b/app/views/layouts/component-preview.njk
@@ -4,8 +4,9 @@
  {{ bodyClasses }}
 {% endset %}
 
+{# Remove standard template banners/headers/frontmatter #}
 {% block skipLink %}{% endblock %}
-
+{% block bodyStart %} {% endblock %}
 {% block header %}{% endblock %}
 
 {% block content %}

--- a/app/views/layouts/full-page-example-legacy.njk
+++ b/app/views/layouts/full-page-example-legacy.njk
@@ -1,0 +1,5 @@
+{% extends "legacy.njk" %}
+
+{% block body_start %}
+  {% include "../partials/exampleBanner.njk" %}
+{% endblock %}

--- a/app/views/layouts/full-page-example.njk
+++ b/app/views/layouts/full-page-example.njk
@@ -1,0 +1,5 @@
+{% extends "_generic.njk" %}
+
+{% block banner %}
+  {% include "../partials/exampleBanner.njk" %}
+{% endblock %}

--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -5,9 +5,7 @@
 {% block pageTitle %}GOV.UK Frontend{% endblock %}
 
 {# Turn the header and footer off #}
-{% block header %}
-  {% include "../partials/banner.njk" %}
-{% endblock %}
+{% block header %}{% endblock %}
 {% block footer %}{% endblock %}
 
 {% block bodyEnd %}

--- a/app/views/partials/exampleBanner.njk
+++ b/app/views/partials/exampleBanner.njk
@@ -2,9 +2,9 @@
 <div class="app-banner app-banner--warning" data-module="app-banner">
   <div class="govuk-width-container">
     <p class="govuk-body">
-      This is an internal development app.
+      This is not a real service, and is used for testing purposes only.
       <br>
-      To learn how to use the GOV.UK Design System in your project, see <a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/get-started/">Get started</a>.
+      See the <a class="govuk-link govuk-link--inverse" href="https://design-system.service.gov.uk/">GOV.UK Design System</a> for recommended guidance.
     </p>
     <form method="post" action="/hide-banner">
       <button class="govuk-button govuk-button--secondary govuk-!-margin-bottom-0">Hide this banner</button>


### PR DESCRIPTION
Fixes [#1955](https://github.com/alphagov/govuk-frontend/issues/1955).

This PR replaces the previous wording and link in the banner for our [review app](https://govuk-frontend-review.herokuapp.com/).

The previous wording made some users think they should not use GOV.UK Frontend in production.