### PR TITLE
Add correct links in css md and improve wording

### DIFF
--- a/docs/contributing/coding-standards/css.md
+++ b/docs/contributing/coding-standards/css.md
@@ -456,8 +456,8 @@ Good:
 More write up on [supported rules](https://stylelint.io/user-guide/rules/list).
 
 ##  SassDoC
-We document SCSS using [SassDoc](http://sassdoc.com/file-level-annotations/). This includes most of the settings, helpers and tools layers, with variables, functions and mixins being marked as private or public.
+We document SCSS using [SassDoc](http://sassdoc.com/). This includes most of the settings, helpers and tools layers, with variables, functions and mixins being marked as private or public.
 
-The syntax is used to generate a [SassDoc application](http://govuk-frontend-review.herokuapp.com/docs/) that documents SCSS in a readable format.
+The SassDoc comments are used to generate the [Sass API reference in the GOV.UK Frontend docs](https://frontend.design-system.service.gov.uk/sass-api-reference/).
 
 See [colour.scss](../../../src/govuk/helpers/_colour.scss) for an example of SassDoc syntax.


### PR DESCRIPTION
Fixes [#2334](https://github.com/alphagov/govuk-frontend/issues/2334).

This PR adds the following to our [CSS Style Guide](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/css.md):

- link to [Sass API reference](https://frontend.design-system.service.gov.uk/sass-api-reference/)
- link to [SassDoc homepage](http://sassdoc.com/)
- text about how our Sass API content is generated

We've added this content because:

- the previous links went to odd places (['File-level annotations' in SassDoc content](http://sassdoc.com/file-level-annotations/), our [review app's docs](http://govuk-frontend-review.herokuapp.com/docs/))
- the previous text was unclear