### PR TITLE
fixup! Bump default Node.js to 14.17.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "govuk-frontend-repository",
   "description": "Used only for the development of GOV.UK Frontend, see `package/package.json` for the published `package.json`",
   "engines": {
-    "node": "14.17.0"
+    "node": "~14.17.6"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
I missed this from #2342 :disappointed:

We need to also bump and relax the constraint on Node in the package.json file, to avoid command line warnings.