### PR TITLE
Fix panel text overflowing when zoomed in on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - [#2339: Add text align override classes](https://github.com/alphagov/govuk-frontend/pull/2339)
 
+### Fixes
+
+- [#2347: Fix panel text overflowing when zoomed in on mobile #2347](https://github.com/alphagov/govuk-frontend/pull/2347)
+
 ## 3.13.1 (Fix release)
 
 ### Fixes

--- a/app/views/full-page-examples/passport-details/confirm.njk
+++ b/app/views/full-page-examples/passport-details/confirm.njk
@@ -2,14 +2,15 @@
 
 {% from "panel/macro.njk" import govukPanel %}
 
-{% set pageTitle = "Passport details submitted" %}
+{% set pageTitle = "We have emailed you a confirmation" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
-        titleText: pageTitle
+        titleText: pageTitle,
+        html: "Your reference number<br><strong>HDJ2123F</strong>"
       }) }}
     </div>
   </div>

--- a/src/govuk/components/panel/_index.scss
+++ b/src/govuk/components/panel/_index.scss
@@ -12,7 +12,19 @@
     text-align: center;
 
     @include govuk-media-query($until: tablet) {
-      padding: govuk-spacing(6) - $govuk-border-width;
+      padding: govuk-spacing(3) - $govuk-border-width;
+
+      // This is an if-all-else-fails attempt to stop long words from overflowing the container
+      // on very narrow viewports by forcing them to break and wrap instead. This
+      // overflowing is more likely to happen when user increases text size on a mobile eg. using
+      // iOS Safari text resize controls.
+      //
+      // The overflowing is a particular problem with the panel component since it uses white
+      // text: when the text overflows the container, it is invisible on the white (page)
+      // background. When the text in our other components overflow, the user might have to scroll
+      // horizontally to view it but the the text remains legible.
+      overflow-wrap: break-word;
+      word-wrap: break-word; // Support IE (autoprefixer doesn't add this as it's not a prefix)
     }
   }
 


### PR DESCRIPTION
As discussed in https://github.com/alphagov/govuk-frontend/issues/2173, the panel heading text can overflow its container when a user increases text size on a mobile eg. using iOS Safari text resize controls. The overflowing is a particular problem with the panel component since it uses white text. When the text overflows the container, it is invisible on the white (page) background. When the text in our other components overflow, the user might have to scroll horizontally to view it but the the text remains legible.

We should aim to meet the [WCAG Text resize Success criterion](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) which requires that
> text can be scaled up to 200%

## How we fix this

To help fix this, this PR:
- Decreases the padding of the panel component on mobile to allow the text flow better.
- As an if-all-else-fails attempt to stop very long words from overflowing, forces them to break and wrap instead. Hopefully this is not something that would happen often since we now also reduce the padding to help with this.

## Possible future improvements

We additionally considered reducing the font size of the heading on a mobile to avoid the text wrapping at very narrow viewports. However, the [`govuk-font` mixin](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-font) uses the responsive font size map which fixes font sizes for different breakpoints to make our components behave consistently. There currently isn’t a way to override those set font sizes for `govuk-font`. Since the other fixes in this commit go a long way towards solving this issue and we haven’t come across this requirement with our other components so far, we’re hesitant to add this new feature to `govuk-font` at this point, but we’ll keep an eye out for similar requirements in the future.

We could consider adding something to the panel guidance about the need to keep the panel heading wording concise.

## iOS 12 mini in Safari at 100% (no zoom)

### Before
![Screenshot 2021-09-14 at 11 34 26](https://user-images.githubusercontent.com/5007934/133242740-bfee2bdd-b3eb-4695-b6bb-699abf51bae9.png)

### After

![Screenshot 2021-09-23 at 13 35 17](https://user-images.githubusercontent.com/5007934/134507750-31692abb-1bdc-4c78-b0bc-5f634abb867a.png)

## iOS 12 mini at 150% zoom 

### Before
![Screenshot 2021-09-14 at 11 34 47](https://user-images.githubusercontent.com/5007934/133242875-64c7d728-ec33-40f5-97b6-56df0735ea3b.png)

### After

![Screenshot 2021-09-23 at 15 33 46](https://user-images.githubusercontent.com/5007934/134529418-b537a7ab-d780-4072-87b5-e327627d35a6.png)

##  iOS 12 mini at 200% zoom 

### Before
![Screenshot 2021-09-14 at 11 37 39](https://user-images.githubusercontent.com/5007934/133243094-8ac3c286-4e56-4fea-8608-8a98b047d418.png)

### After

![Screenshot 2021-09-23 at 15 34 01](https://user-images.githubusercontent.com/5007934/134529505-50d24240-8a85-4bc9-9ce1-d1090915e3f4.png)

## We decided not to hyphenate words that wrap

We also considered progressively enhancing any words that wrap by using `hyphens: auto` to hyphenate them but this seemed to potentially introduce more problems than it was solving. For instance, we found that iOS Safari can omit the dash from some words but not others, see below:

![Screenshot 2021-09-23 at 15 52 48](https://user-images.githubusercontent.com/5007934/134530833-8824d752-ad37-437c-80cd-b9ade57acbd1.png)

iOS Safari can also hyphenate words unnecessarily, see below:
![Screenshot 2021-09-23 at 15 53 36](https://user-images.githubusercontent.com/5007934/134530852-90a42b93-04bd-485b-9f1e-befd6e747c75.png)

Fixes https://github.com/alphagov/govuk-frontend/issues/2173
