### PR TITLE
Add cookie banner examples using `headingHtml` and `html`

### DIFF
--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -25,13 +25,26 @@ notes: >-
 {% set pageTitle = "Apply online for a UK passport" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
+{% set html %}
+  <p class="govuk-body">We’d like to use analytics cookies so we can understand how you use this site.</p>
+  <p class="govuk-body">We also use essential cookies to remember if you’ve accepted analytics cookies.</p>
+{% endset %}
+
+{% set acceptHtml %}
+  <p class="govuk-body">You’ve accepted analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
+{% set rejectHtml %}
+  <p class="govuk-body">You’ve rejected analytics cookies. You can <a class="govuk-link" href="/cookies">change your cookie settings</a> at any time.</p>
+{% endset %}
+
 {% block bodyStart %}
     {{ govukCookieBanner({
     "classes": "js-cookies-banner",
     "messages": [
         {
             "headingText": "Cookies on this government service",
-            "text": "We use analytics cookies to help understand how users use our service.",
+            "html": html,
             "actions": [
                 {
                     "text": "Accept analytics cookies",
@@ -51,7 +64,7 @@ notes: >-
             "classes": "js-question-banner"
         },
         {
-            "text": "Your cookie preferences have been saved. You have accepted cookies.",
+            "html": acceptHtml,
             "role": "alert",
             "actions": [
                 {
@@ -64,7 +77,7 @@ notes: >-
             "hidden": true
         },
         {
-            "text": "Your cookie preferences have been saved. You have rejected cookies.",
+            "html": rejectHtml,
             "role": "alert",
             "actions": [
                 {

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -151,6 +151,23 @@ examples:
             - text: Hide this message
               type: button
 
+  - name: with html
+    data:
+      messages:
+        - headingHtml: Cookies on <span>my service</span>
+          html: <p class="govuk-body">We use cookies in <span>our service</span>.</p><p class="govuk-body">We’d like to use analytics cookies so we can understand how you use the Design System and make improvements.</p>
+          actions:
+            - text: Accept analytics cookies
+              type: submit
+              name: cookies
+              value: accept
+            - text: Reject analytics cookies
+              type: submit
+              name: cookies
+              value: reject
+            - text: View cookie preferences
+              href: /cookie-preferences
+
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: heading html


### PR DESCRIPTION
## What
All of the examples we currently have in the review app used `headingText` and `text` only.
We should have visible examples which use HTML too. This PR adds a visible example to the component examples and also changes a full page example to use `html`.

## Why
Prompted by https://github.com/alphagov/govuk-design-system/issues/1886, I noticed we don't have any visible examples of the cookie banner component in the review app which use HTML.