### PR TITLE
Fix panel text overflowing when zoomed in on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ You can now use the `govuk-!-text-align-left`, `govuk-!-text-align-centre` and `
 
 This was added in [pull request #2368: Add text align override classes](https://github.com/alphagov/govuk-frontend/pull/2368).
 
+### Fixes
+
+- [#2366: Fix panel text overflowing when zoomed in on mobile #2366](https://github.com/alphagov/govuk-frontend/pull/2366)
 
 ## 3.13.1 (Fix release)
 

--- a/app/views/full-page-examples/passport-details/confirm.njk
+++ b/app/views/full-page-examples/passport-details/confirm.njk
@@ -2,14 +2,15 @@
 
 {% from "panel/macro.njk" import govukPanel %}
 
-{% set pageTitle = "Passport details submitted" %}
+{% set pageTitle = "We have emailed you a confirmation" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ govukPanel({
-        titleText: pageTitle
+        titleText: pageTitle,
+        html: "Your reference number<br><strong>HDJ2123F</strong>"
       }) }}
     </div>
   </div>

--- a/src/govuk/components/panel/_index.scss
+++ b/src/govuk/components/panel/_index.scss
@@ -12,7 +12,19 @@
     text-align: center;
 
     @include govuk-media-query($until: tablet) {
-      padding: govuk-spacing(6) - $govuk-border-width;
+      padding: govuk-spacing(3) - $govuk-border-width;
+
+      // This is an if-all-else-fails attempt to stop long words from overflowing the container
+      // on very narrow viewports by forcing them to break and wrap instead. This
+      // overflowing is more likely to happen when user increases text size on a mobile eg. using
+      // iOS Safari text resize controls.
+      //
+      // The overflowing is a particular problem with the panel component since it uses white
+      // text: when the text overflows the container, it is invisible on the white (page)
+      // background. When the text in our other components overflow, the user might have to scroll
+      // horizontally to view it but the the text remains legible.
+      overflow-wrap: break-word;
+      word-wrap: break-word; // Support IE (autoprefixer doesn't add this as it's not a prefix)
     }
   }
 


### PR DESCRIPTION
**Note: this PR cherry-picks commits from https://github.com/alphagov/govuk-frontend/pull/2347 in order to merge and release them from a support branch. Ordinarily, this fix would be made in the support branch first, and then copied over to `main`. However, in this instance, we're testing out the support branch release process in a slightly artificial scenario - the change has already been made (unreleased) in `main`, but we want to trial out releasing it from the `support/v3.x` branch**

As discussed in https://github.com/alphagov/govuk-frontend/issues/2173, the panel heading text can overflow its container when a user increases text size on a mobile eg. using iOS Safari text resize controls. The overflowing is a particular problem with the panel component since it uses white text. When the text overflows the container, it is invisible on the white (page) background. When the text in our other components overflow, the user might have to scroll horizontally to view it but the the text remains legible.

We should aim to meet the [WCAG Text resize Success criterion](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) which requires that
> text can be scaled up to 200%

## How we fix this

To help fix this, this PR:
- Decreases the padding of the panel component on mobile to allow the text flow better.
- As an if-all-else-fails attempt to stop very long words from overflowing, forces them to break and wrap instead. Hopefully this is not something that would happen often since we now also reduce the padding to help with this.

## Possible future improvements

We additionally considered reducing the font size of the heading on a mobile to avoid the text wrapping at very narrow viewports. However, the [`govuk-font` mixin](https://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-font) uses the responsive font size map which fixes font sizes for different breakpoints to make our components behave consistently. There currently isn’t a way to override those set font sizes for `govuk-font`. Since the other fixes in this commit go a long way towards solving this issue and we haven’t come across this requirement with our other components so far, we’re hesitant to add this new feature to `govuk-font` at this point, but we’ll keep an eye out for similar requirements in the future.

We could consider adding something to the panel guidance about the need to keep the panel heading wording concise.