### PR TITLE
Prevent issues with conditionally revealed content when the ID of the revealed content includes characters that have a special meaning in CSS

### DIFF
--- a/src/govuk/components/checkboxes/checkboxes.js
+++ b/src/govuk/components/checkboxes/checkboxes.js
@@ -32,7 +32,7 @@ Checkboxes.prototype.init = function () {
 
     // Skip checkboxes without data-aria-controls attributes, or where the
     // target element does not exist.
-    if (!target || !$module.querySelector('#' + target)) {
+    if (!target || !document.getElementById(target)) {
       return
     }
 

--- a/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/src/govuk/components/checkboxes/checkboxes.test.js
@@ -49,6 +49,7 @@ describe('Checkboxes with conditional reveals', () => {
       expect(hasAriaExpanded).toBeFalsy()
       expect(hasAriaControls).toBeFalsy()
     })
+
     it('falls back to making all conditional content visible', async () => {
       await goToAndGetComponent('checkboxes', 'with-conditional-items')
 
@@ -56,6 +57,7 @@ describe('Checkboxes with conditional reveals', () => {
       expect(isContentVisible).toBeTruthy()
     })
   })
+
   describe('when JavaScript is available', () => {
     it('has conditional content revealed that is associated with a checked input', async () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-item-checked')
@@ -66,6 +68,7 @@ describe('Checkboxes with conditional reveals', () => {
       const isContentVisible = await waitForVisibleSelector(`[id="${inputAriaControls}"]:not(.govuk-checkboxes__conditional--hidden)`)
       expect(isContentVisible).toBeTruthy()
     })
+
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-item-checked')
       const $component = $('.govuk-checkboxes')
@@ -75,6 +78,7 @@ describe('Checkboxes with conditional reveals', () => {
       const isContentHidden = await waitForHiddenSelector(`[id="${uncheckedInputAriaControls}"].govuk-checkboxes__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
+
     it('indicates when conditional content is collapsed or revealed', async () => {
       await goToAndGetComponent('checkboxes', 'with-conditional-items')
 
@@ -86,6 +90,7 @@ describe('Checkboxes with conditional reveals', () => {
       const isExpanded = await waitForVisibleSelector('.govuk-checkboxes__item:first-child .govuk-checkboxes__input[aria-expanded=true]')
       expect(isExpanded).toBeTruthy()
     })
+
     it('toggles the conditional content when clicking an input', async () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-items')
       const $component = $('.govuk-checkboxes')
@@ -102,6 +107,7 @@ describe('Checkboxes with conditional reveals', () => {
       const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"]`)
       expect(isContentHidden).toBeTruthy()
     })
+
     it('toggles the conditional content when using an input with a keyboard', async () => {
       const $ = await goToAndGetComponent('checkboxes', 'with-conditional-items')
       const $component = $('.govuk-checkboxes')
@@ -118,6 +124,11 @@ describe('Checkboxes with conditional reveals', () => {
 
       const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"]`)
       expect(isContentHidden).toBeTruthy()
+    })
+
+    it('does not error when ID of revealed content contains special characters', async () => {
+      // Errors logged to the console will cause this test to fail
+      await goToAndGetComponent('checkboxes', 'with-conditional-items-with-special-characters')
     })
   })
 })

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -416,6 +416,33 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
+- name: with conditional items with special characters
+  data:
+    name: contact-prefs
+    idPrefix: user.profile[contact-prefs]
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: email
+        text: Email
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Email address</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: phone
+        text: Phone
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-phone">Phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+      - value: text
+        text: Text message
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
 - name: with conditional item checked
   data:
     name: how-contacted-checked

--- a/src/govuk/components/radios/radios.js
+++ b/src/govuk/components/radios/radios.js
@@ -32,7 +32,7 @@ Radios.prototype.init = function () {
 
     // Skip radios without data-aria-controls attributes, or where the
     // target element does not exist.
-    if (!target || !$module.querySelector('#' + target)) {
+    if (!target || !document.getElementById(target)) {
       return
     }
 

--- a/src/govuk/components/radios/radios.test.js
+++ b/src/govuk/components/radios/radios.test.js
@@ -49,6 +49,7 @@ describe('Radios with conditional reveals', () => {
       expect(hasAriaExpanded).toBeFalsy()
       expect(hasAriaControls).toBeFalsy()
     })
+
     it('falls back to making all conditional content visible', async () => {
       await goToAndGetComponent('radios', 'with-conditional-items')
 
@@ -66,6 +67,7 @@ describe('Radios with conditional reveals', () => {
       const isContentVisible = await waitForVisibleSelector(`[id="${inputAriaControls}"]:not(.govuk-radios__conditional--hidden)`)
       expect(isContentVisible).toBeTruthy()
     })
+
     it('has no conditional content revealed that is associated with an unchecked input', async () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-item-checked')
       const $component = $('.govuk-radios')
@@ -75,6 +77,7 @@ describe('Radios with conditional reveals', () => {
       const isContentHidden = await waitForHiddenSelector(`[id="${uncheckedInputAriaControls}"].govuk-radios__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
     })
+
     it('indicates when conditional content is collapsed or revealed', async () => {
       await goToAndGetComponent('radios', 'with-conditional-items')
 
@@ -86,6 +89,7 @@ describe('Radios with conditional reveals', () => {
       const isExpanded = await waitForVisibleSelector('.govuk-radios__item:first-child .govuk-radios__input[aria-expanded=true]')
       expect(isExpanded).toBeTruthy()
     })
+
     it('toggles the conditional content when clicking an input', async () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-items')
       const $component = $('.govuk-radios')
@@ -102,6 +106,7 @@ describe('Radios with conditional reveals', () => {
       const isContentHidden = await waitForHiddenSelector(`[id="${firstInputAriaControls}"]`)
       expect(isContentHidden).toBeTruthy()
     })
+
     it('toggles the conditional content when using an input with a keyboard', async () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-items')
       const $component = $('.govuk-radios')
@@ -120,6 +125,11 @@ describe('Radios with conditional reveals', () => {
       expect(isContentHidden).toBeTruthy()
     })
 
+    it('does not error when ID of revealed content contains special characters', async () => {
+      // Errors logged to the console will cause this test to fail
+      await goToAndGetComponent('radios', 'with-conditional-items-with-special-characters')
+    })
+
     describe('with multiple radio groups on the same page', () => {
       it('toggles conditional reveals in other groups', async () => {
         await page.goto(baseUrl + '/examples/multiple-radio-groups', { waitUntil: 'load' })
@@ -133,6 +143,7 @@ describe('Radios with conditional reveals', () => {
         const isWarmConditionalRevealHidden = await waitForHiddenSelector('#conditional-warm')
         expect(isWarmConditionalRevealHidden).toBeTruthy()
       })
+
       it('toggles conditional reveals when not in a form', async () => {
         await page.goto(baseUrl + '/examples/multiple-radio-groups', { waitUntil: 'load' })
 

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -321,6 +321,33 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
+- name: with conditional items with special characters
+  data:
+    idPrefix: user.profile[contact-prefs]
+    name: contact-prefs
+    fieldset:
+      legend:
+        text: How do you want to be contacted?
+    items:
+      - value: email
+        text: Email
+        conditional:
+          html: |
+            <label class="govuk-label" for="context-email">Email address</label>
+            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
+      - value: phone
+        text: Phone
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-phone">Phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
+      - value: text
+        text: Text message
+        conditional:
+          html: |
+            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
+            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
+
 - name: inline with conditional items
   data:
     classes: govuk-radios--inline


### PR DESCRIPTION
Because the string passed to `querySelector` is evaluated as a CSS selector, this can fail (throwing a JavaScript error) if the ID contains characters that have a special meaning in CSS, such as `.` or `[]` – the ID would need to be escaped for it to be evaluated correctly.

Avoid this by using `document.getElementById` instead, so the ID is no longer evaluated as a selector.

The downside is that we can't constrain the scope to the $module. However, we don't think this should cause any issues as the ID _should_ be unique within the document.

Closes #1808