### PR TITLE
Update package.json to 3.14.0

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-frontend",
   "description": "GOV.UK Frontend contains the code you need to start building a user interface for government platforms and services.",
-  "version": "3.13.1",
+  "version": "3.14.0",
   "main": "govuk/all.js",
   "sass": "govuk/all.scss",
   "engines": {


### PR DESCRIPTION
We released 3.14.0 from the support/3.x branch. We now need to make sure `main` is in sync and includes all of the changes that were released in 3.14.0.

The release notes were updated in a separate PR: https://github.com/alphagov/govuk-frontend/pull/2369

The changes themselves were already merged into `main` as we were trialling the support branch release process in a slightly artificial scenario and we decided to do this only after the changes were already in `main`.

That therefore leaves updating the package/package.json file so it's in sync with the latest release version - this is done in this PR