### PR TITLE
Tell users how to report inappropriate content

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-# Code of Conduct
-
-This project follows the 'alphagov' Github organisation's Code of Conduct (https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contribution guidelines
 We love contributions! We've compiled these docs to help you understand our contribution guidelines. If you still have questions, please [contact us](https://design-system.service.gov.uk/#support), we'd be super happy to help.
 
 ## Contents of this file
@@ -26,7 +26,7 @@ We love contributions! We've compiled these docs to help you understand our cont
 
 
 ## Code of Conduct
-Please read [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) before contributing.
+Please read [the `alphagov` CODE_OF_CONDUCT.md](https://github.com/alphagov/blob/main/.github/CODE_OF_CONDUCT.md) before contributing.
 
 ## Application architecture
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,6 @@ GDS is an advocate of responsible vulnerability disclosure. If you’ve found a 
 
 For full details on how to tell us about vulnerabilities, [see our security policy](https://github.com/alphagov/govuk-frontend/security/policy).
 
-The govuk-frontend repository is public. We do not monitor it outside of office hours (10am to 4pm). To learn how to report inappropriate content, see [GitHub's page on reporting abuse or spam](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam). If you're not sure whether some content is appropriate, check it against our [code of conduct](https://github.com/alphagov/govuk-frontend/blob/main/CODE_OF_CONDUCT.md).
-
 ## Licence
 
 Unless stated otherwise, the codebase is released under the MIT License. This
@@ -85,7 +83,12 @@ covers both the codebase and any sample code in the documentation. The
 documentation is &copy; Crown copyright and available under the terms of the
 Open Government 3.0 licence.
 
-## Contribution guidelines
+## Contributing
 
-If you want to help us build GOV.UK Frontend, view our [contribution
-guidelines](CONTRIBUTING.md).
+[To learn how to help us build GOV.UK Frontend, see our contribution guidelines.](https://github.com/alphagov/govuk-frontend/blob/f07569c9e7724606970c0d2764f1e9ce7fa14092/CONTRIBUTING.md)
+
+The govuk-frontend repository is public and we welcome contributions from anyone.
+
+Contributors to alphagov repositories are expected to follow the [Contributor Covenant Code of Conduct](https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct). Contributors working within government are also expected to follow the [Civil Service code](https://www.gov.uk/government/publications/civil-service-code/the-civil-service-code).
+
+We're unable to monitor activity on this repository outside of our office hours (10am to 4pm, UK time). To get a faster response at other times, you can [report abuse or spam to GitHub](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam).

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ GDS is an advocate of responsible vulnerability disclosure. If you’ve found a 
 
 For full details on how to tell us about vulnerabilities, [see our security policy](https://github.com/alphagov/govuk-frontend/security/policy).
 
+The govuk-frontend repository is public. We do not monitor it outside of office hours (10am to 4pm). To learn how to report inappropriate content, see [GitHub's page on reporting abuse or spam](https://docs.github.com/en/communities/maintaining-your-safety-on-github/reporting-abuse-or-spam). If you're not sure whether some content is appropriate, check it against our [code of conduct](https://github.com/alphagov/govuk-frontend/blob/main/CODE_OF_CONDUCT.md).
+
 ## Licence
 
 Unless stated otherwise, the codebase is released under the MIT License. This


### PR DESCRIPTION
Partly addresses [#2396](https://github.com/alphagov/govuk-frontend/issues/2396).

This PR updates the [govuk-frontend README](https://github.com/alphagov/govuk-frontend/blob/main/README.md), so users will know:

- the repo is open, and not monitored outside of office hours
- how to report inappropriate content

We're adding this info because of a [recent security-incident](https://docs.google.com/document/d/1-VZcvII1g9oKFi00JsiuvLE-Y0iAl-qmPeaYLzn6Fmg/edit#).