### PR TITLE
Revert "Update package.json to 3.14.0"

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -1,7 +1,7 @@
 {
   "name": "govuk-frontend",
   "description": "GOV.UK Frontend contains the code you need to start building a user interface for government platforms and services.",
-  "version": "3.14.0",
+  "version": "3.13.1",
   "main": "govuk/all.js",
   "sass": "govuk/all.scss",
   "engines": {


### PR DESCRIPTION
Reverts alphagov/govuk-frontend#2378

We've decided to revert this change because it could be confusing/misleading for anyone looking at the GOV.UK Frontend repo and trying to find the changes we made in 3.14.0. While the code changes and changelog have been updated for the 3.14.0 changes, the package folder hasn't. It seems confusing to have an updated package/package.json file that shows the version as `3.14.0`, but the changes aren't actually present in the package folder.

We'll make sure these changes to the process are reflected in https://github.com/alphagov/govuk-frontend/issues/1958