### PR TITLE
Remove deprecated `govuk-tag--inactive` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ If you’re calling `iff` from your own Sass, you should use [Sass's native `if`
 
 This change was introduced in [pull request #2409: Remove deprecated `iff` Sass function](https://github.com/alphagov/govuk-frontend/pull/2409).
 
+#### Remove deprecated `govuk-tag--inactive` class
+
+We've removed the `govuk-tag--inactive` class which we deprecated in [GOV.UK Frontend v3.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.6.0).
+
+Replace any use of this class with the `govuk-tag--grey` class.
+
+This change was introduced in [pull request #2417: Remove deprecated `govuk-tag--inactive class`](https://github.com/alphagov/govuk-frontend/pull/2417).
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/src/govuk/components/phase-banner/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/phase-banner/__snapshots__/template.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Phase banner with dependant components renders the tag component classes 1`] = `
-<strong class="govuk-tag govuk-phase-banner__content__tag govuk-tag--inactive">
+<strong class="govuk-tag govuk-phase-banner__content__tag govuk-tag--grey">
   alpha
 </strong>
 `;

--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -60,6 +60,6 @@ examples:
     data:
       text: This is a new service – your feedback will help us to improve it
       tag:
-        classes: govuk-tag--inactive
+        classes: govuk-tag--grey
         text: alpha
 

--- a/src/govuk/components/tag/_index.scss
+++ b/src/govuk/components/tag/_index.scss
@@ -34,11 +34,6 @@
     }
   }
 
-  // Deprecated. We'll remove this class in a future release. Use `.govuk-tag--grey` instead.
-  .govuk-tag--inactive {
-    background-color: govuk-colour("dark-grey", $legacy: "grey-1");
-  }
-
   .govuk-tag--grey {
     color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
     background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);

--- a/src/govuk/components/tag/tag.yaml
+++ b/src/govuk/components/tag/tag.yaml
@@ -23,7 +23,7 @@ examples:
 - name: inactive
   data:
     text: alpha
-    classes: govuk-tag--inactive
+    classes: govuk-tag--grey
 - name: grey
   data:
     text: Grey

--- a/src/govuk/components/tag/template.test.js
+++ b/src/govuk/components/tag/template.test.js
@@ -30,7 +30,7 @@ describe('Tag', () => {
       const $ = render('tag', examples.inactive)
 
       const $component = $('.govuk-tag')
-      expect($component.hasClass('govuk-tag--inactive')).toBeTruthy()
+      expect($component.hasClass('govuk-tag--grey')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Fixes #1757 (also see here for details of how this is a breaking change for users).

Class `govuk-tag--inactive` was replaced by `govuk-tag--grey` and deprecated in PR #1711.

This commit removes the class completely. Users should replace any uses of this class with `.govuk-tag--grey`.