### PR TITLE
Add pagination component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3804,7 +3804,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -4039,7 +4039,7 @@
     },
     "debug-log": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
       "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
       "dev": true
     },
@@ -6624,7 +6624,7 @@
     },
     "gulp-better-rollup": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/gulp-better-rollup/-/gulp-better-rollup-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-better-rollup/-/gulp-better-rollup-3.1.0.tgz",
       "integrity": "sha512-jpfkO/UI6ImKfbj3iZuYDJStWIqP7U1FcKr/JAXrzaTSvdI0dlKCLoGXpF8HtXcws112x14Xk1V7kfC0tfY9lQ==",
       "dev": true,
       "requires": {
@@ -14930,7 +14930,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },

--- a/src/govuk/components/_all.scss
+++ b/src/govuk/components/_all.scss
@@ -21,6 +21,7 @@
 @import "inset-text/index";
 @import "label/index";
 @import "notification-banner/index";
+@import "pagination/index";
 @import "panel/index";
 @import "phase-banner/index";
 @import "tabs/index";

--- a/src/govuk/components/pagination/README.md
+++ b/src/govuk/components/pagination/README.md
@@ -1,0 +1,15 @@
+# Pagination
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the panel component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/pagination).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/pagination/#options-panel-example) for details.

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -97,6 +97,7 @@
     padding-right: 0;
     padding-left: 0;
     color: $govuk-secondary-text-colour;
+    pointer-events: none;
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link:before {

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -54,6 +54,7 @@
     .govuk-pagination__icon {
       margin-top: 6px;
       margin-right: govuk-spacing(3);
+      fill: $govuk-secondary-text-colour;
     }
   }
 
@@ -81,6 +82,7 @@
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
+    color: $govuk-secondary-text-colour;
     font-weight: bold;
     text-align: center;
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -30,10 +30,6 @@
     }
   }
 
-  .govuk-pagination__list.govuk-pagination__list--block {
-    display: block;
-  }
-
   .govuk-pagination__results {
     @include govuk-font(19);
     margin-top: 0;
@@ -53,6 +49,14 @@
     @include govuk-media-query($until: tablet) {
       display: none;
     }
+
+    .govuk-pagination__icon {
+      margin-top: 6px;
+    }
+  }
+
+  .govuk-pagination__item--next .govuk-pagination__icon {
+    float: right;
   }
 
   // Only show previous, next, first, last and current items on mobile
@@ -67,17 +71,29 @@
     }
   }
 
-  // When link descriptions are used in previous and next links, align them vertically
-  .govuk-pagination__item.govuk-pagination__item--block {
-    display: block;
+  // Block mode - position previous and next links above and below numbers
+  .govuk-pagination__list--block {
+    .govuk-pagination__list {
+      display: block;
+      text-align: justify;
+    }
+
+    .govuk-pagination__item--prev,
+    .govuk-pagination__item--next {
+      display: block;
+    }
+
+    .govuk-pagination__item--next {
+      border-top: 1px solid $govuk-border-colour;
+
+      .govuk-pagination__icon {
+        float: none;
+      }
+    }
 
     .govuk-pagination__link {
       padding-left: 0;
     }
-  }
-
-  .govuk-pagination__item.govuk-pagination__item--next.govuk-pagination__item--block {
-    border-top: 1px solid $govuk-border-colour;
   }
 
   .govuk-pagination__item--active,
@@ -115,17 +131,25 @@
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
-    //text-align: center;
+
     &:hover {
       background: #f3f2f1;
+    }
+
+    .govuk-pagination__link-label {
+      display: block;
+      padding-left: govuk-spacing(5);
+      @include govuk-font($size: 16, $weight: "regular");
     }
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link {
     padding-left: 0;
+    font-weight: bold;
   }
 
   .govuk-pagination__item--next .govuk-pagination__link {
     padding-right: 0;
+    font-weight: bold;
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -126,13 +126,13 @@
       text-decoration: underline;
     }
 
-    &:hover {
-      color: $govuk-link-colour;
-      background: #f3f2f1;
+    &:focus {
+      box-shadow: 0 0 $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
+      text-decoration: underline;
+    }
 
-      .govuk-pagination__link-label {
-        @include govuk-link-hover-decoration;
-      }
+    &:hover:not(:focus) {
+      background-color: govuk-colour("light-grey", $legacy: "grey-4");
     }
   }
 

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -26,18 +26,18 @@
     @include govuk-media-query($from: tablet) {
       display: inline-block;
       margin-bottom: 0;
-      vertical-align: middle;
     }
   }
 
   .govuk-pagination__results {
     @include govuk-font(19);
     margin-top: 0;
+    margin-bottom: govuk-spacing(4);
     padding: govuk-spacing(1) 0;
     @include govuk-media-query($from: tablet) {
       display: inline-block;
       margin-bottom: 0;
-      vertical-align: middle;
+      //vertical-align: middle;
     }
   }
 
@@ -53,7 +53,7 @@
 
     .govuk-pagination__icon {
       margin-top: 6px;
-      margin-right: govuk-spacing(2);
+      margin-right: govuk-spacing(3);
     }
   }
 
@@ -103,18 +103,18 @@
 
   .govuk-pagination__link {
     @include govuk-link-common;
+    @include govuk-link-style-no-underline;
     box-sizing: border-box;
     display: block;
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
     color: $govuk-link-colour;
-    text-decoration: none;
 
     .govuk-pagination__link-label {
       @include govuk-font($size: 16, $weight: "regular");
       display: block;
-      padding-left: 31px;
+      padding-left: 32px;
       text-decoration: underline;
     }
 
@@ -124,10 +124,6 @@
 
       .govuk-pagination__link-label {
         @include govuk-link-hover-decoration;
-      }
-
-      .govuk-pagination__link-title {
-        //@include govuk-link-hover-decoration;
       }
     }
   }
@@ -166,6 +162,7 @@
 
     .govuk-pagination__link {
       padding-left: 0;
+      text-decoration: none;
     }
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -89,23 +89,10 @@
   .govuk-pagination__link {
     @include govuk-link-common;
     @include govuk-link-style-default;
+    @include govuk-link-style-no-underline;
     display: block;
     min-width: 25px;
     padding: govuk-spacing(1);
     text-align: center;
-    text-decoration: none;
-
-    &:link,
-    &:visited {
-      color: $govuk-link-colour;
-    }
-
-    &:hover {
-      color: govuk-tint($govuk-link-colour, 25);
-    }
-
-    &:focus {
-      color: govuk-colour("black");
-    }
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("govuk/component/pagination") {
   .govuk-pagination {
 
-    @include govuk-media-query($from: desktop) {
+    @include govuk-media-query($from: tablet) {
 
       // Alignment adjustments
       margin-right: - govuk-spacing(1);
@@ -25,7 +25,7 @@
     margin: 0;
     padding: 0;
     list-style: none;
-    @include govuk-media-query($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       display: inline-block;
       margin-bottom: 0;
       vertical-align: middle;
@@ -36,7 +36,7 @@
     @include govuk-font(19);
     margin-top: 0;
     padding: govuk-spacing(1);
-    @include govuk-media-query($from: desktop) {
+    @include govuk-media-query($from: tablet) {
       display: inline-block;
       margin-bottom: 0;
       vertical-align: middle;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -5,8 +5,8 @@
     @include govuk-media-query($from: desktop) {
 
       // Alignment adjustments
-      margin-left: - govuk-spacing(1);
       margin-right: - govuk-spacing(1);
+      margin-left: - govuk-spacing(1);
 
       // Hide whitespace between elements
       font-size: 0;
@@ -20,13 +20,12 @@
         width: 100%;
       }
     }
-
   }
 
   .govuk-pagination__list {
-    list-style: none;
     margin: 0;
     padding: 0;
+    list-style: none;
     @include govuk-media-query($from: desktop) {
       display: inline-block;
       margin-bottom: 0;
@@ -37,6 +36,7 @@
   .govuk-pagination__results {
     @include govuk-font(19);
     margin-top: 0;
+    padding: govuk-spacing(1);
     @include govuk-media-query($from: desktop) {
       display: inline-block;
       margin-bottom: 0;
@@ -51,49 +51,49 @@
 
   .govuk-pagination__item--active,
   .govuk-pagination__item--dots {
-    font-weight: bold;
     height: 25px;
     padding: govuk-spacing(1) govuk-spacing(2);
+    font-weight: bold;
     text-align: center;
   }
 
   .govuk-pagination__item--dots {
-    padding-left: 0;
     padding-right: 0;
+    padding-left: 0;
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link:before,
   .govuk-pagination__item--next .govuk-pagination__link:after {
-      display: inline-block;
-      height: 10px;
-      width: 10px;
-      border-style: solid;
-      color: govuk-colour("black");
-      background: transparent;
-      -webkit-transform: rotate(-45deg);
-      -ms-transform: rotate(-45deg);
-      transform: rotate(-45deg);
-      content: "";
+    content: "";
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    -webkit-transform: rotate(-45deg);
+    -ms-transform: rotate(-45deg);
+    transform: rotate(-45deg);
+    border-style: solid;
+    color: govuk-colour("black");
+    background: transparent;
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link:before {
-      border-width: 3px 0 0 3px;
-      margin-right: govuk-spacing(1);
+    margin-right: govuk-spacing(1);
+    border-width: 3px 0 0 3px;
   }
 
   .govuk-pagination__item--next .govuk-pagination__link:after {
-      border-width: 0 3px 3px 0;
-      margin-left: govuk-spacing(1);
+    margin-left: govuk-spacing(1);
+    border-width: 0 3px 3px 0;
   }
 
   .govuk-pagination__link {
     @include govuk-link-common;
     @include govuk-link-style-default;
     display: block;
+    min-width: 25px;
     padding: govuk-spacing(1);
     text-align: center;
     text-decoration: none;
-    min-width: 25px;
 
     &:link,
     &:visited {
@@ -107,10 +107,5 @@
     &:focus {
       color: govuk-colour("black");
     }
-
-  }
-
-  .govuk-pagination__results {
-    padding: govuk-spacing(1);
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -68,8 +68,7 @@
 
   .govuk-pagination__item--active,
   .govuk-pagination__item--elipses {
-    height: 25px;
-    padding: govuk-spacing(1) govuk-spacing(3);
+    padding: govuk-spacing(2) govuk-spacing(4);
     font-weight: bold;
     text-align: center;
   }
@@ -89,21 +88,12 @@
     border-width: 0 3px 3px 0;
   }
 
-  .govuk-pagination__item--prev {
-    //margin-right: govuk-spacing(2);
-  }
-
-  .govuk-pagination__item--next {
-    //margin-left: govuk-spacing(2);
-  }
-
   .govuk-pagination__link {
     @include govuk-link-common;
     @include govuk-link-style-default;
     @include govuk-link-style-no-underline;
     display: block;
-    min-width: 34px;
-    padding: govuk-spacing(1);
+    padding: govuk-spacing(2) govuk-spacing(4);
     text-align: center;
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -1,0 +1,116 @@
+@include govuk-exports("govuk/component/pagination") {
+  .govuk-pagination {
+    // text-align: center;
+
+    @include govuk-media-query($from: desktop) {
+
+      // Alignment adjustments
+      margin-left: - govuk-spacing(1);
+      margin-right: - govuk-spacing(1);
+
+      // Hide whitespace between elements
+      font-size: 0;
+
+      // Trick to remove the need for floats
+      text-align: justify;
+
+      &:after {
+        content: '';
+        display: inline-block;
+        width: 100%;
+      }
+    }
+
+  }
+
+  .govuk-pagination__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-bottom: 0;
+      vertical-align: middle;
+    }
+  }
+
+  .govuk-pagination__results {
+    @include govuk-font(19);
+    margin-top: 0;
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-bottom: 0;
+      vertical-align: middle;
+    }
+  }
+
+  .govuk-pagination__item {
+    @include govuk-font(19);
+    display: inline-block;
+  }
+
+  .govuk-pagination__item--active,
+  .govuk-pagination__item--dots {
+    font-weight: bold;
+    height: 25px;
+    padding: govuk-spacing(1) govuk-spacing(2);
+    text-align: center;
+  }
+
+  .govuk-pagination__item--dots {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .govuk-pagination__item--prev .govuk-pagination__link:before,
+  .govuk-pagination__item--next .govuk-pagination__link:after {
+      display: inline-block;
+      height: 10px;
+      width: 10px;
+      border-style: solid;
+      color: govuk-colour("black");
+      background: transparent;
+      -webkit-transform: rotate(-45deg);
+      -ms-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+      content: "";
+  }
+
+  .govuk-pagination__item--prev .govuk-pagination__link:before {
+      border-width: 3px 0 0 3px;
+      margin-right: govuk-spacing(1);
+  }
+
+  .govuk-pagination__item--next .govuk-pagination__link:after {
+      border-width: 0 3px 3px 0;
+      margin-left: govuk-spacing(1);
+  }
+
+  .govuk-pagination__link {
+    @include govuk-link-common;
+    @include govuk-link-style-default;
+    display: block;
+    padding: govuk-spacing(1);
+    text-align: center;
+    text-decoration: none;
+    min-width: 25px;
+
+    &:link,
+    &:visited {
+      color: $govuk-link-colour;
+    }
+
+    &:hover {
+      color: govuk-tint($govuk-link-colour, 25);
+    }
+
+    &:focus {
+      color: govuk-colour("black");
+    }
+
+  }
+
+  .govuk-pagination__results {
+    padding: govuk-spacing(1);
+  }
+}

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -44,6 +44,7 @@
   .govuk-pagination__item {
     @include govuk-font(19);
     display: inline-block;
+    margin-bottom: govuk-spacing(4);
 
     // Hide items on small screens
     @include govuk-media-query($until: tablet) {
@@ -71,33 +72,6 @@
   .govuk-pagination__item:nth-last-child(2) {
     @include govuk-media-query($until: tablet) {
       display: inline-block;
-    }
-  }
-
-  // Block mode - position previous and next links above and below numbers
-  .govuk-pagination__list--block {
-    .govuk-pagination__list {
-      display: block;
-      text-align: justify;
-    }
-
-    .govuk-pagination__item--prev,
-    .govuk-pagination__item--next {
-      display: block;
-    }
-
-    .govuk-pagination__item--next {
-      border-top: 1px solid $govuk-border-colour;
-
-      .govuk-pagination__icon {
-        margin-right: govuk-spacing(2);
-        margin-left: 0;
-        float: none;
-      }
-    }
-
-    .govuk-pagination__link {
-      padding-left: 0;
     }
   }
 
@@ -129,22 +103,32 @@
 
   .govuk-pagination__link {
     @include govuk-link-common;
-    @include govuk-link-style-default;
-    @include govuk-link-style-no-underline;
     box-sizing: border-box;
     display: block;
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
-
-    &:hover {
-      background: #f3f2f1;
-    }
+    color: $govuk-link-colour;
+    text-decoration: none;
 
     .govuk-pagination__link-label {
+      @include govuk-font($size: 16, $weight: "regular");
       display: block;
       padding-left: 31px;
-      @include govuk-font($size: 16, $weight: "regular");
+      text-decoration: underline;
+    }
+
+    &:hover {
+      color: $govuk-link-colour;
+      background: #f3f2f1;
+
+      .govuk-pagination__link-label {
+        @include govuk-link-hover-decoration;
+      }
+
+      .govuk-pagination__link-title {
+        //@include govuk-link-hover-decoration;
+      }
     }
   }
 
@@ -156,5 +140,32 @@
   .govuk-pagination__item--next .govuk-pagination__link {
     padding-right: 0;
     font-weight: bold;
+  }
+
+  // Block mode - position previous and next links above and below numbers
+  .govuk-pagination__list--block {
+    .govuk-pagination__list {
+      display: block;
+      text-align: justify;
+    }
+
+    .govuk-pagination__item--prev,
+    .govuk-pagination__item--next {
+      display: block;
+    }
+
+    .govuk-pagination__item--next {
+      border-top: 1px solid $govuk-border-colour;
+
+      .govuk-pagination__icon {
+        margin-right: govuk-spacing(2);
+        margin-left: 0;
+        float: none;
+      }
+    }
+
+    .govuk-pagination__link {
+      padding-left: 0;
+    }
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -71,7 +71,7 @@
   }
 
   // Only show previous, next, first, last and current items on mobile
-  .govuk-pagination__item--active,
+  .govuk-pagination__item--current,
   .govuk-pagination__item--elipses,
   .govuk-pagination__item--prev,
   .govuk-pagination__item--next,
@@ -82,7 +82,7 @@
     }
   }
 
-  .govuk-pagination__item--active,
+  .govuk-pagination__item--current,
   .govuk-pagination__item--elipses {
     box-sizing: border-box;
     min-width: 45px;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -48,13 +48,13 @@
     @include govuk-font(19);
     display: inline-block;
 
-    // Hide pages on small screens
+    // Hide items on small screens
     @include govuk-media-query($until: tablet) {
       display: none;
     }
   }
 
-  // Only show previous, next, first, last and current pages on mobile
+  // Only show previous, next, first, last and current items on mobile
   .govuk-pagination__item--active,
   .govuk-pagination__item--elipses,
   .govuk-pagination__item--prev,
@@ -68,12 +68,16 @@
 
   .govuk-pagination__item--active,
   .govuk-pagination__item--elipses {
-    padding: govuk-spacing(2) govuk-spacing(4);
+    box-sizing: border-box;
+    min-width: 45px;
+    min-height: 45px;
+    padding: 10px 18px;
     font-weight: bold;
     text-align: center;
   }
 
   .govuk-pagination__item--elipses {
+    margin: 0 -22.5px;
     padding-right: 0;
     padding-left: 0;
   }
@@ -92,8 +96,19 @@
     @include govuk-link-common;
     @include govuk-link-style-default;
     @include govuk-link-style-no-underline;
+    box-sizing: border-box;
     display: block;
-    padding: govuk-spacing(2) govuk-spacing(4);
+    min-width: 45px;
+    min-height: 45px;
+    padding: 10px 18px;
     text-align: center;
+  }
+
+  .govuk-pagination__item--prev .govuk-pagination__link {
+    padding-left: 0;
+  }
+
+  .govuk-pagination__item--next .govuk-pagination__link {
+    padding-right: 0;
   }
 }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -1,5 +1,6 @@
 @include govuk-exports("govuk/component/pagination") {
   .govuk-pagination {
+    text-align: center;
 
     @include govuk-media-query($from: tablet) {
 
@@ -46,12 +47,29 @@
   .govuk-pagination__item {
     @include govuk-font(19);
     display: inline-block;
+
+    // Hide pages on small screens
+    @include govuk-media-query($until: tablet) {
+      display: none;
+    }
+  }
+
+  // Only show previous, next, first, last and current pages on mobile
+  .govuk-pagination__item--active,
+  .govuk-pagination__item--dots,
+  .govuk-pagination__item--prev,
+  .govuk-pagination__item--next,
+  .govuk-pagination__item:nth-child(2),
+  .govuk-pagination__item:nth-last-child(2) {
+    @include govuk-media-query($until: tablet) {
+      display: inline-block;
+    }
   }
 
   .govuk-pagination__item--active,
   .govuk-pagination__item--dots {
     height: 25px;
-    padding: govuk-spacing(1) govuk-spacing(1);
+    padding: govuk-spacing(1) govuk-spacing(2);
     font-weight: bold;
     text-align: center;
   }
@@ -72,18 +90,19 @@
   }
 
   .govuk-pagination__item--prev {
-    margin-right: govuk-spacing(2);
+    //margin-right: govuk-spacing(2);
   }
 
   .govuk-pagination__item--next {
-    margin-left: govuk-spacing(2);
+    //margin-left: govuk-spacing(2);
   }
 
   .govuk-pagination__link {
     @include govuk-link-common;
     @include govuk-link-style-default;
     @include govuk-link-style-no-underline;
-    min-width: 25px;
+    display: block;
+    min-width: 34px;
     padding: govuk-spacing(1);
     text-align: center;
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -112,7 +112,7 @@
 
   .govuk-pagination__link {
     @include govuk-link-common;
-    @include govuk-link-style-no-underline;
+    //@include govuk-link-style-no-underline;
     box-sizing: border-box;
     display: block;
     min-width: 45px;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -58,10 +58,16 @@
     }
   }
 
+  // Set next item to relative position, which doesn’t affect its own position, but allows
+  // the SVG icon with it to be positioned relative to this container.
+  .govuk-pagination__item--next {
+    position: relative;
+  }
+
+  // Position SVG right arrow on the right of the link
   .govuk-pagination__item--next .govuk-pagination__icon {
-    margin-right: 0;
-    margin-left: govuk-spacing(3);
-    float: right;
+    position: absolute;
+    right: -15px;
   }
 
   // Only show previous, next, first, last and current items on mobile
@@ -136,7 +142,7 @@
   }
 
   .govuk-pagination__item--next .govuk-pagination__link {
-    padding-right: 0;
+    padding-right: 28px;
     font-weight: bold;
   }
 
@@ -156,9 +162,9 @@
       border-top: 1px solid $govuk-border-colour;
 
       .govuk-pagination__icon {
+        position: initial;
         margin-right: govuk-spacing(2);
         margin-left: 0;
-        float: none;
       }
     }
 

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -88,7 +88,6 @@
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
-    color: $govuk-secondary-text-colour;
     font-weight: bold;
     text-align: center;
   }
@@ -97,6 +96,7 @@
     margin: 0 -22.5px;
     padding-right: 0;
     padding-left: 0;
+    color: $govuk-secondary-text-colour;
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link:before {

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -56,7 +56,7 @@
 
   // Only show previous, next, first, last and current pages on mobile
   .govuk-pagination__item--active,
-  .govuk-pagination__item--dots,
+  .govuk-pagination__item--elipses,
   .govuk-pagination__item--prev,
   .govuk-pagination__item--next,
   .govuk-pagination__item:nth-child(2),
@@ -67,14 +67,14 @@
   }
 
   .govuk-pagination__item--active,
-  .govuk-pagination__item--dots {
+  .govuk-pagination__item--elipses {
     height: 25px;
     padding: govuk-spacing(1) govuk-spacing(3);
     font-weight: bold;
     text-align: center;
   }
 
-  .govuk-pagination__item--dots {
+  .govuk-pagination__item--elipses {
     padding-right: 0;
     padding-left: 0;
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -1,6 +1,5 @@
 @include govuk-exports("govuk/component/pagination") {
   .govuk-pagination {
-    // text-align: center;
 
     @include govuk-media-query($from: desktop) {
 

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -51,7 +51,7 @@
   .govuk-pagination__item--active,
   .govuk-pagination__item--dots {
     height: 25px;
-    padding: govuk-spacing(1) govuk-spacing(2);
+    padding: govuk-spacing(1) govuk-spacing(1);
     font-weight: bold;
     text-align: center;
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -69,7 +69,7 @@
   .govuk-pagination__item--active,
   .govuk-pagination__item--dots {
     height: 25px;
-    padding: govuk-spacing(1) govuk-spacing(2);
+    padding: govuk-spacing(1) govuk-spacing(3);
     font-weight: bold;
     text-align: center;
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -127,6 +127,10 @@
       text-decoration: underline;
     }
 
+    &:hover .govuk-pagination__link-label {
+      @include govuk-link-hover-decoration;
+    }
+
     &:focus {
       box-shadow: 0 0 $govuk-focus-colour, 0 4px $govuk-focus-text-colour;
       text-decoration: underline;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -1,5 +1,6 @@
 @include govuk-exports("govuk/component/pagination") {
   .govuk-pagination {
+    border-top: 1px solid $govuk-border-colour;
     text-align: center;
 
     @include govuk-media-query($from: tablet) {
@@ -27,6 +28,10 @@
       margin-bottom: 0;
       vertical-align: middle;
     }
+  }
+
+  .govuk-pagination__list.govuk-pagination__list--block {
+    display: block;
   }
 
   .govuk-pagination__results {
@@ -60,6 +65,19 @@
     @include govuk-media-query($until: tablet) {
       display: inline-block;
     }
+  }
+
+  // When link descriptions are used in previous and next links, align them vertically
+  .govuk-pagination__item.govuk-pagination__item--block {
+    display: block;
+
+    .govuk-pagination__link {
+      padding-left: 0;
+    }
+  }
+
+  .govuk-pagination__item.govuk-pagination__item--next.govuk-pagination__item--block {
+    border-top: 1px solid $govuk-border-colour;
   }
 
   .govuk-pagination__item--active,
@@ -97,7 +115,10 @@
     min-width: 45px;
     min-height: 45px;
     padding: 10px 18px;
-    text-align: center;
+    //text-align: center;
+    &:hover {
+      background: #f3f2f1;
+    }
   }
 
   .govuk-pagination__item--prev .govuk-pagination__link {

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -52,10 +52,13 @@
 
     .govuk-pagination__icon {
       margin-top: 6px;
+      margin-right: govuk-spacing(2);
     }
   }
 
   .govuk-pagination__item--next .govuk-pagination__icon {
+    margin-right: 0;
+    margin-left: govuk-spacing(3);
     float: right;
   }
 
@@ -87,6 +90,8 @@
       border-top: 1px solid $govuk-border-colour;
 
       .govuk-pagination__icon {
+        margin-right: govuk-spacing(2);
+        margin-left: 0;
         float: none;
       }
     }
@@ -138,7 +143,7 @@
 
     .govuk-pagination__link-label {
       display: block;
-      padding-left: govuk-spacing(5);
+      padding-left: 31px;
       @include govuk-font($size: 16, $weight: "regular");
     }
   }

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -61,20 +61,6 @@
     padding-left: 0;
   }
 
-  .govuk-pagination__item--prev .govuk-pagination__link:before,
-  .govuk-pagination__item--next .govuk-pagination__link:after {
-    content: "";
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    -webkit-transform: rotate(-45deg);
-    -ms-transform: rotate(-45deg);
-    transform: rotate(-45deg);
-    border-style: solid;
-    color: govuk-colour("black");
-    background: transparent;
-  }
-
   .govuk-pagination__item--prev .govuk-pagination__link:before {
     margin-right: govuk-spacing(1);
     border-width: 3px 0 0 3px;
@@ -85,11 +71,18 @@
     border-width: 0 3px 3px 0;
   }
 
+  .govuk-pagination__item--prev {
+    margin-right: govuk-spacing(4);
+  }
+
+  .govuk-pagination__item--next {
+    margin-left: govuk-spacing(4);
+  }
+
   .govuk-pagination__link {
     @include govuk-link-common;
     @include govuk-link-style-default;
     @include govuk-link-style-no-underline;
-    display: block;
     min-width: 25px;
     padding: govuk-spacing(1);
     text-align: center;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -72,11 +72,11 @@
   }
 
   .govuk-pagination__item--prev {
-    margin-right: govuk-spacing(4);
+    margin-right: govuk-spacing(2);
   }
 
   .govuk-pagination__item--next {
-    margin-left: govuk-spacing(4);
+    margin-left: govuk-spacing(2);
   }
 
   .govuk-pagination__link {

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -72,7 +72,7 @@
 
   // Only show previous, next, first, last and current items on mobile
   .govuk-pagination__item--current,
-  .govuk-pagination__item--elipses,
+  .govuk-pagination__item--ellipses,
   .govuk-pagination__item--prev,
   .govuk-pagination__item--next,
   .govuk-pagination__item:nth-child(2),
@@ -83,7 +83,7 @@
   }
 
   .govuk-pagination__item--current,
-  .govuk-pagination__item--elipses {
+  .govuk-pagination__item--ellipses {
     box-sizing: border-box;
     min-width: 45px;
     min-height: 45px;
@@ -92,7 +92,7 @@
     text-align: center;
   }
 
-  .govuk-pagination__item--elipses {
+  .govuk-pagination__item--ellipses {
     margin: 0 -22.5px;
     padding-right: 0;
     padding-left: 0;

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -144,7 +144,7 @@
   .govuk-pagination__list--block {
     .govuk-pagination__list {
       display: block;
-      text-align: justify;
+      text-align: left;
     }
 
     .govuk-pagination__item--prev,

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -4,10 +4,6 @@
 
     @include govuk-media-query($from: tablet) {
 
-      // Alignment adjustments
-      margin-right: - govuk-spacing(1);
-      margin-left: - govuk-spacing(1);
-
       // Hide whitespace between elements
       font-size: 0;
 
@@ -36,7 +32,7 @@
   .govuk-pagination__results {
     @include govuk-font(19);
     margin-top: 0;
-    padding: govuk-spacing(1);
+    padding: govuk-spacing(1) 0;
     @include govuk-media-query($from: tablet) {
       display: inline-block;
       margin-bottom: 0;

--- a/src/govuk/components/pagination/_pagination.scss
+++ b/src/govuk/components/pagination/_pagination.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/src/govuk/components/pagination/macro.njk
+++ b/src/govuk/components/pagination/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukPagination(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -83,7 +83,7 @@ examples:
     - text: '1'
       href: '/page=1'
     - text: '2'
-      selected: true
+      current: true
     - text: '3'
       href: '/page=3'
 - name: with labels but no numbers
@@ -120,7 +120,7 @@ examples:
     - text: '1'
       href: '/page=1'
     - text: '2'
-      selected: true
+      current: true
     - text: '3'
       href: '/page=3'
 - name: with many pages
@@ -142,7 +142,7 @@ examples:
     - text: '9'
       href: '/page=9'
     - text: '10'
-      selected: true
+      current: true
     - text: '11'
       href: '/page=11'
     - text: '12'
@@ -156,7 +156,7 @@ examples:
       href: '/page=2'
     items:
     - text: '1'
-      selected: true
+      current: true
     - text: '2'
       href: '/page=2'
     - text: '3'
@@ -171,7 +171,7 @@ examples:
     - text: '2'
       href: '/page=2'
     - text: '3'
-      selected: true
+      current: true
 - name: with results
   data:
     results:
@@ -186,7 +186,7 @@ examples:
     - text: '1'
       href: '/page=1'
     - text: '2'
-      selected: true
+      current: true
     - text: '3'
       href: '/page=3'
 - name: with a different type of results
@@ -204,6 +204,6 @@ examples:
     - text: '1'
       href: '/page=1'
     - text: '2'
-      selected: true
+      current: true
     - text: '3'
       href: '/page=3'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -11,10 +11,10 @@ params:
   - name: text
     type: string
     required: false
-    description: The previous page link text.
+    description: The previous page link text. Defaults to 'Previous page', where 'page' is visually hidden.
   - name: href
     type: string
-    required: false
+    required: true
     description: The previous page URL.
 - name: next
   type: object
@@ -24,10 +24,10 @@ params:
   - name: text
     type: string
     required: false
-    description: The next page link text.
+    description: The next page link text. Defaults to 'Next page', where 'page' is visually hidden.
   - name: href
     type: string
-    required: false
+    required: true
     description: The next page URL.
 - name: items
   type: array
@@ -76,6 +76,19 @@ examples:
 - name: default
   data:
     previous:
+      href: '/page=1'
+    next:
+      href: '/page=3'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      selected: true
+    - text: '3'
+      href: '/page=3'
+- name: with custom link text
+  data:
+    previous:
       text: 'Previous page'
       href: '/page=1'
     next:
@@ -95,10 +108,8 @@ examples:
       to: 1050
       count: 2000
     previous:
-      text: 'Previous page'
       href: '/page=9'
     next:
-      text: 'Next page'
       href: '/page=11'
     items:
     - text: '1'
@@ -120,7 +131,6 @@ examples:
 - name: first page
   data:
     next:
-      text: 'Next page'
       href: '/page=2'
     items:
     - text: '1'
@@ -132,7 +142,6 @@ examples:
 - name: last page
   data:
     previous:
-      text: 'Previous page'
       href: '/page=1'
     items:
     - text: '1'
@@ -148,10 +157,8 @@ examples:
       to: 100
       count: 150
     previous:
-      text: 'Previous page'
       href: '/page=1'
     next:
-      text: 'Next page'
       href: '/page=3'
     items:
     - text: '1'
@@ -168,10 +175,8 @@ examples:
       count: 60
       type: 'team members'
     previous:
-      text: 'Previous page'
       href: '/page=1'
     next:
-      text: 'Next page'
       href: '/page=3'
     items:
     - text: '1'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -37,11 +37,11 @@ params:
   - name: type
     type: string
     required: false
-    description: Set to 'dots' to add elipses.
+    description: Set to 'dots' to indicate where a list has been truncated.
   - name: selected
     type: boolean
     required: false
-    description: Set to 'dots' to add elipses.
+    description: Set to 'true' to indicate the current page.
   - name: text
     type: string
     required: false
@@ -53,7 +53,7 @@ params:
 - name: results
   type: object
   required: false
-  description: Array of link objects.
+  description: Optional text describing the total number of results and which ones are on the current page.
   params:
   - name: from
     type: string
@@ -70,7 +70,7 @@ params:
   - name: type
     type: string
     required: false
-    description: The type of result. Defaults to 'results'.
+    description: Used to describe the component to screen-readers and in the results text. Defaults to 'results'.
 
 examples:
 - name: default

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -86,6 +86,16 @@ examples:
       selected: true
     - text: '3'
       href: '/page=3'
+- name: with page descriptions but no numbers
+  data:
+    previous:
+      text: 'Previous page'
+      description: '1 of 3'
+      href: '/page=1'
+    next:
+      text: 'Next page'
+      description: '3 of 3'
+      href: '/page=3'
 - name: with custom link text
   data:
     previous:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -76,53 +76,53 @@ examples:
 - name: default
   data:
     previous:
-      href: '/page=1'
+      href: '#'
     next:
-      href: '/page=3'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - text: '2'
       current: true
     - text: '3'
-      href: '/page=3'
+      href: '#'
 - name: with labels but no numbers
   data:
     classes: 'govuk-pagination__list--block'
     previous:
       text: 'Previous page'
       label: '1 of 3'
-      href: '/page=1'
+      href: '#'
     next:
       text: 'Next page'
       label: '3 of 3'
-      href: '/page=3'
+      href: '#'
 - name: with long labels
   data:
     classes: 'govuk-pagination__list--block'
     previous:
       text: 'Previous page'
       label: 'Applying for a provisional lorry or bus licence'
-      href: '/page=1'
+      href: '#'
     next:
       text: 'Next page'
       label: 'Driver CPC part 1 test: theory'
-      href: '/page=3'
+      href: '#'
 - name: with custom link text
   data:
     previous:
       text: 'Previous page'
-      href: '/page=1'
+      href: '#'
     next:
       text: 'Next page'
-      href: '/page=3'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - text: '2'
       current: true
     - text: '3'
-      href: '/page=3'
+      href: '#'
 - name: with many pages
   data:
     results:
@@ -130,46 +130,46 @@ examples:
       to: 1050
       count: 2000
     previous:
-      href: '/page=9'
+      href: '#'
     next:
-      href: '/page=11'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - type: 'ellipses'
     - text: '8'
-      href: '/page=8'
+      href: '#'
     - text: '9'
-      href: '/page=9'
+      href: '#'
     - text: '10'
       current: true
     - text: '11'
-      href: '/page=11'
+      href: '#'
     - text: '12'
-      href: '/page=12'
+      href: '#'
     - type: 'ellipses'
     - text: '40'
-      href: '/page=40'
+      href: '#'
 - name: first page
   data:
     next:
-      href: '/page=2'
+      href: '#'
     items:
     - text: '1'
       current: true
     - text: '2'
-      href: '/page=2'
+      href: '#'
     - text: '3'
-      href: '/page=3'
+      href: '#'
 - name: last page
   data:
     previous:
-      href: '/page=1'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - text: '2'
-      href: '/page=2'
+      href: '#'
     - text: '3'
       current: true
 - name: with results
@@ -179,16 +179,16 @@ examples:
       to: 100
       count: 150
     previous:
-      href: '/page=1'
+      href: '#'
     next:
-      href: '/page=3'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - text: '2'
       current: true
     - text: '3'
-      href: '/page=3'
+      href: '#'
 - name: with a different type of results
   data:
     results:
@@ -197,13 +197,13 @@ examples:
       count: 60
       type: 'team members'
     previous:
-      href: '/page=1'
+      href: '#'
     next:
-      href: '/page=3'
+      href: '#'
     items:
     - text: '1'
-      href: '/page=1'
+      href: '#'
     - text: '2'
       current: true
     - text: '3'
-      href: '/page=3'
+      href: '#'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -97,6 +97,17 @@ examples:
       text: 'Next page'
       label: '3 of 3'
       href: '/page=3'
+- name: with long labels
+  data:
+    classes: 'govuk-pagination__list--block'
+    previous:
+      text: 'Previous page'
+      label: 'Applying for a provisional lorry or bus licence'
+      href: '/page=1'
+    next:
+      text: 'Next page'
+      label: 'Driver CPC part 1 test: theory'
+      href: '/page=3'
 - name: with custom link text
   data:
     previous:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -37,7 +37,7 @@ params:
   - name: type
     type: string
     required: false
-    description: Set to 'dots' to indicate where a list has been truncated.
+    description: Set to 'elipses' to indicate where a list has been truncated.
   - name: selected
     type: boolean
     required: false
@@ -114,7 +114,7 @@ examples:
     items:
     - text: '1'
       href: '/page=1'
-    - type: 'dots'
+    - type: 'elipses'
     - text: '8'
       href: '/page=8'
     - text: '9'
@@ -125,7 +125,7 @@ examples:
       href: '/page=11'
     - text: '12'
       href: '/page=12'
-    - type: 'dots'
+    - type: 'elipses'
     - text: '40'
       href: '/page=40'
 - name: first page

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -37,7 +37,7 @@ params:
   - name: type
     type: string
     required: false
-    description: Set to 'elipses' to indicate where a list has been truncated.
+    description: Set to 'ellipses' to indicate where a list has been truncated.
   - name: selected
     type: boolean
     required: false
@@ -136,7 +136,7 @@ examples:
     items:
     - text: '1'
       href: '/page=1'
-    - type: 'elipses'
+    - type: 'ellipses'
     - text: '8'
       href: '/page=8'
     - text: '9'
@@ -147,7 +147,7 @@ examples:
       href: '/page=11'
     - text: '12'
       href: '/page=12'
-    - type: 'elipses'
+    - type: 'ellipses'
     - text: '40'
       href: '/page=40'
 - name: first page

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -88,13 +88,14 @@ examples:
       href: '/page=3'
 - name: with page descriptions but no numbers
   data:
+    classes: 'govuk-pagination__list--block'
     previous:
       text: 'Previous page'
-      description: '1 of 3'
+      label: '1 of 3'
       href: '/page=1'
     next:
       text: 'Next page'
-      description: '3 of 3'
+      label: '3 of 3'
       href: '/page=3'
 - name: with custom link text
   data:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -1,20 +1,62 @@
 examples:
 - name: default
   data:
-    results:
-      from: 10
-      to: 20
-      count: 30
-    previous:
-      text: 'Previous'
-      href: ''
     next:
-      text: 'Next'
-      href: ''
+      text: 'Next page'
+      href: '/page=2'
     items:
     - text: '1'
       href: '/page=1'
+      selected: true
     - text: '2'
       href: '/page=2'
     - text: '3'
       href: '/page=3'
+- name: with results
+  data:
+    results:
+      from: 50
+      to: 100
+      count: 150
+    previous:
+      text: 'Previous page'
+      href: '/page=1'
+    next:
+      text: 'Next page'
+      href: '/page=3'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      selected: true
+    - text: '3'
+      href: '/page=3'
+- name: with first and last pages
+  data:
+    results:
+      from: 1000
+      to: 1050
+      count: 2000
+    previous:
+      text: 'Previous page'
+      href: '/page=9'
+    next:
+      text: 'Next page'
+      href: '/page=11'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - type: 'dots'
+    - text: '8'
+      href: '/page=8'
+    - text: '9'
+      href: '/page=9'
+    - text: '10'
+      selected: true
+    - text: '11'
+      href: '/page=11'
+    - text: '12'
+      href: '/page=12'
+    - type: 'dots'
+    - text: '40'
+      href: '/page=40'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -86,7 +86,7 @@ examples:
       selected: true
     - text: '3'
       href: '/page=3'
-- name: with page descriptions but no numbers
+- name: with labels but no numbers
   data:
     classes: 'govuk-pagination__list--block'
     previous:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -1,0 +1,20 @@
+examples:
+- name: default
+  data:
+    results:
+      from: 10
+      to: 20
+      count: 30
+    previous:
+      text: 'Previous'
+      href: ''
+    next:
+      text: 'Next'
+      href: ''
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      href: '/page=2'
+    - text: '3'
+      href: '/page=3'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -31,6 +31,26 @@ examples:
       selected: true
     - text: '3'
       href: '/page=3'
+- name: with a different type of results
+  data:
+    results:
+      from: 20
+      to: 40
+      count: 60
+      type: 'team members'
+    previous:
+      text: 'Previous page'
+      href: '/page=1'
+    next:
+      text: 'Next page'
+      href: '/page=3'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      selected: true
+    - text: '3'
+      href: '/page=3'
 - name: with first and last pages
   data:
     results:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -1,17 +1,72 @@
 examples:
 - name: default
   data:
+    previous:
+      text: 'Previous page'
+      href: '/page=1'
+    next:
+      text: 'Next page'
+      href: '/page=3'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      selected: true
+    - text: '3'
+      href: '/page=3'
+- name: with many pages
+  data:
+    results:
+      from: 1000
+      to: 1050
+      count: 2000
+    previous:
+      text: 'Previous page'
+      href: '/page=9'
+    next:
+      text: 'Next page'
+      href: '/page=11'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - type: 'dots'
+    - text: '8'
+      href: '/page=8'
+    - text: '9'
+      href: '/page=9'
+    - text: '10'
+      selected: true
+    - text: '11'
+      href: '/page=11'
+    - text: '12'
+      href: '/page=12'
+    - type: 'dots'
+    - text: '40'
+      href: '/page=40'
+- name: first page
+  data:
     next:
       text: 'Next page'
       href: '/page=2'
     items:
     - text: '1'
-      href: '/page=1'
       selected: true
     - text: '2'
       href: '/page=2'
     - text: '3'
       href: '/page=3'
+- name: last page
+  data:
+    previous:
+      text: 'Previous page'
+      href: '/page=1'
+    items:
+    - text: '1'
+      href: '/page=1'
+    - text: '2'
+      href: '/page=2'
+    - text: '3'
+      selected: true
 - name: with results
   data:
     results:
@@ -51,32 +106,3 @@ examples:
       selected: true
     - text: '3'
       href: '/page=3'
-- name: with first and last pages
-  data:
-    results:
-      from: 1000
-      to: 1050
-      count: 2000
-    previous:
-      text: 'Previous page'
-      href: '/page=9'
-    next:
-      text: 'Next page'
-      href: '/page=11'
-    items:
-    - text: '1'
-      href: '/page=1'
-    - type: 'dots'
-    - text: '8'
-      href: '/page=8'
-    - text: '9'
-      href: '/page=9'
-    - text: '10'
-      selected: true
-    - text: '11'
-      href: '/page=11'
-    - text: '12'
-      href: '/page=12'
-    - type: 'dots'
-    - text: '40'
-      href: '/page=40'

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -1,3 +1,77 @@
+params:
+- name: classes
+  type: string
+  required: false
+  description: The classes that you want to add to the pagination.
+- name: previous
+  type: object
+  required: false
+  description: A link to the previous page, if there is one.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: The previous page link text.
+  - name: href
+    type: string
+    required: false
+    description: The previous page URL.
+- name: next
+  type: object
+  required: false
+  description: A link to the next page, if there is one.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: The next page link text.
+  - name: href
+    type: string
+    required: false
+    description: The next page URL.
+- name: items
+  type: array
+  required: true
+  description: Array of link objects.
+  params:
+  - name: type
+    type: string
+    required: false
+    description: Set to 'dots' to add elipses.
+  - name: selected
+    type: boolean
+    required: false
+    description: Set to 'dots' to add elipses.
+  - name: text
+    type: string
+    required: false
+    description: The link text - usually a page number.
+  - name: href
+    type: string
+    required: false
+    description: The link URL.
+- name: results
+  type: object
+  required: false
+  description: Array of link objects.
+  params:
+  - name: from
+    type: string
+    required: true
+    description: Number of first result on page.
+  - name: to
+    type: string
+    required: true
+    description: Number of last result on page.
+  - name: count
+    type: string
+    required: true
+    description: Total number of results.
+  - name: type
+    type: string
+    required: false
+    description: The type of result. Defaults to 'results'.
+
 examples:
 - name: default
   data:

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -104,7 +104,7 @@ examples:
 - name: with many pages
   data:
     results:
-      from: 1000
+      from: 1001
       to: 1050
       count: 2000
     previous:
@@ -153,7 +153,7 @@ examples:
 - name: with results
   data:
     results:
-      from: 50
+      from: 51
       to: 100
       count: 150
     previous:
@@ -170,7 +170,7 @@ examples:
 - name: with a different type of results
   data:
     results:
-      from: 20
+      from: 21
       to: 40
       count: 60
       type: 'team members'

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -5,7 +5,12 @@
   <ul class="govuk-pagination__list">
     {%- if params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
-        <a class="govuk-pagination__link" href="{{ params.previous.href }}">{{ params.previous.text }}</a>
+          <a class="govuk-pagination__link" href="{{ params.previous.href }}">
+              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+              </svg>
+              {{ params.previous.text }}
+        </a>
       </li>
     {% endif -%}
 
@@ -23,7 +28,11 @@
 
     {%- if params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
-        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}</a>
+        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+        </a>
       </li>
     {% endif -%}
   </ul>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -25,8 +25,8 @@
     {%- if item.type == 'elipses' %}
     <li class="govuk-pagination__item govuk-pagination__item--elipses">…</li>
     {% else %}
-    {%- if item.selected %}
-    <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>
+    {%- if item.current %}
+    <li class="govuk-pagination__item govuk-pagination__item--current"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>
     {% else %}
     <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}"><span class="govuk-visually-hidden">Page </span>{{ item.text }}</a></li>
     {% endif -%}

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -6,7 +6,7 @@
     {%- if params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
           <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="30" viewBox="0 0 17 13">
                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
               </svg>
               {{ params.previous.text }}
@@ -29,7 +29,7 @@
     {%- if params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
         <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}
-          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="30" viewBox="0 0 17 13">
             <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
           </svg>
         </a>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -1,84 +1,61 @@
-{% if params.results.type %}
-  {% set type = params.results.type %}
-{% else %}
-  {# If no type is defined, set it to 'results' #}
-  {% set type = "results" %}
-{% endif %}
+{% set type = params.results.type | default("results") -%}
 
-{% if params.next.description %}
-  {% set block = " govuk-pagination__list--block" %}
-{% else %}
-  {% set block = "" %}
-{% endif %}
 <nav class="govuk-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label" aria-label="{{type}} navigation">
 
-  <ul class="govuk-pagination__list{{block}}">
-    {%- if params.previous and params.next.description  %}
-      <li class="govuk-pagination__item  govuk-pagination__item--prev govuk-pagination__item--block">
-    {%- elseif params.previous %}
-      <li class="govuk-pagination__item  govuk-pagination__item--prev">
-    {% endif -%}
+  <ul class="govuk-pagination__list">
     {%- if params.previous %}
-          <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 19 13">
-                <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-              </svg>
-              {%- if params.previous.text %}
-              {{ params.previous.text }}
-              {% else %}
-              Previous <span class="govuk-visually-hidden">page</span>
-              {% endif -%}
-              {%- if params.previous.description %}
-              <br><span class="govuk-!-font-size-16 govuk-!-padding-left-4">{{ params.previous.description }}</span>
-              {% endif -%}
-        </a>
-      </li>
+    <li class="govuk-pagination__item govuk-pagination__item--prev">
+      <a class="govuk-pagination__link" href="{{ params.previous.href }}">
+        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 19 13">
+          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+        </svg>
+        {%- if params.previous.text %}
+        {{ params.previous.text }}
+        {% else %}
+        Previous <span class="govuk-visually-hidden">page</span>
+        {% endif -%}
+        {%- if params.previous.label %}
+        <span class="govuk-pagination__link-divider govuk-visually-hidden">:</span>
+        <span class="govuk-pagination__link-label">{{ params.previous.label }}</span>
+        {% endif -%}
+      </a>
+    </li>
     {% endif -%}
 
     {%- for item in params.items %}
-      {%- if item.type == 'elipses' %}
-        <li class="govuk-pagination__item govuk-pagination__item--elipses">&hellip;</li>
-      {% else %}
-        {%- if item.selected %}
-          <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>
-        {% else %}
-          <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}"><span class="govuk-visually-hidden">Page </span>{{ item.text }}</a></li>
-        {% endif -%}
-      {% endif -%}
+    {%- if item.type == 'elipses' %}
+    <li class="govuk-pagination__item govuk-pagination__item--elipses">&hellip;</li>
+    {% else %}
+    {%- if item.selected %}
+    <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>
+    {% else %}
+    <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}"><span class="govuk-visually-hidden">Page </span>{{ item.text }}</a></li>
+    {% endif -%}
+    {% endif -%}
     {% endfor -%}
 
-    {%- if params.next and params.next.description %}
-      <li class="govuk-pagination__item  govuk-pagination__item--next govuk-pagination__item--block">
-        <a class="govuk-pagination__link" href="{{ params.next.href }}">
-          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
-            <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-          </svg>
-          {%- if params.next.text %}
-          {{ params.next.text }}
-          {% else %}
-          Next <span class="govuk-visually-hidden">page</span>
-          {% endif -%}
-          <br><span class="govuk-!-font-size-16 govuk-!-padding-left-4">{{ params.next.description }}</span>
-        </a>
-      </li>
-    {%- elseif params.next %}
-      <li class="govuk-pagination__item  govuk-pagination__item--next">
-        <a class="govuk-pagination__link" href="{{ params.next.href }}">
-          {%- if params.next.text %}
-          {{ params.next.text }}
-          {% else %}
-          Next <span class="govuk-visually-hidden">page</span>
-          {% endif -%}
-          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
-            <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-          </svg>
-        </a>
-      </li>
+    {%- if params.next %}
+    <li class="govuk-pagination__item govuk-pagination__item--next">
+      <a class="govuk-pagination__link" href="{{ params.next.href }}">
+        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
+          <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+        </svg>
+        {%- if params.next.text %}
+        {{ params.next.text }}
+        {% else %}
+        Next <span class="govuk-visually-hidden">page</span>
+        {% endif -%}
+        {%- if params.next.label %}
+        <span class="govuk-pagination__link-divider govuk-visually-hidden">:</span>
+        <span class="govuk-pagination__link-label">{{ params.next.label }}</span>
+        {% endif -%}
+      </a>
+    </li>
     {% endif -%}
   </ul>
 
   {%- if params.results %}
-    <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> {{type}}</p>
+  <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> {{type}}</p>
   {% endif -%}
 
 </nav>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -13,7 +13,11 @@
               <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
               </svg>
+              {%- if params.previous.text %}
               {{ params.previous.text }}
+              {% else %}
+              Previous <span class="govuk-visually-hidden">page</span>
+              {% endif -%}
         </a>
       </li>
     {% endif -%}
@@ -32,7 +36,12 @@
 
     {%- if params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
-        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}
+        <a class="govuk-pagination__link" href="{{ params.next.href }}">
+          {%- if params.next.text %}
+          {{ params.next.text }}
+          {% else %}
+          Next <span class="govuk-visually-hidden">page</span>
+          {% endif -%}
           <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
             <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
           </svg>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -6,7 +6,7 @@
     {%- if params.previous %}
     <li class="govuk-pagination__item govuk-pagination__item--prev">
       <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 19 13">
+        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
           <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
         </svg>
         {%- if params.previous.text %}
@@ -37,7 +37,7 @@
     {%- if params.next %}
     <li class="govuk-pagination__item govuk-pagination__item--next">
       <a class="govuk-pagination__link" href="{{ params.next.href }}">
-        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
+        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
           <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
         </svg>
         {%- if params.next.text %}

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -10,7 +10,7 @@
     {%- if params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
           <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
+              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 19 13">
                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
               </svg>
               {%- if params.previous.text %}
@@ -42,7 +42,7 @@
           {% else %}
           Next <span class="govuk-visually-hidden">page</span>
           {% endif -%}
-          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
             <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
           </svg>
         </a>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -5,7 +5,7 @@
   <ul class="govuk-pagination__list">
     {%- if params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
-        <a class="govuk-pagination__link" href="{{ params.previous.href }}">{{ params.previous.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+        <a class="govuk-pagination__link" href="{{ params.previous.href }}">{{ params.previous.text }}</a>
       </li>
     {% endif -%}
 
@@ -23,7 +23,7 @@
 
     {%- if params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
-        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}</a>
       </li>
     {% endif -%}
   </ul>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -23,8 +23,8 @@
     {% endif -%}
 
     {%- for item in params.items %}
-      {%- if item.type == 'dots' %}
-        <li class="govuk-pagination__item govuk-pagination__item--dots">...</li>
+      {%- if item.type == 'elipses' %}
+        <li class="govuk-pagination__item govuk-pagination__item--elipses">&hellip;</li>
       {% else %}
         {%- if item.selected %}
           <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -23,7 +23,7 @@
 
     {%- for item in params.items %}
     {%- if item.type == 'elipses' %}
-    <li class="govuk-pagination__item govuk-pagination__item--elipses">&hellip;</li>
+    <li class="govuk-pagination__item govuk-pagination__item--elipses">…</li>
     {% else %}
     {%- if item.selected %}
     <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -6,14 +6,16 @@
     {%- if params.previous %}
     <li class="govuk-pagination__item govuk-pagination__item--prev">
       <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
-          <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-        </svg>
-        {%- if params.previous.text %}
-        {{ params.previous.text }}
-        {% else %}
-        Previous <span class="govuk-visually-hidden">page</span>
-        {% endif -%}
+        <span class="govuk-pagination__link-title">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
+            <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+          </svg>
+          {%- if params.previous.text %}
+          {{ params.previous.text }}
+          {% else %}
+          Previous <span class="govuk-visually-hidden">page</span>
+          {% endif -%}
+        </span>
         {%- if params.previous.label %}
         <span class="govuk-pagination__link-divider govuk-visually-hidden">:</span>
         <span class="govuk-pagination__link-label">{{ params.previous.label }}</span>
@@ -37,14 +39,16 @@
     {%- if params.next %}
     <li class="govuk-pagination__item govuk-pagination__item--next">
       <a class="govuk-pagination__link" href="{{ params.next.href }}">
-        <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
-          <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
-        </svg>
-        {%- if params.next.text %}
-        {{ params.next.text }}
-        {% else %}
-        Next <span class="govuk-visually-hidden">page</span>
-        {% endif -%}
+        <span class="govuk-pagination__link-title">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
+            <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+          {%- if params.next.text %}
+          {{ params.next.text }}
+          {% else %}
+          Next <span class="govuk-visually-hidden">page</span>
+          {% endif -%}
+        </span>
         {%- if params.next.label %}
         <span class="govuk-pagination__link-divider govuk-visually-hidden">:</span>
         <span class="govuk-pagination__link-label">{{ params.next.label }}</span>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -4,11 +4,21 @@
   {# If no type is defined, set it to 'results' #}
   {% set type = "results" %}
 {% endif %}
+
+{% if params.next.description %}
+  {% set block = " govuk-pagination__list--block" %}
+{% else %}
+  {% set block = "" %}
+{% endif %}
 <nav class="govuk-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label" aria-label="{{type}} navigation">
 
-  <ul class="govuk-pagination__list">
-    {%- if params.previous %}
+  <ul class="govuk-pagination__list{{block}}">
+    {%- if params.previous and params.next.description  %}
+      <li class="govuk-pagination__item  govuk-pagination__item--prev govuk-pagination__item--block">
+    {%- elseif params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
+    {% endif -%}
+    {%- if params.previous %}
           <a class="govuk-pagination__link" href="{{ params.previous.href }}">
               <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 19 13">
                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
@@ -17,6 +27,9 @@
               {{ params.previous.text }}
               {% else %}
               Previous <span class="govuk-visually-hidden">page</span>
+              {% endif -%}
+              {%- if params.previous.description %}
+              <br><span class="govuk-!-font-size-16 govuk-!-padding-left-4">{{ params.previous.description }}</span>
               {% endif -%}
         </a>
       </li>
@@ -34,7 +47,21 @@
       {% endif -%}
     {% endfor -%}
 
-    {%- if params.next %}
+    {%- if params.next and params.next.description %}
+      <li class="govuk-pagination__item  govuk-pagination__item--next govuk-pagination__item--block">
+        <a class="govuk-pagination__link" href="{{ params.next.href }}">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="19" viewBox="0 0 15 13">
+            <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+          </svg>
+          {%- if params.next.text %}
+          {{ params.next.text }}
+          {% else %}
+          Next <span class="govuk-visually-hidden">page</span>
+          {% endif -%}
+          <br><span class="govuk-!-font-size-16 govuk-!-padding-left-4">{{ params.next.description }}</span>
+        </a>
+      </li>
+    {%- elseif params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
         <a class="govuk-pagination__link" href="{{ params.next.href }}">
           {%- if params.next.text %}

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -10,7 +10,7 @@
     {%- if params.previous %}
       <li class="govuk-pagination__item  govuk-pagination__item--prev">
           <a class="govuk-pagination__link" href="{{ params.previous.href }}">
-              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="30" viewBox="0 0 17 13">
+              <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
                 <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
               </svg>
               {{ params.previous.text }}
@@ -33,7 +33,7 @@
     {%- if params.next %}
       <li class="govuk-pagination__item  govuk-pagination__item--next">
         <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}
-          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="30" viewBox="0 0 17 13">
+          <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="20" viewBox="0 0 20 13">
             <path d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
           </svg>
         </a>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -29,7 +29,15 @@
   </ul>
 
   {%- if params.results %}
-    <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> results</p>
+
+  {% if params.results.type %}
+    {% set type = params.results.type %}
+  {% else %}
+    {# If no type is defined, set it to 'results' #}
+    {% set type = "results" %}
+  {% endif %}
+
+    <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> {{type}}</p>
   {% endif -%}
 
 </nav>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -9,11 +9,8 @@
         <span class="govuk-pagination__link-title">
           <svg class="govuk-pagination__icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17">
             <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
-          </svg>
-          {%- if params.previous.text %}
-          {{ params.previous.text }}
-          {% else %}
-          Previous <span class="govuk-visually-hidden">page</span>
+          </svg>{%- if params.previous.text %}{{ params.previous.text }}{% else %}Previous
+          <span class="govuk-visually-hidden">page</span>
           {% endif -%}
         </span>
         {%- if params.previous.label %}

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -1,0 +1,35 @@
+<nav class="govuk-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label">
+
+  <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
+
+  <ul class="govuk-pagination__list">
+    {%- if params.previous %}
+      <li class="govuk-pagination__item  govuk-pagination__item--prev">
+        <a class="govuk-pagination__link" href="{{ params.previous.href }}">{{ params.previous.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+      </li>
+    {% endif -%}
+
+    {%- for item in params.items %}
+      {%- if item.type == 'dots' %}
+        <li class="govuk-pagination__item govuk-pagination__item--dots">...</li>
+      {% else %}
+        {%- if item.selected %}
+          <li class="govuk-pagination__item govuk-pagination__item--active">{{ item.text }}</li>
+        {% else %}
+          <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}">{{ item.text }}</a></li>
+        {% endif -%}
+      {% endif -%}
+    {% endfor -%}
+
+    {%- if params.next %}
+      <li class="govuk-pagination__item  govuk-pagination__item--next">
+        <a class="govuk-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+      </li>
+    {% endif -%}
+  </ul>
+
+  {%- if params.results %}
+    <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> results</p>
+  {% endif -%}
+
+</nav>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -22,8 +22,8 @@
     {% endif -%}
 
     {%- for item in params.items %}
-    {%- if item.type == 'elipses' %}
-    <li class="govuk-pagination__item govuk-pagination__item--elipses">…</li>
+    {%- if item.type == 'ellipses' %}
+    <li class="govuk-pagination__item govuk-pagination__item--ellipses">…</li>
     {% else %}
     {%- if item.current %}
     <li class="govuk-pagination__item govuk-pagination__item--current"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>

--- a/src/govuk/components/pagination/template.njk
+++ b/src/govuk/components/pagination/template.njk
@@ -1,6 +1,10 @@
-<nav class="govuk-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label">
-
-  <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
+{% if params.results.type %}
+  {% set type = params.results.type %}
+{% else %}
+  {# If no type is defined, set it to 'results' #}
+  {% set type = "results" %}
+{% endif %}
+<nav class="govuk-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label" aria-label="{{type}} navigation">
 
   <ul class="govuk-pagination__list">
     {%- if params.previous %}
@@ -19,9 +23,9 @@
         <li class="govuk-pagination__item govuk-pagination__item--dots">...</li>
       {% else %}
         {%- if item.selected %}
-          <li class="govuk-pagination__item govuk-pagination__item--active">{{ item.text }}</li>
+          <li class="govuk-pagination__item govuk-pagination__item--active"><span class="govuk-visually-hidden">Page </span>{{ item.text }}<span class="govuk-visually-hidden"> (current page) </span></li>
         {% else %}
-          <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}">{{ item.text }}</a></li>
+          <li class="govuk-pagination__item"><a class="govuk-pagination__link" href="{{ item.href }}"><span class="govuk-visually-hidden">Page </span>{{ item.text }}</a></li>
         {% endif -%}
       {% endif -%}
     {% endfor -%}
@@ -38,14 +42,6 @@
   </ul>
 
   {%- if params.results %}
-
-  {% if params.results.type %}
-    {% set type = params.results.type %}
-  {% else %}
-    {# If no type is defined, set it to 'results' #}
-    {% set type = "results" %}
-  {% endif %}
-
     <p class="govuk-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{params.results.count}}</b> {{type}}</p>
   {% endif -%}
 

--- a/src/govuk/components/pagination/template.test.js
+++ b/src/govuk/components/pagination/template.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+/* eslint-env jest */
+
+const axe = require('../../../../lib/axe-helper')
+
+const { render, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('pagination')
+
+describe('Pagination', () => {
+  describe('by default', () => {
+    it('passes accessibility tests', async () => {
+      const $ = render('pagination', examples.default)
+
+      const results = await axe($.html())
+      expect(results).toHaveNoViolations()
+    })
+  })
+})


### PR DESCRIPTION
A draft PR for a new contribution: a pagination component.

It's based partly on [this one in the MoJ Pattern Library](https://design-patterns.service.justice.gov.uk/components/pagination/) and partly on [this one in the GOV.UK Component Library](https://components.publishing.service.gov.uk/component-guide/previous_and_next_navigation) - but it takes into account guidance in the [Home Office Design System](https://design.homeoffice.gov.uk/components?name=Pagination), feedback in the [GOV.UK Design System backlog](https://github.com/alphagov/govuk-design-system-backlog/issues/77) and conversations with @adamsilver and @gregtyler (esp. [this issue in moj-frontend](https://github.com/ministryofjustice/moj-frontend/issues/161)). Guidance for the component is being developed in [this branch of govuk-design-system](https://github.com/alphagov/govuk-design-system/tree/add-pagination).

**[Preview this component in the GOV.UK Design System](https://add-pagination--govuk-design-system-preview.netlify.app/components/pagination/)**
