### PR TITLE
Rename exported JavaScript modules to include component name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,29 @@ If you see unexpected behaviour, make sure the `id` for the  textarea is unique 
 
 This change was introduced in [pull request #2408: Prevent issues with character count when textarea `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2408).
 
+#### Make sure individually imported JavaScript modules work as expected
+
+You do not need to do anything if you have either:
+
+- followed our [Getting Started guide](https://frontend.design-system.service.gov.uk/get-started/#5-get-the-javascript-working) and are importing all of the GOV.UK Frontend JavaScript in one go via `all.js`
+- installed GOV.UK Frontend using precompiled files
+
+We've changed the naming of our components' JavaScript modules so that individual imports are now attached to
+`window.GOVUKFrontend.[ComponentName]` instead of `window.GOVUKFrontend`.
+
+You can now import multiple modules without overwriting the previous one, for example:
+
+```
+//= require govuk/components/accordion/accordion.js
+//= require govuk/components/button/button.js
+
+# These modules are available under window.GOVUKFrontend.Accordion and window.GOVUKFrontend.Button respectively
+```
+
+If you're importing JavaScript modules individually, you should check any references to `window.GOVUKFrontend` in your code and update them to point to the correct component, `window.GOVUKFrontend.[ComponentName]`. You can now remove any workarounds you may have implemented.
+
+This change was introduced in [pull request #1836: Rename exported JavaScript modules to include component name](https://github.com/alphagov/govuk-frontend/issues/1836)].
+
 #### Remove calls to deprecated `iff` Sass function
 
 We've removed the `iff` function which we deprecated in [GOV.UK Frontend version 3.6.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.6.0).
@@ -149,6 +172,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2370: Prevent issues with conditionally revealed content when content `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2370)
 - [#2408: Prevent issues with character count when textarea `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2408)
 - [#2434: Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC)](https://github.com/alphagov/govuk-frontend/pull/2434)
+- [#1836: Rename exported JavaScript modules to include component name](https://github.com/alphagov/govuk-frontend/issues/1836))
 
 ## 3.14.0 (Feature release)
 

--- a/lib/helper-functions.js
+++ b/lib/helper-functions.js
@@ -19,3 +19,23 @@ const componentNameToMacroName = componentName => {
   return `govuk${macroName}`
 }
 exports.componentNameToMacroName = componentNameToMacroName
+
+// Convert component name to JavaScript UMD module name
+//
+// This helper function takes a component name and returns the corresponding
+// module name, which is used by rollup to set the `window` global and UMD/AMD export name
+//
+// Component names are lowercase, dash-separated strings (button, date-input),
+// whilst module names have a `GOVUKFrontend.` prefix and are pascal cased (GOVUKFrontend.Button,
+// GOVUKFrontend.CharacterCount).
+const componentNameToJavaScriptModuleName = componentName => {
+  const macroName = componentName
+    .toLowerCase()
+    .split('-')
+    // capitalize each 'word'
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('')
+
+  return `GOVUKFrontend.${macroName}`
+}
+exports.componentNameToJavaScriptModuleName = componentNameToJavaScriptModuleName

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const helperFunctions = require('../../lib/helper-functions')
+
 const path = require('path')
 
 const gulp = require('gulp')

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -13,6 +13,7 @@ const taskArguments = require('./task-arguments')
 const gulpif = require('gulp-if')
 const uglify = require('gulp-uglify')
 const eol = require('gulp-eol')
+const glob = require('glob')
 const rename = require('gulp-rename')
 const cssnano = require('cssnano')
 const postcsspseudoclasses = require('postcss-pseudo-classes')({
@@ -185,31 +186,35 @@ gulp.task('scss:compile', function (done) {
 
 // Compile js task for preview ----------
 // --------------------------------------
-gulp.task('js:compile', () => {
-  // for dist/ folder we only want compiled 'all.js' file
-  const srcFiles = isDist ? configPaths.src + 'all.js' : configPaths.src + '**/*.js'
+gulp.task('js:compile', (done) => {
+  // for dist/ folder we only want compiled 'all.js'
+  const fileLookup = isDist ? configPaths.src + 'all.js' : configPaths.src + '**/!(*.test).js'
+  const srcFiles = glob.sync(fileLookup)
 
-  return gulp.src([
-    srcFiles,
-    '!' + configPaths.src + '**/*.test.js'
-  ])
-    .pipe(rollup({
-      // Used to set the `window` global and UMD/AMD export name.
-      name: 'GOVUKFrontend',
-      // Legacy mode is required for IE8 support
-      legacy: true,
-      // UMD allows the published bundle to work in CommonJS and in the browser.
-      format: 'umd'
-    }))
-    .pipe(gulpif(isDist, uglify({
-      ie8: true
-    })))
-    .pipe(gulpif(isDist,
-      rename({
-        basename: 'govuk-frontend',
-        extname: '.min.js'
-      })
-    ))
-    .pipe(eol())
-    .pipe(gulp.dest(destinationPath))
+  srcFiles.forEach(function (file) {
+    const currentDirectory = path.dirname(file)
+    const newDirectory = currentDirectory.replace('src/govuk', '')
+
+    return gulp.src(file)
+      .pipe(rollup({
+        // Used to set the `window` global and UMD/AMD export name.
+        name: 'GOVUKFrontend',
+        // Legacy mode is required for IE8 support
+        legacy: true,
+        // UMD allows the published bundle to work in CommonJS and in the browser.
+        format: 'umd'
+      }))
+      .pipe(gulpif(isDist, uglify({
+        ie8: true
+      })))
+      .pipe(gulpif(isDist,
+        rename({
+          basename: 'govuk-frontend',
+          extname: '.min.js'
+        })
+      ))
+      .pipe(eol())
+      .pipe(gulp.dest(destinationPath() + newDirectory))
+  })
+  done()
 })


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/1836

## What
Change the `window` global and UMD export name for component JavaScript to include the component name, for example: `GOVUKFrontend.CharacterCount`.

The way this PR currently stands, this new naming applies only to component JavaScript files - not to`all.js`, `common.js` or any vendor/polyfills. Because `all.js` already exports multiple modules, we can keep the original naming of `GOVUKFrontend` and modules will already be automatically nested underneath, e.g: `window.GOVUKFrontend.initAll()`. If the new naming system was also applied to `all.js`, you would end up having to call `window.GOVUKFrontend.All.initAll()`.

This means that if a user imports a specific component JavaScript (e.g: character-count) and then`all.js` -  `all.js` will overwrite any existing modules attached to `window.GOVUKFrontend`. This feels like an unlikely scenario, but I'm not sure I know enough about how users are importing our JavaScript to know if applying this change only to component JavaScript is likely to cause problems - **welcome any thoughts/insights on this**.

## Why
When importing individual scripts, each one was attached to `window.GOVUKFrontend`. This meant that if you imported (for example) the accordion and then imported the button JavaScript, one overwrote the other so that only the button JavaScript would be attached to `window.GOVUKFrontend`.

## Breaking Changes
**Again - I welcome any thoughts/insights on this as I'm not 100% confident I know enough about how users are using our JavaScript to account for all changes that might need to be made**

If a user is importing all our JavaScript, I don't think they'll need to make any changes.

If a user is importing individual component JavaScript, then they will need to switch any calls to `window.GOVUKFrontend` to be to `window.GOVUKFrontend.[ComponentName]`