### PR TITLE
Improve the screen reader experience for the header menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ This change was introduced in [pull request #2323: Avoid invalid nesting of `<sp
 
 We've updated the HTML for the header. This update only affects you if your header includes navigation.
 
+Any additional classes passed using the `navigationClasses` Nunjucks option are now applied to the `<nav>` rather than the `<ul>`. Check that the additional classes are still doing what you expect.
+
 If you're not using Nunjucks macros, then you should move:
 
 - the `<button>` inside the `<nav>`, immediately before the `<ul>`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,19 @@ Do not include an empty `<span class="govuk-summary-list__actions"></span>` with
 
 This change was introduced in [pull request #2323: Avoid invalid nesting of `<span>` within a `<dd>` in summary list](https://github.com/alphagov/govuk-frontend/pull/2323).
 
+#### Update the HTML for navigation in the header
+
+We've updated the HTML for the header. This update only affects you if your header includes navigation.
+
+If you're not using Nunjucks macros, then you should move:
+
+- the `<button>` inside the `<nav>`, immediately before the `<ul>`
+- the `aria-label` from the `<ul>` to the `<nav>`
+
+Check your changes against the [header example in the Design System](https://design-system.service.gov.uk/components/header/#header-with-service-name-and-navigation).
+
+This change was introduced in [pull request #2427: Improve the screen reader experience for the header menu](https://github.com/alphagov/govuk-frontend/pull/2427).
+
 #### Make sure components that conditionally reveal other questions still work as expected
 
 On radios and checkboxes, the JavaScript now looks within the whole page for conditionally revealed content. Before, it only looked within the same set of radios or checkboxes.

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -206,14 +206,16 @@
   }
 
   .govuk-header__navigation {
-    display: block;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-
     @include govuk-media-query ($from: desktop) {
       margin-bottom: govuk-spacing(2);
     }
+  }
+
+  .govuk-header__navigation-list {
+    // Reset user-agent default list styles
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
   .js-enabled {
@@ -224,14 +226,14 @@
       }
     }
 
-    .govuk-header__navigation {
+    .govuk-header__navigation-list {
       display: none;
       @include govuk-media-query ($from: desktop) {
         display: block;
       }
     }
 
-    .govuk-header__navigation--open {
+    .govuk-header__navigation-list--open {
       display: block;
     }
   }

--- a/src/govuk/components/header/header.js
+++ b/src/govuk/components/header/header.js
@@ -21,7 +21,7 @@ Header.prototype.init = function () {
     return
   }
 
-  this.syncState(this.$menu.classList.contains('govuk-header__navigation--open'))
+  this.syncState(this.$menu.classList.contains('govuk-header__navigation-list--open'))
   this.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind(this))
 }
 
@@ -45,7 +45,7 @@ Header.prototype.syncState = function (isVisible) {
  * sync the accessibility state and menu button state
  */
 Header.prototype.handleMenuButtonClick = function () {
-  var isVisible = this.$menu.classList.toggle('govuk-header__navigation--open')
+  var isVisible = this.$menu.classList.toggle('govuk-header__navigation-list--open')
   this.syncState(isVisible)
 }
 

--- a/src/govuk/components/header/header.test.js
+++ b/src/govuk/components/header/header.test.js
@@ -68,8 +68,8 @@ describe('Header navigation', () => {
       })
 
       it('adds the --open modifier class to the menu, making it visible', async () => {
-        const hasOpenClass = await page.$eval('.govuk-header__navigation',
-          el => el.classList.contains('govuk-header__navigation--open')
+        const hasOpenClass = await page.$eval('.govuk-header__navigation-list',
+          el => el.classList.contains('govuk-header__navigation-list--open')
         )
 
         expect(hasOpenClass).toBeTruthy()
@@ -102,8 +102,8 @@ describe('Header navigation', () => {
       })
 
       it('removes the --open modifier class from the menu, hiding it', async () => {
-        const hasOpenClass = await page.$eval('.govuk-header__navigation',
-          el => el.classList.contains('govuk-header__navigation--open')
+        const hasOpenClass = await page.$eval('.govuk-header__navigation-list',
+          el => el.classList.contains('govuk-header__navigation-list--open')
         )
 
         expect(hasOpenClass).toBeFalsy()

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -54,8 +54,8 @@
     </a>
     {% endif %}
     {% if params.navigation %}
-    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide navigation menu') }}">Menu</button>
-    <nav aria-label="{{ params.navigationLabel | default('Navigation menu') }}">
+    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">Menu</button>
+    <nav aria-label="{{ params.navigationLabel | default('Menu') }}">
       <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
         {% for item in params.navigation %}
           {% if item.text or item.html %}

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -55,8 +55,8 @@
     {% endif %}
     {% if params.navigation %}
     <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide navigation menu') }}">Menu</button>
-    <nav>
-      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="{{ params.navigationLabel | default('Navigation menu') }}">
+    <nav aria-label="{{ params.navigationLabel | default('Navigation menu') }}">
+      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
         {% for item in params.navigation %}
           {% if item.text or item.html %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -54,9 +54,10 @@
     </a>
     {% endif %}
     {% if params.navigation %}
-    <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">Menu</button>
     <nav aria-label="{{ params.navigationLabel | default('Menu') }}">
-      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">Menu</button>
+
+      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" >
         {% for item in params.navigation %}
           {% if item.text or item.html %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -54,10 +54,10 @@
     </a>
     {% endif %}
     {% if params.navigation %}
-    <nav aria-label="{{ params.navigationLabel | default('Menu') }}">
+    <nav aria-label="{{ params.navigationLabel | default('Menu') }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">Menu</button>
 
-      <ul id="navigation" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}" >
+      <ul id="navigation" class="govuk-header__navigation-list">
         {% for item in params.navigation %}
           {% if item.text or item.html %}
             <li class="govuk-header__navigation-item{{ ' govuk-header__navigation-item--active' if item.active }}">

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -121,18 +121,18 @@ describe('header', () => {
       const $ = render('header', examples['with navigation'])
 
       const $component = $('.govuk-header')
-      const $list = $component.find('ul.govuk-header__navigation')
+      const $nav = $component.find('nav')
 
-      expect($list.attr('aria-label')).toEqual('Navigation menu')
+      expect($nav.attr('aria-label')).toEqual('Navigation menu')
     })
 
     it('allows navigation label to be customised', () => {
       const $ = render('header', examples['with custom navigation label'])
 
       const $component = $('.govuk-header')
-      const $list = $component.find('ul.govuk-header__navigation')
+      const $nav = $component.find('nav')
 
-      expect($list.attr('aria-label')).toEqual('Custom navigation label')
+      expect($nav.attr('aria-label')).toEqual('Custom navigation label')
     })
 
     it('renders navigation with active item', () => {

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -123,7 +123,7 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
 
-      expect($nav.attr('aria-label')).toEqual('Navigation menu')
+      expect($nav.attr('aria-label')).toEqual('Menu')
     })
 
     it('allows navigation label to be customised', () => {
@@ -191,7 +191,7 @@ describe('header', () => {
 
         const $button = $('.govuk-header__menu-button')
 
-        expect($button.attr('aria-label')).toEqual('Show or hide navigation menu')
+        expect($button.attr('aria-label')).toEqual('Show or hide menu')
       })
       it('allows label to be customised', () => {
         const $ = render('header', examples['with custom menu button label'])

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -109,7 +109,7 @@ describe('header', () => {
       const $ = render('header', examples['with navigation'])
 
       const $component = $('.govuk-header')
-      const $list = $component.find('ul.govuk-header__navigation')
+      const $list = $component.find('ul.govuk-header__navigation-list')
       const $items = $list.find('li.govuk-header__navigation-item')
       const $firstItem = $items.find('a.govuk-header__link:first-child')
       expect($items.length).toEqual(4)


### PR DESCRIPTION
This brings the use of `aria-label` and `aria-controls` in the menu navigation in the header in line with other 'best practise' examples and guidance from W3C.

## Move the label from the `<ul>` to the `<nav>`

Move the 'Navigation menu' label from the `<ul>` to the parent `<nav>` element - this has [previously been flagged as a 'possible misuse of `aria-label`'](https://github.com/alphagov/govuk-frontend/issues/1340#issue-443492815).

According to [WAI ARIA Practises 1.2][2], it's recommended to label navigation regions, especially as ['if a page includes more than one navigation landmark, each should have a unique label'][3].

Lists can optionally be labelled, but this is only '_potentially_ beneficial for users of screen readers that support both list names and navigation among lists on a page'.

Applying the label to both the list and the parent navigation could be noisy – "Potentially a source of distracting or undesirable screen reader verbosity, especially if nested within a named container, such as a navigation region."

The [provided examples][4] also apply the label consistently to the navigation region (albeit using `aria-labelledby`).

## Remove redundant 'navigation' from the nav label

In line with the section ['Composing Effective and User-friendly Accessible Names' in WAI-ARIA Authoring Practices 1.2][5], remove the word navigation from the aria-label on the navigation.

> 'Do NOT include a WAI-ARIA role name in the accessible name. For example, do not include [..] the word "navigation" in the name of a navigation region. Doing so would create duplicate screen reader output since screen readers convey the role of an element in addition to its name.'

Without this change, assistive technologies report this as 'Navigation menu navigation'.

Also remove the word 'navigation' from the button that shows or hides the menu, as it also seems redundant – the word 'menu' should be descriptive enough for users to understand what it represents, especially when encountered inside a header landmark.

## Move the button inside the `<nav>`

Move the menu button inside the navigation region, so that it is discoverable by screen reader users even when the nav is closed:

> Place mobile open/close buttons within the `<nav>` element and use them to toggle state of another child wrapper of the nav. This will ensure that the navigation landmark is still discoverable by screen readers, even if it is in a closed/hidden state.

https://a11y-style-guide.com/style-guide/section-navigation.html#kssref-navigation-navigation-mobile

> Where a lot of people go wrong is by placing the button outside the region. This would mean screen reader users who move to the `<nav>` using a shortcut would find it to be empty, which isn’t very helpful.

https://inclusive-components.design/menus-menu-buttons/#placement

> For instance, a navigation on small screen devices may initially contain only a single toggle button. But that toggle button would reveal additional links and other navigational elements, when activated.

https://www.scottohara.me/blog/2018/03/03/landmarks.html#navigation

[1]: #1340 (comment)
[2]: https://www.w3.org/TR/wai-aria-practices-1.1/#naming_role_guidance
[3]: https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_navigation
[4]: https://www.w3.org/TR/wai-aria-practices-1.1/examples/landmarks/navigation.html
[5]: https://www.w3.org/TR/wai-aria-practices-1.2/#naming_effectively

## Summary of changes to markup

### Before
```html
<button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu" aria-expanded="false">Menu</button>
<nav>
  <ul id="navigation" class="govuk-header__navigation " aria-label="Navigation menu">
      <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
        <a class="govuk-header__link" href="#1">Navigation item 1</a>
      </li>
      <li class="govuk-header__navigation-item">
        <a class="govuk-header__link" href="#2">Navigation item 2</a>
      </li>
      <li class="govuk-header__navigation-item">
        <a class="govuk-header__link" href="#3">Navigation item 3</a>
      </li>
      <li class="govuk-header__navigation-item">
        <a class="govuk-header__link" href="#4">Navigation item 4</a>
      </li>
  </ul>
</nav>
```

### After

```html
<nav aria-label="Menu">
  <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu">Menu</button>

  <ul id="navigation" class="govuk-header__navigation " >
    <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
      <a class="govuk-header__link" href="#1">Navigation item 1</a>
    </li>
    <li class="govuk-header__navigation-item">
      <a class="govuk-header__link" href="#2">Navigation item 2</a>
    </li>
    <li class="govuk-header__navigation-item">
      <a class="govuk-header__link" href="#3">Navigation item 3</a>
    </li>
    <li class="govuk-header__navigation-item">
      <a class="govuk-header__link" href="#4">Navigation item 4</a>
    </li>
  </ul>
</nav>
```

## Summary of changes to AT experience

### JAWS / Chrome

| Before                                                                       | After                                                                                   |                                                                                          |
|------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
| Behaviour when focusing menu button (mobile viewport)                        | Show or hide navigation menu button collapsed, to activate press enter                  | Show or hide menu button collapsed, to activate press enter                              |
| Behaviour when entering navigation region (by tabbing to first link)         | Navigation region, navigation menu list with 8 items. Departments same page link.       | Menu navigation region, list with 8 items. Departments same page link.                   |
| Behaviour when jumping to controlled element (Insert + Alt + M)              | Move to controlled element, list, tab [visible focus moves to the list inside the menu] | Move to controlled element, show or hide menu [visible focus remains on the menu button] |
| Appearance in list of navigation landmarks (Ctrl + Insert + R)               | Banner -> Navigation                                                                    | Banner -> Menu Navigation                                                                |
| Appearance in list of navigation landmarks with nav closed (mobile viewport) | Does not appear in list of landmarks                                                    | Does not appear in list of landmarks                                                     |
| Appearance in list of navigation landmarks with nav open (mobile viewport)   | Banner -> Navigation                                                                    | Banner -> Menu Navigation                                                                |

### NVDA / Firefox

|                                                                              | Before                                                                 | After                                                        |
|------------------------------------------------------------------------------|------------------------------------------------------------------------|--------------------------------------------------------------|
| Behaviour when focusing menu button (mobile viewport)                        | Show or hide navigation menu button collapsed                          | Menu navigation landmark, show or hide menu button collapsed |
| Behaviour when entering navigation region (by tabbing to first link)         | navigation landmark Navigation menu list with 8 items Departments link | list with 8 items Departments link                           |
| Appearance in list of navigation landmarks (Insert + F7)                     | Banner -> Navigation                                                   | Banner -> Menu; navigation                                   |
| Appearance in list of navigation landmarks with nav closed (mobile viewport) | Does not appear in list of landmarks                                   | Banner -> Menu; navigation                                   |
| Appearance in list of navigation landmarks with nav open (mobile viewport)   | Banner -> Navigation                                                   | Banner -> Menu; navigation                                   |

### VoiceOver / Safari (macOS)

|                                                                         | Before                                          | After                                                  |
|-------------------------------------------------------------------------|-------------------------------------------------|--------------------------------------------------------|
| Behaviour when focusing menu button (mobile viewport)                   | Show or hide navigation menu, collapsed, button | Show or hide menu, collapsed, button, Menu, navigation |
| Behaviour when entering navigation region (by tabbing to first link)    | link, Departments, list Navigation menu 8 items | link, Departments, list 8 items                        |
| Appearance in list of landmarks rotor (VO + U)                          | Navigation                                      | Menu navigation                                        |
| Appearance in list of landmarks rotor with nav closed (mobile viewport) | Does not appear                                 | Menu navigation                                        |
| Appearance in list of landmarks rotor with nav open (mobile viewport)   | Navigation                                      | Menu navigation                                        |

### VoiceOver / Safari (iOS)

|                                                               | Before                                                                                      | After                                                                                  |
|---------------------------------------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
| Swiping to menu button                                        | Show or hide navigation menu, button, end banner, collapsed. Double tap to expand.          | Show or hide menu, button, menu, navigation landmark, collapsed. Double tap to expand. |
| Swiping to first link in navigation region                    | Departments, link, list start, navigation menu, landmark                                    | Departments, link, list start                                                          |
| Swiping by landmark (rotor set to landmarks, swiping up/down) | Departments, link, list start, navigation menu, landmark                                    | Departments, link, list start, landmark                                                |
| Swiping by landmark with nav closed                           | Swipes between start of header (GOV.UK logo) and main region ('Press release'), missing nav | Show or hide menu, button, menu, navigation landmark, collapsed. Double tap to expand. |

### TalkBack (Android)

| | Before | After |
|---|---|---|
| Swiping to menu button | Collapsed, "Show or hide navigation menu", button. Double tap to activate, actions available, use tap with three fingers to view. | Collapsed, "Show or hide menu", button. Double tap to activate, actions available, use tap with three fingers to view. |
| Swiping to first link in navigation region | "Departments", link. Double tap to activate, links available, use tap with three fingers to view. | "Departments", link. Double tap to activate, links available, use tap with three fingers to view. |
| Swiping by landmark with menu collapsed (reading controls set to 'landmarks', swiping up/down) | Navigation. | "menu", navigation. |
| Swiping by landmark with menu expanded (reading controls set to 'landmarks', swiping up/down) | Navigation, "navigation menu", list. | "menu", navigation, list. |

Tested by @lfdebrux in https://github.com/alphagov/govuk-frontend/pull/2427#issuecomment-979983062

Closes #1340