### PR TITLE
Fix footer alignment with grid classes

### DIFF
--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -145,10 +145,16 @@
   }
 
   .govuk-footer__navigation {
-    display: flex; // Support: Flexbox
     margin-right: -$govuk-gutter-half;
     margin-left: -$govuk-gutter-half;
-    flex-wrap: wrap; // Support: Flexbox
+  }
+
+  @supports (display: grid) {
+    .govuk-footer__navigation {
+      $minimum-column-size: 250px;
+      display: grid; // Support: Grid
+      grid-template-columns: repeat(auto-fit, minmax($minimum-column-size, 1fr)); // Support: Grid
+    }
   }
 
   .govuk-footer__section {
@@ -157,22 +163,23 @@
     margin-bottom: $govuk-gutter;
     margin-left: $govuk-gutter-half;
     vertical-align: top;
-    // Ensure columns take up equal width (typically one-half:one-half)
-    flex-grow: 1; // Support: Flexbox
-    flex-shrink: 1; // Support: Flexbox
-    @include govuk-media-query ($until: desktop) {
-      // Make sure columns do not drop below 200px in width
-      // Will typically result in wrapping, and end up in a single column on smaller screens.
-      flex-basis: 200px; // Support: Flexbox
-    }
   }
 
-  // If there are only two sections, set the layout to be two-third:one-third on desktop
   @include govuk-media-query ($from: desktop) {
-    // We match the first section with `:first-child`.
-    // To ensure the section is one of two, we can count backwards using `:nth-last-child(2)`.
-    .govuk-footer__section:first-child:nth-last-child(2) {
-      flex-grow: 2; // Support: Flexbox
+    .govuk-footer__section--span-2 {
+      grid-column: span 2; // Support: Grid
+    }
+
+    .govuk-footer__section--span-2 .govuk-footer__list {
+      column-count: 2; // Support: Columns
+    }
+
+    .govuk-footer__section--span-3 {
+      grid-column: span 3; // Support: Grid
+    }
+
+    .govuk-footer__section--span-3 .govuk-footer__list {
+      column-count: 3; // Support: Columns
     }
   }
 
@@ -187,16 +194,6 @@
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1190987
     .govuk-footer__link:hover {
       text-decoration-thickness: auto;
-    }
-  }
-
-  @include govuk-media-query ($from: desktop) {
-    .govuk-footer__list--columns-2 {
-      column-count: 2; // Support: Columns
-    }
-
-    .govuk-footer__list--columns-3 {
-      column-count: 3; // Support: Columns
     }
   }
 

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -155,7 +155,6 @@
 
   .govuk-footer__section {
     box-sizing: inherit;
-    display: inline-block;
     width: 100%;
     margin-bottom: $govuk-gutter;
     padding-right: $govuk-gutter-half;

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -155,16 +155,20 @@
   .govuk-footer__section {
     box-sizing: inherit;
     display: inline-block;
-    width: (100% / 3);
+    width: 100%;
     margin-bottom: $govuk-gutter;
     padding-right: $govuk-gutter-half;
     padding-left: $govuk-gutter-half;
     vertical-align: top;
     flex-grow: 1;
     flex-shrink: 1;
+
+    @include govuk-media-query ($from: tablet) {
+      width: (100% / 3);
+    }
   }
 
-  @include govuk-media-query ($from: desktop) {
+  @include govuk-media-query ($from: tablet) {
     .govuk-footer__section--span-2 {
       flex-grow: 0;
       width: (2 * 100% / 3);

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -136,12 +136,13 @@
   }
 
   .govuk-footer__heading {
-    @include govuk-responsive-margin(7, "bottom");
+    margin-bottom: govuk-spacing(6);
     padding-bottom: govuk-spacing(4);
+    border-bottom: 1px solid $govuk-footer-border;
+
     @include govuk-media-query ($until: tablet) {
       padding-bottom: govuk-spacing(2);
     }
-    border-bottom: 1px solid $govuk-footer-border;
   }
 
   .govuk-footer__navigation {

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -145,6 +145,7 @@
   }
 
   .govuk-footer__navigation {
+    @include govuk-clearfix;
     box-sizing: border-box;
     display: flex;
     margin-right: -$govuk-gutter-half;
@@ -159,6 +160,7 @@
     margin-bottom: $govuk-gutter;
     padding-right: $govuk-gutter-half;
     padding-left: $govuk-gutter-half;
+    float: left;
     vertical-align: top;
     flex-grow: 1;
     flex-shrink: 1;

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -145,29 +145,29 @@
   }
 
   .govuk-footer__navigation {
+    box-sizing: border-box;
+    display: flex;
     margin-right: -$govuk-gutter-half;
     margin-left: -$govuk-gutter-half;
-  }
-
-  @supports (display: grid) {
-    .govuk-footer__navigation {
-      $minimum-column-size: 250px;
-      display: grid; // Support: Grid
-      grid-template-columns: repeat(auto-fit, minmax($minimum-column-size, 1fr)); // Support: Grid
-    }
+    flex-wrap: wrap;
   }
 
   .govuk-footer__section {
+    box-sizing: inherit;
     display: inline-block;
-    margin-right: $govuk-gutter-half;
+    width: (100% / 3);
     margin-bottom: $govuk-gutter;
-    margin-left: $govuk-gutter-half;
+    padding-right: $govuk-gutter-half;
+    padding-left: $govuk-gutter-half;
     vertical-align: top;
+    flex-grow: 1;
+    flex-shrink: 1;
   }
 
   @include govuk-media-query ($from: desktop) {
     .govuk-footer__section--span-2 {
-      grid-column: span 2; // Support: Grid
+      flex-grow: 0;
+      width: (2 * 100% / 3);
     }
 
     .govuk-footer__section--span-2 .govuk-footer__list {
@@ -175,7 +175,8 @@
     }
 
     .govuk-footer__section--span-3 {
-      grid-column: span 3; // Support: Grid
+      flex-grow: 0;
+      width: 100%;
     }
 
     .govuk-footer__section--span-3 .govuk-footer__list {

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -4,15 +4,15 @@
     {% if params.navigation | length %}
       <div class="govuk-footer__navigation">
         {% for nav in params.navigation %}
-          <div class="govuk-footer__section">
+          {% set sectionClasses -%}
+            {%- if nav.columns -%}
+              govuk-footer__section--span-{{ nav.columns }}
+            {%- endif -%}
+          {%- endset %}
+          <div class="govuk-footer__section{% if sectionClasses %} {{ sectionClasses }}{% endif %}">
             <h2 class="govuk-footer__heading govuk-heading-m">{{ nav.title }}</h2>
             {% if nav.items | length %}
-              {% set listClasses %}
-                {% if nav.columns %}
-                  govuk-footer__list--columns-{{ nav.columns }}
-                {% endif %}
-              {% endset %}
-              <ul class="govuk-footer__list {{ listClasses | trim }}">
+              <ul class="govuk-footer__list">
                 {% for item in nav.items %}
                   {% if item.href and item.text %}
                     <li class="govuk-footer__list-item">

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -175,8 +175,8 @@ describe('footer', () => {
       const $ = render('footer', examples['with navigation'])
 
       const $component = $('.govuk-footer')
-      const $list = $component.find('ul.govuk-footer__list')
-      expect($list.hasClass('govuk-footer__list--columns-2')).toBeTruthy()
+      const $section = $component.find('div.govuk-footer__section')
+      expect($section.hasClass('govuk-footer__section--span-2')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1539. It also partly addresses https://github.com/alphagov/govuk-frontend/issues/1726, along with https://github.com/alphagov/govuk-frontend/pull/2446

Unfortunately this PR does not fix any of the other bugs reported in https://github.com/alphagov/govuk-frontend/issues/1680

## What
Adjust the styles of the footer layout to better match up with the grid classes. The screenshot below shows the grid classes and the footer not aligning properly:

<img width="922" alt="mac-chrome-left-before" src="https://user-images.githubusercontent.com/29889908/144250673-90e4643a-c326-4128-8ba8-fb7ff4dd9758.png">

**Note:** It's worth comparing and contrasting these changes with those in branch [`nickcolley-ldeb-spike-footer-grid`](https://github.com/alphagov/govuk-frontend/tree/nickcolley-ldeb-spike-footer-grid), which achieves much the same effect with fewer lines and fewer commits by using CSS grids. The CSS grid version also behaves slightly better as the viewport changes size. However, CSS grids are not supported by all browsers we want to support, so I think this PR that uses flexbox should take precedence.

Browsers to test in:

- [x] Internet Explorer 8
- [x] Internet Explorer 9
- [x] Internet Explorer 10
- [x] Internet Explorer 11
- [x] Chrome on macOS
- [x] Safari on macOS
- [x] Chrome on Windows
- [x] Firefox on macOS
- [x] Edge on Windows
- [x] Firefox on Windows
- [x] Safari on iOS
- [x] Chrome on iOS
- [x] Chrome on Android
- [x] Samsung Internet on Android

For each browser, test the two main footer examples:
 
 - https://govuk-frontend-pr-2428.herokuapp.com/examples/footer-alignment
  - https://govuk-frontend-pr-2428.herokuapp.com/components/footer
 
and zoom in to 400%.

## Screenshots
Note: this is just a sample of screenshots where the change is most visible

### IE8 GOV.UK example - Before vs After
<img width="100%" alt="ie8-govuk-before" src="https://user-images.githubusercontent.com/29889908/144252894-d4fbcdd7-611e-4f10-b14f-5ecbaa5fcc3a.png">
<img width="100%" alt="ie8-govuk-after" src="https://user-images.githubusercontent.com/29889908/144252912-476a3175-f6c3-4b33-80e7-6818541cb95a.png">

### IE8 Two Column Left example - Before vs After
<img width="100%" alt="ie8-left-before" src="https://user-images.githubusercontent.com/29889908/144253137-152b51bf-ce1d-4281-809f-9376f7dd4896.png">
<img width="100%" alt="ie8-left-after" src="https://user-images.githubusercontent.com/29889908/144253166-089b551a-749f-4a25-9549-2c03ab3274ec.png">

### IE8 Two Column Right example - Before vs After
<img width="753" alt="ie8-right-before" src="https://user-images.githubusercontent.com/29889908/144253447-9288189d-dc4b-4073-95c7-3e47f5d5b830.png">
<img width="748" alt="ie8-right-after" src="https://user-images.githubusercontent.com/29889908/144253544-2435c072-3c24-4799-9d41-81e1b6ef5043.png">

### IE8 Equal Three Column example - Before vs After
<img width="748" alt="ie8-three-before" src="https://user-images.githubusercontent.com/29889908/144253643-3a4c2af3-0ebc-4be5-8950-f68f9cc656fc.png">
<img width="772" alt="ie8-three-after" src="https://user-images.githubusercontent.com/29889908/144253659-d96bf3d9-3343-403b-819b-055ff617286b.png">

### IE10 Two Column Right example - Before vs After
<img width="771" alt="ie10-right-before" src="https://user-images.githubusercontent.com/29889908/144253747-c9c84ffb-1e14-49aa-a523-fc08efb243bc.png">
<img width="767" alt="ie10-right-after" src="https://user-images.githubusercontent.com/29889908/144253771-227bf596-e865-4463-87ad-0f6637fbee42.png">