### PR TITLE
Remove default font styles from cookie banner Sass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,14 @@ Replace any use of this class with the `govuk-tag--grey` class.
 
 This change was introduced in [pull request #2417: Remove deprecated `govuk-tag--inactive class`](https://github.com/alphagov/govuk-frontend/pull/2417).
 
+#### Style any custom HTML in your cookie banner
+
+We've removed the default font styles from the cookie banner Sass. This change makes it more obvious when classes and styles have not been added to any custom HTML.
+
+If you're passing custom HTML into the cookie banner component (for example, using the `html` Nunjucks parameter), you must make sure you're applying the appropriate classes and styles to that HTML, such as adding the `govuk-body` class to any paragraph tags. You must do this to prevent your cookie banner displaying with unstyled text.
+
+This change was introduced in [pull request #2432: Remove default font styles from cookie banner Sass](https://github.com/alphagov/govuk-frontend/pull/2432).
+
 ### Optional changes
 
 We've recently made some other changes to GOV.UK Frontend. While these are not breaking changes, implementing them will make your service work better.

--- a/src/govuk/components/cookie-banner/_index.scss
+++ b/src/govuk/components/cookie-banner/_index.scss
@@ -4,8 +4,6 @@
   $border-bottom-width: govuk-spacing(2);
 
   .govuk-cookie-banner {
-    @include govuk-font($size: 19);
-
     padding-top: govuk-spacing(4);
     // The component does not set bottom spacing.
     // The bottom spacing should be created by the items inside the component.


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/2358

## What
Remove the default font styles (setting the font and font-size) from the cookie banner Sass.

## Why
With the default font styles present, it's very difficult to spot if you forget to add the relevant `govuk-body` styles to any `html` you pass into the component. We had [missed this ourselves when we added the cookie banner to the design system](https://github.com/alphagov/govuk-design-system/issues/1886).

## Screenshots
### Before change - cookie banner with `html`, without `govuk-body` classes
<img width="979" alt="Screenshot 2021-11-16 at 15 13 59" src="https://user-images.githubusercontent.com/29889908/142011914-b52515cd-e43d-4d9a-91c7-f622fb326a4b.png">

### After change - cookie banner with `html`, without `govuk-body` classes
<img width="979" alt="Screenshot 2021-11-16 at 13 02 32" src="https://user-images.githubusercontent.com/29889908/142011810-325cc802-9bae-4c39-aca9-c3ccac438e1a.png">

### After change - cookie banner with `html`, with the correct `govuk-body` classes
<img width="974" alt="Screenshot 2021-11-16 at 13 02 53" src="https://user-images.githubusercontent.com/29889908/142012074-5980f5c2-d98e-4bc4-849f-d26bfb247d40.png">

### After change - in the Design System
This work was prompted by when we forgot to [add our own styling classes to the cookie banner on the design system site](https://github.com/alphagov/govuk-design-system/issues/1886), which resulted in slightly incorrect text spacing. This is what the design system cookie banner would now look like if we forgot to add the relevant classes:

<img width="1422" alt="Screenshot 2021-11-16 at 13 58 39" src="https://user-images.githubusercontent.com/29889908/142013503-a7f38d5e-03c4-42fe-9e7a-44dc6472dde3.png">

## Details of breaking change
This is a breaking change because any users who are relying on the default styles will see unstyled text in their cookie banner when they update. Users will need to add the correct classes to style the text - this will probably involve adding the govuk-body class to any HTML paragraph tags they're passing through to the component.

- which users are affected: users who are using the cookie banner component and passing their own `html` into the cookie banner component
- the change that’s been made: we've removed the default font styles from the cookie banner component
- changes users will have to make: users will need to make sure that any HTML they pass into the cookie banner component has the appropriate classes/styles (e.g: `govuk-body`)
- impact of users not making those changes: cookie banners will appear with unstyled text