### PR TITLE
Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2323: Avoid invalid nesting of `<span>` within a `<dd>` in summary list](https://github.com/alphagov/govuk-frontend/pull/2323)
 - [#2370: Prevent issues with conditionally revealed content when content `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2370)
 - [#2408: Prevent issues with character count when textarea `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2408)
+- [#2434: Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC)](https://github.com/alphagov/govuk-frontend/pull/2434)
 
 ## 3.14.0 (Feature release)
 

--- a/src/govuk/settings/_colours-organisations.scss
+++ b/src/govuk/settings/_colours-organisations.scss
@@ -54,6 +54,9 @@ $govuk-colours-organisations: (
     colour: #cf102d,
     colour-websafe: #005ea5
   ),
+  "department-for-levelling-up-housing-and-communities": (
+    colour: #012169,
+  ),
   "department-for-transport": (
     colour: #006c56,
     colour-websafe: #398373


### PR DESCRIPTION
This is a new department, so adding a new brand colour for this organisation.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4712566)