### PR TITLE
Update the docs for publishing a pre-release

### DIFF
--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -33,3 +33,13 @@ Projects can point to this branch in their package.json, instead of to the publi
 1. If you need to update an existing project to use the pre-release, copy the command that displays after the `Success!`message.
 
 2. Navigate to the project in the command line and run the success notification command. Running this command makes the project point to the pre-release branch, instead of to the published [GOV.UK Frontend npm package](https://www.npmjs.com/package/govuk-frontend). You can now preview your trial changes to GOV.UK Frontend.
+
+## Update a pre-release
+
+1. Check out the Git branch you previously pre-released (this is the branch you work on, not the branch the script created).
+
+2. Make the required changes and commit them.
+
+3. Follow steps 3-5 in [Publish a pre-release](#publish-a-pre-release).
+
+4. Follow the steps in [Preview your changes](#preview-your-changes).

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -18,13 +18,15 @@ Projects can point to this branch in their package.json, instead of to the publi
 
 ## Publish a pre-release
 
-1. Run `git checkout -b BRANCH-NAME` to switch to the branch you want to pre-release.
+1. Run `git checkout -b BRANCH-NAME` to check out a new branch you want to pre-release, or `git checkout BRANCH-NAME` to check out an existing branch.
 
-2. Run `nvm use` to make sure you’re using the right version of Node.js and npm.
+2. Make any required changes and commit them.
 
-3. Run `npm install` to make sure you have the latest dependencies installed.
+3. Run `nvm use` to make sure you’re using the right version of Node.js and npm.
 
-4. Run `npm run pre-release` to create and push a new branch that contains your changes. This process may take a few moments and will display a `Success!` message.
+4. Run `npm ci` to make sure you have the correct dependencies installed.
+
+5. Run `npm run pre-release` to create and push a new branch that contains your changes. This process may take a few moments and will display a `Success!` message.
 
 ## Preview your changes
 


### PR DESCRIPTION
Ask users to run `npm ci` instead of `npm install`. Whilst `npm ci` will take a bit longer to run, it will not force any dependencies to update - at this point we just want to ensure that the users of this doc are using the dependencies specified in `package-lock.json`.

Also make the wording of checking out the pre-release branch more ambigious as the current command will create a new branch and this might not be appropriate.

Finally, add some instructions on how to update a previously published pre-release with new changes (@timpaul recently asked about this). 