### PR TITLE
Update legend/label/heading examples to have unique names and ids

### DIFF
--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -266,7 +266,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-heading-hint-error-xl",
     "name": "text-input-heading-hint-error-xl",
     "errorMessage": {
       "text": "Error message goes here"
@@ -282,7 +282,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-heading-hint-error-l",
     "name": "text-input-heading-hint-error-l",
     "errorMessage": {
       "text": "Error message goes here"
@@ -298,7 +298,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-heading-hint-error-m",
     "name": "text-input-heading-hint-error-m",
     "errorMessage": {
       "text": "Error message goes here"
@@ -314,7 +314,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-heading-hint-error-s",
     "name": "text-input-heading-hint-error-s",
     "errorMessage": {
       "text": "Error message goes here"
@@ -330,7 +330,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-heading-hint-error-no-class",
     "name": "text-input-heading-hint-error-no-class",
     "errorMessage": {
       "text": "Error message goes here"
@@ -347,7 +347,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-hint-error-xl",
     "name": "text-input-hint-error-xl",
     "errorMessage": {
       "text": "Error message goes here"
@@ -362,7 +362,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-hint-error-l",
     "name": "text-input-hint-error-l",
     "errorMessage": {
       "text": "Error message goes here"
@@ -377,7 +377,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-hint-error-m",
     "name": "text-input-hint-error-m",
     "errorMessage": {
       "text": "Error message goes here"
@@ -392,7 +392,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-hint-error-s",
     "name": "text-input-hint-error-s",
     "errorMessage": {
       "text": "Error message goes here"
@@ -407,7 +407,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "input-with-error-message",
+    "id": "text-input-hint-error-no-class",
     "name": "text-input-hint-error-no-class",
     "errorMessage": {
       "text": "Error message goes here"

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -27,7 +27,7 @@
       isPageHeading: true,
       classes: 'govuk-label--xl '
     },
-    "id": "",
+    "id": "text-input-heading-xl",
     "name": "text-input-heading-xl"
   }) }}
 
@@ -37,7 +37,7 @@
       isPageHeading: true,
       classes: 'govuk-label--l '
     },
-    "id": "",
+    "id": "text-input-heading-l",
     "name": "text-input-heading-l"
   }) }}
 
@@ -47,7 +47,7 @@
       isPageHeading: true,
       classes: 'govuk-label--m '
     },
-    "id": "",
+    "id": "text-input-heading-m",
     "name": "text-input-heading-m"
   }) }}
 
@@ -57,7 +57,7 @@
       isPageHeading: true,
       classes: 'govuk-label--s '
     },
-    "id": "",
+    "id": "text-input-heading-s",
     "name": "text-input-heading-s"
   }) }}
 
@@ -67,8 +67,8 @@
       isPageHeading: true,
       classes: ''
     },
-    "id": "",
-    "name": "text-input-no-class"
+    "id": "text-input-heading-no-class",
+    "name": "text-input-heading-no-class"
   }) }}
 
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
@@ -78,7 +78,7 @@
       "text": "<label> govuk-label--xl",
       classes: 'govuk-label--xl '
     },
-    "id": "",
+    "id": "text-input-xl",
     "name": "text-input-xl"
   }) }}
 
@@ -87,7 +87,7 @@
       "text": "<label> govuk-label--l",
       classes: 'govuk-label--l '
     },
-    "id": "",
+    "id": "text-input-l",
     "name": "text-input-l"
   }) }}
 
@@ -96,7 +96,7 @@
       "text": "<label> govuk-label--m",
       classes: 'govuk-label--m'
     },
-    "id": "",
+    "id": "text-input-m",
     "name": "text-input-m"
   }) }}
 
@@ -105,7 +105,7 @@
       "text": "<label> govuk-label--s",
       classes: 'govuk-label--s'
     },
-    "id": "",
+    "id": "text-input-s",
     "name": "text-input-s"
   }) }}
 
@@ -114,8 +114,8 @@
       "text": "<label> No class",
       classes: ''
     },
-    "id": "",
-    "name": "text-input-no-class-2"
+    "id": "text-input-no-class",
+    "name": "text-input-no-class"
   }) }}
 
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
@@ -133,7 +133,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-heading-xl",
     "name": "text-input-hint-heading-xl"
   }) }}
 
@@ -146,7 +146,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-heading-l",
     "name": "text-input-hint-heading-l"
   }) }}
 
@@ -159,7 +159,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-heading-m",
     "name": "text-input-hint-heading-m"
   }) }}
 
@@ -172,7 +172,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-heading-s",
     "name": "text-input-hint-heading-s"
   }) }}
 
@@ -185,8 +185,8 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
-    "name": "text-input-hint-no-class"
+    "id": "text-input-hint-heading-no-class",
+    "name": "text-input-hint-heading-no-class"
   }) }}
 
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
@@ -199,7 +199,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-xl",
     "name": "text-input-hint-xl"
   }) }}
 
@@ -211,7 +211,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-l",
     "name": "text-input-hint-l"
   }) }}
 
@@ -223,7 +223,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-m",
     "name": "text-input-hint-m"
   }) }}
 
@@ -235,7 +235,7 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
+    "id": "text-input-hint-s",
     "name": "text-input-hint-s"
   }) }}
 
@@ -247,8 +247,8 @@
     "hint": {
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
-    "id": "",
-    "name": "text-input-hint-no-class-2"
+    "id": "text-input-hint-no-class",
+    "name": "text-input-hint-no-class"
   }) }}
 
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -1440,8 +1440,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1467,8 +1466,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1494,8 +1492,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1521,8 +1518,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1548,8 +1544,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1576,8 +1571,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1602,8 +1596,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1628,8 +1621,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1654,8 +1646,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1680,8 +1671,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1716,8 +1706,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1746,8 +1735,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1776,8 +1764,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1806,8 +1793,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1836,8 +1822,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1867,8 +1852,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1896,8 +1880,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1925,8 +1908,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1954,8 +1936,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -1983,8 +1964,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2022,8 +2002,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2055,8 +2034,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2088,8 +2066,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2121,8 +2098,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2154,8 +2130,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2188,8 +2163,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2220,8 +2194,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2252,8 +2225,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2284,8 +2256,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}
@@ -2316,8 +2287,7 @@
       },
       {
         "value": "no",
-        "text": "No",
-        "checked": true
+        "text": "No"
       }
     ]
   }) }}

--- a/app/views/examples/labels-legends-and-headings/index.njk
+++ b/app/views/examples/labels-legends-and-headings/index.njk
@@ -28,7 +28,7 @@
       classes: 'govuk-label--xl '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-heading-xl"
   }) }}
 
   {{ govukInput({
@@ -38,7 +38,7 @@
       classes: 'govuk-label--l '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-heading-l"
   }) }}
 
   {{ govukInput({
@@ -48,7 +48,7 @@
       classes: 'govuk-label--m '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-heading-m"
   }) }}
 
   {{ govukInput({
@@ -58,7 +58,7 @@
       classes: 'govuk-label--s '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-heading-s"
   }) }}
 
   {{ govukInput({
@@ -68,7 +68,7 @@
       classes: ''
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-no-class"
   }) }}
 
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
@@ -79,7 +79,7 @@
       classes: 'govuk-label--xl '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-xl"
   }) }}
 
   {{ govukInput({
@@ -88,7 +88,7 @@
       classes: 'govuk-label--l '
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-l"
   }) }}
 
   {{ govukInput({
@@ -97,7 +97,7 @@
       classes: 'govuk-label--m'
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-m"
   }) }}
 
   {{ govukInput({
@@ -106,7 +106,7 @@
       classes: 'govuk-label--s'
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-s"
   }) }}
 
   {{ govukInput({
@@ -115,14 +115,10 @@
       classes: ''
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-no-class-2"
   }) }}
 
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
 
   <h2 class="govuk-heading-l">Text input (with hint)</h2>
 
@@ -138,7 +134,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-heading-xl"
   }) }}
 
   {{ govukInput({
@@ -151,7 +147,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-heading-l"
   }) }}
 
   {{ govukInput({
@@ -164,7 +160,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-heading-m"
   }) }}
 
   {{ govukInput({
@@ -177,7 +173,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-heading-s"
   }) }}
 
   {{ govukInput({
@@ -190,7 +186,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-no-class"
   }) }}
 
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
@@ -204,7 +200,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-xl"
   }) }}
 
   {{ govukInput({
@@ -216,7 +212,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-l"
   }) }}
 
   {{ govukInput({
@@ -228,7 +224,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-m"
   }) }}
 
   {{ govukInput({
@@ -240,7 +236,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-s"
   }) }}
 
   {{ govukInput({
@@ -252,12 +248,10 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "",
-    "name": "test-name-1"
+    "name": "text-input-hint-no-class-2"
   }) }}
 
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
 
   <h2 class="govuk-heading-l">Text input (with hint and error)</h2>
 
@@ -273,7 +267,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-heading-hint-error-xl",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -289,7 +283,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-heading-hint-error-l",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -305,7 +299,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-heading-hint-error-m",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -321,7 +315,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-heading-hint-error-s",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -337,7 +331,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-heading-hint-error-no-class",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -354,7 +348,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-hint-error-xl",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -369,7 +363,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-hint-error-l",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -384,7 +378,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-hint-error-m",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -399,7 +393,7 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-hint-error-s",
     "errorMessage": {
       "text": "Error message goes here"
     }
@@ -414,25 +408,20 @@
       "html": "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’."
     },
     "id": "input-with-error-message",
-    "name": "test-name-1",
+    "name": "text-input-hint-error-no-class",
     "errorMessage": {
       "text": "Error message goes here"
     }
   }) }}
 
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
 
   <h2 class="govuk-heading-l">Checkboxes</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -462,8 +451,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -493,8 +481,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -524,8 +511,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -555,8 +541,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -588,8 +573,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -618,8 +602,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -648,8 +631,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -678,8 +660,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -708,8 +689,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -737,24 +717,14 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
-
-
-
-
 
   <h2 class="govuk-heading-l">Checkboxes (with hint)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -787,8 +757,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -821,8 +790,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -855,8 +823,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -889,8 +856,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -925,8 +891,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -958,8 +923,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -991,8 +955,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1024,8 +987,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1057,8 +1019,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1089,21 +1050,14 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
-
 
   <h2 class="govuk-heading-l">Checkboxes (with hint and error)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-error-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1139,8 +1093,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-error-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1176,8 +1129,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-error-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1213,8 +1165,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-error-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1250,8 +1201,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-heading-hint-error-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1289,8 +1239,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-error-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1325,8 +1274,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-error-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1361,8 +1309,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-error-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1397,8 +1344,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-error-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1433,8 +1379,7 @@
   }) }}
 
   {{ govukCheckboxes({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "checkboxes-hint-error-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1468,19 +1413,14 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
 
   <h2 class="govuk-heading-l">Radios</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1507,8 +1447,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1535,8 +1474,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1563,8 +1501,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1591,8 +1528,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1621,8 +1557,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1648,8 +1583,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1675,8 +1609,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1702,8 +1635,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1729,8 +1661,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1755,21 +1686,14 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
-
 
   <h2 class="govuk-heading-l">Radios (with hint)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1799,8 +1723,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1830,8 +1753,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1861,8 +1783,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1892,8 +1813,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1925,8 +1845,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-xl",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1955,8 +1874,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-l",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -1985,8 +1903,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-m",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -2015,8 +1932,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-s",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -2045,8 +1961,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-no-class",
     "fieldset": {
       "classes": "app-fieldset--custom-modifier",
       "attributes": {
@@ -2074,22 +1989,14 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
-
-
 
   <h2 class="govuk-heading-l">Radios (with hint and error)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-error-xl",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2122,8 +2029,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-error-l",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2156,8 +2062,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-error-m",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2190,8 +2095,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-error-s",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2224,8 +2128,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-heading-hint-error-no-class",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2260,8 +2163,7 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-error-xl",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2293,8 +2195,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-error-l",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2326,8 +2227,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-error-m",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2359,8 +2259,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-error-s",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2392,8 +2291,7 @@
   }) }}
 
   {{ govukRadios({
-    "idPrefix": "example",
-    "name": "example",
+    "name": "radios-hint-error-no-class",
     "errorMessage": {
       "text": "Please select an option"
     },
@@ -2424,20 +2322,15 @@
     ]
   }) }}
 
-
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
 
   <h2 class="govuk-heading-l">Date Input</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-xl',
+    name: 'date-heading-xl',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--xl',
@@ -2449,8 +2342,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-l',
+    name: 'date-heading-l',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--l',
@@ -2462,8 +2355,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-m',
+    name: 'date-heading-m',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--m',
@@ -2475,8 +2368,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-s',
+    name: 'date-heading-s',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--s',
@@ -2488,8 +2381,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-no-class',
+    name: 'date-heading-no-class',
     fieldset: {
       legend: {
         text: '<h1> No class',
@@ -2504,8 +2397,8 @@
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-xl',
+    name: 'date-xl',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--xl',
@@ -2516,8 +2409,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-l',
+    name: 'date-l',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--l',
@@ -2528,8 +2421,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-m',
+    name: 'date-m',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--m',
@@ -2540,8 +2433,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-s',
+    name: 'date-s',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--s',
@@ -2552,8 +2445,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-no-class',
+    name: 'date-no-class',
     fieldset: {
       legend: {
         text: '<legend> No class',
@@ -2563,18 +2456,15 @@
     })
   }}
 
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
 
   <h2 class="govuk-heading-l">Date Input (with hint)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-xl',
+    name: 'date-heading-hint-xl',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--xl',
@@ -2589,8 +2479,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-l',
+    name: 'date-heading-hint-l',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--l',
@@ -2605,8 +2495,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-m',
+    name: 'date-heading-hint-m',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--m',
@@ -2621,8 +2511,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-s',
+    name: 'date-heading-hint-s',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--s',
@@ -2637,8 +2527,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-no-class',
+    name: 'date-heading-hint-no-class',
     fieldset: {
       legend: {
         text: '<h1> No class',
@@ -2657,8 +2547,8 @@
   <form action="/" method="post">
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-xl',
+    name: 'date-hint-xl',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--xl',
@@ -2672,8 +2562,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-l',
+    name: 'date-hint-l',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--l',
@@ -2687,8 +2577,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-m',
+    name: 'date-hint-m',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--m',
@@ -2702,8 +2592,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-s',
+    name: 'date-hint-s',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--s',
@@ -2717,8 +2607,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-no-class',
+    name: 'date-hint-no-class',
     fieldset: {
       legend: {
         text: '<legend> No class',
@@ -2731,19 +2621,15 @@
     })
   }}
 
-
   <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-
-
-
 
   <h2 class="govuk-heading-l">Date Input (with hint and error)</h2>
 
   <h3 class="govuk-heading-s">isPageHeading: true</h3>
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-error-xl',
+    name: 'date-heading-hint-error-xl',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--xl',
@@ -2761,8 +2647,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-error-l',
+    name: 'date-heading-hint-error-l',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--l',
@@ -2780,8 +2666,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-error-m',
+    name: 'date-heading-hint-error-m',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--m',
@@ -2800,8 +2686,8 @@
 
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-error-s',
+    name: 'date-heading-hint-error-s',
     fieldset: {
       legend: {
         text: '<h1> govuk-fieldset__legend--s',
@@ -2820,8 +2706,8 @@
 
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-heading-hint-error-no-class',
+    name: 'date-heading-hint-error-no-class',
     fieldset: {
       legend: {
         text: '<h1> No class',
@@ -2838,12 +2724,11 @@
     })
   }}
 
-
   <h3 class="govuk-heading-s">isPageHeading: false</h3>
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-error-xl',
+    name: 'date-hint-error-xl',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--xl',
@@ -2860,8 +2745,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-error-l',
+    name: 'date-hint-error-l',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--l',
@@ -2878,8 +2763,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-error-m',
+    name: 'date-hint-error-m',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--m',
@@ -2896,8 +2781,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-error-s',
+    name: 'date-hint-error-s',
     fieldset: {
       legend: {
         text: '<legend> govuk-fieldset__legend--s',
@@ -2914,8 +2799,8 @@
   }}
 
   {{ govukDateInput({
-    id: 'dob',
-    name: 'dob',
+    id: 'date-hint-error-no-class',
+    name: 'date-hint-error-no-class',
     fieldset: {
       legend: {
         text: '<legend> No class',


### PR DESCRIPTION
I came across this when using these examples to test https://github.com/alphagov/govuk-frontend/issues/2083

The current examples for legends, labels and headings have the same `name` and `id` (or `idPrefix`). This meant for things using checkboxes and radios (for example), the checkboxes were appearing as one list of checkboxes for screenreader users, e.g: tickbox 2 of 60.

It also meant that hints were being read incorrectly for some questions, because all hints on the page had the same `id` (e.g: `example-hint`).

This commit gives each question a unique name, and either removes the `idPrefix` so it falls back to the `name` or gives each question a unique `id` too. 

Each individual commit contains more details on the issues this was causing when testing with assistive technologies and the change that's been made to fix it.

https://govuk-frontend-pr-2441.herokuapp.com/examples/labels-legends-and-headings