### PR TITLE
Footer alignment example should use full width layout

### DIFF
--- a/app/views/examples/footer-alignment/index.njk
+++ b/app/views/examples/footer-alignment/index.njk
@@ -1,7 +1,7 @@
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "footer/macro.njk" import govukFooter %}
 
-{% extends "layout.njk" %}
+{% extends "full-width.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -10,27 +10,29 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">Example: Footer alignment</h1>
+  <div class="govuk-width-container">
+    <h1 class="govuk-heading-l">Example: Footer alignment</h1>
 
-  <h2 class="govuk-heading-m">Three equal columns</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
+    <h2 class="govuk-heading-m">Three equal columns</h2>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
     </div>
   </div>
 
@@ -93,25 +95,27 @@
     ]
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-6">Two column list on the left</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
+  <div class="govuk-width-container">
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Two column list on the left</h2>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
     </div>
   </div>
 
@@ -167,25 +171,27 @@
     ]
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-6">Two column list on the right</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-third">
-      <h3 class="govuk-heading-m">One third</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
+  <div class="govuk-width-container">
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Two column list on the right</h2>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-third">
+        <h3 class="govuk-heading-m">One third</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
     </div>
   </div>
 
@@ -241,31 +247,33 @@
     ]
   }) }}
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-6">Two equal columns</h2>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-quarter">
-      <h3 class="govuk-heading-m">One quarter</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <h3 class="govuk-heading-m">One quarter</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <h3 class="govuk-heading-m">One quarter</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
-    </div>
-    <div class="govuk-grid-column-one-quarter">
-      <h3 class="govuk-heading-m">One quarter</h3>
-      <p class="govuk-body">
-        This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
-      </p>
+  <div class="govuk-width-container">
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">Two equal columns</h2>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-m">One quarter</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-m">One quarter</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-m">One quarter</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
+      <div class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-m">One quarter</h3>
+        <p class="govuk-body">
+          This guide shows how to make your service look consistent with the rest of GOV.UK. It includes example code and guidance for layout, typography, colour, images, icons, forms, buttons and data.
+        </p>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
This commit updates the footer alignment examples to use the full width layout, as the component would normally be full width on the page. This mimics the behaviour of the `footer` and `content` blocks, where the content is normally wrapped in `govuk-width-container` but the footer is not.

The previous implementation nested everything inside a parent with `govuk-width-container` class which pushed the alignment slightly out of place on tablet/mobile.

## Before
<img width="561" alt="Screenshot 2021-11-29 at 09 46 45" src="https://user-images.githubusercontent.com/29889908/143845344-c0605017-bb39-4204-b941-e5c761d074d1.png">

## After
<img width="559" alt="Screenshot 2021-11-29 at 09 46 16" src="https://user-images.githubusercontent.com/29889908/143845361-d6175e14-f5cd-41dd-9ec5-ac889942eb1a.png">
