### PR TITLE
Add support for footer sections that span multiple columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,22 @@ If you're passing custom HTML into the cookie banner component (for example, usi
 
 This change was introduced in [pull request #2432: Remove default font styles from cookie banner Sass](https://github.com/alphagov/govuk-frontend/pull/2432).
 
+#### Check your footer displays as expected
+
+We’ve made some fixes to the alignment of columns within the footer component, so they align with our grid. This involved changing the name and position of the `govuk-footer__list—columns` classes.
+
+Replace any instances of `govuk-footer__list—columns` classes with `govuk-footer__section—columns`.
+
+If you're using HTML, you'll also need to move the classes from the `govuk-footer__list` element to the `govuk-footer__section` element. For example:
+
+```
+<div class="govuk-footer__section govuk-footer__section—columns-2">
+  <ul class="govuk-footer__list">...</ul>
+</div>
+```
+
+This change was introduced in [pull request #2428: Fix footer alignment with grid classes](https://github.com/alphagov/govuk-frontend/pull/2428) and [pull request #2446: Add support for footer sections that span multiple columns](https://github.com/alphagov/govuk-frontend/pull/2446).
+
 ### Optional changes
 
 We've recently made some other changes to GOV.UK Frontend. While these are not breaking changes, implementing them will make your service work better.
@@ -180,6 +196,24 @@ If you’re not using Nunjucks macros, add a new `data-nosnippet` attribute to t
 ```
 
 This was added in [pull request #2192: Add data-nosnippet to prevent cookie banner text appearing in Google Search snippets](https://github.com/alphagov/govuk-frontend/pull/2192).
+
+### New Features
+
+#### Add footer sections which span multiple columns
+
+You can now have footer sections which span multiple columns, but do not contain multiple columns of list items.
+
+This may be helpful if you want to highlight a specific link in the footer, but you also want it to align with a section below that has multiple columns of list items.
+
+To do this, use the `span` macro option. If you're using the HTML component, apply the appropriate class to the `govuk-footer__section` element, for example:
+
+```
+<div class="govuk-footer__section govuk-footer__section—span-2">
+  <ul class="govuk-footer__list">...</ul>
+</div>
+```
+
+This feature was introduced in [pull request #2446: Add support for footer sections that span multiple columns](https://github.com/alphagov/govuk-frontend/pull/2446)
 
 ### Fixes
 

--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -13,6 +13,7 @@ notes: >-
 {% from "header/macro.njk" import govukHeader %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "accordion/macro.njk" import govukAccordion %}
+{% from "footer/macro.njk" import govukFooter %}
 
 {% set pageTitle = "Coronavirus (COVID‑19)" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
@@ -229,4 +230,146 @@ notes: >-
       </div>
     </div>
   </div>
+{% endblock %}
+
+{% block footer %}
+
+
+  {{ govukFooter({
+    navigation: [
+      {
+        title: "Coronavirus (COVID-19)",
+        columns: 2,
+        items: [
+          {
+            href: "#",
+            text: "Coronavirus (COVID-19): guidance and support"
+          },
+          {
+            href: "#",
+            text: "Another link"
+          },
+          {
+            href: "#",
+            text: "Another link"
+          },
+          {
+            href: "#4",
+            text: "Another link"
+          }
+        ]
+      },
+      {
+        title: "Services and Information",
+        columns: 2,
+        items: [
+          {
+            href: "#",
+            text: "Benefits"
+          },
+          {
+            href: "#",
+            text: "Births, deaths and marriages"
+          },
+          {
+            href: "#",
+            text: "Business and self-employed"
+          },
+          {
+            href: "#",
+            text: "Childcare and parenting"
+          },
+          {
+            href: "#",
+            text: "Citizenship and living in the UK"
+          },
+          {
+            href: "#",
+            text: "Crime, justice and the law"
+          },
+          {
+            href: "#",
+            text: "Disabled people"
+          },
+          {
+            href: "#",
+            text: "Driving and transport"
+          },
+          {
+            href: "#",
+            text: "Education and learning"
+          },
+          {
+            href: "#",
+            text: "Employing people"
+          },
+          {
+            href: "#",
+            text: "Environment and countryside"
+          },
+          {
+            href: "#",
+            text: "Housing and local services"
+          },
+          {
+            href: "#",
+            text: "Money and tax"
+          },
+          {
+            href: "#",
+            text: "Passports and living abroad"
+          },
+          {
+            href: "#",
+            text: "Visas and immigration"
+          },
+          {
+            href: "#",
+            text: "Working, jobs and pensions"
+          }
+        ]
+      },
+      {
+        title: "Departments and policy",
+        items: [
+          {
+            href: "#",
+            text: "How government works"
+          },
+          {
+            href: "#",
+            text: "Departments"
+          },
+          {
+            href: "#",
+            text: "Worldwide"
+          },
+          {
+            href: "#",
+            text: "Services"
+          },
+          {
+            href: "#",
+            text: "Guidance and regulation"
+          },
+          {
+            href: "#",
+            text: "News and communications"
+          },
+          {
+            href: "#",
+            text: "Research and statistics"
+          },
+          {
+            href: "#",
+            text: "Policy papers and consultations"
+          },
+          {
+            href: "#",
+            text: "Transparency and freedom of information releases"
+          }
+        ]
+      }
+    ]
+  }) }}
 {% endblock %}

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -171,21 +171,23 @@
   }
 
   @include govuk-media-query ($from: tablet) {
-    .govuk-footer__section--span-2 {
+    .govuk-footer__section--span-2,
+    .govuk-footer__section--columns-2 {
       flex-grow: 0;
       width: (2 * 100% / 3);
     }
 
-    .govuk-footer__section--span-2 .govuk-footer__list {
+    .govuk-footer__section--columns-2 .govuk-footer__list {
       column-count: 2; // Support: Columns
     }
 
-    .govuk-footer__section--span-3 {
+    .govuk-footer__section--span-3,
+    .govuk-footer__section--columns-3 {
       flex-grow: 0;
       width: 100%;
     }
 
-    .govuk-footer__section--span-3 .govuk-footer__list {
+    .govuk-footer__section--columns-3 .govuk-footer__list {
       column-count: 3; // Support: Columns
     }
   }

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -46,6 +46,10 @@ params:
     type: integer
     required: false
     description: Amount of columns to display items in navigation section of the footer.
+  - name: span
+    type: integer
+    required: false
+    description: Amount of columns to span (without wrapping) in navigation section of the footer. Useful if you have a multi-row layout. Overrides columns.
   - name: items
     type: array
     required: false

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -196,6 +196,15 @@ examples:
   description: A full example based on GOV.UK's current footer
   data:
     navigation:
+      - title: Coronavirus (COVID-19)
+        span: 2
+        items:
+          - href: '/coronavirus'
+            text: 'Coronavirus (COVID-19): guidance and support'
+      - title: Brexit
+        items:
+          - href: '/brexit'
+            text: Check what you need to do
       - title: Services and information
         columns: 2
         items:
@@ -239,12 +248,18 @@ examples:
             text: Departments
           - href: '/world'
             text: Worldwide
-          - href: '/government/policies'
-            text: Policies
-          - href: '/government/publications'
-            text: Publications
-          - href: '/government/announcements'
-            text: Announcements
+          - href: '/search/services'
+            text: Services
+          - href: '/search/guidance-and-regulation'
+            text: Guidance and regulation
+          - href: '/search/news-and-communications'
+            text: News and communications
+          - href: '/search/research-and-statistics'
+            text: Research and statistics
+          - href: '/search/policy-papers-and-consultations'
+            text: Policy papers and consultations
+          - href: '/search/transparency-and-freedom-of-information-releases'
+            text: Transparency and freedom of information release
     meta:
       items:
         - href: '/help'

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -192,7 +192,7 @@ examples:
           - href: '#3'
             text: Navigation item 3
 
-- name: GOV.UK
+- name: Full GDS example
   description: A full example based on GOV.UK's current footer
   data:
     navigation:

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -5,8 +5,10 @@
       <div class="govuk-footer__navigation">
         {% for nav in params.navigation %}
           {% set sectionClasses -%}
-            {%- if nav.columns -%}
-              govuk-footer__section--span-{{ nav.columns }}
+            {%- if nav.span -%}
+              govuk-footer__section--span-{{ nav.span }}
+            {%- elif nav.columns -%}
+              govuk-footer__section--columns-{{ nav.columns }}
             {%- endif -%}
           {%- endset %}
           <div class="govuk-footer__section{% if sectionClasses %} {{ sectionClasses }}{% endif %}">

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -176,7 +176,7 @@ describe('footer', () => {
 
       const $component = $('.govuk-footer')
       const $section = $component.find('div.govuk-footer__section')
-      expect($section.hasClass('govuk-footer__section--span-2')).toBeTruthy()
+      expect($section.hasClass('govuk-footer__section--columns-2')).toBeTruthy()
     })
   })
 


### PR DESCRIPTION
Partly fixes https://github.com/alphagov/govuk-frontend/issues/1726

**Note:** this PR is based off the changes made in https://github.com/alphagov/govuk-frontend/pull/2428

Allow having a footer section that spans multiple columns but does not have multiple columns of list items. Useful if you have multiple rows of sections and want to align a section with only a few items with a section with many items (for instance the current GOV.UK footer layout).

<img width="903" alt="Screenshot 2021-12-02 at 11 22 06" src="https://user-images.githubusercontent.com/29889908/144412906-25ee6504-1b70-45fb-9200-8cb244fc1b8b.png">
<img width="916" alt="Screenshot 2021-12-02 at 11 21 19" src="https://user-images.githubusercontent.com/29889908/144412919-389a8ef0-c2e0-42f9-badd-5bf82dacb7f8.png">


Browsers to test in:

- [x] Internet Explorer 8
- [x] Internet Explorer 9
- [x] Internet Explorer 10
- [x] Internet Explorer 11
- [x] Chrome on macOS
- [x] Safari on macOS
- [x] Chrome on Windows
- [x] Firefox on macOS
- [x] Edge on Windows
- [x] Firefox on Windows
- [x] Safari on iOS
- [x] Chrome on iOS
- [x] Chrome on Android
- [x] Samsung Internet on Android

https://govuk-frontend-pr-2446.herokuapp.com/full-page-examples/campaign-page
https://govuk-frontend-pr-2446.herokuapp.com/components/footer/Full-GDS-example/preview