### PR TITLE
Remove bottom margin from navigation on tablets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2408: Prevent issues with character count when textarea `id` includes CSS syntax characters](https://github.com/alphagov/govuk-frontend/pull/2408)
 - [#2426: Rename exported JavaScript modules to include component name](https://github.com/alphagov/govuk-frontend/pull/2426)
 - [#2434: Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC)](https://github.com/alphagov/govuk-frontend/pull/2434)
+- [#2447: Remove bottom margin from navigation on tablets](https://github.com/alphagov/govuk-frontend/pull/2447)
 
 ## 3.14.0 (Feature release)
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -206,11 +206,14 @@
   }
 
   .govuk-header__navigation {
-    @include govuk-responsive-margin(2, "bottom");
     display: block;
     margin: 0;
     padding: 0;
     list-style: none;
+
+    @include govuk-media-query ($from: desktop) {
+      margin-bottom: govuk-spacing(2);
+    }
   }
 
   .js-enabled {


### PR DESCRIPTION
Split out from #2427.

The intention seems to be to add the 10px margin only when the navigation is displayed inline (desktop), so switch to using a media query instead of using the responsive margin mixin.

(Normally `govuk-responsive-margin(2, "bottom")` would create a 10px bottom margin on both mobile and tablet/desktop, except the margin on mobile is currently overridden by `margin: 0`)

| Breakpoint | Before | After |
| -- | -- | -- |
| Mobile (no change) | ![mobile-before](https://user-images.githubusercontent.com/121939/143884951-b6a0376b-68a7-4606-bd89-171e198bb4b8.png) | ![mobile-after](https://user-images.githubusercontent.com/121939/143884947-b8fe6fca-61fd-4b0c-abe6-041a9ba03583.png) |
| Tablet | ![tablet-before](https://user-images.githubusercontent.com/121939/143884954-a3f6d8e2-7dea-480e-9f3e-9e9539195ff2.png) | ![tablet-after](https://user-images.githubusercontent.com/121939/143884952-0afae584-feb8-4b31-89c5-3692d1f8f248.png) |
| Desktop (no change) | ![desktop-before](https://user-images.githubusercontent.com/121939/143884944-b8ebf676-9f9e-443d-b846-cd6c4ed40e26.png) |  ![desktop-after](https://user-images.githubusercontent.com/121939/143884938-27095023-e44f-4443-bb0a-bfbcb690d660.png) |