### PR TITLE
Remove the border from the last item in the collapsible navigation menu in the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2426: Rename exported JavaScript modules to include component name](https://github.com/alphagov/govuk-frontend/pull/2426)
 - [#2434: Add brand colour for Department for Levelling Up, Housing and Communities (DLUHC)](https://github.com/alphagov/govuk-frontend/pull/2434)
 - [#2447: Remove bottom margin from navigation on tablets](https://github.com/alphagov/govuk-frontend/pull/2447)
+- [#2448: Remove the border from the last item in the collapsible navigation menu in the header](https://github.com/alphagov/govuk-frontend/pull/2448)
 
 ## 3.14.0 (Feature release)
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -283,6 +283,7 @@
 
   .govuk-header__navigation-item:last-child {
     margin-right: 0;
+    border-bottom: 0;
   }
 
   @include govuk-media-query($media-type: print) {


### PR DESCRIPTION
Split out from #2427, and builds on #2447 which needs to be merged first.

| Breakpoint | Before | After |
| -- | -- | -- |
| Mobile  | ![mobile-before](https://user-images.githubusercontent.com/121939/144226451-d205a191-1e53-4d97-840d-c74b20b9501b.png) | ![mobile-after](https://user-images.githubusercontent.com/121939/144226446-9f871f7f-0fe2-41ab-9e32-4a5ea467bab6.png) |
| Tablet | ![tablet-before](https://user-images.githubusercontent.com/121939/144226461-cf1049b2-1bf5-4402-8ff9-ad18c68213df.png) | ![tablet-after](https://user-images.githubusercontent.com/121939/144226452-f6ab7ca9-36c2-4d89-b79f-cbf7e772487d.png) |