### PR TITLE
Use native way to output negative spacing in hint

### DIFF
--- a/src/govuk/components/hint/_index.scss
+++ b/src/govuk/components/hint/_index.scss
@@ -37,6 +37,6 @@
 
   // Reduces visual spacing of legend when there is a hint
   .govuk-fieldset__legend + .govuk-hint {
-    margin-top: -(govuk-spacing(1));
+    margin-top: govuk-spacing(-1);
   }
 }


### PR DESCRIPTION
Update the hint component to use the new 'native' way to output negative spacing introduced in ca7a126 (#2348).