### PR TITLE
Add npm configuration file to read token from environment

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: ['dist/**']
 
+env:
+  NPM_TOKEN: none  # needed for npm@6
+
 jobs:
   generate-diff:
     name: Generate Diff

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -2,6 +2,9 @@ name: Sass
 
 on: [push, pull_request]
 
+env:
+  NPM_TOKEN: none  # needed for npm@6
+
 jobs:
   dart-sass:
     name: Dart Sass v1.0.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,14 @@ name: Tests
 
 on: [push, pull_request]
 
+env:
+  NPM_TOKEN: none  # needed for npm@6
+
 jobs:
   run-tests:
     name: Run tests
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
Rather than logging in to npm with a username and password we want to log in using an access token with limited privileges. This commit adds an `.npmrc` file that tells npm to read the access token from the `$NPM_TOKEN` environment variable, following instructions in the npm docs [[1]].

[1]: https://docs.npmjs.com/using-private-packages-in-a-ci-cd-workflow