### PR TITLE
Update publishing instructions to use npm access token

### DIFF
--- a/docs/releasing/publishing-from-a-support-branch.md
+++ b/docs/releasing/publishing-from-a-support-branch.md
@@ -114,7 +114,7 @@ Note: Before you go on annual leave, tell the delivery manager who will be looki
 
 1. Check out `support/<CURRENT MAJOR VERSION NUMBER>.x` and pull the latest changes.
 
-2. Sign in to npm (`npm login`), using the npm/govuk-patterns-and-tools team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
+2. Sign in to npm using the npm/govuk-patterns-and-tools [access token](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools): `export NPM_TOKEN="$(ds-pass npm/govuk-patterns-and-tools/token)"`.
 
 3. Run `npm run publish-release`, which will prompt you to either continue or cancel. Enter `y` to continue.
 
@@ -127,7 +127,7 @@ Note: Before you go on annual leave, tell the delivery manager who will be looki
     - attach the generated ZIP that has been generated at the root of this project
     - publish release
 
-5. Run `npm logout` to sign out from npm.
+5. Run `unset NPM_TOKEN` to log out from npm (do not use `npm logout`, as this will revoke the token).
 
 ## After you publish the new release
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -81,7 +81,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 1. Check out the **main** branch and pull the latest changes.
 
-2. Sign in to npm (`npm login`), using the npm/govuk-patterns-and-tools team [credentials](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools).
+2. Sign in to npm using the npm/govuk-patterns-and-tools [access token](https://github.com/alphagov/design-system-team-credentials/tree/main/npm/govuk-patterns-and-tools): `export NPM_TOKEN="$(ds-pass npm/govuk-patterns-and-tools/token)"`.
 
 3. Run `npm run publish-release`, which will prompt you to either continue or cancel. Enter `y` to continue.
 
@@ -93,7 +93,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
   - attach the generated ZIP that has been generated at the root of this project
   - publish release
 
-5. Run `npm logout` to log out from npm.
+5. Run `unset NPM_TOKEN` to log out from npm (do not use `npm logout`, as this will revoke the token).
 
 # After you publish the new release
 


### PR DESCRIPTION
We want to avoid using the password for our npm account, as if this leaks it can be used to create a lot of havoc. Instead we want to log in using an access token with limited privileges. Unfortunately the npm cli does not allow logging in with a token interactively, so instead we configure the project to look for a token in the `$NPM_TOKEN` environment variable (see #2460) and add instructions to developers on how to add the token to the environment from the credentials store.

---

This PR is a draft so we can test the instructions before reviewing.

Note that the credentials repo does not yet have an access token for npm.