### PR TITLE
Export the notification banner JS in `all.js` and include IE8 polyfill

### DIFF
--- a/src/govuk/all.js
+++ b/src/govuk/all.js
@@ -81,6 +81,7 @@ export {
   Checkboxes,
   ErrorSummary,
   Header,
+  NotificationBanner,
   Radios,
   SkipLink,
   Tabs

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -52,6 +52,7 @@ describe('GOV.UK Frontend', () => {
         'Checkboxes',
         'ErrorSummary',
         'Header',
+        'NotificationBanner',
         'Radios',
         'SkipLink',
         'Tabs'

--- a/src/govuk/components/notification-banner/notification-banner.js
+++ b/src/govuk/components/notification-banner/notification-banner.js
@@ -1,3 +1,5 @@
+import '../../vendor/polyfills/Event' // addEventListener
+
 function NotificationBanner ($module) {
   this.$module = $module
 }


### PR DESCRIPTION
Make the notification banner JavaScript available in the global name space so that it can be imported individually.

Polyfill event listeners to support legacy browsers (IE8). I've tested that this works by removing all the other components from `all.js` and checking that the component works and there are no console errors in IE8-11. 