### PR TITLE
Fix flawed 'components can be initialised' test

### DIFF
--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -58,21 +58,20 @@ describe('GOV.UK Frontend', () => {
         'Tabs'
       ])
     })
-    it('exported Components can be initialised', async () => {
+    it('exported Components have an init function', async () => {
       await page.goto(baseUrl + '/', { waitUntil: 'load' })
 
-      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
+      var componentsWithoutInitFunctions = await page.evaluate(() => {
+        var components = Object.keys(window.GOVUKFrontend)
+          .filter(method => method !== 'initAll')
 
-      var components = Object.keys(GOVUKFrontendGlobal).filter(method => method !== 'initAll')
-
-      // Check that all the components on the GOV.UK Frontend global can be initialised
-      components.forEach(component => {
-        page.evaluate(component => {
-          const Component = window.GOVUKFrontend[component]
-          const $module = document.documentElement
-          new Component($module).init()
-        }, component)
+        return components.filter(component => {
+          var prototype = window.GOVUKFrontend[component].prototype
+          return typeof prototype.init !== 'function'
+        })
       })
+
+      expect(componentsWithoutInitFunctions).toEqual([])
     })
     it('can be initialised scoped to certain sections of the page', async () => {
       await page.goto(baseUrl + '/examples/scoped-initialisation', { waitUntil: 'load' })


### PR DESCRIPTION
The test currently passes `document.documentElement` (the root `<html>` element) as the `$module` when initialising each component. This is not what the component expects – `$module` should be the element with the corresponding `data-module` attribute, for example `<div data-module="govuk-button">`.

If we did want to initialise with the correct HTML for each component, we'd need to make substantial changes to the test. At the minute it runs in the context of the 'home page' of the review app, which doesn't include the majority of the components that have JavaScript.

Given these constraints, replace the test with one that does not try to instantiate or initialise the components, but only check that they all have an `init` function.

We were also not waiting for the Promises returned by `page.evaluate` to by fulfilled, so any errors thrown by the JS could cause unrelated tests that run later to fail. We were seeing this occur in #2467 when adding tests for the new skip link JavaScript.

Fix this by moving the bulk of the test logic into a single `page.evaluate` call and using `await` to pause execution until the returned Promise is fulfilled.

(It would likely make more sense to run these tests against the classes directly, rather than using Puppeteer to assert things about the `window.GOVUKFrontend` global object in a browser. However, we don't currently have a good way to test the component JavaScript directly. When we do, we should revisit this test.)