### PR TITLE
Tweak whitespace in input component HTML for improved readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2475: Tweak whitespace in input component HTML for improved readability](https://github.com/alphagov/govuk-frontend/pull/2475)
+
 ## 4.0.0 (Breaking release)
 
 ### Breaking changes

--- a/src/govuk/components/input/template.njk
+++ b/src/govuk/components/input/template.njk
@@ -38,9 +38,9 @@
   }) | indent(2) | trim }}
 {% endif %}
 
-{%- if params.prefix or params.suffix %}<div class="govuk-input__wrapper">{% endif -%}
+  {%- if params.prefix or params.suffix %}<div class="govuk-input__wrapper">{% endif -%}
 
-  {%- if params.prefix.text or params.prefix.html %}
+  {%- if params.prefix.text or params.prefix.html -%}
     <div class="govuk-input__prefix {{- ' ' + params.prefix.classes if params.prefix.classes }}" aria-hidden="true" {%- for attribute, value in params.prefix.attributes %} {{attribute}}="{{value}}"{% endfor %}>
       {{- params.prefix.html | safe if params.prefix.html else params.prefix.text -}}
     </div>
@@ -55,11 +55,12 @@
   {%- if params.inputmode %} inputmode="{{ params.inputmode }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>
 
-  {%- if params.suffix.text or params.suffix.html %}
+  {%- if params.suffix.text or params.suffix.html -%}
     <div class="govuk-input__suffix {{- ' ' + params.suffix.classes if params.suffix.classes }}" aria-hidden="true" {%- for attribute, value in params.suffix.attributes %} {{attribute}}="{{value}}"{% endfor %}>
       {{- params.suffix.html | safe if params.suffix.html else params.suffix.text -}}
     </div>
   {% endif -%}
 
 {%- if params.prefix or params.suffix %}</div>{% endif %}
+
 </div>


### PR DESCRIPTION
Tweak the input component nunjucks macro slightly to improve the whitespace of the output HTML so that:

- the closing `div` for the form group is on a new line
(https://github.com/alphagov/govuk-design-system/issues/1939)
- there is no unecessary whitespace between the `govuk-input__wrapper`
and `govuk-input__prefix`

## Before vs After (default input example)
Before:
<img width="955" alt="Screenshot 2021-12-14 at 14 36 57" src="https://user-images.githubusercontent.com/29889908/146018856-85a60a7f-178e-4ad9-b022-7932181047d1.png">

After:
<img width="953" alt="Screenshot 2021-12-14 at 14 37 03" src="https://user-images.githubusercontent.com/29889908/146018849-da19ecf1-af0c-4659-a9c9-a5b50741079d.png">

## Before vs After (input with prefix and suffix)
Before:
<img width="959" alt="Screenshot 2021-12-14 at 14 36 29" src="https://user-images.githubusercontent.com/29889908/146019001-85cb167f-6beb-4476-9b2c-05ffcd2cc9be.png">

After:
<img width="956" alt="Screenshot 2021-12-14 at 14 36 37" src="https://user-images.githubusercontent.com/29889908/146018994-989b9542-2b17-4757-bef9-8a6011d66894.png">
