### PR TITLE
Remove unnecessary use of `aria-hidden` in the character count

### DIFF
--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -133,12 +133,8 @@ CharacterCount.prototype.updateCountMessage = function () {
   var thresholdValue = maxLength * thresholdPercent / 100
   if (thresholdValue > currentLength) {
     countMessage.classList.add('govuk-character-count__message--disabled')
-    // Ensure threshold is hidden for users of assistive technologies
-    countMessage.setAttribute('aria-hidden', true)
   } else {
     countMessage.classList.remove('govuk-character-count__message--disabled')
-    // Ensure threshold is visible for users of assistive technologies
-    countMessage.removeAttribute('aria-hidden')
   }
 
   // Update styles

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -124,10 +124,6 @@ describe('Character count', () => {
         it('does not show the limit until the threshold is reached', async () => {
           const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('hidden')
-
-          // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
-          expect(ariaHidden).toEqual('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
@@ -135,10 +131,6 @@ describe('Character count', () => {
 
           const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
-
-          // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
-          expect(ariaHidden).toBeFalsy()
         })
       })
 


### PR DESCRIPTION
The `govuk-character-count__message--disabled` class hides the message using `visibility: hidden`, so there is no need to also use the `aria-hidden` attribute.

> If an interactive element is hidden using `display:none` or `visibility:hidden` (either on the element itself, or any of the element's ancestors), it won't be focusable, and it will also be removed from the accessibility tree. This makes the addition of `aria-hidden="true"` or explicitly setting tabindex="-1" unnecessary.
>
> – https://www.w3.org/TR/using-aria/#4thrule