### PR TITLE
Set granular token permissions for GitHub Actions

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     paths: ['dist/**']
 
+permissions:
+  pull-requests: write
+
 jobs:
   generate-diff:
     name: Generate Diff


### PR DESCRIPTION
Following best practise, [grant the GITHUB_TOKEN only the required permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) – which in this case is write access on pull requests in order to be able to add the comment to the PR.

This also allows us to change the default permissions for workflows to 'Read repository contents' only.