### PR TITLE
Clarify how `expanded` param works on accordion

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -47,7 +47,7 @@ params:
     - name: expanded
       type: boolean
       required: false
-      description: Whether the section should be expanded upon initial load or not. Defaults to `false`.
+      description: Sets whether the section should be expanded when the page loads for the first time. Defaults to `false`.
 
 examples:
 - name: default


### PR DESCRIPTION
Partly addresses [#1443](https://github.com/alphagov/govuk-design-system/issues/1443).

This PR updates the Description for the `expanded` param in the accordion Nunjucks. The previous wording was unclear about when the section expanded.