### PR TITLE
Move font style to `section-button` in accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change was introduced in [#2491: Prevent error summary from being re-focuse
 - [#2491: Prevent error summary from being re-focused after it has been initially focused on page load](https://github.com/alphagov/govuk-frontend/pull/2491)
 - [#2494: Allow disabling autofocus on error summary](https://github.com/alphagov/govuk-frontend/pull/2494)
 - [#2515: Add explicit width to summary list row with no actions pseudoelement](https://github.com/alphagov/govuk-frontend/pull/2515)
+- [#2514: Fix accordion heading style while JavaScript is disabled](https://github.com/alphagov/govuk-frontend/pull/2514)
 
 ## 4.0.0 (Breaking release)
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -22,15 +22,12 @@
   }
 
   .govuk-accordion__section-button {
+    @include govuk-font($size: 24, $weight: bold);
     @include govuk-text-colour;
 
     display: block;
     margin-bottom: 0;
     padding-top: govuk-spacing(3);
-  }
-
-  .govuk-accordion__section-heading-text {
-    @include govuk-font($size: 24, $weight: bold);
   }
 
   // Remove the bottom margin from the last item inside the content
@@ -297,7 +294,8 @@
 
     // Add toggle link with Chevron icon on left.
     .govuk-accordion__section-toggle {
-      @include govuk-font($size: 19);
+      @include govuk-typography-responsive($size: 19);
+      @include govuk-typography-weight-regular;
       color: $govuk-link-colour;
     }
 


### PR DESCRIPTION
The accordion heading text is currently not styled when JavaScript (JS) is disabled. Current font styling applies to `govuk-accordion__section-heading-text`, but that element only exists when JS is enabled.

**This MR:**
- Moves the `govuk-font()` macro to `govuk-accordion__section-button`.
- Removes `govuk-font()` from `govuk-accordion__section-toggle` and replaces with the explicit macros `govuk-typography-responsive($size: 19)` & `govuk-typography-weight-regular` - to reduce the font property duplication; `govuk-accordion__section-toggle` will inherit the font properties from `govuk-accordion__section-button`.

Closes #2481 

Happy to make any changes if required.