### PR TITLE
Remove '`govuk-radios--conditional`'  class

### DIFF
--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -166,14 +166,6 @@
         clear: none;
       }
     }
-
-    // Prevent inline modifier being used with conditional reveals
-    &.govuk-radios--conditional {
-      .govuk-radios__item {
-        margin-right: 0;
-        float: none;
-      }
-    }
   }
 
   // =========================================================

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -348,35 +348,6 @@ examples:
             <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
             <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
 
-- name: inline with conditional items
-  data:
-    classes: govuk-radios--inline
-    idPrefix: how-contacted
-    name: how-contacted
-    fieldset:
-      legend:
-        text: How do you want to be contacted?
-    items:
-      - value: email
-        text: Email
-        conditional:
-          html: |
-            <label class="govuk-label" for="context-email">Email address</label>
-            <input class="govuk-input govuk-!-width-one-third" name="context-email" type="text" id="context-email">
-      - value: phone
-        text: Phone
-        conditional:
-          html: |
-            <label class="govuk-label" for="contact-phone">Phone number</label>
-            <input class="govuk-input govuk-!-width-one-third" name="contact-phone" type="text" id="contact-phone">
-      - value: text
-        text: Text message
-        conditional:
-          html: |
-            <label class="govuk-label" for="contact-text-message">Mobile phone number</label>
-            <input class="govuk-input govuk-!-width-one-third" name="contact-text-message" type="text" id="contact-text-message">
-
-
 - name: with conditional item checked
   data:
     idPrefix: 'how-contacted-checked'


### PR DESCRIPTION
Our guidance says:

> Do not conditionally reveal questions to inline radios

However, we were allowing for this behaviour by including the `govuk-radios--conditional` class, which simply overrides the `govuk-radios--inline` styles.

We think it would be better to remove this entirely and force the component to look broken if a user attempts to combine these incompatible states so that they can catch the problem quickly.

This does create a case where the use of our Nunjucks macro can end up with something that looks broken, which is not great. But given we advise against this scenario, we think this is the better course of action.