### PR TITLE
Fix select component renders with grey background in Firefox and Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change was introduced in [#2491: Prevent error summary from being re-focuse
 - [#2494: Allow disabling autofocus on error summary](https://github.com/alphagov/govuk-frontend/pull/2494)
 - [#2515: Add explicit width to summary list row with no actions pseudoelement](https://github.com/alphagov/govuk-frontend/pull/2515)
 - [#2514: Fix accordion heading style while JavaScript is disabled](https://github.com/alphagov/govuk-frontend/pull/2514)
+- [#2524: Fix select component renders with grey background in Firefox and Safari](https://github.com/alphagov/govuk-frontend/pull/2524)
 
 ## 4.0.0 (Breaking release)
 

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -15,6 +15,11 @@
     padding: govuk-spacing(1); // was 5px 4px 4px - size of it should be adjusted to match other form elements
     border: $govuk-border-width-form-element solid $govuk-input-border-colour;
 
+    // Default user agent colours for selects can have low contrast,
+    // and may look disabled (#2435)
+    color: $govuk-text-colour;
+    background-color: govuk-colour("white");
+
     &:focus {
       outline: $govuk-focus-width solid $govuk-focus-colour;
       // Ensure outline appears outside of the element


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2435

## What
Sets background colour and text colour on the select component so that we have more control over the background and foreground colour and don't get influenced by browser defaults which sometimes default to a grey background.

## Why
We have had two separate reports from users of the select component appearing with a grey background in Firefox and iOS Safari. In iOS Safari, the text within the select also appears as blue - the blue text on grey background does not meet colour contrast (ratio 2.19:1). We should probably raise a WebKit bug for this too, but alongside the issue in Firefox it probably also makes sense for us to look at getting more control over our component styling too.

## Screenshots (default component)

Chrome:
<img width="270" alt="Screenshot 2022-01-31 at 15 25 18" src="https://user-images.githubusercontent.com/29889908/151828017-a02875d3-25a8-45d0-9c84-06b6aff622fd.png">
<img width="304" alt="Screenshot 2022-01-31 at 15 25 25" src="https://user-images.githubusercontent.com/29889908/151828018-31013d6c-ad57-4ac9-9844-e16b521fcc2d.png">

iOS:
<img width="192" alt="Screenshot 2022-01-31 at 15 33 37" src="https://user-images.githubusercontent.com/29889908/151828069-aa9a72f7-8d2f-4d2f-9232-31600cb1df56.png">

Firefox:
<img width="295" alt="Screenshot 2022-01-31 at 15 45 55" src="https://user-images.githubusercontent.com/29889908/151828492-374ac92c-cd61-4dfc-acf8-4eda34b059ee.png">
<img width="298" alt="Screenshot 2022-01-31 at 15 45 52" src="https://user-images.githubusercontent.com/29889908/151828489-eec795af-f096-484e-a5ae-0a01dd9e1338.png">

IE11:
<img width="294" alt="Screenshot 2022-01-31 at 15 49 24" src="https://user-images.githubusercontent.com/29889908/151828596-13791bee-179c-4209-a322-b453d5c13271.png">
<img width="303" alt="Screenshot 2022-01-31 at 15 49 28" src="https://user-images.githubusercontent.com/29889908/151828599-c6742d85-c8a3-4df5-b228-7a95707a8de2.png">


## Screenshots (colours changed)

Windows High Contrast, Edge:
<img width="288" alt="Screenshot 2022-01-31 at 15 17 29" src="https://user-images.githubusercontent.com/29889908/151827198-f25cfba4-dc2f-4691-b96a-e6b18cd71619.png">

Windows High Contrast, Chrome:
<img width="308" alt="Screenshot 2022-01-31 at 15 18 55" src="https://user-images.githubusercontent.com/29889908/151827342-815b1c2e-51c9-4b06-944b-4576f640786c.png">

Windows High Contrast, Firefox:
<img width="296" alt="Screenshot 2022-01-31 at 15 19 42" src="https://user-images.githubusercontent.com/29889908/151827400-46c90bb0-1488-4778-95bc-46f5c20219ce.png">

Windows High Contrast, IE11:
<img width="281" alt="Screenshot 2022-01-31 at 15 20 47" src="https://user-images.githubusercontent.com/29889908/151827559-42fcd843-8f85-45d2-afe3-c86814f47477.png">
<img width="297" alt="Screenshot 2022-01-31 at 15 20 31" src="https://user-images.githubusercontent.com/29889908/151827562-aae8e846-6d24-42a0-8661-76b28b4b39e9.png">

Firefox (changed colours):
<img width="315" alt="Screenshot 2022-01-31 at 15 46 22" src="https://user-images.githubusercontent.com/29889908/151828560-b5c11c3a-cbbc-41a6-b9be-683f16bd8634.png">
<img width="301" alt="Screenshot 2022-01-31 at 15 46 25" src="https://user-images.githubusercontent.com/29889908/151828562-7c047ce8-a6fd-4906-91e7-ae3029d7e69d.png">

