### PR TITLE
Add quotes around the pre-release package in the pre-release script

### DIFF
--- a/bin/pre-release.sh
+++ b/bin/pre-release.sh
@@ -46,4 +46,4 @@ git checkout -
 BRANCH_COMMIT_SHA=$(git rev-parse --short $BRANCH_NAME)
 
 echo
-echo "✅ Success! To install the pushed branch release, run 'npm install --save alphagov/govuk-frontend#$BRANCH_COMMIT_SHA'"
+echo "✅ Success! To install the pushed branch release, run 'npm install --save \"alphagov/govuk-frontend#$BRANCH_COMMIT_SHA\"'"


### PR DESCRIPTION
## What
Adds quote around the pre-release npm package in the terminal command generated by `pre-release.sh`, run as part of `npm run pre-release`.

## Why
This came up recently for me due to issues with how zsh handles this command, I suspect because of potential special characters in the line generated by the `pre-release` command. The quotes mean that these special characters are escaped for anyone using terminals that take exception to said special characters.

This PR is an evolution of the docs updated proposed in https://github.com/alphagov/govuk-frontend/pull/2529 based on a suggestion by @36degrees.