### PR TITLE
Update release docs to move testing content and explain command output

### DIFF
--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -120,7 +120,25 @@ If a snapshot test fails, follow these steps.
 
 Where `<COMPONENT>` is the name of the component you've changed.
 
-## 8. Tell us what you’ve tested and checked
+## 8. Test that your changes work in the GOV.UK Design System (optional)
+
+To make sure your changes work in the Design System, use `npm link` to test before publishing, as follows:
+
+```bash
+cd ../govuk-design-system
+git checkout main
+git pull
+npm install # note running `npm install` after `npm link` will destroy the link.
+npm link ../govuk-frontend/package/
+ ```
+
+When you've finished testing, run this command to unlink the package:
+
+```bash
+npm unlink ../govuk-frontend/package/
+```
+
+## 9. Tell us what you’ve tested and checked
 
 When you create the pull request for your contributions, list what you’ve tested and checked in the pull request description.
 

--- a/docs/releasing/publishing-from-a-support-branch.md
+++ b/docs/releasing/publishing-from-a-support-branch.md
@@ -92,23 +92,17 @@ Note: Before you go on annual leave, tell the delivery manager who will be looki
 
 7. Save the changes. Do not commit.
 
-8. Run `npm run build-release`, which will prompt you to either continue or cancel. Enter `y` to continue.
+8. Run `npm run build-release` to:
 
-9. If you want to make sure your changes work when used in the GOV.UK Design System, use [`npm-link`](https://docs.npmjs.com/cli/v7/commands/npm-link) to test before publishing:
+- build GOV.UK Frontend into the `/package` and `/dist` directories
+- commit the changes
+- push a branch to GitHub
 
-  ```bash
-  cd ../govuk-design-system
-  git checkout main
-  git pull
-  npm install # note running `npm install` after `npm link` will destroy the link.
-  npm link ../govuk-frontend/package/
-  ```
+  You will now be prompted to continue or cancel.
 
-10. When you finish testing, run `npm unlink ../govuk-frontend/package/` to unlink the package.
+9. Raise a pull request, with `support/<CURRENT MAJOR VERSION NUMBER>.x` as the base branch to merge into.
 
-11. Raise a pull request, with `support/<CURRENT MAJOR VERSION NUMBER>.x` as the base branch to merge into.
-
-12. Once a developer approves the pull request, merge it into `support/<CURRENT MAJOR VERSION NUMBER>.x`.
+10. Once a developer approves the pull request, merge it into `support/<CURRENT MAJOR VERSION NUMBER>.x`.
 
 ### Publish the release to npm
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -52,30 +52,18 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 7. Save the changes. Do not commit.
 
-8. Run `npm run build-release`. You will be now be prompted to continue or cancel.
+8. Run `npm run build-release` to:
 
-9. (Optional) Test in [GOV.UK Design System](git@github.com:alphagov/govuk-design-system.git)
+- build GOV.UK Frontend into the `/package` and `/dist` directories
+- commit the changes
+- push a branch to GitHub
 
-  If you want to test that your changes work in the GOV.UK Design System, you can use [npm link](https://docs.npmjs.com/cli/link) to test before publishing.
+  You will now be prompted to continue or cancel.
 
-  ```bash
-  cd ../govuk-design-system
-  git checkout main
-  git pull
-  npm install # note running `npm install` after `npm link` will destroy the link.
-  npm link ../govuk-frontend/package/
-  ```
-
-  When you have finished, you need to unlink the package.
-
-  ```bash
-  npm unlink ../govuk-frontend/package/
-  ```
-
-10. Create a pull request and copy the changelog text.
+9. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version-numbers have been updated and that the compiled assets use this version-number.
 
-11. Once a reviewer approves the pull request, merge it to **main**.
+10. Once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm
 


### PR DESCRIPTION
Fixes [#2537](https://github.com/alphagov/govuk-frontend/issues/2537).

This PR:

- removes redundant content (about testing changes) from our release docs ('Publishing', 'Publishing from a support branch')
- updates the release docs to explain what running `npm run build-release` does
- relocates the removed content to our 'Testing' doc