### PR TITLE
For discussion: Make the labels for checkboxes and radios full-width

### DIFF
--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -64,7 +64,7 @@
   }
 
   .govuk-checkboxes__label {
-    display: inline-block;
+    display: block;
     margin-bottom: 0;
     padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
     cursor: pointer;

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -67,7 +67,7 @@
   }
 
   .govuk-radios__label {
-    display: inline-block;
+    display: block;
     margin-bottom: 0;
     padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
     cursor: pointer;


### PR DESCRIPTION
I noticed recently, when filling out one of the various covid-related services on my phone (in a hurry, and slightly distracted) that I instinctively went to tap the whitespace to the right one of the labels for a checkbox, which didn't work.

A recent [change to the GOV.UK homepage](https://insidegovuk.blog.gov.uk/2021/12/13/updating-the-gov-uk-homepage/) made the tap touch targets there larger (including whitespace and the text below a link).

The [accordion component](https://design-system.service.gov.uk/components/accordion/) also allows you to the tap the whitespace to the right of the label, as does the regular labels for [text inputs](https://design-system.service.gov.uk/components/text-input/).

Should we do the same for radio and checkbox labels? The benefit would be especially felt where the label is very short (eg "Wales" in a list of countries.

One possible reason not to do it might be that some users may select the option accidentally, and not realise. However this risk may be small as the checkbox and radios themselves are quite large, and mobile devices are fairly good at distinguishing between scroll gestures and tap gestures. It's a consideration though.

The NHS Design System already does this for [their checkbox labels](https://service-manual.nhs.uk/design-system/components/checkboxes) (although curiously not for their [radio labels](https://service-manual.nhs.uk/design-system/components/radios)).