### PR TITLE
Add example of type of input control

### DIFF
--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -10,7 +10,7 @@ params:
 - name: type
   type: string
   required: false
-  description: Type of input control to render. Defaults to `text`.
+  description: Type of input control to render, for example, a password input control. Defaults to `text`.
 - name: inputmode
   type: string
   required: false


### PR DESCRIPTION
Fixes [#2542](https://github.com/alphagov/govuk-frontend/issues/2542).

Updates the text input Nunjucks with an example for the `type` parameter.