### PR TITLE
Add Percy visual regression testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,4 +23,6 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: node_modules/.bin/percy exec -- npm test
+        env:
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -1,6 +1,6 @@
 # Testing and linting
 
-The CI lints SASS and JavaScript, runs unit and functional tests with Node, and generates snapshots for visual regression testing (Percy.io).
+The CI lints SASS and JavaScript, runs unit and functional tests with Node, and generates snapshots for [visual regression testing](https://www.browserstack.com/percy/visual-testing).
 
 ## Running all tests locally
 
@@ -50,20 +50,20 @@ This will update the snapshot file. Commit this file separately with a commit me
 
 ## Visual regression testing with Percy
 
-We use [Percy](https://percy.io/), a visual regression testing tool, to generate and store screenshots of our components to help us check for any unintended visual changes.
+[Percy](https://percy.io/) is a visual regression testing tool. We use it to generate and store screenshots of our components to help us check for any unintended visual changes.
 
-We generate two screenshots for each default example of every component: one with JavaScript enabled and one with JavaScript disabled. Screenshots are not taken for all the different variations of each component. This tool is not a replacement for manual testing.
+We generate 2 screenshots for each default example of every component. One example has JavaScript enabled, the other has JavaScript disabled. Screenshots are not taken for all the different variations of each component. This tool is not a replacement for manual testing.
 
-The screenshots are public, so they can be checked without logging in. A BrowserStack account is needed to approve or reject any changes. It's the responsibility of the person reviewing the pull request code to approve any visual changes that Percy highlights.
+The screenshots are public, so you can check them without logging in. A BrowserStack account is needed to approve or reject any changes (if you don't have access, ask your tech lead for help). If you're the reviewer of the pull request code, it's your responsibility to approve or request changes for any visual changes Percy highlights.
 
-When running the tests locally (e.g: via `npm test`), Percy commands are ignored and no screenshots are generated. You will see the following message in your command line output: `[percy] Percy is not running, disabling snapshots`.
+When you run the tests locally (for example, using `npm test`), Percy commands are ignored and Percy does not generate any screenshots. You will see the following message in your command line output: `[percy] Percy is not running, disabling snapshots`.
 
 ### PRs from forks
-When Github Actions is running against a PR from a fork, the Percy secret is not available and therefore no screenshots are generated. Other tests will continue to run as normal. You will see the following messages in the output:
+When Github Actions is running against a PR from a fork, the Percy secret is not available and Percy does not generate any screenshots. Other tests will continue to run as normal. You will see the following messages in the output:
 
 ```
 [percy] Skipping visual tests
 [percy] Error: Missing Percy token
 ```
 
-This is the reason why we are unable to make Percy a required check for this repo. However, we should continue to act as if it is required. Percy runs should be approved before merging, and we should treat any failures as blocking.
+Being unable to run Percy on PRs from forks is the reason we're unable to make Percy a required check for this repo. However, we should continue to act as if a Percy check is required. If the Percy build fails, do not merge the pull request even though GitHub would let you. Continue to review the changes, and approve or reject them as you would normally.

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -1,6 +1,6 @@
 # Testing and linting
 
-The CI lints SASS and JavaScript, and runs unit and functional tests with Node.
+The CI lints SASS and JavaScript, runs unit and functional tests with Node, and generates snapshots for visual regression testing (Percy.io).
 
 ## Running all tests locally
 
@@ -47,3 +47,13 @@ If a snapshot test fails, review the difference in the console. If the change is
 `npm test -- -u src/govuk/components/button`
 
 This will update the snapshot file. Commit this file separately with a commit message that explains you're updating the snapshot file and an explanation of what caused the change.
+
+## Visual regression testing with Percy
+
+We use [Percy](https://percy.io/), a visual regression testing tool, to generate and store screenshots of our components to help us check for any unintended visual changes.
+
+We generate two screenshots for each default example of every component: one with JavaScript enabled and one with JavaScript disabled. Screenshots are not taken for all the different variations of each component. This tool is not a replacement for manual testing.
+
+The screenshots are public, so they can be checked without logging in. A BrowserStack account is needed to approve or reject any changes. It's the responsibility of the person reviewing the pull request code to approve any visual changes that Percy highlights.
+
+Note: when running the tests locally via `npm test`, Percy commands are ignored and no screenshots are generated. You will see the following message in your command line output: `[percy] Percy is not running, disabling snapshots`.

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -56,4 +56,14 @@ We generate two screenshots for each default example of every component: one wit
 
 The screenshots are public, so they can be checked without logging in. A BrowserStack account is needed to approve or reject any changes. It's the responsibility of the person reviewing the pull request code to approve any visual changes that Percy highlights.
 
-Note: when running the tests locally via `npm test`, Percy commands are ignored and no screenshots are generated. You will see the following message in your command line output: `[percy] Percy is not running, disabling snapshots`.
+When running the tests locally (e.g: via `npm test`), Percy commands are ignored and no screenshots are generated. You will see the following message in your command line output: `[percy] Percy is not running, disabling snapshots`.
+
+### PRs from forks
+When Github Actions is running against a PR from a fork, the Percy secret is not available and therefore no screenshots are generated. Other tests will continue to run as normal. You will see the following messages in the output:
+
+```
+[percy] Skipping visual tests
+[percy] Error: Missing Percy token
+```
+
+This is the reason why we are unable to make Percy a required check for this repo. However, we should continue to act as if it is required. Percy runs should be approved before merging, and we should treat any failures as blocking.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1934,6 +1934,24 @@
       "integrity": "sha512-cxCMLQ6uYkfVXIb4qgDnxnYWlgtiLr64LEE6BKQUG6d+3D5TTzfexVXGFc+miB37ntD4aCEvW9WWG8kPswYSSg==",
       "dev": true
     },
+    "@percy/puppeteer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@percy/puppeteer/-/puppeteer-2.0.0.tgz",
+      "integrity": "sha512-AAErUA1NEELBmOIscHBJB064+6x7N2ZIA9EisBfB6ff1HJK58t2x7VGRNQjGsXvq/RP0wrLzmUY3uSSb2gQhVQ==",
+      "dev": true,
+      "requires": {
+        "@percy/sdk-utils": "^1.0.0-beta.32"
+      }
+    },
+    "@percy/sdk-utils": {
+      "version": "1.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.0.0-beta.74.tgz",
+      "integrity": "sha512-bJ6rH4Dw8+Ojedw/QN/D/FD1lZ7fuGQ5yDkjHr7++wBNuEeaSDa49NpwEUfO4GKyKHRJNJjhVFsTzNLvnVPc5w==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.0.0-beta.74"
+      }
+    },
     "@sideway/address": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1440,6 +1440,500 @@
         "fastq": "^1.6.0"
       }
     },
+    "@percy/cli": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli/-/cli-1.0.0-beta.75.tgz",
+      "integrity": "sha512-BKqvdxJ3srxneqnKsmRIgpCkbEG065KRhtrQ28evSiXv/M7AtcEgdL676eAJ5joGjAfCtnZeKROR5H1hIi7Fkw==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-build": "1.0.0-beta.75",
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/cli-config": "1.0.0-beta.75",
+        "@percy/cli-exec": "1.0.0-beta.75",
+        "@percy/cli-snapshot": "1.0.0-beta.75",
+        "@percy/cli-upload": "1.0.0-beta.75",
+        "@percy/client": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-build": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-build/-/cli-build-1.0.0-beta.75.tgz",
+      "integrity": "sha512-wup3ZKTNln+NvyKkz7f3EUAerjdzNPvQtxcuZxiu0qUa2gfuDPGUqQDUPoAcit4Mm9QqkcuSq0BDz0fejp50xg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-command": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-command/-/cli-command-1.0.0-beta.75.tgz",
+      "integrity": "sha512-VxzianYAkjzDhkp3Wu7aGaB+rfPBwufUB3u3zDepKNyTFd1DBJvzev6JC9EBRLj7/98fF9jSysY1sXCV0LFfHw==",
+      "dev": true,
+      "requires": {
+        "@percy/config": "1.0.0-beta.75",
+        "@percy/core": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-config": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-config/-/cli-config-1.0.0-beta.75.tgz",
+      "integrity": "sha512-fBIP7V6ULpkzWJ0djvpLjG9xxxp2M7tH3lxqyo8UiJYlelfNW/hI8ThYknfJBWr4CV9e+bo/dBmprtLE0gRbOA==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/config": "1.0.0-beta.75"
+      }
+    },
+    "@percy/cli-exec": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-exec/-/cli-exec-1.0.0-beta.75.tgz",
+      "integrity": "sha512-csCTzqSx3ItzNJh+TjRhx5ccb53ERjTSmPsZpzmnSSmQ0dwVoxf1+TmEpKOmROL2szswrPXZfV/4lhkiaXF5OQ==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/core": "1.0.0-beta.75",
+        "cross-spawn": "^7.0.3",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "@percy/cli-snapshot": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-snapshot/-/cli-snapshot-1.0.0-beta.75.tgz",
+      "integrity": "sha512-Ww5cRtAO46o0YMhzpt5wxpQ8NgPLt5PYRxJ77GWrOv5PDQOz2twZWH9QStj+XSn24yfVGN+OwpWIS/COzpqWtg==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/config": "1.0.0-beta.75",
+        "@percy/core": "1.0.0-beta.75",
+        "globby": "^11.0.4",
+        "path-to-regexp": "^6.2.0",
+        "picomatch": "^2.3.0",
+        "serve-handler": "^6.1.3",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "path-to-regexp": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
+          "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/cli-upload": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/cli-upload/-/cli-upload-1.0.0-beta.75.tgz",
+      "integrity": "sha512-Fh5eaEH8+GS582GXLcbbgvDPRBSC/xffcIVwIVnI3txVvzvCybSWDdLePzBUp1iHp1XWqbFa3qZvsoZu+6Twaw==",
+      "dev": true,
+      "requires": {
+        "@percy/cli-command": "1.0.0-beta.75",
+        "@percy/client": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75",
+        "globby": "^11.0.4",
+        "image-size": "^1.0.0"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+          "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "dev": true
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+          "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+          "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.2.3"
+          }
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+          "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/client": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/client/-/client-1.0.0-beta.75.tgz",
+      "integrity": "sha512-QHyTQOBLj8iEminAUaIS8QV7CpGdKp6RwHLCTIHaUCGprzU+FZ8+/hhlHVbWwx0EYqeK2DrWr5ruEDdHC9C4oQ==",
+      "dev": true,
+      "requires": {
+        "@percy/env": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/config": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/config/-/config-1.0.0-beta.75.tgz",
+      "integrity": "sha512-UcbMCYlp0NpQcUJo7X6Vwo67OVa/l0XEG00OwOE+XF/aB083Zo4usXO7rRBdn3UuJ4zj5/mqpK/+hiSMdK8PPg==",
+      "dev": true,
+      "requires": {
+        "@percy/logger": "1.0.0-beta.75",
+        "ajv": "^8.6.2",
+        "cosmiconfig": "^7.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        },
+        "ajv": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+          "dev": true,
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+          "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/core": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/core/-/core-1.0.0-beta.75.tgz",
+      "integrity": "sha512-VyaMT6DgOTvqRt55SeVXnCAyX1+4AAqzwHPWksFHPdmtuwpOw7ptDucX/503RTk6KNHsauZ1IxqPipb0fJkKJw==",
+      "dev": true,
+      "requires": {
+        "@percy/client": "1.0.0-beta.75",
+        "@percy/config": "1.0.0-beta.75",
+        "@percy/dom": "1.0.0-beta.75",
+        "@percy/logger": "1.0.0-beta.75",
+        "cross-spawn": "^7.0.3",
+        "extract-zip": "^2.0.1",
+        "rimraf": "^3.0.2",
+        "ws": "^8.0.0"
+      },
+      "dependencies": {
+        "@percy/logger": {
+          "version": "1.0.0-beta.75",
+          "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.75.tgz",
+          "integrity": "sha512-/0otHJcPUAiJwOzyFwwlolp2lGz2Bx11rHy27kUYZpzMoA6mx/9uY6q2rfhuG8/dWbkgAt1Upc7fuMkaGK4P0g==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "ws": {
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+          "dev": true
+        }
+      }
+    },
+    "@percy/dom": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/dom/-/dom-1.0.0-beta.75.tgz",
+      "integrity": "sha512-H+H8141JTTUGHh2w/VslK2Z4UxgH8YWkKTxJ3VPoqbmXoke+jbqdxW++Qe7RFe5gCJAD7u2LvcCNtYvUTckbRQ==",
+      "dev": true
+    },
+    "@percy/env": {
+      "version": "1.0.0-beta.75",
+      "resolved": "https://registry.npmjs.org/@percy/env/-/env-1.0.0-beta.75.tgz",
+      "integrity": "sha512-hu23XMUdkhnSug9XiUgnO9ktzauqE1b+hBwpy/NPR0laFVE1e/v7qJhh8z298L2itisYoNcIBMyej1M7XsM7FQ==",
+      "dev": true
+    },
+    "@percy/logger": {
+      "version": "1.0.0-beta.74",
+      "resolved": "https://registry.npmjs.org/@percy/logger/-/logger-1.0.0-beta.74.tgz",
+      "integrity": "sha512-cxCMLQ6uYkfVXIb4qgDnxnYWlgtiLr64LEE6BKQUG6d+3D5TTzfexVXGFc+miB37ntD4aCEvW9WWG8kPswYSSg==",
+      "dev": true
+    },
     "@sideway/address": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.3.tgz",
@@ -5976,6 +6470,23 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -7833,6 +8344,15 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "image-size": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.0.1.tgz",
+      "integrity": "sha512-VAwkvNSNGClRw9mDHhc5Efax8PLlsOGcUTh0T/LIriC8vPA3U5PdqXWqkz406MoYHMKW8Uf9gWr05T/rYB44kQ==",
+      "dev": true,
+      "requires": {
+        "queue": "6.0.2"
+      }
     },
     "import-cwd": {
       "version": "2.1.0",
@@ -13599,6 +14119,12 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -15534,6 +16060,15 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
       "dev": true
     },
+    "queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "dev": true,
+      "requires": {
+        "inherits": "~2.0.3"
+      }
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -16029,6 +16564,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
     "require-main-filename": {
@@ -16685,6 +17226,63 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "serve-handler": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.3.tgz",
+      "integrity": "sha512-FosMqFBNrLyeiIDvP1zgO6YoTzFYHxLDEIavhlmQ+knB2Z7l1t+kGLHkZIDN7UVWqQAmKI3D20A6F6jo3nDd4w==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+          "dev": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+          "dev": true
+        },
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "dev": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@percy/cli": "^1.0.0-beta.75",
     "@percy/logger": "1.0.0-beta.74",
+    "@percy/puppeteer": "^2.0.0",
     "acorn": "^7.4.0",
     "autoprefixer": "^9.8.6",
     "body-parser": "^1.18.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "lint:scss": "stylelint 'app/**/*.scss' 'src/**/*.scss'"
   },
   "devDependencies": {
+    "@percy/cli": "^1.0.0-beta.75",
+    "@percy/logger": "1.0.0-beta.74",
     "acorn": "^7.4.0",
     "autoprefixer": "^9.8.6",
     "body-parser": "^1.18.3",

--- a/src/govuk/components/all.test.js
+++ b/src/govuk/components/all.test.js
@@ -5,6 +5,11 @@ const { renderSass } = require('../../../lib/jest-helpers')
 
 const configPaths = require('../../../config/paths.json')
 
+const PORT = configPaths.ports.test
+const baseUrl = 'http://localhost:' + PORT
+
+const percySnapshot = require('@percy/puppeteer')
+
 // We can't use the render function from jest-helpers, because we need control
 // over the nunjucks environment.
 const nunjucks = require('nunjucks')
@@ -33,4 +38,9 @@ it.each(allComponents)('%s.scss renders to CSS without errors', (component) => {
   return renderSass({
     file: `${configPaths.src}/components/${component}/_${component}.scss`
   })
+})
+
+it.each(allComponents)('generate screenshots for Percy visual regression', async (component) => {
+  await page.goto(baseUrl + '/components/' + component + '/preview', { waitUntil: 'load' })
+  await percySnapshot(page, component)
 })

--- a/src/govuk/components/all.test.js
+++ b/src/govuk/components/all.test.js
@@ -40,7 +40,14 @@ it.each(allComponents)('%s.scss renders to CSS without errors', (component) => {
   })
 })
 
-it.each(allComponents)('generate screenshots for Percy visual regression', async (component) => {
+it.each(allComponents)('generate screenshots for Percy visual regression, with JavaScript disabled', async (component) => {
+  await page.setJavaScriptEnabled(false)
   await page.goto(baseUrl + '/components/' + component + '/preview', { waitUntil: 'load' })
-  await percySnapshot(page, component)
+  await percySnapshot(page, 'no-js: ' + component)
+})
+
+it.each(allComponents)('generate screenshots for Percy visual regression, with JavaScript enabled', async (component) => {
+  await page.setJavaScriptEnabled(true)
+  await page.goto(baseUrl + '/components/' + component + '/preview', { waitUntil: 'load' })
+  await percySnapshot(page, 'js: ' + component)
 })


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/2070

## What
This PR adds Percy visual regression testing to GOV.UK Frontend. Screenshots are generated for each default example for every component, both with JavaScript enabled and disabled.

## Proposal
As discussed in dev catch-up, we generally think visual regression tools may help us catch unintended visual changes when we're working. There were some concerns around hitting screenshot limits, Percy checks being ignored if approvals aren't required (PRs can get rushed through into `main` without checking the screenshots), and generally it not being a replacement for manual testing as it doesn't cover older browsers, high contrast mode etc.

I'm proposing a trial period with this PR. I suggest we:

1. add Percy to GOV.UK Frontend until the end of the quarter (~ early April) and revisit our experience then
2. ~initially make Percy a required check~ **Edit to add: unfortunately, because PRs from forks don't have access to Github secrets, Percy won't run on these PRs. We therefore can't make it a required check, as it'll never run/pass for these PRs.**
3. put the responsibility for approving Percy runs onto the person reviewing the pull request

With all of the above, we should revisit decisions earlier than April if they're causing us issues and slowing down development.

## Why
Visual regression tools can help us catch visual changes which we weren't expecting, for example: if we make changes to one area of the codebase, without realising that it will have an effect elsewhere.