### PR TITLE
Fix code of conduct URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ We love contributions! We've compiled these docs to help you understand our cont
 
 
 ## Code of Conduct
-Please read [the `alphagov` CODE_OF_CONDUCT.md](https://github.com/alphagov/blob/main/.github/CODE_OF_CONDUCT.md) before contributing.
+Please read [the `alphagov` CODE_OF_CONDUCT.md](https://github.com/alphagov/.github/blob/main/CODE_OF_CONDUCT.md) before contributing.
 
 ## Application architecture
 


### PR DESCRIPTION
Removes 'Not found' error when clicking the code of conduct URL in `CONTRIBUTING.md`.