### PR TITLE
Better handle cases where govuk-text-colour is set to a non-colour value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
-- [#2573: Reinstate support for 'inherit' as a text colour](https://github.com/alphagov/govuk-frontend/pull/2573)
+- [#2573: Better handle cases where govuk-text-colour is set to a non-colour value](https://github.com/alphagov/govuk-frontend/pull/2573)
 
 ## 4.0.1 (Fix release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Fixes
 
-[#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
-[#2573: Reinstate support for 'inherit' as a text colour](https://github.com/alphagov/govuk-frontend/pull/2573)
+- [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
+- [#2573: Reinstate support for 'inherit' as a text colour](https://github.com/alphagov/govuk-frontend/pull/2573)
 
 ## 4.0.1 (Fix release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
+[#2573: Reinstate support for 'inherit' as a text colour](https://github.com/alphagov/govuk-frontend/pull/2573)
 
 ## 4.0.1 (Fix release)
 

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -273,7 +273,7 @@
   // Force a colour change on hover to work around a bug in Safari
   // https://bugs.webkit.org/show_bug.cgi?id=224483
   &:hover {
-    color: rgba($govuk-text-colour, .99);
+    color: if($govuk-text-colour == inherit, inherit, rgba($govuk-text-colour, .99));
   }
 
   &:active,

--- a/src/govuk/helpers/_links.scss
+++ b/src/govuk/helpers/_links.scss
@@ -273,7 +273,9 @@
   // Force a colour change on hover to work around a bug in Safari
   // https://bugs.webkit.org/show_bug.cgi?id=224483
   &:hover {
-    color: if($govuk-text-colour == inherit, inherit, rgba($govuk-text-colour, .99));
+    @if (type-of($govuk-text-colour) == color) {
+      color: rgba($govuk-text-colour, .99);
+    }
   }
 
   &:active,

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -188,9 +188,7 @@ describe('@mixin govuk-link-style-text', () => {
 
       const results = await renderSass({ data: sass, ...sassConfig })
 
-      expect(results.css.toString()).toContain(':hover')
       expect(results.css.toString()).not.toContain('rgba(')
-      expect(results.css.toString()).toContain('color: inherit')
     })
   })
 })

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -156,3 +156,41 @@ describe('@mixin govuk-link-hover-decoration', () => {
     })
   })
 })
+
+describe('@mixin govuk-link-style-text', () => {
+  describe('when $govuk-text-colour is a colour', () => {
+    it('applies the rgba function', async () => {
+      const sass = `
+        $govuk-text-colour: black;
+        @import "base";
+
+        a {
+            @include govuk-link-style-text;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain(':hover')
+      expect(results.css.toString()).toContain('color:')
+      expect(results.css.toString()).toContain('rgba(')
+    })
+  })
+
+  describe('when $govuk-text-colour is inherit', () => {
+    it('does NOT apply the rgba function', async () => {
+      const sass = `
+        $govuk-text-colour: inherit;
+        @import "base";
+
+        a {
+            @include govuk-link-style-text;
+        }`
+
+      const results = await renderSass({ data: sass, ...sassConfig })
+
+      expect(results.css.toString()).toContain(':hover')
+      expect(results.css.toString()).not.toContain('rgba(')
+      expect(results.css.toString()).toContain('color: inherit')
+    })
+  })
+})


### PR DESCRIPTION
Was: Reinstate support for 'inherit' as a text colour

The use of the `rgba` function, which was added to work around a bug in
Safari, prevents users from setting `$rgba-text-colour` to inherit.
This is useful if you wish to control the text colour by cascading a
style down from, say, a body tag, which in turn is useful in order to
apply this control at run-time rather than build-time.

This fixes the problem by first testing for the value `inherit`. When
found we simply evaluate to `inherit`, which is probably the best we
can do in the circumstance. When it is not found we apply the `rgba`
trick.

Addresses: #2231