### PR TITLE
Create build-a-component.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/build-a-component.md
+++ b/.github/ISSUE_TEMPLATE/build-a-component.md
@@ -1,0 +1,57 @@
+---
+name: "Build a component"
+about: Everything we need to do when we build a component
+title: ''
+labels: "contribution or major iteration, design, epic"
+assignees: ''
+
+---
+
+## What
+<!-- Add name of component, plus any relevant links (for example, community backlog issues and comments, pull requests for the component and its guidance) -->
+
+## Why
+<!-- Add reason for building the component -->
+
+## Who needs to know about this
+<!-- Add team roles involved in building the component -->
+
+## Acceptance criteria
+<!-- Customise, and add component-specific checklist items to, this list of criteria all components need to meet -->
+### Accessibility
+In general, the component must:
+- [ ] work with [assistive technologies listed in the service manual(https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices)
+- [ ] pass tests on tools like axe and HTML validator
+- [ ] works when zoomed at high resolution
+- [ ] work in high contrast mode
+- [ ] follow [focus state guidance](https://design-system.service.gov.uk/get-started/focus-states/)
+
+For more information on accessibility testing, [read our documentation on testing components](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/test-components-using-accessibility-acceptance-criteria.md).
+
+### Coding standards
+The component's guidance must include these sections:
+- [ ] have Nunjucks options that are consistent with other Design System components
+- [ ] have commonly available Nunjuck options
+- [ ] follow GOV.UK Frontend coding conventions
+- [ ] follow the code style guide
+
+### Content
+The component must:
+- [ ] include Nunjucks documentation
+- [ ] have PR commits with [commit messages that are easy to understand](https://github.com/alphagov/design-system-team-docs/blob/main/development/commit-messages.md)
+
+### Reviews
+The component must:
+- [ ] be reviewed by the working group at the development stage
+- [ ] in its final version, receive a design crit from the wider community, to see if we've balanced any trade-offs correctly
+
+### Tests
+The component must:
+- [ ] avoid a breaking change
+- [ ] work with Javascript disabled
+- [ ] work and look as expected at different breakpoints
+- [ ] have a macro the user can use to pass data into the component
+- [ ] have unit tests which each macro option passes
+- [ ] support the [browsers listed in the Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices), and have semantic markup
+- [ ] work on devices listed in the Service Manual
+- [ ] pass linter and tests

--- a/.github/ISSUE_TEMPLATE/build-a-component.md
+++ b/.github/ISSUE_TEMPLATE/build-a-component.md
@@ -37,7 +37,7 @@ The component's guidance must include these sections:
 
 ### Content
 The component must:
-- [ ] include Nunjucks documentation
+- [ ] include Nunjucks documentation, which the technical writing community has 2i'd
 - [ ] have PR commits with [commit messages that are easy to understand](https://github.com/alphagov/design-system-team-docs/blob/main/development/commit-messages.md)
 
 ### Reviews

--- a/.github/ISSUE_TEMPLATE/build-a-component.md
+++ b/.github/ISSUE_TEMPLATE/build-a-component.md
@@ -20,7 +20,7 @@ assignees: ''
 <!-- Customise, and add component-specific checklist items to, this list of criteria all components need to meet -->
 ### Accessibility
 In general, the component must:
-- [ ] work with [assistive technologies listed in the service manual(https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices)
+- [ ] work with [assistive technologies listed in the service manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices)
 - [ ] pass tests on tools like axe and HTML validator
 - [ ] works when zoomed at high resolution
 - [ ] work in high contrast mode

--- a/.github/ISSUE_TEMPLATE/build-a-component.md
+++ b/.github/ISSUE_TEMPLATE/build-a-component.md
@@ -33,7 +33,6 @@ The component's guidance must include these sections:
 - [ ] have [Nunjucks options that are consistent with other Design System components](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/nunjucks-api.md)
 - [ ] have commonly available Nunjucks options
 - [ ] follow GOV.UK Frontend coding conventions
-- [ ] follow the code style guide
 
 ### Content
 The component must:
@@ -53,6 +52,7 @@ The component must:
 - [ ] work and look as expected at different breakpoints
 - [ ] have a macro the user can use to pass data into the component
 - [ ] have unit tests which each macro option passes
+- [ ] have JavaScript tests, if the component uses JavaScript
 - [ ] support the [browsers listed in the Service Manual](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices), and have semantic markup
 - [ ] work on devices listed in the Service Manual
 - [ ] pass linter and tests

--- a/.github/ISSUE_TEMPLATE/build-a-component.md
+++ b/.github/ISSUE_TEMPLATE/build-a-component.md
@@ -30,8 +30,8 @@ For more information on accessibility testing, [read our documentation on testin
 
 ### Coding standards
 The component's guidance must include these sections:
-- [ ] have Nunjucks options that are consistent with other Design System components
-- [ ] have commonly available Nunjuck options
+- [ ] have [Nunjucks options that are consistent with other Design System components](https://github.com/alphagov/govuk-frontend/blob/main/docs/contributing/coding-standards/nunjucks-api.md)
+- [ ] have commonly available Nunjucks options
 - [ ] follow GOV.UK Frontend coding conventions
 - [ ] follow the code style guide
 
@@ -49,6 +49,7 @@ The component must:
 The component must:
 - [ ] avoid a breaking change
 - [ ] work with Javascript disabled
+- [ ] work with CSS disabled
 - [ ] work and look as expected at different breakpoints
 - [ ] have a macro the user can use to pass data into the component
 - [ ] have unit tests which each macro option passes


### PR DESCRIPTION
Partly addresses [#2561](alphagov/design-system-team-internal#578).

Adds a new issue-template to the [existing templates in our frontend repo](https://github.com/alphagov/govuk-frontend/tree/main/.github/ISSUE_TEMPLATE).

Hopefully this will save us time in future when we need to create component issues.

This template is for building a component. We're also creating other templates for, respectively, [designing](https://github.com/alphagov/govuk-frontend/pull/2562) and [publishing](https://github.com/alphagov/govuk-frontend/pull/2576) a component.