### PR TITLE
Create publish-a-component.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/publish-a-component.md
+++ b/.github/ISSUE_TEMPLATE/publish-a-component.md
@@ -1,0 +1,25 @@
+---
+name: "Publish a component"
+about: Everything we need to do when we publish a component
+title: ''
+labels: "contribution or major iteration, epic"
+assignees: ''
+
+---
+
+## What
+<!-- Add name of component, plus any relevant links (for example, community backlog issues and comments, pull requests for the component and its guidance) -->
+
+## Why
+<!-- Add reason for publishing the component -->
+
+## Who needs to know about this
+<!-- Add team roles involved in publishing the component -->
+
+## Acceptance criteria
+<!-- Customise, and add component-specific checklist items to, this list of criteria all components need to meet -->
+We need to:
+- [ ] document any decisions we've made
+- [ ] actually publish the component
+- [ ] send out [user comms about the component](https://github.com/alphagov/design-system-team-internal/blob/master/.github/COMMS_ISSUE_TEMPLATE.md)
+- [ ] add the component to the Design System's search functionality


### PR DESCRIPTION
Partly addresses [#2561](alphagov/design-system-team-internal#578).

Adds a new issue-template to the [existing templates in our frontend repo](https://github.com/alphagov/govuk-frontend/tree/main/.github/ISSUE_TEMPLATE).

Hopefully this will save us time in future when we need to create component issues.

This template is for publishing a component. We're also creating other templates for, respectively, [designing](https://github.com/alphagov/govuk-frontend/pull/2562) and [building](https://github.com/alphagov/govuk-frontend/pull/2575) a component.