### PR TITLE
Refactor character count to inject new element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,29 @@
 
 ## Unreleased
 
+### Recommended changes
+
+We've recently made some non-breaking changes to GOV.UK Frontend. Implementing these changes will make your service work better. 
+
+#### Remove `aria-live` from the character count component
+
+If you're not using the Nunjucks macros, remove the `aria-live` attribute from the character count message element. This element's content no longer updates, as we've moved the live counter functionality to a new element injected by JavaScript. 
+
+This change was introduced in [pull request #2577: Refactor character count to inject new element](https://github.com/alphagov/govuk-frontend/pull/2577)
+
 ### Fixes
 
+We've made the following fixes in [pull request #2577: Refactor character count to inject new element](https://github.com/alphagov/govuk-frontend/pull/2577):
+
+- fix character count message being repeated twice by screen readers
+- fix character count hint text being announced as part of the count message
+- fix multiple outdated character count messages being announced at once
+- fix character count message being announced when input length is below a defined threshold
+
+We’ve also made fixes in the following pull requests:
+
 - [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
-- [#2573: Better handle cases where govuk-text-colour is set to a non-colour value](https://github.com/alphagov/govuk-frontend/pull/2573)
+- [#2573: Better handle cases where `$govuk-text-colour` is set to a non-colour value](https://github.com/alphagov/govuk-frontend/pull/2573)
 
 ## 4.0.1 (Fix release)
 

--- a/src/govuk/components/character-count/__snapshots__/template.test.js.snap
+++ b/src/govuk/components/character-count/__snapshots__/template.test.js.snap
@@ -8,7 +8,6 @@ exports[`Character count when it includes a hint renders with hint 1`] = `
 </div>
 <div id="with-hint-info"
      class="govuk-hint govuk-character-count__message"
-     aria-live="polite"
 >
   You can enter up to 10 characters
 </div>

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -6,7 +6,7 @@ function CharacterCount ($module) {
   this.$module = $module
   this.$textarea = $module.querySelector('.govuk-js-character-count')
   if (this.$textarea) {
-    this.$countMessage = document.getElementById(this.$textarea.id + '-info')
+    this.$fallbackLimitMessage = document.getElementById(this.$textarea.id + '-info')
   }
 }
 
@@ -20,15 +20,27 @@ CharacterCount.prototype.init = function () {
   // Check for module
   var $module = this.$module
   var $textarea = this.$textarea
-  var $countMessage = this.$countMessage
+  var $fallbackLimitMessage = this.$fallbackLimitMessage
 
-  if (!$textarea || !$countMessage) {
+  if (!$textarea) {
     return
   }
 
-  // We move count message right after the field
+  // We move fallback count message right after the field
   // Kept for backwards compatibility
-  $textarea.insertAdjacentElement('afterend', $countMessage)
+  $textarea.insertAdjacentElement('afterend', $fallbackLimitMessage)
+
+  // Create our live-updating counter element, copying the classes from the
+  // fallback element for backwards compatibility as these may have been configured
+  var $countMessage = document.createElement('div')
+  $countMessage.className = $fallbackLimitMessage.className
+  $countMessage.classList.add('govuk-character-count__status')
+  $countMessage.setAttribute('aria-live', 'polite')
+  this.$countMessage = $countMessage
+  $fallbackLimitMessage.insertAdjacentElement('afterend', $countMessage)
+
+  // Hide the fallback limit message
+  $fallbackLimitMessage.classList.add('govuk-visually-hidden')
 
   // Read options set using dataset ('data-' values)
   this.options = this.getDataset($module)

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -167,7 +167,7 @@ CharacterCount.prototype.updateVisibleCountMessage = function () {
   }
 
   // Update message
-  $visibleCountMessage.innerHTML = this.formatUpdateMessage()
+  $visibleCountMessage.innerHTML = this.formattedUpdateMessage()
 }
 
 // Update screen reader-specific counter
@@ -183,11 +183,11 @@ CharacterCount.prototype.updateScreenReaderCountMessage = function () {
   }
 
   // Update message
-  $screenReaderCountMessage.innerHTML = this.formatUpdateMessage()
+  $screenReaderCountMessage.innerHTML = this.formattedUpdateMessage()
 }
 
 // Format update message
-CharacterCount.prototype.formatUpdateMessage = function () {
+CharacterCount.prototype.formattedUpdateMessage = function () {
   var $textarea = this.$textarea
   var options = this.options
   var remainingNumber = this.maxLength - this.count($textarea.value)

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -5,9 +5,7 @@ import '../../vendor/polyfills/Element/prototype/classList'
 function CharacterCount ($module) {
   this.$module = $module
   this.$textarea = $module.querySelector('.govuk-js-character-count')
-  if (this.$textarea) {
-    this.$fallbackLimitMessage = document.getElementById(this.$textarea.id + '-info')
-  }
+  this.$countMessage = null
 }
 
 CharacterCount.prototype.defaults = {
@@ -20,7 +18,7 @@ CharacterCount.prototype.init = function () {
   // Check for module
   var $module = this.$module
   var $textarea = this.$textarea
-  var $fallbackLimitMessage = this.$fallbackLimitMessage
+  var $fallbackLimitMessage = document.getElementById(this.$textarea.id + '-info')
 
   if (!$textarea) {
     return

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -17,16 +17,17 @@ CharacterCount.prototype.defaults = {
 
 // Initialize component
 CharacterCount.prototype.init = function () {
-  // Check for module
-  var $module = this.$module
-  var $textarea = this.$textarea
-  var $fallbackLimitMessage = document.getElementById(this.$textarea.id + '-info')
-
-  if (!$textarea) {
+  // Check that required elements are present
+  if (!this.$textarea) {
     return
   }
 
-  // We move fallback count message right after the field
+  // Check for module
+  var $module = this.$module
+  var $textarea = this.$textarea
+  var $fallbackLimitMessage = document.getElementById($textarea.id + '-info')
+
+  // Move the fallback count message to be immediately after the textarea
   // Kept for backwards compatibility
   $textarea.insertAdjacentElement('afterend', $fallbackLimitMessage)
 

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -8,7 +8,6 @@ function CharacterCount ($module) {
   this.$visibleCountMessage = null
   this.$screenReaderCountMessage = null
   this.lastInputTimestamp = null
-  this.debouncedInputTimer = null
 }
 
 CharacterCount.prototype.defaults = {
@@ -224,18 +223,11 @@ CharacterCount.prototype.isOverThreshold = function () {
   return (thresholdValue <= currentLength)
 }
 
-// Handle the user typing.
-// Debounces updating the screen reader counter until after a user has stopped
-// typing for a short period of time. This helps prevent screen readers from
-// queuing up multiple text updates in rapid succession.
+// Update the visible character counter and keep track of when the last update
+// happened for each keypress
 CharacterCount.prototype.handleKeyUp = function () {
-  // Update the visible character counter and keep track of when the update happened
   this.updateVisibleCountMessage()
   this.lastInputTimestamp = Date.now()
-
-  // Clear the previous timeout, as an update has just taken place, and set a new one
-  clearTimeout(this.debouncedInputTimer)
-  this.debouncedInputTimer = setTimeout(this.updateScreenReaderCountMessage.bind(this), 500)
 }
 
 CharacterCount.prototype.handleFocus = function () {
@@ -244,7 +236,7 @@ CharacterCount.prototype.handleFocus = function () {
   // This is so that the update triggered by the manual comparison doesn't
   // conflict with debounced KeyboardEvent updates.
   this.valueChecker = setInterval(function () {
-    if (!this.lastInputTimestamp || (Date.now() - 1000) >= this.lastInputTimestamp) {
+    if (!this.lastInputTimestamp || (Date.now() - 500) >= this.lastInputTimestamp) {
       this.checkIfValueChanged()
     }
   }.bind(this), 1000)

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -231,6 +231,7 @@ CharacterCount.prototype.isOverThreshold = function () {
 CharacterCount.prototype.handleKeyUp = function () {
   // Update the visible character counter and keep track of when the update happened
   this.updateVisibleCountMessage()
+  this.lastInputTimestamp = Date.now()
 
   // Clear the previous timeout, as an update has just taken place, and set a new one
   clearTimeout(this.debouncedInputTimer)
@@ -244,7 +245,7 @@ CharacterCount.prototype.handleFocus = function () {
   // conflict with debounced KeyboardEvent updates.
   this.valueChecker = setInterval(function () {
     if (!this.lastInputTimestamp || (Date.now() - 1000) >= this.lastInputTimestamp) {
-      this.checkIfValueChanged.bind(this)
+      this.checkIfValueChanged()
     }
   }.bind(this), 1000)
 }

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -143,54 +143,54 @@ CharacterCount.prototype.updateCountMessage = function () {
 
 // Update visible counter
 CharacterCount.prototype.updateVisibleCountMessage = function () {
-  var countElement = this.$textarea
-  var countMessage = this.$visibleCountMessage
-  var remainingNumber = this.maxLength - this.count(countElement.value)
+  var $textarea = this.$textarea
+  var $visibleCountMessage = this.$visibleCountMessage
+  var remainingNumber = this.maxLength - this.count($textarea.value)
 
   // If input is over the threshold, remove the disabled class which renders the
   // counter invisible.
   if (this.isOverThreshold()) {
-    countMessage.classList.remove('govuk-character-count__message--disabled')
+    $visibleCountMessage.classList.remove('govuk-character-count__message--disabled')
   } else {
-    countMessage.classList.add('govuk-character-count__message--disabled')
+    $visibleCountMessage.classList.add('govuk-character-count__message--disabled')
   }
 
   // Update styles
   if (remainingNumber < 0) {
-    countElement.classList.add('govuk-textarea--error')
-    countMessage.classList.remove('govuk-hint')
-    countMessage.classList.add('govuk-error-message')
+    $textarea.classList.add('govuk-textarea--error')
+    $visibleCountMessage.classList.remove('govuk-hint')
+    $visibleCountMessage.classList.add('govuk-error-message')
   } else {
-    countElement.classList.remove('govuk-textarea--error')
-    countMessage.classList.remove('govuk-error-message')
-    countMessage.classList.add('govuk-hint')
+    $textarea.classList.remove('govuk-textarea--error')
+    $visibleCountMessage.classList.remove('govuk-error-message')
+    $visibleCountMessage.classList.add('govuk-hint')
   }
 
   // Update message
-  countMessage.innerHTML = this.formatUpdateMessage()
+  $visibleCountMessage.innerHTML = this.formatUpdateMessage()
 }
 
 // Update screen reader-specific counter
 CharacterCount.prototype.updateScreenReaderCountMessage = function () {
-  var countMessage = this.$screenReaderCountMessage
+  var $screenReaderCountMessage = this.$screenReaderCountMessage
 
-  // If other the threshold, remove the aria-hidden attribute, allowing screen
+  // If over the threshold, remove the aria-hidden attribute, allowing screen
   // readers to announce the content of the element.
   if (this.isOverThreshold()) {
-    countMessage.removeAttribute('aria-hidden')
+    $screenReaderCountMessage.removeAttribute('aria-hidden')
   } else {
-    countMessage.setAttribute('aria-hidden', true)
+    $screenReaderCountMessage.setAttribute('aria-hidden', true)
   }
 
   // Update message
-  countMessage.innerHTML = this.formatUpdateMessage()
+  $screenReaderCountMessage.innerHTML = this.formatUpdateMessage()
 }
 
 // Format update message
 CharacterCount.prototype.formatUpdateMessage = function () {
-  var countElement = this.$textarea
+  var $textarea = this.$textarea
   var options = this.options
-  var remainingNumber = this.maxLength - this.count(countElement.value)
+  var remainingNumber = this.maxLength - this.count($textarea.value)
 
   var charVerb = 'remaining'
   var charNoun = 'character'
@@ -210,11 +210,11 @@ CharacterCount.prototype.formatUpdateMessage = function () {
 // If there is no configured threshold, it is set to 0 and this function will
 // always return true.
 CharacterCount.prototype.isOverThreshold = function () {
-  var countElement = this.$textarea
+  var $textarea = this.$textarea
   var options = this.options
 
   // Determine the remaining number of characters/words
-  var currentLength = this.count(countElement.value)
+  var currentLength = this.count($textarea.value)
   var maxLength = this.maxLength
 
   // Set threshold if presented in options

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -31,21 +31,46 @@ describe('Character count', () => {
   })
 
   describe('when JavaScript is available', () => {
+    describe('on page load', () => {
+      beforeAll(async () => {
+        await goToExample()
+      })
+
+      it('injects the visual counter', async () => {
+        const message = await page.$('.govuk-character-count__status') !== null
+        expect(message).toBeTruthy()
+      })
+
+      it('injects the screen reader counter', async () => {
+        const srMessage = await page.$('.govuk-character-count__sr-status') !== null
+        expect(srMessage).toBeTruthy()
+      })
+
+      it('hides the fallback hint', async () => {
+        const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+        expect(messageClasses).toContain('govuk-visually-hidden')
+      })
+    })
+
     describe('when counting characters', () => {
       it('shows the dynamic message', async () => {
         await goToExample()
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 10 characters remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 10 characters remaining')
       })
 
       it('shows the characters remaining if the field is pre-filled', async () => {
         await goToExample('with-default-value')
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 67 characters remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 67 characters remaining')
       })
 
       it('counts down to the character limit', async () => {
@@ -53,8 +78,13 @@ describe('Character count', () => {
         await page.type('.govuk-js-character-count', 'A')
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 9 characters remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 1100))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 9 characters remaining')
       })
 
       it('uses the singular when there is only one character remaining', async () => {
@@ -62,8 +92,13 @@ describe('Character count', () => {
         await page.type('.govuk-js-character-count', 'A'.repeat(9))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 1 character remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 1100))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 1 character remaining')
       })
 
       describe('when the character limit is exceeded', () => {
@@ -75,6 +110,12 @@ describe('Character count', () => {
         it('shows the number of characters over the limit', async () => {
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 1 character too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 1 character too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
@@ -82,6 +123,12 @@ describe('Character count', () => {
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 characters too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 2 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
@@ -103,6 +150,9 @@ describe('Character count', () => {
         it('shows the number of characters over the limit', async () => {
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 23 characters too many')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 23 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
@@ -154,8 +204,10 @@ describe('Character count', () => {
           await goToExample('with-id-starting-with-number')
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
           expect(message).toEqual('You have 10 characters remaining')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 10 characters remaining')
         })
       })
 
@@ -164,8 +216,10 @@ describe('Character count', () => {
           await goToExample('with-id-with-special-characters')
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
           expect(message).toEqual('You have 10 characters remaining')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 10 characters remaining')
         })
       })
     })
@@ -175,8 +229,10 @@ describe('Character count', () => {
         await goToExample('with-word-count')
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 10 words remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 10 words remaining')
       })
 
       it('counts down to the word limit', async () => {
@@ -184,8 +240,13 @@ describe('Character count', () => {
         await page.type('.govuk-js-character-count', 'Hello world')
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 8 words remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 1100))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 8 words remaining')
       })
 
       it('uses the singular when there is only one word remaining', async () => {
@@ -193,8 +254,13 @@ describe('Character count', () => {
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-
         expect(message).toEqual('You have 1 word remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 1100))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 1 word remaining')
       })
 
       describe('when the word limit is exceeded', () => {
@@ -206,6 +272,12 @@ describe('Character count', () => {
         it('shows the number of words over the limit', async () => {
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 1 word too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 1 word too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
@@ -213,6 +285,12 @@ describe('Character count', () => {
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 words too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 2 words too many')
         })
 
         it('adds error styles to the textarea', async () => {

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -52,9 +52,6 @@ describe('Character count', () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A')
 
-        // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 300))
-
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 9 characters remaining')
@@ -63,9 +60,6 @@ describe('Character count', () => {
       it('uses the singular when there is only one character remaining', async () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A'.repeat(9))
-
-        // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 300))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
@@ -76,9 +70,6 @@ describe('Character count', () => {
         beforeAll(async () => {
           await goToExample()
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
-
-          // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 300))
         })
 
         it('shows the number of characters over the limit', async () => {
@@ -88,9 +79,6 @@ describe('Character count', () => {
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'A')
-
-          // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 300))
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 characters too many')
@@ -137,22 +125,25 @@ describe('Character count', () => {
           const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('hidden')
 
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
           // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__status', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
           expect(ariaHidden).toEqual('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
-          // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 300))
-
           const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
 
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 1100))
+
           // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__status', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
           expect(ariaHidden).toBeFalsy()
         })
       })
@@ -192,9 +183,6 @@ describe('Character count', () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello world')
 
-        // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 300))
-
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 8 words remaining')
@@ -203,9 +191,6 @@ describe('Character count', () => {
       it('uses the singular when there is only one word remaining', async () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
-
-        // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 300))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
@@ -216,9 +201,6 @@ describe('Character count', () => {
         beforeAll(async () => {
           await goToExample('with-word-count')
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
-
-          // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 300))
         })
 
         it('shows the number of words over the limit', async () => {
@@ -228,9 +210,6 @@ describe('Character count', () => {
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'World')
-
-          // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 300))
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 words too many')

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -4,6 +4,10 @@ const configPaths = require('../../../../config/paths.json')
 const PORT = configPaths.ports.test
 const baseUrl = `http://localhost:${PORT}`
 
+// The longest possible time from a keyboard user ending input and the screen
+// reader counter being updated: handleFocus interval time + last input wait time
+const debouncedWaitTime = 1500
+
 const goToExample = (exampleName = false) => {
   const url = exampleName
     ? `${baseUrl}/components/character-count/${exampleName}/preview`
@@ -81,7 +85,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 9 characters remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 1100))
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
         const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
         expect(srMessage).toEqual('You have 9 characters remaining')
@@ -95,7 +99,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 1 character remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 1100))
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
         const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
         expect(srMessage).toEqual('You have 1 character remaining')
@@ -112,7 +116,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 character too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
           expect(srMessage).toEqual('You have 1 character too many')
@@ -125,7 +129,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 2 characters too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
           expect(srMessage).toEqual('You have 2 characters too many')
@@ -176,7 +180,7 @@ describe('Character count', () => {
           expect(visibility).toEqual('hidden')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           // Ensure threshold is hidden for users of assistive technologies
           const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
@@ -190,7 +194,7 @@ describe('Character count', () => {
           expect(visibility).toEqual('visible')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           // Ensure threshold is visible for users of assistive technologies
           const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
@@ -243,7 +247,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 8 words remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 1100))
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
         const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
         expect(srMessage).toEqual('You have 8 words remaining')
@@ -257,7 +261,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 1 word remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, 1100))
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
         const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
         expect(srMessage).toEqual('You have 1 word remaining')
@@ -274,7 +278,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 word too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
           expect(srMessage).toEqual('You have 1 word too many')
@@ -287,7 +291,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 2 words too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, 1100))
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
           expect(srMessage).toEqual('You have 2 words too many')

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -35,7 +35,7 @@ describe('Character count', () => {
       it('shows the dynamic message', async () => {
         await goToExample()
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 10 characters remaining')
       })
@@ -43,7 +43,7 @@ describe('Character count', () => {
       it('shows the characters remaining if the field is pre-filled', async () => {
         await goToExample('with-default-value')
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 67 characters remaining')
       })
@@ -52,7 +52,7 @@ describe('Character count', () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A')
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 9 characters remaining')
       })
@@ -61,7 +61,7 @@ describe('Character count', () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A'.repeat(9))
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 1 character remaining')
       })
@@ -73,14 +73,14 @@ describe('Character count', () => {
         })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 1 character too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'A')
 
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 characters too many')
         })
 
@@ -90,7 +90,7 @@ describe('Character count', () => {
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
@@ -101,7 +101,7 @@ describe('Character count', () => {
         })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 23 characters too many')
         })
 
@@ -111,7 +111,7 @@ describe('Character count', () => {
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
@@ -122,22 +122,22 @@ describe('Character count', () => {
         })
 
         it('does not show the limit until the threshold is reached', async () => {
-          const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('hidden')
 
           // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval('.govuk-character-count__status', el => el.getAttribute('aria-hidden'))
           expect(ariaHidden).toEqual('true')
         })
 
         it('becomes visible once the threshold is reached', async () => {
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
-          const visibility = await page.$eval('.govuk-character-count__message', el => window.getComputedStyle(el).visibility)
+          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
 
           // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__message', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval('.govuk-character-count__status', el => el.getAttribute('aria-hidden'))
           expect(ariaHidden).toBeFalsy()
         })
       })
@@ -147,7 +147,7 @@ describe('Character count', () => {
         it('still works correctly', async () => {
           await goToExample('with-id-starting-with-number')
 
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
           expect(message).toEqual('You have 10 characters remaining')
         })
@@ -157,7 +157,7 @@ describe('Character count', () => {
         it('still works correctly', async () => {
           await goToExample('with-id-with-special-characters')
 
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
           expect(message).toEqual('You have 10 characters remaining')
         })
@@ -168,7 +168,7 @@ describe('Character count', () => {
       it('shows the dynamic message', async () => {
         await goToExample('with-word-count')
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 10 words remaining')
       })
@@ -177,7 +177,7 @@ describe('Character count', () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello world')
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 8 words remaining')
       })
@@ -186,7 +186,7 @@ describe('Character count', () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
 
-        const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 1 word remaining')
       })
@@ -198,14 +198,14 @@ describe('Character count', () => {
         })
 
         it('shows the number of words over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 1 word too many')
         })
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'World')
 
-          const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 words too many')
         })
 
@@ -215,7 +215,7 @@ describe('Character count', () => {
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
           expect(messageClasses).toContain('govuk-error-message')
         })
       })

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -52,6 +52,9 @@ describe('Character count', () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A')
 
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 9 characters remaining')
@@ -60,6 +63,9 @@ describe('Character count', () => {
       it('uses the singular when there is only one character remaining', async () => {
         await goToExample()
         await page.type('.govuk-js-character-count', 'A'.repeat(9))
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 300))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
@@ -70,6 +76,9 @@ describe('Character count', () => {
         beforeAll(async () => {
           await goToExample()
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 300))
         })
 
         it('shows the number of characters over the limit', async () => {
@@ -79,6 +88,9 @@ describe('Character count', () => {
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'A')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 300))
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 characters too many')
@@ -133,6 +145,9 @@ describe('Character count', () => {
         it('becomes visible once the threshold is reached', async () => {
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 300))
+
           const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
 
@@ -177,6 +192,9 @@ describe('Character count', () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello world')
 
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 300))
+
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
         expect(message).toEqual('You have 8 words remaining')
@@ -185,6 +203,9 @@ describe('Character count', () => {
       it('uses the singular when there is only one word remaining', async () => {
         await goToExample('with-word-count')
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, 300))
 
         const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
 
@@ -195,6 +216,9 @@ describe('Character count', () => {
         beforeAll(async () => {
           await goToExample('with-word-count')
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 300))
         })
 
         it('shows the number of words over the limit', async () => {
@@ -204,6 +228,9 @@ describe('Character count', () => {
 
         it('uses the plural when the limit is exceeded by 2 or more', async () => {
           await page.type('.govuk-js-character-count', 'World')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, 300))
 
           const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
           expect(message).toEqual('You have 2 words too many')

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -29,9 +29,6 @@
   {{ govukHint({
     text: 'You can enter up to ' + (params.maxlength or params.maxwords) + (' words' if params.maxwords else ' characters'),
     id: params.id + '-info',
-    classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes),
-    attributes: {
-      'aria-live': 'polite'
-    }
+    classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}
 </div>

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -114,13 +114,6 @@ describe('Character count', () => {
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.hasClass('app-custom-count-message')).toBeTruthy()
     })
-
-    it('renders with aria live set to polite', () => {
-      const $ = render('character-count', examples.default)
-
-      const $countMessage = $('.govuk-character-count__message')
-      expect($countMessage.attr('aria-live')).toEqual('polite')
-    })
   })
 
   describe('when it has the spellcheck attribute', () => {


### PR DESCRIPTION
Modifies the character count JavaScript to compose and inject new elements that are live-updated, instead of overwriting the content of the initial HTML hint.

There are now three elements responsible for character count announcements:

- A static element that describes the character limit (e.g. "You can use up to 200 characters"). 
  - This is present in HTML, and serves as the fallback if JavaScript is unavailable. 
  - It is visible if JavaScript is unavailable, and visually hidden if it is.
  - It is announced by screen readers when the user first focuses on the textarea, before they type. 
  - Screen readers will always read this out, even if a counter utilises a threshold.
- An injected, live-updating element showing the characters remaining (e.g. "You have 200 characters remaining"). 
  - This is visible, updates immediately in response to user input, and uses `aria-hidden` to hide itself from screen readers.
  - If the counter has a threshold, this is invisible until after the user has passed the threshold. 
- An injected, debounced element showing the characters remaining (e.g. "You have 200 characters remaining"). 
  - This is invisible, only updates after one second of inactivity, and is announced by screen readers following input using `aria-live="polite"`.
  - If the counter has a threshold, this is only announced once the user has passed the threshold. 

Only the first element must be present in the initial HTML. The other two are injected when JavaScript runs. 

## Upgrading

Users of the govuk-frontend Nunjucks macros do not have to make any changes. 

Users of static HTML can remove the hardcoded `aria-live="polite"` attribute from `.govuk-character-count__message`. We haven't found any negative repercussions to it still being present, but it is not needed as this element's content no longer updates. 

For backwards compatibility, custom classes that have been added to the HTML count element are copied onto the visible, injected counter. If you previously used a custom class to change the visibility of the counter outside of the existing threshold functionality, this may no longer work as expected. The screen reader only counter does not inherit any classes. 

## Why these changes have been made

These changes are intended to resolve a number of issues that came up in a recent investigation into how the character count interacted with more recent versions of screen readers: #2539 

Should resolve:
- #2485
- #2486
- #2488 
- #2487 

## Current known issues

- JAWS 2021.2103.174 / IE 11 will always read the character count, even if the input length is below a set threshold. 
- JAWS 2021.2103.174 / Chrome 99 will refuse to announce input hints if the input has a prefilled value. This is not an issue introduced by this PR, but was found during testing for it. Raised as a new issue: #2585. 