### PR TITLE
Maxlength attribute should not be present on textarea after character-count JavaScript has kicked in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We’ve also made fixes in the following pull requests:
 
 - [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
 - [#2573: Better handle cases where `$govuk-text-colour` is set to a non-colour value](https://github.com/alphagov/govuk-frontend/pull/2573)
+- [#2590: Maxlength attribute should not be present on textarea after character-count JavaScript has kicked in](https://github.com/alphagov/govuk-frontend/pull/2590)
 
 ## 4.0.1 (Fix release)
 

--- a/src/govuk/components/character-count/character-count.js
+++ b/src/govuk/components/character-count/character-count.js
@@ -69,7 +69,7 @@ CharacterCount.prototype.init = function () {
   }
 
   // Remove hard limit if set
-  $module.removeAttribute('maxlength')
+  $textarea.removeAttribute('maxlength')
 
   this.bindChangeEvents()
 

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -226,6 +226,17 @@ describe('Character count', () => {
           expect(srMessage).toEqual('You have 10 characters remaining')
         })
       })
+
+      describe('when a maxlength attribute is specified on the textarea', () => {
+        beforeAll(async () => {
+          await goToExample('with-textarea-maxlength-attribute')
+        })
+
+        it('should not have a maxlength attribute once the JS has run', async () => {
+          const textareaMaxLength = await page.$eval('.govuk-textarea', el => el.getAttribute('maxlength'))
+          expect(textareaMaxLength).toBeNull()
+        })
+      })
     })
 
     describe('when counting words', () => {

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -239,6 +239,7 @@ examples:
       label:
         text: Full address
   - name: with textarea maxlength attribute
+    hidden: true
     data:
       id: maxlength-should-be-removed
       name: address

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -238,3 +238,12 @@ examples:
       maxlength: 10
       label:
         text: Full address
+  - name: with textarea maxlength attribute
+    data:
+      id: maxlength-should-be-removed
+      name: address
+      maxlength: 10
+      attributes:
+        maxlength: 10
+      label:
+        text: Full address


### PR DESCRIPTION
If a `maxlength` attribute is specified on the `textarea`, this should be removed after the character-count JS has kicked in. At the moment however, the JS is trying to remove the attribute from the wrapping `div` which does not do anything.