### PR TITLE
Update publishing doc card examples

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -18,7 +18,7 @@
   - create a card for the new release of GOV.UK Prototype Kit (example card: [#917](https://github.com/alphagov/govuk-prototype-kit/issues/917))
   - update the GOV.UK Prototype Kit to use the new release (example card: [#923](https://github.com/alphagov/govuk-prototype-kit/issues/923))
 
-3. Person leading the release to add the issues to the [Design System sprint board](https://github.com/orgs/alphagov/projects/4).
+3. Person leading the release to add the issues to the [Design System kanban board](https://github.com/orgs/alphagov/projects/4).
 
 4. Content designer to:
   - write announcements to post on Slack after we release:

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -3,20 +3,20 @@
 1. At stand up, person leading the release to tell the GOV.UK Design System team we are close to releasing so we can coordinate the final cutoff date. Once the cutoff date passes, do not add any further major changes to the release. We can still add small fixes before step 7 as long as we notify the content designer and technical writer. However, we should try to avoid adding too many fixes in this way, as it requires us to repeat some of steps 4-6.
 
 2. Developers to raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs), [govuk-prototype-kit](https://github.com/alphagov/govuk-prototype-kit)) to:
-  - draft comms for the new release (example card: [#2507](https://github.com/alphagov/govuk-frontend/issues/2507))
-  - create release notes for the new release (example card: [#2508](https://github.com/alphagov/govuk-frontend/issues/2508))
-  - release the new version of GOV.UK Frontend to NPM (example card: [#2509](https://github.com/alphagov/govuk-frontend/issues/2509))
-  - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example card: [#2024](https://github.com/alphagov/govuk-design-system/issues/2024))
-  - update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example card: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184))
-  - post the comms and do tidy-up tasks (example card: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
+  - draft comms for the new release (example issue: [#2507](https://github.com/alphagov/govuk-frontend/issues/2507))
+  - create release notes for the new release (example issue: [#2508](https://github.com/alphagov/govuk-frontend/issues/2508))
+  - release the new version of GOV.UK Frontend to NPM (example issue: [#2509](https://github.com/alphagov/govuk-frontend/issues/2509))
+  - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example issue: [#2024](https://github.com/alphagov/govuk-design-system/issues/2024))
+  - update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example issue: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184))
+  - post the comms and do tidy-up tasks (example issue: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
 
-  Once the developers have created these cards, the person leading the release should add them to an epic (example card: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)).
+  Once the developers have created these issues, the person leading the release should add them to an epic (example issue: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)).
 
   You should also check with the GOV.UK Prototype Kit team to see if they'll be doing a corresponding release. If they will, then the people responsible for the Kit release will need to:
 
-  - create release notes for the new release of GOV.UK Prototype Kit (example card: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
-  - create a card for the new release of GOV.UK Prototype Kit (example card: [#917](https://github.com/alphagov/govuk-prototype-kit/issues/917))
-  - update the GOV.UK Prototype Kit to use the new release (example card: [#923](https://github.com/alphagov/govuk-prototype-kit/issues/923))
+  - create release notes for the new release of GOV.UK Prototype Kit (example issue: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
+  - create an issue for the new release of GOV.UK Prototype Kit (example issue: [#917](https://github.com/alphagov/govuk-prototype-kit/issues/917))
+  - update the GOV.UK Prototype Kit to use the new release (example issue: [#923](https://github.com/alphagov/govuk-prototype-kit/issues/923))
 
 3. Person leading the release to add the issues to the [Design System kanban board](https://github.com/orgs/alphagov/projects/4).
 
@@ -102,6 +102,6 @@ Developers should pair on releases. When remote working, it can be useful to be 
   - let the team know they can post social comms
   - let stakeholders know the release is live
 
-3. Move cards on the [Design System Kanban board](https://github.com/orgs/alphagov/projects/4) from the **Ready to Release** column to **Done**.
+3. Move issues on the [Design System Kanban board](https://github.com/orgs/alphagov/projects/4) from the **Ready to Release** column to **Done**.
 
 4. Close any associated milestones.

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -10,6 +10,8 @@
   - update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example card: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184))
   - post the comms and do tidy-up tasks (example card: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
 
+  Once the developers have created these cards, the person leading the release should add them to an epic (example card: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)).
+
   - create release notes for the new release of GOV.UK Prototype Kit (example card: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
   - create a card for the new release of GOV.UK Frontend (example card: [#1987](https://github.com/alphagov/govuk-frontend/issues/1987))
   - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example card: [#1347](https://github.com/alphagov/govuk-design-system/issues/1347))

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -3,8 +3,13 @@
 1. At stand up, person leading the release to tell the GOV.UK Design System team we are close to releasing so we can coordinate the final cutoff date. Once the cutoff date passes, do not add any further major changes to the release. We can still add small fixes before step 7 as long as we notify the content designer and technical writer. However, we should try to avoid adding too many fixes in this way, as it requires us to repeat some of steps 4-6.
 
 2. Developers to raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs), [govuk-prototype-kit](https://github.com/alphagov/govuk-prototype-kit)) to:
-  - create announcement draft for the new release (example card: [#2108](https://github.com/alphagov/govuk-frontend/issues/2108))
-  - create release notes for the new release (example card: [#1986](https://github.com/alphagov/govuk-frontend/issues/1986))
+  - draft comms for the new release (example card: [#2507](https://github.com/alphagov/govuk-frontend/issues/2507))
+  - create release notes for the new release (example card: [#2508](https://github.com/alphagov/govuk-frontend/issues/2508))
+  - release the new version of GOV.UK Frontend to NPM (example card: [#2509](https://github.com/alphagov/govuk-frontend/issues/2509))
+  - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example card: [#2024](https://github.com/alphagov/govuk-design-system/issues/2024))
+  - update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example card: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184))
+  - post the comms and do tidy-up tasks (example card: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
+
   - create release notes for the new release of GOV.UK Prototype Kit (example card: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
   - create a card for the new release of GOV.UK Frontend (example card: [#1987](https://github.com/alphagov/govuk-frontend/issues/1987))
   - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example card: [#1347](https://github.com/alphagov/govuk-design-system/issues/1347))

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -12,9 +12,9 @@
 
   Once the developers have created these cards, the person leading the release should add them to an epic (example card: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)).
 
+  You should also check with the GOV.UK Prototype Kit team to see if they'll be doing a corresponding release. If they will, then the people responsible for the Kit release will need to:
+
   - create release notes for the new release of GOV.UK Prototype Kit (example card: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
-  - create a card for the new release of GOV.UK Frontend (example card: [#1987](https://github.com/alphagov/govuk-frontend/issues/1987))
-  - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example card: [#1347](https://github.com/alphagov/govuk-design-system/issues/1347))
   - create a card for the new release of GOV.UK Prototype Kit (example card: [#917](https://github.com/alphagov/govuk-prototype-kit/issues/917))
   - update the GOV.UK Prototype Kit to use the new release (example card: [#923](https://github.com/alphagov/govuk-prototype-kit/issues/923))
 


### PR DESCRIPTION
Update the publishing docs to point to newer examples of our release cards. I noticed when drafting the cards for the v4.1.0 release that some of these were outdated and didn't follow our latest way of doing things, e.g:

- splitting out comms into separate cards for drafting and posting
- having one overarching epic card for the release, which all release cards are linked to
- mention of working with the new separate GOV.UK Prototype team