### PR TITLE
Test Sass compiles using the latest compilers

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -27,7 +27,13 @@ jobs:
       - run: |
           npm install -g sass@v1
           sass --version
-      - run: time sass src/govuk/all.scss > /dev/null
+      # Treat GOV.UK Frontend as a dependency by importing it via load paths,
+      # allowing us to mimic the way we recommend our users silence deprecation
+      # warnings using the `quiet-deps` flag.
+      #
+      # Run the command through a shell to ensure `time` measures the time
+      # taken by the entire pipeline, as we are now piping input into `sass`.
+      - run: time sh -c 'echo "@import "\""govuk/all"\"";" | sass --stdin --quiet-deps --load-path=src > /dev/null'
 
 
   # Node Sass v3.4.0 = LibSass v3.3.0

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -16,6 +16,21 @@ jobs:
           sass --version
       - run: time sass src/govuk/all.scss > /dev/null
 
+  dart-sass-latest:
+    name: Dart Sass v1 (latest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: |
+          npm install -g sass@v1
+          sass --version
+      - run: time sass src/govuk/all.scss > /dev/null
+
+
+  # Node Sass v3.4.0 = LibSass v3.3.0
   lib-sass:
     name: LibSass v3.3.0 (deprecated)
     runs-on: ubuntu-latest
@@ -29,6 +44,20 @@ jobs:
           node-sass --version
       - run: time node-sass src/govuk/all.scss > /dev/null
 
+  # Node Sass v7.x = LibSass v3 latest
+  lib-sass-latest:
+    name: LibSass v3 (latest, deprecated)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: |
+          npm install -g node-sass@v7
+          node-sass --version
+      - run: time node-sass src/govuk/all.scss > /dev/null
+
   ruby-sass:
     name: Ruby Sass v3.4.0 (deprecated)
     runs-on: ubuntu-latest
@@ -39,5 +68,19 @@ jobs:
           ruby-version: 2.1.9 # Oldest version available on ruby/setup-ruby
       - run: |
           gem install sass -v 3.4.0
+          sass --version
+      - run: time sass src/govuk/all.scss > /dev/null
+
+  # Ruby Sass is EOL so we can pin to the last release
+  ruby-sass-latest:
+    name: Ruby Sass v3.7.4 (latest, deprecated)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6 # Latest Ruby when Ruby Sass was EOL'ed (April 2019)
+      - run: |
+          gem install sass -v 3.7.4
           sass --version
       - run: time sass src/govuk/all.scss > /dev/null

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -77,9 +77,8 @@ jobs:
           sass --version
       - run: time sass src/govuk/all.scss > /dev/null
 
-  # Ruby Sass is EOL so we can pin to the last release
   ruby-sass-latest:
-    name: Ruby Sass v3.7.4 (latest, deprecated)
+    name: Ruby Sass v3 (latest, deprecated)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -87,6 +86,6 @@ jobs:
         with:
           ruby-version: 2.6 # Latest Ruby when Ruby Sass was EOL'ed (April 2019)
       - run: |
-          gem install sass -v 3.7.4
+          gem install sass -v '~> 3.0'
           sass --version
       - run: time sass src/govuk/all.scss > /dev/null


### PR DESCRIPTION
We have existing checks to ensure that GOV.UK Frontend compiles successfully when using the oldest versions of the Sass compilers we support.

We want to ensure that we maintain compatibility with the latest versions of the Sass compilers as well. As the compilers should be following semantic versioning we don't anticipate this to be a problem, but this will give us confidence and flag any issues that may come up in new versions (of Dart Sass, in particular).

Add additional jobs to the GitHub Actions workflow to ensure GOV.UK Frontend also compiles with the latest compatible versions of:

- Dart Sass (v1)
- LibSass (v3)
- Ruby Sass (v3)

Because these jobs are able to run in parallel, this thankfully doesn't have much impact on the overall time it takes for the action to run. The action has run a few times whilst putting this PR together, and tends to complete in 36-38s. For comparison, the most recent runs on the main branch look to have taken between 30-33s (very unscientifically based on glancing at the first page of runs on that branch).

Closes #2589 