### PR TITLE
Fix hints for disabled checkboxes/radios appearing darker than the associated labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ We’ve also made fixes in the following pull requests:
 - [#2549: Fix header with product name focus and hover state length](https://github.com/alphagov/govuk-frontend/pull/2549)
 - [#2573: Better handle cases where `$govuk-text-colour` is set to a non-colour value](https://github.com/alphagov/govuk-frontend/pull/2573)
 - [#2590: Remove `maxlength` attribute from `textarea` after character count JavaScript has been initialised](https://github.com/alphagov/govuk-frontend/pull/2590)
+- [#2615: Fix hints for disabled checkboxes/radios appearing darker than the associated labels](https://github.com/alphagov/govuk-frontend/pull/2615)
 
 ## 4.0.1 (Fix release)
 

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -150,7 +150,8 @@
     cursor: default;
   }
 
-  .govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
+  .govuk-checkboxes__input:disabled + .govuk-checkboxes__label,
+  .govuk-checkboxes__input:disabled ~ .govuk-hint {
     opacity: .5;
   }
 

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -219,14 +219,24 @@ examples:
 
 - name: with disabled item
   data:
-    name: colours
+    name: sign-in
+    fieldset:
+      legend:
+        text: How do you want to sign in?
+        isPageHeading: true
     items:
-      - value: red
-        text: Red
-      - value: green
-        text: Green
-      - value: blue
-        text: Blue
+      - name: gateway
+        id: government-gateway
+        value: gov-gateway
+        text: Sign in with Government Gateway
+        hint:
+          text: You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.
+      - name: verify
+        id: govuk-verify
+        value: gov-verify
+        text: Sign in with GOV.UK Verify
+        hint:
+          text: You'll have an account if you've already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
         disabled: true
 
 - name: with legend as a page heading

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -148,7 +148,8 @@
     cursor: default;
   }
 
-  .govuk-radios__input:disabled + .govuk-radios__label {
+  .govuk-radios__input:disabled + .govuk-radios__label,
+  .govuk-radios__input:disabled ~ .govuk-hint {
     opacity: .5;
   }
 

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -137,19 +137,23 @@ examples:
 
 - name: with disabled
   data:
-    idPrefix: example-disabled
-    name: example-disabled
+    idPrefix: gov
+    name: gov
     fieldset:
       legend:
-        text: Have you changed your name?
-    hint:
-      text: This includes changing your last name or spelling your name differently.
+        text: How do you want to sign in?
+        isPageHeading: true
     items:
-      - value: yes
-        text: Yes
-        disabled: true
-      - value: no
-        text: No
+      - value: gateway
+        text: Sign in with Government Gateway
+        id: gateway
+        hint:
+          text: You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.
+      - value: verify
+        text: Sign in with GOV.UK Verify
+        id: verify
+        hint:
+          text: You’ll have an account if you’ve already proved your identity with either Barclays, CitizenSafe, Digidentity, Experian, Post Office, Royal Mail or SecureIdentity.
         disabled: true
 
 - name: with legend as page heading

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -117,10 +117,7 @@ describe('Radios', () => {
 
       const $component = $('.govuk-radios')
 
-      const $firstInput = $component.find('.govuk-radios__item:first-child input')
-      expect($firstInput.attr('disabled')).toEqual('disabled')
-
-      const $lastInput = $component.find('.govuk-radios__item:last-child input')
+      const $lastInput = $component.find('input[value="verify"]')
       expect($lastInput.attr('disabled')).toEqual('disabled')
     })
 


### PR DESCRIPTION
When checkboxes or radios with hints are disabled, the hint text ends up being darker than the label because the opacity of the label is reduced to 50%, but the opacity of the hint is not changed and so remains a darker grey.

Reduce the opacity of the hints associated with disabled radios and checkboxes so that it is also ‘greyed out’ proportional to the label.

Update the examples for disabled radios and checkboxes to include hints so that we have a visual example of this in the review app.

## Before

<img width="957" alt="Screenshot 2022-05-12 at 17 11 55" src="https://user-images.githubusercontent.com/121939/168120983-1c83829d-7d98-4ece-b28d-7fdf6754ba41.png">

<img width="957" alt="Screenshot 2022-05-12 at 17 11 49" src="https://user-images.githubusercontent.com/121939/168120987-277a9b7e-aa76-4bd2-9e5e-0b3e28fe49ec.png">

## After

<img width="957" alt="Screenshot 2022-05-12 at 17 12 10" src="https://user-images.githubusercontent.com/121939/168120976-23b1f7fb-3766-4925-9660-5cd80de58a5d.png">

<img width="957" alt="Screenshot 2022-05-12 at 17 12 08" src="https://user-images.githubusercontent.com/121939/168120980-1194dca4-fdc6-4dd8-8252-a11acfd961ac.png">

Fixes #2581.