### PR TITLE
Use ‘option’ instead of ‘argument’ in macro options documentation

### DIFF
--- a/src/govuk/components/back-link/back-link.yaml
+++ b/src/govuk/components/back-link/back-link.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: false
-  description: Text to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to 'Back'.
+  description: Text to use within the back link component. If `html` is provided, the `text` option will be ignored. Defaults to 'Back'.
 - name: html
   type: string
   required: false
-  description: HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored. Defaults to 'Back'.
+  description: HTML to use within the back link component. If `html` is provided, the `text` option will be ignored. Defaults to 'Back'.
 - name: href
   type: string
   required: true

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -7,11 +7,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within the breadcrumbs item. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within the breadcrumbs item. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML to use within the breadcrumbs item. If `html` is provided, the `text` option will be ignored.
   - name: href
     type: string
     required: false

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -6,11 +6,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.
+  description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This option has no effect if `element` is set to `input`.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` argument will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This argument has no effect if `element` is set to `input`.
+  description: If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This option has no effect if `element` is set to `input`.
 - name: name
   type: string
   required: false

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -18,11 +18,11 @@ params:
 - name: maxlength
   type: string
   required: true
-  description: If `maxwords` is set, this is not required. The maximum number of characters. If `maxwords` is provided, the `maxlength` argument will be ignored.
+  description: If `maxwords` is set, this is not required. The maximum number of characters. If `maxwords` is provided, the `maxlength` option will be ignored.
 - name: maxwords
   type: string
   required: true
-  description: If `maxlength` is set, this is not required. The maximum number of words. If `maxwords` is provided, the `maxlength` argument will be ignored.
+  description: If `maxlength` is set, this is not required. The maximum number of words. If `maxwords` is provided, the `maxlength` option will be ignored.
 - name: threshold
   type: string
   required: false

--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -43,11 +43,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within each checkbox item label. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within each checkbox item label. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML to use within each checkbox item label. If `html` is provided, the `text` option will be ignored.
   - name: id
     type: string
     required: false

--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -2,19 +2,19 @@ params:
 - name: summaryText
   type: string
   required: true
-  description: If `summmaryHtml` is set, this is not required. Text to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.
+  description: If `summmaryHtml` is set, this is not required. Text to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` option will be ignored.
 - name: summaryHtml
   type: string
   required: true
-  description: If `summmaryText` is set, this is not required. HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` argument will be ignored.
+  description: If `summmaryText` is set, this is not required. HTML to use within the summary element (the visible part of the details element). If `summaryHtml` is provided, the `summaryText` option will be ignored.
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the disclosed part of the details element. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the disclosed part of the details element. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the disclosed part of the details element. If `html` is provided, the `text` option will be ignored.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the error message. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the error message. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the error message. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the error message. If `html` is provided, the `text` option will be ignored.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -18,7 +18,7 @@ params:
 - name: errorList
   type: array
   required: true
-  description: Contains an array of error link items and all their available arguments.
+  description: The list of errors to include in the summary
   params:
   - name: href
     type: string
@@ -27,11 +27,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text for the error link item. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text for the error link item. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML for the error link item. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML for the error link item. If `html` is provided, the `text` option will be ignored.
   - name: attributes
     type: object
     required: false

--- a/src/govuk/components/fieldset/fieldset.yaml
+++ b/src/govuk/components/fieldset/fieldset.yaml
@@ -11,11 +11,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within the legend. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within the legend. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within the legend. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML to use within the legend. If `html` is provided, the `text` option will be ignored.
   - name: classes
     type: string
     required: false

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -27,11 +27,11 @@ params:
   - name: text
     type: string
     required: true
-    description: Text for the navigation item. If `html` is provided, the `text` argument will be ignored.
+    description: Text for the navigation item. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: HTML for the navigation item. If `html` is provided, the `text` argument will be ignored.
+    description: HTML for the navigation item. If `html` is provided, the `text` option will be ignored.
   - name: href
     type: string
     required: false

--- a/src/govuk/components/hint/hint.yaml
+++ b/src/govuk/components/hint/hint.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the hint. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the hint. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the hint. If `html` is provided, the `text` option will be ignored.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -46,11 +46,11 @@ params:
     - name: text
       type: string
       required: true
-      description: Required. If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: Required. If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` option will be ignored.
     - name: html
       type: string
       required: true
-      description: Required. If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: Required. If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` option will be ignored.
     - name: classes
       type: string
       required: false
@@ -67,11 +67,11 @@ params:
     - name: text
       type: string
       required: true
-      description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` option will be ignored.
     - name: html
       type: string
       required: true
-      description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+      description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` option will be ignored.
     - name: classes
       type: string
       required: false

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` option will be ignored.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/label/label.yaml
+++ b/src/govuk/components/label/label.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the label. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the label. If `html` is provided, the `text` option will be ignored.
 - name: for
   type: string
   required: false

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -2,11 +2,11 @@ params:
 - name: titleText
   type: string
   required: true
-  description: If `titleHtml` is set, this is not required. Text to use within the panel. If `titleHtml` is provided, the `titleText` argument will be ignored.
+  description: If `titleHtml` is set, this is not required. Text to use within the panel. If `titleHtml` is provided, the `titleText` option will be ignored.
 - name: titleHtml
   type: string
   required: true
-  description: If `titleText` is set, this is not required. HTML to use within the panel. If `titleHtml` is provided, the `titleText` argument will be ignored.
+  description: If `titleText` is set, this is not required. HTML to use within the panel. If `titleHtml` is provided, the `titleText` option will be ignored.
 - name: headingLevel
   type: integer
   required: false
@@ -14,11 +14,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the panel content. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the panel content. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the panel content. If `html` is provided, the `text` option will be ignored.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the phase banner. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the phase banner. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the phase banner. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the phase banner. If `html` is provided, the `text` option will be ignored.
 - name: tag
   type: object
   required: false

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -39,11 +39,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within each radio item label. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within each radio item label. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within each radio item label. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML to use within each radio item label. If `html` is provided, the `text` option will be ignored.
   - name: id
     type: string
     required: false

--- a/src/govuk/components/skip-link/skip-link.yaml
+++ b/src/govuk/components/skip-link/skip-link.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the skip link component. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the skip link component. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the skip link component. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the skip link component. If `html` is provided, the `text` option will be ignored.
 - name: href
   type: string
   required: false

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -11,7 +11,7 @@ params:
   - name: key.text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within the each key. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within the each key. If `html` is provided, the `text` option will be ignored.
   - name: key.html
     type: string
     required: true
@@ -22,11 +22,11 @@ params:
   - name: value.text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within the each value. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text to use within the each value. If `html` is provided, the `text` option will be ignored.
   - name: value.html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within the each value. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML to use within the each value. If `html` is provided, the `text` option will be ignored.
   - name: value.classes
     type: string
     required: false
@@ -47,11 +47,11 @@ params:
     - name: text
       type: string
       required: true
-      description: If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` argument will be ignored.
+      description: If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` option will be ignored.
     - name: html
       type: string
       required: true
-      description: If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` argument will be ignored.
+      description: If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` option will be ignored.
     - name: visuallyHiddenText
       type: string
       required: false

--- a/src/govuk/components/table/table.yaml
+++ b/src/govuk/components/table/table.yaml
@@ -7,11 +7,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text for cells in table rows. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text for cells in table rows. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML for cells in table rows. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML for cells in table rows. If `html` is provided, the `text` option will be ignored.
   - name: format
     type: string
     required: false
@@ -40,11 +40,11 @@ params:
   - name: text
     type: string
     required: false
-    description: If `html` is set, this is not required. Text for table head cells. If `html` is provided, the `text` argument will be ignored.
+    description: If `html` is set, this is not required. Text for table head cells. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: false
-    description: If `text` is set, this is not required. HTML for table head cells. If `html` is provided, the `text` argument will be ignored.
+    description: If `text` is set, this is not required. HTML for table head cells. If `html` is provided, the `text` option will be ignored.
   - name: format
     type: string
     required: false

--- a/src/govuk/components/tabs/tabs.yaml
+++ b/src/govuk/components/tabs/tabs.yaml
@@ -36,11 +36,11 @@ params:
       - name: text
         type: string
         required: true
-        description: If `html` is set, this is not required. Text to use within each tab panel. If `html` is provided, the `text` argument will be ignored.
+        description: If `html` is set, this is not required. Text to use within each tab panel. If `html` is provided, the `text` option will be ignored.
       - name: html
         type: string
         required: true
-        description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` argument will be ignored.
+        description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` option will be ignored.
       - name: attributes
         type: object
         required: false

--- a/src/govuk/components/tag/tag.yaml
+++ b/src/govuk/components/tag/tag.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the tag component. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the tag component. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the tag component. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the tag component. If `html` is provided, the `text` option will be ignored.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -2,11 +2,11 @@ params:
 - name: text
   type: string
   required: true
-  description: If `html` is set, this is not required. Text to use within the warning text component. If `html` is provided, the `text` argument will be ignored.
+  description: If `html` is set, this is not required. Text to use within the warning text component. If `html` is provided, the `text` option will be ignored.
 - name: html
   type: string
   required: true
-  description: If `text` is set, this is not required. HTML to use within the warning text component. If `html` is provided, the `text` argument will be ignored.
+  description: If `text` is set, this is not required. HTML to use within the warning text component. If `html` is provided, the `text` option will be ignored.
 - name: iconFallbackText
   type: string
   required: true


### PR DESCRIPTION
To be consistent with the language we use elsewhere in the documentation and in the Design System, use ‘option’ instead of ‘argument’ in the macro options documentation.