### PR TITLE
Add top padding to accordion section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change was introduced in [pull request #2617: Do not make the service name 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2617: Do not make the service name in the header a link if no `serviceUrl` is provided](https://github.com/alphagov/govuk-frontend/pull/2617)
+- [#2640: Add top padding to accordion section](https://github.com/alphagov/govuk-frontend/pull/2640)
 
 ## 4.1.0 (Feature release)
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -50,6 +50,7 @@
     .govuk-accordion__section-content {
       display: none;
       @include govuk-responsive-padding(8, "bottom");
+      @include govuk-responsive-padding(3, "top");
     }
 
     // Show the body of expanded sections


### PR DESCRIPTION
## What/Why
Fixes https://github.com/alphagov/govuk-frontend/issues/2608

Adds top padding to the toggleable accordion section so that the touch area between the accordion heading button and any potential touch targets within that accordion section eg: a link aren't too close together.

## Visual changes
### Before
Open:
<img width="276" alt="Screenshot 2022-05-24 at 09 49 22" src="https://user-images.githubusercontent.com/64783893/169990987-15bb5deb-269b-4970-a59c-a14954cf6e6f.png">

Open with hover state:
<img width="272" alt="Screenshot 2022-05-24 at 09 49 28" src="https://user-images.githubusercontent.com/64783893/169991027-257085ba-1b74-44ff-a15a-6b66dab334b7.png">

### After
Open:
<img width="301" alt="Screenshot 2022-05-24 at 09 48 48" src="https://user-images.githubusercontent.com/64783893/169991058-6b7aa47a-3ad4-4211-8b99-7d1697cde06d.png">

Open with hover state:
<img width="296" alt="Screenshot 2022-05-24 at 09 48 56" src="https://user-images.githubusercontent.com/64783893/169991087-94251ac4-c145-4408-a4ce-07af5845ee03.png">

