### PR TITLE
Add link from review app to Frontend Sass docs

### DIFF
--- a/app/views/layouts/index.njk
+++ b/app/views/layouts/index.njk
@@ -40,7 +40,7 @@
       <h2 class="govuk-heading-m">Misc</h2>
 
       <ul class="govuk-list">
-        <li><a href="/docs" class="govuk-link">Sass Documentation</a></li>
+        <li>[Sass Documentation](https://frontend.design-system.service.gov.uk/sass-api-reference/#sass-api-reference)</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Partly addresses [#1892](https://github.com/alphagov/govuk-frontend/issues/1892).

The front page of the [review app](https://govuk-frontend-review.herokuapp.com/) contains a link ('Sass documentation') to http://govuk-frontend-review.herokuapp.com/docs/.

Seeing the same Sass content in 2 places might be confusing for users.

This PR replaces the current link with one to the [Sass content on our Frontend docs site](https://frontend.design-system.service.gov.uk/sass-api-reference/#sass-api-reference).