### PR TITLE
Allow users to use `require.resolve` to import GOV.UK Frontend JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2617: Do not make the service name in the header a link if no `serviceUrl` is provided](https://github.com/alphagov/govuk-frontend/pull/2617)
 - [#2640: Add top padding to accordion section](https://github.com/alphagov/govuk-frontend/pull/2640)
+- [#2644: Allow users to use require.resolve to import GOV.UK Frontend JavaScript](https://github.com/alphagov/govuk-frontend/pull/2644)
 
 ## 4.1.0 (Feature release)
 

--- a/package/package.json
+++ b/package/package.json
@@ -5,7 +5,8 @@
   "main": "govuk/all.js",
   "module": "govuk-esm/all.mjs",
   "exports": {
-    "import": "./govuk-esm/all.mjs"
+    "import": "./govuk-esm/all.mjs",
+    "require": "./govuk/all.js"
   },
   "sideEffects": [
     "govuk-esm/vendor/**"


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2643

## What
Add `require` entry point to `package/package.json` file.

## Why
When we introduced ECMAScript modules, we broke the ability to `require` the
JavaScript. By defining an entry point for `require` statements in the package.json
file, we add back that functionality.

https://nodejs.org/api/packages.html#conditional-exports

## Tested with

- [x] [Basic require setup](https://github.com/vanitabarrett/require-govuk-frontend/blob/master/index.js#L8)
- [x] Webpack, to ensure ESM `import` not affected
- [x] Rollup, to ensure ESM `import` not affected
- [x] Parcel, to ensure ESM `import` not affected
- [x] esbuild, to ensure ESM `import` not affected
- [x] Prototype Kit, to ensure change is still backwards compatible
- [x] Design System