### PR TITLE
Allow users to import sass files via Webpack `sass-loader`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2617: Do not make the service name in the header a link if no `serviceUrl` is provided](https://github.com/alphagov/govuk-frontend/pull/2617)
 - [#2640: Add top padding to accordion section](https://github.com/alphagov/govuk-frontend/pull/2640)
 - [#2644: Allow users to use require.resolve to import GOV.UK Frontend JavaScript](https://github.com/alphagov/govuk-frontend/pull/2644)
+- [#2647: Allow users to import sass files via Webpack sass-loader](https://github.com/alphagov/govuk-frontend/pull/2647)
 
 ## 4.1.0 (Feature release)
 

--- a/package/package.json
+++ b/package/package.json
@@ -9,7 +9,8 @@
       "sass": "./govuk/all.scss",
       "import": "./govuk-esm/all.mjs",
       "require": "./govuk/all.js"
-    }
+    },
+    "./govuk/": "./govuk/"
   },
   "sideEffects": [
     "govuk-esm/vendor/**"

--- a/package/package.json
+++ b/package/package.json
@@ -10,7 +10,8 @@
       "import": "./govuk-esm/all.mjs",
       "require": "./govuk/all.js"
     },
-    "./govuk/": "./govuk/"
+    "./govuk/": "./govuk/",
+    "./govuk-esm/": "./govuk-esm/"
   },
   "sideEffects": [
     "govuk-esm/vendor/**"

--- a/package/package.json
+++ b/package/package.json
@@ -5,8 +5,11 @@
   "main": "govuk/all.js",
   "module": "govuk-esm/all.mjs",
   "exports": {
-    "import": "./govuk-esm/all.mjs",
-    "require": "./govuk/all.js"
+    ".": {
+      "sass": "./govuk/all.scss",
+      "import": "./govuk-esm/all.mjs",
+      "require": "./govuk/all.js"
+    }
   },
   "sideEffects": [
     "govuk-esm/vendor/**"


### PR DESCRIPTION
Fixes #2645 

## What
Add `sass` field to package.json `exports`. 

## Why
Webpack prefers the "exports" field over any other entry in the package.json, which is why the existing `sass` entry is not enough.

> exports field is preferred over other package entry fields like main, module, browser or custom ones

https://webpack.js.org/guides/package-exports/