### PR TITLE
[WIP][DO NOT MERGE] Nunjucks internationalisation support

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -37,6 +37,10 @@ params:
   required: false
   description: Options for the hint component.
   isComponent: true
+- name: limitHint
+  type: string
+  required: false
+  description: Text describing the maximum number of characters or words that can be entered, which is announced to screen readers and displayed as a fallback if the character count JavaScript does not run. Instances of `%{count}` within the string will be replaced by the value of either the `maxlength` or `maxwords` parameters. By default, fallback text in English is constructed based on what other parameters are provided to the component.
 - name: errorMessage
   type: object
   required: false
@@ -92,6 +96,16 @@ examples:
       hint:
         text: Don't include personal or financial information, eg your
               National Insurance number or credit card details.
+  
+  - name: with customised limit hint
+    description: Fallback limit text translated to Welsh
+    data:
+      name: with-limit-hint
+      id: with-limit-hint
+      maxlength: 10
+      label:
+        text: Can you provide more detail?
+      limitHint: Gallwch nodi hyd at %{count} nod
 
   - name: with default value
     data:

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -26,8 +26,11 @@
     errorMessage: params.errorMessage,
     attributes: params.attributes
   }) }}
+
+  {%- set limitHintLength = params.maxlength or params.maxwords %}
+  {%- set limitHintDefault = 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {{ govukHint({
-    text: 'You can enter up to ' + (params.maxlength or params.maxwords) + (' words' if params.maxwords else ' characters'),
+    text: (params.limitHint or limitHintDefault) | replace('%{count}', limitHintLength),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -67,6 +67,14 @@ params:
       type: object
       required: false
       description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
+- name: contentLicence
+  type: string
+  required: false
+  description: HTML or text to replace the default Open Government Licence notice with.
+- name: copyright
+  type: string
+  required: false
+  description: Text to replace the default Crown Copyright notice with.
 - name: containerClasses
   type: string
   required: false
@@ -117,6 +125,12 @@ examples:
   data:
     {}
 
+- name: with custom licence and copyright notices
+  description: Licence and copyright information translated into Welsh
+  data:
+    contentLicence: 'Mae’r holl gynnwys ar gael dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, ac eithrio lle nodir yn wahanol'
+    copyright: '© Hawlfraint y Goron'
+
 - name: with meta
   description: Secondary navigation with meta information relating to the site
   data:
@@ -158,12 +172,6 @@ examples:
         - href: '#8'
           text:  Ligula Nullam Ultricies
       html: Built by the <a href="#" class="govuk-footer__link">Department of Magical Law Enforcement</a>
-
-- name: with custom meta
-  description: Custom meta section
-  data:
-    meta:
-      text: GOV.UK Prototype Kit v7.0.1
 
 - name: with default width navigation (one column)
   data:

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -71,10 +71,18 @@ params:
   type: string
   required: false
   description: HTML or text to replace the default Open Government Licence notice with.
+- name: hideOpenGovernmentLicenceLogo
+  type: boolean
+  required: false
+  description: Removes the Open Government Licence logo, if the licence being used isn't the OGL.
 - name: copyright
   type: string
   required: false
   description: Text to replace the default Crown Copyright notice with.
+- name: hideCrownCopyrightArms
+  type: boolean
+  required: false
+  description: Removes the Crown Copyright notice and royal coat of arms.
 - name: containerClasses
   type: string
   required: false
@@ -130,6 +138,14 @@ examples:
   data:
     contentLicence: 'Mae’r holl gynnwys ar gael dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, ac eithrio lle nodir yn wahanol'
     copyright: '© Hawlfraint y Goron'
+
+- name: with licence and copyright graphics removed
+  description: Suitable for services where the Open Government Licence and Crown Copyright don't apply, such as internal caseworking systems
+  data:
+    hideOpenGovernmentLicenceLogo: true
+    hideCrownCopyrightArms: true
+    copyright: © Megadodo Publications
+    contentLicence: <i>The Hitchhiker's Guide</i> is available under a <a class="govuk-footer__link" rel="license" href="http://creativecommons.org/licenses/by/4.0/">CC Attribution 4.0 Interplanetary Licence</a>
 
 - name: with meta
   description: Secondary navigation with meta information relating to the site

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -68,19 +68,23 @@
           />
         </svg>
         <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
+          {%- if params.contentLicence %}
+            {{ params.contentLicence | safe }}
+          {%- else %}
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          {%- endif %}
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >© Crown copyright</a>
+        >{{ params.copyright | default("© Crown copyright") }}</a>
       </div>
     </div>
   </div>

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -50,41 +50,47 @@
             </div>
           {% endif %}
         {% endif %}
-        {#- The SVG needs `focusable="false"` so that Internet Explorer does not
-        treat it as an interactive element - without this it will be
-        'focusable' when using the keyboard to navigate. #}
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          class="govuk-footer__licence-logo"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 483.2 195.7"
-          height="17"
-          width="41"
-        >
-          <path
-            fill="currentColor"
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-          />
-        </svg>
+        {% if not params.hideOpenGovernmentLicenceLogo %}
+          {#- The SVG needs `focusable="false"` so that Internet Explorer does not
+          treat it as an interactive element - without this it will be
+          'focusable' when using the keyboard to navigate. #}
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            class="govuk-footer__licence-logo"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 483.2 195.7"
+            height="17"
+            width="41"
+          >
+            <path
+              fill="currentColor"
+              d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
+            />
+          </svg>
+        {% endif %}
         <span class="govuk-footer__licence-description">
-          {%- if params.contentLicence %}
+          {% if params.contentLicence %}
             {{ params.contentLicence | safe }}
-          {%- else %}
+          {% else %}
             All content is available under the
             <a
               class="govuk-footer__link"
               href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
               rel="license"
             >Open Government Licence v3.0</a>, except where otherwise stated
-          {%- endif %}
+          {% endif %}
         </span>
       </div>
       <div class="govuk-footer__meta-item">
+      {% if not params.hideCrownCopyrightArms %}
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
         >{{ params.copyright | default("© Crown copyright") }}</a>
+      {% else %}
+        {{ params.copyright }}
+      {% endif %}
       </div>
     </div>
   </div>

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -51,11 +51,15 @@ params:
 - name: navigationLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the navigation. Defaults to 'Navigation menu'.
+  description: Text for the `aria-label` attribute of the navigation. Defaults to 'Menu'.
 - name: menuButtonLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide navigation menu'.
+  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide menu'.
+- name: menuButton
+  type: string
+  required: false
+  description: Text for the button that toggles the navigation. Defaults to 'Menu'.
 - name: containerClasses
   type: string
   required: false
@@ -131,6 +135,21 @@ examples:
         text: Navigation item 3
       - href: '#4'
         text: Navigation item 4
+        
+- name: with custom menu button text
+  description: Button translated into Welsh
+  data:
+    menuButton: Dewislen
+    navigation:
+      - href: '#1'
+        text: Eitem llywio 1
+        active: true
+      - href: '#2'
+        text: Eitem llywio 2
+      - href: '#3'
+        text: Eitem llywio 3
+      - href: '#4'
+        text: Eitem llywio 4
 
 - name: with custom menu button label
   data:

--- a/src/govuk/components/header/template.njk
+++ b/src/govuk/components/header/template.njk
@@ -61,7 +61,7 @@
     {% endif %}
     {% if params.navigation %}
     <nav aria-label="{{ params.navigationLabel | default('Menu') }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
-      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">Menu</button>
+      <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="{{ params.menuButtonLabel | default('Show or hide menu') }}">{{ params.menuButton | default('Menu') }}</button>
 
       <ul id="navigation" class="govuk-header__navigation-list">
         {% for item in params.navigation %}


### PR DESCRIPTION
In addition to updating our JavaScript to allow for localisation (#2614), we also have a few instances of hardcoded strings and fixed word order in our Nunjucks code that need to made configurable. There isn't a 'one size fits all' approach to doing this and we'll probably need to use slightly different methods for enabling localisation of each component. 

## Identified issues

- [x] Character count: Fallback hint text is not editable within Nunjucks. Nunjucks parameters are interpolated into the hint in a fixed content order.
  - #1681
- [ ] Error message: Some visually hidden text (which defaults to ‘Error’) and a colon (:) are hardcoded to appear before the error message, creating a fixed content order.
  - #2650
- [x] Footer: Content licence and Crown copyright notices are hardcoded. 
  - #1290 
  - #1291
- [x] Header: The visible 'menu' link text is hardcoded. Currently, it will overlap the GOV.UK branding if the replacement label is quite long.
  - #1904
- [ ] Summary list: The row key is interpolated alongside action text in a fixed content order.
  - #2094
  - #2649

## Possible improvements

- Date input: Each input's label is localisable, but only by providing the entire `items` array, requiring service users to also re-define the default `name` and `classes` if they don't want these to change. There may be a nicer way of doing this.
- Error summary: The description is always be interpolated between paragraph tags, even if the description is provided via the `html` parameter. This is the only component to do this; other components only add paragraph tags if the content is provided via `text`.

None of the above changes are to enable RTL language support.