### PR TITLE
Change cookie hide button text examples

### DIFF
--- a/app/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -68,7 +68,7 @@ notes: >-
             "role": "alert",
             "actions": [
                 {
-                    "text": "Hide this message",
+                    "text": "Hide cookie message",
                     "type": "button",
                     "classes": "js-hide"
                 }
@@ -81,7 +81,7 @@ notes: >-
             "role": "alert",
             "actions": [
                 {
-                    "text": "Hide this message",
+                    "text": "Hide cookie message",
                     "type": "button",
                     "classes": "js-hide"
                 }

--- a/app/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/app/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -38,7 +38,7 @@ notes: >-
                 href: "#"
               },
               {
-                text: "Hide this message",
+                text: "Hide cookie message",
                 type: "submit",
                 name: "cookies",
                 value: "cookie-banner-dismissed",

--- a/app/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/app/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -42,7 +42,7 @@ notes: >-
             "role": "alert",
             "actions": [
                 {
-                    "text": "Hide this message",
+                    "text": "Hide cookie message",
                     "href": currentUrl,
                     "type": "button",
                     "classes": "js-hide"

--- a/src/govuk/components/cookie-banner/cookie-banner.yaml
+++ b/src/govuk/components/cookie-banner/cookie-banner.yaml
@@ -110,7 +110,7 @@ examples:
         - text: Your cookie preferences have been saved. You have accepted cookies.
           role: alert
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button
 
   - name: rejected confirmation banner
@@ -119,7 +119,7 @@ examples:
         - text: Your cookie preferences have been saved. You have rejected cookies.
           role: alert
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button
 
   - name: client-side implementation
@@ -142,13 +142,13 @@ examples:
           role: alert
           hidden: true
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button
         - text: Your cookie preferences have been saved. You have rejected cookies.
           role: alert
           hidden: true
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button
 
   - name: with html
@@ -305,10 +305,10 @@ examples:
         - text: Your cookie preferences have been saved. You have accepted cookies.
           role: alert
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button
         - text: Your cookie preferences have been saved. You have rejected cookies.
           role: alert
           actions:
-            - text: Hide this message
+            - text: Hide cookie message
               type: button


### PR DESCRIPTION
Related to https://github.com/alphagov/govuk-design-system/issues/2087

The original hide button text 'Hide this message' was raised in audits as being unclear to users of assistive tech. This isn't hardcoded into the component, but we do have examples which we should update with our [new recommended text](https://github.com/alphagov/govuk-design-system/pull/2207): Hide cookie message.