### PR TITLE
Fix Summary List action link alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2668: Fix Summary List action link alignment](https://github.com/alphagov/govuk-frontend/pull/2668)
+
 ## 4.2.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/summary-list/_index.scss
+++ b/src/govuk/components/summary-list/_index.scss
@@ -93,21 +93,43 @@
   }
 
   .govuk-summary-list__actions-list-item {
-    display: inline;
-    margin-right: govuk-spacing(2);
-    padding-right: govuk-spacing(2);
+    display: inline-block;
   }
 
   // In older browsers such as IE8, :last-child is not available,
   // so only show the border divider where it is available.
-  .govuk-summary-list__actions-list-item:not(:last-child) {
-    border-right: 1px solid $govuk-border-colour;
+  @include govuk-media-query($until: tablet) {
+    .govuk-summary-list__actions-list-item {
+      margin-right: govuk-spacing(2);
+      padding-right: govuk-spacing(2);
+    }
+
+    .govuk-summary-list__actions-list-item:not(:last-child) {
+      border-right: 1px solid $govuk-border-colour;
+    }
+
+    .govuk-summary-list__actions-list-item:last-child {
+      margin-right: 0;
+      padding-right: 0;
+      border: 0;
+    }
   }
 
-  .govuk-summary-list__actions-list-item:last-child {
-    margin-right: 0;
-    padding-right: 0;
-    border: 0;
+  @include govuk-media-query($from: tablet) {
+    .govuk-summary-list__actions-list-item {
+      margin-left: govuk-spacing(2);
+      padding-left: govuk-spacing(2);
+    }
+
+    .govuk-summary-list__actions-list-item:not(:first-child) {
+      border-left: 1px solid $govuk-border-colour;
+    }
+
+    .govuk-summary-list__actions-list-item:first-child {
+      margin-left: 0;
+      padding-left: 0;
+      border: 0;
+    }
   }
 
   // No border on entire summary list

--- a/src/govuk/components/summary-list/template.njk
+++ b/src/govuk/components/summary-list/template.njk
@@ -29,11 +29,11 @@
               {{ _actionLink(row.actions.items[0]) | indent(12) | trim }}
             {% else %}
               <ul class="govuk-summary-list__actions-list">
-                {% for action in row.actions.items %}
+                {%- for action in row.actions.items -%}
                   <li class="govuk-summary-list__actions-list-item">
-                    {{ _actionLink(action) | indent(18) | trim }}
+                    {{- _actionLink(action) | indent(18) | trim -}}
                   </li>
-                {% endfor %}
+                {%- endfor -%}
               </ul>
             {% endif %}
           </dd>

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -21,7 +21,7 @@ const cssnano = require('cssnano')
 const postcsspseudoclasses = require('postcss-pseudo-classes')({
   // Work around a bug in pseudo classes plugin that badly transforms
   // :not(:whatever) pseudo selectors
-  blacklist: [':not(', ':disabled)', ':last-child)', ':focus)', ':active)', ':hover)']
+  blacklist: [':not(', ':disabled)', ':first-child)', ':last-child)', ':focus)', ':active)', ':hover)']
 })
 
 // Compile CSS and JS task --------------


### PR DESCRIPTION
When there are several action links in the Summary List component, the links become misaligned on large screens, due to the links being right-aligned and the separator being appended to the right of each link. Links are aligned correctly on narrow screens, as the links are left-aligned in that context.

Additionally, the spacing on each side of the separator is uneven due to extra whitespace being counted between each link.

This PR intends to fix these issues by:
- Using media queries to swap which side of the link the separator line, margin and padding are applied to, depending on the viewport size.
- Using flexbox on the link container, so that whitespace isn't included in layout calculations. 

Fixes #2281. 

## Comparisons

### Small screens (modern browsers, IE11, IE10)

|Before|After|
|:-|:-|
| <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175040620-e5278253-f0fb-4f7c-a75e-a67c33118ff0.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175040680-0fbd93c4-8412-4d56-9b5e-1eca15b76529.png"> |

### Large screens (modern browsers, IE11, IE10)

|Before|After|
|:-|:-|
| <img width="384" alt="image" src="https://user-images.githubusercontent.com/1253214/175040082-61297d26-9786-4dbe-94ee-f20da1f5b796.png"> | <img width="384" alt="image" src="https://user-images.githubusercontent.com/1253214/175039780-6445d1e5-c2d0-4b3a-8d73-4b3ef420b142.png"> |

### Large screens (IE9)

Flexbox is not supported by IE9, so the uneven spacing between separators is still present.

|Before|After|
|:-|:-|
| <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175042050-fec957c5-60c3-4ca8-92cb-9af60bf3b22b.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175041968-71d71e82-d072-4bd4-935f-a173f08a310a.png"> |

### Large screens (IE8)

Neither flexbox, nor the `:first-child` and `:last-child` pseudo-selectors, are supported in IE8.

|Before|After|
|:-|:-|
| <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175041562-bc2ad1cd-9365-4a05-a107-50d24916055a.png"> | <img width="372" alt="image" src="https://user-images.githubusercontent.com/1253214/175041614-b03cd9c3-507e-4cd9-a12d-2f13b30105da.png"> |
