### PR TITLE
Define mininimum width for select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ In [pull request 2678: Replace ex units with ems for input lengths](https://gith
 We’ve also made fixes in the following pull requests:
 
 - [#2668: Fix Summary List action link alignment](https://github.com/alphagov/govuk-frontend/pull/2668)
+- [#2670: Define mininimum width for select component](https://github.com/alphagov/govuk-frontend/pull/2670)
 
 ## 4.2.0 (Feature release)
 

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -7,6 +7,12 @@
     @include govuk-font($size: 19, $line-height: 1.25);
 
     box-sizing: border-box; // should this be global?
+
+    // This min-width was chosen because:
+    // - it makes the Select noticeably wider than it is taller (which is what users expect)
+    // - 23ex matches the 'length-10' variant of the input component
+    // - it fits comfortably on screens as narrow as 240px wide
+    min-width: 23ex;
     max-width: 100%;
     height: 40px;
     @if $govuk-typography-use-rem {

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -10,9 +10,9 @@
 
     // This min-width was chosen because:
     // - it makes the Select noticeably wider than it is taller (which is what users expect)
-    // - 23ex matches the 'length-10' variant of the input component
+    // - 11.5em matches the 'length-10' variant of the input component
     // - it fits comfortably on screens as narrow as 240px wide
-    min-width: 23ex;
+    max-width: 11.5em;
     max-width: 100%;
     height: 40px;
     @if $govuk-typography-use-rem {

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -12,7 +12,7 @@
     // - it makes the Select noticeably wider than it is taller (which is what users expect)
     // - 11.5em matches the 'length-10' variant of the input component
     // - it fits comfortably on screens as narrow as 240px wide
-    max-width: 11.5em;
+    min-width: 11.5em;
     max-width: 100%;
     height: 40px;
     @if $govuk-typography-use-rem {

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -92,6 +92,13 @@ examples:
           value: 3
           text: GOV.UK frontend option 3
           disabled: true
+  - name: with no items
+    data:
+      id: select-1
+      name: select-1
+      label:
+        text: Horse with no name
+      items: []
   - name: with selected value
     data:
       id: select-1


### PR DESCRIPTION
Adds a minimum width of the select component to account for situations where the value list may be loaded asyncronously, as requested in #2170.

As there is no 'standard' minimum width for selects, I opted to use 23 ex—equivalent to about 184 pixels wide on mobile, and 218 pixels wide on tablet and above. 

I used 23 ex for a few reasons:
- It is wide enough that it looks 'as expected' for a select, in the sense that it is noticably wider than it is tall. 
- It's the same width as a text input with the `.govuk-input--width-10` class applied.
- It can sit within `.govuk-width-container` and still comfortably fit on screens 240 pixels wide, which is the narrowest screen resolution with any significant presence in GOV.UK's analytics (the narrowest to be in triple digits, anyway), and one apparently [still used on modern feature phones](https://www.gsmarena.com/nokia_2720_v_flip-10910.php)(!)

## Comparisons

### Mobile

|Before|After|
|:-|:-|
| ![image](https://user-images.githubusercontent.com/1253214/175336085-dd42b30a-5638-4c0f-873c-732b88b82e2e.png) | ![image](https://user-images.githubusercontent.com/1253214/175336135-306fb019-e8c0-4f76-b103-c50cb0e37ad3.png) |

### Tablet/desktop

|Before|After|
|:-|:-|
| ![image](https://user-images.githubusercontent.com/1253214/175336183-a98e39b9-10b9-4e62-a2ce-61d369f6acd0.png) | ![image](https://user-images.githubusercontent.com/1253214/175336247-dafd70ba-7f0c-4258-a857-92a5f377bda4.png) |