### PR TITLE
Remove acorn as a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@percy/cli": "^1.0.0-beta.75",
         "@percy/logger": "1.0.0-beta.74",
         "@percy/puppeteer": "^2.0.0",
-        "acorn": "^7.4.0",
         "autoprefixer": "^9.8.6",
         "body-parser": "^1.18.3",
         "cheerio": "^1.0.0-rc.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@percy/cli": "^1.0.0-beta.75",
     "@percy/logger": "1.0.0-beta.74",
     "@percy/puppeteer": "^2.0.0",
-    "acorn": "^7.4.0",
     "autoprefixer": "^9.8.6",
     "body-parser": "^1.18.3",
     "cheerio": "^1.0.0-rc.3",


### PR DESCRIPTION
We added `acorn` as part of [updating Gulp and Jest](https://github.com/alphagov/govuk-frontend/pull/1277) back in 2019.

I've done a brief investigation using that PR's node/npm version and package.json file, and I can't recreate any peer dependency warnings for packages that need `acorn`. It's not used anywhere in our code, and removing it doesn't seem to break anything - it pops up as a sub-dependency here and there with no problem. I think we're mostly putting this down to "legacy npm nonsense".