### PR TITLE
Replace ex units with ems for input lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixes
 
-We’ve made fixes to GOV.UK Frontend in the following pull requests:
+In [pull request 2678: Replace ex units with ems for input lengths](https://github.com/alphagov/govuk-frontend/pull/2678), we changed how we define input lengths in our CSS. Browsers might now display these inputs as being slightly wider than before. The difference is usually fewer than 3 pixels.  
+
+We’ve also made fixes in the following pull requests:
 
 - [#2668: Fix Summary List action link alignment](https://github.com/alphagov/govuk-frontend/pull/2668)
 

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -59,36 +59,35 @@
     }
   }
 
-  // The ex measurements are based on the number of W's that can fit inside the input
-  // Extra space is left on the right hand side to allow for the Safari prefill icon
-  // Linear regression estimation based on visual tests: y = 1.76 + 1.81x
+  // em measurements are based on the point size of the typeface
+  // Extra space is added on the right hand side to allow for the Safari prefill icon
 
   .govuk-input--width-30 {
-    max-width: 56ex + 3ex;
+    max-width: 29.5em;
   }
 
   .govuk-input--width-20 {
-    max-width: 38ex + 3ex;
+    max-width: 20.5em;
   }
 
   .govuk-input--width-10 {
-    max-width: 20ex + 3ex;
+    max-width: 11.5em;
   }
 
   .govuk-input--width-5 {
-    max-width: 10.8ex;
+    max-width: 5.5em;
   }
 
   .govuk-input--width-4 {
-    max-width: 9ex;
+    max-width: 4.5em;
   }
 
   .govuk-input--width-3 {
-    max-width: 7.2ex;
+    max-width: 3.75em;
   }
 
   .govuk-input--width-2 {
-    max-width: 5.4ex;
+    max-width: 2.75em;
   }
 
   .govuk-input__wrapper {


### PR DESCRIPTION
It was recently questioned why we were using `ex` units (a unit equivalent to the font's [x-height](https://en.wikipedia.org/wiki/X-height)) to define the width of inputs. Ultimately, the original reasoning appears to have been lost to time.

This PR replaces the use of `ex` units with `em` equivalents for Input lengths. 

This makes sense as:
- `em` units are based on typeface width, rather than the height
- `em` and `ex` are both based on the font size, both affect the width of the input when the body font size is changed
- `ex` units are calculated differently by different browsers — IE 'cheats' and makes `ex` always equal half of `em`

Rather than make one-to-one replacements of `ex` for `em`, I rounded the `em` units up to the nearest .25. This prevents an excessive amount of decimal places in the resulting pixel measurements, but does mean that these inputs are up to a few pixels wider than previously. 

| Input length | old `ex` | new `em` | old `px` | new `px` |
|:-|-:|-:|-:|-:|
|2 | 5.4| 2.75| 51.217|52.25|
|3 | 7.2| 3.75| 68.283|71.25|
|4 | 9.0| 4.50| 85.350|85.50|
|5 |10.8| 5.50|102.417|104.50|
|10|23.0|11.50|218.117|218.50|
|20|41.0|20.50|388.817|389.50|
|30|59.0|29.50|559.517|560.50|