### PR TITLE
Add docs on managing change

### DIFF
--- a/docs/contributing/managing-change.md
+++ b/docs/contributing/managing-change.md
@@ -1,0 +1,173 @@
+# Managing change
+
+Follow the processes in this document to make it easier for users to migrate to new major versions.
+
+## Deprecating and removing features
+
+Wherever possible, deprecate features as part of a minor release, before removing them in the next major release.
+
+This gives users the option of migrating away from using the deprecated features at their own pace, minimising the amount of work that needs to be done when new major versions are released.
+
+Features should not be deprecated while they are relied on by other parts of GOV.UK Frontend.
+
+Deprecations should not be made in patch releases.
+
+### Tell users about the deprecation
+
+Tell users about the deprecation in the release notes.
+
+Do not assume that users will understand the term 'deprecation'. Wherever possible, explain why we are deprecating the feature and what we want users to do if they are currently using it.
+
+Depending on what is being deprecated, we might want to throw deprecation warnings from the code to help users find where they are using the deprecated feature in their own codebase. See the guidance on deprecating specific types of features below.
+
+You can mention the warnings in the release notes to help users understand if they are affected.
+
+For example:
+
+> If you import specific files from the core or overrides layers, you’ll now see a deprecation warning when compiling Sass if you do not import `node_modules/govuk-frontend/govuk/base` first.
+> 
+> To fix the warning, import `node_modules/govuk-frontend/govuk/base` first. For example:
+> 
+> ```scss
+> @import "node_modules/govuk-frontend/govuk/base";
+> @import "node_modules/govuk-frontend/core/typography";
+> ```
+> 
+> If you do not import `node_modules/govuk-frontend/govuk/base` first, your service will no longer work from GOV.UK Frontend v4.0.0.
+
+### Make sure we remember to remove the deprecated feature
+
+Create a GitHub issue for removing the deprecated feature. If there are multiple related things that should be removed at the same time then you can create a single issue that covers all of them.
+
+The issue should include:
+
+- clear instructions for removal
+- the reason for the deprecation and removal
+
+Attach the GitHub issue to the milestone for the next major version.
+
+### Deprecating a Sass function or mixin
+
+Include the [`@deprecated` annotation](http://sassdoc.com/annotations/#deprecated) in the Sassdoc comment block for the function, variable or mixin.
+
+In the annotation description include:
+
+- the suggested alternative, if there is one
+- a link to the GitHub issue for its removal
+
+If possible, update the mixin or function to output a warning (using `@warn`).
+
+For example:
+
+```scss
+/// Double a number
+///
+/// A contrived example function that takes a number and multiplies it by 2.
+///
+/// @deprecated Use govuk-multiply(number, 2) instead.
+///   See https://github.com/alphagov/govuk-frontend/issues/1234
+@function govuk-double($number) {
+  @warn "govuk-double($number) is deprecated. Use govuk-multiply($number, 2) instead.";
+  @return govuk-multiply($number, 2);
+}
+```
+
+### Deprecating a parameter for a Sass mixin or function
+
+If possible, update the mixin or function to maintain the existing functionality while outputting a warning.
+
+```scss
+/// Reticulate splines
+///
+/// An even more contrived example function
+///
+/// @param {String} $spline Spline to reticulate
+/// @param {Number} $angle Angle to reticulate by
+/// @param {Boolean} $rightAngle Deprecated. Use $angle: 90 instead.
+@mixin govuk-reticulate-splines($spline, $angle: 180, $rightAngle: false) {
+  @if ($rightAngle != false) {
+    @warn "Passing $rightAngle to govuk-reticulate-splines is deprecated. Pass $angle: 90 instead.";
+
+    $angle: 90;
+  }
+
+  // Reticulate the $spline by $angle degrees!
+}
+```
+
+### Deprecating a CSS class
+
+```scss
+// @deprecated
+.govuk-foo-old-class-name {
+  foo: bar;
+}
+```
+
+## Renaming things
+
+When renaming things, keep the old name available as an alias and mark it as deprecated, following the steps above to [make sure we remember to remove the deprecated feature](#make-sure-we-remember-to-remove-the-deprecated-feature).
+
+### Renaming Sass mixins and functions
+
+Include the [`@alias`](http://sassdoc.com/annotations/#alias) and [`@deprecated`](http://sassdoc.com/annotations/#deprecated) annotations in the Sassdoc comment block for the old mixin or function.
+
+For example:
+
+```scss
+/// The old way of doing something
+///
+/// @param {String} $foo Foo, obviously.
+/// @return String Modified foo!
+///
+/// @alias the-new-name
+/// @deprecated Use the-new-name($foo) instead.
+@function the-old-name($foo) {
+  @warn "the-old-name is deprecated. Use the-new-name instead.";
+  @return the-new-name($foo);
+}
+
+/// The new way of doing something
+///
+/// @param {String} $foo Foo, obviously.
+/// @return {String} Modified foo!
+@function the-new-name($foo) {
+  // do something...
+}
+```
+
+### Renaming Sass parameters
+
+Keep the old name around as an optional parameter and print a warning if anyone passes it, so they know to migrate to the new parameter.
+
+Add 'Deprecated.' to the description for the parameter.
+
+```scss
+/// Reticulate splines
+///
+/// An even more contrived example function
+///
+/// @param {String} $spline Spline to reticulate
+/// @param {String} $spilne Deprecated. Use $spline instead.
+@function govuk-reticulate-splines($spline, $spilne: false) {
+  @if ($spilne != false) {
+    @warn "Passing $spilne to govuk-reticulate-splines is deprecated. Pass $spline instead.";
+
+    $spline: $spilne;
+  }
+
+  // Do something with $spline
+}
+```
+
+### Renaming CSS classes
+
+Keep the old name in the selector list, and mark it as deprecated.
+
+```scss
+// govuk-old-class-name is deprecated. Use govuk-new-class-name instead.
+.govuk-old-class-name,
+.govuk-new-class-name {
+  foo: bar;
+}
+```

--- a/docs/contributing/versioning.md
+++ b/docs/contributing/versioning.md
@@ -31,7 +31,7 @@ We would not make breaking changes for:
 
 This is similar to how we try to tackle most problems, by focusing on user needs first.
 
-Whenever we decide to make a breaking change we must ensure we do our best to try to first [deprecate the feature](#deprecation) and allow a [migration path](#migration).
+Whenever we decide to make a breaking change we must ensure we do our best to [manage the change](./managing-change.md).
 
 ## Proposal
 
@@ -40,40 +40,6 @@ Some breaking changes that need discussion may first be proposed in the [GOV.UK 
 This is to ensure the community can get involved with the decision.
 
 Make an active effort to involve the community, this might be in the form of presentations or meetings.
-
-## Deprecation
-
-Deprecation is the practice of communicating features in the library that should no longer be used and requires a user change behaviour in their application.
-
-Deprecating features in the library helps users migrate to the new code while still being able to run the older code.
-
-Note: Our users may not know what 'deprecation' means, so it's important to also clarify that we are no longer recommending the use of a feature.
-
-Example 1: Fixing a typo in a CSS class name.
-
-1. We discover the class name `.govuk-visually-hidden-focussable` includes the typo 'focussable'
-2. We raise a pull request that renames the class to `.govuk-visually-hidden-focusable` while keeping
-the previous class available.
-3. We add a comment to the source code that indicates this is deprecated, and raise an issue to remove it in a future breaking release.
-4. When releasing the change we include a clear summary that indicates what was the problem, what we've changed and how a user can migrate before the future breaking release.
-
-Sometimes it is not possible to deprecate code, this is OK but try to make this a last resort.
-
-### Sass doc deprecation annotations
-
-When deprecating Sass, you can use the [deprecated annotation](http://sassdoc.com/annotations/#deprecated).
-
-If there is an alias, for example if you are renaming something, you can use the [alias annotation](http://sassdoc.com/annotations/#alias).
-
-See [an example of deprecating a Sass mixin on GitHub](https://github.com/alphagov/govuk-frontend/blob/9424d87ed54764d2d8afe35d6e0077ee43d231e1/src/helpers/_grid.scss#L20-L26).
-
-## Migration
-
-Migration is the practice of a user moving from one approach to an equivalent approach.
-
-It is very important that we make it easy to migrate when we make deprecations.
-
-If possible include clear steps for users should update their code directly in the CHANGELOG entry that introduces the deprecation.
 
 ## Public API
 
@@ -109,9 +75,9 @@ Internal changes to the project that are not part of the public API do not need 
 
 These sections follow [semantic versioning](https://semver.org/), where:
 
-- `Breaking changes` corresponds to a `major` (1.X.X) change.
-- `New features` corresponds to a `minor` (X.1.X) change.
-- `Fixes` corresponds to a `patch` (X.X.1) change.
+- Breaking changes correspond to a `major` (1.X.X) change.
+- New features or deprecations correspond to a `minor` (X.1.X) change.
+- Bug fixes correspond to a `patch` (X.X.1) change.
 
 See the [`CHANGELOG_TEMPLATE.md`](/docs/contributing/CHANGELOG_TEMPLATE.md) for an example for how this looks.
 


### PR DESCRIPTION
Split out the documentation on deprecations from the versioning documentation, as the new documentation supercedes it.