### PR TITLE
Add missing ID to select example

### DIFF
--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -310,6 +310,7 @@ examples:
     hidden: true
     data:
       name: colors
+      id: colors
       items:
         - value: red
           text: Red


### PR DESCRIPTION
The example added in f321a1c is missing an id.

The id Nunjucks option is required, as a valid id attribute is required on the select element in order to create the association with the label.

Add an appropriate id to the example.

Fixes #2683.