### PR TITLE
Update header macro documentation for `navigationLabel` and `menuButtonLabel`

### DIFF
--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -51,11 +51,11 @@ params:
 - name: navigationLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the navigation. Defaults to 'Navigation menu'.
+  description: Text for the `aria-label` attribute of the navigation. Defaults to 'Menu'.
 - name: menuButtonLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide navigation menu'.
+  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide menu'.
 - name: containerClasses
   type: string
   required: false


### PR DESCRIPTION
We removed the redundant 'navigation' text in the navigationLabel and
menuButtonLabel in https://github.com/alphagov/govuk-frontend/commit/aed4b3e60f991d47595f4af7a7d03c8ff7f22455

However, we didn't update the macro documentation to match.

This commit updates the macro documentation to the correct defaults.