### PR TITLE
Update link to contribution guidance in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Open Government 3.0 licence.
 
 ## Contributing
 
-[To learn how to help us build GOV.UK Frontend, see our contribution guidelines.](https://github.com/alphagov/govuk-frontend/blob/f07569c9e7724606970c0d2764f1e9ce7fa14092/CONTRIBUTING.md)
+[To learn how to help us build GOV.UK Frontend, see our contribution guidelines.](CONTRIBUTING.md)
 
 The govuk-frontend repository is public and we welcome contributions from anyone.
 


### PR DESCRIPTION
The link to the contribution guidance in the readme was linking to a specific version of the guidance. This means that updates to the guidance when navigated to from the readme would be lost. This change ensures it stays up to date.