### PR TITLE
Add a Github issue template for spikes

### DIFF
--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -20,6 +20,7 @@ assignees: ''
 <!-- Any assumptions about this piece of work which may be helpful to document -->
 
 ## Timebox
+<!-- e.g: 2 days -->
 We should review progress after this period of time has elapsed, even [if the spike has not been 'completed'](https://docs.google.com/document/d/17W_d0aYszgh7HTgnTHZLxXDu_TJyu8zzWt_lXH8VaHA/edit#heading=h.jd56itytegn6)
 
 ## Who is working on this?

--- a/.github/ISSUE_TEMPLATE/spike.md
+++ b/.github/ISSUE_TEMPLATE/spike.md
@@ -1,0 +1,45 @@
+---
+name: "Spike"
+about: For internal use only - issue template for spikes, research and investigation pieces
+title: ''
+labels: '🔍 investigation'
+assignees: ''
+
+---
+
+<!--
+  This is a template for creating issues for spikes, research and investigation pieces.
+  If you're unsure whether a spike is appropriate, read this guidance on using spikes: https://docs.google.com/document/d/17W_d0aYszgh7HTgnTHZLxXDu_TJyu8zzWt_lXH8VaHA/edit#
+-->
+
+## What
+
+## Why
+
+## Assumptions
+<!-- Any assumptions about this piece of work which may be helpful to document -->
+
+## Timebox
+We should review progress after this period of time has elapsed, even [if the spike has not been 'completed'](https://docs.google.com/document/d/17W_d0aYszgh7HTgnTHZLxXDu_TJyu8zzWt_lXH8VaHA/edit#heading=h.jd56itytegn6)
+
+## Who is working on this?
+<!-- We have agreed as a team to trial a process where each spike has a 'lead' and a 'buddy'. It is up to the lead and buddy to agree how much involvement the buddy has. This may vary depending on what the spike is, ranging from heavily involved (pairing) to less involved (reviewing/bouncing ideas off) -->
+
+Spike lead:
+
+Spike buddy:
+
+## Questions to answer
+<!-- Remember, smaller and more defined questions are easier to focus in on -->
+
+- [ ] Questions go here...
+
+
+## Done when
+<!-- Template ‘done when ‘ criteria have automatically been added - add/remove/tweak these as appropriate -->
+
+You may find it helpful to refer to our [expected outcomes of spikes](https://docs.google.com/document/d/17W_d0aYszgh7HTgnTHZLxXDu_TJyu8zzWt_lXH8VaHA/edit#heading=h.mmkqzigd11rs).
+
+- [ ] Questions have been answered or we have a clearer idea of how to get to our goal
+- [ ] Findings have been reviewed and agreed with at least one other person
+- [ ] Findings have been shared, e.g: via a write-up on the ticket, at a show & tell or team meeting


### PR DESCRIPTION
A Github issue template for spikes, research and investigative pieces of work.
This template is accompanied by [a doc in the Google Drive](https://docs.google.com/document/d/17W_d0aYszgh7HTgnTHZLxXDu_TJyu8zzWt_lXH8VaHA/edit#) which it links out to, which could also do with a review.