### PR TITLE
Deprecate `.govuk-header__navigation--no-service-name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Deprecated features
+
+#### Remove deprecated `govuk-header__navigation--no-service-name` class in the header
+
+We've deprecated the `govuk-header__navigation--no-service-name` class, and will remove it in a future major release.
+
+This change was introduced in [pull request #2694: Deprecate `.govuk-header__navigation--no-service-name`](https://github.com/alphagov/govuk-frontend/pull/2694).
+
 ### Fixes
 
 In [pull request 2678: Replace ex units with ems for input lengths](https://github.com/alphagov/govuk-frontend/pull/2678), we changed how we define input lengths in our CSS. Browsers might now display these inputs as being slightly wider than before. The difference is usually fewer than 3 pixels.  

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -259,6 +259,8 @@
     }
   }
 
+  // The govuk-header__navigation--no-service-name class is deprecated and will
+  // be removed in the next major release.
   .govuk-header__navigation--no-service-name {
     padding-top: govuk-spacing(7);
   }


### PR DESCRIPTION
Marks the `.govuk-header__navigation--no-service-name` as having been deprecated in our Sass and changelog, as per #2216.

The class is not documented in our docs or review app, serves a dubiously useful use case, and I couldn't find any instances of it being used when searching public GitHub repos, with it only appearing in forks of Frontend and automatically-generated documentation.