### PR TITLE
Allow localisation of content licence and copyright notices in Footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Additionally, the default Open Graph image URL meta tag will now only be include
 
 This change was introduced in [pull request #2673: Allow Open Graph image URL to be customised](https://github.com/alphagov/govuk-frontend/pull/2673).
 
+#### Localise the content licence and copyright statements
+
+When using the [footer](https://design-system.service.gov.uk/components/footer/) Nunjucks macro, you can now translate the text of the Open Government Licence (OGL) and Crown copyright statements using the `contentLicence` and `copyright` parameters.
+
+Visit The National Archives' [documentation on OGL and Crown copyright](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/open-government-licence/copyright-notices-attribution-statements/) for information on what needs to be included in these statements.
+
+This was added in [pull request #2702: Allow localisation of content licence and copyright notices in Footer](https://github.com/alphagov/govuk-frontend/pull/2702).
+
 ### Deprecated features
 
 #### Remove deprecated `govuk-header__navigation--no-service-name` class in the header

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -67,6 +67,32 @@ params:
       type: object
       required: false
       description: HTML attributes (for example data attributes) to add to the anchor in the footer navigation section.
+- name: contentLicence
+  type: object
+  required: false
+  description: Object containing options for the content licence.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. If neither are provided, the text for the Open Government Licence is used.
+  - name: html
+    type: string
+    required: false
+    description: If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. If neither are provided, the text for the Open Government Licence is used. The content licence is inside a `<span>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it.
+- name: copyright
+  type: object
+  required: false
+  description: Object containing options for the copyright notice.
+  params:
+  - name: text
+    type: string
+    required: false
+    description: If `html` is set, this is not required. If `html` is provided, the `text` option will be ignored. If neither are provided, Crown copyright is used.
+  - name: html
+    type: string
+    required: false
+    description: If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. If neither are provided, Crown copyright is used. The copyright notice is inside an `<a>` element, so you can only use text formatting elements within it.
 - name: containerClasses
   type: string
   required: false
@@ -116,6 +142,22 @@ examples:
 - name: default
   data:
     {}
+
+- name: with custom HTML content licence and copyright notice
+  description: Open Government Licence and Crown copyright notice translated into Welsh
+  data:
+    contentLicence:
+      html: 'Mae’r holl gynnwys ar gael dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, ac eithrio lle nodir yn wahanol'
+    copyright:
+      html: '<span>Hawlfraint y Goron</span>'
+
+- name: with custom text content licence and copyright notice
+  description: Open Government Licence and Crown copyright notice translated into Welsh
+  data:
+    contentLicence:
+      text: 'Mae’r holl gynnwys ar gael dan Drwydded y Llywodraeth Agored v3.0, ac eithrio lle nodir yn wahanol'
+    copyright:
+      text: '© Hawlfraint y Goron'
 
 - name: with meta
   description: Secondary navigation with meta information relating to the site
@@ -378,6 +420,13 @@ examples:
   hidden: true
   data:
     containerClasses: app-width-container
+- name: with HTML passed as text content
+  hidden: true
+  data:
+    contentLicence:
+      text: 'Mae’r holl gynnwys ar gael dan <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>, ac eithrio lle nodir yn wahanol'
+    copyright:
+      text: '<span>Hawlfraint y Goron</span>'
 - name: with empty meta
   hidden: true
   data:

--- a/src/govuk/components/footer/template.njk
+++ b/src/govuk/components/footer/template.njk
@@ -68,19 +68,29 @@
           />
         </svg>
         <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license"
-          >Open Government Licence v3.0</a>, except where otherwise stated
+          {% if params.contentLicence.html or params.contentLicence.text %}
+            {{ params.contentLicence.html | safe if params.contentLicence.html else params.contentLicence.text }}
+          {% else %}
+            All content is available under the
+            <a
+              class="govuk-footer__link"
+              href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+              rel="license"
+            >Open Government Licence v3.0</a>, except where otherwise stated
+          {% endif %}
         </span>
       </div>
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-        >© Crown copyright</a>
+        >
+          {%- if params.copyright.html or params.copyright.text -%}
+            {{ params.copyright.html | safe if params.copyright.html else params.copyright.text }}
+          {%- else -%}
+            © Crown copyright
+          {%- endif -%}
+        </a>
       </div>
     </div>
   </div>

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -207,4 +207,64 @@ describe('footer', () => {
       expect($sectionBreak.length).toBeFalsy()
     })
   })
+
+  describe('content licence', () => {
+    it('is visible', () => {
+      const $ = render('footer', examples.default)
+
+      const $licenceMessage = $('.govuk-footer__licence-description')
+      expect($licenceMessage.text()).toContain('Open Government Licence v3.0')
+    })
+
+    it('can be customised with `text` parameter', () => {
+      const $ = render('footer', examples['with custom text content licence and copyright notice'])
+
+      const $licenceMessage = $('.govuk-footer__licence-description')
+      expect($licenceMessage.text()).toContain('Drwydded y Llywodraeth Agored v3.0')
+    })
+
+    it('can be customised with `html` parameter', () => {
+      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
+
+      const $licenceMessage = $('.govuk-footer__licence-description')
+      expect($licenceMessage.html()).toContain('<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>')
+    })
+
+    it('escapes HTML in the `text` parameter', () => {
+      const $ = render('footer', examples['with HTML passed as text content'])
+
+      const $licenceMessage = $('.govuk-footer__licence-description')
+      expect($licenceMessage.html()).toContain('&lt;a class=&quot;govuk-footer__link&quot; href=&quot;https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/&quot; rel=&quot;license&quot;&gt;Drwydded y Llywodraeth Agored v3.0&lt;/a&gt;')
+    })
+  })
+
+  describe('crown copyright', () => {
+    it('is visible', () => {
+      const $ = render('footer', examples.default)
+
+      const $copyrightMessage = $('.govuk-footer__copyright-logo')
+      expect($copyrightMessage.text()).toContain('© Crown copyright')
+    })
+
+    it('can be customised with `text` parameter', () => {
+      const $ = render('footer', examples['with custom text content licence and copyright notice'])
+
+      const $copyrightMessage = $('.govuk-footer__copyright-logo')
+      expect($copyrightMessage.text()).toContain('© Hawlfraint y Goron')
+    })
+
+    it('can be customised with `html` parameter', () => {
+      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
+
+      const $copyrightMessage = $('.govuk-footer__copyright-logo')
+      expect($copyrightMessage.html()).toContain('<span>Hawlfraint y Goron</span>')
+    })
+
+    it('escapes HTML in the `text` parameter', () => {
+      const $ = render('footer', examples['with HTML passed as text content'])
+
+      const $copyrightMessage = $('.govuk-footer__copyright-logo')
+      expect($copyrightMessage.html()).toContain('&lt;span&gt;Hawlfraint y Goron&lt;/span&gt;')
+    })
+  })
 })


### PR DESCRIPTION
This are the bare minimum changes needed for enable localisation of the Footer component's content licence and copyright notices. In this case, it is assumed that an Open Government Licence (OGL) and Crown copyright are still being used, and that the notices are only being translated into another language.

This differs slightly from the internationalisation spike work, as I've split the `contentLicence` and `copyright` parameters into `html` and `text` versions to facilitate extending them with more options, as described below. 

---

Issues #1290 and #1291 originally asked that it be possible to remove the OGL and Crown graphics. This hasn't been done in this PR, as it isn't strictly needed for the current localisation work and (for the most part) public-facing GOV.UK services will have been made available under OGL and Crown copyright. 

I've created a version of this work with more customisation options, including changing/removing the Crown copyright URL and removing the licence/copyright graphics, as a separate branch. You can [compare those branches here](https://github.com/alphagov/govuk-frontend/compare/kg-footer-i18n..kg-footer-i18n-extended). Whether we consider these changes necessary or not is up for discussion!