### PR TITLE
Redirect Sass docs when running on Heroku

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -13,6 +13,8 @@ const helperFunctions = require('../lib/helper-functions')
 const fileHelper = require('../lib/file-helper')
 const configPaths = require('../config/paths.json')
 
+const isDeployedToHeroku = !!process.env.HEROKU_APP
+
 const appViews = [
   configPaths.layouts,
   configPaths.views,
@@ -65,7 +67,13 @@ module.exports = (options) => {
   // Set up middleware to serve static assets
   app.use('/public', express.static(configPaths.public))
 
-  app.use('/docs', express.static(configPaths.sassdoc))
+  env.addGlobal('isDeployedToHeroku', isDeployedToHeroku)
+
+  if (isDeployedToHeroku) {
+    app.use('/docs', (req, res) => res.redirect('https://frontend.design-system.service.gov.uk/sass-api-reference/'))
+  } else {
+    app.use('/docs', express.static(configPaths.sassdoc))
+  }
 
   // serve html5-shiv from node modules
   app.use('/vendor/html5-shiv/', express.static('node_modules/html5shiv/dist/'))

--- a/app/views/index.njk
+++ b/app/views/index.njk
@@ -37,10 +37,13 @@
       {% endfor %}
       </ul>
 
-      <h2 class="govuk-heading-m">Misc</h2>
+      <h2 class="govuk-heading-m">Sass Documentation</h2>
 
       <ul class="govuk-list">
-        <li><a href="/docs" class="govuk-link">Sass Documentation</a></li>
+        <li><a href="https://frontend.design-system.service.gov.uk/sass-api-reference/" class="govuk-link">Latest release</a></li>
+        {% if not isDeployedToHeroku %}
+        <li><a href="/docs" class="govuk-link">Local version</a></li>
+        {% endif %}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
When running on Heroku (based on the presence of the `HEROKU_APP` environment variable set in `app.json`):

- link to the live API reference docs from the homepage of the review app
- redirect requests for `/docs` to the live API reference docs

This avoids the confusion of having two ‘live’ versions of the Sass docs available, whilst redirecting anyone who may have the existing docs bookmarked.

However, it’s still useful to be able to run the 'generic' Sass docs locally so that we can use it to preview documentation before we do a release. As such, when running locally:

- link to both the live API reference docs and the ‘local’ docs from the homepage of the review app
- preserve the existing behaviour of serving the locally generate Sass docs when visiting `/docs`

Closes #1892.