### PR TITLE
Remove redundant `aria-hidden` attribute from the content when using the Details polyfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ We’ve also made fixes in the following pull requests:
 - [#2668: Fix Summary List action link alignment](https://github.com/alphagov/govuk-frontend/pull/2668)
 - [#2670: Define mininimum width for select component](https://github.com/alphagov/govuk-frontend/pull/2670)
 - [#2723: Style accordion and tabs text content with `govuk-body` class](https://github.com/alphagov/govuk-frontend/pull/2723)
+- [#2724: Remove redundant `aria-hidden` attribute from the content when using the Details polyfill](https://github.com/alphagov/govuk-frontend/pull/2724)
 
 ## 4.2.0 (Feature release)
 

--- a/src/govuk/components/details/details.mjs
+++ b/src/govuk/components/details/details.mjs
@@ -65,8 +65,7 @@ Details.prototype.polyfillDetails = function () {
   $summary.tabIndex = 0
 
   // Detect initial open state
-  var openAttr = $module.getAttribute('open') !== null
-  if (openAttr === true) {
+  if (this.$module.hasAttribute('open')) {
     $summary.setAttribute('aria-expanded', 'true')
   } else {
     $summary.setAttribute('aria-expanded', 'false')
@@ -82,21 +81,14 @@ Details.prototype.polyfillDetails = function () {
 * @param {object} summary element
 */
 Details.prototype.polyfillSetAttributes = function () {
-  var $module = this.$module
-  var $summary = this.$summary
-  var $content = this.$content
-
-  var expanded = $summary.getAttribute('aria-expanded') === 'true'
-
-  $summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
-
-  $content.style.display = (expanded ? 'none' : '')
-
-  var hasOpenAttr = $module.getAttribute('open') !== null
-  if (!hasOpenAttr) {
-    $module.setAttribute('open', 'open')
+  if (this.$module.hasAttribute('open')) {
+    this.$module.removeAttribute('open')
+    this.$summary.setAttribute('aria-expanded', 'false')
+    this.$content.style.display = 'none'
   } else {
-    $module.removeAttribute('open')
+    this.$module.setAttribute('open', 'open')
+    this.$summary.setAttribute('aria-expanded', 'true')
+    this.$content.style.display = ''
   }
 
   return true

--- a/src/govuk/components/details/details.mjs
+++ b/src/govuk/components/details/details.mjs
@@ -68,10 +68,8 @@ Details.prototype.polyfillDetails = function () {
   var openAttr = $module.getAttribute('open') !== null
   if (openAttr === true) {
     $summary.setAttribute('aria-expanded', 'true')
-    $content.setAttribute('aria-hidden', 'false')
   } else {
     $summary.setAttribute('aria-expanded', 'false')
-    $content.setAttribute('aria-hidden', 'true')
     $content.style.display = 'none'
   }
 
@@ -89,10 +87,8 @@ Details.prototype.polyfillSetAttributes = function () {
   var $content = this.$content
 
   var expanded = $summary.getAttribute('aria-expanded') === 'true'
-  var hidden = $content.getAttribute('aria-hidden') === 'true'
 
   $summary.setAttribute('aria-expanded', (expanded ? 'false' : 'true'))
-  $content.setAttribute('aria-hidden', (hidden ? 'false' : 'true'))
 
   $content.style.display = (expanded ? 'none' : '')
 

--- a/src/govuk/components/details/details.test.js
+++ b/src/govuk/components/details/details.test.js
@@ -45,13 +45,15 @@ describe('details', () => {
       expect(summaryAriaExpanded).toBe('false')
     })
 
-    it('should present the content as hidden using aria-hidden', async () => {
+    it('should hide the content using display: none', async () => {
       await page.goto(baseUrl + '/examples/details-polyfill', { waitUntil: 'load' })
 
-      const hiddenContainerAriaHidden = await page.evaluate(() => {
-        return document.getElementById('default').querySelector('.govuk-details__text').getAttribute('aria-hidden')
+      const containerDisplay = await page.evaluate(() => {
+        const container = document.getElementById('default').querySelector('.govuk-details__text')
+        return window.getComputedStyle(container).getPropertyValue('display')
       })
-      expect(hiddenContainerAriaHidden).toBe('true')
+
+      expect(containerDisplay).toBe('none')
     })
 
     it('should indicate the open state of the content', async () => {
@@ -75,15 +77,17 @@ describe('details', () => {
         expect(summaryAriaExpanded).toBe('true')
       })
 
-      it('should indicate the visible state of the content using aria-hidden', async () => {
+      it('should make the content visible', async () => {
         await page.goto(baseUrl + '/examples/details-polyfill', { waitUntil: 'load' })
 
         await page.click('#default summary')
 
-        const hiddenContainerAriaHidden = await page.evaluate(() => {
-          return document.getElementById('default').querySelector('.govuk-details__text').getAttribute('aria-hidden')
+        const containerDisplay = await page.evaluate(() => {
+          const container = document.getElementById('default').querySelector('.govuk-details__text')
+          return window.getComputedStyle(container).getPropertyValue('display')
         })
-        expect(hiddenContainerAriaHidden).toBe('false')
+
+        expect(containerDisplay).toBe('block')
       })
 
       it('should indicate the open state of the content', async () => {
@@ -109,13 +113,15 @@ describe('details', () => {
       expect(summaryAriaExpanded).toBe('true')
     })
 
-    it('should indicate the visible state of the content using aria-hidden', async () => {
+    it('should keep the content visible', async () => {
       await page.goto(baseUrl + '/examples/details-polyfill', { waitUntil: 'load' })
 
-      const hiddenContainerAriaHidden = await page.evaluate(() => {
-        return document.getElementById('expanded').querySelector('.govuk-details__text').getAttribute('aria-hidden')
+      const containerDisplay = await page.evaluate(() => {
+        const container = document.getElementById('expanded').querySelector('.govuk-details__text')
+        return window.getComputedStyle(container).getPropertyValue('display')
       })
-      expect(hiddenContainerAriaHidden).toBe('false')
+
+      expect(containerDisplay).toBe('block')
     })
 
     it('should indicate the open state of the content', async () => {
@@ -150,15 +156,17 @@ describe('details', () => {
         expect(summaryAriaExpanded).toBe('false')
       })
 
-      it('should indicate the visible state of the content using aria-hidden', async () => {
+      it('should hide the content using display: none', async () => {
         await page.goto(baseUrl + '/examples/details-polyfill', { waitUntil: 'load' })
 
         await page.click('#expanded summary')
 
-        const hiddenContainerAriaHidden = await page.evaluate(() => {
-          return document.getElementById('expanded').querySelector('.govuk-details__text').getAttribute('aria-hidden')
+        const containerDisplay = await page.evaluate(() => {
+          const container = document.getElementById('expanded').querySelector('.govuk-details__text')
+          return window.getComputedStyle(container).getPropertyValue('display')
         })
-        expect(hiddenContainerAriaHidden).toBe('true')
+
+        expect(containerDisplay).toBe('none')
       })
 
       it('should indicate the open state of the content', async () => {


### PR DESCRIPTION
As discussed in https://github.com/alphagov/govuk-design-system/pull/2261#issuecomment-1192385380, when `$content` is hidden it is removed from the accessibility tree through the use of `display: none;`. The `aria-hidden` attribute is redundant and can be removed:

> If an interactive element is hidden using display:none or visibility:hidden (either on the element itself, or any of the element's ancestors), it won't be focusable, and it will also be removed from the accessibility tree. This makes the addition of aria-hidden="true" or explicitly setting tabindex="-1" unnecessary.
>
> https://www.w3.org/TR/using-aria/#4thrule

I've also tried to simplify the function slightly by:

- setting all of the attributes based on the `open` attribute to avoid the possibility of the different attributes getting out of sync
- setting everything in one logical flow rather than setting some things using ternary and some things in an if/else

(It's probably easier to review the 2 commits individually)