### PR TITLE
Remove padding-right from last column in summary list row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ We’ve also made fixes in the following pull requests:
 - [#2670: Define mininimum width for select component](https://github.com/alphagov/govuk-frontend/pull/2670)
 - [#2723: Style accordion and tabs text content with `govuk-body` class](https://github.com/alphagov/govuk-frontend/pull/2723)
 - [#2724: Remove redundant `aria-hidden` attribute from the content when using the Details polyfill](https://github.com/alphagov/govuk-frontend/pull/2724)
+- [#2725: Remove padding-right from last column in summary list row](https://github.com/alphagov/govuk-frontend/pull/2725)
 
 ## 4.2.0 (Feature release)
 

--- a/src/govuk/components/summary-list/_index.scss
+++ b/src/govuk/components/summary-list/_index.scss
@@ -24,7 +24,7 @@
   }
 
   // Remove right padding from the last column in the row
-  .govuk-summary-list__row > :last-child {
+  .govuk-summary-list__row:not(.govuk-summary-list__row--no-actions) > :last-child {
     padding-right: 0;
   }
 

--- a/src/govuk/components/summary-list/_index.scss
+++ b/src/govuk/components/summary-list/_index.scss
@@ -23,6 +23,11 @@
     }
   }
 
+  // Remove right padding from the last column in the row
+  .govuk-summary-list__row > :last-child {
+    padding-right: 0;
+  }
+
   // Provide an empty 'cell' for rows that don't have actions – otherwise the
   // bottom border is not drawn for that part of the row in some browsers.
   .govuk-summary-list__row--no-actions {
@@ -52,7 +57,7 @@
     margin-bottom: govuk-spacing(3);
     @include govuk-media-query($from: tablet) {
       width: 20%;
-      padding-right: 0;
+      padding-right: 0; // Needed for IE8
       text-align: right;
     }
   }


### PR DESCRIPTION
Tiny change to CSS so that the last column in a summary list always has right padding removed, not only if the last column is an actions column. Resolves #1928. 

The line that removes right padding from the actions column has been maintained for IE8, which doesn't support `:last-child`.