### PR TITLE
Hide character count example intended for tests from review app

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -233,6 +233,7 @@ examples:
       label:
         text: Can you provide more detail?
   - name: with id with special characters
+    hidden: true
     data:
       id: user1.profile[address]
       name: address


### PR DESCRIPTION
Little cleanup thing. 

The 'Character count with ID with special characters' exists for automated testing purposes and is grouped with similar examples, the rest of which are hidden. This example is missing the `hidden` flag, however, so appears in the review app.

This PR adds the missing `hidden` flag. 