### PR TITLE
Update various components to be callable

### DIFF
--- a/src/govuk/components/details/details.yaml
+++ b/src/govuk/components/details/details.yaml
@@ -15,6 +15,10 @@ params:
   type: string
   required: true
   description: If `text` is set, this is not required. HTML to use within the disclosed part of the details element. If `html` is provided, the `text` option will be ignored.
+- name: caller
+  type: nunjucks-block
+  required: false
+  description: Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire details component in a `call` block.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/details/template.njk
+++ b/src/govuk/components/details/template.njk
@@ -5,6 +5,6 @@
     </span>
   </summary>
   <div class="govuk-details__text">
-    {{ params.html | safe if params.html else params.text }}
+    {{ caller() if caller else (params.html | safe if params.html else params.text) }}
   </div>
 </details>

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -53,6 +53,12 @@ describe('Details', () => {
     expect($summary.get(0).tagName).toEqual('summary')
   })
 
+  it('renders nested components using `call`', () => {
+    const $ = render('details', {}, '<div class="app-nested-component"></div>')
+
+    expect($('.govuk-details .app-nested-component').length).toBeTruthy()
+  })
+
   it('allows text to be passed whilst escaping HTML entities', () => {
     const $ = render('details', examples['html as text'])
 

--- a/src/govuk/components/inset-text/inset-text.yaml
+++ b/src/govuk/components/inset-text/inset-text.yaml
@@ -7,6 +7,10 @@ params:
   type: string
   required: true
   description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` option will be ignored.
+- name: caller
+  type: nunjucks-block
+  required: false
+  description: Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire inset text component in a `call` block.
 - name: id
   type: string
   required: false

--- a/src/govuk/components/inset-text/template.njk
+++ b/src/govuk/components/inset-text/template.njk
@@ -1,4 +1,4 @@
 <div {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-inset-text {%- if params.classes %} {{ params.classes }}{% endif %}"
 {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  {{ params.html | safe if params.html else params.text }}
+  {{ caller() if caller else (params.html | safe if params.html else params.text) }}
 </div>

--- a/src/govuk/components/inset-text/template.test.js
+++ b/src/govuk/components/inset-text/template.test.js
@@ -32,6 +32,12 @@ describe('Inset text', () => {
       expect($component.attr('id')).toEqual('my-inset-text')
     })
 
+    it('renders nested components using `call`', () => {
+      const $ = render('inset-text', {}, '<div class="app-nested-component"></div>')
+
+      expect($('.govuk-inset-text .app-nested-component').length).toBeTruthy()
+    })
+
     it('allows text to be passed whilst escaping HTML entities', () => {
       const $ = render('inset-text', examples['html as text'])
 

--- a/src/govuk/components/panel/panel.yaml
+++ b/src/govuk/components/panel/panel.yaml
@@ -19,6 +19,10 @@ params:
   type: string
   required: true
   description: If `text` is set, this is not required. HTML to use within the panel content. If `html` is provided, the `text` option will be ignored.
+- name: caller
+  type: nunjucks-block
+  required: false
+  description: Not strictly a parameter but [Nunjucks code convention](https://mozilla.github.io/nunjucks/templating.html#call). Using a `call` block enables you to call a macro with all the text inside the tag. This is helpful if you want to pass a lot of content into a macro. To use it, you will need to wrap the entire panel component in a `call` block.
 - name: classes
   type: string
   required: false

--- a/src/govuk/components/panel/template.njk
+++ b/src/govuk/components/panel/template.njk
@@ -5,9 +5,9 @@
   <h{{ headingLevel }} class="govuk-panel__title">
     {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
   </h{{ headingLevel }}>
-  {% if params.html or params.text %}
+  {% if caller or params.html or params.text %}
   <div class="govuk-panel__body">
-    {{ params.html | safe if params.html else params.text }}
+    {{ caller() if caller else (params.html | safe if params.html else params.text) }}
   </div>
   {% endif %}
 </div>

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -69,6 +69,12 @@ describe('Panel', () => {
       expect(panelTitle).toEqual('Application <strong>not</strong> complete')
     })
 
+    it('renders nested components using `call`', () => {
+      const $ = render('panel', {}, '<div class="app-nested-component"></div>')
+
+      expect($('.govuk-panel .app-nested-component').length).toBeTruthy()
+    })
+
     it('allows body text to be passed whilst escaping HTML entities', () => {
       const $ = render('panel', examples['body html as text'])
 


### PR DESCRIPTION
Updates various components to be [callable](https://mozilla.github.io/nunjucks/templating.html#call). 

Callers make it easier for users of the Design System to pass large amounts of HTML directly into a component, without having to first assign it to a variable and then pass it to the `html` parameter. 

Suggested in #941, and based on the list of components I commented there, with some changes. 

---

I intend to make these components callable. In all situations, the called content will replace and take priority over the `html` and `text` parameters. 

- [x] Details 
- [ ] Error summary (replacing the `descriptionHtml` and `descriptionText` parameters)
- [x] Inset text
- [ ] Notification banner
- [x] Panel

I'm no longer considering the following components:

- Cookie banner: This component accepts looping content to allow for segregating consent into multiple groups. This is incompatible with using a caller, which only supports one slot of called content per component. 
- Warning text: The main text of this component is presented inside of a `<strong>` element, negating the usefulness of using a caller, as it's unlikely to ever be more than one line of text.


