### PR TITLE
Error message and summary list translated examples

### DIFF
--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -43,6 +43,11 @@ examples:
   data:
     text: Error message about full name goes here
 
+- name: translated
+  data:
+    visuallyHiddenText: false
+    html: <span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma
+
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 - name: id
   hidden: true

--- a/src/govuk/components/error-message/template.test.js
+++ b/src/govuk/components/error-message/template.test.js
@@ -73,4 +73,11 @@ describe('Error message', () => {
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('There is an error on line 42')
   })
+
+  it('allows the visually hidden prefix to be removed and then manually added with HTML', () => {
+    const $ = render('error-message', examples.translated)
+
+    const $component = $('.govuk-error-message')
+    expect($component.html().trim()).toContain('<span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma')
+  })
 })

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -145,6 +145,49 @@ examples:
               - href: '#'
                 text: Change
                 visuallyHiddenText: contact information
+  - name: translated
+    data:
+      rows:
+        - key:
+            text: Enw
+          value:
+            text: Firstname Lastname
+          actions:
+            items:
+              - href: '#'
+                html: Golygu<span class="govuk-visually-hidden"> enw</span>
+                visuallyHiddenText: false
+              - href: '#'
+                html: Dileu<span class="govuk-visually-hidden"> enw</span>
+                visuallyHiddenText: false
+        - key:
+            text: Dyddiad geni
+          value:
+            text: 13/08/1980
+          actions:
+            items:
+              - href: '#'
+                html: Golygu<span class="govuk-visually-hidden"> dyddiad geni</span>
+                visuallyHiddenText: false
+        - key:
+            text: Gwybodaeth cyswllt
+          value:
+            html: |
+              <p class="govuk-body">
+               email@email.com
+              </p>
+              <p class="govuk-body">
+                Address line 1<br>
+                Address line 2<br>
+                Address line 3<br>
+                Address line 4<br>
+                Address line 5
+              </p>
+          actions:
+            items:
+              - href: '#'
+                html: Golygu<span class="govuk-visually-hidden"> gwybodaeth cyswllt</span>
+                visuallyHiddenText: false
   - name: with some actions
     data:
       rows:

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -137,6 +137,15 @@ describe('Summary list', () => {
         expect($actionLink.html()).toContain('Edit<span class="visually-hidden"> name</span>')
       })
 
+      it('allows the visually hidden prefix to be removed and then manually added with HTML', async () => {
+        const $ = render('summary-list', examples.translated)
+
+        const $component = $('.govuk-summary-list')
+        const $actionLink = $component.find('.govuk-summary-list__actions > a')
+
+        expect($actionLink.html()).toContain('Golygu<span class="govuk-visually-hidden"> dyddiad geni</span>')
+      })
+
       it('renders custom accessible name', async () => {
         const $ = render('summary-list', examples['with actions'])
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2690

## What
Add visual examples to the review app for translating the error message and summary list actions.
Add tests for translating the error message and summary list actions.

## Why
Both components have hardcoded visually hidden text. To translate these you can use a bit of a workaround - remove the visually hidden text using `visuallyHiddenText: false` and setting your own `html` which includes the visually hidden text.

We should have examples and tests for this, so we don't change the logic without considering this use case.