### PR TITLE
Add ability to customise character count fallback text

### DIFF
--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -26,7 +26,7 @@ describe('Character count', () => {
       await page.setJavaScriptEnabled(true)
     })
 
-    it('shows the static message', async () => {
+    it('shows the fallback message', async () => {
       await goToExample()
       const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
@@ -318,6 +318,15 @@ describe('Character count', () => {
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
+    })
+  })
+
+  describe('custom options', () => {
+    it('allows customisation of the fallback message', async () => {
+      await goToExample('with-custom-fallback-text')
+      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+
+      expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
     })
   })
 })

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -40,7 +40,7 @@ params:
 - name: fallbackHintText
   type: string
   required: false
-  description: Text describing the maximum number of characters or words that can be entered, which is announced to screen readers and displayed as a fallback if the character count JavaScript does not run. Instances of `%{count}` within the hint will be replaced by the value of `maxwords` if configured, otherwise it uses `maxlength`. By default, fallback text is provided in English based on what parameters are provided to the component.
+  description: Text describing the maximum number of characters you can enter, which is announced to screen readers. The text is displayed as a fallback if the character count JavaScript does not run. Depending on how you configure this component and what parameters you add, instances of `%{count}` are replaced by the value of `maxwords`. If not configured, it uses `maxlength`. By default, fallback text is provided in English.
 - name: errorMessage
   type: object
   required: false

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -37,6 +37,10 @@ params:
   required: false
   description: Options for the hint component.
   isComponent: true
+- name: fallbackHintText
+  type: string
+  required: false
+  description: Text describing the maximum number of characters or words that can be entered, which is announced to screen readers and displayed as a fallback if the character count JavaScript does not run. Instances of `%{count}` within the hint will be replaced by the value of `maxwords` if configured, otherwise it uses `maxlength`. By default, fallback text is provided in English based on what parameters are provided to the component.
 - name: errorMessage
   type: object
   required: false
@@ -81,6 +85,14 @@ examples:
       maxlength: 10
       label:
         text: Can you provide more detail?
+  
+  - name: with custom fallback text
+    description: with no-js fallback text translated into Welsh
+    data:
+      name: custom-fallback
+      id: custom-fallback
+      maxlength: 10
+      fallbackHintText: Gallwch ddefnyddio hyd at %{count} nod
 
   - name: with hint
     data:

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -26,8 +26,10 @@
     errorMessage: params.errorMessage,
     attributes: params.attributes
   }) }}
+  {%- set fallbackHintLength = params.maxwords or params.maxlength %}
+  {%- set fallbackHintDefault = 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {{ govukHint({
-    text: 'You can enter up to ' + (params.maxlength or params.maxwords) + (' words' if params.maxwords else ' characters'),
+    text: (params.fallbackHintText or fallbackHintDefault) | replace('%{count}', fallbackHintLength),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}


### PR DESCRIPTION
Adds a new Nunjucks parameter (`fallbackHintText`) which allows the user to customise the fallback message used on the character count in situations where JavaScript is not available. This text is also exposed to assistive technologies, regardless of JavaScript availability. 

It uses [Nunjucks' `replace` filter](https://mozilla.github.io/nunjucks/templating.html#replace) to swap instances of the string `%{count}` with the value of `maxwords`, if defined, or `maxlength`. 

Closes #2687.

## Questions
1. Does `fallbackHintText` make sense as the name for this parameter? It was named `limitHint` in the i18n tech spike, but I changed it here as this piece of text is commonly referred to as being the fallback and it helps avoid confusion with the live limit counter that the JS adds. 
2. Currently only one parameter is made available for customisation. Our English language default switches strings dynamically depending on whether we're counting characters or words, however this would only be possible with localisation if we provided two separate parameters—should we do so? 
3. Currently this doesn't support HTML. Does we want it to? 

> I'm keeping this in draft for the time being as this work doesn't really make sense without the equivalent JavaScript portion (a user is unlikely to customise one and not the other), and we probably want to merge them into main for the same release.