### PR TITLE
Fix issue with passport details example

### DIFF
--- a/app/views/full-page-examples/passport-details/index.js
+++ b/app/views/full-page-examples/passport-details/index.js
@@ -28,7 +28,7 @@ module.exports = (app) => {
       // If any of the date inputs error apply a general error.
       const expiryNamePrefix = 'expiry'
       const expiryErrors = Object.values(errors).filter(error => error.id.includes(expiryNamePrefix + '-'))
-      if (expiryErrors) {
+      if (expiryErrors.length) {
         const firstExpiryErrorId = expiryErrors[0].id
         // Get the first error message and merge it into a single error message.
         errors[expiryNamePrefix] = {


### PR DESCRIPTION
With the passport details full page example, if you fill in the expiry date correctly but leave the passport number blank then the review app throws an Internal Server Error:

```
TypeError: Cannot read properties of undefined (reading 'id')
    at /Users/oliver.byford/Code/govuk-frontend/app/views/full-page-examples/passport-details/index.js:33:52
    at Layer.handle [as handle_request] (/Users/oliver.byford/Code/govuk-frontend/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/oliver.byford/Code/govuk-frontend/node_modules/express/lib/router/route.js:137:13)
    at middleware (/Users/oliver.byford/Code/govuk-frontend/node_modules/express-validator/src/middlewares/check.js:16:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
        Server started at http://localhost:3000
```

This is because:

- `expiryErrors` is an empty array
- empty arrays are truthy in JavaScript (`[] == true`)
- we then try to get the id of the first element from the empty array

Instead, check `expiryErrors.length` which will be 0 when the array is empty, which is falsey in JavaScript.