### PR TITLE
Expand testing docs

### DIFF
--- a/docs/contributing/coding-standards/components.md
+++ b/docs/contributing/coding-standards/components.md
@@ -21,7 +21,7 @@ When creating your component, you should create the following files in the compo
 If your component uses JavaScript, you must also create the following files in the component’s folder:
 
       - `_[component-name].mjs`
-      - `_[component-name].test.js`
+      - `[component-name].test.js`
 
 ## Building your components
 

--- a/docs/contributing/coding-standards/components.md
+++ b/docs/contributing/coding-standards/components.md
@@ -20,7 +20,8 @@ When creating your component, you should create the following files in the compo
 
 If your component uses JavaScript, you must also create the following files in the component’s folder:
 
-      - `_[component-name].mjs`
+      - `[component-name].mjs`
+      - `[component-name].unit.test.mjs`
       - `[component-name].test.js`
 
 ## Building your components

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -77,6 +77,8 @@ You should write new tests if you’ve created a new component, or changed the w
 - changing or adding to the component's Nunjucks macro
 - creating or updating a Sass mixin or function
 
+If you're new to testing, see existing test files for examples of things to do. Do not let the tests keep you from submitting your contribution! If you're not sure which tests are needed or are having trouble updating them, submit your pull request anyway. We will help you create the tests and solve problems during code review.
+
 Test files use examples from each component’s `.yaml` file, for example `src/govuk/components/button/button.yaml`. When you add or update tests, you can use the existing examples or add new ones.
 
 Use `hidden: true` in a new example if you do not want to include the example in the review app. The example will still appear in our [test fixtures](http://frontend.design-system.service.gov.uk/testing-your-html/).

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -88,6 +88,8 @@ Some test files use examples from each component’s `.yaml` file, for example `
 
 Use `hidden: true` in a new example if you do not want to include the example in the review app. The example will still appear in our [test fixtures](http://frontend.design-system.service.gov.uk/testing-your-html/).
 
+All tests should try and meet [our testing conventions](../releasing/testing-and-linting#conventions)
+
 ### If you created a component
 
 Create the following files in the `src/govuk/components` folder:

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -65,11 +65,16 @@ You should test that your contribution works:
 
 ## 5. Run the automated tests
 
+Automated testing helps ensure that the code changes we make do not unintentionally break functionality.
+Tests are automatically run against a branch, pull request, or when the project is built for release, and will notify us if a test has failed.
+
 In your project folder, run `npm test` to run the automated tests, including linting.
 
 If a test fails, you should check your code for any errors, then update any tests you need to.
 
 ## 6. Write new tests
+
+You can [read more about the different types of tests in this project](../releasing/testing-and-linting).
 
 You should write new tests if you’ve created a new component, or changed the way a component works by:
 

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -84,7 +84,7 @@ You should write new tests if you’ve created a new component, or changed the w
 
 If you're new to testing, see existing test files for examples of things to do. Do not let the tests keep you from submitting your contribution! If you're not sure which tests are needed or are having trouble updating them, submit your pull request anyway. We will help you create the tests and solve problems during code review.
 
-Test files use examples from each component’s `.yaml` file, for example `src/govuk/components/button/button.yaml`. When you add or update tests, you can use the existing examples or add new ones.
+Some test files use examples from each component’s `.yaml` file, for example `src/govuk/components/button/button.yaml`. When you add or update these tests, you can use the existing examples or add new ones.
 
 Use `hidden: true` in a new example if you do not want to include the example in the review app. The example will still appear in our [test fixtures](http://frontend.design-system.service.gov.uk/testing-your-html/).
 
@@ -93,6 +93,7 @@ Use `hidden: true` in a new example if you do not want to include the example in
 Create the following files in the `src/govuk/components` folder:
 
 - `<COMPONENT>/<COMPONENT>.test.js` - to test functionality if the component uses JavaScript
+- `<COMPONENT>/<COMPONENT>.unit.test.mjs` - to unit test any JavaScript logic
 - `<COMPONENT>/template.test.js` - to test the Nunjucks macro
 
 Where `<COMPONENT>` is the name of the component you created.
@@ -104,6 +105,7 @@ You can use the existing files in the `src/govuk/components` folder as templates
 In the `src/govuk/components` folder, update or add tests to:
 
 - `<COMPONENT>/<COMPONENT>.test.js` - if you updated functionality
+- `<COMPONENT>/<COMPONENT>.unit.test.mjs` - if you updated JavaScript logic
 - `<COMPONENT>/template.test.js` - if you updated the Nunjucks macro
 
 Where `<COMPONENT>` is the name of the component you changed or added to.

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -68,7 +68,11 @@ You should also test component Javascript logic with unit tests, in a `[componen
 We write functional tests for checking our JavaScript exports and our global sass variables - see [all.test.js](../../src/govuk/all.test.js) for examples of global tests we run.
 
 ### Conventions
-We aim to write the description of our tests in as "natural language" as possible, for instance "back-link component fails to render if the required fields are not included".
+We aim to write the test descriptions in everyday language. For example, "back-link component fails to render if the required fields are not included".
+
+Keep all tests separate from each other. It should not matter the order or amount of tests you run from a test suite.
+
+Try and keep assertions small, so each test only checks for one thing. This makes tests more readable and makes it easier to see what's happening if a test is failing.
 
 ## Updating component snapshots
 For components, the snapshots are stored in `[component-name directory]/_snapshots_`.

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -83,7 +83,7 @@ If a snapshot test fails, review the difference in the console. If the change is
 
 This will update the snapshot file. Commit this file separately with a commit message that explains you're updating the snapshot file and an explanation of what caused the change.
 
-## Visual regression testing with Percy
+## Visual regression testing with [Percy](https://percy.io/)
 
 We generate 2 screenshots for each default example of every component. One example has JavaScript enabled, the other has JavaScript disabled. Screenshots are not taken for all the different variations of each component. This tool is not a replacement for manual testing.
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -31,11 +31,11 @@ See [Tasks](tasks.md) for details of what `npm test` does.
 ### Running individual tests
 You can run a subset of the test suite that only tests components by running:
 
-    `npm test -- --testPathPattern=src/govuk/components/button`
+    `npx jest src/govuk/components/button`
 
 Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
 
-    `npm test -- --watch src/govuk/components/button`
+    `npx jest --watch src/govuk/components/button`
 
 ### Running only SASS linting
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -41,7 +41,7 @@ We aim to write the description of our tests in as "natural language" as possibl
 ### Running individual tests
 You can run a subset of the test suite that only tests components by running:
 
-    `npm test -- src/govuk/components/button`
+    `npm test -- --testPathPattern=src/govuk/components/button`
 
 Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -16,9 +16,17 @@ See [Tasks](tasks.md) for details of what `npm test` does.
 
 ## SASS linting
 
+```
+npm run lint:scss
+```
+
 See [CSS Coding Standards](/docs/contributing/coding-standards/css.md#linting) for details.
 
 ## Javascript linting
+
+```
+npm run lint:js
+```
 
 See [JavaScript Coding Standards](/docs/contributing/coding-standards/js.md#formatting-and-linting) for details.
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -2,7 +2,21 @@
 
 The CI lints SASS and JavaScript, runs unit and functional tests with Node, and generates snapshots for [visual regression testing](https://www.browserstack.com/percy/visual-testing).
 
-## Running all tests locally
+## Testing terminology
+
+We use different types of tests to check different areas of our code are working as expected.
+
+Unit tests are small, modular tests that verify a "unit" of code. We write unit tests to check our JavaScript logic, particularly 'background logic' that does not heavily rely on [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model/Introduction) interaction (where functional tests may be better suited).
+
+Functional tests verify the output of an action and do not check the intermediate states of the system when performing that action. We write functional tests to check component interactions have the expected results, so we also refer to these as component tests. We also write functional tests to check that our Nunjucks code outputs expected HTML, and we refer to these as our Nunjucks tests.
+
+[Snapshot tests](https://facebook.github.io/jest/docs/en/snapshot-testing.html) are used for preventing unintended changes to our component markup. When the snapshot test runs, it  compares the previously captured snapshot to the current markup.
+
+Visual regression tests help us check for any unintended visual changes to our components. We use [Percy](https://percy.io/) to generate and store screenshots of our components.
+
+## Running linting and tests
+
+### Running all tests locally
 
 To check the whole codebase, run:
 
@@ -10,11 +24,20 @@ To check the whole codebase, run:
 npm test
 ```
 
-This will trigger [standard](https://github.com/standard/standard) and [stylelint](https://github.com/stylelint/stylelint) for linting, and [Jest](https://github.com/facebook/jest) for unit and functional tests.
+This will trigger [standard](https://github.com/standard/standard) and [stylelint](https://github.com/stylelint/stylelint) for linting, and [Jest](https://github.com/facebook/jest) for our testing.
 
 See [Tasks](tasks.md) for details of what `npm test` does.
 
-## SASS linting
+### Running individual tests
+You can run a subset of the test suite that only tests components by running:
+
+    `npm test -- --testPathPattern=src/govuk/components/button`
+
+Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
+
+    `npm test -- --watch src/govuk/components/button`
+
+### Running only SASS linting
 
 ```
 npm run lint:scss
@@ -22,7 +45,7 @@ npm run lint:scss
 
 See [CSS Coding Standards](/docs/contributing/coding-standards/css.md#linting) for details.
 
-## Javascript linting
+### Running only JavaScript linting
 
 ```
 npm run lint:js
@@ -34,21 +57,21 @@ See [JavaScript Coding Standards](/docs/contributing/coding-standards/js.md#form
 
 We use [Jest](https://jestjs.io/), an automated testing platform with an assertion library, and [Puppeteer](https://pptr.dev/) that is used to control [headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome).
 
-We test individual components and for instance global Sass files. See [all.test.js](../../src/govuk/all.test.js). for examples of global tests we run, and  [checkboxes.test.js](../../src/govuk/components/checkboxes/checkboxes.test.js) for an example of component tests.
+### Component tests
+We write functional tests for every component to check the output of our Nunjucks code. These are found in `template.test.js` files in each component directory. These Nunjucks tests render the component examples defined in the component yaml files, and assert that the HTML tags, attributes and classes are as expected. For example: checking that when you pass in an `id` to the component using the Nunjucks macro, it outputs the component with an `id` attribute equal to that value.
 
+If a component uses JavaScript, we also write functional tests in a `[component name].test.js` file, for example [checkboxes.test.js](../../src/govuk/components/checkboxes/checkboxes.test.js). These component tests check that interactions, such as a mouse click, have the expected result.
+
+You should also test component Javascript logic with unit tests, in a `[component name].unit.test.mjs` file. These tests are better suited for testing behind-the-scenes logic, or in cases where the final output of some logic is not a change to the component markup.
+
+### Global tests
+We write functional tests for checking our JavaScript exports and our global sass variables - see [all.test.js](../../src/govuk/all.test.js) for examples of global tests we run.
+
+### Conventions
 We aim to write the description of our tests in as "natural language" as possible, for instance "back-link component fails to render if the required fields are not included".
 
-### Running individual tests
-You can run a subset of the test suite that only tests components by running:
-
-    `npm test -- --testPathPattern=src/govuk/components/button`
-
-Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
-
-    `npm test -- --watch src/govuk/components/button`
-
-### Updating component snapshots
-[Snapshot tests](https://facebook.github.io/jest/docs/en/snapshot-testing.html) are used for preventing unintended changes - when the snapshot test runs, it  compares the previously captured snapshot to the current markup. For components, the snapshots are stored in `[component-name directory]/_snapshots_`.
+## Updating component snapshots
+For components, the snapshots are stored in `[component-name directory]/_snapshots_`.
 
 If a snapshot test fails, review the difference in the console. If the change is the correct change to make, run:
 
@@ -57,8 +80,6 @@ If a snapshot test fails, review the difference in the console. If the change is
 This will update the snapshot file. Commit this file separately with a commit message that explains you're updating the snapshot file and an explanation of what caused the change.
 
 ## Visual regression testing with Percy
-
-[Percy](https://percy.io/) is a visual regression testing tool. We use it to generate and store screenshots of our components to help us check for any unintended visual changes.
 
 We generate 2 screenshots for each default example of every component. One example has JavaScript enabled, the other has JavaScript disabled. Screenshots are not taken for all the different variations of each component. This tool is not a replacement for manual testing.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "pre-release": "node bin/check-nvmrc.js && ./bin/pre-release.sh",
     "build:package": "node bin/check-nvmrc.js && gulp build:package --destination 'package' && npm run test:build:package",
     "build:dist": "node bin/check-nvmrc.js && gulp build:dist --destination 'dist' && npm run test:build:dist",
-    "test": "npm run test:dependencies && gulp copy-assets && jest --testPathIgnorePatterns='after-*'",
+    "test": "npm run test:dependencies && gulp copy-assets && jest --testPathIgnorePatterns=after-*",
     "test:dependencies": "npm ls --depth=0",
     "test:build:package": "jest tasks/gulp/__tests__/after-build-package.test.js",
     "test:build:dist": "jest tasks/gulp/__tests__/after-build-dist.test.js",


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/2721

Expand our existing testing documentation to talk about the different types of testing we do and when to use them.
Make reference to unit testing, which we're introducing for JavaScript logic.