### PR TITLE
Ensure accordion uses overriden focus colour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ We’ve also made fixes in the following pull requests:
 - [#2724: Remove redundant `aria-hidden` attribute from the content when using the Details polyfill](https://github.com/alphagov/govuk-frontend/pull/2724)
 - [#2725: Remove padding-right from last column in summary list row](https://github.com/alphagov/govuk-frontend/pull/2725)
 - [#2737: Avoid unnecessary spacing-related media queries](https://github.com/alphagov/govuk-frontend/pull/2737)
+- [#2747: Ensure accordion uses overriden focus colour](https://github.com/alphagov/govuk-frontend/pull/2747) - thanks @NickColley
 
 ## 4.2.0 (Feature release)
 

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -1,7 +1,7 @@
 @include govuk-exports("govuk/component/accordion") {
   $govuk-accordion-base-colour: govuk-colour("black");
   $govuk-accordion-hover-colour: govuk-colour("light-grey", $legacy: "grey-3");
-  $govuk-accordion-icon-focus-colour: govuk-colour("yellow");
+  $govuk-accordion-icon-focus-colour: $govuk-focus-colour;
   $govuk-accordion-bottom-border-width: 1px;
 
   .govuk-accordion {


### PR DESCRIPTION
At the moment if you override the focus colour and focus this component this icon will remain yellow.
By using the `$govuk-focus-colour` variable we allow this to change as expected.

Before:

<img width="224" alt="Focused accordion with yellow inside the chevron icon" src="https://user-images.githubusercontent.com/2445413/182838293-8452a1b7-4a46-45ca-a3e6-d1a1e24bfcc0.png">

After:

<img width="200" alt="Focused accordion with overriden colour inside the chevron icon" src="https://user-images.githubusercontent.com/2445413/182838406-d598129a-d8f6-4387-81df-ac09ec934389.png">

