### PR TITLE
Provide more details in our publishing docs

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -64,7 +64,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 9. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version-numbers have been updated and that the compiled assets use this version-number.
 
-10. Once a reviewer approves the pull request, merge it to **main**.
+10. Once a reviewer approves the pull request, merge it to **main**. This will automatically create a tag in Github which you can later use to create a Github release.
 
 ## Publish a release to npm
 
@@ -77,19 +77,24 @@ Developers should pair on releases. When remote working, it can be useful to be 
   If you're following these instructions, you're probably doing a sequential release, meaning
   the tag should be 'latest'.
 
-  Enter `y` to continue. If you think the tag should be different, enter `N` to have the option to set your own npm tag.
+4. Enter `y` to continue. If you think the tag should be different, enter `N` to have the option to set your own npm tag.
 
-4. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
-
-5. View the created tag in the [Github interface](https://github.com/alphagov/govuk-frontend/releases) as follows:
-  - select the latest tag
-  - press **Create release from tag**
-  - set 'GOV.UK Frontend v[version-number]' as the title
-  - add release notes from changelog
-  - attach the generated ZIP that has been generated at the root of this project
-  - publish release
-
+5. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
+  
+  This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
+  
 6. Run `npm logout` to log out from npm.
+
+## Create a release on Github
+
+You can view the tag created during step 10 of creating the new version in the [Github interface](https://github.com/alphagov/govuk-frontend/tags). To create a new Github release, do the following:
+
+1. Select the latest tag
+2. Press **Create release from tag**
+3. Set 'GOV.UK Frontend v[version-number]' as the title
+4. Add release notes from changelog
+5. Attach the ZIP file that has been generated at the root of this project during the npm publishing phase
+6. Publish release
 
 # After you publish the new release
 


### PR DESCRIPTION
## What
Makes the following changes to our [publishing documentation](https://github.com/alphagov/govuk-frontend/blob/main/docs/releasing/publishing.md):

- Explains that merging a release branch will automatically create a tag in Github
- Separates out instructions on publishing to npm and creating a release on Github
- Explains that the npm publishing process produces a ZIP file which is used to create a Github release

## Why
So that we are clear about what is happening per step in the publishing process so that those carrying out the publishing aren't tripped up by unexpected elements.

## Reviewing
- [Current publishing docs](https://github.com/alphagov/govuk-frontend/blob/main/docs/releasing/publishing.md)
- [Publishing docs after this change](https://github.com/alphagov/govuk-frontend/blob/update-publishing-docs/docs/releasing/publishing.md)