### PR TITLE
Deprecate smaller font sizes in the font scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+### Deprecated features
+
+#### Using `14` on the font scale and `16` and `19` dropping to a different size on mobile
+
+From GOV.UK Frontend v5.0.0, you will no longer be able to use `14` as a `$size` value when doing the following:
+
+- Calling the `govuk-typography-responsive` mixin
+- Calling the `govuk-font` mixin
+
+You will also no longer be able to use the override class `govuk-!-font-size-14`.
+
+In addition, the font scale values `16` and `19` when used in the aforementioned mixins or via their associated override classes will no longer drop down to different font sizes on small screen sizes (`14px` for `16`, `16px` for `19`) and will instead retain their size across all screen sizes. Bear this in mind when designing your services.
+
 ## 4.3.0 (Feature release)
 
 ### New features

--- a/src/govuk/helpers/_typography.scss
+++ b/src/govuk/helpers/_typography.scss
@@ -109,6 +109,14 @@
 ///
 /// @param {Number} $size - Point from the spacing scale (the size as it would
 ///   appear on tablet and above)
+///   Deprecations:
+///     14 on the typography scale aka: 14px on large screens (from tablet), 12px
+///     on small screens (until tablet), is deprecated. Use a higher point on the
+///     typography scale instead.
+///     On typography scale points 16 and 19, the small screen value (until tablet)
+///     for each of these (14px and 16px respectively) are deprecated, meaning that
+///     both points will use the same font size across all screen sizes in the next
+///     breaking release. Keep this in mind when designing your service.
 /// @param {Number} $override-line-height [false] - Non responsive custom line
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as

--- a/src/govuk/overrides/_typography.scss
+++ b/src/govuk/overrides/_typography.scss
@@ -4,6 +4,15 @@
   // Generate typography override classes for each responsive font map in the
   // typography scale eg .govuk-\!-font-size-80
   @each $size in map-keys($govuk-typography-scale) {
+    // Deprecations:
+    //  govuk-!-font-size-14 aka: 14px on large screens (from tablet), 12px
+    //  on small screens (until tablet), is deprecated. Use a class referencing a
+    //  higher point on the typography scale instead.
+    //  For classes govuk-!-font-size-16 and govuk-!-font-size-19, the small screen
+    //  value (until tablet) for each of these (14px and 16px respectively) are
+    //  deprecated, meaning that both points will use the same font size across all
+    //  screen sizes in the next breaking release. Keep this in mind when designing
+    //  your service.
     .govuk-\!-font-size-#{$size} {
       @include govuk-typography-responsive($size, $important: true);
     }


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2760

Part of https://github.com/alphagov/govuk-design-system/issues/2289

Deprecates the following as options for `$size` in `govuk-typography-responsive` and as possible values for `govuk-!-font-size={value}`:

- 14 as an option at all
- 16 dropping down to 14 on smaller screen sizes
- 19 dropping down to 16 on smaller screen sizes
