### PR TITLE
Remove unused `console.log` calls from accordion JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ We've deprecated the `govuk-!-margin-static` and `govuk-!-padding-static` classe
 
 This change was introduced in [pull request #2770: Fix ordering of properties in static spacing override classes](https://github.com/alphagov/govuk-frontend/pull/2770). Thanks to @garrystewart for reporting this issue.
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2766: Remove unused `console.log` calls from accordion JavaScript](https://github.com/alphagov/govuk-frontend/pull/2766)
+
 ## 4.3.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -301,9 +301,7 @@ var helper = {
       window.sessionStorage.removeItem(testString)
       return result
     } catch (exception) {
-      if ((typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.log('Notice: sessionStorage not available.')
-      }
+      return false
     }
   }
 }
@@ -319,14 +317,6 @@ Accordion.prototype.storeState = function ($section) {
     if ($button) {
       var contentId = $button.getAttribute('aria-controls')
       var contentState = $button.getAttribute('aria-expanded')
-
-      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.error(new Error('No aria controls present in accordion section heading.'))
-      }
-
-      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.error(new Error('No aria expanded present in accordion section heading.'))
-      }
 
       // Only set the state when both `contentId` and `contentState` are taken from the DOM.
       if (contentId && contentState) {


### PR DESCRIPTION
Because of the way the if statements are written, these attempts to call `console.log` and `console.error` will only ever run if either `console` or `console.log` is undefined (and therfore _not_ a function). They will never successfully write anything to the console log.

Given that they’ve been like this for several years (since 027373d), we can safely assume they’re not doing anything useful, and can remove them.