### PR TITLE
Hotfix Sassdoc not being able to build for Heroku

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,6 +87,8 @@ gulp.task('build:dist', gulp.series(
   updateDistAssetsVersion
 ))
 
+gulp.task('sassdoc', buildSassdocs)
+
 // Default task -------------------------
 // Lists out available tasks.
 // --------------------------------------


### PR DESCRIPTION
Hotfixes the Heroku script failing as Sassdoc cannot be built. This is because Sassdoc is being called through Gulp, but the Sassdoc build script no longer uses it as of #2764.

Fixes this by creating a single-use Gulp task that calls the Sassdoc function. 

In the long term, we will need to change the Heroku script to call Sassdoc through some other method. 