### PR TITLE
fix(): Replace `console.log` with `info()` and `error`

### DIFF
--- a/app/start.js
+++ b/app/start.js
@@ -4,5 +4,5 @@ const PORT = process.env.PORT || configPaths.ports.app
 const app = require('./app.js')()
 
 app.listen(PORT, () => {
-  console.log('Server started at http://localhost:' + PORT)
+  console.info('Server started at http://localhost:' + PORT)
 })

--- a/bin/check-nvmrc.js
+++ b/bin/check-nvmrc.js
@@ -20,7 +20,7 @@ fs.readFile(path.join(__dirname, '../.nvmrc'), 'utf8', function (error, data) {
   var nvmInstallText = 'To do this you can install nvm (https://github.com/creationix/nvm) then run `nvm install`.'
 
   if (versionMatchesMajor) {
-    console.log('' +
+    console.info('' +
       'Warning: You are using Node.js version ' + currentVersion + ' which we do not use. ' +
       '\n\n' +
       'You may encounter issues, consider installing Node.js version ' + expectedVersion + '.' +
@@ -30,7 +30,7 @@ fs.readFile(path.join(__dirname, '../.nvmrc'), 'utf8', function (error, data) {
     process.exit()
   }
 
-  console.log('' +
+  console.info('' +
     'You are using Node.js version ' + currentVersion + ' which we do not support. ' +
     '\n\n' +
     'Please install Node.js version ' + expectedVersion + ' and try again.' +

--- a/package/govuk-esm/components/accordion/accordion.mjs
+++ b/package/govuk-esm/components/accordion/accordion.mjs
@@ -301,8 +301,8 @@ var helper = {
       window.sessionStorage.removeItem(testString)
       return result
     } catch (exception) {
-      if ((typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.log('Notice: sessionStorage not available.')
+      if ((typeof console === 'undefined' || typeof console.info === 'undefined')) {
+        console.info('Notice: sessionStorage not available.')
       }
     }
   }
@@ -320,11 +320,11 @@ Accordion.prototype.storeState = function ($section) {
       var contentId = $button.getAttribute('aria-controls')
       var contentState = $button.getAttribute('aria-expanded')
 
-      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria controls present in accordion section heading.'))
       }
 
-      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria expanded present in accordion section heading.'))
       }
 

--- a/package/govuk/all.js
+++ b/package/govuk/all.js
@@ -1055,8 +1055,8 @@ var helper = {
       window.sessionStorage.removeItem(testString);
       return result
     } catch (exception) {
-      if ((typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.log('Notice: sessionStorage not available.');
+      if ((typeof console === 'undefined' || typeof console.info === 'undefined')) {
+        console.info('Notice: sessionStorage not available.');
       }
     }
   }
@@ -1074,11 +1074,11 @@ Accordion.prototype.storeState = function ($section) {
       var contentId = $button.getAttribute('aria-controls');
       var contentState = $button.getAttribute('aria-expanded');
 
-      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria controls present in accordion section heading.'));
       }
 
-      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria expanded present in accordion section heading.'));
       }
 

--- a/package/govuk/components/accordion/accordion.js
+++ b/package/govuk/components/accordion/accordion.js
@@ -1040,8 +1040,8 @@ var helper = {
       window.sessionStorage.removeItem(testString);
       return result
     } catch (exception) {
-      if ((typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.log('Notice: sessionStorage not available.');
+      if ((typeof console === 'undefined' || typeof console.info === 'undefined')) {
+        console.info('Notice: sessionStorage not available.');
       }
     }
   }
@@ -1059,11 +1059,11 @@ Accordion.prototype.storeState = function ($section) {
       var contentId = $button.getAttribute('aria-controls');
       var contentState = $button.getAttribute('aria-expanded');
 
-      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria controls present in accordion section heading.'));
       }
 
-      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria expanded present in accordion section heading.'));
       }
 

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -301,8 +301,8 @@ var helper = {
       window.sessionStorage.removeItem(testString)
       return result
     } catch (exception) {
-      if ((typeof console === 'undefined' || typeof console.log === 'undefined')) {
-        console.log('Notice: sessionStorage not available.')
+      if ((typeof console === 'undefined' || typeof console.info === 'undefined')) {
+        console.info('Notice: sessionStorage not available.')
       }
     }
   }
@@ -320,11 +320,11 @@ Accordion.prototype.storeState = function ($section) {
       var contentId = $button.getAttribute('aria-controls')
       var contentState = $button.getAttribute('aria-expanded')
 
-      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentId === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria controls present in accordion section heading.'))
       }
 
-      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.log === 'undefined')) {
+      if (typeof contentState === 'undefined' && (typeof console === 'undefined' || typeof console.error === 'undefined')) {
         console.error(new Error('No aria expanded present in accordion section heading.'))
       }
 

--- a/tasks/asset-version.js
+++ b/tasks/asset-version.js
@@ -28,7 +28,7 @@ function updateDistAssetsVersion (cb) {
       path.resolve(destFilename),
       error => {
         if (error) throw error
-        console.log(`Moved ${srcFilename} to ${destFilename}.`)
+        console.info(`Moved ${srcFilename} to ${destFilename}.`)
       }
     )
   })

--- a/tasks/gulp/lint.js
+++ b/tasks/gulp/lint.js
@@ -9,7 +9,7 @@ const { spawn } = require('child_process')
 gulp.task('js:lint', (done) => {
   const command = process.platform === 'win32' ? 'npm.cmd' : 'npm'
   const lint = spawn(command, ['run', 'lint:js', '--silent'])
-  lint.stdout.on('data', (data) => console.log(data.toString()))
+  lint.stdout.on('data', (data) => console.info(data.toString()))
   lint.stderr.on('data', (data) => console.error(data.toString()))
   lint.on('exit', done)
 })
@@ -17,7 +17,7 @@ gulp.task('js:lint', (done) => {
 gulp.task('scss:lint', (done) => {
   const command = process.platform === 'win32' ? 'npm.cmd' : 'npm'
   const lint = spawn(command, ['run', 'lint:scss', '--silent'])
-  lint.stdout.on('data', (data) => console.log(data.toString()))
+  lint.stdout.on('data', (data) => console.info(data.toString()))
   lint.stderr.on('data', (data) => console.error(data.toString()))
   lint.on('exit', done)
 })

--- a/tasks/sassdoc.js
+++ b/tasks/sassdoc.js
@@ -28,7 +28,7 @@ function buildSassdocs (cb) {
       'objects/layout': 'Objects / Layout'
     }
   }).then(() => {
-    console.log('Sassdoc built.')
+    console.info('Sassdoc built.')
   }, err => {
     throw err
   })


### PR DESCRIPTION
## Introduction

`console.log()` should only be used for development purpose (ideally on local dev environment). This PR aims to replace `.log()` calls with `.info()` and `error()` where appropriate. This also ensures any linting rules which prohibits usage of `.log()` calls are also compatible.

* Packages have also been updated here (purely for flagging purpose).
* `typeof console.error` have been used when an error is being thrown using `console.error()`.