### PR TITLE
Improve Pagination component print styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ This will enable screen reader users to have a better, more coherent experience 
 
 This was added in [pull request #2677: Amend error summary markup to fix page load focus bug in JAWS 2022](https://github.com/alphagov/govuk-frontend/pull/2677)
 
+### Fixes
+
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#2800: Improve Pagination component print styles](https://github.com/alphagov/govuk-frontend/pull/2800)
+
 ## 4.3.1 (Patch release)
 
 ### Recommended changes

--- a/src/govuk/components/pagination/_index.scss
+++ b/src/govuk/components/pagination/_index.scss
@@ -106,13 +106,16 @@
     display: block;
     min-width: govuk-spacing(3);
 
-    &:after {
-      content: "";
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
+    // Increase the touch area for the link to the parent element.
+    @media screen {
+      &:after {
+        content: "";
+        position: absolute;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+      }
     }
 
     // Add link hover decoration to prev/next text if no label present on prev/next only mode


### PR DESCRIPTION
By default `.govuk-link` print styles will output the `href` attribute
in brackets after the link. For example: "Home (/homepage)".

This is done with the `::after` pseudo selector.
So when this was styled to increase the touch area of the pagination link
it resulted in the bracketed information overlapping the component in
a difficult to read way.

By only applying this touch area improvement in the `screen` media context
we avoid overwriting this inherited print style and allow the default
`.govuk-link` behaviour to apply as usual.

In practice I think many GOV.UK Frontend users might hide this component from their print views so impact on end-users is low.

I'd be down for doing something more holistic as part of https://github.com/alphagov/govuk-frontend/issues/573 if you're interested in that contribution (including thinking about it from a more high level design pov), but I noticed this just at a quick glance.

## Screenshots

| Before | After |
|-|-|
| ![Print mode shows overlapping links](https://user-images.githubusercontent.com/2445413/185645606-c3f08b12-76bd-47f4-81ee-acb4f843cc60.png) | ![Print mode has pagination links are shown inline without overlap](https://user-images.githubusercontent.com/2445413/185645474-7d4f24fb-7339-4d15-ab9a-a099a4a5fa8a.png) |