### PR TITLE
[SPIKE][DO NOT MERGE] Create IE-compatible configuration merging function

### DIFF
--- a/package/govuk-esm/components/accordion/accordion.mjs
+++ b/package/govuk-esm/components/accordion/accordion.mjs
@@ -15,16 +15,27 @@
 
 */
 
-import { nodeListForEach } from '../../common.mjs'
+import { nodeListForEach, getModuleConfig } from '../../common.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
-function Accordion ($module) {
+function Accordion ($module, options) {
   this.$module = $module
   this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
+  
+  const defaultOptions = {
+    i18n: {
+      hideAllSections: 'Hide all sections',
+      hideSection: 'Hide <span class="govuk-visually-hidden">this section</span>',
+      showAllSections: 'Show all sections',
+      showSection: 'Show <span class="govuk-visually-hidden">this section</span>'
+    }
+  }
+  this.config = getModuleConfig($module, defaultOptions, options)
+  console.log(defaultOptions, this.config)
 
   this.controlsClass = 'govuk-accordion__controls'
   this.showAllClass = 'govuk-accordion__show-all'

--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -26,7 +26,7 @@ function initAll (options) {
 
   var $accordions = scope.querySelectorAll('[data-module="govuk-accordion"]')
   nodeListForEach($accordions, function ($accordion) {
-    new Accordion($accordion).init()
+    new Accordion($accordion, options.accordion || {}).init()
   })
 
   var $details = scope.querySelectorAll('[data-module="govuk-details"]')

--- a/src/govuk/common.mjs
+++ b/src/govuk/common.mjs
@@ -39,7 +39,7 @@ export function generateUniqueID () {
  * @param {...Object} - Any number of objects to merge together.
  * @returns {Object} - A flattened object of key-value pairs.
  */
-export function getModuleConfig () {
+export function mergeConfigs () {
   // Function to take nested objects and flatten them to a dot-separated keyed
   // object. Doing this means we don't need to do any deep/recursive merging of
   // each of our objects, nor transform our dataset from a flat list into a

--- a/src/govuk/common.mjs
+++ b/src/govuk/common.mjs
@@ -15,7 +15,7 @@ export function nodeListForEach (nodes, callback) {
 }
 
 /**
- *  Used to generate a unique string, allows multiple instances of the component without
+ * Used to generate a unique string, allows multiple instances of the component without
  * Them conflicting with each other.
  * https://stackoverflow.com/a/8809472
  */
@@ -36,8 +36,8 @@ export function generateUniqueID () {
  * namespaced key-value pairs, (e.g. {'i18n.showSection': 'Show section'}) and
  * combines them together, with greatest priority on the LAST item passed in.
  *
- * @param {...object} - Any number of objects to merge together.
- * @returns {object} - A flattened object of key-value pairs.
+ * @param {...Object} - Any number of objects to merge together.
+ * @returns {Object} - A flattened object of key-value pairs.
  */
 export function getModuleConfig () {
   // Function to take nested objects and flatten them to a dot-separated keyed
@@ -74,7 +74,7 @@ export function getModuleConfig () {
     return flattenedObject
   }
 
-  // Start with an empty  object as our base
+  // Start with an empty object as our base
   var configObject = {}
 
   // Loop through each of the remaining passed objects and push their keys

--- a/src/govuk/common.mjs
+++ b/src/govuk/common.mjs
@@ -1,3 +1,5 @@
+import './vendor/polyfills/Element/prototype/dataset.mjs'
+
 /**
  * TODO: Ideally this would be a NodeList.prototype.forEach polyfill
  * This seems to fail in IE8, requires more investigation.
@@ -12,9 +14,11 @@ export function nodeListForEach (nodes, callback) {
   }
 }
 
-// Used to generate a unique string, allows multiple instances of the component without
-// Them conflicting with each other.
-// https://stackoverflow.com/a/8809472
+/**
+ *  Used to generate a unique string, allows multiple instances of the component without
+ * Them conflicting with each other.
+ * https://stackoverflow.com/a/8809472
+ */
 export function generateUniqueID () {
   var d = new Date().getTime()
   if (typeof window.performance !== 'undefined' && typeof window.performance.now === 'function') {
@@ -25,4 +29,65 @@ export function generateUniqueID () {
     d = Math.floor(d / 16)
     return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16)
   })
+}
+
+/**
+ * Config flattening function. Takes any number of objects, flattens them into
+ * namespaced key-value pairs, (e.g. {'i18n.showSection': 'Show section'}) and
+ * combines them together, with greatest priority on the LAST item passed in.
+ *
+ * @param {...object} - Any number of objects to merge together.
+ * @returns {object} - A flattened object of key-value pairs.
+ */
+export function getModuleConfig () {
+  // Function to take nested objects and flatten them to a dot-separated keyed
+  // object. Doing this means we don't need to do any deep/recursive merging of
+  // each of our objects, nor transform our dataset from a flat list into a
+  // nested object.
+  var flattenObject = function (optionsObject) {
+    // Prepare an empty return object
+    var flattenedObject = {}
+
+    // Our flattening function, this is called recursively for each level of
+    // depth in the object. At each level we prepend the previous level names to
+    // the key using `prefix`.
+    var flattenLoop = function (obj, prefix) {
+      // Loop through keys...
+      for (var key in obj) {
+        // Check to see if this is a prototypical key/value,
+        // if it is, skip it.
+        if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+          continue
+        }
+        var value = obj[key]
+        var prefixedKey = prefix ? prefix + '.' + key : key
+        if (typeof value === 'object') {
+          // If the value is a nested object, recurse over that too
+          flattenLoop(value, prefixedKey)
+        } else {
+          // Otherwise, add this value to our return object
+          flattenedObject[prefixedKey] = value
+        }
+      }
+    }
+    flattenLoop(optionsObject)
+    return flattenedObject
+  }
+
+  // Start with an empty  object as our base
+  var configObject = {}
+
+  // Loop through each of the remaining passed objects and push their keys
+  // one-by-one into configObject. Any duplicate keys will override the existing
+  // key with the new value.
+  for (var i = 0; i < arguments.length; i++) {
+    var obj = flattenObject(arguments[i])
+    for (var key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        configObject[key] = obj[key]
+      }
+    }
+  }
+
+  return configObject
 }

--- a/src/govuk/common.mjs
+++ b/src/govuk/common.mjs
@@ -39,12 +39,12 @@ export function generateUniqueID () {
  * @param {...Object} - Any number of objects to merge together.
  * @returns {Object} - A flattened object of key-value pairs.
  */
-export function mergeConfigs () {
+export function mergeConfigs (/* ...config objects */) {
   // Function to take nested objects and flatten them to a dot-separated keyed
   // object. Doing this means we don't need to do any deep/recursive merging of
   // each of our objects, nor transform our dataset from a flat list into a
   // nested object.
-  var flattenObject = function (optionsObject) {
+  var flattenObject = function (configObject) {
     // Prepare an empty return object
     var flattenedObject = {}
 
@@ -70,12 +70,12 @@ export function mergeConfigs () {
         }
       }
     }
-    flattenLoop(optionsObject)
+    flattenLoop(configObject)
     return flattenedObject
   }
 
   // Start with an empty object as our base
-  var configObject = {}
+  var formattedConfigObject = {}
 
   // Loop through each of the remaining passed objects and push their keys
   // one-by-one into configObject. Any duplicate keys will override the existing
@@ -84,10 +84,10 @@ export function mergeConfigs () {
     var obj = flattenObject(arguments[i])
     for (var key in obj) {
       if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        configObject[key] = obj[key]
+        formattedConfigObject[key] = obj[key]
       }
     }
   }
 
-  return configObject
+  return formattedConfigObject
 }

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -15,16 +15,34 @@
 
 */
 
-import { nodeListForEach } from '../../common.mjs'
+import { nodeListForEach, getModuleConfig } from '../../common.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
-function Accordion ($module) {
+function Accordion ($module, options) {
   this.$module = $module
   this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
+
+  var defaultOptions = {
+    i18n: {
+      hideAllSections: 'Hide all sections',
+      hideSection: 'Hide <span class="govuk-visually-hidden">this section</span>',
+      showAllSections: 'Show all sections',
+      showSection: 'Show <span class="govuk-visually-hidden">this section</span>'
+    }
+  }
+  this.config = getModuleConfig(defaultOptions, options, $module.dataset)
+
+  // DEBUGGING: IE friendly object output
+  if ('console' in window) {
+    console.log('Accordion configuration:')
+    for (var key in this.config) {
+      console.log('    ' + key + ': ' + this.config[key])
+    }
+  }
 
   this.controlsClass = 'govuk-accordion__controls'
   this.showAllClass = 'govuk-accordion__show-all'

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -15,7 +15,7 @@
 
 */
 
-import { nodeListForEach, getModuleConfig } from '../../common.mjs'
+import { nodeListForEach, mergeConfigs } from '../../common.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
@@ -34,7 +34,7 @@ function Accordion ($module, options) {
       showSection: 'Show <span class="govuk-visually-hidden">this section</span>'
     }
   }
-  this.config = getModuleConfig(defaultOptions, options, $module.dataset)
+  this.config = mergeConfigs(defaultOptions, options, $module.dataset)
 
   // DEBUGGING: IE friendly object output
   if ('console' in window) {

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -19,14 +19,14 @@ import { nodeListForEach, mergeConfigs } from '../../common.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
-function Accordion ($module, options) {
+function Accordion ($module, config) {
   this.$module = $module
   this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 
-  var defaultOptions = {
+  var defaultConfig = {
     i18n: {
       hideAllSections: 'Hide all sections',
       hideSection: 'Hide <span class="govuk-visually-hidden">this section</span>',
@@ -34,7 +34,7 @@ function Accordion ($module, options) {
       showSection: 'Show <span class="govuk-visually-hidden">this section</span>'
     }
   }
-  this.config = mergeConfigs(defaultOptions, options, $module.dataset)
+  this.config = mergeConfigs(defaultConfig, config, $module.dataset)
 
   // DEBUGGING: IE friendly object output
   if ('console' in window) {

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -169,6 +169,21 @@ examples:
         content:
           html: <a class="govuk-link" href="#">Link B</a>
 
+- name: with localisations
+  data:
+    id: with-localisations
+    items:
+    - heading:
+        text: Section A
+      content:
+        html: <a class="govuk-link" href="#">Link A</a>
+    - heading:
+        text: Section B
+      content:
+        html: <a class="govuk-link" href="#">Link B</a>
+    showAllSectionsText: Show everything
+    showSectionText: Show<span class="govuk-visually-hidden"> something</span>
+
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 - name: classes
   hidden: true

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -181,8 +181,8 @@ examples:
         text: Section B
       content:
         html: <a class="govuk-link" href="#">Link B</a>
-    showAllSectionsText: Show everything
-    showSectionText: Show<span class="govuk-visually-hidden"> something</span>
+    showAllSectionsHtml: Show everything
+    showSectionHtml: Show<span class="govuk-visually-hidden"> something</span>
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 - name: classes

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -1,8 +1,15 @@
 {% set id = params.id %}
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
-<div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}" data-module="govuk-accordion" id="{{ id }}"
-{%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+<div
+  class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}"
+  data-module="govuk-accordion"
+  id="{{ id }}"
+  {%- if params.showAllSectionsText %} data-i18n.show-all-sections="{{ params.showAllSectionsText }}"{% endif %}
+  {%- if params.hideAllSectionsText %} data-i18n.hide-all-sections="{{ params.hideAllSectionsText }}"{% endif %}
+  {%- if params.showSectionText %} data-i18n.show-section="{{ params.showSectionText }}"{% endif %}
+  {%- if params.hideSectionText %} data-i18n.hide-section="{{ params.hideSectionText }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}
       <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -5,10 +5,10 @@
   class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}"
   data-module="govuk-accordion"
   id="{{ id }}"
-  {%- if params.showAllSectionsText %} data-i18n.show-all-sections="{{ params.showAllSectionsText }}"{% endif %}
-  {%- if params.hideAllSectionsText %} data-i18n.hide-all-sections="{{ params.hideAllSectionsText }}"{% endif %}
-  {%- if params.showSectionText %} data-i18n.show-section="{{ params.showSectionText }}"{% endif %}
-  {%- if params.hideSectionText %} data-i18n.hide-section="{{ params.hideSectionText }}"{% endif %}
+  {%- if params.showAllSectionsHtml %} data-i18n.show-all-sections="{{ params.showAllSectionsHtml }}"{% endif %}
+  {%- if params.hideAllSectionsHtml %} data-i18n.hide-all-sections="{{ params.hideAllSectionsHtml }}"{% endif %}
+  {%- if params.showSectionHtml %} data-i18n.show-section="{{ params.showSectionHtml }}"{% endif %}
+  {%- if params.hideSectionHtml %} data-i18n.hide-section="{{ params.hideSectionHtml }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}

--- a/src/govuk/vendor/polyfills/Element/prototype/dataset.mjs
+++ b/src/govuk/vendor/polyfills/Element/prototype/dataset.mjs
@@ -1,0 +1,68 @@
+import '../../Object/defineProperty.mjs'
+import '../../Element.mjs'
+
+(function(undefined) {
+
+  // Detection from https://raw.githubusercontent.com/Financial-Times/polyfill-library/13cf7c340974d128d557580b5e2dafcd1b1192d1/polyfills/Element/prototype/dataset/detect.js
+  var detect = (function(){
+    if (!document.documentElement.dataset) {
+      return false;
+    }
+    var el = document.createElement('div');
+    el.setAttribute("data-a-b", "c");
+    return el.dataset && el.dataset.aB == "c";
+  }())
+
+  if (detect) return
+
+  // Polyfill from https://raw.githubusercontent.com/Financial-Times/polyfill-library/13cf7c340974d128d557580b5e2dafcd1b1192d1/polyfills/Element/prototype/dataset/polyfill.js
+  Object.defineProperty(Element.prototype, 'dataset', {
+    get: function() {
+      var element = this;
+      var attributes = this.attributes;
+      var map = {};
+  
+      for (var i = 0; i < attributes.length; i++) {
+        var attribute = attributes[i];
+  
+        // Note: The regex has been edited from the original polyfill, to add
+        // support for period (.) separators in data-* attribute names. These
+        // are allowed in the HTML spec, but were not covered by the original
+        // polyfill's regex. We use periods in our i18n implementation.
+        if (attribute && attribute.name && (/^data-\w[.\w-]*$/).test(attribute.name)) {
+          var name = attribute.name;
+          var value = attribute.value;
+  
+          var propName = name.substr(5).replace(/-./g, function (prop) {
+            return prop.charAt(1).toUpperCase();
+          });
+          
+          // If this browser supports __defineGetter__ and __defineSetter__,
+          // continue using defineProperty. If not, use a really, really hacky
+          // fallback. If all is well, only IE8 should need the fallback.
+          if ('__defineGetter__' in Object.prototype && '__defineSetter__' in Object.prototype) {
+            Object.defineProperty(map, propName, {
+              enumerable: true,
+              get: function() {
+                return this.value;
+              }.bind({value: value || ''}),
+              set: function setter(name, value) {
+                if (typeof value !== 'undefined') {
+                  this.setAttribute(name, value);
+                } else {
+                  this.removeAttribute(name);
+                }
+              }.bind(element, name)
+            });
+          } else {
+            map[propName] = value
+          }
+
+        }
+      }
+  
+      return map;
+    }
+  });
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});


### PR DESCRIPTION
Spike to see if I could make a version of the configuration merging function that works back to IE8. 

This exists as a helper function (`getModuleConfig`) that takes an unlimited number of configuration objects, flattens them into a non-nested list of key-value pairs, and merges them into one object. Objects are merged from left to right, in the order they're passed into the function (aka, the last object has the highest priority). 

Also includes a polyfill for `Element.prototype.dataset`. This is derived from [the one formerly served by polyfill.io](https://raw.githubusercontent.com/Financial-Times/polyfill-library/13cf7c340974d128d557580b5e2dafcd1b1192d1/polyfills/Element/prototype/dataset/polyfill.js), with some modifications:
- The regex used to detect data-* attributes has been altered so that it catches attributes containing full stops (.), as we're using these to namespace i18n attributes.
- A feature detection for `Object.prototype.__defineGetter__` and `Object.prototype.__defineSetter__` has been added, as these are required by the polyfill but unavailable in IE8, and the existing `Object.defineProperty` polyfill doesn't cover these. Instead, a (very hacky) fallback is used if these aren't detected.

## Seeing it in action

The Accordion component has been modified to accept i18n options and to use the helper function. Currently, no visual changes take place and the resulting configuration object is logged in the console instead (in a way that IE8 won't fall over on!)

A new example has been added to the review app, ['Accordion with localisations'](https://govuk-frontend-pr-2810.herokuapp.com/components/accordion/with-localisations/preview), which overrides the `i18n.showSection` and `i18n.showAllSections` strings, exhibiting how the default configuration and data-* attribute configuration options get merged and flattened.

If all is working as expected, you should get this logged to the console on every browser: 

```
Accordion configuration:
    i18n.hideAllSections: Hide all sections
    i18n.hideSection: Hide <span class="govuk-visually-hidden">this section</span>
    i18n.showAllSections: Show everything
    i18n.showSection: Show<span class="govuk-visually-hidden"> something</span>
    module: govuk-accordion
```