### PR TITLE
Use Element.id to get module id for accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This was added in [pull request #2677: Amend error summary markup to fix page lo
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2807: Tidy up and refactor the Character Count JavaScript](https://github.com/alphagov/govuk-frontend/pull/2807)
+- [#2811: Use Element.id to get module id for accordion](https://github.com/alphagov/govuk-frontend/pull/2811)
 
 ## 4.3.1 (Patch release)
 

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -21,7 +21,6 @@ import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
 function Accordion ($module) {
   this.$module = $module
-  this.moduleId = $module.getAttribute('id')
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
@@ -116,7 +115,7 @@ Accordion.prototype.constructHeaderMarkup = function ($headerWrapper, index) {
   // Create a button element that will replace the '.govuk-accordion__section-button' span
   var $button = document.createElement('button')
   $button.setAttribute('type', 'button')
-  $button.setAttribute('aria-controls', this.moduleId + '-content-' + (index + 1))
+  $button.setAttribute('aria-controls', this.$module.id + '-content-' + (index + 1))
 
   // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
   for (var i = 0; i < $span.attributes.length; i++) {


### PR DESCRIPTION
Use the native `Element.id` IDL property ([supported by all modern browsers including IE6+](https://caniuse.com/mdn-api_element_id)) rather than `Element.getAttribute('id')`

As `this.moduleId` is only used once, replace it with a call to `this.$module.id`.