### PR TITLE
Fix incorrect type in JSDoc

### DIFF
--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -211,7 +211,7 @@ CharacterCount.prototype.updateScreenReaderCountMessage = function () {
  * in the given text
  *
  * @param {String} text - The text to count the characters of
- * @returns {Integer} the number of characters (or words) in the text
+ * @returns {Number} the number of characters (or words) in the text
  */
 CharacterCount.prototype.count = function (text) {
   if (this.options.maxwords) {


### PR DESCRIPTION
JavaScript doesn't have an Integer type, only Numbers.

I don't think this needs a changelog entry as it's a tweak to changes introduced in a PR that's already listed in the changelog (#2807)?