### PR TITLE
Set up the ability to add unit tests using Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,25 @@
+const config = {
+  projects: [
+    {
+      displayName: 'Snapshot tests',
+      testMatch: ['./**/template.test.js'],
+      snapshotSerializers: [
+        'jest-serializer-html'
+      ],
+      setupFilesAfterEnv: [
+        './config/jest-setup.js'
+      ]
+    },
+    {
+      displayName: 'JavaScript behaviour tests',
+      testMatch: ['./**/*.test.js', '!./**/template.test.js'],
+      preset: 'jest-puppeteer'
+    },
+    {
+      displayName: 'JavaScript unit tests',
+      testMatch: ['./**/*.unit.test.js, ./**/*.unit.test.mjs']
+    }
+  ]
+}
+
+module.exports = config

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,11 @@ const config = {
     },
     {
       displayName: 'JavaScript unit tests',
-      testMatch: ['./**/*.unit.test.js, ./**/*.unit.test.mjs']
+      transform: {
+        '.*.js$': 'rollup-jest'
+      },
+      moduleFileExtensions: ['js', 'mjs'],
+      testMatch: ['./**/*.unit.test.mjs', './**/*.unit.test.js']
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "govuk-frontend-repository",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "rollup-jest": "^3.0.0"
+      },
       "devDependencies": {
         "@percy/cli": "^1.0.0-beta.75",
         "@percy/logger": "1.0.0-beta.74",
@@ -4978,6 +4981,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "node_modules/concat-merge": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/concat-merge/-/concat-merge-1.0.3.tgz",
+      "integrity": "sha512-VuEIlh5YcPYJohvBsZrQNzVjSG5Z0fcmiaiBfluY/2WAzY20HJF9YgPkGRVMYcljzGEKW+I++TX/2tsO/S+RSw=="
+    },
     "node_modules/concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -8882,6 +8890,15 @@
         "rollup": ">=0.48 <0.57",
         "vinyl": "^2.1.0",
         "vinyl-sourcemaps-apply": "^0.2.1"
+      }
+    },
+    "node_modules/gulp-better-rollup/node_modules/rollup": {
+      "version": "0.56.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
+      "integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA==",
+      "dev": true,
+      "bin": {
+        "rollup": "bin/rollup"
       }
     },
     "node_modules/gulp-eol": {
@@ -20040,12 +20057,46 @@
       }
     },
     "node_modules/rollup": {
-      "version": "0.56.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
-      "integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA==",
-      "dev": true,
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "peer": true,
       "bin": {
-        "rollup": "bin/rollup"
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-jest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-jest/-/rollup-jest-3.0.0.tgz",
+      "integrity": "sha512-6v3s4q5z7+PkL1hUYg6KWlL2kUVkjUHLAlMsaHANmuwOrM1GSlRifiJkazdqymVPFfeBfpooDEtz04Q7qwuGaw==",
+      "dependencies": {
+        "concat-merge": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.3.0"
+      }
+    },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/run-async": {
@@ -28319,6 +28370,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "concat-merge": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/concat-merge/-/concat-merge-1.0.3.tgz",
+      "integrity": "sha512-VuEIlh5YcPYJohvBsZrQNzVjSG5Z0fcmiaiBfluY/2WAzY20HJF9YgPkGRVMYcljzGEKW+I++TX/2tsO/S+RSw=="
+    },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -31554,6 +31610,14 @@
         "rollup": ">=0.48 <0.57",
         "vinyl": "^2.1.0",
         "vinyl-sourcemaps-apply": "^0.2.1"
+      },
+      "dependencies": {
+        "rollup": {
+          "version": "0.56.5",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
+          "integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA==",
+          "dev": true
+        }
       }
     },
     "gulp-eol": {
@@ -40148,10 +40212,30 @@
       }
     },
     "rollup": {
-      "version": "0.56.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.56.5.tgz",
-      "integrity": "sha512-IGPk5vdWrsc4vkiW9XMeXr5QMtxmvATTttTi59w2jBQWe9G/MMQtn8teIBAj+DdK51TrpVT6P0aQUaQUlUYCJA==",
-      "dev": true
+      "version": "2.78.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "peer": true,
+      "requires": {
+        "fsevents": "~2.3.2"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
+    "rollup-jest": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-jest/-/rollup-jest-3.0.0.tgz",
+      "integrity": "sha512-6v3s4q5z7+PkL1hUYg6KWlL2kUVkjUHLAlMsaHANmuwOrM1GSlRifiJkazdqymVPFfeBfpooDEtz04Q7qwuGaw==",
+      "requires": {
+        "concat-merge": "^1.0.2"
+      }
     },
     "run-async": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -108,14 +108,5 @@
       "/package/**/*.mjs",
       "/src/govuk/vendor/polyfills/**/*.mjs"
     ]
-  },
-  "jest": {
-    "preset": "jest-puppeteer",
-    "setupFilesAfterEnv": [
-      "./config/jest-setup.js"
-    ],
-    "snapshotSerializers": [
-      "jest-serializer-html"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,5 +108,8 @@
       "/package/**/*.mjs",
       "/src/govuk/vendor/polyfills/**/*.mjs"
     ]
+  },
+  "dependencies": {
+    "rollup-jest": "^3.0.0"
   }
 }

--- a/package.json.test.js
+++ b/package.json.test.js
@@ -13,7 +13,7 @@ describe('because rollup 0.60 drops support for Internet Explorer 8', () => {
   describe('rollup', () => {
     it('should be pinned to 0.56.5 in package-lock.json', () => {
       expect(packageLockJson.dependencies['gulp-better-rollup'].requires.rollup).toEqual('>=0.48 <0.57')
-      expect(packageLockJson.dependencies.rollup.version).toEqual('0.56.5')
+      expect(packageLockJson.dependencies['gulp-better-rollup'].dependencies.rollup.version).toEqual('0.56.5')
     })
   })
 })


### PR DESCRIPTION
Following the unit testing spike and the new documentation which talks about unit testing, we should probably make the necessary changes to allow for unit testing with Jest! 

This PR moves the Jest config from the package.json into a separate jest.config.js file for better readability, especially as we're expanding the config, and uses rollup-jest to allow us to test `.mjs` files.