### PR TITLE
Use empty strings for visually hidden text

### DIFF
--- a/src/govuk/components/error-message/error-message.yaml
+++ b/src/govuk/components/error-message/error-message.yaml
@@ -45,7 +45,7 @@ examples:
 
 - name: translated
   data:
-    visuallyHiddenText: false
+    visuallyHiddenText: ''
     html: <span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
@@ -83,4 +83,4 @@ examples:
   hidden: true
   data:
     text: There is an error on line 42
-    visuallyHiddenText: false
+    visuallyHiddenText: ''

--- a/src/govuk/components/summary-list/summary-list.yaml
+++ b/src/govuk/components/summary-list/summary-list.yaml
@@ -156,10 +156,10 @@ examples:
             items:
               - href: '#'
                 html: Golygu<span class="govuk-visually-hidden"> enw</span>
-                visuallyHiddenText: false
+                visuallyHiddenText: ''
               - href: '#'
                 html: Dileu<span class="govuk-visually-hidden"> enw</span>
-                visuallyHiddenText: false
+                visuallyHiddenText: ''
         - key:
             text: Dyddiad geni
           value:
@@ -168,7 +168,7 @@ examples:
             items:
               - href: '#'
                 html: Golygu<span class="govuk-visually-hidden"> dyddiad geni</span>
-                visuallyHiddenText: false
+                visuallyHiddenText: ''
         - key:
             text: Gwybodaeth cyswllt
           value:
@@ -187,7 +187,7 @@ examples:
             items:
               - href: '#'
                 html: Golygu<span class="govuk-visually-hidden"> gwybodaeth cyswllt</span>
-                visuallyHiddenText: false
+                visuallyHiddenText: ''
   - name: with some actions
     data:
       rows:


### PR DESCRIPTION
The visuallyHiddenText option is expected to be a string (according to the params definition) but we're setting it to `false` in cases where we don't want to include visually hidden text.

Set it to an empty string instead to avoid using a boolean where we should be using a string.

Fixes #2803.