### PR TITLE
Avoid copying tests ending in `.mjs` to package folder

### DIFF
--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -40,7 +40,7 @@ describe('package/', () => {
     const expectedPackageFiles = () => {
       const filesToIgnore = [
         '.DS_Store',
-        '*.test.js',
+        '*.test.*',
         '*.yaml',
         '*.snap',
         '*/govuk/README.md'

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -87,7 +87,7 @@ function generateFixtures (file) {
 }
 
 gulp.task('js:copy-esm', () => {
-  return gulp.src([configPaths.src + '**/*.mjs', configPaths.src + '**/*.js', '!' + configPaths.src + '/**/*.test.js'])
+  return gulp.src([configPaths.src + '**/*.mjs', configPaths.src + '**/*.js', '!' + configPaths.src + '/**/*.test.*'])
     .pipe(gulp.dest(taskArguments.destination + '/govuk-esm/'))
 })
 

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -87,7 +87,11 @@ function generateFixtures (file) {
 }
 
 gulp.task('js:copy-esm', () => {
-  return gulp.src([configPaths.src + '**/*.mjs', configPaths.src + '**/*.js', '!' + configPaths.src + '/**/*.test.*'])
+  return gulp.src([
+    `${configPaths.src}**/*.mjs`,
+    `${configPaths.src}**/*.js`,
+    `!${configPaths.src}**/*.test.*`
+  ])
     .pipe(gulp.dest(taskArguments.destination + '/govuk-esm/'))
 })
 


### PR DESCRIPTION
Without this change e.g. `src/govuk/i18n.unit.test.mjs` is copied to `package/govuk-esm/i18n.unit.test.mjs`, as it ends in `.test.mjs` rather than `.test.js`.