### PR TITLE
Add unit tests for helpers

### DIFF
--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -30,7 +30,7 @@ const getComponentData = componentName => {
       fs.readFileSync(yamlPath, 'utf8'), { json: true }
     )
   } catch (error) {
-    return new Error(error)
+    throw new Error(error)
   }
 }
 

--- a/lib/file-helper.unit.test.js
+++ b/lib/file-helper.unit.test.js
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+
+const path = require('path')
+const fileHelper = require('../lib/file-helper')
+
+describe('getComponentData', () => {
+  it('returns an error if unable to load component data', () => {
+    expect(() => { fileHelper.getComponentData('not-a-real-component') }).toThrow(Error)
+  })
+
+  it('looks up the correct component path', () => {
+    jest.spyOn(path, 'join')
+
+    fileHelper.getComponentData('accordion')
+
+    expect(path.join).toHaveBeenCalledWith('src/govuk/components/', 'accordion', 'accordion.yaml')
+  })
+
+  it('outputs objects with an array of params and examples', () => {
+    var componentData = fileHelper.getComponentData('accordion')
+
+    expect(componentData).toEqual(expect.objectContaining({
+      params: expect.any(Array),
+      examples: expect.any(Array)
+    }))
+  })
+
+  it('outputs a param for each object with the expected attributes', () => {
+    var componentData = fileHelper.getComponentData('accordion')
+
+    componentData.params.forEach((param) => {
+      expect(param).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          type: expect.any(String),
+          required: expect.any(Boolean),
+          description: expect.any(String)
+        })
+      )
+    })
+  })
+
+  it('contains example objects with the expected attributes', () => {
+    var componentData = fileHelper.getComponentData('accordion')
+
+    componentData.examples.forEach((example) => {
+      expect(example).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          data: expect.any(Object)
+        })
+      )
+    })
+  })
+})
+
+describe('fullPageExamples', () => {
+  it('contains name and path of each example, at a minimum', () => {
+    var fullPageExamples = fileHelper.fullPageExamples()
+
+    fullPageExamples.forEach((example) => {
+      expect(example).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          path: expect.any(String)
+        })
+      )
+    })
+  })
+})

--- a/lib/helper-functions.unit.test.js
+++ b/lib/helper-functions.unit.test.js
@@ -1,0 +1,31 @@
+/* eslint-env jest */
+
+const helperFunctions = require('../lib/helper-functions')
+
+describe('componentNameToMacroName', () => {
+  it('transfoms a single word component name', () => {
+    var macroName = helperFunctions.componentNameToMacroName('button')
+
+    expect(macroName).toBe('govukButton')
+  })
+
+  it('transfoms a multi-word component name', () => {
+    var macroName = helperFunctions.componentNameToMacroName('character-count')
+
+    expect(macroName).toBe('govukCharacterCount')
+  })
+})
+
+describe('componentNameToJavaScriptModuleName', () => {
+  it('transfoms a single word component name', () => {
+    var moduleName = helperFunctions.componentNameToJavaScriptModuleName('button')
+
+    expect(moduleName).toBe('GOVUKFrontend.Button')
+  })
+
+  it('transfoms a multi-word component name', () => {
+    var moduleName = helperFunctions.componentNameToJavaScriptModuleName('character-count')
+
+    expect(moduleName).toBe('GOVUKFrontend.CharacterCount')
+  })
+})


### PR DESCRIPTION
This PR adds some unit tests for `lib/file-helpers.js` and `lib/helper-functions.js`.

Things I considered in scope for this testing:

- error handling
- checking expected results from any data manipulation

Things I considered out of scope for this testing:

- functions which essentially act as a wrapper around built-in functions, e.g: `readFileContents` which just calls `fs.readFileSync`
- axe-helper.js, as it simply sets up aXe with a set of config
- jest-helpers.js - I *think* if any of these changed/broke, our component tests would break. These also felt tricky to unit test, as they mostly render out HTML or CSS