### PR TITLE
Avoid duplicated `--error` class on character count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2807: Tidy up and refactor the Character Count JavaScript](https://github.com/alphagov/govuk-frontend/pull/2807)
 - [#2811: Use Element.id to get module id for accordion](https://github.com/alphagov/govuk-frontend/pull/2811)
+- [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)
 
 ## 4.3.1 (Patch release)
 

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -13,7 +13,7 @@
     spellcheck: params.spellcheck,
     value: params.value,
     formGroup: params.formGroup,
-    classes: 'govuk-js-character-count' + (' govuk-textarea--error' if params.errorMessage) + (' ' + params.classes if params.classes),
+    classes: 'govuk-js-character-count' + (' ' + params.classes if params.classes),
     label: {
       html: params.label.html,
       text: params.label.text,


### PR DESCRIPTION
The character count is adding the `--error` modifier class when there is an error message passed, but as part of a call to the textarea component which is already handling this for us using similar logic:

https://github.com/alphagov/govuk-frontend/blob/8f8fa6f9a64753f4bc3c36328c6fdb0539cbb52c/src/govuk/components/textarea/template.njk#L40

As a result, when an error message is passed we currently end up with duplicated `--error` modifier classes on the textarea:

```html
<textarea class="govuk-textarea govuk-textarea--error govuk-js-character-count govuk-textarea--error" id="exceeding-characters" name="exceeding" rows="5" aria-describedby="exceeding-characters-info exceeding-characters-error">
</textarea>
```

Remove the logic to add the `--error` modifier class from the character count component and leave it to the textarea component to handle this.