### PR TITLE
Add string interpolation functionality to i18n

### DIFF
--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -27,7 +27,7 @@ I18n.prototype.t = function (lookupKey, options) {
     var translationString = this.translations[lookupKey]
 
     // Check for ${} placeholders in the translation string
-    if (translationString.match(/\${(.\S+)}/)) {
+    if (translationString.match(/%{(.\S+)}/)) {
       if (!options) {
         throw new Error('i18n: cannot replace placeholders in string if no option data provided')
       }
@@ -51,7 +51,7 @@ I18n.prototype.t = function (lookupKey, options) {
  * @returns  {String}             - The translation string to output, with ${} placeholders replaced
  */
 I18n.prototype.replacePlaceholders = function (translationString, options) {
-  var placeholderRegex = RegExp(/\${(.\S+)}/, 'g')
+  var placeholderRegex = RegExp(/%{(.\S+)}/, 'g')
   var placeholderMatch
 
   // Use `exec` for fetching regex matches, as matchAll() is not supported in IE

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -15,19 +15,63 @@ function I18n (translations) {
  * returns the appropriate string.
  *
  * @param    {String}  lookupKey  - The lookup key of the string to use.
+ * @param    {Object}  options    - Any options passed with the translation string, e.g: for string interpolation.
  * @returns  {String}             - The appropriate translation string.
  */
-I18n.prototype.t = function (lookupKey) {
+I18n.prototype.t = function (lookupKey, options) {
   if (!lookupKey) {
     // Print a console error if no lookup key has been provided
     throw new Error('i18n lookup key missing.')
   } else if (lookupKey in this.translations) {
-    // Return the translation string if it exists in the object
-    return this.translations[lookupKey]
+    // Fetch the translation string for that lookup key
+    var translationString = this.translations[lookupKey]
+
+    // Check for ${} placeholders in the translation string
+    if (translationString.match(/\${(.\S+)}/)) {
+      if (!options) {
+        throw new Error('i18n: cannot replace placeholders in string if no option data provided')
+      }
+
+      return this.replacePlaceholders(translationString, options)
+    } else {
+      return translationString
+    }
   } else {
     // Otherwise, return the lookup key itself as the fallback
     return lookupKey
   }
+}
+
+/**
+ * Takes a translation string with placeholders, and replaces the placeholders
+ * with the provided data
+ *
+ * @param    {String}  translationString  - The translation string
+ * @param    {Object}  options    - Any options passed with the translation string, e.g: for string interpolation.
+ * @returns  {String}             - The translation string to output, with ${} placeholders replaced
+ */
+I18n.prototype.replacePlaceholders = function (translationString, options) {
+  var placeholderRegex = RegExp(/\${(.\S+)}/, 'g')
+  var placeholderMatch
+
+  // Use `exec` for fetching regex matches, as matchAll() is not supported in IE
+  while ((placeholderMatch = placeholderRegex.exec(translationString)) !== null) {
+    var placeholderIncludingBraces = placeholderMatch[0]
+    var placeholderKey = placeholderMatch[1]
+    if (Object.prototype.hasOwnProperty.call(options, placeholderKey)) {
+      // If a user has passed `false` as the value for the placeholder
+      // treat it as though the value should not be displayed
+      if (options[placeholderKey] === false) {
+        translationString = translationString.replace(placeholderIncludingBraces, '')
+      }
+
+      translationString = translationString.replace(placeholderIncludingBraces, options[placeholderKey])
+    } else {
+      throw new Error('i18n: no data found to replace ' + placeholderMatch[0] + ' placeholder in string')
+    }
+  }
+
+  return translationString
 }
 
 export default I18n

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -3,8 +3,6 @@
  */
 /* eslint-env jest */
 
-/* eslint-disable no-template-curly-in-string */
-
 import I18n from './i18n.mjs'
 
 describe('I18n', () => {
@@ -44,7 +42,7 @@ describe('I18n', () => {
 
   describe('string interpolation', () => {
     const config = {
-      nameString: 'My name is ${name}'
+      nameString: 'My name is %{name}'
     }
 
     it('throws an error if the options data is not present', () => {
@@ -54,33 +52,40 @@ describe('I18n', () => {
 
     it('throws an error if the options object is empty', () => {
       const i18n = new I18n(config)
-      expect(() => { i18n.t('nameString', {}) }).toThrowError('i18n: no data found to replace ${name} placeholder in string')
+      expect(() => { i18n.t('nameString', {}) }).toThrowError('i18n: no data found to replace %{name} placeholder in string')
     })
 
     it('throws an error if the options object does not have a matching key', () => {
       const i18n = new I18n(config)
-      expect(() => { i18n.t('nameString', { unrelatedThing: 'hello' }) }).toThrowError('i18n: no data found to replace ${name} placeholder in string')
+      expect(() => { i18n.t('nameString', { unrelatedThing: 'hello' }) }).toThrowError('i18n: no data found to replace %{name} placeholder in string')
     })
 
-    it('only matches ${} as a placeholder', () => {
+    it('only matches %{} as a placeholder', () => {
       const i18n = new I18n({
-        price: '${name}, this } item ${ costs $5.00'
+        price: '%{name}, this } item %{ costs $5.00'
       })
-      expect(i18n.t('price', { name: 'John' })).toBe('John, this } item ${ costs $5.00')
+      expect(i18n.t('price', { name: 'John' })).toBe('John, this } item %{ costs $5.00')
     })
 
     it('can lookup a placeholder value with non-alphanumeric key', () => {
       const i18n = new I18n({
-        age: 'My age is ${current-age}'
+        age: 'My age is %{current-age}'
       })
       expect(i18n.t('age', { 'current-age': 55 })).toBe('My age is 55')
     })
 
     it('can lookup a placeholder value with reserved name as key', () => {
       const i18n = new I18n({
-        age: 'My age is ${assign}'
+        age: 'My age is %{valueOf}'
       })
-      expect(i18n.t('age', { assign: 55 })).toBe('My age is 55')
+      expect(i18n.t('age', { valueOf: 55 })).toBe('My age is 55')
+    })
+
+    it('throws an expected error if placeholder key with reserved name is not present in options', () => {
+      const i18n = new I18n({
+        age: 'My age is %{valueOf}'
+      })
+      expect(() => { i18n.t('age', {}) }).toThrowError('i18n: no data found to replace %{valueOf} placeholder in string')
     })
 
     it('replaces the placeholder with the provided data', () => {
@@ -90,8 +95,8 @@ describe('I18n', () => {
 
     it('can replace a placeholder with a falsey value', () => {
       const i18n = new I18n({
-        nameString: 'My name is ${name}',
-        stock: 'Stock level: ${quantity}'
+        nameString: 'My name is %{name}',
+        stock: 'Stock level: %{quantity}'
       })
       expect(i18n.t('nameString', { name: '' })).toBe('My name is ')
       expect(i18n.t('stock', { quantity: 0 })).toBe('Stock level: 0')
@@ -99,7 +104,7 @@ describe('I18n', () => {
 
     it('can pass false as a placeholder replacement to hide the value', () => {
       const i18n = new I18n({
-        personalDetails: 'John Smith ${age}'
+        personalDetails: 'John Smith %{age}'
       })
       expect(i18n.t('personalDetails', { age: false })).toBe('John Smith ')
     })
@@ -111,21 +116,21 @@ describe('I18n', () => {
 
     it('replaces multiple placeholders, if present', () => {
       const i18n = new I18n({
-        nameString: 'Their name is ${name}. ${name} is ${age} years old'
+        nameString: 'Their name is %{name}. %{name} is %{age} years old'
       })
       expect(i18n.t('nameString', { number: 50, name: 'Andrew', otherName: 'Vic', age: 22 })).toBe('Their name is Andrew. Andrew is 22 years old')
     })
 
     it('nested placeholder only resolves with a matching key', () => {
       const i18n = new I18n({
-        nameString: 'Their name is ${name${age}}'
+        nameString: 'Their name is %{name%{age}}'
       })
-      expect(i18n.t('nameString', { name: 'Andrew', age: 55, 'name${age}': 'Testing' })).toBe('Their name is Testing')
+      expect(i18n.t('nameString', { name: 'Andrew', age: 55, 'name%{age}': 'Testing' })).toBe('Their name is Testing')
     })
 
     it('handles placeholder-style text within options values', () => {
       const i18n = new I18n(config)
-      expect(i18n.t('nameString', { name: '${name}' })).toBe('My name is ${name}')
+      expect(i18n.t('nameString', { name: '%{name}' })).toBe('My name is %{name}')
     })
   })
 })

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -3,6 +3,8 @@
  */
 /* eslint-env jest */
 
+/* eslint-disable no-template-curly-in-string */
+
 import I18n from './i18n.mjs'
 
 describe('I18n', () => {
@@ -37,6 +39,93 @@ describe('I18n', () => {
     it('throws an error if no lookup key is provided', () => {
       const i18n = new I18n(config)
       expect(() => i18n.t()).toThrow('i18n lookup key missing.')
+    })
+  })
+
+  describe('string interpolation', () => {
+    const config = {
+      nameString: 'My name is ${name}'
+    }
+
+    it('throws an error if the options data is not present', () => {
+      const i18n = new I18n(config)
+      expect(() => { i18n.t('nameString') }).toThrowError('i18n: cannot replace placeholders in string if no option data provided')
+    })
+
+    it('throws an error if the options object is empty', () => {
+      const i18n = new I18n(config)
+      expect(() => { i18n.t('nameString', {}) }).toThrowError('i18n: no data found to replace ${name} placeholder in string')
+    })
+
+    it('throws an error if the options object does not have a matching key', () => {
+      const i18n = new I18n(config)
+      expect(() => { i18n.t('nameString', { unrelatedThing: 'hello' }) }).toThrowError('i18n: no data found to replace ${name} placeholder in string')
+    })
+
+    it('only matches ${} as a placeholder', () => {
+      const i18n = new I18n({
+        price: '${name}, this } item ${ costs $5.00'
+      })
+      expect(i18n.t('price', { name: 'John' })).toBe('John, this } item ${ costs $5.00')
+    })
+
+    it('can lookup a placeholder value with non-alphanumeric key', () => {
+      const i18n = new I18n({
+        age: 'My age is ${current-age}'
+      })
+      expect(i18n.t('age', { 'current-age': 55 })).toBe('My age is 55')
+    })
+
+    it('can lookup a placeholder value with reserved name as key', () => {
+      const i18n = new I18n({
+        age: 'My age is ${assign}'
+      })
+      expect(i18n.t('age', { assign: 55 })).toBe('My age is 55')
+    })
+
+    it('replaces the placeholder with the provided data', () => {
+      const i18n = new I18n(config)
+      expect(i18n.t('nameString', { name: 'John' })).toBe('My name is John')
+    })
+
+    it('can replace a placeholder with a falsey value', () => {
+      const i18n = new I18n({
+        nameString: 'My name is ${name}',
+        stock: 'Stock level: ${quantity}'
+      })
+      expect(i18n.t('nameString', { name: '' })).toBe('My name is ')
+      expect(i18n.t('stock', { quantity: 0 })).toBe('Stock level: 0')
+    })
+
+    it('can pass false as a placeholder replacement to hide the value', () => {
+      const i18n = new I18n({
+        personalDetails: 'John Smith ${age}'
+      })
+      expect(i18n.t('personalDetails', { age: false })).toBe('John Smith ')
+    })
+
+    it('selects the correct data to replace in the string', () => {
+      const i18n = new I18n(config)
+      expect(i18n.t('nameString', { number: 50, name: 'Claire', otherName: 'Zoe' })).toBe('My name is Claire')
+    })
+
+    it('replaces multiple placeholders, if present', () => {
+      const i18n = new I18n({
+        nameString: 'Their name is ${name}. ${name} is ${age} years old'
+      })
+      expect(i18n.t('nameString', { number: 50, name: 'Andrew', otherName: 'Vic', age: 22 })).toBe('Their name is Andrew. Andrew is 22 years old')
+    })
+
+    it('nested placeholder only resolves with a matching key', () => {
+      const i18n = new I18n({
+        nameString: 'Their name is ${name${age}}'
+      })
+      expect(i18n.t('nameString', { name: 'Andrew', age: 55, 'name${age}': 'Testing' })).toBe('Their name is Testing')
+    })
+
+    it('handles placeholder-style text within options values', () => {
+      const i18n = new I18n(config)
+      expect(i18n.t('nameString', { name: '${name}' })).toBe('My name is ${name}')
     })
   })
 })


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/2700

## What
Adds logic to `i18n.mjs` to allow strings with placeholders to be passed in and replaced with dynamic data.

For example:
```
{
    "nameString": "My name is ${name}"
}

I18n.t('nameString', { name: "Vanita" })
```

Note: at the moment, the logic throws an error if it can't replace placeholder strings because it can't find the relevant data in the options object. Unsure if this is the behaviour we want, or if we just want to return the string with placeholders present, but I've gone with error in this PR so far. Happy to hear other thoughts. 🤷‍♀️ 
