### PR TITLE
Remove aria-expanded from radios with conditional content when JS is enabled

### DIFF
--- a/package/govuk-esm/components/radios/radios.mjs
+++ b/package/govuk-esm/components/radios/radios.mjs
@@ -82,7 +82,6 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
   if ($target && $target.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked
 
-    $input.setAttribute('aria-expanded', inputIsChecked)
     $target.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
   }
 }

--- a/package/govuk/all.js
+++ b/package/govuk/all.js
@@ -2408,7 +2408,6 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
   if ($target && $target.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked;
 
-    $input.setAttribute('aria-expanded', inputIsChecked);
     $target.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked);
   }
 };

--- a/package/govuk/components/radios/radios.js
+++ b/package/govuk/components/radios/radios.js
@@ -1106,7 +1106,6 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
   if ($target && $target.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked;
 
-    $input.setAttribute('aria-expanded', inputIsChecked);
     $target.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked);
   }
 };

--- a/src/govuk/components/radios/radios.mjs
+++ b/src/govuk/components/radios/radios.mjs
@@ -82,7 +82,6 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
   if ($target && $target.classList.contains('govuk-radios__conditional')) {
     var inputIsChecked = $input.checked
 
-    $input.setAttribute('aria-expanded', inputIsChecked)
     $target.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
   }
 }

--- a/src/govuk/components/radios/radios.test.js
+++ b/src/govuk/components/radios/radios.test.js
@@ -43,10 +43,8 @@ describe('Radios with conditional reveals', () => {
       const $ = await goToAndGetComponent('radios', 'with-conditional-items')
       const $component = $('.govuk-radios')
 
-      const hasAriaExpanded = $component.find('.govuk-radios__input[aria-expanded]').length
       const hasAriaControls = $component.find('.govuk-radios__input[aria-controls]').length
 
-      expect(hasAriaExpanded).toBeFalsy()
       expect(hasAriaControls).toBeFalsy()
     })
 
@@ -76,18 +74,6 @@ describe('Radios with conditional reveals', () => {
 
       const isContentHidden = await waitForHiddenSelector(`[id="${uncheckedInputAriaControls}"].govuk-radios__conditional--hidden`)
       expect(isContentHidden).toBeTruthy()
-    })
-
-    it('indicates when conditional content is collapsed or revealed', async () => {
-      await goToAndGetComponent('radios', 'with-conditional-items')
-
-      const isNotExpanded = await waitForVisibleSelector('.govuk-radios__item:first-child .govuk-radios__input[aria-expanded=false]')
-      expect(isNotExpanded).toBeTruthy()
-
-      await page.click('.govuk-radios__item:first-child .govuk-radios__input')
-
-      const isExpanded = await waitForVisibleSelector('.govuk-radios__item:first-child .govuk-radios__input[aria-expanded=true]')
-      expect(isExpanded).toBeTruthy()
     })
 
     it('toggles the conditional content when clicking an input', async () => {


### PR DESCRIPTION
This PR removes the `aria-expanded` attribute from radios with conditional content.

Without this change, accessibility tools such as AXE and Lighthouse flag a critical issue:

> ARIA attribute is not allowed: aria-expanded="false"

Currently, `aria-expanded` is not supported for radio buttons. This may change: https://github.com/w3c/aria/issues/1404