### PR TITLE
Add complementary aria role to phase banner

### DIFF
--- a/app/views/partials/banner.njk
+++ b/app/views/partials/banner.njk
@@ -1,5 +1,5 @@
 {% if shouldShowAppBanner %}
-<div class="app-banner app-banner--warning" data-module="app-banner">
+<div class="app-banner app-banner--warning" data-module="app-banner" role="complementary">
   <div class="govuk-width-container">
     <p class="govuk-body">
       This is an internal development app.

--- a/app/views/partials/exampleBanner.njk
+++ b/app/views/partials/exampleBanner.njk
@@ -1,5 +1,5 @@
 {% if shouldShowAppBanner %}
-<div class="app-banner app-banner--warning" data-module="app-banner">
+<div class="app-banner app-banner--warning" data-module="app-banner" role="complementary">
   <div class="govuk-width-container">
     <p class="govuk-body">
       This is not a real service, and is used for testing purposes only.

--- a/package/govuk/components/phase-banner/template.njk
+++ b/package/govuk/components/phase-banner/template.njk
@@ -1,7 +1,7 @@
 {% from "../tag/macro.njk" import govukTag -%}
 
 <div class="govuk-phase-banner
-  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} role="complementary">
   <p class="govuk-phase-banner__content">
     {{ govukTag({
       text: params.tag.text,

--- a/src/govuk/components/phase-banner/template.njk
+++ b/src/govuk/components/phase-banner/template.njk
@@ -1,7 +1,7 @@
 {% from "../tag/macro.njk" import govukTag -%}
 
 <div class="govuk-phase-banner
-  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+  {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} role="complementary">
   <p class="govuk-phase-banner__content">
     {{ govukTag({
       text: params.tag.text,

--- a/src/govuk/components/phase-banner/template.test.js
+++ b/src/govuk/components/phase-banner/template.test.js
@@ -25,6 +25,13 @@ describe('Phase banner', () => {
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
+    it('renders `complementary` role attribute', () => {
+      const $ = render('phase-banner', examples.attributes)
+
+      const $component = $('.govuk-phase-banner')
+      expect($component.attr('role')).toEqual('complementary')
+    })
+
     it('renders banner text', () => {
       const $ = render('phase-banner', examples.text)
       const phaseBannerText = $('.govuk-phase-banner__text').text().trim()


### PR DESCRIPTION
This PR adds a `complementary` landmark role attribute to the phase banner.

> [landmark role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles#landmark_roles) is used to designate a supporting section that relates to the main content, yet can stand alone when separated. These sections are frequently presented as sidebars or call-out boxes

Without this, accessibility tools such as AXE flag a moderate issue:

> "All page content should be contained by landmarks"
> "Some page content is not contained by landmarks"