### PR TITLE
Add support for localisation via JavaScript configuration to Accordion component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,12 @@ If you're not using the Nunjucks macro, you can customise these using data-* att
 - `data-i18n.show-all-sections`
 - `data-i18n.hide-all-sections`
 
-This was added in [pull request #2818: Add support for localisation via data-* attributes to Accordion component](https://github.com/alphagov/govuk-frontend/pull/2818).
+You can also change this text for all instances of the Accordion using a JavaScript configuration object. See [our guidance on localising GOV.UK Frontend](https://design-system.service.gov.uk/get-started/localisation/) for how to do this. 
+
+This was added in pull requests:
+
+- [#2818: Add support for localisation via data-* attributes to Accordion component](https://github.com/alphagov/govuk-frontend/pull/2818)
+- [#2826: Add support for localisation via JavaScript configuration to Accordion component](https://github.com/alphagov/govuk-frontend/pull/2826)
 
 ### Recommended changes
 

--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -870,3 +870,19 @@
     iconFallbackText: "Rhybudd"
   }) }}
 {% endblock %}
+
+{% block bodyEnd %}
+  <script src="/public/all.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll({
+      accordion: {
+        i18n: {
+          showAllSections: "Dangos adrannau",
+          hideAllSections: "Cuddio adrannau",
+        },
+        "i18n.showSection": "Dangos<span class=\"govuk-visually-hidden\"> adran</span>",
+        "i18n.hideSection": "Cuddio<span class=\"govuk-visually-hidden\"> adran</span>",
+      }
+    })
+  </script>
+{% endblock %}

--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -26,7 +26,7 @@ function initAll (options) {
 
   var $accordions = scope.querySelectorAll('[data-module="govuk-accordion"]')
   nodeListForEach($accordions, function ($accordion) {
-    new Accordion($accordion).init()
+    new Accordion($accordion, options.accordion).init()
   })
 
   var $details = scope.querySelectorAll('[data-module="govuk-details"]')

--- a/src/govuk/common.unit.test.mjs
+++ b/src/govuk/common.unit.test.mjs
@@ -53,6 +53,16 @@ describe('Common JS utilities', () => {
       })
     })
 
+    it('ignores empty objects when merging', () => {
+      const test1 = mergeConfigs({}, config1)
+      const test2 = mergeConfigs(config1, {}, config2)
+      const test3 = mergeConfigs(config3, {})
+
+      expect(test1).toEqual(mergeConfigs(config1))
+      expect(test2).toEqual(mergeConfigs(config1, config2))
+      expect(test3).toEqual(mergeConfigs(config3))
+    })
+
     it('prioritises the last parameter provided', () => {
       const config = mergeConfigs(config1, config2, config3, config1)
       expect(config).toEqual({

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -20,7 +20,8 @@ import I18n from '../../i18n.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
-function Accordion ($module) {
+function Accordion ($module, config) {
+  config = config || {}
   this.$module = $module
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
@@ -34,7 +35,7 @@ function Accordion ($module) {
       showSection: 'Show<span class="govuk-visually-hidden"> this section</span>'
     }
   }
-  this.config = mergeConfigs(defaultConfig, $module.dataset)
+  this.config = mergeConfigs(defaultConfig, config, $module.dataset)
   this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
 
   this.controlsClass = 'govuk-accordion__controls'

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -21,7 +21,6 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 
 function Accordion ($module, config) {
-  config = config || {}
   this.$module = $module
   this.$sections = $module.querySelectorAll('.govuk-accordion__section')
   this.$showAllButton = ''
@@ -35,7 +34,7 @@ function Accordion ($module, config) {
       showSection: 'Show<span class="govuk-visually-hidden"> this section</span>'
     }
   }
-  this.config = mergeConfigs(defaultConfig, config, $module.dataset)
+  this.config = mergeConfigs(defaultConfig, config || {}, $module.dataset)
   this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
 
   this.controlsClass = 'govuk-accordion__controls'

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -272,6 +272,14 @@ describe('/components/accordion', () => {
           expect(allSectionsToggleText).toEqual(showAllSectionsDataAttribute)
         })
 
+        it('should localise "Show all sections" based on JavaScript configuration', async () => {
+          await page.goto(baseUrl + '/examples/translated', { waitUntil: 'load' })
+
+          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+
+          expect(allSectionsToggleText).toBe('Dangos adrannau')
+        })
+
         it('should localise "Hide all sections" based on data attribute', async () => {
           await page.goto(baseUrl + '/components/accordion/with-translations/preview', { waitUntil: 'load' })
           await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
@@ -283,6 +291,18 @@ describe('/components/accordion', () => {
           expect(allSectionsToggleText).toEqual(hideAllSectionsDataAttribute)
         })
 
+        it('should localise "Hide all sections" based on JavaScript configuration', async () => {
+          await page.goto(baseUrl + '/examples/translated', { waitUntil: 'load' })
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(4) .govuk-accordion__section-header')
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(5) .govuk-accordion__section-header')
+
+          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+
+          expect(allSectionsToggleText).toBe('Cuddio adrannau')
+        })
+
         it('should localise "Show section" based on data attribute', async () => {
           await page.goto(baseUrl + '/components/accordion/with-translations/preview', { waitUntil: 'load' })
 
@@ -290,6 +310,14 @@ describe('/components/accordion', () => {
           const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
 
           expect(firstSectionToggleText).toEqual(showSectionDataAttribute)
+        })
+
+        it('should localise "Show section" based on JavaScript configuration', async () => {
+          await page.goto(baseUrl + '/examples/translated', { waitUntil: 'load' })
+
+          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+
+          expect(firstSectionToggleText).toBe('Dangos<span class="govuk-visually-hidden"> adran</span>')
         })
 
         it('should localise "Hide section" based on data attribute', async () => {
@@ -300,6 +328,15 @@ describe('/components/accordion', () => {
           const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
 
           expect(firstSectionToggleText).toEqual(hideSectionDataAttribute)
+        })
+
+        it('should localise "Hide section" based on JavaScript configuration', async () => {
+          await page.goto(baseUrl + '/examples/translated', { waitUntil: 'load' })
+          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+
+          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+
+          expect(firstSectionToggleText).toBe('Cuddio<span class="govuk-visually-hidden"> adran</span>')
         })
       })
     })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -293,10 +293,7 @@ describe('/components/accordion', () => {
 
         it('should localise "Hide all sections" based on JavaScript configuration', async () => {
           await page.goto(baseUrl + '/examples/translated', { waitUntil: 'load' })
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(4) .govuk-accordion__section-header')
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(5) .govuk-accordion__section-header')
+          await page.click('.govuk-accordion .govuk-accordion__show-all')
 
           const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
 


### PR DESCRIPTION
This is related to two issues, #2802 and #2698, as I couldn't find a way to cleanly separate them.

- Modifies the `initAll` function to pass `options.accordion` into the accordion initialisation.
- Modifies the accordion component to accept a second `config` parameter (defaults to an empty object).
- Modifies the accordion component's config merging to accept the `config` parameter. 
- Updates the 'translated' full-page example to call `initAll` with a custom configuration.
- Adds integration tests checking that the accordion's text is modified according to the configuration.
- Adds unit tests to the existing `mergeConfig` function to ensure that it supports empty objects.

## Todo

#2802 includes a task to ensure that "Data attribute translations take priority over JS translations, if both provided"

This is partially covered by the configuration merging function's unit tests, though that function also doesn't make an explicit distinction between configuration passed from data-* attributes and those from JavaScript. Do we feel like we need to explicitly test for parameter ordering? 