### PR TITLE
Add checkbox mousedown event handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2807: Tidy up and refactor the Character Count JavaScript](https://github.com/alphagov/govuk-frontend/pull/2807)
 - [#2811: Use Element.id to get module id for accordion](https://github.com/alphagov/govuk-frontend/pull/2811)
 - [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)
+- [#2837: Target label active state as well as input focus on checkbox focus styles](https://github.com/alphagov/govuk-frontend/pull/2827). Thanks to [Ed Horsford](https://github.com/edwardhorsford) for raising and investigating this issue
 
 ## 4.3.1 (Patch release)
 

--- a/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/src/govuk/components/checkboxes/checkboxes.mjs
@@ -58,6 +58,7 @@ Checkboxes.prototype.init = function () {
   this.syncAllConditionalReveals()
 
   $module.addEventListener('click', this.handleClick.bind(this))
+  $module.addEventListener('mousedown', this.handleMousedown.bind(this))
 }
 
 /**
@@ -159,6 +160,23 @@ Checkboxes.prototype.handleClick = function (event) {
   } else {
     this.unCheckExclusiveInputs($target)
   }
+}
+
+/**
+ * Mousedown event handler
+ *
+ * An additional handler for the mousedown event. If the user clicks the label then
+ * prevent default mousedown behaviour. This is to handle a visual glitch where for
+ * the period that the label is :active (pointer is held down the label) the input
+ * focus state disappears. This is caused by focus moving away from the input due
+ * to the click on the label and the focus targeting no longer working.
+ */
+Checkboxes.prototype.handleMousedown = function (event) {
+  console.log(document.activeElement)
+  if (event.target.tagName === 'LABEL') {
+    // event.preventDefault()
+  }
+  console.log(document.activeElement)
 }
 
 export default Checkboxes


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/1906

Handles the visual bug mentioned in the issue using a `mousedown` event handler that targets checkbox labels. More details can be found in the commit message.

Thanks to @edwardhorsford for his investigation into this issue and original PR https://github.com/alphagov/govuk-frontend/pull/1907