### PR TITLE
Cleanup the JavaScript for the button component

### DIFF
--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -10,47 +10,50 @@ function Button ($module) {
 }
 
 /**
-* Initialise an event listener for keydown at document level
-* this will help listening for later inserted elements with a role="button"
-*/
+ * Initialise component
+ */
 Button.prototype.init = function () {
   this.$module.addEventListener('keydown', this.handleKeyDown)
   this.$module.addEventListener('click', this.debounce)
 }
 
 /**
-* JavaScript 'shim' to trigger the click event of element(s) when the space key is pressed.
-*
-* Created since some Assistive Technologies (for example some Screenreaders)
-* will tell a user to press space on a 'button', so this functionality needs to be shimmed
-* See https://github.com/alphagov/govuk_elements/pull/272#issuecomment-233028270
-*
-* @param {object} event event
-*/
+ * Trigger a click event when the space key is pressed
+ *
+ * Some screen readers tell users they can activate things with the 'button'
+ * role, so we need to match the functionality of native HTML buttons
+ *
+ * See https://github.com/alphagov/govuk_elements/pull/272#issuecomment-233028270
+ *
+ * @param {KeyboardEvent} event
+ */
 Button.prototype.handleKeyDown = function (event) {
-  // get the target element
   var target = event.target
-  // if the element has a role='button' and the pressed key is a space, we'll simulate a click
+
   if (target.getAttribute('role') === 'button' && event.keyCode === KEY_SPACE) {
-    event.preventDefault()
-    // trigger the target's click event
+    event.preventDefault() // prevent the page from scrolling
     target.click()
   }
 }
 
 /**
-* If the click quickly succeeds a previous click then nothing will happen.
-* This stops people accidentally causing multiple form submissions by
-* double clicking buttons.
-*/
+ * Debounce double-clicks
+ *
+ * If the click quickly succeeds a previous click then nothing will happen. This
+ * stops people accidentally causing multiple form submissions by double
+ * clicking buttons.
+ *
+ * @param {MouseEvent} event
+ */
 Button.prototype.debounce = function (event) {
   var target = event.target
-  // Check the button that is clicked on has the preventDoubleClick feature enabled
+
+  // Check the button that was clicked has preventDoubleClick enabled
   if (target.getAttribute('data-prevent-double-click') !== 'true') {
     return
   }
 
-  // If the timer is still running then we want to prevent the click from submitting the form
+  // If the timer is still running, prevent the click from submitting the form
   if (this.debounceFormSubmitTimer) {
     event.preventDefault()
     return false

--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -10,6 +10,15 @@ function Button ($module) {
 }
 
 /**
+* Initialise an event listener for keydown at document level
+* this will help listening for later inserted elements with a role="button"
+*/
+Button.prototype.init = function () {
+  this.$module.addEventListener('keydown', this.handleKeyDown)
+  this.$module.addEventListener('click', this.debounce)
+}
+
+/**
 * JavaScript 'shim' to trigger the click event of element(s) when the space key is pressed.
 *
 * Created since some Assistive Technologies (for example some Screenreaders)
@@ -50,15 +59,6 @@ Button.prototype.debounce = function (event) {
   this.debounceFormSubmitTimer = setTimeout(function () {
     this.debounceFormSubmitTimer = null
   }.bind(this), DEBOUNCE_TIMEOUT_IN_SECONDS * 1000)
-}
-
-/**
-* Initialise an event listener for keydown at document level
-* this will help listening for later inserted elements with a role="button"
-*/
-Button.prototype.init = function () {
-  this.$module.addEventListener('keydown', this.handleKeyDown)
-  this.$module.addEventListener('click', this.debounce)
 }
 
 export default Button


### PR DESCRIPTION
- Move the init function to the top
- Edit the comments for the other functions for brevity
- Fix indentation and wrap at 80 characters
- Remove redundant comments where the code is already self-documenting or covered by the JSDoc
- Remove a lie (that we listen for events at the document level)