### PR TITLE
Normalise booleans and numbers in data attributes

### DIFF
--- a/src/govuk/common.mjs
+++ b/src/govuk/common.mjs
@@ -129,3 +129,59 @@ export function extractConfigByNamespace (configObject, namespace) {
   }
   return newObject
 }
+
+/**
+ * Normalise string
+ *
+ * 'If it looks like a duck, and it quacks like a duck…' 🦆
+ *
+ * If the passed value looks like a boolean or a number, convert it to a boolean
+ * or number.
+ *
+ * Designed to be used to convert config passed via data attributes (which are
+ * always strings) into something sensible.
+ *
+ * @param {String} value - The value to normalise
+ * @returns {(String|Boolean|Number)} Normalised data
+ */
+export function normaliseString (value) {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  var trimmedValue = value.trim()
+
+  if (trimmedValue === 'true') {
+    return true
+  }
+
+  if (trimmedValue === 'false') {
+    return false
+  }
+
+  // Empty / whitespace-only strings are considered finite so we need to check
+  // the length of the trimmed string as well
+  if (trimmedValue.length > 0 && isFinite(trimmedValue)) {
+    return Number(trimmedValue)
+  }
+
+  return value
+}
+
+/**
+ * Normalise dataset
+ *
+ * Loop over an object and normalise each value using normaliseData function
+ *
+ * @param {DOMStringMap} dataset
+ * @returns {Object} Normalised dataset
+ */
+export function normaliseDataset (dataset) {
+  var out = {}
+
+  for (var key in dataset) {
+    out[key] = normaliseString(dataset[key])
+  }
+
+  return out
+}

--- a/src/govuk/common.unit.test.mjs
+++ b/src/govuk/common.unit.test.mjs
@@ -3,7 +3,7 @@
  */
 /* eslint-env jest */
 
-import { mergeConfigs, extractConfigByNamespace } from './common.mjs'
+import { mergeConfigs, extractConfigByNamespace, normaliseString, normaliseDataset } from './common.mjs'
 
 // TODO: Write unit tests for `nodeListForEach` and `generateUniqueID`
 
@@ -108,6 +108,113 @@ describe('Common JS utilities', () => {
 
     it('throws an error if no `namespace` is provided', () => {
       expect(() => extractConfigByNamespace(flattenedConfig)).toThrow()
+    })
+  })
+
+  describe('normaliseString', () => {
+    it('does not normalise non-strings', () => {
+      expect(normaliseString(100)).toEqual(100)
+      expect(normaliseString(false)).toEqual(false)
+      expect(normaliseString({})).toEqual({})
+      expect(normaliseString(NaN)).toEqual(NaN)
+    })
+
+    it('normalises the string "true" to boolean true', () => {
+      expect(normaliseString('true')).toEqual(true)
+    })
+
+    it('normalises the string "false" to boolean false', () => {
+      expect(normaliseString('false')).toEqual(false)
+    })
+
+    it('normalises the string " true " to boolean true', () => {
+      expect(normaliseString(' true ')).toEqual(true)
+    })
+
+    it('normalises the string " false " to boolean false', () => {
+      expect(normaliseString(' false ')).toEqual(false)
+    })
+
+    it('does not normalise non-lowercase booleans', () => {
+      expect(normaliseString('TRUE')).toEqual('TRUE')
+      expect(normaliseString('True')).toEqual('True')
+      expect(normaliseString('FALSE')).toEqual('FALSE')
+      expect(normaliseString('False')).toEqual('False')
+    })
+
+    it('does not normalise strings that contain booleans', () => {
+      expect(normaliseString('true!')).toEqual('true!')
+    })
+
+    it('normalises the string "0" to the number 0', () => {
+      expect(normaliseString('0')).toEqual(0)
+    })
+
+    it('normalises strings representing positive numbers to numbers', () => {
+      expect(normaliseString('1337')).toEqual(1337)
+    })
+
+    it('normalises strings representing negative numbers to numbers', () => {
+      expect(normaliseString('-1337')).toEqual(-1337)
+    })
+
+    it('converts strings representing decimal numbers to numbers', () => {
+      expect(normaliseString('0.5')).toEqual(0.5)
+    })
+
+    it('normalises strings representing decimal numbers with extra precision to numbers', () => {
+      expect(normaliseString('100.500')).toEqual(100.5)
+    })
+
+    it('normalises strings representing decimal numbers with no integer-part to numbers', () => {
+      expect(normaliseString('.5')).toEqual(0.5)
+    })
+
+    it('normalises strings representing numbers with whitespace to numbers', () => {
+      expect(normaliseString('   1337   ')).toEqual(1337)
+    })
+
+    it('does not normalise the string "NaN"', () => {
+      expect(normaliseString('NaN')).toEqual('NaN')
+    })
+
+    it('does not normalise the string "Infinity"', () => {
+      expect(normaliseString('Infinity')).toEqual('Infinity')
+    })
+
+    it('normalises strings that represent very big positive numbers to numbers', () => {
+      const biggestNumber = Number.MAX_SAFE_INTEGER + 1
+      expect(normaliseString(biggestNumber.toString())).toEqual(biggestNumber)
+    })
+
+    it('does not normalise strings that contain numbers', () => {
+      expect(normaliseString('100%')).toEqual('100%')
+    })
+
+    it('does not normalise empty strings', () => {
+      expect(normaliseString('')).toEqual('')
+    })
+
+    it('does not normalise whitespace only strings', () => {
+      expect(normaliseString('   ')).toEqual('   ')
+    })
+  })
+
+  describe('normaliseDataset', () => {
+    it('normalises the entire dataset', () => {
+      expect(normaliseDataset({
+        aNumber: '1000',
+        aDecimalNumber: '100.50',
+        aBoolean: 'true',
+        aString: 'Hello!',
+        anOptionalString: ''
+      })).toEqual({
+        aNumber: 1000,
+        aDecimalNumber: 100.5,
+        aBoolean: true,
+        aString: 'Hello!',
+        anOptionalString: ''
+      })
     })
   })
 })

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -15,7 +15,7 @@
 
 */
 
-import { nodeListForEach, mergeConfigs, extractConfigByNamespace } from '../../common.mjs'
+import { nodeListForEach, mergeConfigs, extractConfigByNamespace, normaliseDataset } from '../../common.mjs'
 import I18n from '../../i18n.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
@@ -34,7 +34,11 @@ function Accordion ($module, config) {
       showSection: 'Show<span class="govuk-visually-hidden"> this section</span>'
     }
   }
-  this.config = mergeConfigs(defaultConfig, config || {}, $module.dataset)
+  this.config = mergeConfigs(
+    defaultConfig,
+    config || {},
+    normaliseDataset($module.dataset)
+  )
   this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
 
   this.controlsClass = 'govuk-accordion__controls'


### PR DESCRIPTION
Attributes passed via data attributes will always be strings, but in some cases we want to be able to treat them as booleans or numbers.

For example:

- `data-prevent-double-click` on buttons which is a boolean
- `data-maxlength` on the character count which is a number

Ensure that config passed by data attributes is typed sensibly for the way we want to use it.

This is heavily inspired by [Bootstrap's approach to dealing with data attributes][1].

Closes #2832 

[1]: https://github.com/twbs/bootstrap/blob/6e55fa929797a2d1d5250e1630615f515c45d0db/js/src/dom/manipulator.js#L8-L34