### PR TITLE
Allow notification banner configuration to be passed at construction

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -208,6 +208,13 @@ module.exports = (options) => {
     })
   })
 
+  // Test view for injecting rendered components
+  // and testing specific JavaScript configurations
+  // Example view
+  app.get('/tests/boilerplate', function (req, res) {
+    res.render('tests/boilerplate')
+  })
+
   // Full page example views
   require('./full-page-examples.js')(app)
 

--- a/app/views/tests/boilerplate.njk
+++ b/app/views/tests/boilerplate.njk
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8"/>
+    <title>Test Boilerplate</title>
+    <link rel="stylesheet" href="/public/app.css">
+  </head>
+  <body>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <h1 class="govuk-heading-l">Test boilerplate</h1>
+    <p class="govuk-body">
+      Used for injecting rendered components from tests
+      and test specific configurations
+    </p>
+    <div id="slot"></div>
+    <script src="/public/all.js"></script>
+	</body>
+</html>

--- a/app/views/tests/boilerplate.njk
+++ b/app/views/tests/boilerplate.njk
@@ -9,8 +9,7 @@
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
     <h1 class="govuk-heading-l">Test boilerplate</h1>
     <p class="govuk-body">
-      Used for injecting rendered components from tests
-      and test specific configurations
+      Used during testing to inject rendered components and test specific configurations
     </p>
     <div id="slot"></div>
     <script src="/public/all.js"></script>

--- a/lib/helper-functions.js
+++ b/lib/helper-functions.js
@@ -1,14 +1,17 @@
 'use strict'
 
 /**
- * Convert kebab-cased component name to PascalCase
+ * Convert a kebab-cased string to a PascalCased one
+ *
+ * @param {String} value -
+ * @returns {String}
  */
-function componentNameToPascalCase (componentName) {
-  return componentName
+function kebabCaseToPascalCase (value) {
+  return value
     .toLowerCase()
     .split('-')
     // capitalize each 'word'
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join('')
 }
 
@@ -17,9 +20,22 @@ function componentNameToPascalCase (componentName) {
  *
  * Component names are kebab-cased (button, date-input), whilst macro names have
  * a `govuk` prefix and are camel cased (govukButton, govukDateInput).
+ *
+ * @param {String} componentName - A kebab-cased component name
+ * @returns {String} The name of its corresponding Nunjucks macro
  */
 function componentNameToMacroName (componentName) {
-  return `govuk${componentNameToPascalCase(componentName)}`
+  return `govuk${kebabCaseToPascalCase(componentName)}`
+}
+
+/**
+ * Convert component name to its JavaScript class name
+ *
+ * @param {String} componentName - A kebab-cased component name
+ * @returns {String} The name of its corresponding JavaScript class
+ */
+function componentNameToJavaScriptClassName (componentName) {
+  return kebabCaseToPascalCase(componentName)
 }
 
 /**
@@ -28,15 +44,18 @@ function componentNameToMacroName (componentName) {
  * Used by rollup to set the `window` global and UMD/AMD export name
  *
  * Component names are kebab-cased strings (button, date-input), whilst module
- * names have a `GOVUKFrontend.` prefix and are pascal cased
+ * names have a `GOVUKFrontend.` prefix and are PascalCased
  * (GOVUKFrontend.Button, GOVUKFrontend.CharacterCount).
+ *
+ * @param {String} componentName - A kebab-cased component name
+ * @returns {String} The name of its corresponding module
  */
 function componentNameToJavaScriptModuleName (componentName) {
-  return `GOVUKFrontend.${componentNameToPascalCase(componentName)}`
+  return `GOVUKFrontend.${componentNameToJavaScriptClassName(componentName)}`
 }
 
 module.exports = {
-  componentNameToPascalCase,
+  componentNameToJavaScriptClassName,
   componentNameToMacroName,
   componentNameToJavaScriptModuleName
 }

--- a/lib/helper-functions.js
+++ b/lib/helper-functions.js
@@ -1,41 +1,42 @@
 'use strict'
 
-// Convert component name to macro name
-//
-// This helper function takes a component name and returns the corresponding
-// macro name.
-//
-// Component names are lowercase, dash-separated strings (button, date-input),
-// whilst macro names have a `govuk` prefix and are camel cased (govukButton,
-// govukDateInput).
-const componentNameToMacroName = componentName => {
-  const macroName = componentName
+/**
+ * Convert kebab-cased component name to PascalCase
+ */
+function componentNameToPascalCase (componentName) {
+  return componentName
     .toLowerCase()
     .split('-')
     // capitalize each 'word'
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))
     .join('')
-
-  return `govuk${macroName}`
 }
-exports.componentNameToMacroName = componentNameToMacroName
 
-// Convert component name to JavaScript UMD module name
-//
-// This helper function takes a component name and returns the corresponding
-// module name, which is used by rollup to set the `window` global and UMD/AMD export name
-//
-// Component names are lowercase, dash-separated strings (button, date-input),
-// whilst module names have a `GOVUKFrontend.` prefix and are pascal cased (GOVUKFrontend.Button,
-// GOVUKFrontend.CharacterCount).
-const componentNameToJavaScriptModuleName = componentName => {
-  const macroName = componentName
-    .toLowerCase()
-    .split('-')
-    // capitalize each 'word'
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('')
-
-  return `GOVUKFrontend.${macroName}`
+/**
+ * Convert component name to macro name
+ *
+ * Component names are kebab-cased (button, date-input), whilst macro names have
+ * a `govuk` prefix and are camel cased (govukButton, govukDateInput).
+ */
+function componentNameToMacroName (componentName) {
+  return `govuk${componentNameToPascalCase(componentName)}`
 }
-exports.componentNameToJavaScriptModuleName = componentNameToJavaScriptModuleName
+
+/**
+ * Convert component name to JavaScript UMD module name
+ *
+ * Used by rollup to set the `window` global and UMD/AMD export name
+ *
+ * Component names are kebab-cased strings (button, date-input), whilst module
+ * names have a `GOVUKFrontend.` prefix and are pascal cased
+ * (GOVUKFrontend.Button, GOVUKFrontend.CharacterCount).
+ */
+function componentNameToJavaScriptModuleName (componentName) {
+  return `GOVUKFrontend.${componentNameToPascalCase(componentName)}`
+}
+
+module.exports = {
+  componentNameToPascalCase,
+  componentNameToMacroName,
+  componentNameToJavaScriptModuleName
+}

--- a/lib/helper-functions.unit.test.js
+++ b/lib/helper-functions.unit.test.js
@@ -2,14 +2,14 @@
 
 const helpers = require('../lib/helper-functions')
 
-describe('componentNameToPascalCase', () => {
+describe('componentNameToJavaScriptClassName', () => {
   it('transforms a single word component name', () => {
-    expect(helpers.componentNameToPascalCase('button'))
+    expect(helpers.componentNameToJavaScriptClassName('button'))
       .toBe('Button')
   })
 
   it('transforms a multi-word component name', () => {
-    expect(helpers.componentNameToPascalCase('character-count'))
+    expect(helpers.componentNameToJavaScriptClassName('character-count'))
       .toBe('CharacterCount')
   })
 })

--- a/lib/helper-functions.unit.test.js
+++ b/lib/helper-functions.unit.test.js
@@ -1,31 +1,39 @@
 /* eslint-env jest */
 
-const helperFunctions = require('../lib/helper-functions')
+const helpers = require('../lib/helper-functions')
 
-describe('componentNameToMacroName', () => {
-  it('transfoms a single word component name', () => {
-    var macroName = helperFunctions.componentNameToMacroName('button')
-
-    expect(macroName).toBe('govukButton')
+describe('componentNameToPascalCase', () => {
+  it('transforms a single word component name', () => {
+    expect(helpers.componentNameToPascalCase('button'))
+      .toBe('Button')
   })
 
-  it('transfoms a multi-word component name', () => {
-    var macroName = helperFunctions.componentNameToMacroName('character-count')
+  it('transforms a multi-word component name', () => {
+    expect(helpers.componentNameToPascalCase('character-count'))
+      .toBe('CharacterCount')
+  })
+})
 
-    expect(macroName).toBe('govukCharacterCount')
+describe('componentNameToMacroName', () => {
+  it('transforms a single word component name', () => {
+    expect(helpers.componentNameToMacroName('button'))
+      .toBe('govukButton')
+  })
+
+  it('transforms a multi-word component name', () => {
+    expect(helpers.componentNameToMacroName('character-count'))
+      .toBe('govukCharacterCount')
   })
 })
 
 describe('componentNameToJavaScriptModuleName', () => {
-  it('transfoms a single word component name', () => {
-    var moduleName = helperFunctions.componentNameToJavaScriptModuleName('button')
-
-    expect(moduleName).toBe('GOVUKFrontend.Button')
+  it('transforms a single word component name', () => {
+    expect(helpers.componentNameToJavaScriptModuleName('button'))
+      .toBe('GOVUKFrontend.Button')
   })
 
-  it('transfoms a multi-word component name', () => {
-    var moduleName = helperFunctions.componentNameToJavaScriptModuleName('character-count')
-
-    expect(moduleName).toBe('GOVUKFrontend.CharacterCount')
+  it('transforms a multi-word component name', () => {
+    expect(helpers.componentNameToJavaScriptModuleName('character-count'))
+      .toBe('GOVUKFrontend.CharacterCount')
   })
 })

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -13,7 +13,7 @@ const sass = require('node-sass')
 const sassRender = util.promisify(sass.render)
 
 const configPaths = require('../config/paths.json')
-const { componentNameToMacroName } = require('./helper-functions.js')
+const { componentNameToMacroName, componentNameToPascalCase } = require('./helper-functions.js')
 
 const nunjucksEnv = nunjucks.configure([configPaths.src, configPaths.components], {
   trimBlocks: true,
@@ -84,6 +84,53 @@ function renderTemplate (params = {}, blocks = {}) {
 }
 
 /**
+ * Render and initialise a component within test boilerplate
+ *
+ * Renders a component's Nunjucks macro with the given params, injects it into
+ * the test boilerplate page, then initialises it with either:
+ *
+ * - the provided JavaScript configuration, used to instanciate the relevant
+ *   component class
+ * - a custom initialiser function (that'll let you run arbitrary code, like
+ *   `initAll` in the browser)
+ *
+ * @param {String} componentName - The kebab-cased name of the component
+ * @param {Object} options
+ * @param {String} options.baseUrl - The base URL of the test server
+ * @param {Object} options.nunjucksParams - Params passed to the Nunjucks macro
+ * @param {Object} [options.javascriptConfig] - The configuration hash passed to
+ *  the component's class for initialisation
+ * @param {Function} [options.initialiser] - A function that'll run in the
+ *  browser to execute arbitrary initialisation. Receives an object with the
+ *  passed configuration as `config` and the PascalCased component name as
+ *  `componentClassName`
+ * @returns {Promise}
+ */
+async function renderAndInitialise (componentName, options = {}) {
+  await page.goto(`${options.baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+  const html = renderHtml('notification-banner', options.nunjucksParams)
+
+  // Inject rendered HTML into the slot
+  await page.$eval('#slot', (slot, htmlForSlot) => {
+    slot.innerHTML = htmlForSlot
+  }, html)
+
+  const initialiser = options.initialiser || function ({ config, componentClassName }) {
+    var $component = document.querySelector('[data-module]')
+    new window.GOVUKFrontend[componentClassName]($component, config).init()
+  }
+
+  if (initialiser) {
+    // Run a script to init the JavaScript component
+    await page.evaluate(initialiser, {
+      config: options.javascriptConfig,
+      componentClassName: componentNameToPascalCase(componentName)
+    })
+  }
+}
+
+/**
  * Get examples from a component's metadata file
  * @param {string} componentName
  * @returns {object} returns object that includes all examples at once
@@ -136,4 +183,4 @@ function htmlWithClassName ($, className) {
   return $.html($component)
 }
 
-module.exports = { render, renderHtml, getExamples, htmlWithClassName, renderSass, renderTemplate }
+module.exports = { render, renderHtml, renderAndInitialise, getExamples, htmlWithClassName, renderSass, renderTemplate }

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -13,7 +13,7 @@ const sass = require('node-sass')
 const sassRender = util.promisify(sass.render)
 
 const configPaths = require('../config/paths.json')
-const { componentNameToMacroName, componentNameToPascalCase } = require('./helper-functions.js')
+const { componentNameToMacroName, componentNameToJavaScriptClassName } = require('./helper-functions.js')
 
 const nunjucksEnv = nunjucks.configure([configPaths.src, configPaths.components], {
   trimBlocks: true,
@@ -84,15 +84,16 @@ function renderTemplate (params = {}, blocks = {}) {
 }
 
 /**
- * Render and initialise a component within test boilerplate
+ * Render and initialise a component within test boilerplate HTML
  *
  * Renders a component's Nunjucks macro with the given params, injects it into
- * the test boilerplate page, then initialises it with either:
+ * the test boilerplate page, then either:
  *
- * - the provided JavaScript configuration, used to instanciate the relevant
- *   component class
- * - a custom initialiser function (that'll let you run arbitrary code, like
- *   `initAll` in the browser)
+ * - instantiates the component class, passing the provided JavaScript
+ *   configuration, and calls the init function
+ * - runs the passed initialiser function inside the browser
+ *   (which lets you instantiate it a different way, like using `initAll`,
+ *   or run arbitrary code)
  *
  * @param {String} componentName - The kebab-cased name of the component
  * @param {Object} options
@@ -111,7 +112,7 @@ async function renderAndInitialise (componentName, options = {}) {
 
   const html = renderHtml('notification-banner', options.nunjucksParams)
 
-  // Inject rendered HTML into the slot
+  // Inject rendered HTML into the page
   await page.$eval('#slot', (slot, htmlForSlot) => {
     slot.innerHTML = htmlForSlot
   }, html)
@@ -125,7 +126,7 @@ async function renderAndInitialise (componentName, options = {}) {
     // Run a script to init the JavaScript component
     await page.evaluate(initialiser, {
       config: options.javascriptConfig,
-      componentClassName: componentNameToPascalCase(componentName)
+      componentClassName: componentNameToJavaScriptClassName(componentName)
     })
   }
 }

--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -54,7 +54,7 @@ function initAll (options) {
 
   var $notificationBanners = scope.querySelectorAll('[data-module="govuk-notification-banner"]')
   nodeListForEach($notificationBanners, function ($notificationBanner) {
-    new NotificationBanner($notificationBanner).init()
+    new NotificationBanner($notificationBanner, options.notificationBanner).init()
   })
 
   var $radios = scope.querySelectorAll('[data-module="govuk-radios"]')

--- a/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,7 +1,17 @@
 import '../../vendor/polyfills/Event.mjs' // addEventListener
 
-function NotificationBanner ($module) {
+import { mergeConfigs, normaliseDataset } from '../../common.mjs'
+function NotificationBanner ($module, config) {
   this.$module = $module
+
+  var defaultConfig = {
+    disableAutoFocus: false
+  }
+  this.config = mergeConfigs(
+    defaultConfig,
+    config || {},
+    normaliseDataset($module.dataset)
+  )
 }
 
 /**
@@ -30,7 +40,7 @@ NotificationBanner.prototype.init = function () {
 NotificationBanner.prototype.setFocus = function () {
   var $module = this.$module
 
-  if ($module.getAttribute('data-disable-auto-focus') === 'true') {
+  if (this.config.disableAutoFocus) {
     return
   }
 

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-const { renderHtml, getExamples } = require('../../../../lib/jest-helpers')
+const { renderAndInitialise, getExamples } = require('../../../../lib/jest-helpers')
 
 const examples = getExamples('notification-banner')
 
@@ -54,22 +54,13 @@ describe('Notification banner, when type is set to "success"', () => {
 
   describe('and auto-focus is disabled using JavaScript configuration', () => {
     beforeAll(async () => {
-      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-      // Render the notification banner Nunjucks template
-      const html = renderHtml('notification-banner', examples['with type as success'])
-
-      // Inject rendered HTML into the slot
-      await page.$eval('#slot', (slot, htmlForSlot) => {
-        slot.innerHTML = htmlForSlot
-      }, html)
-
-      // Run a script to init the JavaScript component
-      await page.evaluate(() => {
-        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
-        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+      await renderAndInitialise('notification-banner', {
+        baseUrl,
+        nunjucksParams:
+          examples['with type as success'],
+        javascriptConfig: {
           disableAutoFocus: true
-        }).init()
+        }
       })
     })
 
@@ -88,23 +79,17 @@ describe('Notification banner, when type is set to "success"', () => {
 
   describe('and auto-focus is disabled using options passed to initAll', () => {
     beforeAll(async () => {
-      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-      // Render the notification banner Nunjucks template
-      const html = renderHtml('notification-banner', examples['with type as success'])
-
-      // Inject rendered HTML into the slot
-      await page.$eval('#slot', (slot, htmlForSlot) => {
-        slot.innerHTML = htmlForSlot
-      }, html)
-
-      // Run a script to init the JavaScript component
-      await page.evaluate(() => {
-        window.GOVUKFrontend.initAll({
-          notificationBanner: {
-            disableAutoFocus: true
-          }
-        })
+      await renderAndInitialise('notification-banner', {
+        baseUrl,
+        nunjucksParams:
+          examples['with type as success'],
+        initialiser () {
+          window.GOVUKFrontend.initAll({
+            notificationBanner: {
+              disableAutoFocus: true
+            }
+          })
+        }
       })
     })
 
@@ -123,22 +108,12 @@ describe('Notification banner, when type is set to "success"', () => {
 
   describe('and autofocus is disabled in JS but enabled in data attributes, attributes win', () => {
     beforeAll(async () => {
-      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-      // Render the notification banner Nunjucks template
-      const html = renderHtml('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
-
-      // Inject rendered HTML into the slot
-      await page.$eval('#slot', (slot, htmlForSlot) => {
-        slot.innerHTML = htmlForSlot
-      }, html)
-
-      // Run a script to init the JavaScript component
-      await page.evaluate(() => {
-        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
-        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+      await renderAndInitialise('notification-banner', {
+        baseUrl,
+        nunjucksParams: examples['auto-focus explicitly enabled, with type as success'],
+        javascriptConfig: {
           disableAutoFocus: true
-        }).init()
+        }
       })
     })
 

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -35,92 +35,124 @@ describe('/components/notification-banner/with-type-as-success', () => {
   })
 })
 
-describe('components/notification-banner/auto-focus-disabled,-with-type-as-success/', () => {
-  describe('when auto-focus is disabled using data attributes', () => {
-    beforeAll(async () => {
-      await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
-    })
+describe('when auto-focus is disabled using data attributes', () => {
+  beforeAll(async () => {
+    await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+  })
 
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+  it('does not have a tabindex attribute', async () => {
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      expect(tabindex).toBeNull()
-    })
+    expect(tabindex).toBeNull()
+  })
 
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+  it('does not focus the notification banner', async () => {
+    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-      expect(activeElement).not.toBe('govuk-notification-banner')
+    expect(activeElement).not.toBe('govuk-notification-banner')
+  })
+})
+
+describe('when auto-focus is disabled using JavaScript configuration', () => {
+  beforeAll(async () => {
+    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+    // Render the notification banner Nunjucks template
+    const html = renderHtml('notification-banner', examples['with type as success'])
+
+    // Inject rendered HTML into the slot
+    await page.$eval('#slot', (slot, htmlForSlot) => {
+      slot.innerHTML = htmlForSlot
+    }, html)
+
+    // Run a script to init the JavaScript component
+    await page.evaluate(() => {
+      var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
+      new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+        disableAutoFocus: true
+      }).init()
     })
   })
 
-  describe('when auto-focus is disabled using JavaScript configuration', () => {
-    beforeAll(async () => {
-      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+  it('does not have a tabindex attribute', async () => {
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      // Render the notification banner Nunjucks template
-      const html = renderHtml('notification-banner', examples['with type as success'])
+    expect(tabindex).toBeNull()
+  })
 
-      // Inject rendered HTML into the slot
-      await page.$eval('#slot', (slot, htmlForSlot) => {
-        slot.innerHTML = htmlForSlot
-      }, html)
+  it('does not focus the notification banner', async () => {
+    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-      // Run a script to init the JavaScript component
-      await page.evaluate(() => {
-        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
-        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+    expect(activeElement).not.toBe('govuk-notification-banner')
+  })
+})
+
+describe('when auto-focus is disabled using options passed to initAll', () => {
+  beforeAll(async () => {
+    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+    // Render the notification banner Nunjucks template
+    const html = renderHtml('notification-banner', examples['with type as success'])
+
+    // Inject rendered HTML into the slot
+    await page.$eval('#slot', (slot, htmlForSlot) => {
+      slot.innerHTML = htmlForSlot
+    }, html)
+
+    // Run a script to init the JavaScript component
+    await page.evaluate(() => {
+      window.GOVUKFrontend.initAll({
+        notificationBanner: {
           disableAutoFocus: true
-        }).init()
+        }
       })
-    })
-
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
-
-      expect(tabindex).toBeNull()
-    })
-
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
-
-      expect(activeElement).not.toBe('govuk-notification-banner')
     })
   })
 
-  describe('when auto-focus is disabled using options passed to initAll', () => {
-    beforeAll(async () => {
-      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+  it('does not have a tabindex attribute', async () => {
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      // Render the notification banner Nunjucks template
-      const html = renderHtml('notification-banner', examples['with type as success'])
+    expect(tabindex).toBeNull()
+  })
 
-      // Inject rendered HTML into the slot
-      await page.$eval('#slot', (slot, htmlForSlot) => {
-        slot.innerHTML = htmlForSlot
-      }, html)
+  it('does not focus the notification banner', async () => {
+    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-      // Run a script to init the JavaScript component
-      await page.evaluate(() => {
-        window.GOVUKFrontend.initAll({
-          notificationBanner: {
-            disableAutoFocus: true
-          }
-        })
-      })
+    expect(activeElement).not.toBe('govuk-notification-banner')
+  })
+})
+
+describe('when autofocus is disabled in JS but enabled in data attributes, attributes win', () => {
+  beforeAll(async () => {
+    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+    // Render the notification banner Nunjucks template
+    const html = renderHtml('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
+
+    // Inject rendered HTML into the slot
+    await page.$eval('#slot', (slot, htmlForSlot) => {
+      slot.innerHTML = htmlForSlot
+    }, html)
+
+    // Run a script to init the JavaScript component
+    await page.evaluate(() => {
+      var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
+      new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+        disableAutoFocus: true
+      }).init()
     })
+  })
 
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+  it('has the correct tabindex attribute to be focused with JavaScript', async () => {
+    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-      expect(tabindex).toBeNull()
-    })
+    expect(tabindex).toEqual('-1')
+  })
 
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+  it('is automatically focused when the page loads', async () => {
+    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-      expect(activeElement).not.toBe('govuk-notification-banner')
-    })
+    expect(activeElement).toBe('govuk-notification-banner')
   })
 })
 

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -87,6 +87,41 @@ describe('components/notification-banner/auto-focus-disabled,-with-type-as-succe
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
   })
+
+  describe('when auto-focus is disabled using options passed to initAll', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+      // Render the notification banner Nunjucks template
+      const html = renderHtml('notification-banner', examples['with type as success'])
+
+      // Inject rendered HTML into the slot
+      await page.$eval('#slot', (slot, htmlForSlot) => {
+        slot.innerHTML = htmlForSlot
+      }, html)
+
+      // Run a script to init the JavaScript component
+      await page.evaluate(() => {
+        window.GOVUKFrontend.initAll({
+          notificationBanner: {
+            disableAutoFocus: true
+          }
+        })
+      })
+    })
+
+    it('does not have a tabindex attribute', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toBeNull()
+    })
+
+    it('does not focus the notification banner', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+      expect(activeElement).not.toBe('govuk-notification-banner')
+    })
+  })
 })
 
 describe('components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success', () => {

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -1,4 +1,7 @@
 /* eslint-env jest */
+const { renderHtml, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('notification-banner')
 
 const configPaths = require('../../../../config/paths.json')
 const PORT = configPaths.ports.test
@@ -33,18 +36,52 @@ describe('/components/notification-banner/with-type-as-success', () => {
 })
 
 describe('components/notification-banner/auto-focus-disabled,-with-type-as-success/', () => {
-  describe('when auto-focus is disabled', () => {
-    it('does not have a tabindex attribute', async () => {
+  describe('when auto-focus is disabled using data attributes', () => {
+    beforeAll(async () => {
       await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+    })
 
+    it('does not have a tabindex attribute', async () => {
       const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
       expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
-      await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
+      expect(activeElement).not.toBe('govuk-notification-banner')
+    })
+  })
+
+  describe('when auto-focus is disabled using JavaScript configuration', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
+
+      // Render the notification banner Nunjucks template
+      const html = renderHtml('notification-banner', examples['with type as success'])
+
+      // Inject rendered HTML into the slot
+      await page.$eval('#slot', (slot, htmlForSlot) => {
+        slot.innerHTML = htmlForSlot
+      }, html)
+
+      // Run a script to init the JavaScript component
+      await page.evaluate(() => {
+        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
+        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+          disableAutoFocus: true
+        }).init()
+      })
+    })
+
+    it('does not have a tabindex attribute', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toBeNull()
+    })
+
+    it('does not focus the notification banner', async () => {
       const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
       expect(activeElement).not.toBe('govuk-notification-banner')

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -106,7 +106,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
   })
 
-  describe('and autofocus is disabled in JS but enabled in data attributes, attributes win', () => {
+  describe('and autofocus is disabled in JS but enabled in data attributes', () => {
     beforeAll(async () => {
       await renderAndInitialise('notification-banner', {
         baseUrl,

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -8,7 +8,7 @@ const PORT = configPaths.ports.test
 
 const baseUrl = 'http://localhost:' + PORT
 
-describe('/components/notification-banner/with-type-as-success', () => {
+describe('Notification banner, when type is set to "success"', () => {
   it('has the correct tabindex attribute to be focused with JavaScript', async () => {
     await page.goto(baseUrl + '/components/notification-banner/with-type-as-success/preview', { waitUntil: 'load' })
 
@@ -33,131 +33,129 @@ describe('/components/notification-banner/with-type-as-success', () => {
     const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
     expect(tabindex).toBeNull()
   })
-})
 
-describe('when auto-focus is disabled using data attributes', () => {
-  beforeAll(async () => {
-    await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
-  })
+  describe('and auto-focus is disabled using data attributes', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/components/notification-banner/auto-focus-disabled,-with-type-as-success/preview`, { waitUntil: 'load' })
+    })
 
-  it('does not have a tabindex attribute', async () => {
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+    it('does not have a tabindex attribute', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-    expect(tabindex).toBeNull()
-  })
+      expect(tabindex).toBeNull()
+    })
 
-  it('does not focus the notification banner', async () => {
-    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+    it('does not focus the notification banner', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-    expect(activeElement).not.toBe('govuk-notification-banner')
-  })
-})
-
-describe('when auto-focus is disabled using JavaScript configuration', () => {
-  beforeAll(async () => {
-    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-    // Render the notification banner Nunjucks template
-    const html = renderHtml('notification-banner', examples['with type as success'])
-
-    // Inject rendered HTML into the slot
-    await page.$eval('#slot', (slot, htmlForSlot) => {
-      slot.innerHTML = htmlForSlot
-    }, html)
-
-    // Run a script to init the JavaScript component
-    await page.evaluate(() => {
-      var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
-      new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
-        disableAutoFocus: true
-      }).init()
+      expect(activeElement).not.toBe('govuk-notification-banner')
     })
   })
 
-  it('does not have a tabindex attribute', async () => {
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+  describe('and auto-focus is disabled using JavaScript configuration', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
 
-    expect(tabindex).toBeNull()
-  })
+      // Render the notification banner Nunjucks template
+      const html = renderHtml('notification-banner', examples['with type as success'])
 
-  it('does not focus the notification banner', async () => {
-    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      // Inject rendered HTML into the slot
+      await page.$eval('#slot', (slot, htmlForSlot) => {
+        slot.innerHTML = htmlForSlot
+      }, html)
 
-    expect(activeElement).not.toBe('govuk-notification-banner')
-  })
-})
-
-describe('when auto-focus is disabled using options passed to initAll', () => {
-  beforeAll(async () => {
-    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-    // Render the notification banner Nunjucks template
-    const html = renderHtml('notification-banner', examples['with type as success'])
-
-    // Inject rendered HTML into the slot
-    await page.$eval('#slot', (slot, htmlForSlot) => {
-      slot.innerHTML = htmlForSlot
-    }, html)
-
-    // Run a script to init the JavaScript component
-    await page.evaluate(() => {
-      window.GOVUKFrontend.initAll({
-        notificationBanner: {
+      // Run a script to init the JavaScript component
+      await page.evaluate(() => {
+        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
+        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
           disableAutoFocus: true
-        }
+        }).init()
       })
     })
-  })
 
-  it('does not have a tabindex attribute', async () => {
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+    it('does not have a tabindex attribute', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
 
-    expect(tabindex).toBeNull()
-  })
+      expect(tabindex).toBeNull()
+    })
 
-  it('does not focus the notification banner', async () => {
-    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+    it('does not focus the notification banner', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
 
-    expect(activeElement).not.toBe('govuk-notification-banner')
-  })
-})
-
-describe('when autofocus is disabled in JS but enabled in data attributes, attributes win', () => {
-  beforeAll(async () => {
-    await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
-
-    // Render the notification banner Nunjucks template
-    const html = renderHtml('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
-
-    // Inject rendered HTML into the slot
-    await page.$eval('#slot', (slot, htmlForSlot) => {
-      slot.innerHTML = htmlForSlot
-    }, html)
-
-    // Run a script to init the JavaScript component
-    await page.evaluate(() => {
-      var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
-      new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
-        disableAutoFocus: true
-      }).init()
+      expect(activeElement).not.toBe('govuk-notification-banner')
     })
   })
 
-  it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+  describe('and auto-focus is disabled using options passed to initAll', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
 
-    expect(tabindex).toEqual('-1')
+      // Render the notification banner Nunjucks template
+      const html = renderHtml('notification-banner', examples['with type as success'])
+
+      // Inject rendered HTML into the slot
+      await page.$eval('#slot', (slot, htmlForSlot) => {
+        slot.innerHTML = htmlForSlot
+      }, html)
+
+      // Run a script to init the JavaScript component
+      await page.evaluate(() => {
+        window.GOVUKFrontend.initAll({
+          notificationBanner: {
+            disableAutoFocus: true
+          }
+        })
+      })
+    })
+
+    it('does not have a tabindex attribute', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toBeNull()
+    })
+
+    it('does not focus the notification banner', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+      expect(activeElement).not.toBe('govuk-notification-banner')
+    })
   })
 
-  it('is automatically focused when the page loads', async () => {
-    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+  describe('and autofocus is disabled in JS but enabled in data attributes, attributes win', () => {
+    beforeAll(async () => {
+      await page.goto(`${baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
 
-    expect(activeElement).toBe('govuk-notification-banner')
+      // Render the notification banner Nunjucks template
+      const html = renderHtml('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
+
+      // Inject rendered HTML into the slot
+      await page.$eval('#slot', (slot, htmlForSlot) => {
+        slot.innerHTML = htmlForSlot
+      }, html)
+
+      // Run a script to init the JavaScript component
+      await page.evaluate(() => {
+        var $notificationBanner = document.querySelector('[data-module="govuk-notification-banner"]')
+        new window.GOVUKFrontend.NotificationBanner($notificationBanner, {
+          disableAutoFocus: true
+        }).init()
+      })
+    })
+
+    it('has the correct tabindex attribute to be focused with JavaScript', async () => {
+      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+
+      expect(tabindex).toEqual('-1')
+    })
+
+    it('is automatically focused when the page loads', async () => {
+      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+
+      expect(activeElement).toBe('govuk-notification-banner')
+    })
   })
-})
 
-describe('components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success', () => {
-  describe('when role is not alert', () => {
+  describe('and role is overridden to "region"', () => {
     it('does not have a tabindex attribute', async () => {
       await page.goto(`${baseUrl}/components/notification-banner/role=alert-overridden-to-role=region,-with-type-as-success/preview`, { waitUntil: 'load' })
 
@@ -174,11 +172,9 @@ describe('components/notification-banner/role=alert-overridden-to-role=region,-w
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
   })
-})
 
-describe('/components/notification-banner/custom-tabindex', () => {
-  describe('when custom tabindex set', () => {
-    it('it does not remove the tabindex attribute on blur', async () => {
+  describe('and a custom tabindex is set', () => {
+    it('does not remove the tabindex attribute on blur', async () => {
       await page.goto(baseUrl + '/components/notification-banner/custom-tabindex/preview', { waitUntil: 'load' })
 
       await page.$eval('.govuk-notification-banner', el => el.blur())

--- a/src/govuk/components/notification-banner/notification-banner.yaml
+++ b/src/govuk/components/notification-banner/notification-banner.yaml
@@ -105,6 +105,11 @@ examples:
     type: success
     disableAutoFocus: true
     text: Email sent to example@email.com
+- name: auto-focus explicitly enabled, with type as success
+  data:
+    type: success
+    disableAutoFocus: false
+    text: Email sent to example@email.com
 - name:  role=alert overridden to role=region, with type as success
   data:
     type: success

--- a/src/govuk/components/notification-banner/template.njk
+++ b/src/govuk/components/notification-banner/template.njk
@@ -29,7 +29,7 @@
 <div class="govuk-notification-banner{% if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}"
   aria-labelledby="{{ params.titleId | default('govuk-notification-banner-title')}}"
   data-module="govuk-notification-banner"
-  {%- if params.disableAutoFocus %} data-disable-auto-focus="true"{% endif %}
+  {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-notification-banner__header">
     <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title" id="{{ params.titleId | default('govuk-notification-banner-title') }}" >

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -120,11 +120,18 @@ describe('Notification-banner', () => {
       expect(ariaAttr).toEqual('my-id')
     })
 
-    it('adds the data-disable-auto-focus attribute so component is not focused on page load', () => {
+    it('adds data-disable-auto-focus="true" if disableAutoFocus is true', () => {
       const $ = render('notification-banner', examples['auto-focus disabled, with type as success'])
 
       const $component = $('.govuk-notification-banner')
-      expect($component.attr('data-disable-auto-focus')).toBeTruthy()
+      expect($component.attr('data-disable-auto-focus')).toBe('true')
+    })
+
+    it('adds data-disable-auto-focus="false" if disableAutoFocus is false', () => {
+      const $ = render('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
+
+      const $component = $('.govuk-notification-banner')
+      expect($component.attr('data-disable-auto-focus')).toBe('false')
     })
 
     it('renders classes', () => {


### PR DESCRIPTION
The intention of this PR is to ensure that the config that can currently be set via data attributes can also be set when instantiating the component. Closes #2839.

This builds on conventions already established during work on the accordion component in #2826.

As part of this, we realised that the Nunjucks macro only included the data attribute if the value of `disableAutoFocus` was truthy. To ensure that it's always possible to override the JavaScript config we've updated this so that it will output the value of `disableAutoFocus` as long as it is defined.

We've also introduced a new way to test the behaviour of a component whilst having control over how the component is inititialised, by:
- rendering the HTML for the component manually and then injecting it into an empty 'test boilerplate' page
- control the config passed when the component is instantiated on the page
- or, alternatively, use a custom function to initialise the component which allows you to test the behaviour of `initAll`

Suggest reviewing commit-by-commit.