### PR TITLE
Fix hardcoded component name in renderAndInitialise

### DIFF
--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -110,7 +110,7 @@ function renderTemplate (params = {}, blocks = {}) {
 async function renderAndInitialise (componentName, options = {}) {
   await page.goto(`${options.baseUrl}/tests/boilerplate`, { waitUntil: 'load' })
 
-  const html = renderHtml('notification-banner', options.nunjucksParams)
+  const html = renderHtml(componentName, options.nunjucksParams)
 
   // Inject rendered HTML into the page
   await page.$eval('#slot', (slot, htmlForSlot) => {


### PR DESCRIPTION
[When refactoring boilerplate in a helper](https://github.com/alphagov/govuk-frontend/pull/2843/commits/e57cf9915729d0065c1ec6e55ef555821caa9e93) for #2843, we forgot to make used the passed `componentName` for picking which component to render 😬 