### PR TITLE
Add pluralisation support to i18n functionality

### DIFF
--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -27,7 +27,7 @@ function I18n (translations, config) {
 I18n.prototype.t = function (lookupKey, options) {
   if (!lookupKey) {
     // Print a console error if no lookup key has been provided
-    throw new Error('i18n lookup key missing.')
+    throw new Error('i18n: lookup key missing')
   }
 
   // If the `count` option is set, determine which plural suffix is needed and
@@ -43,6 +43,11 @@ I18n.prototype.t = function (lookupKey, options) {
 
     // Overwrite our existing lookupKey
     lookupKey = lookupKey + pluralSuffix
+
+    // Throw an error if this new key doesn't exist
+    if (!(lookupKey in this.translations)) {
+      throw new Error('i18n: Plural form "' + pluralSuffix + '" is required for "' + this.locale + '" locale')
+    }
   }
 
   if (lookupKey in this.translations) {
@@ -250,6 +255,8 @@ I18n.prototype.pluralRules = {
     if (last === 1 && lastTwo !== 11) { return 'one' }
     if (last >= 2 && last <= 4 && !(lastTwo >= 12 && lastTwo <= 14)) { return 'few' }
     if (last === 0 || (last >= 5 && last <= 9) || (lastTwo >= 11 && lastTwo <= 14)) { return 'many' }
+    // Note: The 'other' suffix is only used by decimal numbers in Russian.
+    // We don't anticipate it being used, but it's here for consistency.
     return 'other'
   },
   scottish: function (n) {

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -151,7 +151,7 @@ I18n.prototype.hasIntlNumberFormatSupport = function () {
  */
 I18n.prototype.getPluralSuffix = function (count) {
   var locale = this.locale
-  var localeShort = (locale.length > 2) ? locale.substring(0, 2) : locale
+  var localeShort = locale.split('-')[0]
   var keySuffix = 'other'
 
   // Validate that the number is actually a number.

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -2,12 +2,18 @@
  * i18n support initialisation function
  *
  * @constructor
- * @param    {Object}  translations  - Key-value pairs of the translation
-                                       strings to use.
+ * @param  {Object}  translations   - Key-value pairs of the translation strings to use.
+ * @param  {Object}  config         - Configuration options for the function.
+ * @param  {String}  config.locale  - An overriding locale for the PluralRules functionality.
  */
-function I18n (translations) {
+function I18n (translations, config) {
+  config = config || {}
+
   // Make list of translations available throughout function
   this.translations = translations || {}
+
+  // The locale to use for PluralRules and NumberFormat
+  this.locale = config.locale || document.documentElement.lang || 'en'
 }
 
 /**
@@ -22,7 +28,24 @@ I18n.prototype.t = function (lookupKey, options) {
   if (!lookupKey) {
     // Print a console error if no lookup key has been provided
     throw new Error('i18n lookup key missing.')
-  } else if (lookupKey in this.translations) {
+  }
+
+  // If the `count` option is set, determine which plural suffix is needed and
+  // change the lookupKey to match. We check to see if it's undefined instead of
+  // falsy, as this could legitimately be 0.
+  if (options && typeof options.count !== 'undefined') {
+    // Get the plural suffix
+    var pluralSuffix = this.getPluralSuffix(options.count)
+
+    // We need to transform this to have an initial uppercase letter,
+    // as our keys are stored in camelCase
+    pluralSuffix = pluralSuffix.charAt(0).toUpperCase() + pluralSuffix.slice(1)
+
+    // Overwrite our existing lookupKey
+    lookupKey = lookupKey + pluralSuffix
+  }
+
+  if (lookupKey in this.translations) {
     // Fetch the translation string for that lookup key
     var translationString = this.translations[lookupKey]
 
@@ -37,7 +60,8 @@ I18n.prototype.t = function (lookupKey, options) {
       return translationString
     }
   } else {
-    // Otherwise, return the lookup key itself as the fallback
+    // If the key wasn't found in our translations object,
+    // return the lookup key itself as the fallback
     return lookupKey
   }
 }
@@ -72,6 +96,181 @@ I18n.prototype.replacePlaceholders = function (translationString, options) {
   }
 
   return translationString
+}
+
+/**
+ * Check to see if the browser supports Intl and Intl.PluralRules.
+ *
+ * It requires all conditions to be met in order to be supported:
+ * - The browser supports the Intl class (true in IE11)
+ * - The implementation of Intl supports PluralRules (NOT true in IE11)
+ * - The browser/OS has plural rules for the current locale (browser dependent)
+ *
+ * @returns  {boolean}  - Returns true if all conditions are met. Returns false otherwise.
+ */
+I18n.prototype.hasIntlPluralRulesSupport = function () {
+  return Boolean(window.Intl && ('PluralRules' in window.Intl && Intl.PluralRules.supportedLocalesOf(this.locale).length))
+}
+
+/**
+ * Get the appropriate suffix for the plural form.
+ *
+ * The locale may include a regional indicator (such as en-GB), but we don't
+ * usually care about this part, as pluralisation rules are usually the same
+ * regardless of region. There are exceptions, however, (e.g. Portuguese) so
+ * this searches by both the full and shortened locale codes, just to be sure.
+ *
+ * @param    {number}  count       - Number used to determine which pluralisation to use.
+ * @returns  {string}              - The suffix associated with the correct pluralisation for this locale.
+ */
+I18n.prototype.getPluralSuffix = function (count) {
+  var locale = this.locale
+  var localeShort = (locale.length > 2) ? locale.substring(0, 2) : locale
+  var keySuffix = 'other'
+
+  // Validate that the number is actually a number.
+  //
+  // Number(count) will turn anything that can't be converted to a Number type
+  // into 'NaN'. isFinite filters out NaN, as it isn't a finite number.
+  count = Number(count)
+  if (!isFinite(count)) { return keySuffix }
+
+  // Check to verify that all the requirements for Intl.PluralRules are met.
+  // If so, we can use that instead of our custom implementation. Otherwise,
+  // use the hardcoded fallback.
+  if (this.hasIntlPluralRulesSupport()) {
+    var pluralRules = new Intl.PluralRules(this.locale)
+    keySuffix = pluralRules.select(count)
+  } else {
+    // Currently our custom code can only handle positive integers, so let's
+    // make sure our number is one of those.
+    count = Math.abs(Math.floor(count))
+
+    // Look through the plural rules map to find which `pluralRule` is
+    // appropriate for our current `locale`.
+    for (var pluralRule in this.pluralRulesMap) {
+      if (Object.prototype.hasOwnProperty.call(this.pluralRulesMap, pluralRule)) {
+        var languages = this.pluralRulesMap[pluralRule]
+        if (languages.indexOf(locale) > -1 || languages.indexOf(localeShort) > -1) {
+          keySuffix = this.pluralRules[pluralRule](count)
+          break
+        }
+      }
+    }
+  }
+
+  return keySuffix
+}
+
+/**
+ * Map of plural rules to languages where those rules apply.
+ *
+ * Note: These groups are named for the most dominant or recognisable language
+ * that uses each system. The groupings do not imply that the languages are
+ * related to one another. Many languages have evolved the same systems
+ * independently of one another.
+ *
+ * Code to support more languages can be found in the i18n spike:
+ * https://github.com/alphagov/govuk-frontend/blob/spike-i18n-support/src/govuk/i18n.mjs
+ *
+ * Languages currently supported:
+ *
+ * Arabic: Arabic (ar)
+ * Chinese: Burmese (my), Chinese (zh), Indonesian (id), Japanese (ja),
+ *   Javanese (jv), Korean (ko), Malay (ms), Thai (th), Vietnamese (vi)
+ * French: Armenian (hy), Bangla (bn), French (fr), Gujarati (gu), Hindi (hi),
+ *   Persian Farsi (fa), Punjabi (pa), Zulu (zu)
+ * German: Afrikaans (af), Albanian (sq), Azerbaijani (az), Basque (eu),
+ *   Bulgarian (bg), Catalan (ca), Danish (da), Dutch (nl), English (en),
+ *   Estonian (et), Finnish (fi), Georgian (ka), German (de), Greek (el),
+ *   Hungarian (hu), Luxembourgish (lb), Norwegian (no), Somali (so),
+ *   Swahili (sw), Swedish (sv), Tamil (ta), Telugu (te), Turkish (tr),
+ *   Urdu (ur)
+ * Irish: Irish Gaelic (ga)
+ * Russian: Russian (ru), Ukrainian (uk)
+ * Scottish: Scottish Gaelic (gd)
+ * Spanish: European Portuguese (pt-PT), Italian (it), Spanish (es)
+ * Welsh: Welsh (cy)
+ */
+I18n.prototype.pluralRulesMap = {
+  arabic: ['ar'],
+  chinese: ['my', 'zh', 'id', 'ja', 'jv', 'ko', 'ms', 'th', 'vi'],
+  french: ['hy', 'bn', 'fr', 'gu', 'hi', 'fa', 'pa', 'zu'],
+  german: [
+    'af', 'sq', 'az', 'eu', 'bg', 'ca', 'da', 'nl', 'en', 'et', 'fi', 'ka',
+    'de', 'el', 'hu', 'lb', 'no', 'so', 'sw', 'sv', 'ta', 'te', 'tr', 'ur'
+  ],
+  irish: ['ga'],
+  russian: ['ru', 'uk'],
+  scottish: ['gd'],
+  spanish: ['pt-PT', 'it', 'es'],
+  welsh: ['cy']
+}
+
+/**
+ * Different pluralisation rule sets
+ *
+ * Returns the appropriate suffix for the plural form associated with `n`.
+ * Possible suffixes: 'zero', 'one', 'two', 'few', 'many', 'other' (the actual
+ * meaning of each differs per locale). 'other' should always exist, even in
+ * languages without plurals, such as Chinese.
+ * https://unicode-org.github.io/cldr-staging/charts/latest/supplemental/language_plural_rules.html
+ *
+ * @param    {number}  n  - The `count` number being passed through. This must be a positive integer. Negative numbers and decimals aren't accounted for.
+ * @returns  {string}     - The string that needs to be suffixed to the key (without separator).
+ */
+I18n.prototype.pluralRules = {
+  arabic: function (n) {
+    if (n === 0) { return 'zero' }
+    if (n === 1) { return 'one' }
+    if (n === 2) { return 'two' }
+    if (n % 100 >= 3 && n % 100 <= 10) { return 'few' }
+    if (n % 100 >= 11 && n % 100 <= 99) { return 'many' }
+    return 'other'
+  },
+  chinese: function () {
+    return 'other'
+  },
+  french: function (n) {
+    return n === 0 || n === 1 ? 'one' : 'other'
+  },
+  german: function (n) {
+    return n === 1 ? 'one' : 'other'
+  },
+  irish: function (n) {
+    if (n === 1) { return 'one' }
+    if (n === 2) { return 'two' }
+    if (n >= 3 && n <= 6) { return 'few' }
+    if (n >= 7 && n <= 10) { return 'many' }
+    return 'other'
+  },
+  russian: function (n) {
+    var lastTwo = n % 100
+    var last = lastTwo % 10
+    if (last === 1 && lastTwo !== 11) { return 'one' }
+    if (last >= 2 && last <= 4 && !(lastTwo >= 12 && lastTwo <= 14)) { return 'few' }
+    if (last === 0 || (last >= 5 && last <= 9) || (lastTwo >= 11 && lastTwo <= 14)) { return 'many' }
+    return 'other'
+  },
+  scottish: function (n) {
+    if (n === 1 || n === 11) { return 'one' }
+    if (n === 2 || n === 12) { return 'two' }
+    if ((n >= 3 && n <= 10) || (n >= 13 && n <= 19)) { return 'few' }
+    return 'other'
+  },
+  spanish: function (n) {
+    if (n === 1) { return 'one' }
+    if (n % 1000000 === 0 && n !== 0) { return 'many' }
+    return 'other'
+  },
+  welsh: function (n) {
+    if (n === 0) { return 'zero' }
+    if (n === 1) { return 'one' }
+    if (n === 2) { return 'two' }
+    if (n === 3) { return 'few' }
+    if (n === 6) { return 'many' }
+    return 'other'
+  }
 }
 
 export default I18n

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -88,13 +88,20 @@ I18n.prototype.replacePlaceholders = function (translationString, options) {
     var placeholderIncludingBraces = placeholderMatch[0]
     var placeholderKey = placeholderMatch[1]
     if (Object.prototype.hasOwnProperty.call(options, placeholderKey)) {
+      let placeholderValue = options[placeholderKey]
+
       // If a user has passed `false` as the value for the placeholder
       // treat it as though the value should not be displayed
-      if (options[placeholderKey] === false) {
+      if (placeholderValue === false) {
         translationString = translationString.replace(placeholderIncludingBraces, '')
       }
 
-      translationString = translationString.replace(placeholderIncludingBraces, options[placeholderKey])
+      // If the placeholder's value is a number, localise the number formatting
+      if (typeof placeholderValue === 'number' && this.hasIntlNumberFormatSupport()) {
+        placeholderValue = new Intl.NumberFormat(this.locale).format(placeholderValue)
+      }
+
+      translationString = translationString.replace(placeholderIncludingBraces, placeholderValue)
     } else {
       throw new Error('i18n: no data found to replace ' + placeholderMatch[0] + ' placeholder in string')
     }
@@ -115,6 +122,20 @@ I18n.prototype.replacePlaceholders = function (translationString, options) {
  */
 I18n.prototype.hasIntlPluralRulesSupport = function () {
   return Boolean(window.Intl && ('PluralRules' in window.Intl && Intl.PluralRules.supportedLocalesOf(this.locale).length))
+}
+
+/**
+ * Check to see if the browser supports Intl and Intl.NumberFormat.
+ *
+ * It requires all conditions to be met in order to be supported:
+ * - The browser supports the Intl class (true in IE11)
+ * - The implementation of Intl supports NumberFormat (also true in IE11)
+ * - The browser/OS has number formatting rules for the current locale (browser dependent)
+ *
+ * @returns  {boolean}  - Returns true if all conditions are met. Returns false otherwise.
+ */
+I18n.prototype.hasIntlNumberFormatSupport = function () {
+  return Boolean(window.Intl && ('NumberFormat' in window.Intl && Intl.NumberFormat.supportedLocalesOf(this.locale).length))
 }
 
 /**

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -183,7 +183,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.arabic(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.arabic(num)).toBe(intl.select(num))
         })
       })
 
@@ -195,7 +195,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.chinese(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.chinese(num)).toBe(intl.select(num))
         })
       })
 
@@ -207,7 +207,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.french(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.french(num)).toBe(intl.select(num))
         })
       })
 
@@ -219,7 +219,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.german(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.german(num)).toBe(intl.select(num))
         })
       })
 
@@ -231,7 +231,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.irish(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.irish(num)).toBe(intl.select(num))
         })
       })
 
@@ -243,7 +243,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.russian(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.russian(num)).toBe(intl.select(num))
         })
       })
 
@@ -255,7 +255,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.scottish(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.scottish(num)).toBe(intl.select(num))
         })
       })
 
@@ -267,7 +267,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.spanish(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.spanish(num)).toBe(intl.select(num))
         })
       })
 
@@ -279,7 +279,7 @@ describe('I18n', () => {
         const intl = new Intl.PluralRules(locale)
 
         testNumbers.concat(localeNumbers).forEach(num => {
-          expect(i18n.pluralRules.welsh(num)).toEqual(intl.select(num))
+          expect(i18n.pluralRules.welsh(num)).toBe(intl.select(num))
         })
       })
     })

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -134,11 +134,12 @@ describe('I18n', () => {
     })
 
     it('formats numbers that are passed as placeholders', () => {
-      const i18n = new I18n({
-        ageString: 'I am %{age} years old'
-      })
+      const translations = { ageString: 'I am %{age} years old' }
+      const i18nEn = new I18n(translations, { locale: 'en' })
+      const i18nDe = new I18n(translations, { locale: 'de' })
 
-      expect(i18n.t('ageString', { age: 2000 })).toBe('I am 2,000 years old')
+      expect(i18nEn.t('ageString', { age: 2000 })).toBe('I am 2,000 years old')
+      expect(i18nDe.t('ageString', { age: 2000 })).toBe('I am 2.000 years old')
     })
 
     it('does not format number-like strings that are passed as placeholders', () => {

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -36,7 +36,7 @@ describe('I18n', () => {
 
     it('throws an error if no lookup key is provided', () => {
       const i18n = new I18n(config)
-      expect(() => i18n.t()).toThrow('i18n lookup key missing.')
+      expect(() => i18n.t()).toThrow('i18n: lookup key missing')
     })
   })
 
@@ -131,6 +131,141 @@ describe('I18n', () => {
     it('handles placeholder-style text within options values', () => {
       const i18n = new I18n(config)
       expect(i18n.t('nameString', { name: '%{name}' })).toBe('My name is %{name}')
+    })
+  })
+
+  describe('pluralisation', () => {
+    it('throws an error if a required plural form is not provided ', () => {
+      const i18n = new I18n({
+        testOther: 'testing testing'
+      }, {
+        locale: 'en'
+      })
+      expect(() => { i18n.t('test', { count: 1 }) }).toThrowError('i18n: Plural form "One" is required for "en" locale')
+    })
+
+    it('interpolates the count variable into the correct plural form', () => {
+      const i18n = new I18n({
+        testOne: '%{count} test',
+        testOther: '%{count} tests'
+      }, {
+        locale: 'en'
+      })
+
+      expect(i18n.t('test', { count: 1 })).toBe('1 test')
+      expect(i18n.t('test', { count: 5 })).toBe('5 tests')
+    })
+
+    describe('fallback plural rules', () => {
+      const testNumbers = [0, 1, 2, 5, 25, 100]
+
+      it('returns the correct plural form for a given count (Arabic rules)', () => {
+        const locale = 'ar'
+        const localeNumbers = [105, 125]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.arabic(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Chinese rules)', () => {
+        const locale = 'zh'
+        const localeNumbers = []
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.chinese(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (French rules)', () => {
+        const locale = 'fr'
+        const localeNumbers = []
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.french(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (German rules)', () => {
+        const locale = 'de'
+        const localeNumbers = []
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.german(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Irish rules)', () => {
+        const locale = 'ga'
+        const localeNumbers = [9]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.irish(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Russian rules)', () => {
+        const locale = 'ru'
+        const localeNumbers = [3, 13, 101]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.russian(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Scottish rules)', () => {
+        const locale = 'gd'
+        const localeNumbers = [15]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.scottish(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Spanish rules)', () => {
+        const locale = 'es'
+        const localeNumbers = [1000000, 2000000]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.spanish(num)).toEqual(intl.select(num))
+        })
+      })
+
+      it('returns the correct plural form for a given count (Welsh rules)', () => {
+        const locale = 'cy'
+        const localeNumbers = [3, 6]
+
+        const i18n = new I18n({}, { locale: locale })
+        const intl = new Intl.PluralRules(locale)
+
+        testNumbers.concat(localeNumbers).forEach(num => {
+          expect(i18n.pluralRules.welsh(num)).toEqual(intl.select(num))
+        })
+      })
     })
   })
 })

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -132,6 +132,22 @@ describe('I18n', () => {
       const i18n = new I18n(config)
       expect(i18n.t('nameString', { name: '%{name}' })).toBe('My name is %{name}')
     })
+
+    it('formats numbers that are passed as placeholders', () => {
+      const i18n = new I18n({
+        ageString: 'I am %{age} years old'
+      })
+
+      expect(i18n.t('ageString', { age: 2000 })).toBe('I am 2,000 years old')
+    })
+
+    it('does not format number-like strings that are passed as placeholders', () => {
+      const i18n = new I18n({
+        yearString: 'Happy new year %{year}'
+      })
+
+      expect(i18n.t('yearString', { year: '2023' })).toBe('Happy new year 2023')
+    })
   })
 
   describe('pluralisation', () => {


### PR DESCRIPTION
Expands the i18n functionality to add pluralisation support, via passing the special `count` option through the `t()` method. Doing so will locate the appropriate plural form suffix for the current locale and append this to the lookup key. 

Suffixes are based on the [Unicode CLDR specification](https://cldr.unicode.org/index/cldr-spec/plural-rules) and align with the output of the [Intl.PluralRules implementation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/select).

For example, calling the method with `testKey` will instead use the following lookup keys in the configured locales:

```js
t('testKey', { count: 0 })
// locale: 'en' => testKeyOther
// locale: 'cy' => testKeyZero
// locale: 'fr' => testKeyOne

t('testKey', { count: 1 })
// locale: 'en' => testKeyOne
// locale: 'cy' => testKeyOne
// locale: 'zh' => testKeyOther

t('testKey', { count: 6 })
// locale: 'en' => testKeyOther
// locale: 'cy' => testKeyMany
// locale: 'ga' => testKeyFew
```

Closes #2804.

## Changes

- Added `config` parameter to the I18n constructor. Currently this only has one option, `locale`. Unlike the `locale` option in earlier spikes, this one is [only intended to be used internally](https://github.com/alphagov/govuk-frontend/issues/2804#issuecomment-1246451644) and isn't configurable by users. Falls back to the document language if not specified. 
- Modifies the `t` method to check for the presence of a `count` option and, if present, calls `getPluralSuffix` and modifies the lookup key to point to the appropriate plural form. 
- Modifies the `replacePlaceholders` method to check if the placeholder is of type 'number' and, if so, to format it according to the configured locale. The number will not be formatted if `Intl.NumberFormat` isn't supported.
- Added three of new functions to I18n:
   - `hasIntlPluralRulesSupport`: Checks for browser support for `Intl.PluralRules` and related dependencies. Used by `getPluralSuffix`.
   - `hasIntlNumberFormatSupport`: Checks for browser support for `Init.NumberFormat` and related dependencies. Used by `replacePlaceholders`.
   - `getPluralSuffix`: Gets the CLDR specification plural form type (`zero`, `one`, `two`, `few`, `many` or `other`) based on the given number and configured locale.  Falls back to the hardcoded plural rules if `Intl.PluralRules` is not supported.
- Added two lookup maps to I18n:
  - `pluralRules`: Provides a fallback set of functions for determining the correct plural suffix to use for a given number and language.
  - `pluralRulesMap`: Object mapping language codes to the appropriate function within `pluralRules`.
- Added unit tests.
  - Checks that placeholders of type 'number' are formatted as numbers.
  - Checks that placeholders that look like numbers, but are not (i.e. strings) are not formatted as numbers.
  - Checks that an error is thrown if the currently required plural form hasn't been passed in the `translations` object.
  - Checks that string interpolation of the `count` option is possible and uses the appropriate plural form for the value of `count`.
  - Checks that the fallback `pluralRules` functions produce values consistent with `Intl.PluralRules`.

## Supported fallback languages
Browsers that support `Intl.PluralRules` theoretically support any language the browser vendor chooses to support. For older browsers (primarily Internet Explorer), we provide a set of fallback functions for a limited set of languages. 

We don't have any definitive data on what languages are used by forms services on GOV.UK (the main expected use case for these changes). This list has been compiled by combining languages we *know* are used by GOV.UK services, some assumptions, and languages that, although not in known use, have plural rules identical to other supported languages and are 'quick wins' for support.

Known in use by GOV.UK services:
- Arabic (ar)
- Bangla (bn)
- Chinese (zh)
- English (en)
- French (fr)
- Gujarati (gu)
- Hindi (hi)
- Indonesian (id)
- Japanese (jp)
- Korean (ko)
- Russian (ru)
- Spanish (es)
- Tamil (ta)
- Thai (th)
- Turkish (tr)
- Urdu (ur)
- Vietnamese (vi)
- Welsh (cy)

Languages that are assumed may be in use:
- Irish Gaelic (ga)
- Scottish Gaelic (gd)

'Quick win' languages:
- Afrikaans (af)
- Albanian (sq)
- Armenian (hy)
- Azerbaijani (az)
- Basque (eu)
- Bulgarian (bg)
- Burmese (my)
- Catalan (ca)
- Danish (da)
- Dutch (nl)
- Estonian (et)
- Farsi (fa)
- Finnish (fi)
- Georgian (ka)
- German (de)
- Greek (el)
- Hungarian (hl)
- Italian (it)
- Javanese (jv)
- Luxembourgish (lb)
- Malay (ms)
- Norwegian (de)
- Portuguese (European) (pt-PT)
- Punjabi (pa)
- Somali (so)
- Swahili (sw)
- Swedish (sv)
- Telugu (te)
- Ukrainian (uk)
- Zulu (zu)