### PR TITLE
Allow ErrorSummary to receive JavaScript config

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -57,11 +57,15 @@ function initAll (config) {
 
   // Find first error summary module to enhance.
   var $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
-  new ErrorSummary($errorSummary, config.errorSummary).init()
+  if ($errorSummary) {
+    new ErrorSummary($errorSummary, config.errorSummary).init()
+  }
 
   // Find first header module to enhance.
   var $header = $scope.querySelector('[data-module="govuk-header"]')
-  new Header($header).init()
+  if ($header) {
+    new Header($header).init()
+  }
 
   var $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')
   nodeListForEach($notificationBanners, function ($notificationBanner) {

--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -21,6 +21,7 @@ import Tabs from './components/tabs/tabs.mjs'
  * @param {HTMLElement} [config.scope=document] - scope to query for components
  * @param {Object} [config.accordion] - accordion config
  * @param {Object} [config.notificationBanner] - notification banner config
+ * @param {Object} [config.errorSummary] - error summary config
  */
 function initAll (config) {
   config = typeof config !== 'undefined' ? config : {}
@@ -56,7 +57,7 @@ function initAll (config) {
 
   // Find first error summary module to enhance.
   var $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
-  new ErrorSummary($errorSummary).init()
+  new ErrorSummary($errorSummary, config.errorSummary).init()
 
   // Find first header module to enhance.
   var $header = $scope.querySelector('[data-module="govuk-header"]')

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -3,6 +3,17 @@ import '../../vendor/polyfills/Event.mjs' // addEventListener
 import '../../vendor/polyfills/Element/prototype/closest.mjs'
 
 import { mergeConfigs, normaliseDataset } from '../../common.mjs'
+
+/**
+ * JavaScript enhancements for the ErrorSummary
+ *
+ * Takes focus on initialisation for accessible announcement, unless disabled in configuration.
+ *
+ * @class
+ * @param {HTMLElement} $module - The element this component controls
+ * @param {Object} config
+ * @param {Boolean} [config.disableAutoFocus=false] - Whether to disable the component taking focus on initialisation
+ */
 function ErrorSummary ($module, config) {
   this.$module = $module
 

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -2,8 +2,18 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Event.mjs' // addEventListener
 import '../../vendor/polyfills/Element/prototype/closest.mjs'
 
-function ErrorSummary ($module) {
+import { mergeConfigs, normaliseDataset } from '../../common.mjs'
+function ErrorSummary ($module, config) {
   this.$module = $module
+
+  var defaultConfig = {
+    disableAutoFocus: false
+  }
+  this.config = mergeConfigs(
+    defaultConfig,
+    config || {},
+    normaliseDataset($module.dataset)
+  )
 }
 
 ErrorSummary.prototype.init = function () {
@@ -22,7 +32,7 @@ ErrorSummary.prototype.init = function () {
 ErrorSummary.prototype.setFocus = function () {
   var $module = this.$module
 
-  if ($module.getAttribute('data-disable-auto-focus') === 'true') {
+  if (this.config.disableAutoFocus) {
     return
   }
 

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -15,6 +15,19 @@ import { mergeConfigs, normaliseDataset } from '../../common.mjs'
  * @param {Boolean} [config.disableAutoFocus=false] - Whether to disable the component taking focus on initialisation
  */
 function ErrorSummary ($module, config) {
+  // Some consuming code may not be passing a module,
+  // for example if they initialise the component
+  // on their own by directly passing the result
+  // of `document.querySelector`.
+  // To avoid breaking further JavaScript initialisation
+  // we need to safeguard against this so things keep
+  // working the same now we read the elements data attributes
+  if (!$module) {
+    // Little safety in case code gets ported as-is
+    // into and ES6 class constructor, where the return value matters
+    return this
+  }
+
   this.$module = $module
 
   var defaultConfig = {

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -88,6 +88,21 @@ describe('Error Summary', () => {
       })
     })
 
+    describe('using JavaScript configuration, with no elements on the page', () => {
+      it('does not prevent further JavaScript from running', async () => {
+        const result = await page.evaluate(() => {
+          // `undefined` simulates the element being missing,
+          // from an unchecked `document.querySelector` for example
+          new window.GOVUKFrontend.ErrorSummary(undefined).init()
+
+          // If our component initialisation breaks, this won't run
+          return true
+        })
+
+        expect(result).toBe(true)
+      })
+    })
+
     describe('using JavaScript configuration, but enabled via data-attributes', () => {
       beforeAll(async () => {
         await renderAndInitialise('error-summary', {

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -87,6 +87,38 @@ describe('Error Summary', () => {
         expect(activeElement).not.toBe('govuk-error-summary')
       })
     })
+
+    describe('using `initAll`', () => {
+      beforeAll(async () => {
+        await renderAndInitialise('error-summary', {
+          baseUrl,
+          nunjucksParams: examples.default,
+          initialiser () {
+            window.GOVUKFrontend.initAll({
+              errorSummary: {
+                disableAutoFocus: true
+              }
+            })
+          }
+        })
+      })
+
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus on page load', async () => {
+        const activeElement = await page.evaluate(
+          () => document.activeElement.dataset.module
+        )
+
+        expect(activeElement).not.toBe('govuk-error-summary')
+      })
+    })
   })
 
   const inputTypes = [

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -88,6 +88,29 @@ describe('Error Summary', () => {
       })
     })
 
+    describe('using JavaScript configuration, but enabled via data-attributes', () => {
+      beforeAll(async () => {
+        await renderAndInitialise('error-summary', {
+          baseUrl,
+          nunjucksParams: examples['autofocus explicitly enabled']
+        })
+      })
+
+      it('adds the tabindex attribute on page load', async () => {
+        const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+          el.getAttribute('tabindex')
+        )
+        expect(tabindex).toEqual('-1')
+      })
+
+      it('is automatically focused when the page loads', async () => {
+        const moduleName = await page.evaluate(
+          () => document.activeElement.dataset.module
+        )
+        expect(moduleName).toBe('govuk-error-summary')
+      })
+    })
+
     describe('using `initAll`', () => {
       beforeAll(async () => {
         await renderAndInitialise('error-summary', {

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -1,6 +1,9 @@
 /**
  * @jest-environment puppeteer
  */
+const { renderAndInitialise, getExamples } = require('../../../../lib/jest-helpers')
+
+const examples = getExamples('error-summary')
 
 const configPaths = require('../../../../config/paths.js')
 const PORT = configPaths.ports.test
@@ -32,20 +35,57 @@ describe('Error Summary', () => {
   })
 
   describe('when auto-focus is disabled', () => {
-    it('does not have a tabindex attribute', async () => {
-      await page.goto(`${baseUrl}/components/error-summary/autofocus-disabled/preview`, { waitUntil: 'load' })
+    describe('using data-attributes', () => {
+      beforeAll(async () => {
+        await page.goto(
+          `${baseUrl}/components/error-summary/autofocus-disabled/preview`,
+          { waitUntil: 'load' }
+        )
+      })
 
-      const tabindex = await page.$eval('.govuk-error-summary', el => el.getAttribute('tabindex'))
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+          el.getAttribute('tabindex')
+        )
 
-      expect(tabindex).toBeNull()
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus on page load', async () => {
+        const activeElement = await page.evaluate(
+          () => document.activeElement.dataset.module
+        )
+
+        expect(activeElement).not.toBe('govuk-error-summary')
+      })
     })
 
-    it('does not focus on page load', async () => {
-      await page.goto(`${baseUrl}/components/error-summary/autofocus-disabled/preview`, { waitUntil: 'load' })
+    describe('using JavaScript configuration', () => {
+      beforeAll(async () => {
+        await renderAndInitialise('error-summary', {
+          baseUrl,
+          nunjucksParams: examples.default,
+          javascriptConfig: {
+            disableAutoFocus: true
+          }
+        })
+      })
 
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+          el.getAttribute('tabindex')
+        )
 
-      expect(activeElement).not.toBe('govuk-error-summary')
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus on page load', async () => {
+        const activeElement = await page.evaluate(
+          () => document.activeElement.dataset.module
+        )
+
+        expect(activeElement).not.toBe('govuk-error-summary')
+      })
     })
   })
 

--- a/src/govuk/components/error-summary/error-summary.yaml
+++ b/src/govuk/components/error-summary/error-summary.yaml
@@ -196,3 +196,8 @@ examples:
   data:
     titleText: There is a problem
     disableAutoFocus: true
+- name: autofocus explicitly enabled
+  hidden: true
+  data:
+    titleText: There is a problem
+    disableAutoFocus: false  

--- a/src/govuk/components/error-summary/template.njk
+++ b/src/govuk/components/error-summary/template.njk
@@ -1,6 +1,6 @@
 <div class="govuk-error-summary
   {%- if params.classes %} {{ params.classes }}{% endif %}"
-  {%- if params.disableAutoFocus %} data-disable-auto-focus="true"{% endif %}
+  {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-error-summary">
   {# Keep the role="alert" in a seperate child container to prevent a race condition between
   the focusing js at the alert, resulting in information getting missed in screen reader announcements #}

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -154,5 +154,19 @@ describe('Error-summary', () => {
 
       expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
     })
+
+    it('allows to disable autofocus', () => {
+      const $ = render('error-summary', examples['autofocus disabled'])
+
+      const $component = $('.govuk-error-summary')
+      expect($component.attr('data-disable-auto-focus')).toBe('true')
+    })
+
+    it('allows to explicitely enable autofocus', () => {
+      const $ = render('error-summary', examples['autofocus explicitly enabled'])
+
+      const $component = $('.govuk-error-summary')
+      expect($component.attr('data-disable-auto-focus')).toBe('false')
+    })
   })
 })


### PR DESCRIPTION
Following the tracks of #2843 for the notification banner, and #2826 for the accordion, this PR adds the possibility to configure the `ErrorSummary` component through Javascript, alongside its existing data attributes.

Each commit takes care of one of the 3 things that needed to happen for that:
1. Allowing the component to receive JavaScript configuration
2. Letting `initAll` pass through any configuration when instantiating `ErrorSummary`
3. Making sure that the data attribute takes precedence over the JavaScript configuration

Closes #2838 