### PR TITLE
Replace deprecated `request` package with Fetch API

### DIFF
--- a/app/app.test.js
+++ b/app/app.test.js
@@ -1,5 +1,5 @@
-const request = require('request')
 const cheerio = require('cheerio')
+const { Agent, fetch, setGlobalDispatcher } = require('undici')
 
 const lib = require('../lib/file-helper')
 
@@ -18,58 +18,52 @@ const expectedPages = [
   '/examples/template-custom'
 ]
 
-// Returns a wrapper for `request` which applies these options by default
-const requestPath = request.defaults({
-  baseUrl: `http://localhost:${PORT}`,
-  headers: {
-    'Content-Type': 'text/plain'
-  }
-})
+// Reduce test keep-alive
+setGlobalDispatcher(new Agent({
+  keepAliveTimeout: 10,
+  keepAliveMaxTimeout: 10
+}))
+
+// Returns Fetch API wrapper which applies these options by default
+const fetchPath = (path, options) => {
+  return fetch(`http://localhost:${PORT}${path}`, options)
+}
 
 describe(`http://localhost:${PORT}`, () => {
   describe.each(expectedPages)('%s', path => {
-    it('should resolve with a http status code of 200', done => {
-      requestPath.get(path, (err, res) => {
-        expect(res.statusCode).toEqual(200)
-        done(err)
-      })
+    it('should resolve with a http status code of 200', async () => {
+      const { status } = await fetchPath(path, { method: 'HEAD' })
+      expect(status).toEqual(200)
     })
 
-    it('should resolve with a ‘Content-Type’ header of "text/html"', done => {
-      requestPath.get(path, (err, res) => {
-        expect(res.headers['content-type']).toContain('text/html')
-        done(err)
-      })
+    it('should resolve with a ‘Content-Type’ header of "text/html"', async () => {
+      const { headers } = await fetchPath(path, { method: 'HEAD' })
+      expect(headers.get('content-type')).toContain('text/html')
     })
 
-    it('should prevent search indexing', done => {
-      requestPath.get(path, (err, res) => {
-        expect(res.headers['x-robots-tag']).toEqual('none')
-        done(err)
-      })
+    it('should prevent search indexing', async () => {
+      const { headers } = await fetchPath(path, { method: 'HEAD' })
+      expect(headers.get('x-robots-tag')).toEqual('none')
     })
   })
 
   describe('/', () => {
-    it('should display the list of components', done => {
-      requestPath('/', (err, res) => {
-        const $ = cheerio.load(res.body)
-        const componentsList = $('li a[href^="/components/"]').get()
-        // Since we have an 'all' component link that renders the default example of all
-        // components, there will always be one more expected link.
-        const expectedComponentLinks = lib.allComponents.length + 1
-        expect(componentsList.length).toEqual(expectedComponentLinks)
-        done(err)
-      })
+    it('should display the list of components', async () => {
+      const response = await fetchPath('/')
+      const $ = cheerio.load(await response.text())
+      const componentsList = $('li a[href^="/components/"]').get()
+      // Since we have an 'all' component link that renders the default example of all
+      // components, there will always be one more expected link.
+      const expectedComponentLinks = lib.allComponents.length + 1
+      expect(componentsList.length).toEqual(expectedComponentLinks)
     })
   })
 
   describe('/robots.txt', () => {
-    it('should allow crawling by robots', done => {
-      requestPath('/robots.txt', (err, res) => {
-        expect(res.body).toMatch(/^Allow: \/$/m)
-        done(err)
-      })
+    it('should allow crawling by robots', async () => {
+      const response = await fetchPath('/robots.txt')
+      const body = await response.text()
+      expect(body).toMatch(/^Allow: \/$/m)
     })
   })
 
@@ -82,144 +76,127 @@ describe(`http://localhost:${PORT}`, () => {
       'main',
       'content',
       'bodyEnd'
-    ])('should have a %s block set', (block, done) => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        expect($.html()).toContain(`<!-- block:${block} -->`)
-        done(err)
-      })
+    ])('should have a %s block set', async (block) => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+      expect($.html()).toContain(`<!-- block:${block} -->`)
     })
 
-    it('should have additional `htmlClasses`', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $html = $('html')
+    it('should have additional `htmlClasses`', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($html.attr('class')).toBe('govuk-template app-html-class')
-        done(err)
-      })
+      const $html = $('html')
+      expect($html.attr('class')).toBe('govuk-template app-html-class')
     })
 
-    it('should have assets overriden', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $linkAsset = $('link[href^="/images/"]')
-        expect($linkAsset.length).toBe(6)
-        done(err)
-      })
+    it('should have assets overriden', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $linkAsset = $('link[href^="/images/"]')
+      expect($linkAsset.length).toBe(6)
     })
 
-    it('should have theme-color overriden', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $linkMaskIcon = $('link[rel="mask-icon"]')
-        const $metaThemeColor = $('meta[name="theme-color"]')
+    it('should have theme-color overriden', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($linkMaskIcon.attr('color')).toBe('blue')
-        expect($metaThemeColor.attr('content')).toBe('blue')
-        done(err)
-      })
+      const $linkMaskIcon = $('link[rel="mask-icon"]')
+      const $metaThemeColor = $('meta[name="theme-color"]')
+
+      expect($linkMaskIcon.attr('color')).toBe('blue')
+      expect($metaThemeColor.attr('content')).toBe('blue')
     })
 
-    it('should have additional `bodyClasses`', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $body = $('body')
+    it('should have additional `bodyClasses`', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($body.attr('class')).toBe('govuk-template__body app-body-class')
-        done(err)
-      })
+      const $body = $('body')
+      expect($body.attr('class')).toBe('govuk-template__body app-body-class')
     })
 
-    it('should have `pageTitle` overriden', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $title = $('title')
+    it('should have `pageTitle` overriden', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($title.html()).toBe('GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l&apos;information')
-        done(err)
-      })
+      const $title = $('title')
+      expect($title.html()).toBe('GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l&apos;information')
     })
 
-    it('should have an application stylesheet', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $appStylesheet = $('link[href="/public/app.css"]')
-        expect($appStylesheet.length).toBe(1)
-        done(err)
-      })
+    it('should have an application stylesheet', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $appStylesheet = $('link[href="/public/app.css"]')
+      expect($appStylesheet.length).toBe(1)
     })
 
-    it('should have a custom Skip link component', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $skipLink = $('.govuk-skip-link')
-        expect($skipLink.html()).toBe('Passer au contenu principal')
-        done(err)
-      })
+    it('should have a custom Skip link component', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $skipLink = $('.govuk-skip-link')
+      expect($skipLink.html()).toBe('Passer au contenu principal')
     })
 
-    it('should have a custom Header component', done => {
-      requestPath(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $header = $('.govuk-header')
-        const $serviceName = $header.find('.govuk-header__service-name')
-        expect($serviceName.html()).toContain('Nom du service')
-        done(err)
-      })
+    it('should have a custom Header component', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $header = $('.govuk-header')
+      const $serviceName = $header.find('.govuk-header__service-name')
+
+      expect($serviceName.html()).toContain('Nom du service')
     })
 
-    it('should have a Phase banner component', done => {
-      requestPath.get(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $phaseBanner = $('.govuk-phase-banner')
-        const $text = $phaseBanner.find('.govuk-phase-banner__text')
-        expect($text.html()).toContain('C&apos;est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront &#xE0; l&apos;am&#xE9;liorer.')
-        done(err)
-      })
+    it('should have a Phase banner component', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $phaseBanner = $('.govuk-phase-banner')
+      const $text = $phaseBanner.find('.govuk-phase-banner__text')
+
+      expect($text.html()).toContain('C&apos;est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront &#xE0; l&apos;am&#xE9;liorer.')
     })
 
-    it('should have a custom Footer component', done => {
-      requestPath.get(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $footer = $('.govuk-footer')
-        const $footerLink = $footer.find('.govuk-footer__link')
-        expect($footerLink.html()).toContain('Aidez-moi')
-        done(err)
-      })
+    it('should have a custom Footer component', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
+
+      const $footer = $('.govuk-footer')
+      const $footerLink = $footer.find('.govuk-footer__link')
+
+      expect($footerLink.html()).toContain('Aidez-moi')
     })
 
-    it('should have `content` within the main section of the page', done => {
-      requestPath.get(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $main = $('main')
+    it('should have `content` within the main section of the page', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($main.html()).toContain('<!-- block:content -->')
-        done(err)
-      })
+      const $main = $('main')
+      expect($main.html()).toContain('<!-- block:content -->')
     })
 
-    it('should have `beforeContent` outside the main section of the page', done => {
-      requestPath.get(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $container = $('.govuk-width-container')
-        const $phaseBanner = $container.find('> .govuk-phase-banner')
-        const $backLink = $container.find('> .govuk-back-link')
+    it('should have `beforeContent` outside the main section of the page', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($phaseBanner.length).toBe(1)
-        expect($backLink.length).toBe(1)
-        done(err)
-      })
+      const $container = $('.govuk-width-container')
+      const $phaseBanner = $container.find('> .govuk-phase-banner')
+      const $backLink = $container.find('> .govuk-back-link')
+
+      expect($phaseBanner.length).toBe(1)
+      expect($backLink.length).toBe(1)
     })
 
-    it('should have set `mainClasses`', done => {
-      requestPath.get(templatePath, (err, res) => {
-        const $ = cheerio.load(res.body)
-        const $main = $('main')
+    it('should have set `mainClasses`', async () => {
+      const response = await fetchPath(templatePath)
+      const $ = cheerio.load(await response.text())
 
-        expect($main.attr('class')).toBe('govuk-main-wrapper govuk-main-wrapper--auto-spacing app-main-class')
-        done(err)
-      })
+      const $main = $('main')
+      expect($main.attr('class')).toBe('govuk-main-wrapper govuk-main-wrapper--auto-spacing app-main-class')
     })
   })
 })

--- a/app/banner.test.js
+++ b/app/banner.test.js
@@ -1,45 +1,46 @@
-const request = require('request')
 const cheerio = require('cheerio')
+const { Agent, fetch, setGlobalDispatcher } = require('undici')
 
 const configPaths = require('../config/paths.js')
 const PORT = configPaths.ports.test
 
-// Returns a wrapper for `request` which applies these options by default
-const requestPath = request.defaults({
-  baseUrl: `http://localhost:${PORT}`,
-  headers: {
-    'Content-Type': 'text/plain'
-  }
-})
+// Reduce test keep-alive timeouts
+setGlobalDispatcher(new Agent({
+  keepAliveTimeout: 10,
+  keepAliveMaxTimeout: 10
+}))
+
+// Returns Fetch API wrapper which applies these options by default
+const fetchPath = (path, options) => {
+  return fetch(`http://localhost:${PORT}${path}`, options)
+}
 
 describe('Banner', () => {
-  it('is visible by default', done => {
-    requestPath.get('/', (err, res) => {
-      const $ = cheerio.load(res.body)
+  it('is visible by default', async () => {
+    const response = await fetchPath('/')
+    const body = await response.text()
+    const $ = cheerio.load(body)
 
-      // Check the page responded correctly
-      expect(res.statusCode).toBe(200)
-      expect($.html()).toContain('GOV.UK Frontend')
+    // Check the page responded correctly
+    expect(response.status).toBe(200)
+    expect($.html()).toContain('GOV.UK Frontend')
 
-      // Check that the banner is visible
-      const appBanner = $('[data-module="app-banner"]')
-      expect(appBanner.length).toBeTruthy()
-      done(err)
-    })
+    // Check that the banner is visible
+    const appBanner = $('[data-module="app-banner"]')
+    expect(appBanner.length).toBeTruthy()
   })
 
-  it('can be hidden using a url parameter', done => {
-    requestPath.get('/?hide-banner', (err, res) => {
-      const $ = cheerio.load(res.body)
+  it('can be hidden using a url parameter', async () => {
+    const response = await fetchPath('/?hide-banner')
+    const body = await response.text()
+    const $ = cheerio.load(body)
 
-      // Check the page responded correctly
-      expect(res.statusCode).toBe(200)
-      expect($.html()).toContain('GOV.UK Frontend')
+    // Check the page responded correctly
+    expect(response.status).toBe(200)
+    expect($.html()).toContain('GOV.UK Frontend')
 
-      // Check that the banner is visible
-      const appBanner = $('[data-module="app-banner"]')
-      expect(appBanner.length).toBeFalsy()
-      done(err)
-    })
+    // Check that the banner is visible
+    const appBanner = $('[data-module="app-banner"]')
+    expect(appBanner.length).toBeFalsy()
   })
 })


### PR DESCRIPTION
I've split this change from https://github.com/alphagov/govuk-frontend/pull/2850 so it's easier to review

The changes [resolve 3x vulnerabilities in `node-sass`](https://github.com/sass/node-sass/releases/tag/v7.0.3) and removes this message on install:

>npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

We'll see to check for CSS changes from [`node-sass@7.01`](https://github.com/sass/node-sass/releases/tag/v7.0.1) → [`node-sass@7.03`](https://github.com/sass/node-sass/releases/tag/v7.0.3)

I've replaced  `request()` with [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) following this approach (until native support arrives in Node.js 17):
https://blog.logrocket.com/fetch-api-node-js/#undici