### PR TITLE
Ensure all gulp tasks run to completion

### DIFF
--- a/tasks/asset-version.js
+++ b/tasks/asset-version.js
@@ -1,39 +1,35 @@
 const configPaths = require('../config/paths.js')
-const fs = require('fs')
-const path = require('path')
+const { rename, writeFile } = require('fs/promises')
+const { basename, resolve } = require('path')
 
 // Update assets' version numbers
 // Uses the version number from `package/package.json` and writes it to various places
-function updateDistAssetsVersion (cb) {
+async function updateDistAssetsVersion () {
   const distFolder = 'dist'
-  const pkg = require('../' + configPaths.package + 'package.json')
 
-  // Write VERSION.txt file
-  fs.writeFileSync(distFolder + '/VERSION.txt', pkg.version + '\r\n')
+  const pkg = require('../' + configPaths.package + 'package.json')
 
   // Files to process
   const assetFiles = [
-    distFolder + '/govuk-frontend.min.css',
-    distFolder + '/govuk-frontend-ie8.min.css',
-    distFolder + '/govuk-frontend.min.js'
+    resolve(`${distFolder}/govuk-frontend.min.css`),
+    resolve(`${distFolder}/govuk-frontend-ie8.min.css`),
+    resolve(`${distFolder}/govuk-frontend.min.js`)
   ]
 
-  // Loop through files and move them to their new locations
-  assetFiles.forEach(srcFilename => {
+  // Loop through files
+  const assetTasks = assetFiles.map(srcFilename => {
     const destFilename = srcFilename.replace(/(govuk.*)(?=\.min)/g, '$1-' + pkg.version)
-    fs.rename(
-      path.resolve(srcFilename),
-      path.resolve(destFilename),
-      error => {
-        if (error) throw error
-        console.log(`Moved ${srcFilename} to ${destFilename}.`)
-      }
-    )
+
+    // Move to new location
+    return rename(srcFilename, destFilename)
+      .then(() => console.log(`Moved ${basename(srcFilename)} to ${basename(destFilename)}.`))
   })
 
-  // Required for Gulp task to complete successfully.
-  // Can be removed once this no longer runs via Gulp.
-  cb()
+  // Write VERSION.txt file
+  assetTasks.push(writeFile(resolve(`${distFolder}/VERSION.txt`), pkg.version + '\r\n'))
+
+  // Resolve on completion
+  return Promise.all(assetTasks)
 }
 
 module.exports = updateDistAssetsVersion

--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -178,7 +178,7 @@ describe('package/', () => {
           expect(parsedData).toEqual(
             expect.objectContaining({
               component: name,
-              fixtures: expect.any(Object)
+              fixtures: expect.any(Array)
             })
           )
 

--- a/tasks/sassdoc.js
+++ b/tasks/sassdoc.js
@@ -1,8 +1,8 @@
 const sassdoc = require('sassdoc')
 const paths = require('../config/paths.js')
 
-function buildSassdocs (cb) {
-  sassdoc([paths.src + '**/**/*.scss', `!${paths.src}/vendor/*`], {
+function buildSassdocs () {
+  return sassdoc([paths.src + '**/**/*.scss', `!${paths.src}/vendor/*`], {
     dest: paths.sassdoc,
     groups: {
       'components/button': 'Components / Button',
@@ -28,15 +28,7 @@ function buildSassdocs (cb) {
       objects: 'Objects',
       'objects/layout': 'Objects / Layout'
     }
-  }).then(() => {
-    console.log('Sassdoc built.')
-  }, err => {
-    throw err
   })
-
-  // Required for Gulp task to complete successfully.
-  // Can be removed once this no longer runs via Gulp.
-  cb()
 }
 
 module.exports = buildSassdocs


### PR DESCRIPTION
This PR ensures all Gulp tasks returns either a Promise or `gulp.src()` stream

The CLI wasn't waiting for tasks to run to completion, ~including a “write after end” YAML error~ see https://github.com/alphagov/govuk-frontend/pull/2870

**Fixes this workaround**
```js
// Required for Gulp task to complete successfully.
// Can be removed once this no longer runs via Gulp.
cb()
```