### PR TITLE
Fix stray `let` in I18n preventing uglify

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,8 +34,11 @@ jobs:
         if: steps.npm-cache.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: Build assets
-        run: npm run build:assets
+      - name: Build
+        run: |
+          npm run build:assets
+          npm run build:package
+          npm run build:dist
 
       - name: Run test projects
         run: |

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -89,7 +89,7 @@ I18n.prototype.replacePlaceholders = function (translationString, options) {
     var placeholderIncludingBraces = placeholderMatch[0]
     var placeholderKey = placeholderMatch[1]
     if (Object.prototype.hasOwnProperty.call(options, placeholderKey)) {
-      let placeholderValue = options[placeholderKey]
+      var placeholderValue = options[placeholderKey]
 
       // If a user has passed `false` as the value for the placeholder
       // treat it as though the value should not be displayed


### PR DESCRIPTION
This PR fixes a tiny `let` → `var` which caused a fairly obscure **GulpUglifyError**

```console
[18:55:27] GulpUglifyError: unable to minify JavaScript
Caused by: SyntaxError: Unexpected token: name «placeholderValue», expected: punc «;»
File: /Users/colin/Sites/GDS/govuk-frontend/src/govuk/all.mjs
Line: 524
Col: 10
```

To catch this next time I've added the other npm `build:*` scripts to the GitHub workflow:

```yaml
- name: Build
  run: |
    npm run build:assets
    npm run build:package
    npm run build:dist
```