### PR TITLE
Reword $percentage sassdoc for govuk-tint and govuk-shade

### DIFF
--- a/src/govuk/helpers/_colour.scss
+++ b/src/govuk/helpers/_colour.scss
@@ -75,7 +75,7 @@
 /// Make a colour darker by mixing it with black
 ///
 /// @param {Colour} $colour - colour to shade
-/// @param {Number} $percentage - percentage of `$colour` in returned colour
+/// @param {Number} $percentage - percentage of black to mix with $colour
 /// @return {Colour}
 /// @access public
 
@@ -86,7 +86,7 @@
 /// Make a colour lighter by mixing it with white
 ///
 /// @param {Colour} $colour - colour to tint
-/// @param {Number} $percentage - percentage of `$colour` in returned colour
+/// @param {Number} $percentage - percentage of white to mix with $colour
 /// @return {Colour}
 /// @access public
 


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2873

As noted in the linked issue, we're providing incorrect information in the sassdoc for both `govuk-tint` and `govuk-shade` in that `$percentage` isn't actually a percentage of `$colour` but a percentage of the white and black being passed to each respective mixin. This change rewords the sassdoc for each mixin to be more accurate.