### PR TITLE
Ensure gulp tests return Promises

### DIFF
--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -44,7 +44,7 @@ describe('dist/', () => {
 
       // Compare the expected directory listing with the files we expect
       // to be present
-      Promise.all([actualDistAssets(), expectedDistAssets()])
+      return Promise.all([actualDistAssets(), expectedDistAssets()])
         .then(results => {
           const [actualDistAssets, expectedDistAssets] = results
 

--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -87,7 +87,7 @@ describe('package/', () => {
 
     // Compare the expected directory listing with the files we expect
     // to be present
-    Promise.all([actualPackageFiles(), expectedPackageFiles()])
+    return Promise.all([actualPackageFiles(), expectedPackageFiles()])
       .then(results => {
         const [actualPackageFiles, expectedPackageFiles] = results
 


### PR DESCRIPTION
Fixes a couple of instances where Jest test functions were creating `Promise`s without returning them, so the test runner would get confused about which test was failing.