### PR TITLE
Don’t copy *.js files into `govuk-esm`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,8 +74,7 @@ gulp.task('dev', gulp.series(
 gulp.task('build:package', gulp.series(
   cleanPackage,
   'copy-files',
-  'js:compile',
-  'js:copy-esm'
+  'js:compile'
 ))
 
 gulp.task('build:dist', gulp.series(

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -18,7 +18,6 @@ gulp.task('copy-files', () => {
     // Copy source JavaScript
     gulp.src([
       `${configPaths.src}**/*.mjs`,
-      `${configPaths.src}**/*.js`,
       `!${configPaths.src}**/*.test.*`
     ]).pipe(gulp.dest(`${taskArguments.destination}/govuk-esm/`)),
 

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -15,54 +15,62 @@ const taskArguments = require('../task-arguments')
 
 gulp.task('copy-files', () => {
   return merge(
+    // Copy source JavaScript
     gulp.src([
-      `${configPaths.src}**/*`,
+      `${configPaths.src}**/*.mjs`,
+      `${configPaths.src}**/*.js`,
+      `!${configPaths.src}**/*.test.*`
+    ]).pipe(gulp.dest(`${taskArguments.destination}/govuk-esm/`)),
 
-      // Exclude files from copy
-      '!**/.DS_Store',
-      '!**/*.mjs',
-      '!**/*.test.*',
-      '!**/__snapshots__/',
-      '!**/__snapshots__/**',
+    merge(
+      gulp.src([
+        `${configPaths.src}**/*`,
 
-      // Preserve destination README when copying to ./package
-      // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
-      `!${configPaths.src}README.md`,
+        // Exclude files from copy
+        '!**/.DS_Store',
+        '!**/*.mjs',
+        '!**/*.test.*',
+        '!**/__snapshots__/',
+        '!**/__snapshots__/**',
 
-      // Exclude files from other streams
-      `!${configPaths.src}**/*.scss`,
-      `!${configPaths.components}**/*.yaml`
-    ]),
+        // Preserve destination README when copying to ./package
+        // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
+        `!${configPaths.src}README.md`,
 
-    // Add CSS prefixes to Sass
-    gulp.src(`${configPaths.src}**/*.scss`)
-      .pipe(postcss([autoprefixer], { syntax: postcssScss })),
+        // Exclude files from other streams
+        `!${configPaths.src}**/*.scss`,
+        `!${configPaths.components}**/*.yaml`
+      ]),
 
-    // Generate fixtures.json from ${component}.yaml
-    gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
-      .pipe(map((file, done) =>
-        generateFixtures(file)
-          .then((fixture) => done(null, fixture))
-          .catch(done)
-      ))
-      .pipe(rename({
-        basename: 'fixtures',
-        extname: '.json'
-      })),
+      // Add CSS prefixes to Sass
+      gulp.src(`${configPaths.src}**/*.scss`)
+        .pipe(postcss([autoprefixer], { syntax: postcssScss })),
 
-    // Generate macro-options.json from ${component}.yaml
-    gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
-      .pipe(map((file, done) =>
-        generateMacroOptions(file)
-          .then((macro) => done(null, macro))
-          .catch(done)
-      ))
-      .pipe(rename({
-        basename: 'macro-options',
-        extname: '.json'
-      }))
+      // Generate fixtures.json from ${component}.yaml
+      gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
+        .pipe(map((file, done) =>
+          generateFixtures(file)
+            .then((fixture) => done(null, fixture))
+            .catch(done)
+        ))
+        .pipe(rename({
+          basename: 'fixtures',
+          extname: '.json'
+        })),
+
+      // Generate macro-options.json from ${component}.yaml
+      gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
+        .pipe(map((file, done) =>
+          generateMacroOptions(file)
+            .then((macro) => done(null, macro))
+            .catch(done)
+        ))
+        .pipe(rename({
+          basename: 'macro-options',
+          extname: '.json'
+        }))
+    ).pipe(gulp.dest(`${taskArguments.destination}/govuk/`))
   )
-    .pipe(gulp.dest(`${taskArguments.destination}/govuk/`))
 })
 
 /**
@@ -108,15 +116,6 @@ async function generateFixtures (file) {
   file.contents = Buffer.from(JSON.stringify(fixtures, null, 4))
   return file
 }
-
-gulp.task('js:copy-esm', () => {
-  return gulp.src([
-    `${configPaths.src}**/*.mjs`,
-    `${configPaths.src}**/*.js`,
-    `!${configPaths.src}**/*.test.*`
-  ])
-    .pipe(gulp.dest(taskArguments.destination + '/govuk-esm/'))
-})
 
 /**
  * Replace file content with macro-options.json

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -15,17 +15,24 @@ const taskArguments = require('../task-arguments')
 
 gulp.task('copy-files', () => {
   return merge(
-    // Copy source JavaScript
+    /**
+     * Copy files to destination with './govuk-esm' suffix
+     * Includes only source JavaScript ECMAScript (ES) modules
+     */
     gulp.src([
       `${configPaths.src}**/*.mjs`,
       `!${configPaths.src}**/*.test.*`
     ]).pipe(gulp.dest(`${taskArguments.destination}/govuk-esm/`)),
 
+    /**
+     * Copy files to destination with './govuk' suffix
+     * Includes fonts, images, polyfills, component files
+     */
     merge(
       gulp.src([
         `${configPaths.src}**/*`,
 
-        // Exclude files from copy
+        // Exclude files we don't want to publish
         '!**/.DS_Store',
         '!**/*.mjs',
         '!**/*.test.*',
@@ -36,8 +43,10 @@ gulp.task('copy-files', () => {
         // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
         `!${configPaths.src}README.md`,
 
-        // Exclude files from other streams
+        // Exclude Sass files handled by PostCSS stream below
         `!${configPaths.src}**/*.scss`,
+
+        // Exclude source YAML handled by JSON streams below
         `!${configPaths.components}**/*.yaml`
       ]),
 


### PR DESCRIPTION
In response to [comment regarding ***.js** files in `govuk-esm`](https://github.com/alphagov/govuk-frontend/pull/2851#issuecomment-1254698677)

>So I think we can just remove the `${configPaths.src}**/*.js` glob from the `js:copy-esm` task?

This PR includes:

1. Combine `js:copy-esm` task → `copy-files`
2. Remove `${configPaths.src}**/*.js` glob so only ***.mjs** are copied