### PR TITLE
Add `postcss.config.js`/`.browserslistrc` configs

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,14 @@
+# This list builds on the GOV.UK service manual's browser testing recommendations
+# https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices
+
+> 0.1%
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Edge versions
+last 2 Samsung versions
+Safari >= 9
+ie 8-11
+iOS >= 9
+
+[node]
+node 16

--- a/package.json
+++ b/package.json
@@ -98,15 +98,5 @@
   },
   "optionalDependencies": {
     "fsevents": "*"
-  },
-  "browserslist": [
-    ">0.1%",
-    "last 2 Chrome versions",
-    "last 2 Firefox versions",
-    "last 2 Edge versions",
-    "last 2 Samsung versions",
-    "Safari >= 9",
-    "ie 8-11",
-    "iOS >= 9"
-  ]
+  }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,59 @@
+const { parse } = require('path')
+const autoprefixer = require('autoprefixer')
+const cssnano = require('cssnano')
+const oldie = require('oldie')
+const pseudoclasses = require('postcss-pseudo-classes')
+
+/**
+ * PostCSS config
+ *
+ * @param {object} context - PostCSS context
+ * @param {string} context.env - Browserslist environment
+ * @param {import('vinyl')} context.file - File object
+ */
+module.exports = ({ env, file }) => {
+  const { dir, name } = parse(file.path)
+
+  const plugins = [
+    autoprefixer({ env })
+  ]
+
+  // Minify CSS
+  if (name.endsWith('.min')) {
+    plugins.push(cssnano())
+  }
+
+  // Add review app auto-generated 'companion' classes for each pseudo-class
+  // For example ':hover' and ':focus' classes to simulate form label states
+  if (dir.endsWith('app/assets/scss') && (name === 'app' || name.startsWith('app-'))) {
+    plugins.push(pseudoclasses({
+      // Work around a bug in pseudo classes plugin that badly transforms
+      // :not(:whatever) pseudo selectors
+      blacklist: [
+        ':not(',
+        ':disabled)',
+        ':first-child)',
+        ':last-child)',
+        ':focus)',
+        ':active)',
+        ':hover)'
+      ]
+    }))
+  }
+
+  // Transpile CSS for Internet Explorer
+  if (name.endsWith('-ie8') || name.endsWith('-ie8.min')) {
+    plugins.push(
+      oldie({
+        rgba: { filter: true },
+        rem: { disable: true },
+        unmq: { disable: true },
+        pseudo: { disable: true }
+      })
+    )
+  }
+
+  return {
+    plugins
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -9,10 +9,10 @@ const pseudoclasses = require('postcss-pseudo-classes')
  *
  * @param {object} context - PostCSS context
  * @param {string} context.env - Browserslist environment
- * @param {import('vinyl')} context.file - File object
+ * @param {string | import('vinyl')} [context.file] - File path or object
  */
-module.exports = ({ env, file }) => {
-  const { dir, name } = parse(file.path)
+module.exports = ({ env, file = '' }) => {
+  const { dir, name } = parse(typeof file === 'object' ? file.path : file)
 
   const plugins = [
     autoprefixer({ env })

--- a/postcss.config.unit.test.js
+++ b/postcss.config.unit.test.js
@@ -1,0 +1,145 @@
+const Vinyl = require('vinyl')
+const configFn = require('./postcss.config.js')
+
+describe('PostCSS config', () => {
+  let env
+
+  function getPluginNames ({ plugins }) {
+    return plugins.map(({ postcssPlugin }) => postcssPlugin)
+  }
+
+  beforeAll(() => {
+    env = 'production'
+  })
+
+  describe('Default', () => {
+    it.each(
+      [
+        { path: 'example.css' },
+        { path: 'example.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual(['autoprefixer'])
+      }
+    })
+  })
+
+  describe('Default + IE8', () => {
+    it.each(
+      [
+        { path: 'example-ie8.css' },
+        { path: 'example-ie8.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual([
+            'autoprefixer',
+            'oldie'
+          ])
+      }
+    })
+  })
+
+  describe('Default + Minification', () => {
+    it.each(
+      [
+        { path: 'example.min.css' },
+        { path: 'example.min.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual([
+            'autoprefixer',
+            'cssnano'
+          ])
+      }
+    })
+  })
+
+  describe('Default + Minification + IE8', () => {
+    it.each(
+      [
+        { path: 'example-ie8.min.css' },
+        { path: 'example-ie8.min.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual([
+            'autoprefixer',
+            'cssnano',
+            'oldie'
+          ])
+      }
+    })
+  })
+
+  describe('Review app only', () => {
+    it.each(
+      [
+        { path: 'app/assets/scss/app.scss' },
+        { path: 'app/assets/scss/app-legacy.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual([
+            'autoprefixer',
+            'postcss-pseudo-classes'
+          ])
+      }
+    })
+  })
+
+  describe('Review app only + IE8', () => {
+    it.each(
+      [
+        { path: 'app/assets/scss/app-ie8.scss' },
+        { path: 'app/assets/scss/app-legacy-ie8.scss' }
+      ]
+    )('Adds plugins for $path', ({ path }) => {
+      const input = new Vinyl({ path })
+
+      // Confirm plugins for both file object and path
+      for (const file of [input, input.path]) {
+        const config = configFn({ env, file })
+
+        expect(getPluginNames(config))
+          .toEqual([
+            'autoprefixer',
+            'postcss-pseudo-classes',
+            'oldie'
+          ])
+      }
+    })
+  })
+})


### PR DESCRIPTION
This PR adds two new config files `postcss.config.js` and `.browserslistrc`

### PostCSS config via `postcss.config.js`
To make it simpler to configure our CSS output the following `postcss()` calls now share the same config

* [Adding CSS prefixes to Sass files in **./package**](https://github.com/alphagov/govuk-frontend/blob/main/tasks/gulp/copy-to-destination.js#L55)
* [Autoprefixer + CSSNANO for **./dist** output](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L56)
* [Autoprefixer + CSSNANO + "Old IE" for **./dist** (IE 8 styles)](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L82)
* [Autoprefixer + 'companion' pseudo-selector classes for **./public**](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L60)
* [Autoprefixer + 'companion' pseudo-selector classes for **./public** (Legacy styles)](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L118)
* [Autoprefixer + 'companion' pseudo-selector classes + "Old IE" for **./public** (Legacy + IE8 styles)](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L133)
* [Autoprefixer + "Old IE" for **./public** (IE 8 styles)](https://github.com/alphagov/govuk-frontend/tree/bfccd7e9c31e1a051f576c2d7f191d478bb7f9f6/tasks/gulp/compile-assets.js#L93)

### Browser config via `.browserslistrc`
It's nice to have a separate shareable config which could also be used by Babel, Jest, ESLint, in future

Breaking changes have been moved into a second PR https://github.com/alphagov/govuk-frontend/pull/2924