### PR TITLE
Deprecate compatibility mode settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,16 @@ This was added in [pull request #2677: Amend error summary markup to fix page lo
 
 ### Deprecated features
 
+#### Stop using the compatibility mode settings
+
+In GOV.UK Frontend v5.0 we will stop supporting compatibility with legacy codebases. We are therefore deprecating the compatibility mode variables associated with legacy codebases:
+
+- `$govuk-compatibility-govukfrontendtoolkit`
+- `$govuk-compatibility-govuktemplate`
+- `$govuk-compatibility-govukelements`
+
+This was introduced in [pull request #2882: Deprecate compatibility mode settings](https://github.com/alphagov/govuk-frontend/pull/2882).
+
 #### Stop using settings associated with legacy codebases
 
 In GOV.UK Frontend v5.0 we will stop supporting compatibility with legacy codebases. As part of this, we are deprecating settings controlled by compatibility mode variables. This includes the `govuk-compatibility` mixin and the following settings:
@@ -95,7 +105,7 @@ In GOV.UK Frontend v5.0 we will stop supporting compatibility with legacy codeba
 - `$govuk-typography-use-rem`
 - `$govuk-font-family-tabular`
 
-This was introduced in [pull request #2844: Deprecate compatibility mode settings](https://github.com/alphagov/govuk-frontend/pull/2844).
+This was introduced in [pull request #2844: Remove compatibility mode from govuk-frontend](https://github.com/alphagov/govuk-frontend/pull/2844).
 
 ### Fixes
 

--- a/app/assets/scss/app-legacy-ie8.scss
+++ b/app/assets/scss/app-legacy-ie8.scss
@@ -8,6 +8,11 @@ $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 
+// Suppress compatibility mode deprecation warnings locally
+$govuk-suppressed-warnings: (
+  "compatibility-mode"
+);
+
 // Set Elements assets path
 $path: "/vendor/govuk_frontend_toolkit/assets/";
 

--- a/app/assets/scss/app-legacy.scss
+++ b/app/assets/scss/app-legacy.scss
@@ -8,6 +8,11 @@ $govuk-compatibility-govukfrontendtoolkit: true;
 $govuk-compatibility-govuktemplate: true;
 $govuk-compatibility-govukelements: true;
 
+// Suppress compatibility mode deprecation warnings locally
+$govuk-suppressed-warnings: (
+  "compatibility-mode"
+);
+
 // Set Elements assets path
 $path: "/vendor/govuk_frontend_toolkit/assets/";
 

--- a/src/govuk/settings/_compatibility.scss
+++ b/src/govuk/settings/_compatibility.scss
@@ -23,8 +23,16 @@
 ///
 /// @type Boolean
 /// @access public
+/// @deprecated Will be removed in v5.0 with the rest of the compatibility mode
+/// suite of tools and settings
 
 $govuk-compatibility-govukfrontendtoolkit: false !default;
+
+@if $govuk-compatibility-govukfrontendtoolkit == true {
+  @include _warning("compatibility-mode", "$govuk-compatibility-govukfrontendtoolkit " +
+  "is deprecated. From version 5.0, GOV.UK Frontend will remove compatibility " +
+  "with the legacy library govuk_frontend_toolkit.");
+}
 
 /// Compatibility Mode: alphagov/govuk_template
 ///
@@ -41,8 +49,16 @@ $govuk-compatibility-govukfrontendtoolkit: false !default;
 ///
 /// @type Boolean
 /// @access public
+/// @deprecated Will be removed in v5.0 with the rest of the compatibility mode
+/// suite of tools and settings
 
 $govuk-compatibility-govuktemplate: false !default;
+
+@if $govuk-compatibility-govuktemplate == true {
+  @include _warning("compatibility-mode", "$govuk-compatibility-govuktemplate " +
+  "is deprecated. From version 5.0, GOV.UK Frontend will remove " +
+  "compatibility with the legacy library govuk_template.");
+}
 
 /// Compatibility Mode: alphagov/govuk_elements
 ///
@@ -56,8 +72,16 @@ $govuk-compatibility-govuktemplate: false !default;
 ///
 /// @type Boolean
 /// @access public
+/// @deprecated Will be removed in v5.0 with the rest of the compatibility mode
+/// suite of tools and settings
 
 $govuk-compatibility-govukelements: false !default;
+
+@if $govuk-compatibility-govukelements == true {
+  @include _warning("compatibility-mode", "$govuk-compatibility-govukelements " +
+  "is deprecated. From version 5.0, GOV.UK Frontend will remove compatibility " +
+  "with the legacy library govuk_elements.");
+}
 
 /// Compatibility Product Map
 ///
@@ -66,6 +90,8 @@ $govuk-compatibility-govukelements: false !default;
 ///
 /// @type Map
 /// @access private
+/// @deprecated Will be removed in v5.0 with the rest of the compatibility mode
+/// suite of tools and settings
 
 $_govuk-compatibility: (
   govuk_frontend_toolkit: $govuk-compatibility-govukfrontendtoolkit,


### PR DESCRIPTION
Fixes https://github.com/alphagov/govuk-frontend/issues/2788

## What/Why
Deprecates the compatibility mode variables.

Additionally adds a call to `$govuk-suppressed-warnings` in the legacy review app stylesheets to suppress warnings when developing locally.

## Notes
I've attempted to be consistent in my wording with the warnings introduced in https://github.com/alphagov/govuk-frontend/pull/2844.

This also includes a slight history rewrite in a change to the changelog entry for https://github.com/alphagov/govuk-frontend/pull/2844 to reflect a change to the PR's title to better describe the change and differentiate it from this one.