### PR TITLE
Move from default to named export for I18n

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -10,6 +10,7 @@ import Header from './components/header/header.mjs'
 import Radios from './components/radios/radios.mjs'
 import SkipLink from './components/skip-link/skip-link.mjs'
 import Tabs from './components/tabs/tabs.mjs'
+import { I18n } from './i18n.mjs'
 
 /**
  * Initialise all components
@@ -101,5 +102,6 @@ export {
   NotificationBanner,
   Radios,
   SkipLink,
-  Tabs
+  Tabs,
+  I18n
 }

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -35,12 +35,20 @@ describe('GOV.UK Frontend', () => {
 
       expect(typeofInitAll).toEqual('function')
     })
+    it('exports `I18n` function', async () => {
+      await goTo(page, '/')
+
+      const typeofI18n = await page.evaluate(() => typeof window.GOVUKFrontend.I18n)
+
+      expect(typeofI18n).toEqual('function')
+    })
     it('exports Components', async () => {
       await goTo(page, '/')
 
       const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
 
-      var components = Object.keys(GOVUKFrontendGlobal).filter(method => method !== 'initAll')
+      const components = Object.keys(GOVUKFrontendGlobal)
+        .filter(method => !['initAll', 'I18n'].includes(method))
 
       // Ensure GOV.UK Frontend exports the expected components
       expect(components).toEqual([
@@ -61,8 +69,8 @@ describe('GOV.UK Frontend', () => {
       await goTo(page, '/')
 
       var componentsWithoutInitFunctions = await page.evaluate(() => {
-        var components = Object.keys(window.GOVUKFrontend)
-          .filter(method => method !== 'initAll')
+        const components = Object.keys(window.GOVUKFrontend)
+          .filter(method => !['initAll', 'I18n'].includes(method))
 
         return components.filter(component => {
           var prototype = window.GOVUKFrontend[component].prototype

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -1,5 +1,5 @@
 import { nodeListForEach, mergeConfigs, extractConfigByNamespace, normaliseDataset } from '../../common.mjs'
-import I18n from '../../i18n.mjs'
+import { I18n } from '../../i18n.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -6,7 +6,7 @@
  * @param  {Object}  config         - Configuration options for the function.
  * @param  {String}  config.locale  - An overriding locale for the PluralRules functionality.
  */
-function I18n (translations, config) {
+export function I18n (translations, config) {
   config = config || {}
 
   // Make list of translations available throughout function
@@ -301,5 +301,3 @@ I18n.prototype.pluralRules = {
     return 'other'
   }
 }
-
-export default I18n

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import I18n from './i18n.mjs'
+import { I18n } from './i18n.mjs'
 
 describe('I18n', () => {
   describe('retrieving translations', () => {


### PR DESCRIPTION
This PR responds to a Rollup warning and closes https://github.com/alphagov/govuk-frontend/issues/2829

>Entry module “src/govuk/i18n.mjs” is implicitly using “default” export mode, which means for CommonJS output that its default export is assigned to “module.exports”. For many tools, such CommonJS output will not be interchangeable with the original ES module. If this is intended, explicitly set “output.exports” to either “auto” or “default”, otherwise you might want to consider changing the signature of “src/govuk/i18n.mjs” to use named exports only.

## Why do we see this?

Rollup has explained that by using a "default export" we've accidentally prevented our future selves from adding "named exports" later on. This PR makes sure we use a named export `export function I18n` before we release

Rollup will warn us about _every_ "default import" but it's [only seen once](https://github.com/alphagov/govuk-frontend/blob/68568a2ab61c5d21d41df1593d24e7e27381fd41/src/govuk/components/accordion/accordion.mjs#L19) in non-test files

The fix?

1. Prefer **named** `export function I18n` for new tooling like `I18n`
2. Prefer **default** `export default Accordion` for already-published components (not breaking)

## Some history

When transpiling from ESM to CommonJS, it's not possible to use named and default exports alongside each other. Tooling has learned to fake it with some complex abstractions behind the scenes.

This is what Rollup is warning us about ⚠️ 

What's involved? Transpilers and bundlers have historically added extra code to do this

[For Babel especially](https://github.com/babel/babel/blob/master/packages/babel-helper-module-transforms/src/index.js#L215) you'll see `_interopRequireDefault()` and `__esModule` working together:

```mjs
function _interopRequireDefault(obj) {
    return obj && obj.__esModule ? obj : { default: obj };
}
```

For Rollup too, it'll add `__esModule` should we turn off [`{ legacy: true }`](https://github.com/alphagov/govuk-frontend/blob/30f581b47ccd8c2510d9e98cc71ae7116b49c676/tasks/gulp/compile-assets.js#L203) (but we need IE 8 support)

What's our conclusion?

1. For now, we shouldn't mix named and default exports in the same files
2. Worse still, we'd lack the `__esModule` shim due to IE8 `{ legacy: true }`

## An example

This is behind the scenes compatibility in action

### Input

**ECMAScript module `hello.mjs`** to be transpiled to `hello.cjs`
Using default and named exports

```mjs
export function Hello ($module, config) {}
export const greeting = 'Hello world'
export default Hello
```

### Output

**CommonJS module `hello.cjs` transpiled from `hello.mjs`**
Using default and named exports

```mjs
function Hello ($module, config) {}

exports.__esModule = true
exports.greeting = 'Hello world'
exports.default = Hello
```

The breaking change?

By using a named `greeting` export we're forced to move `{ Hello }` to `{ default: Hello }`

### Interoperability

Thanks to some magic in newer bundlers we don't have to change our code:

**With `__esModule` magic**
```cjs
const Hello = require('./hello.cjs')
```

**Without `__esModule` magic**
```cjs
const Hello = require('./hello.cjs').default
```

## Some more history

We've talked more about [using `__esModule`](https://github.com/alphagov/govuk-frontend/issues/2829#issuecomment-1260759628) in https://github.com/alphagov/govuk-frontend/issues/2829

For continued IE8 support [we run an older version of Rollup](https://github.com/alphagov/govuk-frontend/commit/7803347e936ac93c10a71262d2876b8b0155fcf6), configuring `{ legacy: true }`