### PR TITLE
Cache generation of `componentsData` and directory lookups for tests

### DIFF
--- a/config/jest/environment/jsdom.mjs
+++ b/config/jest/environment/jsdom.mjs
@@ -1,8 +1,10 @@
 import { TestEnvironment } from 'jest-environment-jsdom'
 
+import { globals } from '../globals.mjs'
+
 /**
  * Virtual browser environment
- * Adds jsdom window/document globals
+ * Adds jsdom window/document globals, shared test globals
  */
 class BrowserVirtualEnvironment extends TestEnvironment {
   async setup () {
@@ -13,6 +15,10 @@ class BrowserVirtualEnvironment extends TestEnvironment {
 
     // Ensure test fails for browser exceptions
     virtualConsole.on('jsdomError', (error) => process.emit('error', error))
+
+    // Add shared test globals
+    // componentsData, componentsDirectory, examplesDirectory
+    this.global.cache ??= await globals()
   }
 }
 

--- a/config/jest/environment/node.mjs
+++ b/config/jest/environment/node.mjs
@@ -1,11 +1,18 @@
 import TestEnvironment from 'jest-environment-node'
 
+import { globals } from '../globals.mjs'
+
 /**
  * Default Node.js environment
+ * Adds shared test globals
  */
 class NodeEnvironment extends TestEnvironment {
   async setup () {
     await super.setup()
+
+    // Add shared test globals
+    // componentsData, componentsDirectory, examplesDirectory
+    this.global.cache ??= await globals()
   }
 }
 

--- a/config/jest/environment/node.mjs
+++ b/config/jest/environment/node.mjs
@@ -1,0 +1,12 @@
+import TestEnvironment from 'jest-environment-node'
+
+/**
+ * Default Node.js environment
+ */
+class NodeEnvironment extends TestEnvironment {
+  async setup () {
+    await super.setup()
+  }
+}
+
+export default NodeEnvironment

--- a/config/jest/environment/puppeteer.mjs
+++ b/config/jest/environment/puppeteer.mjs
@@ -1,8 +1,10 @@
 import PuppeteerEnvironment from 'jest-environment-puppeteer'
 
+import { globals } from '../globals.mjs'
+
 /**
  * Automation browser environment
- * Adds Puppeteer page/browser globals
+ * Adds Puppeteer page/browser globals, shared test globals
  */
 class BrowserAutomationEnvironment extends PuppeteerEnvironment {
   async setup () {
@@ -19,6 +21,10 @@ class BrowserAutomationEnvironment extends PuppeteerEnvironment {
       // Ensure test fails
       process.emit('error', error)
     })
+
+    // Add shared test globals
+    // componentsData, componentsDirectory, examplesDirectory
+    this.global.cache ??= await globals()
   }
 }
 

--- a/config/jest/globals.mjs
+++ b/config/jest/globals.mjs
@@ -1,0 +1,39 @@
+import configPaths from '../paths.js'
+import { getDirectories, getComponentsData } from '../../lib/file-helper.js'
+
+/**
+ * Cache store
+ */
+const store = new Map()
+
+/**
+ * Cache frequently used paths
+ */
+const paths = [
+  configPaths.components,
+  configPaths.examples,
+  configPaths.fullPageExamples
+]
+
+/**
+ * Cache test globals
+ */
+export async function globals () {
+  if (!store.has('globals')) {
+    const componentsData = await getComponentsData()
+
+    // Run directory lookups
+    const directoryEntries = await Promise.all(paths.map(
+      async (path) => [path, await getDirectories(path)]
+    ))
+
+    // Save to cache
+    store.set('globals', {
+      directories: new Map(directoryEntries),
+      componentsData
+    })
+  }
+
+  // Retrieve from cache
+  return store.get('globals')
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const config = {
     'config/*',
     'vendor/*'
   ],
+  testEnvironment: './config/jest/environment/node.mjs',
   transform: {
     '^.+\\.m?js$': ['babel-jest', { rootMode: 'upward' }]
   }

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -6,6 +6,14 @@ const fm = require('front-matter')
 const configPaths = require('../config/paths.js')
 
 /**
+ * Test environment globals
+ * Used to cache slow operations
+ *
+ * See `config/jest/globals.mjs`
+ */
+const cache = global.cache || {}
+
+/**
  * Directory listing for path
  *
  * @param {string} directoryPath
@@ -35,6 +43,14 @@ const getListing = async (directoryPath) => {
  * @returns {Promise<DirectoryListing>} Directory entries
  */
 const getDirectories = async (directoryPath) => {
+  const directories = cache.directories?.get(directoryPath)
+
+  // Retrieve from cache
+  if (directories) {
+    return directories
+  }
+
+  // Read from disk
   const listing = await getListing(directoryPath)
 
   // Directories only
@@ -84,13 +100,22 @@ const getFilesByDirectory = async (directoryPath) => {
  * @returns {Promise<ComponentData>} Component data
  */
 const getComponentData = async (componentName) => {
+  const componentData = cache.componentsData
+    ?.find(({ name }) => name === componentName)
+
+  // Retrieve from cache
+  if (componentData) {
+    return componentData
+  }
+
+  // Read from disk
   try {
     const yamlPath = join(configPaths.components, componentName, `${componentName}.yaml`)
-    const componentData = yaml.load(await readFile(yamlPath, 'utf8'), { json: true })
+    const yamlData = yaml.load(await readFile(yamlPath, 'utf8'), { json: true })
 
     return {
       name: componentName,
-      ...componentData
+      ...yamlData
     }
   } catch (error) {
     throw new Error(error)
@@ -103,6 +128,11 @@ const getComponentData = async (componentName) => {
  * @returns {Promise<ComponentData[]>} Components' data
  */
 const getComponentsData = async () => {
+  if (cache.componentsData) {
+    return cache.componentsData
+  }
+
+  // Read from disk
   const directories = await getDirectories(configPaths.components)
   return Promise.all([...directories.keys()].map(getComponentData))
 }

--- a/lib/file-helper.unit.test.js
+++ b/lib/file-helper.unit.test.js
@@ -14,8 +14,8 @@ describe('getComponentData', () => {
     expect(componentData)
       .toEqual(expect.objectContaining({
         name: componentName,
-        params: expect.any(Array),
-        examples: expect.any(Array)
+        params: expect.arrayContaining([expect.any(Object)]),
+        examples: expect.arrayContaining([expect.any(Object)])
       }))
   })
 


### PR DESCRIPTION
For slower computers (GitHub containers too) you'll notice our tests are still a bit slow 😅 

We've got a [collection of helpers in **./lib**](https://github.com/alphagov/govuk-frontend/tree/main/lib) `file-helper`, `jest-helper` etc

But Jest doesn't implement `require.cache` so you'll notice that any files we require/import in tests are executed hundreds of times—this does start to add up when you're looping directory listings 😮

So every call to `getExamples()` or `getComponent()` starts from scratch

### Test environments
This PR makes three changes:

1. Creates a custom Jest environment for Node.js
2. Caches frequently uses directory lookups and `getComponentsData`
3. Adds cached globals to our custom Jest environments

This is the same approach as [**jest-puppeteer**](https://github.com/smooth-code/jest-puppeteer) adding `page` and `browser` globals

Follows on from the work in https://github.com/alphagov/govuk-frontend/pull/2933