### PR TITLE
Remove Cheerio from behaviour tests for radios and checkboxes

### DIFF
--- a/lib/puppeteer-helpers.js
+++ b/lib/puppeteer-helpers.js
@@ -111,10 +111,22 @@ async function getProperty ($element, propertyName) {
   return handle.jsonValue()
 }
 
+/**
+ * Get attribute value for element
+ *
+ * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {string} attributeName - Attribute name to return value for
+ * @returns {Promise<string | null>} Attribute value
+ */
+function getAttribute ($element, attributeName) {
+  return $element.evaluate((el, name) => el.getAttribute(name), attributeName)
+}
+
 module.exports = {
   renderAndInitialise,
   goTo,
   goToComponent,
   goToExample,
+  getAttribute,
   getProperty
 }

--- a/lib/puppeteer-helpers.js
+++ b/lib/puppeteer-helpers.js
@@ -99,9 +99,22 @@ function goToComponent (page, componentName, { exampleName } = {}) {
   return goTo(page, componentPath)
 }
 
+/**
+ * Get property value for element
+ *
+ * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @param {string} propertyName - Property name to return value for
+ * @returns {Promise<unknown>} Property value
+ */
+async function getProperty ($element, propertyName) {
+  const handle = await $element.getProperty(propertyName)
+  return handle.jsonValue()
+}
+
 module.exports = {
   renderAndInitialise,
   goTo,
   goToComponent,
-  goToExample
+  goToExample,
+  getProperty
 }

--- a/lib/puppeteer-helpers.js
+++ b/lib/puppeteer-helpers.js
@@ -122,11 +122,22 @@ function getAttribute ($element, attributeName) {
   return $element.evaluate((el, name) => el.getAttribute(name), attributeName)
 }
 
+/**
+ * Check if element is visible
+ *
+ * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
+ * @returns {Promise<Boolean>} Element visibility
+ */
+async function isVisible ($element) {
+  return !!await $element.boundingBox()
+}
+
 module.exports = {
   renderAndInitialise,
   goTo,
   goToComponent,
   goToExample,
   getAttribute,
-  getProperty
+  getProperty,
+  isVisible
 }


### PR DESCRIPTION
This PR closes #2898

But also makes a few other changes:

1. Uses Puppeteer jQuery-style `$()` and `$$()` methods
2. Adds `beforeAll()` with **$components**, **$inputs** for each test
3. Adds new `getAttribute()`, `getProperty()`, `isVisible()` puppeteer helpers

Keeps each test block short and understandable