### PR TITLE
Fix JavaScript errors when entering text into the Character Count in IE8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#2811: Use Element.id to get module id for accordion](https://github.com/alphagov/govuk-frontend/pull/2811)
 - [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)
 - [#2800: Improve Pagination component print styles](https://github.com/alphagov/govuk-frontend/pull/2800)
+- [#2909: Fix JavaScript errors when entering text into the Character Count in IE8](https://github.com/alphagov/govuk-frontend/pull/2909)
 
 ## 4.3.1 (Patch release)
 

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -1,3 +1,4 @@
+import '../../vendor/polyfills/Date/now.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 import '../../vendor/polyfills/Event.mjs' // addEventListener and event.target normalisation
 import '../../vendor/polyfills/Element/prototype/classList.mjs'

--- a/src/govuk/vendor/polyfills/Date/now.mjs
+++ b/src/govuk/vendor/polyfills/Date/now.mjs
@@ -1,0 +1,13 @@
+(function(undefined) {
+
+    // Detection from https://github.com/Financial-Times/polyfill-library/blob/v3.111.0/polyfills/Date/now/detect.js
+    var detect = ('Date' in self && 'now' in self.Date && 'getTime' in self.Date.prototype)
+
+    if (detect) return
+
+    // Polyfill from https://polyfill.io/v3/polyfill.js?version=3.111.0&features=Date.now&flags=always
+    Date.now = function () {
+        return new Date().getTime();
+    };
+
+}).call('object' === typeof window && window || 'object' === typeof self && self || 'object' === typeof global && global || {});


### PR DESCRIPTION
The Character Count makes use of [`Date.now`][1] to record the time of the last input to the textarea, debouncing screen reader updates to prevent them from being read too often or queued up.

However, [`Date.now` is not supported in IE8][2].

This causes a script error on the `keyup` event when typing in to the Character Count, although the script continues to run.

Add a polyfill for `Date.now` based on [Polyfill.io's implementation][3], adapted to match the format used for the existing polyfills.

Closes #2904.

[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
[2]: https://caniuse.com/mdn-javascript_builtins_date_now
[3]: https://polyfill.io/v3/polyfill.js?version=3.111.0&features=Date.now&flags=always