### PR TITLE
Add non-broken fallback text when maxlength/maxwords is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This was added in [pull request #2752: Change the Button component background an
 
 When using the [header](https://design-system.service.gov.uk/components/header/) Nunjucks macro, you can now translate the text of the mobile navigation menu toggle button by using the `menuButtonText` parameter.
 
-You should avoid lengthy values for the `menuButtonText` parameter, as the text can overflow and cause visual issues if too long. 
+You should avoid lengthy values for the `menuButtonText` parameter, as the text can overflow and cause visual issues if too long.
 
 This was added in [pull request #2720: Add parameter to localise mobile menu toggle button](https://github.com/alphagov/govuk-frontend/pull/2720).
 
@@ -65,6 +65,17 @@ See [our guidance on localising GOV.UK Frontend](https://design-system.service.g
 This was added in the following pull requests:
 [#2895 Add macro options to configure CharacterCount translations](https://github.com/alphagov/govuk-frontend/pull/2895)
 [#2887 Allow CharacterCount component to receive i18n config via JS](https://github.com/alphagov/govuk-frontend/pull/2887)
+
+####  Localise the character count's input description for assistive technologies
+
+When configuring the character count's limit in JavaScript, you can customise the description provided to assistive technologies when users focus the input (so it indicates the overall limit of characters or words).
+
+You can pass the description in the HTML, using `data-i18n.fallback-hint.{other,many,few,two,one,zero}` attribute on the element, depending on the [plural form required by your locale](https://design-system.service.gov.uk/get-started/localisation/#pluralisation), to provide the text to set as the description.
+
+You can also provide these messages using a JavaScript configuration object when creating an instance of the component or initialising all components.
+See [our guidance on localising GOV.UK Frontend](https://design-system.service.gov.uk/get-started/localisation/) for how to do this.
+
+This was added in [pull request #2915](https://github.com/alphagov/govuk-frontend/pull/2915).
 
 #### Localise the accordion's toggle buttons
 
@@ -248,9 +259,9 @@ To apply spacing in a single direction, include `left-`, `right-`, `top-`, or `b
 
 For example:
 
--   `govuk-!-static-margin-9` will apply a 60px margin to all sides of the element at all screen sizes
--   `govuk-!-static-padding-right-5` will apply 25px of padding to the right side of the element at all screen sizes
--   `govuk-!-static-margin-0` will remove all margins at all screen sizes
+- `govuk-!-static-margin-9` will apply a 60px margin to all sides of the element at all screen sizes
+- `govuk-!-static-padding-right-5` will apply 25px of padding to the right side of the element at all screen sizes
+- `govuk-!-static-margin-0` will remove all margins at all screen sizes
 
 This was added in [pull request #2672: Add static spacing override classes](https://github.com/alphagov/govuk-frontend/pull/2672). Thanks to @patrickpatrickpatrick for this contribution.
 
@@ -460,6 +471,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 ## 4.0.0 (Breaking release)
 
 ### Breaking changes
+
 This release contains a lot of breaking changes, but we expect many of them will only affect a small number of users. However, to make sure your service still works after you upgrade, you should read the release notes and make any required changes.
 
 #### Check your accordions still display as expected
@@ -838,6 +850,7 @@ This was added in [pull request #2183: Updates to link styles and link hover sta
 #### Style links to remove underlines
 
 You can now remove underlines from links by using either the:
+
 - [`govuk-link-style-no-underline` mixin](http://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-link-style-no-underline) in your Sass, or
 - [`govuk-link--no-underline` class](https://design-system.service.gov.uk/styles/typography/#links-without-underlines) in your HTML
 
@@ -848,6 +861,7 @@ This was added in [pull request #2214: Add no-underline mixin and modifier class
 #### Style links on dark backgrounds
 
 You can now style links on dark backgrounds to use white text colour by using either the:
+
 - [`govuk-link-style-inverse` mixin](http://frontend.design-system.service.gov.uk/sass-api-reference/#govuk-link-style-inverse) in your Sass, or
 - [`govuk-link--inverse` class](https://design-system.service.gov.uk/styles/typography/#links-on-dark-backgrounds) in your HTML
 
@@ -1168,7 +1182,6 @@ The [back link](https://design-system.service.gov.uk/components/back-link/) comp
 
 This was added in [pull request #1753: Make back link arrow consistent with breadcrumb component](https://github.com/alphagov/govuk-frontend/pull/1753). Thanks to [@vanitabarrett](https://github.com/vanitabarrett) and [@miaallers](https://github.com/miaallers).
 
-
 ### Deprecated features
 
 #### Importing from the `core` and `overrides` layers without `base`
@@ -1186,7 +1199,6 @@ If you do not import `node_modules/govuk-frontend/govuk/base` first, your servic
 
 This was added in [pull request #1807: Warn if importing core, overrides without dependencies](https://github.com/alphagov/govuk-frontend/pull/1807).
 
-
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
@@ -1194,7 +1206,6 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#1778: Fix accordion underline hover state being removed when hovering plus/minus symbol](https://github.com/alphagov/govuk-frontend/pull/1778)
 - [#1765: Import textarea from character count](https://github.com/alphagov/govuk-frontend/pull/1765)
 - [#1796: Standardise accordion section headings font size (reduce height of section headings on mobile)](https://github.com/alphagov/govuk-frontend/pull/1796)
-
 
 ## 3.6.0 (Feature release)
 
@@ -1295,7 +1306,7 @@ You can now add attributes to the `<body>` element of a page, by using the [`bod
 
 - [Pull request #1594: Refactor handling of count message in character count JavaScript](https://github.com/alphagov/govuk-frontend/pull/1594).
 - [Pull request #1609: Update hex value for secondary text to improve contrast](https://github.com/alphagov/govuk-frontend/pull/1609).
-- [Pull request #1620: Only add underline to back link when href exists ](https://github.com/alphagov/govuk-frontend/pull/1620).
+- [Pull request #1620: Only add underline to back link when href exists](https://github.com/alphagov/govuk-frontend/pull/1620).
 - [Pull request #1631: Fix classes on character count when in error state](https://github.com/alphagov/govuk-frontend/pull/1631).
 
 ## 3.3.0 (Feature release)
@@ -1323,6 +1334,7 @@ Align ‘Warning text’ icon with first line of the content fixing [#1352](http
 - [Pull request #1578: Change position and spacing relationship of warning text icon](https://github.com/alphagov/govuk-frontend/pull/1578)
 
 ### Fixes
+
 - [Pull request #1574: Make form elements scale correctly when text resized by user](https://github.com/alphagov/govuk-frontend/pull/1574).
 - [Pull request #1584: Fix text resize issue with warning text icon](https://github.com/alphagov/govuk-frontend/pull/1584)
 - [Pull request #1570: Prevent inputs ending up off screen or obscured by keyboards when linking from the error summary to inputs within a large fieldset](https://github.com/alphagov/govuk-frontend/pull/1570)
@@ -1383,7 +1395,6 @@ govukInput({
 
 - [Pull request #1527: Add inputmode option to the input component](https://github.com/alphagov/govuk-frontend/pull/1527)
 
-
 ### Fixes
 
 - [Pull request #1523: Improve accessibility of details component by polyfilling only where the native element is not available](https://github.com/alphagov/govuk-frontend/pull/1523).
@@ -1394,9 +1405,11 @@ govukInput({
 ## 3.0.0 (Breaking release)
 
 ### Breaking changes
+
 You must make the following changes when you migrate to this release, or your service may break.
 
 #### Update file paths, attributes and class names
+
 To make sure GOV.UK Frontend's files do not conflict with your code, we've moved our package files into a directory called `govuk`.
 
 ##### If you’re using Sass
@@ -1408,13 +1421,14 @@ For example:
 ```scss
 @import "node_modules/govuk-frontend/govuk/all";
 ```
+
 If you’ve [added `node_modules/govuk-frontend` as a Sass include path](https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/installing-with-npm.md#optional-resolving-scss-import-paths), add `govuk/` to your `@import` paths:
 
 ```scss
 @import "govuk/all";
 ```
 
-#####  If you’re using Javascript
+##### If you’re using Javascript
 
 You must do the following.
 
@@ -1499,6 +1513,7 @@ If your code uses Express.js, you must also use the following code in your confi
 ```javascript
 app.use('/assets', express.static(path.join(__dirname, '/node_modules/govuk-frontend/govuk/assets')))
 ```
+
 Pull requests:
 
 - [#1458: Namespace nunjucks and components](https://github.com/alphagov/govuk-frontend/pull/1458)
@@ -1531,7 +1546,6 @@ Pull requests:
 - [#1324: Update accordion to use new WCAG 2.1 compliant focus style](https://github.com/alphagov/govuk-frontend/pull/1324)
 - [#1326: Update tabs component to WCAG 2.1 compliant focus style](https://github.com/alphagov/govuk-frontend/pull/1326)
 - [#1361: Remove `govuk-focusable`, `govuk-focusable-fill` mixins, introduce `govuk-focus-text` mixin](https://github.com/alphagov/govuk-frontend/pull/1361)
-
 
 #### Update colours
 
@@ -1696,7 +1710,6 @@ If you use Sass and you’ve extended or created components that use the border 
 You can now add attributes like classes, rowspan and colspan to table row headers.
 
 [Pull request #1367: Allow for classes, rowspan, colspan and attributes on row headers](https://github.com/alphagov/govuk-frontend/pull/1367). Thanks to [edwardhorsford](https://github.com/edwardhorsford).
-
 
 #### Use page wrapper auto spacing
 
@@ -1937,10 +1950,9 @@ If you're using your own components that rely on the overflow state of the docum
   may add scroll bars causing the page to jump horizontally in position.
 
   To avoid this, re-introduce fix from GOV.UK Template:
-  https://github.com/alphagov/govuk-frontend/issues/1204
+  <https://github.com/alphagov/govuk-frontend/issues/1204>
 
   ([PR #1230](https://github.com/alphagov/govuk-frontend/pull/1230))
-
 
 - Accommodate camera notches on new devices (iPhone X, Google Pixel 3 etc)
 
@@ -1948,16 +1960,14 @@ If you're using your own components that rely on the overflow state of the docum
   landscape orientation (known as pillarboxing) so content isn't obscured.
 
   To avoid this, support has been added for `viewport-fit=cover` as shown here:
-  https://webkit.org/blog/7929/designing-websites-for-iphone-x/
+  <https://webkit.org/blog/7929/designing-websites-for-iphone-x/>
 
   ([PR #1176](https://github.com/alphagov/govuk-frontend/pull/1176))
-
 
 - Prefix error messages with a visually hidden "Error:", to make it clearer to
   users of assistive technologies
 
   ([PR #1221](https://github.com/alphagov/govuk-frontend/pull/1221))
-
 
 - Prevent accidental multiple submissions of forms
 
@@ -1983,7 +1993,6 @@ If you're using your own components that rely on the overflow state of the docum
 
   ([PR #1018](https://github.com/alphagov/govuk-frontend/pull/1018))
 
-
 🔧 Fixes:
 
 - Ensure that files within the core, objects and overrides layers can be
@@ -2002,13 +2011,11 @@ If you're using your own components that rely on the overflow state of the docum
 
   ([PR #1235](https://github.com/alphagov/govuk-frontend/pull/1235))
 
-
 - Ensure inset component does not misalign nested components
 
   Thanks to [Paul Hayes](https://github.com/fofr) for raising this issue.
 
   ([PR #1232](https://github.com/alphagov/govuk-frontend/pull/1232))
-
 
 - Improve word wrapping in summary list component
 
@@ -2017,7 +2024,6 @@ If you're using your own components that rely on the overflow state of the docum
   Also thanks to [Malcolm Butler](https://github.com/MoJ-Longbeard) for exploring a [previous version of this fix](https://github.com/alphagov/govuk-frontend/pull/1185).
 
   ([PR #1220](https://github.com/alphagov/govuk-frontend/pull/1220))
-
 
 ## 2.7.0 (Feature release)
 
@@ -2269,7 +2275,6 @@ If you're using your own components that rely on the overflow state of the docum
 
   ([PR #959](https://github.com/alphagov/govuk-frontend/pull/959))
 
-
 🔧 Fixes:
 
 - Apply max-width to the `<select>` element
@@ -2462,6 +2467,7 @@ If you're using your own components that rely on the overflow state of the docum
   $govuk-compatibility-govukelements: true;
   @import "govuk-frontend/all";
   ```
+
   ([PR #981](https://github.com/alphagov/govuk-frontend/pull/981))
 
 - Turn on relative typography (rem) by default
@@ -2473,11 +2479,13 @@ If you're using your own components that rely on the overflow state of the docum
   If you need to change this setting for compatibility with [GOV.UK Elements](https://github.com/alphagov/govuk_elements), [GOV.UK Template](https://github.com/alphagov/govuk_template), [GOV.UK Frontend Toolkit](https://github.com/alphagov/govuk_frontend_toolkit) consider enabling [compatibility mode](./docs/installation/installing-with-npm.md#compatibility-mode).
 
   Otherwise, set `$govuk-typography-use-rem` to `false` before importing GOV.UK Frontend styles into your app:
+
   ```SCSS
   // application.scss
   $govuk-typography-use-rem: false;
   @import "govuk-frontend/all";
   ```
+
   ([PR #981](https://github.com/alphagov/govuk-frontend/pull/981))
 
 - Remove anchor styling in govuk-lists
@@ -2678,10 +2686,9 @@ If you're using your own components that rely on the overflow state of the docum
   that use alphagov/govuk_template this should be 10px.
 
   The intention is to enable this by default in the next major version:
-  https://github.com/alphagov/govuk-frontend/issues/868
+  <https://github.com/alphagov/govuk-frontend/issues/868>
 
   ([PR #858](https://github.com/alphagov/govuk-frontend/pull/858))
-
 
 🔧 Fixes:
 
@@ -2801,7 +2808,6 @@ If you're using your own components that rely on the overflow state of the docum
   `<label>` or `<label class="govuk-label--s">`.
   ([PR #806](https://github.com/alphagov/govuk-frontend/pull/806))
 
-
 🏠 Internal:
 
 - Remove instructions to login with npm, which is no longer required
@@ -2839,16 +2845,20 @@ If you're using your own components that rely on the overflow state of the docum
   This allows you to initialize only the components you need, and gives you finer control over when the JavaScript for GOV.UK Frontend runs.
 
   To migrate your project you need to change
+
   ```html
     <script src="{path-to-govuk-frontend}/all.js"></script>
   ```
+
   to
+
   ```html
     <script src="{path-to-govuk-frontend}/all.js"></script>
     <script>window.GOVUKFrontend.initAll()</script>
   ```
 
   Now, if you only want to initialize a specific component you can now do so by:
+
   ```html
     <script src="{path-to-govuk-frontend}/all.js"></script>
     <script>
@@ -2863,13 +2873,16 @@ If you're using your own components that rely on the overflow state of the docum
 - Consistently structure the Details and Button component, so that they can be instantiated the same as the other components.
 
   If you're using `GOVUKFrontend.initAll()` you do not need to make any changes, otherwise you need to change
+
   ```html
     <script>
       new Button().init()
       new Details().init()
     </script>
   ```
+
   to
+
   ```html
     <script>
       new Button(document).init()
@@ -2880,6 +2893,7 @@ If you're using your own components that rely on the overflow state of the docum
       })
     </script>
   ```
+
   ([PR #761](https://github.com/alphagov/govuk-frontend/pull/761))
 
 - All sass-mq settings have now been made private. We are now exposing new
@@ -2906,25 +2920,33 @@ If you're using your own components that rely on the overflow state of the docum
 - Spacing has been refactored. You will need to update Sass that currently uses GOV.UK Frontend spacing:
 
   - Instead of
+
   ``` css
   $govuk-spacing-scale-*
   ```
+
   use
+
   ``` css
   govuk-spacing(*)
   ```
+
   where `*` is the number on the spacing scale. The scale itself has remained the same so that `$govuk-spacing-scale-3` corresponds to `govuk-spacing(3)`. This change allows us to control the error messaging when incorrect values are used and to deprecate variables. The values of spacing variables can also be overridden by consumers.
 
   - Instead of:
+
   ``` css
   @include govuk-responsive-margin($govuk-spacing-responsive-2, "bottom");
   @include govuk-responsive-padding($govuk-spacing-responsive-2, "bottom");
   ```
+
   use
+
   ``` css
   @include govuk-responsive-margin(2, "bottom");
   @include govuk-responsive-padding(2, "bottom");
   ```
+
   This change, again, allows us to control the error messaging since spacing variables are not exposed directly. Also, the spacing scale itself has not changed so that `$govuk-spacing-responsive-2` corresponds to `2` when passed to the padding and margin mixins.
 
   This PR also updates tests and sass-docs of spacing variables and helpers.
@@ -3072,17 +3094,18 @@ If you're using your own components that rely on the overflow state of the docum
 - Add explicit dependency on colour maps
   ([PR #790](https://github.com/alphagov/govuk-frontend/pull/790))
 
-
 🆕 New features:
 
 - Components are now available to use from the `GOVUKFrontend` global.
 You can now initialize individual components like so:
+
 ```html
   <script>
     var Radios = window.GOVUKFrontend.Radios
     new Radios(document).init()
   </script>
 ```
+
 ([PR #759](https://github.com/alphagov/govuk-frontend/pull/759))
 
 - Add `beforeContent` block to the template, for content that does not belong inside `<main>` element.
@@ -3098,7 +3121,6 @@ You can now initialize individual components like so:
 - Most of the settings can now be overridden in your application (they are now
   marked as !default)
   ([PR #748](https://github.com/alphagov/govuk-frontend/pull/748))
-
 
 🏠 Internal:
 
@@ -3129,7 +3151,6 @@ You can now initialize individual components like so:
   own styles you will need to update your code to use the new variable name.
   ([PR #726](https://github.com/alphagov/govuk-frontend/pull/726))
 
-
 🔧 Fixes:
 
 - Namespacing SCSS exports with 'govuk' prefix to avoid clashes with
@@ -3138,7 +3159,7 @@ You can now initialize individual components like so:
 
 - Fixes a bug whereby print styles were being 'rasterized' into the screen
   styles when generating the IE8 stylesheet (this is a bug in sass-mq, and has
-  also been raised upstream – https://github.com/sass-mq/sass-mq/pull/111).
+  also been raised upstream – <https://github.com/sass-mq/sass-mq/pull/111>).
   ([PR #726](https://github.com/alphagov/govuk-frontend/pull/726))
 
 - Removed some duplicated CSS rules from the outputted CSS
@@ -3148,7 +3169,6 @@ You can now initialize individual components like so:
   rendering the shadow using a border for IE8 specifically – IE8 does not
   support box-shadow
   ([PR #737](https://github.com/alphagov/govuk-frontend/pull/737))
-
 
 🆕 New features:
 
@@ -3342,14 +3362,12 @@ You can now initialize individual components like so:
 
   ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
 
-
 - Added new modifier classes for labels to allow you to create a label that
   visually corresponds to the equivalent heading class (for example, a
   `.govuk-label--xl` will have the same font size and weight as a
   `.govuk-heading-xl`)
 
   ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
-
 
 - The arguments for a fieldset's legend have been rolled up into an object. For
   example, the following macro call:
@@ -3377,7 +3395,6 @@ You can now initialize individual components like so:
 
   ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
 
-
 - The fieldset component has a new parameter legend.isPageHeading, which defines
   whether the legend text should be wrapped in an h1:
 
@@ -3392,7 +3409,6 @@ You can now initialize individual components like so:
   its styling.
 
   ([PR #684](https://github.com/alphagov/govuk-frontend/pull/684))
-
 
 - Added new modifier classes for legends to allow you to create a legend that
   visually corresponds to the equivalent heading class (for example, a
@@ -3414,6 +3430,7 @@ You can now initialize individual components like so:
   - Remove -o, -c and -h prefixes from class names in your markup
 
   For example, change:
+
   ```HTML
   <button class="govuk-c-button">Save and continue</button>
   ```
@@ -3433,6 +3450,7 @@ You can now initialize individual components like so:
   - Change grid class names in your markup
 
   For example, change:
+
   ```HTML
   <div class="govuk-o-grid">
     <div class="govuk-o-grid__item govuk-o-grid__item--two-thirds">
@@ -3462,7 +3480,6 @@ You can now initialize individual components like so:
   see original pull request for usage.
 
   ([PR #665](https://github.com/alphagov/govuk-frontend/pull/665))
-
 
 🔧 Fixes:
 
@@ -3528,6 +3545,7 @@ You can now initialize individual components like so:
 
 Fixes incomplete release from `packages/` and `dist/` in 0.0.27-alpha release.
 Missing files were:
+
 - `globals/tools/_compatibility.scss`
 - `globals/tools/_ie8.scss`
 - `globals/settings/_compatibility.scss`
@@ -3559,6 +3577,7 @@ Missing files were:
 - Rename captionSize table argument to captionClasses ([PR #643](https://github.com/alphagov/govuk-frontend/pull/643))
 
 🔧 Fixes:
+
 - Link styles, as well as links within the  back-link, breadcrumbs, button,
   error summary, footer and skip link components defend against the
   `a:link:focus` selector in GOV.UK Template, which was overriding focussed
@@ -3568,6 +3587,7 @@ Missing files were:
   (PR [#633](https://github.com/alphagov/govuk-frontend/pull/633))
 
 🆕 New features:
+
 - Add `govuk-main-wrapper--l` a variant of the main page wrapper to use when a
   design does not include back links, breadcrumbs or phase banners
   (PR [#602](https://github.com/alphagov/govuk-frontend/pull/602))
@@ -3592,6 +3612,7 @@ Missing files were:
  Note: Our JavaScript work is ongoing. In the next release of GOV.UK Frontend both of our script will be modularised and split into common functions. This will allow you to use the polyfills in your bundler/build pipeline. For this reason, you might want to wait until the next release before adding these polyfill scripts into your project.
 
 🏠 Internal:
+
 - Update check script for new components and tweak docs
   (PR [#589](https://github.com/alphagov/govuk-frontend/pull/589))
 - Listen for development server on different port for tests
@@ -3656,6 +3677,7 @@ Missing files were:
   type="text" (PR [#568](https://github.com/alphagov/govuk-frontend/pull/568))
 
 🔧 Fixes:
+
 - The transparent outline has been removed from the button, as it already has
   a transparent border which is visible when overriding colours in the browser
   (PR [#552](https://github.com/alphagov/govuk-frontend/pull/552))
@@ -3670,6 +3692,7 @@ Missing files were:
   (PR [#568](https://github.com/alphagov/govuk-frontend/pull/568))
 
 🏠 Internal:
+
 - The logic to determine button text colour automatically has been removed and
   replaced with a new variable $govuk-button-text-colour
   (PR [#552](https://github.com/alphagov/govuk-frontend/pull/552))
@@ -3702,6 +3725,7 @@ gulp tasks (PR [#545](https://github.com/alphagov/govuk-frontend/pull/545))
   (PR [#551](https://github.com/alphagov/govuk-frontend/pull/551))
 
 🔧 Fixes:
+
 - Removes media query display on body from compiled CSS
   (PR [#560](https://github.com/alphagov/govuk-frontend/pull/560))
 
@@ -3862,6 +3886,7 @@ border for errors and a bottom margin. Add example of form errors to preview app
 - Remove readme content from review app (PR [#482](https://github.com/alphagov/govuk-frontend/pull/482))
 
 ## 0.0.21-alpha (Breaking release)
+
 Skipped 0.0.20-alpha due to difficulties with publishing.
 
 💥 Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ You should avoid lengthy values for the `menuButtonText` parameter, as the text 
 
 This was added in [pull request #2720: Add parameter to localise mobile menu toggle button](https://github.com/alphagov/govuk-frontend/pull/2720).
 
-#### Localise the character count's fallback text
+#### Localise the character count's textarea description/fallback text
 
-When using the [character count](https://design-system.service.gov.uk/components/character-count/) Nunjucks macro, you can now translate the text of the fallback counter message by using the `fallbackHintText` parameter.
+When using the [character count](https://design-system.service.gov.uk/components/character-count/) Nunjucks macro, you can now translate the description of textarea by using the `textareaDescriptionText` option.
 
-This text is announced by screen readers when the character count input is focused. It's also displayed visually if JavaScript is not available.
+This text is announced by screen readers when the character count input is focused. It's also displayed visually as a fallback if JavaScript is not available.
 
-This was added in [pull request #2742: Add ability to customise character count fallback text](https://github.com/alphagov/govuk-frontend/pull/2742).
+This was added in [pull request #2742: Add ability to customise character count fallback text](https://github.com/alphagov/govuk-frontend/pull/2742), and the option renamed to `textareaDescriptionText` in [pull request #2915](https://github.com/alphagov/govuk-frontend/pull/2915).
 
 #### Localise the character count's counter message
 
@@ -70,7 +70,7 @@ This was added in the following pull requests:
 
 When configuring the character count's limit in JavaScript, you can customise the description provided to assistive technologies when users focus the input (so it indicates the overall limit of characters or words).
 
-You can pass the description in the HTML, using `data-i18n.fallback-hint.{other,many,few,two,one,zero}` attribute on the element, depending on the [plural form required by your locale](https://design-system.service.gov.uk/get-started/localisation/#pluralisation), to provide the text to set as the description.
+You can pass the description in the HTML, using `data-i18n.textarea-description.{other,many,few,two,one,zero}` attribute on the element, depending on the [plural form required by your locale](https://design-system.service.gov.uk/get-started/localisation/#pluralisation), to provide the text to set as the description.
 
 You can also provide these messages using a JavaScript configuration object when creating an instance of the component or initialising all components.
 See [our guidance on localising GOV.UK Frontend](https://design-system.service.gov.uk/get-started/localisation/) for how to do this.

--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -136,7 +136,7 @@
     hint: {
       text: "Peidiwch â chynnwys gwybodaeth bersonol neu ariannol fel eich rhif Yswiriant Gwladol neu fanylion eich cerdyn credyd."
     },
-    fallbackHintText: "Gallwch ddefnyddio hyd at %{count} nod",
+    textareaDescriptionText: "Gallwch ddefnyddio hyd at %{count} nod",
     charactersUnderLimitHtml: {
       one: "Mae gennych %{count} nod ar ôl",
       two: "Mae gennych %{count} nod ar ôl",
@@ -163,7 +163,7 @@
       classes: "govuk-label--l",
       isPageHeading: true
     },
-    fallbackHintText: "Gallwch ddefnyddio hyd at %{count} gair",
+    textareaDescriptionText: "Gallwch ddefnyddio hyd at %{count} gair",
     hint: {
       text: "Peidiwch â chynnwys gwybodaeth bersonol neu ariannol fel eich rhif Yswiriant Gwladol neu fanylion eich cerdyn credyd."
     },

--- a/src/govuk/components/character-count/_index.scss
+++ b/src/govuk/components/character-count/_index.scss
@@ -17,6 +17,15 @@
     @include govuk-font($size: false, $tabular: true);
     margin-top: 0;
     margin-bottom: 0;
+
+    &:after {
+      // Zero-width space that will reserve vertical space when no hint is provided
+      // as:
+      // - setting a min-height is not possible without a magic number
+      //   because the line-height is set by the `govuk-font` call above
+      // - using `:empty` is not possible as the hint macro outputs line breaks
+      content: "\200B";
+    }
   }
 
   .govuk-character-count__message--disabled {

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -121,18 +121,18 @@ CharacterCount.prototype.init = function () {
   }
 
   var $textarea = this.$textarea
-  var $fallbackLimitMessage = document.getElementById($textarea.id + '-info')
+  var $textareaDescription = document.getElementById($textarea.id + '-info')
 
   // Inject a decription for the textarea if none is present already
   // for when the component was rendered with no maxlength, maxwords
   // nor custom textareaDescriptionText
-  if ($fallbackLimitMessage.textContent.match(/^\s*$/)) {
-    $fallbackLimitMessage.textContent = this.i18n.t('textareaDescription', { count: this.maxLength })
+  if ($textareaDescription.textContent.match(/^\s*$/)) {
+    $textareaDescription.textContent = this.i18n.t('textareaDescription', { count: this.maxLength })
   }
 
-  // Move the fallback count message to be immediately after the textarea
+  // Move the textarea description to be immediately after the textarea
   // Kept for backwards compatibility
-  $textarea.insertAdjacentElement('afterend', $fallbackLimitMessage)
+  $textarea.insertAdjacentElement('afterend', $textareaDescription)
 
   // Create the *screen reader* specific live-updating counter
   // This doesn't need any styling classes, as it is never visible
@@ -140,20 +140,20 @@ CharacterCount.prototype.init = function () {
   $screenReaderCountMessage.className = 'govuk-character-count__sr-status govuk-visually-hidden'
   $screenReaderCountMessage.setAttribute('aria-live', 'polite')
   this.$screenReaderCountMessage = $screenReaderCountMessage
-  $fallbackLimitMessage.insertAdjacentElement('afterend', $screenReaderCountMessage)
+  $textareaDescription.insertAdjacentElement('afterend', $screenReaderCountMessage)
 
   // Create our live-updating counter element, copying the classes from the
-  // fallback element for backwards compatibility as these may have been
+  // textarea description for backwards compatibility as these may have been
   // configured
   var $visibleCountMessage = document.createElement('div')
-  $visibleCountMessage.className = $fallbackLimitMessage.className
+  $visibleCountMessage.className = $textareaDescription.className
   $visibleCountMessage.classList.add('govuk-character-count__status')
   $visibleCountMessage.setAttribute('aria-hidden', 'true')
   this.$visibleCountMessage = $visibleCountMessage
-  $fallbackLimitMessage.insertAdjacentElement('afterend', $visibleCountMessage)
+  $textareaDescription.insertAdjacentElement('afterend', $visibleCountMessage)
 
-  // Hide the fallback limit message
-  $fallbackLimitMessage.classList.add('govuk-visually-hidden')
+  // Hide the textarea description
+  $textareaDescription.classList.add('govuk-visually-hidden')
 
   // Remove hard limit if set
   $textarea.removeAttribute('maxlength')

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -29,7 +29,7 @@ var TRANSLATIONS_DEFAULT = {
     one: 'You have %{count} word too many',
     other: 'You have %{count} words too many'
   },
-  fallbackHint: {
+  textareaDescription: {
     other: ''
   }
 }
@@ -125,9 +125,9 @@ CharacterCount.prototype.init = function () {
 
   // Inject a decription for the textarea if none is present already
   // for when the component was rendered with no maxlength, maxwords
-  // nor custom fallbackHintText
+  // nor custom textareaDescriptionText
   if ($fallbackLimitMessage.textContent.match(/^\s*$/)) {
-    $fallbackLimitMessage.textContent = this.i18n.t('fallbackHint', { count: this.maxLength })
+    $fallbackLimitMessage.textContent = this.i18n.t('textareaDescription', { count: this.maxLength })
   }
 
   // Move the fallback count message to be immediately after the textarea
@@ -383,7 +383,7 @@ export default CharacterCount
  * @property {PluralisedTranslation} [wordsUnderLimit] - Words under limit
  * @property {string} [wordsAtLimit] - Words at limit
  * @property {PluralisedTranslation} [wordsOverLimit] - Words over limit
- * @property {PluralisedTranslation} [fallbackHint] - Fallback hint
+ * @property {PluralisedTranslation} [textareaDescription] - Fallback hint
  */
 
 /**

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -120,6 +120,13 @@ CharacterCount.prototype.init = function () {
   var $textarea = this.$textarea
   var $fallbackLimitMessage = document.getElementById($textarea.id + '-info')
 
+  // Inject a decription for the textarea if none is present already
+  // for when the component was rendered with no maxlength, maxwords
+  // nor custom fallbackHintText
+  if ($fallbackLimitMessage.textContent.match(/^\s*$/)) {
+    $fallbackLimitMessage.textContent = this.i18n.t('fallbackHint', { count: this.maxLength })
+  }
+
   // Move the fallback count message to be immediately after the textarea
   // Kept for backwards compatibility
   $textarea.insertAdjacentElement('afterend', $fallbackLimitMessage)
@@ -373,6 +380,7 @@ export default CharacterCount
  * @property {PluralisedTranslation} [wordsUnderLimit] - Words under limit
  * @property {string} [wordsAtLimit] - Words at limit
  * @property {PluralisedTranslation} [wordsOverLimit] - Words over limit
+ * @property {PluralisedTranslation} [fallbackHint] - Fallback hint
  */
 
 /**

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -28,6 +28,9 @@ var TRANSLATIONS_DEFAULT = {
   wordsOverLimit: {
     one: 'You have %{count} word too many',
     other: 'You have %{count} words too many'
+  },
+  fallbackHint: {
+    other: ''
   }
 }
 

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -429,6 +429,26 @@ describe('Character count', () => {
           const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
           expect(visibility).toEqual('visible')
         })
+
+        it('fills the accessible description of the textarea once the maximum is known', async () => {
+          // This tests that any fallback hint provided through data-attributes
+          // (or the Nunjucks macro) waiting for a maximum to be provided in JavaScript config
+          // will lead to the message being injected in the element holding the textarea's accessible description
+          // (and interpolated to replace `%{count}` with the maximum)
+
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['no maximum'],
+            javascriptConfig: {
+              maxlength: 10
+            }
+          })
+
+          const message = await page.$eval(
+            '.govuk-character-count__message',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('No more than 10 characters')
+        })
       })
 
       describe('via `initAll`', () => {

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -437,7 +437,8 @@ describe('Character count', () => {
           // (and interpolated to replace `%{count}` with the maximum)
 
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['no maximum'],
+            nunjucksParams:
+              examples['when neither maxlength nor maxwords are set'],
             javascriptConfig: {
               maxlength: 10
             }

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -31,7 +31,7 @@ describe('Character count', () => {
       await page.setJavaScriptEnabled(true)
     })
 
-    it('shows the fallback message', async () => {
+    it('shows the textarea description', async () => {
       await goToComponent(page, 'character-count')
       const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
 
@@ -55,7 +55,7 @@ describe('Character count', () => {
         expect(srMessage).toBeTruthy()
       })
 
-      it('hides the fallback hint', async () => {
+      it('hides the textarea description', async () => {
         const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
         expect(messageClasses).toContain('govuk-visually-hidden')
       })
@@ -437,7 +437,7 @@ describe('Character count', () => {
           await renderAndInitialise(page, 'character-count', {
             nunjucksParams:
               examples[
-                'when neither maxlength/maxwords nor fallback hint are set'
+                'when neither maxlength/maxwords nor textarea description are set'
               ],
             javascriptConfig: {
               maxlength: 10,
@@ -606,8 +606,8 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 word too many')
         })
 
-        it('interpolates the fallback hint in data attributes with the maximum set in JavaScript', async () => {
-          // This tests that any fallback hint provided through data-attributes
+        it('interpolates the textarea description in data attributes with the maximum set in JavaScript', async () => {
+          // This tests that any textarea description provided through data-attributes
           // (or the Nunjucks macro), waiting for a maximum to be provided in
           // JavaScript config, will lead to the message being injected in the
           // element holding the textarea's accessible description

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -430,11 +430,9 @@ describe('Character count', () => {
           expect(visibility).toEqual('visible')
         })
 
-        it('fills the accessible description of the textarea once the maximum is known', async () => {
-          // This tests that any fallback hint provided through data-attributes
-          // (or the Nunjucks macro) waiting for a maximum to be provided in JavaScript config
-          // will lead to the message being injected in the element holding the textarea's accessible description
-          // (and interpolated to replace `%{count}` with the maximum)
+        it('configures the description of the textarea', async () => {
+          // This tests that a description can be provided through JavaScript attributes
+          // and interpolated with the limit provided to the character count in JS.
 
           await renderAndInitialise(page, 'character-count', {
             nunjucksParams:
@@ -608,10 +606,11 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 word too many')
         })
 
-        it('fills interpolates the fallback hint in data attributes with the maximum set in JavaScript', async () => {
+        it('interpolates the fallback hint in data attributes with the maximum set in JavaScript', async () => {
           // This tests that any fallback hint provided through data-attributes
-          // (or the Nunjucks macro) waiting for a maximum to be provided in JavaScript config
-          // will lead to the message being injected in the element holding the textarea's accessible description
+          // (or the Nunjucks macro), waiting for a maximum to be provided in
+          // JavaScript config, will lead to the message being injected in the
+          // element holding the textarea's accessible description
           // (and interpolated to replace `%{count}` with the maximum)
 
           await renderAndInitialise(page, 'character-count', {

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -442,7 +442,7 @@ describe('Character count', () => {
             javascriptConfig: {
               maxlength: 10,
               i18n: {
-                fallbackHint: {
+                textareaDescription: {
                   other: 'No more than %{count} characters'
                 }
               }

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -438,9 +438,16 @@ describe('Character count', () => {
 
           await renderAndInitialise(page, 'character-count', {
             nunjucksParams:
-              examples['when neither maxlength nor maxwords are set'],
+              examples[
+                'when neither maxlength/maxwords nor fallback hint are set'
+              ],
             javascriptConfig: {
-              maxlength: 10
+              maxlength: 10,
+              i18n: {
+                fallbackHint: {
+                  other: 'No more than %{count} characters'
+                }
+              }
             }
           })
 
@@ -599,6 +606,27 @@ describe('Character count', () => {
             (el) => el.innerHTML.trim()
           )
           expect(message).toEqual('You have 1 word too many')
+        })
+
+        it('fills interpolates the fallback hint in data attributes with the maximum set in JavaScript', async () => {
+          // This tests that any fallback hint provided through data-attributes
+          // (or the Nunjucks macro) waiting for a maximum to be provided in JavaScript config
+          // will lead to the message being injected in the element holding the textarea's accessible description
+          // (and interpolated to replace `%{count}` with the maximum)
+
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams:
+              examples['when neither maxlength nor maxwords are set'],
+            javascriptConfig: {
+              maxlength: 10
+            }
+          })
+
+          const message = await page.$eval(
+            '.govuk-character-count__message',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('No more than 10 characters')
         })
       })
     })

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -297,7 +297,7 @@ examples:
       label:
         text: Full address
       fallbackHintText: 'No more than %{count} characters'
-  - name: no maximum no fallback hint
+  - name: when neither maxlength/maxwords nor fallback hint are set
     hidden: true
     data:
       id: no-maximum

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -37,7 +37,7 @@ params:
   required: false
   description: Options for the hint component.
   isComponent: true
-- name: fallbackHintText
+- name: textareaDescriptionText
   type: string
   required: false
   description: Text describing the maximum number of characters you can enter, which is announced to screen readers. The text is displayed as a fallback if the character count JavaScript does not run. Depending on how you configure this component and what parameters you add, instances of `%{count}` are replaced by the value of `maxwords`. If not configured, it uses `maxlength`. By default, fallback text is provided in English.
@@ -92,7 +92,7 @@ examples:
       name: custom-fallback
       id: custom-fallback
       maxlength: 10
-      fallbackHintText: Gallwch ddefnyddio hyd at %{count} nod
+      textareaDescriptionText: Gallwch ddefnyddio hyd at %{count} nod
 
   - name: with hint
     data:
@@ -296,7 +296,7 @@ examples:
       name: no-maximum
       label:
         text: Full address
-      fallbackHintText: 'No more than %{count} characters'
+      textareaDescriptionText: 'No more than %{count} characters'
   - name: when neither maxlength/maxwords nor fallback hint are set
     hidden: true
     data:

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -187,7 +187,6 @@ examples:
         other: '%{count} words too many'
         one: 'One word too many'
       
-
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes
     hidden: true
@@ -290,3 +289,11 @@ examples:
       name: address
       label:
         text: Full address
+  - name: no maximum
+    hidden: true
+    data:
+      id: no-maximum
+      name: no-maximum
+      label:
+        text: Full address
+      fallbackHintText: 'No more than %{count} characters'

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -289,7 +289,7 @@ examples:
       name: address
       label:
         text: Full address
-  - name: no maximum
+  - name: when neither maxlength nor maxwords are set
     hidden: true
     data:
       id: no-maximum
@@ -297,3 +297,10 @@ examples:
       label:
         text: Full address
       fallbackHintText: 'No more than %{count} characters'
+  - name: no maximum no fallback hint
+    hidden: true
+    data:
+      id: no-maximum
+      name: no-maximum
+      label:
+        text: Full address

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -40,7 +40,7 @@ params:
 - name: textareaDescriptionText
   type: string
   required: false
-  description: Text describing the maximum number of characters you can enter, which is announced to screen readers. The text is displayed as a fallback if the character count JavaScript does not run. Depending on how you configure this component and what parameters you add, instances of `%{count}` are replaced by the value of `maxwords`. If not configured, it uses `maxlength`. By default, fallback text is provided in English.
+  description: Text describing the maximum number of characters you can enter, which is announced to screen readers. The text is displayed as a fallback if the character count JavaScript does not run. Depending on how you configure this component and what parameters you add, instances of `%{count}` are replaced by the value of `maxwords`. If not configured, it uses `maxlength`. By default, textarea description is provided in English.
 - name: errorMessage
   type: object
   required: false
@@ -86,11 +86,11 @@ examples:
       label:
         text: Can you provide more detail?
   
-  - name: with custom fallback text
-    description: with no-js fallback text translated into Welsh
+  - name: with custom textarea description
+    description: with textarea description translated into Welsh
     data:
-      name: custom-fallback
-      id: custom-fallback
+      name: custom-textarea-description
+      id: custom-textarea-description
       maxlength: 10
       textareaDescriptionText: Gallwch ddefnyddio hyd at %{count} nod
 
@@ -297,7 +297,7 @@ examples:
       label:
         text: Full address
       textareaDescriptionText: 'No more than %{count} characters'
-  - name: when neither maxlength/maxwords nor fallback hint are set
+  - name: when neither maxlength/maxwords nor textarea description are set
     hidden: true
     data:
       id: no-maximum

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -3,10 +3,14 @@
 {% from "../textarea/macro.njk" import govukTextarea %}
 {% from "../hint/macro.njk" import govukHint %}
 
+{%- set hasNoLimit = (not params.maxwords and not params.maxlength) %}
+{%- set fallbackHintText = params.fallbackHintText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
+
 <div class="govuk-character-count" data-module="govuk-character-count"
 {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
 {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
 {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
+{%- if hasNoLimit %}{{govukPluralisedI18nAttributes('fallback-hint', {other: fallbackHintText})}}{% endif %}
 {%- if params.charactersUnderLimitText %}{{govukPluralisedI18nAttributes('characters-under-limit', params.charactersUnderLimitText)}}{% endif %}
 {%- if params.charactersAtLimitText %} data-i18n.characters-at-limit="{{ params.charactersAtLimitText | escape}}"{% endif %}
 {%- if params.charactersOverLimitText %}{{govukPluralisedI18nAttributes('characters-over-limit', params.charactersOverLimitText)}}{% endif %}
@@ -35,9 +39,14 @@
     attributes: params.attributes
   }) }}
   {%- set fallbackHintLength = params.maxwords or params.maxlength %}
-  {%- set fallbackHintDefault = 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
+  {#
+    Use the fact that `html` has precedence over `text` to override content
+    when no limit is set and reserve vertical space to avoid layout shifting
+    by injecting a non-breakable space
+  #}
   {{ govukHint({
-    text: (params.fallbackHintText or fallbackHintDefault) | replace('%{count}', fallbackHintLength),
+    text: ((fallbackHintText) | replace('%{count}', fallbackHintLength) if not hasNoLimit),
+    html: ('&nbsp;' if hasNoLimit),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -11,8 +11,9 @@
 {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
 {#
   Without maxlength or maxwords, we can't guess if the component will count words or characters.
-  This means we can't compute a default fallback message (also used as the textarea accessible
-  description) to be interpolated in JavaScript once the maximum gets configured there
+  We can't guess a default textarea description to be interpolated in JavaScript
+  once the maximum gets configured there.
+  So we only add the attribute if a textarea description was explicitely provided.
 #}
 {%- if hasNoLimit and params.textareaDescriptionText %}{{govukPluralisedI18nAttributes('textarea-description', {other: params.textareaDescriptionText})}}{% endif %}
 {%- if params.charactersUnderLimitText %}{{govukPluralisedI18nAttributes('characters-under-limit', params.charactersUnderLimitText)}}{% endif %}

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -4,13 +4,17 @@
 {% from "../hint/macro.njk" import govukHint %}
 
 {%- set hasNoLimit = (not params.maxwords and not params.maxlength) %}
-{%- set fallbackHintText = params.fallbackHintText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
 
 <div class="govuk-character-count" data-module="govuk-character-count"
 {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
 {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
 {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
-{%- if hasNoLimit %}{{govukPluralisedI18nAttributes('fallback-hint', {other: fallbackHintText})}}{% endif %}
+{#
+  Without maxlength or maxwords, we can't guess if the component will count words or characters.
+  This means we can't compute a default fallback message (also used as the textarea accessible
+  description) to be interpolated in JavaScript once the maximum gets configured there
+#}
+{%- if hasNoLimit and params.fallbackHintText %}{{govukPluralisedI18nAttributes('fallback-hint', {other: params.fallbackHintText})}}{% endif %}
 {%- if params.charactersUnderLimitText %}{{govukPluralisedI18nAttributes('characters-under-limit', params.charactersUnderLimitText)}}{% endif %}
 {%- if params.charactersAtLimitText %} data-i18n.characters-at-limit="{{ params.charactersAtLimitText | escape}}"{% endif %}
 {%- if params.charactersOverLimitText %}{{govukPluralisedI18nAttributes('characters-over-limit', params.charactersOverLimitText)}}{% endif %}
@@ -39,6 +43,7 @@
     attributes: params.attributes
   }) }}
   {%- set fallbackHintLength = params.maxwords or params.maxlength %}
+  {%- set fallbackHintText = params.fallbackHintText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {#
     Use the fact that `html` has precedence over `text` to override content
     when no limit is set and reserve vertical space to avoid layout shifting

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -45,13 +45,12 @@
   {%- set fallbackHintLength = params.maxwords or params.maxlength %}
   {%- set fallbackHintText = params.fallbackHintText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {#
-    Use the fact that `html` has precedence over `text` to override content
-    when no limit is set and reserve vertical space to avoid layout shifting
-    by injecting a non-breakable space
+    If the limit is set in JavaScript, we won't be able to interpolate the message
+    until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
+    were provided to the macro.
   #}
   {{ govukHint({
     text: ((fallbackHintText) | replace('%{count}', fallbackHintLength) if not hasNoLimit),
-    html: ('&nbsp;' if hasNoLimit),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}

--- a/src/govuk/components/character-count/template.njk
+++ b/src/govuk/components/character-count/template.njk
@@ -14,7 +14,7 @@
   This means we can't compute a default fallback message (also used as the textarea accessible
   description) to be interpolated in JavaScript once the maximum gets configured there
 #}
-{%- if hasNoLimit and params.fallbackHintText %}{{govukPluralisedI18nAttributes('fallback-hint', {other: params.fallbackHintText})}}{% endif %}
+{%- if hasNoLimit and params.textareaDescriptionText %}{{govukPluralisedI18nAttributes('textarea-description', {other: params.textareaDescriptionText})}}{% endif %}
 {%- if params.charactersUnderLimitText %}{{govukPluralisedI18nAttributes('characters-under-limit', params.charactersUnderLimitText)}}{% endif %}
 {%- if params.charactersAtLimitText %} data-i18n.characters-at-limit="{{ params.charactersAtLimitText | escape}}"{% endif %}
 {%- if params.charactersOverLimitText %}{{govukPluralisedI18nAttributes('characters-over-limit', params.charactersOverLimitText)}}{% endif %}
@@ -42,15 +42,15 @@
     errorMessage: params.errorMessage,
     attributes: params.attributes
   }) }}
-  {%- set fallbackHintLength = params.maxwords or params.maxlength %}
-  {%- set fallbackHintText = params.fallbackHintText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
+  {%- set textareaDescriptionLength = params.maxwords or params.maxlength %}
+  {%- set textareaDescriptionText = params.textareaDescriptionText or 'You can enter up to %{count} ' + ('words' if params.maxwords else 'characters') %}
   {#
     If the limit is set in JavaScript, we won't be able to interpolate the message
     until JavaScript, so we only set a text if the `maxlength` or `maxwords` options
     were provided to the macro.
   #}
   {{ govukHint({
-    text: ((fallbackHintText) | replace('%{count}', fallbackHintLength) if not hasNoLimit),
+    text: ((textareaDescriptionText) | replace('%{count}', textareaDescriptionLength) if not hasNoLimit),
     id: params.id + '-info',
     classes: 'govuk-character-count__message' + (' ' + params.countMessage.classes if params.countMessage.classes)
   }) }}

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -269,11 +269,10 @@ describe('Character count', () => {
         const $component = $('[data-module]')
         expect($component.attr('data-i18n.fallback-hint.other')).toEqual('No more than %{count} characters')
 
-        // A non-breaking space is set as the count message to reserve space
-        // and prevent a layout shift when the JavaScript component
-        // initialises and fills the element with the relevant text
+        // No content is set as the accessible description cannot be interpolated on the backend
+        // It'll be up to the JavaScript to fill it in
         const $countMessage = $('.govuk-character-count__message')
-        expect($countMessage.html()).toContain('&nbsp;')
+        expect($countMessage.html()).toMatch(/^\s*$/) // The macro outputs linebreaks around the hint itself
       })
     })
 

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -256,4 +256,23 @@ describe('Character count', () => {
       })
     })
   })
+
+  describe('no maximum', () => {
+    // If the template has no maxwords or maxlength to go for
+    // it needs to pass down any fallback hint to the JavaScript
+    // so it can inject the limit it may have received at instantiation
+    it('renders the fallback hint as a data attribute', () => {
+      const $ = render('character-count', examples['no maximum'])
+
+      // Fallback hint is passed as data attribute
+      const $component = $('[data-module]')
+      expect($component.attr('data-i18n.fallback-hint.other')).toEqual('No more than %{count} characters')
+
+      // A non-breaking space is set as the count message to reserve space
+      // and prevent a layout shift when the JavaScript component
+      // initialises and fills the element with the relevant text
+      const $countMessage = $('.govuk-character-count__message')
+      expect($countMessage.html()).toContain('&nbsp;')
+    })
+  })
 })

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -225,9 +225,9 @@ describe('Character count', () => {
     })
   })
 
-  describe('with custom fallback text', () => {
-    it('allows customisation of the fallback message', () => {
-      const $ = render('character-count', examples['with custom fallback text'])
+  describe('with custom textarea description', () => {
+    it('allows customisation of the textarea description', () => {
+      const $ = render('character-count', examples['with custom textarea description'])
 
       const message = $('.govuk-character-count__message').text().trim()
       expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
@@ -258,11 +258,11 @@ describe('Character count', () => {
   })
 
   describe('when neither maxlength nor maxwords are set', () => {
-    describe('with fallback hint set', () => {
+    describe('with textarea description set', () => {
       // If the template has no maxwords or maxlength to go for
-      // it needs to pass down any fallback hint to the JavaScript
+      // it needs to pass down any textarea description to the JavaScript
       // so it can inject the limit it may have received at instantiation
-      it('renders the fallback hint as a data attribute', () => {
+      it('renders the textarea description as a data attribute', () => {
         const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
 
         // Fallback hint is passed as data attribute
@@ -276,11 +276,11 @@ describe('Character count', () => {
       })
     })
 
-    describe('without fallback hint', () => {
-      it('does not render a fallback hint data attribute', () => {
+    describe('without textarea description', () => {
+      it('does not render a textarea description data attribute', () => {
         const $ = render(
           'character-count',
-          examples['when neither maxlength/maxwords nor fallback hint are set']
+          examples['when neither maxlength/maxwords nor textarea description are set']
         )
 
         const $component = $('[data-module]')

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -258,21 +258,35 @@ describe('Character count', () => {
   })
 
   describe('when neither maxlength nor maxwords are set', () => {
-    // If the template has no maxwords or maxlength to go for
-    // it needs to pass down any fallback hint to the JavaScript
-    // so it can inject the limit it may have received at instantiation
-    it('renders the fallback hint as a data attribute', () => {
-      const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
+    describe('with fallback hint set', () => {
+      // If the template has no maxwords or maxlength to go for
+      // it needs to pass down any fallback hint to the JavaScript
+      // so it can inject the limit it may have received at instantiation
+      it('renders the fallback hint as a data attribute', () => {
+        const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
 
-      // Fallback hint is passed as data attribute
-      const $component = $('[data-module]')
-      expect($component.attr('data-i18n.fallback-hint.other')).toEqual('No more than %{count} characters')
+        // Fallback hint is passed as data attribute
+        const $component = $('[data-module]')
+        expect($component.attr('data-i18n.fallback-hint.other')).toEqual('No more than %{count} characters')
 
-      // A non-breaking space is set as the count message to reserve space
-      // and prevent a layout shift when the JavaScript component
-      // initialises and fills the element with the relevant text
-      const $countMessage = $('.govuk-character-count__message')
-      expect($countMessage.html()).toContain('&nbsp;')
+        // A non-breaking space is set as the count message to reserve space
+        // and prevent a layout shift when the JavaScript component
+        // initialises and fills the element with the relevant text
+        const $countMessage = $('.govuk-character-count__message')
+        expect($countMessage.html()).toContain('&nbsp;')
+      })
+    })
+
+    describe('without fallback hint', () => {
+      it('does not render a fallback hint data attribute', () => {
+        const $ = render(
+          'character-count',
+          examples['when neither maxlength/maxwords nor fallback hint are set']
+        )
+
+        const $component = $('[data-module]')
+        expect($component.attr('data-i18n.fallback-hint.other')).toBeFalsy()
+      })
     })
   })
 })

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -267,7 +267,7 @@ describe('Character count', () => {
 
         // Fallback hint is passed as data attribute
         const $component = $('[data-module]')
-        expect($component.attr('data-i18n.fallback-hint.other')).toEqual('No more than %{count} characters')
+        expect($component.attr('data-i18n.textarea-description.other')).toEqual('No more than %{count} characters')
 
         // No content is set as the accessible description cannot be interpolated on the backend
         // It'll be up to the JavaScript to fill it in
@@ -284,7 +284,7 @@ describe('Character count', () => {
         )
 
         const $component = $('[data-module]')
-        expect($component.attr('data-i18n.fallback-hint.other')).toBeFalsy()
+        expect($component.attr('data-i18n.textarea-description.other')).toBeFalsy()
       })
     })
   })

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -257,12 +257,12 @@ describe('Character count', () => {
     })
   })
 
-  describe('no maximum', () => {
+  describe('when neither maxlength nor maxwords are set', () => {
     // If the template has no maxwords or maxlength to go for
     // it needs to pass down any fallback hint to the JavaScript
     // so it can inject the limit it may have received at instantiation
     it('renders the fallback hint as a data attribute', () => {
-      const $ = render('character-count', examples['no maximum'])
+      const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
 
       // Fallback hint is passed as data attribute
       const $component = $('[data-module]')


### PR DESCRIPTION
Avoids displaying a "You can enter **undefined** characters" to users if neither `maxlength` nor `maxwords` is set.

This'll avoid services from getting an unsavory message in front of their users if they chose to use JavaScript to pass the `maxlength` or `maxcount` option. (Closes https://github.com/alphagov/govuk-frontend/issues/2910).

Unfortunately, before JavaScript kicks in, we can't tell if it'll be characters or words (nor the limit obviously), so the message is pretty vague (but still better than having a message that looks like there was a bug). @claireashworth, if you have a better wording, I'm open to suggestions.

Given we're expecting JavaScript to kick in and set a dynamic text based on the content of the component, we do need to have an element on the page taking some vertical space to avoid layout shifts, so some content is required. And as we're passing the option as `text`, `&nbsp;` or other kind of HTML entities will be escaped.

