### PR TITLE
Fall back to 'other' if a plural form is missing

### DIFF
--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -1,3 +1,5 @@
+{% set htmlLang = 'cy-GB' %}
+
 {% from "accordion/macro.njk" import govukAccordion %}
 {% from "back-link/macro.njk" import govukBackLink %}
 {% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -35,26 +35,7 @@ I18n.prototype.t = function (lookupKey, options) {
   // falsy, as this could legitimately be 0.
   if (options && typeof options.count !== 'undefined') {
     // Get the plural suffix
-    var pluralSuffix = this.getPluralSuffix(options.count)
-
-    // Use the correct plural form if provided
-    if (lookupKey + '.' + pluralSuffix in this.translations) {
-      lookupKey = lookupKey + '.' + pluralSuffix
-    // Fall back to `other` if the plural form is missing, but log a warning
-    // to the console
-    } else if (lookupKey + '.other' in this.translations) {
-      if (console && 'warn' in console) {
-        console.warn('i18n: Missing plural form ".' + pluralSuffix + '" for "' +
-          this.locale + '" locale. Falling back to ".other".')
-      }
-
-      lookupKey = lookupKey + '.other'
-    // If the required `other` plural form is missing, all we can do is error
-    } else {
-      throw new Error(
-        'i18n: Plural form ".other" is required for "' + this.locale + '" locale'
-      )
-    }
+    lookupKey = lookupKey + '.' + this.getPluralSuffix(lookupKey, options.count)
   }
 
   if (lookupKey in this.translations) {
@@ -149,10 +130,18 @@ I18n.prototype.hasIntlNumberFormatSupport = function () {
 /**
  * Get the appropriate suffix for the plural form.
  *
+ * Uses Intl.PluralRules (or our own fallback implementation) to get the
+ * 'preferred' form to use for the given count.
+ *
+ * Checks that a translation has been provided for that plural form – if it
+ * hasn't, it'll fall back to the 'other' plural form (unless that doesn't exist
+ * either, in which case an error will be thrown)
+ *
+ * @param {string} lookupKey - The lookup key of the string to use.
  * @param {number} count - Number used to determine which pluralisation to use.
  * @returns {PluralRule} The suffix associated with the correct pluralisation for this locale.
  */
-I18n.prototype.getPluralSuffix = function (count) {
+I18n.prototype.getPluralSuffix = function (lookupKey, count) {
   // Validate that the number is actually a number.
   //
   // Number(count) will turn anything that can't be converted to a Number type
@@ -160,13 +149,34 @@ I18n.prototype.getPluralSuffix = function (count) {
   count = Number(count)
   if (!isFinite(count)) { return 'other' }
 
+  var preferredForm
+
   // Check to verify that all the requirements for Intl.PluralRules are met.
   // If so, we can use that instead of our custom implementation. Otherwise,
   // use the hardcoded fallback.
   if (this.hasIntlPluralRulesSupport()) {
-    return new Intl.PluralRules(this.locale).select(count)
+    preferredForm = new Intl.PluralRules(this.locale).select(count)
   } else {
-    return this.selectPluralRuleFromFallback(count)
+    preferredForm = this.selectPluralRuleFromFallback(count)
+  }
+
+  // Use the correct plural form if provided
+  if (lookupKey + '.' + preferredForm in this.translations) {
+    return preferredForm
+  // Fall back to `other` if the plural form is missing, but log a warning
+  // to the console
+  } else if (lookupKey + '.other' in this.translations) {
+    if (console && 'warn' in console) {
+      console.warn('i18n: Missing plural form ".' + preferredForm + '" for "' +
+        this.locale + '" locale. Falling back to ".other".')
+    }
+
+    return 'other'
+  // If the required `other` plural form is missing, all we can do is error
+  } else {
+    throw new Error(
+      'i18n: Plural form ".other" is required for "' + this.locale + '" locale'
+    )
   }
 }
 

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -157,7 +157,7 @@ I18n.prototype.getPluralSuffix = function (lookupKey, count) {
   if (this.hasIntlPluralRulesSupport()) {
     preferredForm = new Intl.PluralRules(this.locale).select(count)
   } else {
-    preferredForm = this.selectPluralRuleFromFallback(count)
+    preferredForm = this.selectPluralFormUsingFallbackRules(count)
   }
 
   // Use the correct plural form if provided
@@ -181,15 +181,15 @@ I18n.prototype.getPluralSuffix = function (lookupKey, count) {
 }
 
 /**
- * Get the plural rule using our fallback implementation
+ * Get the plural form using our fallback implementation
  *
  * This is split out into a separate function to make it easier to test the
  * fallback behaviour in an environment where Intl.PluralRules exists.
  *
  * @param {number} count - Number used to determine which pluralisation to use.
- * @returns {PluralRule} The suffix associated with the correct pluralisation for this locale.
+ * @returns {PluralRule} The pluralisation form for count in this locale.
  */
-I18n.prototype.selectPluralRuleFromFallback = function (count) {
+I18n.prototype.selectPluralFormUsingFallbackRules = function (count) {
   // Currently our custom code can only handle positive integers, so let's
   // make sure our number is one of those.
   count = Math.abs(Math.floor(count))

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -37,12 +37,23 @@ I18n.prototype.t = function (lookupKey, options) {
     // Get the plural suffix
     var pluralSuffix = this.getPluralSuffix(options.count)
 
-    // Overwrite our existing lookupKey
-    lookupKey = lookupKey + '.' + pluralSuffix
+    // Use the correct plural form if provided
+    if (lookupKey + '.' + pluralSuffix in this.translations) {
+      lookupKey = lookupKey + '.' + pluralSuffix
+    // Fall back to `other` if the plural form is missing, but log a warning
+    // to the console
+    } else if (lookupKey + '.other' in this.translations) {
+      if (console && 'warn' in console) {
+        console.warn('i18n: Missing plural form ".' + pluralSuffix + '" for "' +
+          this.locale + '" locale. Falling back to ".other".')
+      }
 
-    // Throw an error if this new key doesn't exist
-    if (!(lookupKey in this.translations)) {
-      throw new Error('i18n: Plural form ".' + pluralSuffix + '" is required for "' + this.locale + '" locale')
+      lookupKey = lookupKey + '.other'
+    // If the required `other` plural form is missing, all we can do is error
+    } else {
+      throw new Error(
+        'i18n: Plural form ".other" is required for "' + this.locale + '" locale'
+      )
     }
   }
 

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -150,40 +150,6 @@ describe('I18n', () => {
     })
 
     describe('pluralisation', () => {
-      it('falls back to `other` if a plural form is not provided', () => {
-        const i18n = new I18n({
-          'test.other': 'testing testing'
-        }, {
-          locale: 'en'
-        })
-        expect(i18n.t('test', { count: 1 })).toBe('testing testing')
-      })
-
-      it('logs a console warning when falling back to `other`', () => {
-        const consoleWarn = jest.spyOn(global.console, 'warn')
-        const i18n = new I18n({
-          'test.other': 'testing testing'
-        }, {
-          locale: 'en'
-        })
-
-        i18n.t('test', { count: 1 })
-
-        expect(consoleWarn).toHaveBeenCalledWith(
-          'i18n: Missing plural form ".one" for "en" locale. Falling back to ".other".'
-        )
-      })
-
-      it('throws an error if a plural form is not provided and neither is `other`', () => {
-        const i18n = new I18n({
-          'test.one': 'testing testing'
-        }, {
-          locale: 'en'
-        })
-        expect(() => { i18n.t('test', { count: 2 }) }).toThrowError('i18n: Plural form ".other" is required for "en" locale')
-      })
-
-
       it('interpolates the count variable into the correct plural form', () => {
         const i18n = new I18n({
           'test.one': '%{count} test',
@@ -195,6 +161,52 @@ describe('I18n', () => {
         expect(i18n.t('test', { count: 1 })).toBe('1 test')
         expect(i18n.t('test', { count: 5 })).toBe('5 tests')
       })
+    })
+  })
+
+  describe('.getPluralSuffix', () => {
+    it('returns the preferred plural form for the locale if a translation exists', () => {
+      const i18n = new I18n({
+        'test.one': 'test',
+        'test.other': 'test'
+      }, {
+        locale: 'en'
+      })
+      expect(i18n.getPluralSuffix('test', 1)).toBe('one')
+    })
+
+    it('falls back to `other` if a translation for the plural form does not exist', () => {
+      const i18n = new I18n({
+        'test.other': 'test'
+      }, {
+        locale: 'en'
+      })
+      expect(i18n.getPluralSuffix('test', 1)).toBe('other')
+    })
+
+    it('logs a console warning when falling back to `other`', () => {
+      const consoleWarn = jest.spyOn(global.console, 'warn')
+      const i18n = new I18n({
+        'test.other': 'test'
+      }, {
+        locale: 'en'
+      })
+
+      i18n.getPluralSuffix('test', 1)
+
+      expect(consoleWarn).toHaveBeenCalledWith(
+        'i18n: Missing plural form ".one" for "en" locale. Falling back to ".other".'
+      )
+    })
+
+    it('throws an error if a plural form is not provided and neither is `other`', () => {
+      const i18n = new I18n({
+        'test.one': 'test'
+      }, {
+        locale: 'en'
+      })
+      expect(() => { i18n.getPluralSuffix('test', 2) })
+        .toThrowError('i18n: Plural form ".other" is required for "en" locale')
     })
   })
 

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -150,14 +150,39 @@ describe('I18n', () => {
     })
 
     describe('pluralisation', () => {
-      it('throws an error if a required plural form is not provided ', () => {
+      it('falls back to `other` if a plural form is not provided', () => {
         const i18n = new I18n({
           'test.other': 'testing testing'
         }, {
           locale: 'en'
         })
-        expect(() => { i18n.t('test', { count: 1 }) }).toThrowError('i18n: Plural form ".one" is required for "en" locale')
+        expect(i18n.t('test', { count: 1 })).toBe('testing testing')
       })
+
+      it('logs a console warning when falling back to `other`', () => {
+        const consoleWarn = jest.spyOn(global.console, 'warn')
+        const i18n = new I18n({
+          'test.other': 'testing testing'
+        }, {
+          locale: 'en'
+        })
+
+        i18n.t('test', { count: 1 })
+
+        expect(consoleWarn).toHaveBeenCalledWith(
+          'i18n: Missing plural form ".one" for "en" locale. Falling back to ".other".'
+        )
+      })
+
+      it('throws an error if a plural form is not provided and neither is `other`', () => {
+        const i18n = new I18n({
+          'test.one': 'testing testing'
+        }, {
+          locale: 'en'
+        })
+        expect(() => { i18n.t('test', { count: 2 }) }).toThrowError('i18n: Plural form ".other" is required for "en" locale')
+      })
+
 
       it('interpolates the count variable into the correct plural form', () => {
         const i18n = new I18n({

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -230,7 +230,7 @@ describe('I18n', () => {
     })
   })
 
-  describe('.selectPluralRuleFromFallback', () => {
+  describe('.selectPluralFormUsingFallbackRules', () => {
     // The locales we want to test, with numbers for any 'special cases' in
     // those locales we want to ensure are handled correctly
     const locales = [
@@ -252,7 +252,7 @@ describe('I18n', () => {
       const numbersToTest = [0, 1, 2, 5, 25, 100, ...localeNumbers]
 
       numbersToTest.forEach(num => {
-        expect(i18n.selectPluralRuleFromFallback(num)).toBe(intl.select(num))
+        expect(i18n.selectPluralFormUsingFallbackRules(num)).toBe(intl.select(num))
       })
     })
 
@@ -263,7 +263,7 @@ describe('I18n', () => {
       const numbersToTest = [0, 1, 2, 5, 25, 100]
 
       numbersToTest.forEach(num => {
-        expect(i18n.selectPluralRuleFromFallback(num)).toBe('other')
+        expect(i18n.selectPluralFormUsingFallbackRules(num)).toBe('other')
       })
     })
   })


### PR DESCRIPTION
If a service currently has a character count inside an element with a non-English `lang` tag and tried to use the current implementation, the Character Count may throw an error and not update the count message when the user has a certain number of characters remaining.

This is because we are only providing default translations for the `one` and `other` plural forms (the only forms required in English).

But if the character count was in a `cy-GB` locale for example it would expect plural forms for `two`, `few` and `many`, and when the user got down to 6-2 characters remaining an error would be thrown and the count message would not be updated.

In order to preserve the existing behaviour, falling back to `other` is a reasonable thing to do, even if it may lead to incorrect plural forms being used in some cases.

Closes #2918.