### PR TITLE
Remove history rewriting and new tab functionality from HtP button

### DIFF
--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -5,7 +5,7 @@ function HideThisPage ($module) {
   this.escCounter = 0
 }
 
-HideThisPage.prototype.openNewTab = function (e) {
+HideThisPage.prototype.exitPage = function (e) {
   var isClickEvent = typeof e !== 'undefined'
 
   if (isClickEvent) {
@@ -13,8 +13,6 @@ HideThisPage.prototype.openNewTab = function (e) {
   }
 
   var target = isClickEvent ? e.target : document.querySelector('.govuk-js-hide-this-page-button')
-
-  window.open(target.getAttribute('data-new-tab-url'), '_newtab')
   window.location.href = target.href
 }
 
@@ -22,7 +20,7 @@ HideThisPage.prototype.init = function () {
   // We put the loop here instead of in all.js because we want to have both listeners on the individual buttons for clicks
   // and a single listener for the keyboard shortcut
   nodeListForEach(this.$module, function ($button) {
-    $button.querySelector('.govuk-js-hide-this-page-button').addEventListener('click', this.openNewTab)
+    $button.querySelector('.govuk-js-hide-this-page-button').addEventListener('click', this.exitPage)
   }.bind(this))
 
   window.addEventListener('keydown', function (e) {
@@ -31,7 +29,7 @@ HideThisPage.prototype.init = function () {
 
       if (this.escCounter === 3) {
         this.escCounter = 0
-        this.openNewTab()
+        this.exitPage()
       }
 
       setTimeout(function () {

--- a/src/govuk/components/hide-this-page/hide-this-page.test.js
+++ b/src/govuk/components/hide-this-page/hide-this-page.test.js
@@ -23,24 +23,6 @@ describe('/components/hide-this-page', () => {
     expect(url).toBe(href)
   })
 
-  it('opens a page in a new tab when the button is clicked', async () => {
-    const expectedNewTabUrl = await page.evaluate((buttonClass) => document.querySelector(buttonClass).getAttribute('data-new-tab-url'), buttonClass)
-    const pageTarget = page.target()
-
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(buttonClass)
-    ])
-
-    // Because we're opening a new tab, we need to wait for that tab to open and load before we can test for it
-    // We do do this by waiting for a new target to appear in the browser object which was opened by our button and getting it's page object
-    const newTarget = await browser.waitForTarget(target => target.opener() === pageTarget)
-    const newPage = await newTarget.page()
-    const newTabUrl = await newPage.url()
-
-    expect(newTabUrl).toBe(expectedNewTabUrl)
-  })
-
   it('activates the button functionality when the escape key is pressed 3 times', async () => {
     const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
 

--- a/src/govuk/components/hide-this-page/hide-this-page.yaml
+++ b/src/govuk/components/hide-this-page/hide-this-page.yaml
@@ -3,18 +3,10 @@ params:
   type: string
   required: false
   description: Text for the link. Defaults to `Hide this page`.
-- name: currentTabURL
+- name: redirectUrl
   type: string
   required: false
   description: URL to redirect the current tab to. Defaults to `https://www.google.com`.
-- name: newTabURL
-  type: string
-  required: false
-  description: URL to open a new tab to. Defaults to `https://www.bbc.co.uk/weather`.
-- name: fakePageTitle
-  type: string
-  required: false
-  description: Fake title that will be passed to the original page's title attribute to mask the user's history. Defaults to `How to prevent the spread of Coronavirus - GOV.UK`.
 - name: id
   type: string
   required: false
@@ -32,9 +24,7 @@ examples:
 - name: default  
   data:
     text: Hide this page
-    currentTabURL: "https://www.gov.uk"
-    newTabURL: "https://www.google.com/search?q=weather"
-    fakePageTitle: How to prevent the spread of Coronavirus - GOV.UK
+    redirectUrl: "https://www.gov.uk"
     id: null
     classes: null
     attributes:
@@ -45,9 +35,7 @@ examples:
   hidden: true
   data:
     text: Hide this test
-    currentTabURL: "https://www.test.co.uk"
-    newTabURL: "https://www.google.com/search?q=test"
-    fakePageTitle: This is a test
+    redirectUrl: "https://www.test.co.uk"
     id: test-id
     classes: test-class
     attributes:

--- a/src/govuk/components/hide-this-page/template.njk
+++ b/src/govuk/components/hide-this-page/template.njk
@@ -1,8 +1,6 @@
 {% from "../button/macro.njk" import govukButton %}
-{% set currentTabURL = params.currentTabURL | default() -%}
-{% set newTabURL = params.newTabURL | default() -%}
+{% set redirectUrl = params.redirectUrl | default() -%}
 {% set text = params.text | default() -%}
-{% set fakePageTitle = params.fakePageTitle | default() -%}
 
 <div
   {%- if params.id %} id="{{ params.id }}"{% endif %}
@@ -12,10 +10,6 @@
   {{ govukButton({
     text: params.text,
     classes: "govuk-button--warning govuk-hide-this-page__button govuk-js-hide-this-page-button",
-    href: currentTabURL,
-    attributes: {
-      "data-new-tab-url": newTabURL,
-      "data-fake-page-title": fakePageTitle
-    }
+    href: redirectUrl
   })}}
 </div>

--- a/src/govuk/components/hide-this-page/template.test.js
+++ b/src/govuk/components/hide-this-page/template.test.js
@@ -27,8 +27,6 @@ describe('Hide this page', () => {
       expect($button.hasClass('govuk-button--warning')).toBeTruthy()
       expect($button.text()).toContain('Hide this page')
       expect($button.attr('href')).toBe('https://www.gov.uk')
-      expect($button.attr('data-new-tab-url')).toBe('https://www.google.com/search?q=weather')
-      expect($button.attr('data-fake-page-title')).toBe('How to prevent the spread of Coronavirus - GOV.UK')
     })
   })
 
@@ -45,13 +43,6 @@ describe('Hide this page', () => {
       const $button = $('.govuk-hide-this-page').find('.govuk-button')
 
       expect($button.attr('href')).toBe('https://www.test.co.uk')
-    })
-
-    it('renders with a new tab URL', () => {
-      const $ = render('hide-this-page', examples.testing)
-      const $button = $('.govuk-hide-this-page').find('.govuk-button')
-
-      expect($button.attr('data-new-tab-url')).toBe('https://www.google.com/search?q=test')
     })
 
     it('renders with a custom id', () => {


### PR DESCRIPTION
Removes the functionality to open a page in a new tab and to rewrite the current page's title in history, so we have a simpler base from which to produce new spikes from.

Closes #2384.