### PR TITLE
Move custom fallback text test

### DIFF
--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -586,17 +586,4 @@ describe('Character count', () => {
       })
     })
   })
-
-  describe('custom options', () => {
-    beforeAll(async () => {
-      await goToComponent(page, 'character-count', {
-        exampleName: 'with-custom-fallback-text'
-      })
-    })
-
-    it('allows customisation of the fallback message', async () => {
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
-      expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
-    })
-  })
 })

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -229,6 +229,15 @@ describe('Character count', () => {
     })
   })
 
+  describe('with custom fallback text', () => {
+    it('allows customisation of the fallback message', () => {
+      const $ = render('character-count', examples['with custom fallback text'])
+
+      const message = $('.govuk-character-count__message').text().trim()
+      expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
+    })
+  })
+
   describe('translations', () => {
     it('renders with translation data attributes', () => {
       const $ = render('character-count', examples['with translations'])


### PR DESCRIPTION
This is testing the output of the Nunjucks macro rather than the JavaScript, so there's no need to use Puppeteer and it makes sense for it to live in `template.test.js`.