### PR TITLE
Ensure tests fail for browser exceptions

### DIFF
--- a/config/jest/environment/jsdom.mjs
+++ b/config/jest/environment/jsdom.mjs
@@ -7,6 +7,12 @@ import { TestEnvironment } from 'jest-environment-jsdom'
 class BrowserVirtualEnvironment extends TestEnvironment {
   async setup () {
     await super.setup()
+
+    // Access virtual console
+    const { virtualConsole } = this.dom
+
+    // Ensure test fails for browser exceptions
+    virtualConsole.on('jsdomError', (error) => process.emit('error', error))
   }
 }
 

--- a/config/jest/environment/jsdom.mjs
+++ b/config/jest/environment/jsdom.mjs
@@ -1,0 +1,13 @@
+import { TestEnvironment } from 'jest-environment-jsdom'
+
+/**
+ * Virtual browser environment
+ * Adds jsdom window/document globals
+ */
+class BrowserVirtualEnvironment extends TestEnvironment {
+  async setup () {
+    await super.setup()
+  }
+}
+
+export default BrowserVirtualEnvironment

--- a/config/jest/environment/puppeteer.mjs
+++ b/config/jest/environment/puppeteer.mjs
@@ -7,6 +7,18 @@ import PuppeteerEnvironment from 'jest-environment-puppeteer'
 class BrowserAutomationEnvironment extends PuppeteerEnvironment {
   async setup () {
     await super.setup()
+
+    // Listen for browser exceptions
+    this.global.page.on('pageerror', (error) => {
+      this.context.console.error(error)
+
+      // Ensure error appears in in reporter summary
+      // as Jest suppresses errors with stack traces
+      delete error.stack
+
+      // Ensure test fails
+      process.emit('error', error)
+    })
   }
 }
 

--- a/config/jest/environment/puppeteer.mjs
+++ b/config/jest/environment/puppeteer.mjs
@@ -1,0 +1,13 @@
+import PuppeteerEnvironment from 'jest-environment-puppeteer'
+
+/**
+ * Automation browser environment
+ * Adds Puppeteer page/browser globals
+ */
+class BrowserAutomationEnvironment extends PuppeteerEnvironment {
+  async setup () {
+    await super.setup()
+  }
+}
+
+export default BrowserAutomationEnvironment

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -3,6 +3,12 @@ module.exports = {
   browserPerWorker: true,
 
   /**
+   * Workaround for jest-environment-puppeteer 'uncaughtException'
+   * see error handling in ./config/jest/environment/puppeteer.mjs
+   */
+  exitOnPageError: false,
+
+  /**
    * @type {import('puppeteer').PuppeteerLaunchOptions}
    */
   launch: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
       snapshotSerializers: [
         'jest-serializer-html'
       ],
-      testEnvironment: require.resolve('jest-environment-jsdom'),
+      testEnvironment: './config/jest/environment/jsdom.mjs',
       testMatch: [
         '**/(*.)?template.test.{js,mjs}'
       ]
@@ -63,7 +63,7 @@ module.exports = {
     {
       ...config,
       displayName: 'JavaScript component tests',
-      testEnvironment: require.resolve('jest-environment-puppeteer'),
+      testEnvironment: './config/jest/environment/puppeteer.mjs',
       testMatch: [
         '**/all.test.{js,mjs}',
         '**/components/*/*.test.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,6 +28,7 @@ module.exports = {
       snapshotSerializers: [
         'jest-serializer-html'
       ],
+      testEnvironment: require.resolve('jest-environment-jsdom'),
       testMatch: [
         '**/(*.)?template.test.{js,mjs}'
       ]
@@ -62,6 +63,7 @@ module.exports = {
     {
       ...config,
       displayName: 'JavaScript component tests',
+      testEnvironment: require.resolve('jest-environment-puppeteer'),
       testMatch: [
         '**/all.test.{js,mjs}',
         '**/components/*/*.test.js',

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,7 @@ module.exports = {
     {
       ...config,
       displayName: 'JavaScript unit tests',
+      testEnvironment: './config/jest/environment/jsdom.mjs',
       testMatch: [
         '**/*.unit.test.{js,mjs}'
       ]

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const sassdoc = require('sassdoc')
 
 const configPaths = require('../../config/paths.js')

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -5,16 +5,6 @@ const configPaths = require('../../config/paths.js')
 const { renderSass } = require('../../lib/jest-helpers')
 const { goTo, goToExample } = require('../../lib/puppeteer-helpers')
 
-beforeAll(() => {
-  // Capture JavaScript errors.
-  page.on('pageerror', error => {
-    // If the stack trace includes 'all.js' then we want to fail these tests.
-    if (error.stack.includes('all.js')) {
-      throw error
-    }
-  })
-})
-
 describe('GOV.UK Frontend', () => {
   describe('javascript', () => {
     it('can be accessed via `GOVUKFrontend`', async () => {

--- a/src/govuk/common.unit.test.mjs
+++ b/src/govuk/common.unit.test.mjs
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { mergeConfigs, extractConfigByNamespace, normaliseString, normaliseDataset, closestAttributeValue } from './common.mjs'
 
 // TODO: Write unit tests for `nodeListForEach` and `generateUniqueID`

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { goToComponent, goToExample } = require('../../../../lib/puppeteer-helpers')
 
 describe('/components/accordion', () => {

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Accordion', () => {

--- a/src/govuk/components/all.test.js
+++ b/src/govuk/components/all.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { fetch } = require('undici')
 const { WebSocket } = require('ws')
 

--- a/src/govuk/components/back-link/template.test.js
+++ b/src/govuk/components/back-link/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('back-link component', () => {

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Breadcrumbs', () => {

--- a/src/govuk/components/button/button.test.js
+++ b/src/govuk/components/button/button.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { getExamples } = require('../../../../lib/jest-helpers')
 const { goTo, goToComponent, renderAndInitialise } = require('../../../../lib/puppeteer-helpers')
 

--- a/src/govuk/components/button/template.test.js
+++ b/src/govuk/components/button/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Button', () => {

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const jestPuppeteerConfig = require('../../../../jest-puppeteer.config.js')
 const { getExamples } = require('../../../../lib/jest-helpers.js')
 const { goToComponent, renderAndInitialise } = require('../../../../lib/puppeteer-helpers')

--- a/src/govuk/components/character-count/character-count.unit.test.mjs
+++ b/src/govuk/components/character-count/character-count.unit.test.mjs
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import CharacterCount from './character-count.mjs'
 
 describe('CharacterCount', () => {

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/src/govuk/components/checkboxes/checkboxes.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { goToComponent, goToExample, getAttribute, getProperty, isVisible } = require('../../../../lib/puppeteer-helpers.js')
 
 describe('Checkboxes with conditional reveals', () => {

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Cookie Banner', () => {

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/details/details.test.js
+++ b/src/govuk/components/details/details.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { goToComponent, goToExample } = require('../../../../lib/puppeteer-helpers.js')
 
 describe('details', () => {

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Details', () => {

--- a/src/govuk/components/error-message/template.test.js
+++ b/src/govuk/components/error-message/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Error message', () => {

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { getExamples } = require('../../../../lib/jest-helpers')
 const { goToComponent, goToExample, renderAndInitialise } = require('../../../../lib/puppeteer-helpers')
 

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Error-summary', () => {

--- a/src/govuk/components/fieldset/template.test.js
+++ b/src/govuk/components/fieldset/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('fieldset', () => {

--- a/src/govuk/components/file-upload/template.test.js
+++ b/src/govuk/components/file-upload/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('footer', () => {

--- a/src/govuk/components/header/header.test.js
+++ b/src/govuk/components/header/header.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { devices } = require('puppeteer')
 const iPhone = devices['iPhone 6']
 

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('header', () => {

--- a/src/govuk/components/hint/template.test.js
+++ b/src/govuk/components/hint/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Hint', () => {

--- a/src/govuk/components/input/template.test.js
+++ b/src/govuk/components/input/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/inset-text/template.test.js
+++ b/src/govuk/components/inset-text/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Inset text', () => {

--- a/src/govuk/components/label/template.test.js
+++ b/src/govuk/components/label/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Label', () => {

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { getExamples } = require('../../../../lib/jest-helpers')
 const { renderAndInitialise, goToComponent } = require('../../../../lib/puppeteer-helpers')
 

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Notification-banner', () => {

--- a/src/govuk/components/pagination/template.test.js
+++ b/src/govuk/components/pagination/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Pagination', () => {

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Panel', () => {

--- a/src/govuk/components/phase-banner/template.test.js
+++ b/src/govuk/components/phase-banner/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 describe('Phase banner', () => {

--- a/src/govuk/components/radios/radios.test.js
+++ b/src/govuk/components/radios/radios.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { goToComponent, goToExample, getProperty, getAttribute, isVisible } = require('../../../../lib/puppeteer-helpers.js')
 
 describe('Radios with conditional reveals', () => {

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/select/template.test.js
+++ b/src/govuk/components/select/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/skip-link/skip-link.test.js
+++ b/src/govuk/components/skip-link/skip-link.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { goToExample } = require('../../../../lib/puppeteer-helpers.js')
 
 describe('/examples/template-default', () => {

--- a/src/govuk/components/skip-link/template.test.js
+++ b/src/govuk/components/skip-link/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Skip link', () => {

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Summary list', () => {

--- a/src/govuk/components/table/template.test.js
+++ b/src/govuk/components/table/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Table', () => {

--- a/src/govuk/components/tabs/tabs.test.js
+++ b/src/govuk/components/tabs/tabs.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment puppeteer
- */
-
 const { devices } = require('puppeteer')
 const iPhone = devices['iPhone 6']
 

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Tabs', () => {

--- a/src/govuk/components/tag/template.test.js
+++ b/src/govuk/components/tag/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Tag', () => {

--- a/src/govuk/components/textarea/template.test.js
+++ b/src/govuk/components/textarea/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples, htmlWithClassName } = require('../../../../lib/jest-helpers')
 
 const WORD_BOUNDARY = '\\b'

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 const { axe, render, getExamples } = require('../../../../lib/jest-helpers')
 
 describe('Warning text', () => {

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -1,7 +1,3 @@
-/**
- * @jest-environment jsdom
- */
-
 import { I18n } from './i18n.mjs'
 
 describe('I18n', () => {


### PR DESCRIPTION
This PR ensures all browser tests (Puppeteer, jsdom) fail for unhandled browser exceptions

It does a few separate things:

1. Adds [Jest custom environments](https://jestjs.io/docs/configuration#testenvironment-string) for Puppeteer, jsdom
2. Adds `process.emit('error', error)` to ensure browser exceptions fail tests
3. Prevents Jest Puppeteer incorrectly emitting `uncaughtException`
4. Sets the unit test default environment to jsdom (not Node.js)