### PR TITLE
Update translated example for Character Count in the review app

### DIFF
--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -110,7 +110,6 @@
     name: "with-hint",
     id: "with-hint",
     maxlength: 200,
-    fallbackHintText: "Gallwch ddefnyddio hyd at %{count} nod",
     label: {
       text: "Allwch chi roi mwy o fanylion?",
       classes: "govuk-label--l",
@@ -118,6 +117,52 @@
     },
     hint: {
       text: "Peidiwch â chynnwys gwybodaeth bersonol neu ariannol fel eich rhif Yswiriant Gwladol neu fanylion eich cerdyn credyd."
+    },
+    fallbackHintText: "Gallwch ddefnyddio hyd at %{count} nod",
+    charactersUnderLimitHtml: {
+      one: "Mae gennych %{count} nod ar ôl",
+      two: "Mae gennych %{count} nod ar ôl",
+      few: "Mae gennych %{count} nod ar ôl",
+      many: "Mae gennych %{count} nod ar ôl",
+      other: "Mae gennych %{count} nod ar ôl"
+    },
+    charactersAtLimitHtml: "Mae gennych 0 nod ar ôl",
+    charactersOverLimitHtml: {
+      one: "Mae gennych %{count} nod yn ormod",
+      two: "Mae gennych %{count} nod yn ormod",
+      few: "Mae gennych %{count} nod yn ormod",
+      many: "Mae gennych %{count} nod yn ormod",
+      other: "Mae gennych chi %{count} nod yn ormod"
+    }
+  }) }}
+
+  {{ govukCharacterCount({
+    name: "with-words",
+    id: "with-words",
+    maxwords: 10,
+    label: {
+      text: "Allwch chi roi mwy o fanylion?",
+      classes: "govuk-label--l",
+      isPageHeading: true
+    },
+    fallbackHintText: "Gallwch ddefnyddio hyd at %{count} gair",
+    hint: {
+      text: "Peidiwch â chynnwys gwybodaeth bersonol neu ariannol fel eich rhif Yswiriant Gwladol neu fanylion eich cerdyn credyd."
+    },
+    wordsUnderLimitHtml: {
+      one: "Mae gennych %{count} gair ar ôl",
+      two: "Mae gennych %{count} air ar ôl",
+      many: "Mae gennych %{count} o eiriau ar ôl",
+      few: "Mae gennych %{count} o eiriau ar ôl",
+      other: "Mae gennych %{count} o eiriau ar ôl"
+    },
+    wordsAtLimitHtml: "Mae gennych 0 gair ar ôl",
+    wordsOverLimitHtml: {
+      one: "Mae gennych %{count} gair yn ormod",
+      two: "Mae gennych %{count} air yn ormod",
+      many: "Mae gennych %{count} o eiriau yn ormod",
+      few: "Mae gennych %{count} o eiriau yn ormod",
+      other: "Mae gennych %{count} o eiriau yn ormod"
     }
   }) }}
 

--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -32,6 +32,8 @@
 
 {% extends "layout.njk" %}
 
+{% block pageTitle %}Translated examples - GOV.UK Frontend{% endblock %}
+
 {% block beforeContent %}
   {{ govukBackLink({
     "href": "/"
@@ -39,7 +41,23 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">Translated</h1>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Translated examples</h1>
+
+      <p class="govuk-body-l">
+        These examples only illustrate how our components display translated text.
+        We do not guarantee that they are accurate.
+      </p>
+
+      {{ govukWarningText({
+        text: "Please do not use these translations directly in your application.",
+        iconFallbackText: "Warning"
+      }) }}
+
+      <hr class="govuk-section-break govuk-section-break--xl">
+    </div>
+  </div>
 
   {{ govukAccordion({
     id: "accordion-default",


### PR DESCRIPTION
- Updates the character counting component with translations
- Adds a word counting component, to illustrate variations between "one", "two" and "other"
- Adds a warning notification banner to tell not to use our translations (which I'd be very happy for the wording to be tweaked if necessary @claireashworth).

A shortcut to the resulting page: https://govuk-frontend-pr-2934.herokuapp.com/examples/translated

This should be the last step to close #2701 🎉 