### PR TITLE
IE8 fixes for I18n

### DIFF
--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -223,8 +223,10 @@ I18n.prototype.getPluralRulesForLocale = function () {
   for (var pluralRule in I18n.pluralRulesMap) {
     if (Object.prototype.hasOwnProperty.call(I18n.pluralRulesMap, pluralRule)) {
       var languages = I18n.pluralRulesMap[pluralRule]
-      if (languages.indexOf(locale) > -1 || languages.indexOf(localeShort) > -1) {
-        return pluralRule
+      for (var i = 0; i < languages.length; i++) {
+        if (languages[i] === locale || languages[i] === localeShort) {
+          return pluralRule
+        }
       }
     }
   }

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -69,7 +69,7 @@ I18n.prototype.t = function (lookupKey, options) {
  */
 I18n.prototype.replacePlaceholders = function (translationString, options) {
   // eslint-disable-next-line prefer-regex-literals
-  var placeholderRegex = RegExp(/%{(.\S+)}/, 'g')
+  var placeholderRegex = /%{(.\S+)}/g
   var placeholderMatch
 
   // Use `exec` for fetching regex matches, as matchAll() is not supported in IE


### PR DESCRIPTION
- Avoid using `Array.prototype.indexOf` [which isn't supported by IE8](https://caniuse.com/mdn-javascript_builtins_array_indexof) – use a simple loop instead
- IE8 doesn't like us passing flags alongside a literal regex when calling RegExp (this [seems to be an ES6 feature](https://github.com/mdn/content/blob/ae586f9996f622b40379283f727febe94258b8c0/files/en-us/web/javascript/reference/global_objects/regexp/index.md#flags-in-constructor)). General best practise seems to be to avoid calling RegExp if we don't need to construct the expression dynamically – as we already have a literal regex, let's just use that and pass the flags as part of the literal regex.

  (I've manually tested in IE8 to verify that this works, and that the global flag is being applied and multiple placeholders are replaced if passed)