### PR TITLE
Avoid trap where RegExp.exec misses placeholders

### DIFF
--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -119,6 +119,13 @@ describe('I18n', () => {
         expect(i18n.t('nameString', { number: 50, name: 'Andrew', otherName: 'Vic', age: 22 })).toBe('Their name is Andrew. Andrew is 22 years old')
       })
 
+      it('replaces very long placeholders', () => {
+        const i18n = new I18n({
+          nameString: 'Hi %{aVeryLongPlaceholderName}. %{aVeryLongPlaceholderName}, it sure is nice to meet you.'
+        })
+        expect(i18n.t('nameString', { aVeryLongPlaceholderName: 'Bob' })).toBe('Hi Bob. Bob, it sure is nice to meet you.')
+      })
+
       it('nested placeholder only resolves with a matching key', () => {
         const i18n = new I18n({
           nameString: 'Their name is %{name%{age}}'


### PR DESCRIPTION
RegExp.exec uses a `lastIndex` to remember where in the string to start searching on the next iteration.

So given a string like this:

```
Hi, %{name}. %{name}, it sure is nice to meet you.
```

After the first call to RegExp.exec `lastIndex` will point here:

```
Hi, %{name}. %{name}, it sure is nice to meet you.
           ↑ lastIndex
```

If we then alter the string by replacing the placeholder with text that is shorter than the placeholder, we'll then start searching from _after_ the next placeholder, and so will never match it:

```
Hi, Bob. %{name}, it's nice to meet you.
           ↑ lastIndex
```

Avoid this issue by updating the `replacePlaceholders` function to use `String.replace` instead, passing a function to take care of determining the replacement value using the same logic as before.

Move the construction of the `Intl.NumberFormat` outside of the object so that we don't have to bind the replacement function to `this`, and to save constructing multiple instances of `Intl.NumberFormat` when we only need one.

Add a test which fails without the changes to the `replacePlaceholders` function.