### PR TITLE
Add `cross-env-shell` for Windows support

### DIFF
--- a/config/jest/server/start.mjs
+++ b/config/jest/server/start.mjs
@@ -30,7 +30,11 @@ export default async function serverStart () {
   try {
     await ready({ timeout })
   } catch (error) {
-    await setup({ command: `PORT=${PORT} node app/start.js`, port: PORT })
+    await setup({
+      // Ensure PORT works (on Windows) + SIGINT/SIGTERM signal events
+      command: `cross-env-shell PORT=${PORT} node app/start.js`,
+      port: PORT
+    })
     await ready()
   }
 }


### PR DESCRIPTION
This PR adds `cross-env-shell` to restore Windows support

This ensures our process exit signals work correctly with `jest-dev-server`

https://www.npmjs.com/package/cross-env#cross-env-vs-cross-env-shell
>On Windows you need to use cross-env-shell, if you want to handle [signal events](https://nodejs.org/api/process.html#process_signal_events) inside of your program. A common case for that is when you want to capture a SIGINT event invoked by pressing Ctrl + C on the command-line interface.

For context, we accidentally removed `cross-env` in #2850 (kindly contributed as a fix in https://github.com/alphagov/govuk-frontend/pull/2572)

This PR is number 2) in a three-part special:

1. https://github.com/alphagov/govuk-frontend/pull/2946
2. https://github.com/alphagov/govuk-frontend/pull/2938
3. https://github.com/alphagov/govuk-frontend/pull/2945