### PR TITLE
Allow Node.js LTS ‘Gallium’ (v16) release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,8 +89,8 @@
         "yargs": "^15.4.1"
       },
       "engines": {
-        "node": "^16.17.0",
-        "npm": "^8.5.0"
+        "node": "^16.13.0",
+        "npm": "^8.1.0"
       },
       "optionalDependencies": {
         "fsevents": "*"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "name": "govuk-frontend-repository",
   "description": "Used only for the development of GOV.UK Frontend, see `package/package.json` for the published `package.json`",
   "engines": {
-    "node": "^16.17.0",
-    "npm": "^8.5.0"
+    "node": "^16.13.0",
+    "npm": "^8.1.0"
   },
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
This PR lowers the minimum Node.js 16 and npm versions allowed

Why? Across our projects we have a mismatch in our supported Node.js versions. This makes `npm link` a bit painful with tools like [nvm](https://github.com/nvm-sh/nvm#readme) and [asdf](https://github.com/asdf-vm/asdf#readme) as they partition dependencies by Node.js version

**`lts/gallium`** → https://github.com/alphagov/govuk-frontend/blob/main/.nvmrc
**`16.14.2`** → https://github.com/alphagov/govuk-design-system/blob/main/.nvmrc
**`16.16.0`** → https://github.com/alphagov/govuk-prototype-kit/blob/v13/.nvmrc

### Before
Latest Node.js LTS ‘Gallium’ (v16) release when https://github.com/alphagov/govuk-frontend/pull/2842 was opened

```json
"engines": {
  "node": "^16.17.0",
  "npm": "^8.5.0"
},
```

### After
All Node.js LTS ‘Gallium’ (v16) releases from initial LTS launch are now supported

```json
"engines": {
  "node": "^16.13.0",
  "npm": "^8.1.0"
},
```