### PR TITLE
[Spike] Add visual escape key indicators to exit this page button

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -66,7 +66,9 @@ function initAll (config) {
 
   var $hideThisPageButtons = $scope.querySelectorAll('[data-module="govuk-hide-this-page"]')
   if ($hideThisPageButtons.length > 0) {
-    new HideThisPage($hideThisPageButtons).init()
+    nodeListForEach($hideThisPageButtons, function ($button) {
+      new HideThisPage($button).init()
+    })
   }
 
   var $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -23,6 +23,23 @@
     margin-bottom: 0;
   }
 
+  .govuk-hide-this-page__indicator {
+    display: inline;
+  }
+
+  .govuk-hide-this-page__indicator-light {
+    display: inline-block;
+    width: .5em;
+    height: .5em;
+    margin: 0 .125em;
+    border: 1px solid currentcolor;
+    border-radius: 50%;
+  }
+
+  .govuk-hide-this-page__indicator-light--on {
+    background-color: currentcolor;
+  }
+
   @media only print {
     .govuk-hide-this-page {
       display: none;

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -25,18 +25,18 @@
 
   .govuk-hide-this-page__indicator {
     @include govuk-responsive-padding(2);
-    display: block;
-    border: 1px solid $govuk-border-colour;
-    border-top: none;
+    display: none;
+    padding-bottom: 0;
     opacity: 0;
-    color: $govuk-text-colour;
-    background-color: $govuk-body-background-colour;
+    color: govuk-colour("white");
+    background-color: govuk-colour("red");
     line-height: 0; // removes extra negative space below the indicators
     text-align: center;
     pointer-events: none;
   }
 
   .govuk-hide-this-page__indicator--visible {
+    display: block;
     opacity: 1;
   }
 

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -24,10 +24,20 @@
   }
 
   .govuk-hide-this-page__indicator {
-    @include govuk-responsive-padding(1);
+    @include govuk-responsive-padding(2);
     display: block;
+    border: 1px solid $govuk-border-colour;
+    border-top: none;
+    opacity: 0;
+    color: $govuk-text-colour;
+    background-color: $govuk-body-background-colour;
+    line-height: 0; // removes extra negative space below the indicators
     text-align: center;
     pointer-events: none;
+  }
+
+  .govuk-hide-this-page__indicator--visible {
+    opacity: 1;
   }
 
   .govuk-hide-this-page__indicator-light {
@@ -37,17 +47,10 @@
     margin: 0 .125em;
     border: 2px solid currentcolor;
     border-radius: 50%;
-    opacity: 0;
-    background-color: govuk-colour("white");
   }
 
   .govuk-hide-this-page__indicator-light--on {
     background-color: currentcolor;
-  }
-
-  .govuk-hide-this-page__indicator-light--on,
-  .govuk-hide-this-page__indicator-light--on ~ .govuk-hide-this-page__indicator-light {
-    opacity: 1;
   }
 
   @media only print {

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -24,7 +24,10 @@
   }
 
   .govuk-hide-this-page__indicator {
-    display: inline;
+    @include govuk-responsive-padding(1);
+    display: block;
+    text-align: center;
+    pointer-events: none;
   }
 
   .govuk-hide-this-page__indicator-light {
@@ -32,12 +35,19 @@
     width: .5em;
     height: .5em;
     margin: 0 .125em;
-    border: 1px solid currentcolor;
+    border: 2px solid currentcolor;
     border-radius: 50%;
+    opacity: 0;
+    background-color: govuk-colour("white");
   }
 
   .govuk-hide-this-page__indicator-light--on {
     background-color: currentcolor;
+  }
+
+  .govuk-hide-this-page__indicator-light--on,
+  .govuk-hide-this-page__indicator-light--on ~ .govuk-hide-this-page__indicator-light {
+    opacity: 1;
   }
 
   @media only print {

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -15,7 +15,7 @@ HideThisPage.prototype.initUpdateSpan = function () {
   this.$updateSpan.setAttribute('aria-live', 'polite')
   this.$updateSpan.setAttribute('class', 'govuk-visually-hidden')
 
-  this.$module.appendChild(this.$updateSpan)
+  this.$button.appendChild(this.$updateSpan)
 }
 
 HideThisPage.prototype.initButtonClickHandler = function () {
@@ -38,7 +38,7 @@ HideThisPage.prototype.buildIndicator = function () {
   }
 
   // Append it all to the module
-  this.$module.appendChild(this.$indicatorContainer)
+  this.$button.appendChild(this.$indicatorContainer)
 }
 
 HideThisPage.prototype.updateIndicator = function () {

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -2,27 +2,58 @@ import { nodeListForEach } from '../../common.mjs'
 
 function HideThisPage ($module) {
   this.$module = $module
-  this.firstButton = this.$module[0].querySelector('.govuk-js-hide-this-page-button')
-  this.updateSpan = null
+  this.$button = $module.querySelector('.govuk-hide-this-page__button')
+  this.$updateSpan = null
+  this.$indicatorContainer = null
   this.escCounter = 0
   this.escTimerActive = false
 }
 
 HideThisPage.prototype.initUpdateSpan = function () {
-  this.updateSpan = document.createElement('span')
-  this.updateSpan.setAttribute('aria-live', 'polite')
-  this.updateSpan.setAttribute('class', 'govuk-visually-hidden')
+  this.$updateSpan = document.createElement('span')
+  this.$updateSpan.setAttribute('aria-live', 'polite')
+  this.$updateSpan.setAttribute('class', 'govuk-visually-hidden')
 
-  this.$module[0].appendChild(this.updateSpan)
+  this.$module.appendChild(this.$updateSpan)
 }
 
 HideThisPage.prototype.initButtonClickHandler = function () {
-  // We put the loop here instead of in all.js because we want to have both
-  // listeners on the individual buttons for clicks and a single listener for
-  // the keyboard shortcut
-  nodeListForEach(this.$module, function ($button) {
-    $button.querySelector('.govuk-js-hide-this-page-button').addEventListener('click', this.exitPage.bind(this))
-  }.bind(this))
+  this.$button.addEventListener('click', this.exitPage.bind(this))
+}
+
+HideThisPage.prototype.buildIndicator = function () {
+  // Build container
+  // Putting `aria-hidden` on it as it won't contain any readable information
+  this.$indicatorContainer = document.createElement('div')
+  this.$indicatorContainer.className = 'govuk-hide-this-page__indicator'
+  this.$indicatorContainer.setAttribute('data-status', '0')
+  this.$indicatorContainer.setAttribute('aria-hidden', 'true')
+
+  // Create three 'lights' and place them within the container
+  for (var i = 0; i < 3; i++) {
+    var $indicator = document.createElement('div')
+    $indicator.className = 'govuk-hide-this-page__indicator-light'
+    this.$indicatorContainer.appendChild($indicator)
+  }
+
+  // Append it all to the module
+  this.$button.appendChild(this.$indicatorContainer)
+}
+
+HideThisPage.prototype.updateIndicator = function () {
+  console.log(this.escCounter)
+
+  // Turn out all the lights
+  var $lightsOn = this.$indicatorContainer.querySelectorAll('.govuk-hide-this-page__indicator-light--on')
+  nodeListForEach($lightsOn, function ($light) {
+    $light.classList.remove('govuk-hide-this-page__indicator-light--on')
+  })
+
+  // Turn on the ones we want on
+  var $lightsQueried = this.$indicatorContainer.querySelectorAll('.govuk-hide-this-page__indicator-light:nth-child(-n+' + this.escCounter + ')')
+  nodeListForEach($lightsQueried, function ($light) {
+    $light.classList.add('govuk-hide-this-page__indicator-light--on')
+  })
 }
 
 HideThisPage.prototype.exitPage = function (e) {
@@ -33,12 +64,15 @@ HideThisPage.prototype.handleEscKeypress = function (e) {
   if (e.key === 'Esc' || e.keyCode === 27 || e.which === 27) {
     this.escCounter += 1
 
+    // Update the indicator before the below if statement can reset it back to 0
+    this.updateIndicator()
+
     if (this.escCounter >= 3) {
       this.escCounter = 0
-      this.updateSpan.innerText = 'Exit this page activated'
-      window.location.href = this.firstButton.href
+      this.$updateSpan.innerText = 'Exit this page activated'
+      window.location.href = this.$button.href
     } else {
-      this.updateSpan.innerText = 'Exit this Page key press ' + this.escCounter + ' of 3'
+      this.$updateSpan.innerText = 'Exit this Page key press ' + this.escCounter + ' of 3'
     }
 
     this.setEscTimer()
@@ -52,15 +86,22 @@ HideThisPage.prototype.setEscTimer = function () {
     setTimeout(function () {
       this.escCounter = 0
       this.escTimerActive = false
-      this.updateSpan.innerText = ''
+      this.$updateSpan.innerText = ''
+      this.updateIndicator()
     }.bind(this), 2000)
   }
 }
 
 HideThisPage.prototype.init = function () {
+  this.buildIndicator()
   this.initUpdateSpan()
   this.initButtonClickHandler()
-  document.addEventListener('keyup', this.handleEscKeypress.bind(this), true)
+
+  // Check to see if this has already been done by a previous initialisation of HideThisPage
+  if (!('govukFrontendHideThisPageEsc' in document.body.dataset)) {
+    document.addEventListener('keyup', this.handleEscKeypress.bind(this), true)
+    document.body.dataset.govukFrontendHideThisPageEsc = true
+  }
 }
 
 export default HideThisPage

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -1,4 +1,5 @@
 import { nodeListForEach } from '../../common.mjs'
+import '../../vendor/polyfills/Element/prototype/dataset.mjs'
 
 function HideThisPage ($module) {
   this.$module = $module

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -37,7 +37,7 @@ HideThisPage.prototype.buildIndicator = function () {
   }
 
   // Append it all to the module
-  this.$button.appendChild(this.$indicatorContainer)
+  this.$module.appendChild(this.$indicatorContainer)
 }
 
 HideThisPage.prototype.updateIndicator = function () {

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -43,6 +43,13 @@ HideThisPage.prototype.buildIndicator = function () {
 HideThisPage.prototype.updateIndicator = function () {
   console.log(this.escCounter)
 
+  // Show or hide the indicator container depending on escCounter value
+  if (this.escCounter > 0) {
+    this.$indicatorContainer.classList.add('govuk-hide-this-page__indicator--visible')
+  } else {
+    this.$indicatorContainer.classList.remove('govuk-hide-this-page__indicator--visible')
+  }
+
   // Turn out all the lights
   var $lightsOn = this.$indicatorContainer.querySelectorAll('.govuk-hide-this-page__indicator-light--on')
   nodeListForEach($lightsOn, function ($light) {


### PR DESCRIPTION
Related to https://github.com/alphagov/govuk-design-system/issues/2390.

A first pass at adding a visual indicator of the 3× escape key functionality on the Hide/Exit This Page button. 

Standalone example: https://govuk-frontend-pr-2940.herokuapp.com/components/hide-this-page/preview

## Changes

- Add a function to dynamically build and inject the indicators into the page. They don't do anything without JavaScript, so it seemed sensible to not include them in the HTML/Nunjucks that we ship.
- Add a function to update the indicators by adding and removing classes from each individual 'light'. I originally tried something with fancy CSS, but it was hard to read and seemed unlikely to work properly in older browsers.

Other changes:

- Moves the loop that initialises the component to all.mjs. This makes each instance of the component functionally independent, aligning this component with how others work and preventing some issues with cross-contamination if there were multiple buttons on the page. 
- Relatedly, there is now an explicit check to see if the escape key functionality (which we don't want initialising multiple times) has already been initialised.
- Renamed some variables to match the convention of prefixing $ to variables containing elements.

## Implementation thoughts

At the moment, I've made it so that the indicator lights are always visible. This is so that the button doesn't need to change size (potentially requiring page content to reflow) when the user hits the escape key.

No part of it concerns itself with screen reader announcements, as that is covered by a different spike: https://github.com/alphagov/govuk-design-system/issues/2386

I've not made any major assumptions about the visual design this could take on. I've started with 'three lights' as that was the idea posed in the initial issue. I've pondered some others, but not prototyped them:

- A 'progress bar' style design would be more subtle and potentially space efficient, but also be easier to miss without utilising a more bespoke design (e.g. filling up the background of the button).
- A circle that fills itself up in three slices would be more space efficient, but is more technically complex and could be confused for a 'stuck' loading indicator by an end user.
- The existing 'three lights' but in a different arrangement (such as a triangle) would also be more space efficient, but removes the visual association of progress brought on from the lights moving from left to right. 