### PR TITLE
Make the I18n class private

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -10,7 +10,6 @@ import Header from './components/header/header.mjs'
 import Radios from './components/radios/radios.mjs'
 import SkipLink from './components/skip-link/skip-link.mjs'
 import Tabs from './components/tabs/tabs.mjs'
-import { I18n } from './i18n.mjs'
 
 /**
  * Initialise all components
@@ -102,6 +101,5 @@ export {
   NotificationBanner,
   Radios,
   SkipLink,
-  Tabs,
-  I18n
+  Tabs
 }

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -35,20 +35,13 @@ describe('GOV.UK Frontend', () => {
 
       expect(typeofInitAll).toEqual('function')
     })
-    it('exports `I18n` function', async () => {
-      await goTo(page, '/')
-
-      const typeofI18n = await page.evaluate(() => typeof window.GOVUKFrontend.I18n)
-
-      expect(typeofI18n).toEqual('function')
-    })
     it('exports Components', async () => {
       await goTo(page, '/')
 
       const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
 
       const components = Object.keys(GOVUKFrontendGlobal)
-        .filter(method => !['initAll', 'I18n'].includes(method))
+        .filter(method => !['initAll'].includes(method))
 
       // Ensure GOV.UK Frontend exports the expected components
       expect(components).toEqual([
@@ -70,7 +63,7 @@ describe('GOV.UK Frontend', () => {
 
       var componentsWithoutInitFunctions = await page.evaluate(() => {
         const components = Object.keys(window.GOVUKFrontend)
-          .filter(method => !['initAll', 'I18n'].includes(method))
+          .filter(method => !['initAll'].includes(method))
 
         return components.filter(component => {
           var prototype = window.GOVUKFrontend[component].prototype

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -1,7 +1,9 @@
 /**
- * i18n support initialisation function
+ * Internal support for selecting messages to render, with placeholder
+ * interpolation and locale-aware number formatting and pluralisation
  *
  * @class
+ * @private
  * @param {object} translations - Key-value pairs of the translation strings to use.
  * @param {object} config - Configuration options for the function.
  * @param {string} config.locale - An overriding locale for the PluralRules functionality.


### PR DESCRIPTION
## Removes the class export from the `all.mjs` module
   
   This makes the class unavailable when `import`ing from the `all.mjs`, and removes the `I18n` property from the `GOVUKFrontent` object. Tests have been updated to not check the presence of the property (and tidied up as they were excluding it when bulk testing the components were available on the object).


## Flags the class with `@private` in its JSDoc and reinforce that its internal in its description

   It won't stop anyone from running `import {I18n} from 'govuk-front/govuk-esm/I18n.mjs`, but will make it clear that they'd be using a private class that may change in the future. Unfortunately, we do need to have that file in the package as the `accordion.mjs` and `character-count.mjs` files will `import` it if they're imported individually.

Closes #2927.