### PR TITLE
Fix exit this page test failures

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -71,7 +71,9 @@ function initAll (config) {
   }
 
   var $hideThisPageButtons = $scope.querySelectorAll('[data-module="govuk-hide-this-page"]')
-  new HideThisPage($hideThisPageButtons).init()
+  if ($hideThisPageButtons.length > 0) {
+    new HideThisPage($hideThisPageButtons).init()
+  }
 
   var $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')
   nodeListForEach($notificationBanners, function ($notificationBanner) {

--- a/src/govuk/components/hide-this-page/hide-this-page.test.js
+++ b/src/govuk/components/hide-this-page/hide-this-page.test.js
@@ -27,10 +27,10 @@ describe('/components/hide-this-page', () => {
     const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
 
     await Promise.all([
-      await page.keyboard.press('Esc'),
-      await page.keyboard.press('Esc'),
-      await page.keyboard.press('Esc'),
-      await page.waitForNavigation()
+      page.keyboard.press('Escape'),
+      page.keyboard.press('Escape'),
+      page.keyboard.press('Escape'),
+      page.waitForNavigation()
     ])
 
     const url = await page.url()


### PR DESCRIPTION
Fixes 2 issues with tests in the Exit this Page prototype: https://github.com/alphagov/govuk-frontend/pull/2545

- We don't detect if there aren't any buttons on a page
- We're using the wrong keyboard key when using puppeteer to test for esc key press

This may interact in an awkward way with https://github.com/alphagov/govuk-frontend/pull/2940 as it's up in the air if we're likely to have more than one exit this page button on the page or how we handle this.