### PR TITLE
Add (optional) GitHub Action checkbox for runner OS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,15 @@ on:
       - 'support/**'
 
   workflow_dispatch:
+    inputs:
+      runner:
+        description: Run tests on
+        type: choice
+        default: ubuntu-latest
+        options:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
 
 concurrency:
   group: tests-${{ github.head_ref || github.run_id }}
@@ -18,7 +27,7 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
 
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
@@ -32,7 +41,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     steps:
@@ -43,15 +52,15 @@ jobs:
         uses: ./.github/workflows/actions/build
 
   lint:
-    name: ${{ matrix.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }}
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
       fail-fast: false
 
       matrix:
-        include:
+        task:
           - description: Lint Sass
             name: lint-scss
             run: npm run lint:scss
@@ -82,22 +91,22 @@ jobs:
         if: ${{ matrix.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache-${{ runner.os }}
-          path: ${{ matrix.cache }}
+          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          path: ${{ matrix.task.cache }}
 
       - name: Run lint task
-        run: ${{ matrix.run }}
+        run: ${{ matrix.task.run }}
 
   test:
-    name: ${{ matrix.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }}
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
       fail-fast: false
 
       matrix:
-        include:
+        task:
           - description: Nunjucks macro tests
             name: test-macro
             run: npx jest --color --selectProjects "Nunjucks macro tests"
@@ -116,32 +125,32 @@ jobs:
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache task
-        if: ${{ matrix.cache }}
+        if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache-${{ runner.os }}
-          path: ${{ matrix.cache }}
+          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          path: ${{ matrix.task.cache }}
 
       - name: Run test task
-        run: ${{ matrix.run }}
+        run: ${{ matrix.task.run }}
 
       - name: Save test coverage
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.description }} coverage
+          name: ${{ matrix.task.description }} coverage
           path: coverage
           if-no-files-found: ignore
 
   verify:
-    name: ${{ matrix.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }}
+    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
     strategy:
       fail-fast: false
 
       matrix:
-        include:
+        task:
           - description: Verify package build
             name: test-build-package
             run: npm run build:package
@@ -172,15 +181,15 @@ jobs:
       - name: Restore build
         uses: ./.github/workflows/actions/build
 
-      - name: Cache task
-        if: ${{ matrix.cache }}
+      - name: Cache Jest
+        if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache-${{ runner.os }}
-          path: ${{ matrix.cache }}
+          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          path: ${{ matrix.task.cache }}
 
       - name: Run verify task
-        run: ${{ matrix.run }}
+        run: ${{ matrix.task.run }}
 
   regression:
     name: Percy

--- a/config/jest/browser/open.mjs
+++ b/config/jest/browser/open.mjs
@@ -8,16 +8,6 @@ import { download } from '../../../tasks/browser/download.mjs'
  * @param {import('jest').Config} jestConfig - Jest config
  */
 export default async function browserOpen (jestConfig) {
-  const { maxWorkers } = jestConfig
-
-  /**
-   * Increase Node.js max listeners warning threshold by Jest --maxWorkers
-   * Allows jest-puppeteer.config.js `browserPerWorker: true` to open multiple browsers
-   */
-  if (Number.isFinite(maxWorkers)) {
-    process.setMaxListeners(1 + maxWorkers)
-  }
-
   await download() // Download browser
   return setup(jestConfig) // Open browser, start server
 }

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -2,7 +2,6 @@ const devServerOptions = require('./jest-dev-server.config.js')
 
 module.exports = {
   browserContext: 'incognito',
-  browserPerWorker: true,
 
   /**
    * Workaround for jest-environment-puppeteer 'uncaughtException'


### PR DESCRIPTION
Split out from #2938 and enables a choice of GitHub test runner:

```
- macos-latest
- ubuntu-latest
- windows-latest
```

<img width="361" alt="Choice of runner OS" src="https://user-images.githubusercontent.com/415517/220475909-1464d977-d7e3-4868-ab77-fdc9e3633a4c.png">

This PR is number 3) in a three-part special:

1. https://github.com/alphagov/govuk-frontend/pull/2946
2. https://github.com/alphagov/govuk-frontend/pull/2938
3. https://github.com/alphagov/govuk-frontend/pull/2945