### PR TITLE
[Spike] Move exit this page button to bottom of mobile viewport

### DIFF
--- a/app/views/full-page-examples/child-maintenance/index.njk
+++ b/app/views/full-page-examples/child-maintenance/index.njk
@@ -24,6 +24,7 @@ scenario: >-
 {% from "inset-text/macro.njk" import govukInsetText %}
 {% from "details/macro.njk" import govukDetails %}
 {% from "button/macro.njk" import govukButton %}
+{% from "input/macro.njk" import govukInput %}
 
 {% set pageTitle = "Child maintenance" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
@@ -48,7 +49,21 @@ scenario: >-
         <li>making your own arrangement</li>
         <li>using the Child Maintenance Service</li>
       </ul>
-      
+
+      {{ govukInput({
+        id: 'input',
+        name: 'input',
+        value: data['input'],
+        label: {
+          html: 'Test',
+          isPageHeading: false
+        },
+        hint: {
+          html: 'Hint text'
+        },
+        spellcheck: false
+      }) }}
+
       <p class="govuk-body-m">
         <a class="govuk-link" href="contact-child-maintenance-choices">Contact Child Maintenance Choices if you live in Northern Ireland</a>
       </p>

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -4,7 +4,7 @@
   .govuk-hide-this-page {
     position: fixed;
     z-index: 1000;
-    top: 0;
+    bottom: 0;
     left: 0;
     width: 100%;
 


### PR DESCRIPTION
Spike for https://github.com/alphagov/govuk-design-system/issues/2387, to investigate any benefits gained or problems introduced from moving the EtP button to the bottom of the viewport on mobile. 

Standalone example: https://govuk-frontend-pr-2947.herokuapp.com/components/hide-this-page/preview
In-situ example: https://govuk-frontend-pr-2947.herokuapp.com/full-page-examples/child-maintenance

## Changes

- Update CSS to show the EtP button at the bottom of the viewport on mobile.
- Update the EtP full page example to have a (somewhat random) form input, to allow for testing how the EtP button interacts with the virtual keyboard. 

## Implementation thoughts 

See this comment for my personal findings: https://github.com/alphagov/govuk-design-system/issues/2387#issuecomment-1292051137

