### PR TITLE
[Spike] Immediately hide the page when the Exit this Page button is interacted with

### DIFF
--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -58,4 +58,14 @@
       display: none;
     }
   }
+
+  .govuk-hide-this-page-overlay {
+    position: fixed;
+    z-index: 9999;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: govuk-colour("white");
+  }
 }

--- a/src/govuk/components/hide-this-page/_index.scss
+++ b/src/govuk/components/hide-this-page/_index.scss
@@ -59,7 +59,7 @@
     }
   }
 
-  .govuk-hide-this-page-overlay {
+  .govuk-hide-this-page__overlay {
     position: fixed;
     z-index: 9999;
     top: 0;

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -75,7 +75,7 @@ HideThisPage.prototype.exitPage = function (e) {
   this.$overlay.className = 'govuk-hide-this-page-overlay'
   document.body.appendChild(this.$overlay)
 
-  window.location.href = this.firstButton.href
+  window.location.href = this.$button.href
 }
 
 HideThisPage.prototype.handleEscKeypress = function (e) {
@@ -129,7 +129,7 @@ HideThisPage.prototype.init = function () {
     document.addEventListener('keyup', this.handleEscKeypress.bind(this), true)
     document.body.dataset.govukFrontendHideThisPageEsc = true
   }
-  
+
   // When the page is restored after navigating 'back' in some browsers the
   // blank overlay remains present, rendering the page unusable. Here, we check
   // to see if it's present on page (re)load, and remove it if so.

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -72,7 +72,7 @@ HideThisPage.prototype.exitPage = function (e) {
 
   // Blank the page
   this.$overlay = document.createElement('div')
-  this.$overlay.className = 'govuk-hide-this-page-overlay'
+  this.$overlay.className = 'govuk-hide-this-page__overlay'
   document.body.appendChild(this.$overlay)
 
   window.location.href = this.$button.href

--- a/src/govuk/components/hide-this-page/hide-this-page.mjs
+++ b/src/govuk/components/hide-this-page/hide-this-page.mjs
@@ -88,7 +88,7 @@ HideThisPage.prototype.handleEscKeypress = function (e) {
     if (this.escCounter >= 3) {
       this.escCounter = 0
       this.$updateSpan.innerText = 'Exit this page activated'
-      window.location.href = this.$button.href
+      this.exitPage()
     } else {
       this.$updateSpan.innerText = 'Exit this Page key press ' + this.escCounter + ' of 3'
     }


### PR DESCRIPTION
Spike for alphagov/govuk-design-system#2389. Immediately applies a white overlay on top of the current page when the Exit this Page button has been activated, to prevent a slow connection potentially leaving the page content visible for longer than desired. 

Tested in:
* Apple Safari 16.0 (macOS)
* Apple Safari (iOS 12–16)
* Google Chrome 106 (macOS)
* Google Chrome (Android 9–13)
* Mozilla Firefox 106 (macOS)

## Changes

- JavaScript now creates and injects a new HTML element before the closing body tag when the button has been activated.
  - The element is at the root of the document, rather than nested within the EtP component, to avoid potential issues with how z-index works within nested elements. 

## Investigations

### Does the ghost page need some text or a loading indicator?

I personally don't think this is necessary, for the following reasons:

- Browsers do not usually show loading information within the viewport, rather this information is in the browser UI. It is therefore unusual to show loading text or graphics on the ghost page, and this may get noticed by tech-savvy abusers. 
- In-page loading indicators, such as those used by SPAs (e.g. Gmail), are usually branded according to the service rather than being generic. A loading indicator would therefore be expected to match the appearance of the service the button is directing to, which we don't control.
- Even if we create a loading indicator that purposefully does not align with the GOV.UK design language, GOV.UK is well-known and used enough that—with time—the design of the ghost page may become recognisable. 
- The user has, presumably, knowingly activated a function that hides the current page, thus they do not need an indication of what is happening. 

With those aspects in mind, I believe—to quote Ronan Keating—"you say it best, when you say nothing at all". 

### Does the ghost page functionality still work if the button is a standard link and doesn't use `e.preventDefault`? 

In all browsers tested, the ghost page is activated without requiring `preventDefault`. 

### What are the risks of the functionality breaking and leaving the user on a screen they cannot interact with?

If the component is misconfigured and the URL being redirected to is malformed, or it directs to a URL that cannot be displayed by the browser and will be downloaded instead (e.g. a Word document), then the user will be stuck on the ghost page. 

In Chrome and Safari, clicking the back button from the redirected page restores the page's previous state—including the white overlay. (A fix for this problem exists on the [conditional radio button reveals](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/radios/radios.mjs#L51-L64), so may be resolveable.)

If the user purposefully halts the loading of the new page, then they will remain on the ghost page. This is potentially a problem in conjunction with the 3× Escape key functionality, as all tested browsers will stop an in-progress page load when the Escape key is pressed. For example, if a user accidentally presses the Escape key four times, they will activate the ghost page but halt the loading of the subsequent page. 

### Other note: Scrolling on mobile devices

On both Safari/iOS and Chrome/Android, the user is still able to scroll the page when the 'ghost' overlay container is open. When doing so, page content can be briefly seen below the container. 

This is because the overlay is styled with `position: fixed` with all sides (top/right/bottom/left) set to 0, however scrolling causes the mobile UI to expand and collapse, in turn changing the dimensions of the 'ghost'. I don't think this is a blocking issue, as it's only possible during the brief period between the ghost page kicking in and the user being navigated away, and it requires user intervention to make occur. 