### PR TITLE
Update all dependencies using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+    schedule:
+      interval: daily
+    allow:
+      - dependency-type: all

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    reviewers:
+      - alphagov/design-system-developers
+    schedule:
+      interval: daily

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,20 @@ updates:
     allow:
       - dependency-type: all
 
+    ignore:
+      # Ignore major updates (breaks IE8 PostCSS plugins)
+      - dependency-name: autoprefixer
+        update-types: ['version-update:semver-major']
+
+      # Ignore major updates (breaks IE8 PostCSS plugins)
+      - dependency-name: cssnano
+        update-types: ['version-update:semver-major']
+
+      # Always ignore legacy packages
+      - dependency-name: gulp-better-rollup
+      - dependency-name: jquery
+      - dependency-name: rollup
+
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This PR enables Dependabot updates for npm and GitHub Actions

Previously only security-related updates were included

I've ignored intentionally pinned "do not update" packages flagged via https://github.com/alphagov/govuk-frontend/pull/2937