### PR TITLE
Use absolute directory paths everywhere

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -93,7 +93,7 @@ module.exports = async (options) => {
   app.use('/vendor/govuk_frontend_toolkit/', express.static('node_modules/govuk_frontend_toolkit/javascripts/govuk/'))
   app.use('/vendor/jquery/', express.static('node_modules/jquery/dist'))
 
-  app.use('/assets', express.static(join(configPaths.src, 'assets')))
+  app.use('/assets', express.static(configPaths.assets))
 
   // Turn form POSTs into data that can be used for validation.
   app.use(bodyParser.urlencoded({ extended: true }))

--- a/app/app.js
+++ b/app/app.js
@@ -16,7 +16,7 @@ const appViews = [
   configPaths.layouts,
   configPaths.views,
   configPaths.components,
-  configPaths.src,
+  join(configPaths.src, 'govuk'),
   join(configPaths.node_modules, 'govuk_template_jinja')
 ]
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -7,7 +7,7 @@ const rootPath = dirname(__dirname)
  * Config root paths
  */
 const configPaths = {
-  src: join(rootPath, 'src/govuk'),
+  src: join(rootPath, 'src'),
   config: join(rootPath, 'config'),
   node_modules: join(rootPath, 'node_modules'),
 

--- a/config/paths.js
+++ b/config/paths.js
@@ -30,6 +30,7 @@ module.exports = {
   ...configPaths,
 
   // Source paths
+  assets: join(configPaths.src, 'govuk/assets'),
   components: join(configPaths.src, 'govuk/components'),
 
   // Review application views

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,19 +1,45 @@
+const { dirname, join } = require('path')
+
+// Repository root directory
+const rootPath = dirname(__dirname)
+
+/**
+ * Config root paths
+ */
+const configPaths = {
+  src: join(rootPath, 'src/govuk'),
+  config: join(rootPath, 'config'),
+  node_modules: join(rootPath, 'node_modules'),
+
+  // Build: Release distribution
+  dist: join(rootPath, 'dist'),
+
+  // Build: Package for npm publish
+  package: join(rootPath, 'package'),
+
+  // Review application
+  app: join(rootPath, 'app'),
+  public: join(rootPath, 'public'),
+
+  // Documentation
+  jsdoc: join(rootPath, 'jsdoc'),
+  sassdoc: join(rootPath, 'sassdoc')
+}
+
 module.exports = {
-  app: 'app/',
-  views: 'app/views/',
-  examples: 'app/views/examples/',
-  fullPageExamples: 'app/views/full-page-examples/',
-  partials: 'app/views/partials/',
-  layouts: 'app/views/layouts/',
-  config: 'config/',
-  dist: 'dist/',
-  node_modules: 'node_modules/',
-  package: 'package/',
-  public: 'public/',
-  jsdoc: 'jsdoc/',
-  sassdoc: 'sassdoc/',
-  src: 'src/govuk/',
-  components: 'src/govuk/components/',
+  ...configPaths,
+
+  // Source paths
+  components: join(configPaths.src, 'govuk/components'),
+
+  // Review application views
+  views: join(configPaths.app, 'views'),
+  examples: join(configPaths.app, 'views/examples'),
+  fullPageExamples: join(configPaths.app, 'views/full-page-examples'),
+  partials: join(configPaths.app, 'views/partials'),
+  layouts: join(configPaths.app, 'views/layouts'),
+
+  // Review application ports
   ports: {
     app: 3000,
     test: 8888

--- a/config/paths.js
+++ b/config/paths.js
@@ -37,7 +37,6 @@ module.exports = {
   views: join(configPaths.app, 'views'),
   examples: join(configPaths.app, 'views/examples'),
   fullPageExamples: join(configPaths.app, 'views/full-page-examples'),
-  partials: join(configPaths.app, 'views/partials'),
   layouts: join(configPaths.app, 'views/layouts'),
 
   // Review application ports

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,10 +38,10 @@ gulp.task('styles', gulp.series(
 
 /**
  * Copy assets task
- * Copies assets to taskArguments.destination (public)
+ * Copies assets to taskArguments.destination (dist)
  */
 gulp.task('copy:assets', () => {
-  return gulp.src(slash(join(configPaths.src, 'assets/**/*')))
+  return gulp.src(slash(join(configPaths.assets, '**/*')))
     .pipe(gulp.dest(slash(join(destination, 'assets'))))
 })
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,7 +41,7 @@ gulp.task('styles', gulp.series(
  * Copies assets to taskArguments.destination (public)
  */
 gulp.task('copy:assets', () => {
-  return gulp.src(`${configPaths.src}assets/**/*`)
+  return gulp.src(slash(join(configPaths.src, 'assets/**/*')))
     .pipe(gulp.dest(slash(join(destination, 'assets'))))
 })
 

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -1,6 +1,5 @@
 const { readFile } = require('fs/promises')
 const { join, parse, ParsedPath, relative } = require('path')
-const { cwd } = require('process')
 const { promisify } = require('util')
 const glob = promisify(require('glob'))
 const yaml = require('js-yaml')
@@ -28,7 +27,7 @@ const cache = global.cache || {}
 const getListing = async (directoryPath, pattern = '**/*', options = {}) => {
   const listing = await glob(pattern, {
     allowEmpty: true,
-    cwd: join(cwd(), directoryPath),
+    cwd: directoryPath,
     matchBase: true,
     nodir: true,
     realpath: true,

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -1,3 +1,4 @@
+const { join } = require('path')
 const util = require('util')
 
 const cheerio = require('cheerio')
@@ -12,7 +13,7 @@ const configPaths = require('../config/paths.js')
 const { getComponentData } = require('./file-helper.js')
 const { componentNameToMacroName } = require('./helper-functions.js')
 
-const nunjucksEnv = nunjucks.configure([configPaths.src, configPaths.components], {
+const nunjucksEnv = nunjucks.configure([join(configPaths.src, 'govuk'), configPaths.components], {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -122,7 +123,7 @@ async function getExamples (componentName) {
  */
 function renderSass (options) {
   return sassRender({
-    includePaths: [configPaths.src],
+    includePaths: [join(configPaths.src, 'govuk')],
     ...options
   })
 }

--- a/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -18,11 +18,8 @@ export default async () => {
       const [macroPath] = componentsFiles
         .filter(filterPath([`${componentName}/macro.njk`]))
 
-      // Relative path to src without 'govuk'
-      const rootPath = join(configPaths.src, '../')
-
       return {
-        importFrom: slash(relative(rootPath, join(configPaths.components, macroPath))),
+        importFrom: slash(relative(configPaths.src, join(configPaths.components, macroPath))),
         macroName: componentNameToMacroName(componentName)
       }
     })

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -1,4 +1,5 @@
 const sassdoc = require('sassdoc')
+const slash = require('slash')
 
 const configPaths = require('../../config/paths.js')
 
@@ -146,8 +147,8 @@ describe('GOV.UK Frontend', () => {
   describe('Sass documentation', () => {
     it('associates everything with a group', async () => {
       return sassdoc.parse([
-        `${configPaths.src}/**/*.scss`,
-        `!${configPaths.src}/vendor/*.scss`
+        `${slash(configPaths.src)}/**/*.scss`,
+        `!${slash(configPaths.src)}/vendor/*.scss`
       ])
         .then(docs => docs.forEach(doc => {
           return expect(doc).toMatchObject({

--- a/src/govuk/all.test.js
+++ b/src/govuk/all.test.js
@@ -147,8 +147,8 @@ describe('GOV.UK Frontend', () => {
   describe('Sass documentation', () => {
     it('associates everything with a group', async () => {
       return sassdoc.parse([
-        `${slash(configPaths.src)}/**/*.scss`,
-        `!${slash(configPaths.src)}/vendor/*.scss`
+        `${slash(configPaths.src)}/govuk/**/*.scss`,
+        `!${slash(configPaths.src)}/govuk/vendor/*.scss`
       ])
         .then(docs => docs.forEach(doc => {
           return expect(doc).toMatchObject({

--- a/src/govuk/components/components.template.test.js
+++ b/src/govuk/components/components.template.test.js
@@ -1,3 +1,4 @@
+const { join } = require('path')
 const { HtmlValidate } = require('html-validate')
 
 // We can't use the render function from jest-helpers, because we need control
@@ -18,7 +19,7 @@ describe('Components', () => {
   beforeAll(async () => {
     // Create a new Nunjucks environment that uses the src directory as its
     // base path, rather than the components folder itself
-    nunjucksEnvCustom = nunjucks.configure(configPaths.src)
+    nunjucksEnvCustom = nunjucks.configure(join(configPaths.src, 'govuk'))
     nunjucksEnvDefault = nunjucksEnv
 
     // Components list

--- a/src/govuk/helpers/helpers.test.js
+++ b/src/govuk/helpers/helpers.test.js
@@ -10,13 +10,13 @@ describe('The helpers layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'helpers/**/*.scss', {
+    sassFiles = await getListing(configPaths.src, 'govuk/helpers/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const helpers = join(configPaths.src, 'helpers', '_all.scss')
+    const helpers = join(configPaths.src, 'govuk/helpers/_all.scss')
 
     const output = await renderSass({ file: helpers })
     expect(output.css.toString()).toEqual('')
@@ -39,7 +39,7 @@ describe('The helpers layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "helpers" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'helpers', '*.scss'))
+      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/helpers/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/objects/objects.test.js
+++ b/src/govuk/objects/objects.test.js
@@ -10,7 +10,7 @@ describe('The objects layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'objects/**/*.scss', {
+    sassFiles = await getListing(configPaths.src, 'govuk/objects/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
@@ -32,7 +32,7 @@ describe('The objects layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "objects" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'objects', '*.scss'))
+      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/objects/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/settings/colours.test.js
+++ b/src/govuk/settings/colours.test.js
@@ -1,9 +1,10 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { join } = require('path')
 
+const { renderSass } = require('../../../lib/jest-helpers')
 const configPaths = require('../../../config/paths.js')
 
 const sassConfig = {
-  includePaths: [configPaths.src, 'node_modules/'],
+  includePaths: [join(configPaths.src, 'govuk'), 'node_modules/'],
   outputStyle: 'compressed'
 }
 

--- a/src/govuk/settings/settings.test.js
+++ b/src/govuk/settings/settings.test.js
@@ -10,13 +10,13 @@ describe('The settings layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'settings/**/*.scss', {
+    sassFiles = await getListing(configPaths.src, 'govuk/settings/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const settings = join(configPaths.src, 'settings', '_all.scss')
+    const settings = join(configPaths.src, 'govuk/settings/_all.scss')
 
     const output = await renderSass({ file: settings })
     expect(output.css.toString()).toEqual('')
@@ -39,7 +39,7 @@ describe('The settings layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "settings" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'settings', '*.scss'))
+      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/settings/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -1,13 +1,15 @@
+const crypto = require('crypto')
+const { join } = require('path')
+
 const nunjucks = require('nunjucks')
 const configPaths = require('../../config/paths.js')
-const crypto = require('crypto')
 
 const { renderTemplate } = require('../../lib/jest-helpers')
 
 describe('Template', () => {
   describe('with default nunjucks configuration', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(configPaths.src)
+      nunjucks.configure(join(configPaths.src, 'govuk'))
       const output = nunjucks.render('./template.njk')
       expect(output.charAt(0)).toEqual('<')
     })
@@ -15,7 +17,7 @@ describe('Template', () => {
 
   describe('with nunjucks block trimming enabled', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(configPaths.src, {
+      nunjucks.configure(join(configPaths.src, 'govuk'), {
         trimBlocks: true,
         lstripBlocks: true
       })

--- a/src/govuk/tools/tools.test.js
+++ b/src/govuk/tools/tools.test.js
@@ -10,13 +10,13 @@ describe('The tools layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'tools/**/*.scss', {
+    sassFiles = await getListing(configPaths.src, 'govuk/tools/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const tools = join(configPaths.src, 'tools', '_all.scss')
+    const tools = join(configPaths.src, 'govuk/tools/_all.scss')
 
     const output = await renderSass({ file: tools })
     expect(output.css.toString()).toEqual('')
@@ -39,7 +39,7 @@ describe('The tools layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "tools" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'tools', '*.scss'))
+      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/tools/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/tasks/asset-version.js
+++ b/tasks/asset-version.js
@@ -1,7 +1,6 @@
 const { rename, writeFile } = require('fs/promises')
 const { basename, join } = require('path')
 const { EOL } = require('os')
-const { cwd } = require('process')
 
 const configPaths = require('../config/paths.js')
 const { destination, isDist } = require('./task-arguments.js')
@@ -9,7 +8,7 @@ const { destination, isDist } = require('./task-arguments.js')
 // Update assets' version numbers
 // Uses the version number from `package/package.json` and writes it to various places
 async function updateDistAssetsVersion () {
-  const pkg = require(join(cwd(), configPaths.package, 'package.json'))
+  const pkg = require(join(configPaths.package, 'package.json'))
 
   if (!isDist) {
     throw new Error('Asset versions can only be applied to ./dist')

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,17 +1,20 @@
+const { basename, join } = require('path')
 const del = require('del')
+const slash = require('slash')
 
 const { destination } = require('./task-arguments.js')
+const cleanPath = slash(destination)
 
 function paths () {
-  const param = [`${destination}/**/*`]
+  const param = [slash(join(cleanPath, '**/*'))]
 
   // Preserve package files
-  if (destination === 'package') {
+  if (basename(cleanPath) === 'package') {
     param.push(
-      `!${destination}/`,
-      `!${destination}/package.json`,
-      `!${destination}/govuk-prototype-kit.config.json`,
-      `!${destination}/README.md`
+      `!${cleanPath}/`,
+      `!${cleanPath}/package.json`,
+      `!${cleanPath}/govuk-prototype-kit.config.json`,
+      `!${cleanPath}/README.md`
     )
   }
 
@@ -22,7 +25,7 @@ function clean () {
   return del(paths())
 }
 
-clean.displayName = `clean:${destination}`
+clean.displayName = `clean:${basename(cleanPath)}`
 
 module.exports = {
   paths,

--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -11,7 +11,7 @@ describe('dist/', () => {
   let listingDistAssets
 
   beforeAll(async () => {
-    listingSourceAssets = await getListing(join(configPaths.src, 'govuk/assets'))
+    listingSourceAssets = await getListing(configPaths.assets)
     listingDistAssets = await getListing(join(configPaths.dist, 'assets'))
   })
 

--- a/tasks/gulp/__tests__/after-build-dist.test.js
+++ b/tasks/gulp/__tests__/after-build-dist.test.js
@@ -1,18 +1,17 @@
 const { readFile } = require('fs/promises')
 const { join } = require('path')
-const { cwd } = require('process')
 
 const configPaths = require('../../../config/paths.js')
 const { getListing } = require('../../../lib/file-helper')
 
 describe('dist/', () => {
-  const pkg = require(join(cwd(), configPaths.package, 'package.json'))
+  const pkg = require(join(configPaths.package, 'package.json'))
 
   let listingSourceAssets
   let listingDistAssets
 
   beforeAll(async () => {
-    listingSourceAssets = await getListing(join(configPaths.src, 'assets'))
+    listingSourceAssets = await getListing(join(configPaths.src, 'govuk/assets'))
     listingDistAssets = await getListing(join(configPaths.dist, 'assets'))
   })
 

--- a/tasks/gulp/__tests__/after-build-package.test.js
+++ b/tasks/gulp/__tests__/after-build-package.test.js
@@ -18,7 +18,7 @@ describe('package/', () => {
   let componentNames
 
   beforeAll(async () => {
-    listingSource = await getListing(join(configPaths.src, '../'))
+    listingSource = await getListing(configPaths.src)
     listingPackage = await getListing(configPaths.package)
 
     componentsFilesSource = await getListing(configPaths.components)

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -30,14 +30,14 @@ gulp.task('scss:compile', function () {
   if (isDist) {
     return merge(
       compileStyles(
-        gulp.src(`${configPaths.src}all.scss`)
+        gulp.src(`${slash(configPaths.src)}/all.scss`)
           .pipe(rename({
             basename: 'govuk-frontend',
             extname: '.min.css'
           }))),
 
       compileStyles(
-        gulp.src(`${configPaths.src}all-ie8.scss`)
+        gulp.src(`${slash(configPaths.src)}/all-ie8.scss`)
           .pipe(rename({
             basename: 'govuk-frontend-ie8',
             extname: '.min.css'
@@ -49,15 +49,15 @@ gulp.task('scss:compile', function () {
   // Review application
   return merge(
     compileStyles(
-      gulp.src(`${configPaths.app}assets/scss/app?(-ie8).scss`)),
+      gulp.src(`${slash(configPaths.app)}/assets/scss/app?(-ie8).scss`)),
 
     compileStyles(
-      gulp.src(`${configPaths.app}assets/scss/app-legacy?(-ie8).scss`), {
+      gulp.src(`${slash(configPaths.app)}/assets/scss/app-legacy?(-ie8).scss`), {
         includePaths: ['node_modules/govuk_frontend_toolkit/stylesheets', 'node_modules']
       }),
 
     compileStyles(
-      gulp.src(`${configPaths.fullPageExamples}**/styles.scss`)
+      gulp.src(`${slash(configPaths.fullPageExamples)}/**/styles.scss`)
         .pipe(rename((path) => {
           path.basename = path.dirname
           path.dirname = 'full-page-examples'
@@ -105,10 +105,10 @@ gulp.task('js:compile', async () => {
 
     // This is combined with destPath in gulp.dest()
     // so the files are output to the correct folders
-    const modulePath = slash(srcPath).replace(/^govuk/, '')
+    const modulePath = slash(srcPath).replace(/^govuk\/?/, '')
 
     // We only want to give component JavaScript a unique module name
-    const moduleName = minimatch(srcPath, 'components/**')
+    const moduleName = minimatch(srcPath, '**/components/**')
       ? componentNameToJavaScriptModuleName(name)
       : 'GOVUKFrontend'
 

--- a/tasks/gulp/compile-assets.js
+++ b/tasks/gulp/compile-assets.js
@@ -30,14 +30,14 @@ gulp.task('scss:compile', function () {
   if (isDist) {
     return merge(
       compileStyles(
-        gulp.src(`${slash(configPaths.src)}/all.scss`)
+        gulp.src(`${slash(configPaths.src)}/govuk/all.scss`)
           .pipe(rename({
             basename: 'govuk-frontend',
             extname: '.min.css'
           }))),
 
       compileStyles(
-        gulp.src(`${slash(configPaths.src)}/all-ie8.scss`)
+        gulp.src(`${slash(configPaths.src)}/govuk/all-ie8.scss`)
           .pipe(rename({
             basename: 'govuk-frontend-ie8',
             extname: '.min.css'
@@ -95,7 +95,7 @@ gulp.task('js:compile', async () => {
     : destination
 
   // For dist/ folder we only want compiled 'all.js'
-  const fileLookup = isDist ? 'all.mjs' : '**/!(*.test).mjs'
+  const fileLookup = isDist ? 'govuk/all.mjs' : 'govuk/**/!(*.test).mjs'
 
   // Perform a search and return an array of matching file names
   const srcFiles = await getListing(configPaths.src, fileLookup)

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -21,8 +21,8 @@ gulp.task('copy:files', () => {
      * Includes only source JavaScript ECMAScript (ES) modules
      */
     gulp.src([
-      `${slash(configPaths.src)}/**/*.mjs`,
-      `!${slash(configPaths.src)}/**/*.test.*`
+      `${slash(configPaths.src)}/govuk/**/*.mjs`,
+      `!${slash(configPaths.src)}/govuk/**/*.test.*`
     ]).pipe(gulp.dest(slash(join(destination, 'govuk-esm')))),
 
     /**
@@ -31,7 +31,7 @@ gulp.task('copy:files', () => {
      */
     merge(
       gulp.src([
-        `${slash(configPaths.src)}/**/*`,
+        `${slash(configPaths.src)}/govuk/**/*`,
 
         // Exclude files we don't want to publish
         '!**/.DS_Store',
@@ -42,22 +42,22 @@ gulp.task('copy:files', () => {
 
         // Preserve destination README when copying to ./package
         // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
-        `!${slash(configPaths.src)}/README.md`,
+        `!${slash(configPaths.src)}/govuk/README.md`,
 
         // Exclude Sass files handled by PostCSS stream below
-        `!${slash(configPaths.src)}/**/*.scss`,
+        `!${slash(configPaths.src)}/govuk/**/*.scss`,
 
         // Exclude source YAML handled by JSON streams below
         `!${slash(configPaths.components)}/**/*.yaml`
       ]),
 
       // Add CSS prefixes to Sass
-      gulp.src(`${slash(configPaths.src)}/**/*.scss`)
+      gulp.src(`${slash(configPaths.src)}/govuk/**/*.scss`)
         .pipe(postcss([autoprefixer], { syntax: postcssScss })),
 
       // Generate fixtures.json from ${componentName}.yaml
       gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
-        base: slash(configPaths.src)
+        base: slash(`${configPaths.src}/govuk`)
       })
         .pipe(map((file, done) =>
           generateFixtures(file)
@@ -71,7 +71,7 @@ gulp.task('copy:files', () => {
 
       // Generate macro-options.json from ${componentName}.yaml
       gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
-        base: slash(configPaths.src)
+        base: slash(`${configPaths.src}/govuk`)
       })
         .pipe(map((file, done) =>
           generateMacroOptions(file)

--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -21,8 +21,8 @@ gulp.task('copy:files', () => {
      * Includes only source JavaScript ECMAScript (ES) modules
      */
     gulp.src([
-      `${configPaths.src}**/*.mjs`,
-      `!${configPaths.src}**/*.test.*`
+      `${slash(configPaths.src)}/**/*.mjs`,
+      `!${slash(configPaths.src)}/**/*.test.*`
     ]).pipe(gulp.dest(slash(join(destination, 'govuk-esm')))),
 
     /**
@@ -31,7 +31,7 @@ gulp.task('copy:files', () => {
      */
     merge(
       gulp.src([
-        `${configPaths.src}**/*`,
+        `${slash(configPaths.src)}/**/*`,
 
         // Exclude files we don't want to publish
         '!**/.DS_Store',
@@ -42,21 +42,23 @@ gulp.task('copy:files', () => {
 
         // Preserve destination README when copying to ./package
         // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
-        `!${configPaths.src}README.md`,
+        `!${slash(configPaths.src)}/README.md`,
 
         // Exclude Sass files handled by PostCSS stream below
-        `!${configPaths.src}**/*.scss`,
+        `!${slash(configPaths.src)}/**/*.scss`,
 
         // Exclude source YAML handled by JSON streams below
-        `!${configPaths.components}**/*.yaml`
+        `!${slash(configPaths.components)}/**/*.yaml`
       ]),
 
       // Add CSS prefixes to Sass
-      gulp.src(`${configPaths.src}**/*.scss`)
+      gulp.src(`${slash(configPaths.src)}/**/*.scss`)
         .pipe(postcss([autoprefixer], { syntax: postcssScss })),
 
       // Generate fixtures.json from ${componentName}.yaml
-      gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
+      gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
+        base: slash(configPaths.src)
+      })
         .pipe(map((file, done) =>
           generateFixtures(file)
             .then((fixture) => done(null, fixture))
@@ -68,7 +70,9 @@ gulp.task('copy:files', () => {
         })),
 
       // Generate macro-options.json from ${componentName}.yaml
-      gulp.src(`${configPaths.components}**/*.yaml`, { base: configPaths.src })
+      gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
+        base: slash(configPaths.src)
+      })
         .pipe(map((file, done) =>
           generateMacroOptions(file)
             .then((macro) => done(null, macro))

--- a/tasks/gulp/watch.js
+++ b/tasks/gulp/watch.js
@@ -1,4 +1,6 @@
 const gulp = require('gulp')
+const slash = require('slash')
+
 const configPaths = require('../../config/paths.js')
 
 /**
@@ -11,15 +13,15 @@ gulp.task('watch', () => {
   return Promise.all([
     gulp.watch([
       'sassdoc.config.yaml',
-      `${configPaths.src}**/**/*.scss`,
-      `${configPaths.app}assets/scss/**/*.scss`,
-      `${configPaths.fullPageExamples}**/*.scss`,
-      `!${configPaths.src}vendor/*`
+      `${slash(configPaths.src)}/**/**/*.scss`,
+      `${slash(configPaths.app)}/assets/scss/**/*.scss`,
+      `${slash(configPaths.fullPageExamples)}/**/*.scss`,
+      `!${slash(configPaths.src)}/vendor/*`
     ], gulp.series('styles')),
 
     gulp.watch([
       'jsdoc.config.js',
-      `${configPaths.src}**/**/*.mjs`
+      `${slash(configPaths.src)}/**/*.mjs`
     ], gulp.series('scripts'))
   ])
 })

--- a/tasks/gulp/watch.js
+++ b/tasks/gulp/watch.js
@@ -13,15 +13,15 @@ gulp.task('watch', () => {
   return Promise.all([
     gulp.watch([
       'sassdoc.config.yaml',
-      `${slash(configPaths.src)}/**/**/*.scss`,
+      `${slash(configPaths.src)}/govuk/**/**/*.scss`,
       `${slash(configPaths.app)}/assets/scss/**/*.scss`,
       `${slash(configPaths.fullPageExamples)}/**/*.scss`,
-      `!${slash(configPaths.src)}/vendor/*`
+      `!${slash(configPaths.src)}/govuk/vendor/*`
     ], gulp.series('styles')),
 
     gulp.watch([
       'jsdoc.config.js',
-      `${slash(configPaths.src)}/**/*.mjs`
+      `${slash(configPaths.src)}/govuk/**/*.mjs`
     ], gulp.series('scripts'))
   ])
 })

--- a/tasks/prototype-kit-config.js
+++ b/tasks/prototype-kit-config.js
@@ -1,8 +1,8 @@
 const { copyFile, mkdir, writeFile } = require('fs/promises')
 const { EOL } = require('os')
 const { dirname, join } = require('path')
-const { cwd } = require('process')
 
+const configPaths = require('../config/paths.js')
 const { destination } = require('./task-arguments.js')
 
 /**
@@ -21,8 +21,8 @@ async function updatePrototypeKitConfig () {
 
   // Copy files to destination
   const configTasks = copyFiles.map(async (file) => {
-    const fileSource = join(cwd(), 'src', file)
-    const fileTarget = join(cwd(), destination, file)
+    const fileSource = join(configPaths.src, file)
+    const fileTarget = join(destination, file)
 
     // Create destination directory
     await mkdir(dirname(fileTarget), { recursive: true })

--- a/tasks/task-arguments.js
+++ b/tasks/task-arguments.js
@@ -1,4 +1,4 @@
-const { dirname, relative, resolve } = require('path')
+const { dirname, resolve } = require('path')
 
 const slash = require('slash')
 const { argv } = require('yargs')
@@ -23,13 +23,13 @@ const destination = argv.destination || (destinations
   .filter(({ task }) => tasks.includes(task))[0]?.destination ?? 'public')
 
 const rootPath = dirname(__dirname)
-const destPath = resolve(rootPath, destination)
+const destPath = resolve(rootPath, slash(destination))
 
 module.exports = {
   argv,
 
-  // Normalise slashes (Windows) for gulp.src
-  destination: slash(relative(rootPath, destPath)),
+  // Absolute path to destination
+  destination: destPath,
 
   // Check destination flags
   isPackage: destination === 'package',

--- a/tasks/task-arguments.unit.test.js
+++ b/tasks/task-arguments.unit.test.js
@@ -1,3 +1,8 @@
+const { cwd } = require('process')
+const { join } = require('path')
+
+const configPaths = require('../config/paths.js')
+
 describe('Task arguments', () => {
   let args
 
@@ -28,49 +33,49 @@ describe('Task arguments', () => {
           process.argv = [...argv]
 
           const { destination } = await import('./task-arguments.js')
-          expect(destination).toEqual('public')
+          expect(destination).toEqual(configPaths.public)
         })
 
         it('defaults to ./public for "gulp build:compile"', async () => {
           process.argv = [...argv, 'build:compile']
 
           const { destination } = await import('./task-arguments.js')
-          expect(destination).toEqual('public')
+          expect(destination).toEqual(configPaths.public)
         })
 
         it('defaults to ./package for "gulp build:package"', async () => {
           process.argv = [...argv, 'build:package']
 
           const { destination } = await import('./task-arguments.js')
-          expect(destination).toEqual('package')
+          expect(destination).toEqual(configPaths.package)
         })
 
         it('defaults to ./dist for "gulp build:dist"', async () => {
           process.argv = [...argv, 'build:dist']
 
           const { destination } = await import('./task-arguments.js')
-          expect(destination).toEqual('dist')
+          expect(destination).toEqual(configPaths.dist)
         })
       })
 
       describe.each(
         [
-        // Override to public
-          { flag: 'public', destination: 'public' },
-          { flag: './public', destination: 'public' },
+          // Override to public
+          { flag: 'public', destination: configPaths.public },
+          { flag: './public', destination: configPaths.public },
 
           // Override to package
-          { flag: 'package', destination: 'package' },
-          { flag: './package', destination: 'package' },
+          { flag: 'package', destination: configPaths.package },
+          { flag: './package', destination: configPaths.package },
 
           // Override to dist
-          { flag: 'dist', destination: 'dist' },
-          { flag: './dist', destination: 'dist' },
+          { flag: 'dist', destination: configPaths.dist },
+          { flag: './dist', destination: configPaths.dist },
 
           // Override to custom
-          { flag: 'custom/location/here', destination: 'custom/location/here' },
-          { flag: 'custom\\location\\here', destination: 'custom/location/here' },
-          { flag: './custom/location/here', destination: 'custom/location/here' }
+          { flag: 'custom/location/here', destination: join(cwd(), 'custom/location/here') },
+          { flag: 'custom\\location\\here', destination: join(cwd(), 'custom/location/here') },
+          { flag: './custom/location/here', destination: join(cwd(), 'custom/location/here') }
         ]
       )('Override --destination "$flag"', ({ flag, destination: expected }) => {
         it('uses flag by default', async () => {


### PR DESCRIPTION
This PR addresses a few code review comments that have come up recently

**Where are my files?**
Having to use the variable `process.cwd()` to find where the project root

```mjs
const pathToPackage = join(cwd(), configPaths.package, 'package.json')
```

**Where is the src directory?**
We suffix "govuk" into `configPaths.src` but (can) forget to join it to destination paths

```mjs
const pathToSrc = join(configPaths.src, 'all.scss') // Hmm, no `govuk`?
const pathToDest = join(configPaths.package, 'govuk', 'all.scss')
```

**Where is the _actual_ src directory?**
Remembering to add `../` to remove the "govuk" suffix

```mjs
const pathToSrcForReal = join(cwd(), configPaths.src, '../')
```

This PR makes all our config paths absolute and removes the "govuk" suffix by default

## Config paths
We currently used relative paths with trailing slashes

### Before
Relative ish file paths
```mjs
import configPaths from '../../config/paths.js'

configPaths.app     // relative 'app/'
configPaths.dist    // relative 'dist/'
configPaths.package // relative 'package/'
configPaths.public  // relative 'public/'
```

### After (macOS, Linux)
Absolute file paths

```mjs
import configPaths from '../../config/paths.js'

configPaths.app     // absolute '/path/to/project/govuk-frontend/app'
configPaths.dist    // absolute '/path/to/project/govuk-frontend/dist'
configPaths.package // absolute '/path/to/project/govuk-frontend/package'
configPaths.public  // absolute '/path/to/project/govuk-frontend/public'
```

### After (Windows)
Absolute file paths

```mjs
import configPaths from '../../config/paths.js'

configPaths.app     // absolute 'C:\\path\\to\\project\\govuk-frontend\\app'
configPaths.dist    // absolute 'C:\\path\\to\\project\\govuk-frontend\\dist'
configPaths.package // absolute 'C:\\path\\to\\project\\govuk-frontend\\package'
configPaths.public  // absolute 'C:\\path\\to\\project\\govuk-frontend\\public'
```