### PR TITLE
Prevent Percy duplicate Chromium download

### DIFF
--- a/.percy.js
+++ b/.percy.js
@@ -1,0 +1,11 @@
+const { executablePath } = require('puppeteer')
+
+/** @type {import('@percy/config').PercyConfigObject} */
+module.exports = {
+  discovery: {
+    launchOptions: {
+      executable: executablePath()
+    }
+  },
+  version: 2
+}

--- a/.percy.js
+++ b/.percy.js
@@ -7,5 +7,8 @@ module.exports = {
       executable: executablePath()
     }
   },
+  percy: {
+    deferUploads: true
+  },
   version: 2
 }


### PR DESCRIPTION
This PR stops Percy downloading Chromium when it's already saved

For context, the [Puppeteer v19.00 update](https://github.com/puppeteer/puppeteer/releases/tag/v19.0.0) moved the Chromium binary download location to `~/.cache/puppeteer` (global) from the old `./node_modules/puppeteer-core/.local-chromium` (local)

Percy looks in the previous `.local-chromium` location
https://github.com/percy/cli/blob/bf551295a8a618502bb2db92ff302e19dc956b51/packages/core/src/install.js#L129

```console
[percy] A new version of @percy/cli is available! 1.12.0 -> 1.13.0

[percy] Downloading Chromium 929511...
[percy] Successfully downloaded Chromium 929511
[percy] Percy has started!
```

Our screenshot tests have started running slower recently, but until [`@percy/puppeteer`](https://github.com/percy/percy-puppeteer) upgrades to Puppeteer v19.00 we can remove the Chromium download time by setting the path in [`.percy.js`](https://github.com/alphagov/govuk-frontend/blob/percy-chromium-double-download/.percy.js) instead (see [**Configuration** docs](https://docs.percy.io/docs/cli-configuration))

This PR includes a few things:

1. Prevent Percy duplicate Chromium download
2. Delay Percy screenshot upload until all captures are complete