### PR TITLE
Update `copy:files` to glob “src” not “src/govuk”

### DIFF
--- a/tasks/gulp/copy-to-destination.js
+++ b/tasks/gulp/copy-to-destination.js
@@ -31,7 +31,7 @@ gulp.task('copy:files', () => {
      */
     merge(
       gulp.src([
-        `${slash(configPaths.src)}/govuk/**/*`,
+        `${slash(configPaths.src)}/**/*`,
 
         // Exclude files we don't want to publish
         '!**/.DS_Store',
@@ -45,19 +45,19 @@ gulp.task('copy:files', () => {
         `!${slash(configPaths.src)}/govuk/README.md`,
 
         // Exclude Sass files handled by PostCSS stream below
-        `!${slash(configPaths.src)}/govuk/**/*.scss`,
+        `!${slash(configPaths.src)}/**/*.scss`,
 
         // Exclude source YAML handled by JSON streams below
         `!${slash(configPaths.components)}/**/*.yaml`
       ]),
 
       // Add CSS prefixes to Sass
-      gulp.src(`${slash(configPaths.src)}/govuk/**/*.scss`)
+      gulp.src(`${slash(configPaths.src)}/**/*.scss`)
         .pipe(postcss([autoprefixer], { syntax: postcssScss })),
 
       // Generate fixtures.json from ${componentName}.yaml
       gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
-        base: slash(`${configPaths.src}/govuk`)
+        base: slash(configPaths.src)
       })
         .pipe(map((file, done) =>
           generateFixtures(file)
@@ -71,7 +71,7 @@ gulp.task('copy:files', () => {
 
       // Generate macro-options.json from ${componentName}.yaml
       gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
-        base: slash(`${configPaths.src}/govuk`)
+        base: slash(configPaths.src)
       })
         .pipe(map((file, done) =>
           generateMacroOptions(file)
@@ -82,7 +82,7 @@ gulp.task('copy:files', () => {
           basename: 'macro-options',
           extname: '.json'
         }))
-    ).pipe(gulp.dest(slash(join(destination, 'govuk'))))
+    ).pipe(gulp.dest(slash(destination)))
   )
 })
 

--- a/tasks/prototype-kit-config.js
+++ b/tasks/prototype-kit-config.js
@@ -1,8 +1,7 @@
-const { copyFile, mkdir, writeFile } = require('fs/promises')
+const { writeFile } = require('fs/promises')
 const { EOL } = require('os')
-const { dirname, join } = require('path')
+const { join } = require('path')
 
-const configPaths = require('../config/paths.js')
 const { destination } = require('./task-arguments.js')
 
 /**
@@ -13,33 +12,12 @@ const { destination } = require('./task-arguments.js')
 async function updatePrototypeKitConfig () {
   const { default: configFn } = await import('../src/govuk-prototype-kit/govuk-prototype-kit.config.mjs')
 
-  // Files to copy
-  const copyFiles = [
-    join('govuk-prototype-kit', 'init.js'),
-    join('govuk-prototype-kit', 'init.scss')
-  ]
-
-  // Copy files to destination
-  const configTasks = copyFiles.map(async (file) => {
-    const fileSource = join(configPaths.src, file)
-    const fileTarget = join(destination, file)
-
-    // Create destination directory
-    await mkdir(dirname(fileTarget), { recursive: true })
-
-    // Copy file to destination
-    return copyFile(fileSource, fileTarget)
-  })
-
   // JSON config file path + contents
   const configPath = join(destination, 'govuk-prototype-kit.config.json')
   const configJSON = JSON.stringify(await configFn(), null, 2) + EOL
 
   // Write JSON config file
-  configTasks.push(writeFile(configPath, configJSON))
-
-  // Resolve on completion
-  return Promise.all(configTasks)
+  return writeFile(configPath, configJSON)
 }
 
 updatePrototypeKitConfig.displayName = 'update-prototype-kit-config'


### PR DESCRIPTION
This PR widens `gulp copy:files` to glob `./src/**/*` not just the "govuk" directory

Why? Since https://github.com/alphagov/govuk-frontend/pull/2851 was merged we're now running build tasks on files within:

```console
./src/govuk
./src/govuk-prototype-kit
```



As suggested by @36degrees in https://github.com/alphagov/govuk-frontend/pull/2851#pullrequestreview-1167005193 we could remove some unnecessary file operations:

> (I think it'd be neater if the `.js` and `.scss` files were handled by the existing copy-files task, but that looks like it's caught up in the fact that config.src is actually `src/govuk` so happy to revisit that later)

These changes were made possible by:

* https://github.com/alphagov/govuk-frontend/pull/2962 