### PR TITLE
Improve colour contrast of Crown Copyright logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ This was introduced in [pull request #2844: Remove compatibility mode from govuk
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
+- [#2972: Improve colour contrast of Crown Copyright logo](https://github.com/alphagov/govuk-frontend/pull/2972)
 - [#2807: Tidy up and refactor the Character Count JavaScript](https://github.com/alphagov/govuk-frontend/pull/2807)
 - [#2811: Use Element.id to get module id for accordion](https://github.com/alphagov/govuk-frontend/pull/2811)
 - [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -121,7 +121,6 @@
     @include govuk-device-pixel-ratio {
       background-image: govuk-image-url("govuk-crest-2x.png");
     }
-    background-repeat: no-repeat;
     background-size: contain;
 
     @supports (mask-image: url("")) {
@@ -132,7 +131,6 @@
       @include govuk-device-pixel-ratio {
         mask-image: govuk-image-url("govuk-crest-2x.png");
       }
-      mask-repeat: no-repeat;
       mask-size: contain;
     }
   }

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -106,17 +106,35 @@
 
   .govuk-footer__copyright-logo {
     display: inline-block;
-    min-width: $govuk-footer-crest-image-width;
-    padding-top: ($govuk-footer-crest-image-height + govuk-spacing(2));
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .govuk-footer__copyright-logo:before {
+    content: "";
+    display: block;
+    width: $govuk-footer-crest-image-width;
+    height: $govuk-footer-crest-image-height;
+    margin: auto;
+    margin-bottom: govuk-spacing(2);
     background-image: govuk-image-url("govuk-crest.png");
     @include govuk-device-pixel-ratio {
       background-image: govuk-image-url("govuk-crest-2x.png");
     }
     background-repeat: no-repeat;
-    background-position: 50% 0%;
-    background-size: $govuk-footer-crest-image-width $govuk-footer-crest-image-height;
-    text-align: center;
-    white-space: nowrap;
+    background-size: contain;
+
+    @supports (mask-image: url("")) {
+      // Use masks to change the colour of the crest to match the current text color
+      // to increase the contrast of the logo
+      background: currentcolor;
+      mask-image: govuk-image-url("govuk-crest.png");
+      @include govuk-device-pixel-ratio {
+        mask-image: govuk-image-url("govuk-crest-2x.png");
+      }
+      mask-repeat: no-repeat;
+      mask-size: contain;
+    }
   }
 
   .govuk-footer__inline-list {


### PR DESCRIPTION
Increases the copyright crest logo contrast to match the surrounding text and match the OGL logo.

[mask-image is available in modern browsers (with -webkit- prefix for some which is generated automatically)](https://caniuse.com/?search=mask-image) and we fallback to regular background-image in all other browsers.

Tested as functional (same as before) in  Internet Explorer 9-11.

Tested to increase contrast in Firefox latest, Chrome latest, Safari latest, iOS Safari latest, Chrome for Android latest.

## Screenshots

| Before | After |
| - | - |
| ![Crest with light grey color](https://user-images.githubusercontent.com/2445413/200349246-cbafd679-4d9e-4d31-a0f3-c42868e1d560.png) | ![Crest with darker colour matching text](https://user-images.githubusercontent.com/2445413/200349343-941675fe-8f7b-4365-ae09-e4e3630f256d.png) |


Closes #2134