### PR TITLE
Use `innerText` instead of `textContent`

### DIFF
--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -261,16 +261,16 @@ Accordion.prototype.setExpanded = function (expanded, $section) {
     ? this.i18n.t('hideSection')
     : this.i18n.t('showSection')
 
-  $showHideText.textContent = newButtonText
+  $showHideText.innerText = newButtonText
   $button.setAttribute('aria-expanded', expanded)
 
   // Update aria-label combining
   var $header = $section.querySelector('.' + this.sectionHeadingTextClass)
-  var ariaLabelParts = [$header.textContent.trim()]
+  var ariaLabelParts = [$header.innerText.trim()]
 
   var $summary = $section.querySelector('.' + this.sectionSummaryClass)
   if ($summary) {
-    ariaLabelParts.push($summary.textContent.trim())
+    ariaLabelParts.push($summary.innerText.trim())
   }
 
   var ariaLabelMessage = expanded
@@ -323,7 +323,7 @@ Accordion.prototype.updateShowAllButton = function (expanded) {
     ? this.i18n.t('hideAllSections')
     : this.i18n.t('showAllSections')
   this.$showAllButton.setAttribute('aria-expanded', expanded)
-  $showAllText.textContent = newButtonText
+  $showAllText.innerText = newButtonText
 
   // Swap icon, toggle class
   if (expanded) {

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -128,8 +128,8 @@ CharacterCount.prototype.init = function () {
   // Inject a decription for the textarea if none is present already
   // for when the component was rendered with no maxlength, maxwords
   // nor custom textareaDescriptionText
-  if ($textareaDescription.textContent.match(/^\s*$/)) {
-    $textareaDescription.textContent = this.i18n.t('textareaDescription', { count: this.maxLength })
+  if ($textareaDescription.innerText.match(/^\s*$/)) {
+    $textareaDescription.innerText = this.i18n.t('textareaDescription', { count: this.maxLength })
   }
 
   // Move the textarea description to be immediately after the textarea
@@ -281,7 +281,7 @@ CharacterCount.prototype.updateVisibleCountMessage = function () {
   }
 
   // Update message
-  $visibleCountMessage.textContent = this.getCountMessage()
+  $visibleCountMessage.innerText = this.getCountMessage()
 }
 
 /**
@@ -299,7 +299,7 @@ CharacterCount.prototype.updateScreenReaderCountMessage = function () {
   }
 
   // Update message
-  $screenReaderCountMessage.textContent = this.getCountMessage()
+  $screenReaderCountMessage.innerText = this.getCountMessage()
 }
 
 /**


### PR DESCRIPTION
IE8 [does not support `Node.textContent`][1] but [does support `HTMLElement.innerText`][2].

This means at the minute in IE8:
- we're seeing the error "'textContent' is null or not an object" on any page that uses the Character Count or Accordion (which also causes script execution to stop, affecting other components on the page)
- the Accordion is missing text for the 'Show/Hide all sections' and 'Show/Hide section' buttons
- the Character Count is displaying the fallback message

[According to MDN][3], the main differences between `Node.textContent` and `HTMLElement.innerText` are:

> - `textContent` gets the content of all elements, including `<script>` and `<style>` elements. In contrast, `innerText` only shows "human-readable" elements.
> - `textContent` returns every element in the node. In contrast, `innerText` is aware of styling and won't return the text of "hidden" elements. Moreover, since `innerText` takes CSS styles into account, reading the value of `innerText` triggers a reflow to ensure up-to-date computed styles. (Reflows can be computationally expensive, and thus should be avoided when possible.)
> - Both `textContent` and `innerText` remove child nodes when altered, but altering `innerText` in Internet Explorer (version 11 and below) also permanently destroys all descendant text nodes. It is impossible to insert the nodes again into any other element or into the same element after doing so.

Other than triggering a reflow, I don't think any of these are relevant where we're currently using `textContent`, so we should use `innerText` in order to support these older browsers.

(We might want to consider swapping back to `textContent` once we have dropped support for IE8 to avoid the unneccesary reflows)

[1]: https://caniuse.com/textcontent
[2]: https://caniuse.com/innertext
[3]: https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent#differences_from_innertext