### PR TITLE
Updates documentation of Nunjucks options

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -18,27 +18,27 @@ params:
 - name: hideAllSectionsText
   type: string
   required: false
-  description: The text content of the toggle at the top of the accordion when all sections are expanded. Defaults to 'Hide all sections'.
+  description: The text content of the 'Hide all sections' button at the top of the accordion when at least one section is expanded.
 - name: hideSectionText
   type: string
   required: false
-  description: The text content of the toggle within each section of the accordion, visible when the section is expanded. Defaults to 'Hide'.
+  description: The text content of the 'Hide' button within each section of the accordion, which is visible when the section is expanded.
 - name: hideSectionAriaLabelText
   type: string
   required: false
-  description: Text made available to assistive technologies, like screen-readers, as part of the toggle's accessible name when the section is expanded. Defaults to 'Hide this section'
+  description: Text made available to assistive technologies, like screen-readers, as the final part of the toggle's accessible name when the section is expanded. Defaults to 'Hide this section'.
 - name: showAllSectionsText
   type: string
   required: false
-  description: The text content of the toggle at the top of the accordion when some or all sections are collapsed. Defaults to 'Show all sections'.
+  description: The text content of the 'Show all sections' button at the top of the accordion when all sections are collapsed.
 - name: showSectionText
   type: string
   required: false
-  description: The text content of the toggle within each section of the accordion, visible when the section is collapsed. Defaults to 'Show'.
+  description: The text content of the 'Show' button within each section of the accordion, which is visible when the section is collapsed.
 - name: showSectionAriaLabelText
   type: string
   required: false
-  description: Text made available to assistive technologies, like screen-readers, as part of the toggle's accessible name when the section is collapsed. Defaults to 'Show this section'
+  description: Text made available to assistive technologies, like screen-readers, as the final part of the toggle's accessible name when the section is collapsed. Defaults to 'Show this section'.
 - name: items
   type: array
   required: true

--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -37,10 +37,6 @@ params:
   required: false
   description: Options for the hint component.
   isComponent: true
-- name: textareaDescriptionText
-  type: string
-  required: false
-  description: Text describing the maximum number of characters you can enter, which is announced to screen readers. The text is displayed as a fallback if the character count JavaScript does not run. Depending on how you configure this component and what parameters you add, instances of `%{count}` are replaced by the value of `maxwords`. If not configured, it uses `maxlength`. By default, textarea description is provided in English.
 - name: errorMessage
   type: object
   required: false
@@ -76,6 +72,34 @@ params:
     type: string
     required: false
     description: Classes to add to the count message.
+- name: textareaDescriptionText
+  type: string
+  required: false
+  description: Message made available to assistive technologies to describe that the component accepts only a limited amount of content. It is visible on the page when JavaScript is unavailable. The component will replace the `%{count}` placeholder with the value of the `maxlength` or `maxwords` parameter.
+- name: charactersUnderLimitText
+  type: object
+  required: false
+  description: Message displayed when the number of characters is under the configured maximum, `maxlength`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of remaining characters. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+- name: charactersAtLimitText
+  type: string
+  required: false
+  description: Message displayed when the number of characters reaches the configured maximum, `maxlength`. This message is displayed visually and through assistive technologies.
+- name: charactersUnderLimitText
+  type: object
+  required: false
+  description: Message displayed when the number of characters is over the configured maximum, `maxlength`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of characters above the maximum. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+- name: wordsUnderLimitText
+  type: object
+  required: false
+  description: Message displayed when the number of words is under the configured maximum, `maxwords`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of remaining words. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+- name: wordsAtLimitText
+  type: string
+  required: false
+  description: Message displayed when the number of words reaches the configured maximum, `maxwords`. This message is displayed visually and through assistive technologies.
+- name: wordsUnderLimitText
+  type: object
+  required: false
+  description: Message displayed when the number of words is over the configured maximum, `maxwords`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of characters above the maximum. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
 
 examples:
   - name: default

--- a/src/govuk/components/footer/footer.yaml
+++ b/src/govuk/components/footer/footer.yaml
@@ -70,7 +70,7 @@ params:
 - name: contentLicence
   type: object
   required: false
-  description: Object containing options for the content licence.
+  description: The content licence information. Defaults to Open Government Licence (OGL) v3 licence.
   params:
   - name: text
     type: string
@@ -83,7 +83,7 @@ params:
 - name: copyright
   type: object
   required: false
-  description: Object containing options for the copyright notice.
+  description: The copyright information, this defaults to Crown Copyright.
   params:
   - name: text
     type: string

--- a/src/govuk/components/header/header.yaml
+++ b/src/govuk/components/header/header.yaml
@@ -55,11 +55,11 @@ params:
 - name: menuButtonLabel
   type: string
   required: false
-  description: Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to 'Show or hide menu'.
+  description: Text for the `aria-label` attribute of the button that opens the mobile navigation, if there is a mobile navigation menu. Defaults to 'Show or hide menu'.
 - name: menuButtonText
   type: string
   required: false
-  description: Text for the button that toggles the navigation. This should be the shortest useful text that describes the button's purpose. Defaults to 'Menu'.
+  description: Text of the button that opens the mobile navigation menu, if there is a mobile navigation menu. There is no enforced character limit, but there is a limited display space so keep text as short as possible. By default, this is set to 'Menu'.
 - name: containerClasses
   type: string
   required: false


### PR DESCRIPTION
Pulls documentation of the Nunjucks options related to I18n from the draft and into each component's YAML file (half the last step of #2944, other half being #2986).

These are the following components:
- Accordion - Default values have been set in quotes rather than bold for consistency with the rest of our options documentation. 
- Character Count - Missing options have been added
- Footer - Draft listed options that have not been implemented as part of this work, so that don't appear here. Unlike other components, note that options describe their default, and don't provide their actual value as they're a bit more than just text 
- Header - Default value has been set in quotes. The `menuButtonLabel` option has also be updated to match how the button was described.