### PR TITLE
Update content of JSDoc

### DIFF
--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -405,16 +405,20 @@ export default Accordion
 
 /**
  * @typedef {object} AccordionTranslations
- * @property {string} [hideAllSections] - Text for 'Hide all sections' button,
- *   used when at least one section is expanded
- * @property {string} [hideSection] - Text for 'Hide' button, used when a
- * section is expanded
- * @property {string} [hideSectionAriaLabel] - Text appended to the 'Hide'
- * button's accessible name when a section is expanded
- * @property {string} [showAllSections] - Text for 'Show all sections' button,
- *   used when all sections are collapsed
- * @property {string} [showSection] - Text for 'Show' button, used when a
- * section is collapsed
- * @property {string} [showSectionAriaLabel] - Text appended to the 'Show'
- * button's accessible name when a section is collapsed
+ *
+ * Messages used by the component for the labels of its buttons. This includes
+ * the visible text shown on screen, and text to help assistive technology users
+ * for the buttons toggling each section.
+ * @property {string} [hideAllSections] - The text content for the 'Hide all
+ * sections' button, used when at least one section is expanded.
+ * @property {string} [hideSection] - The text content for the 'Hide'
+ * button, used when a section is expanded.
+ * @property {string} [hideSectionAriaLabel] - The text content appended to the
+ * 'Hide' button's accessible name when a section is expanded.
+ * @property {string} [showAllSections] - The text content for the 'Show all
+ * sections' button, used when all sections are collapsed.
+ * @property {string} [showSection] - The text content for the 'Show'
+ * button, used when a section is collapsed.
+ * @property {string} [showSectionAriaLabel] - The text content appended to the
+ * 'Show' button's accessible name when a section is expanded.
  */

--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -12,7 +12,9 @@ var DEBOUNCE_TIMEOUT_IN_SECONDS = 1
  * @class
  * @param {HTMLElement} $module - The element this component controls
  * @param {object} config - Button config
- * @param {boolean} [config.preventDoubleClick=false] - Whether the button should prevent double clicks
+ * @param {boolean} [config.preventDoubleClick=false] -
+ *  Prevent accidental double clicks on submit buttons from submitting forms
+ *  multiple times.
  */
 function Button ($module, config) {
   if (!$module) {

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -49,10 +49,8 @@ var TRANSLATIONS_DEFAULT = {
  * @class
  * @param {HTMLElement} $module - The element this component controls
  * @param {object} config - Character count config
- * @param {number} config.maxlength - If `maxwords` is set, this is not required.
- * The maximum number of characters. If `maxwords` is provided, it will be ignored.
- * @param {number} config.maxwords - If `maxlength` is set, this is not required.
- * The maximum number of words. If `maxwords` is provided, `maxlength` will be ignored.
+ * @param {number} config.maxlength - The maximum number of characters. If maxwords is provided, the maxlength option will be ignored.
+ * @param {number} config.maxwords - The maximum number of words. If maxwords is provided, the maxlength option will be ignored.
  * @param {number} [config.threshold=0] - The percentage value of the limit at
  * which point the count message is displayed. If this attribute is set, the
  * count message will be hidden by default.
@@ -379,13 +377,46 @@ export default CharacterCount
 
 /**
  * @typedef {object} CharacterCountTranslations
- * @property {PluralisedTranslation} [charactersUnderLimit] - Characters under limit
- * @property {string} [charactersAtLimit] - Characters at limit
- * @property {PluralisedTranslation} [charactersOverLimit] - Characters over limit
- * @property {PluralisedTranslation} [wordsUnderLimit] - Words under limit
- * @property {string} [wordsAtLimit] - Words at limit
- * @property {PluralisedTranslation} [wordsOverLimit] - Words over limit
- * @property {PluralisedTranslation} [textareaDescription] - Fallback hint
+ *
+ * Messages shown to users as they type. It provides feedback on how many words
+ * or characters they have remaining or if they are over the limit. This also
+ * includes a message used as an accessible description for the textarea.
+ * @property {PluralisedTranslation} [charactersUnderLimit] - Message displayed
+ *   when the number of characters is under the configured maximum, `maxlength`.
+ *   This message is displayed visually and through assistive technologies. The
+ *   component will replace the `%{count}` placeholder with the number of
+ *   remaining characters. This is a [pluralised list of
+ *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+ * @property {string} [charactersAtLimit] - Message displayed when the number of
+ *   characters reaches the configured maximum, `maxlength`. This message is
+ *   displayed visually and through assistive technologies.
+ * @property {PluralisedTranslation} [charactersOverLimit] - Message displayed
+ *   when the number of characters is over the configured maximum, `maxlength`.
+ *   This message is displayed visually and through assistive technologies. The
+ *   component will replace the `%{count}` placeholder with the number of
+ *   remaining characters. This is a [pluralised list of
+ *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+ * @property {PluralisedTranslation} [wordsUnderLimit] - Message displayed when
+ *   the number of words is under the configured maximum, `maxlength`. This
+ *   message is displayed visually and through assistive technologies. The
+ *   component will replace the `%{count}` placeholder with the number of
+ *   remaining words. This is a [pluralised list of
+ *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+ * @property {string} [wordsAtLimit] - Message displayed when the number of
+ *   words reaches the configured maximum, `maxlength`. This message is
+ *   displayed visually and through assistive technologies.
+ * @property {PluralisedTranslation} [wordsOverLimit] - Message displayed when
+ *   the number of words is over the configured maximum, `maxlength`. This
+ *   message is displayed visually and through assistive technologies. The
+ *   component will replace the `%{count}` placeholder with the number of
+ *   remaining words. This is a [pluralised list of
+ *   messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
+ * @property {PluralisedTranslation} [textareaDescription] - Message made
+ *   available to assistive technologies, if none is already present in the
+ *   HTML, to describe that the component accepts only a limited amount of
+ *   content. It is visible on the page when JavaScript is unavailable. The
+ *   component will replace the `%{count}` placeholder with the value of the
+ *   `maxlength` or `maxwords` parameter.
  */
 
 /**

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -13,7 +13,7 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
  * @class
  * @param {HTMLElement} $module - The element this component controls
  * @param {object} config - Error summary config
- * @param {boolean} [config.disableAutoFocus=false] - Whether to disable the component taking focus on initialisation
+ * @param {boolean} [config.disableAutoFocus=false] - If set to `true` the error summary will not be focussed when the page loads.
  */
 function ErrorSummary ($module, config) {
   // Some consuming code may not be passing a module,

--- a/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/src/govuk/components/notification-banner/notification-banner.mjs
@@ -9,7 +9,11 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
  * @class
  * @param {HTMLElement} $module - HTML element to use for notification banner
  * @param {object} config - Error summary config
- * @param {boolean} [config.disableAutoFocus=false] - Whether to disable the component taking focus on initialisation
+ * @param {boolean} [config.disableAutoFocus=false] -
+ *   If set to `true` the notification banner will not be focussed when the page
+ *   loads. This only applies if the component has a `role` of `alert` – in
+ *   other cases the component will not be focused on page load, regardless of
+ *   this option.
  */
 function NotificationBanner ($module, config) {
   this.$module = $module


### PR DESCRIPTION
Pulls JSDoc related to components configuration and I18n into the relevant files (second half of the last step of #2944, other half being #2985).

The components impacted are:
- Accordion - Default values have been set in quotes rather than bold for consistency with Nujucks docs.
- Button
- CharacterCount
- ErrorSummary
- Notification Banner

Closes #2944