### PR TITLE
Enable `package.json` updates for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - alphagov/design-system-developers
     schedule:
       interval: daily
+    versioning-strategy: increase
+
     allow:
       - dependency-type: all
 


### PR DESCRIPTION
We think Dependabot is only making `package-lock.json` changes rather than `package.json` increases

For example:

https://github.com/alphagov/govuk-frontend/pull/2990 – Updating `@percy/sdk-utils` (child dependency) instead of **`@percy/cli`**
https://github.com/alphagov/govuk-frontend/pull/2973 – Updating `jest-runtime` (child dependency) instead of **`jest`**

This PR adds to the **dependabot.yml** config:

```yaml
- package-ecosystem: npm
  versioning-strategy: increase
```

Related `versioning-strategy` documentation:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy