### PR TITLE
Correct documentation for Accordion Nunjucks 'Show All' / 'Hide All' options

### DIFF
--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -18,7 +18,7 @@ params:
 - name: hideAllSectionsText
   type: string
   required: false
-  description: The text content of the 'Hide all sections' button at the top of the accordion when at least one section is expanded.
+  description: The text content of the 'Hide all sections' button at the top of the accordion when all sections are expanded.
 - name: hideSectionText
   type: string
   required: false
@@ -30,7 +30,7 @@ params:
 - name: showAllSectionsText
   type: string
   required: false
-  description: The text content of the 'Show all sections' button at the top of the accordion when all sections are collapsed.
+  description: The text content of the 'Show all sections' button at the top of the accordion when at least one section is collapsed.
 - name: showSectionText
   type: string
   required: false


### PR DESCRIPTION
Entirely my fault – I suggested these changes originally but whilst testing I've realised I had the behaviour backwards – the only case where 'Hide all sections' is used is if *every* section is expanded.