### PR TITLE
Refactor back link and breadcrumb chevrons to use ems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
+
 ## 4.4.0 (Feature release)
 
 ### New features
@@ -206,7 +210,6 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)
 - [#2800: Improve Pagination component print styles](https://github.com/alphagov/govuk-frontend/pull/2800)
 - [#2909: Fix JavaScript errors when entering text into the Character Count in IE8](https://github.com/alphagov/govuk-frontend/pull/2909)
-- [#2998: Change back link arrow measurements to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 
 ## 4.3.1 (Patch release)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#2821: Avoid duplicated --error class on Character Count](https://github.com/alphagov/govuk-frontend/pull/2821)
 - [#2800: Improve Pagination component print styles](https://github.com/alphagov/govuk-frontend/pull/2800)
 - [#2909: Fix JavaScript errors when entering text into the Character Count in IE8](https://github.com/alphagov/govuk-frontend/pull/2909)
+- [#2998: Change back link arrow measurements to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 
 ## 4.3.1 (Patch release)
 

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -7,8 +7,6 @@
   $chevron-size: govuk-em(7px, $font-size);
 
   // Size of chevron border
-  // Awkward syntax hack to ensure we're using the CSS max() function and not
-  // the Sass one. This can be called normally once we're using Sass modules.
   $chevron-border-width: govuk-em(1px, $font-size);
 
   // Colour of chevron

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -1,19 +1,19 @@
 @include govuk-exports("govuk/component/back-link") {
   // Component font-size on the Frontend (used for calculations)
-  $font-scale-size: 16;
-  $font-size: $font-scale-size * 1px;
+  $font-size: 16;
 
   // Size of chevron (excluding border)
   $chevron-size: govuk-em(7px, $font-size);
 
   // Size of chevron border
-  $chevron-border-width: govuk-em(1px, $font-size);
+  $chevron-border-min-width: 1px;
+  $chevron-border-width: govuk-em($chevron-border-min-width, $font-size);
 
   // Colour of chevron
   $chevron-border-colour: $govuk-secondary-text-colour;
 
   .govuk-back-link {
-    @include govuk-typography-responsive($size: $font-scale-size);
+    @include govuk-typography-responsive($size: $font-size);
     @include govuk-link-common;
     @include govuk-link-style-text;
 
@@ -56,8 +56,12 @@
     transform: rotate(225deg);
 
     border: solid;
-    border-width: $chevron-border-width $chevron-border-width 0 0;
+    border-width: $chevron-border-min-width $chevron-border-min-width 0 0;
     border-color: $chevron-border-colour;
+
+    @supports (border-width: unquote("max(0px)")) {
+      border-width: unquote("max(#{$chevron-border-min-width}, #{$chevron-border-width}) max(#{$chevron-border-min-width}, #{$chevron-border-width})") 0 0;
+    }
 
     // Fall back to a less than sign for IE8
     @include govuk-if-ie8 {

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -1,10 +1,10 @@
 @include govuk-exports("govuk/component/back-link") {
 
   // Size of chevron (excluding border)
-  $chevron-size: 7px;
+  $chevron-size: .4375em;
 
   // Size of chevron border
-  $chevron-border-width: 1px;
+  $chevron-border-width: .0625em;
 
   // Colour of chevron
   $chevron-border-colour: $govuk-secondary-text-colour;
@@ -21,7 +21,7 @@
     margin-bottom: govuk-spacing(3);
 
     // Allow space for the arrow
-    padding-left: 14px;
+    padding-left: .875em;
   }
 
   // Prepend left pointing chevron

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -61,6 +61,9 @@
 
     @supports (border-width: unquote("max(0px)")) {
       border-width: unquote("max(#{$chevron-border-min-width}, #{$chevron-border-width}) max(#{$chevron-border-min-width}, #{$chevron-border-width})") 0 0;
+
+      // Ensure that the chevron never gets smaller than 16px
+      font-size: unquote("max(#{$font-size * 1px}, 1em)");
     }
 
     // Fall back to a less than sign for IE8

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -1,16 +1,21 @@
 @include govuk-exports("govuk/component/back-link") {
+  // Component font-size on the Frontend (used for calculations)
+  $font-scale-size: 16;
+  $font-size: $font-scale-size * 1px;
 
   // Size of chevron (excluding border)
-  $chevron-size: .4375em;
+  $chevron-size: govuk-em(7px, $font-size);
 
   // Size of chevron border
-  $chevron-border-width: .0625em;
+  // Awkward syntax hack to ensure we're using the CSS max() function and not
+  // the Sass one. This can be called normally once we're using Sass modules.
+  $chevron-border-width: govuk-em(1px, $font-size);
 
   // Colour of chevron
   $chevron-border-colour: $govuk-secondary-text-colour;
 
   .govuk-back-link {
-    @include govuk-typography-responsive($size: 16);
+    @include govuk-typography-responsive($size: $font-scale-size);
     @include govuk-link-common;
     @include govuk-link-style-text;
 
@@ -21,7 +26,7 @@
     margin-bottom: govuk-spacing(3);
 
     // Allow space for the arrow
-    padding-left: .875em;
+    padding-left: govuk-em(14px, $font-size);
   }
 
   // Prepend left pointing chevron
@@ -35,14 +40,15 @@
     @if $govuk-use-legacy-font {
       // Begin adjustments for font baseline offset
       // These should be removed when legacy font support is dropped
-      top: -1px;
-      bottom: 1px;
+      $offset: govuk-em(1px, $font-size);
+      top: $offset * -1;
+      bottom: $offset;
     } @else {
       top: 0;
       bottom: 0;
     }
 
-    left: 3px;
+    left: govuk-em(3px, $font-size);
 
     width: $chevron-size;
     height: $chevron-size;
@@ -80,16 +86,5 @@
     right: 0;
     bottom: -14px;
     left: 0;
-  }
-
-  @if $govuk-use-legacy-font {
-    // Begin adjustments for font baseline offset
-    // These should be removed when legacy font support is dropped
-    .govuk-back-link:before {
-      $offset: 1px;
-
-      top: $offset * -1;
-      bottom: $offset;
-    }
   }
 }

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -83,6 +83,9 @@
 
       @supports (border-width: unquote("max(0px)")) {
         border-width: unquote("max(#{$chevron-border-min-width}, #{$chevron-border-width}) max(#{$chevron-border-min-width}, #{$chevron-border-width})") 0 0;
+
+        // Ensure that the chevron never gets smaller than 16px
+        font-size: unquote("max(#{$font-size * 1px}, 1em)");
       }
 
       // Fall back to a greater than sign for IE8

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -1,13 +1,13 @@
 @include govuk-exports("govuk/component/breadcrumbs") {
   // Component font-size on the Frontend (used for calculations)
-  $font-scale-size: 16;
-  $font-size: $font-scale-size * 1px;
+  $font-size: 16;
 
   // Size of chevron (excluding border)
   $chevron-size: govuk-em(7px, $font-size);
 
   // Size of chevron border
-  $chevron-border-width: govuk-em(1px, $font-size);
+  $chevron-border-min-width: 1px;
+  $chevron-border-width: govuk-em($chevron-border-min-width, $font-size);
 
   // Colour of chevron
   $chevron-border-colour: $govuk-secondary-text-colour;
@@ -19,7 +19,7 @@
   $chevron-altitude-calculated: govuk-em(5.655px, $font-size);
 
   .govuk-breadcrumbs {
-    @include govuk-font($size: $font-scale-size);
+    @include govuk-font($size: $font-size);
     @include govuk-text-colour;
 
     margin-top: govuk-spacing(3);
@@ -78,8 +78,12 @@
       transform: rotate(45deg);
 
       border: solid;
-      border-width: $chevron-border-width $chevron-border-width 0 0;
+      border-width: $chevron-border-min-width $chevron-border-min-width 0 0;
       border-color: $chevron-border-colour;
+
+      @supports (border-width: unquote("max(0px)")) {
+        border-width: unquote("max(#{$chevron-border-min-width}, #{$chevron-border-width}) max(#{$chevron-border-min-width}, #{$chevron-border-width})") 0 0;
+      }
 
       // Fall back to a greater than sign for IE8
       @include govuk-if-ie8 {

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -1,10 +1,13 @@
 @include govuk-exports("govuk/component/breadcrumbs") {
+  // Component font-size on the Frontend (used for calculations)
+  $font-scale-size: 16;
+  $font-size: $font-scale-size * 1px;
 
   // Size of chevron (excluding border)
-  $chevron-size: 7px;
+  $chevron-size: govuk-em(7px, $font-size);
 
   // Size of chevron border
-  $chevron-border-width: 1px;
+  $chevron-border-width: govuk-em(1px, $font-size);
 
   // Colour of chevron
   $chevron-border-colour: $govuk-secondary-text-colour;
@@ -13,10 +16,10 @@
   // of length 8 (7px + 1px border):
   //
   // √(8² + 8²) * 0.5 ≅ 5.655
-  $chevron-altitude-calculated: 5.655px;
+  $chevron-altitude-calculated: govuk-em(5.655px, $font-size);
 
   .govuk-breadcrumbs {
-    @include govuk-font($size: 16);
+    @include govuk-font($size: $font-scale-size);
     @include govuk-text-colour;
 
     margin-top: govuk-spacing(3);
@@ -40,8 +43,8 @@
 
     // Add both margin and padding such that the chevron appears centrally
     // between each breadcrumb item
-    margin-left: govuk-spacing(2);
-    padding-left: govuk-spacing(2) + $chevron-altitude-calculated;
+    margin-left: govuk-em(govuk-spacing(2), $font-size);
+    padding-left: govuk-em(govuk-spacing(2), $font-size) + $chevron-altitude-calculated;
 
     float: left;
 
@@ -55,8 +58,9 @@
       @if $govuk-use-legacy-font {
         // Begin adjustments for font baseline offset
         // These should be removed when legacy font support is dropped
-        top: -1px;
-        bottom: 1px;
+        $offset: govuk-em(1px, $font-size);
+        top: $offset * -1;
+        bottom: $offset;
       } @else {
         top: 0;
         bottom: 0;
@@ -118,7 +122,7 @@
         }
 
         &:before {
-          top: 6px;
+          top: govuk-em(6px, $font-size);
           margin: 0;
         }
       }


### PR DESCRIPTION
Currently the back link is measured in pixels. This prevents the arrow from changing size when text zooming is used. Changing this to em units allows the arrow to scale along with the text.

em units have been calculated by taking the previous pixel value and dividing it by the text's pixel size (16). 
e.g. 7px ÷ 16px = 0.4375em

Fixes #1717. 

||100% zoom|400% zoom|
|:-|:-:|:-:|
|Before|<img width="259" alt="Screenshot 2022-11-10 at 11 51 45" src="https://user-images.githubusercontent.com/1253214/201094464-4fe99d1b-82d7-4b2f-970a-dde2b9980213.png">|<img width="259" alt="Screenshot 2022-11-10 at 11 51 53" src="https://user-images.githubusercontent.com/1253214/201094536-a676e060-0915-4925-8f54-05025100867b.png">|
|After|<img width="259" alt="Screenshot 2022-11-10 at 11 51 19" src="https://user-images.githubusercontent.com/1253214/201094500-a88a9db1-d993-4325-8dfb-6b986c0fb93e.png">|<img width="259" alt="Screenshot 2022-11-10 at 11 51 11" src="https://user-images.githubusercontent.com/1253214/201094567-e18d4cb0-c0cd-4a89-a716-50d3af166a57.png">|

A side effect of this is that the chevron now also scales _down_ on small screens, where text is displayed at 14px, which it didn't do previously.

||Narrow view|
|:-|:-:|
|Before|<img width="135" alt="Screenshot 2022-11-10 at 16 26 34" src="https://user-images.githubusercontent.com/1253214/201151406-3d66a09f-e38c-401e-b935-26f2a53255fb.png">|
|After|<img width="135" alt="Screenshot 2022-11-10 at 16 26 26" src="https://user-images.githubusercontent.com/1253214/201151457-c4735bc7-bc10-4a6e-83a0-f9d6cd07356a.png">|


Screenshots from Firefox 106 on macOS 12.6.

Also tested in Chrome 107, Safari 16.0, and Internet Explorers 9 through 11. 

