### PR TITLE
Switch review app to Heroku-22 stack (Ubuntu-22.04 LTS)

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "env": {
     "HEROKU_APP": "REVIEW"
   },
-  "stack": "heroku-20",
+  "stack": "heroku-22",
   "formation": {
   },
   "addons": [

--- a/app.json
+++ b/app.json
@@ -6,11 +6,6 @@
     "HEROKU_APP": "REVIEW"
   },
   "stack": "heroku-22",
-  "formation": {
-  },
-  "addons": [
-
-  ],
   "buildpacks": [
     {
       "url": "heroku/nodejs"


### PR DESCRIPTION
GitHub has announced that the [`ubuntu-22.04` runner](https://github.blog/changelog/2022-08-09-github-actions-ubuntu-22-04-is-now-generally-available-on-github-hosted-runners/) will become [`ubuntu-latest` by December 1st](https://github.com/actions/runner-images/issues/6399)

I've created the [`trial-ubuntu-22.04-runners`](https://github.com/alphagov/govuk-frontend/tree/trial-ubuntu-22.04-runners) branch as an early preview

✅ [**Tests** (install + build)](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml) workflow run: [govuk-frontend/actions/runs/3486587411](https://github.com/alphagov/govuk-frontend/actions/runs/3486587411)
✅ [**Sass** compilation](https://github.com/alphagov/govuk-frontend/actions/workflows/sass.yaml) workflow run: [govuk-frontend/actions/runs/3486588008](https://github.com/alphagov/govuk-frontend/actions/runs/3486588008)

This PR configures our review app for the [**Heroku-22** stack](https://devcenter.heroku.com/articles/heroku-22-stack) using [Ubuntu-22.04 LTS](https://canonical.com/blog/ubuntu-22-04-lts-released)