### PR TITLE
Printing style for current page link in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
+- [#3021 Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
 
 ## 4.4.0 (Feature release)
 

--- a/src/govuk/components/header/_index.scss
+++ b/src/govuk/components/header/_index.scss
@@ -281,6 +281,12 @@
         color: $govuk-header-link-active;
       }
 
+      // When printing, use the normal blue as this contrasts better with the
+      // white printing header
+      @include govuk-media-query($media-type: print) {
+        color: $govuk-brand-colour;
+      }
+
       // When focussed, the text colour needs to be darker to ensure that colour
       // contrast is still acceptable
       &:focus {


### PR DESCRIPTION
Changing the blue back to the brand colour `#1d70b8` when printing.  The colour `#1d8feb` is presumably to contrast against the black `#0b0c0c` header, but when printing the header is white `#ffffff`, so it makes sense to use a darker blue which contrasts better against white.