### PR TITLE
Add source maps to compiled JavaScript + CSS

### DIFF
--- a/tasks/asset-version.mjs
+++ b/tasks/asset-version.mjs
@@ -1,41 +1,26 @@
-import { readFile, rename, writeFile } from 'fs/promises'
+import { readFile, writeFile } from 'fs/promises'
 import { EOL } from 'os'
-import { basename, join } from 'path'
+import { join } from 'path'
 
 import configPaths from '../config/paths.js'
 
 import { destination, isDist } from './task-arguments.mjs'
 
-// Update assets' version numbers
-// Uses the version number from `package/package.json` and writes it to various places
+/**
+ * Write VERSION.txt
+ * with `package/package.json` version
+ *
+ * @returns {Promise<void>}
+ */
 export async function updateDistAssetsVersion () {
   const pkg = JSON.parse(await readFile(join(configPaths.package, 'package.json'), 'utf8'))
 
   if (!isDist) {
-    throw new Error('Asset versions can only be applied to ./dist')
+    throw new Error('Asset version can only be applied to ./dist')
   }
 
-  // Files to process
-  const assetFiles = [
-    join(destination, 'govuk-frontend.min.css'),
-    join(destination, 'govuk-frontend-ie8.min.css'),
-    join(destination, 'govuk-frontend.min.js')
-  ]
-
-  // Loop through files
-  const assetTasks = assetFiles.map(srcFilename => {
-    const destFilename = srcFilename.replace(/(govuk.*)(?=\.min)/g, '$1-' + pkg.version)
-
-    // Move to new location
-    return rename(srcFilename, destFilename)
-      .then(() => console.log(`Moved ${basename(srcFilename)} to ${basename(destFilename)}.`))
-  })
-
   // Write VERSION.txt file
-  assetTasks.push(writeFile(join(destination, 'VERSION.txt'), pkg.version + EOL))
-
-  // Resolve on completion
-  return Promise.all(assetTasks)
+  return writeFile(join(destination, 'VERSION.txt'), pkg.version + EOL)
 }
 
 updateDistAssetsVersion.displayName = 'update-dist-assets-version'

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -22,10 +22,12 @@ describe('dist/', () => {
   })
 
   describe('govuk-frontend-[version].min.css', () => {
+    let filename
     let stylesheet
 
     beforeAll(async () => {
-      stylesheet = await readFile(join(configPaths.dist, `govuk-frontend-${pkg.version}.min.css`), 'utf8')
+      filename = `govuk-frontend-${pkg.version}.min.css`
+      stylesheet = await readFile(join(configPaths.dist, filename), 'utf8')
     })
 
     it('should not contain current media query displayed on body element', () => {
@@ -35,17 +37,27 @@ describe('dist/', () => {
     it('should contain the copyright notice', () => {
       expect(stylesheet).toContain('/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */')
     })
+
+    it('should contain source mapping URL', () => {
+      expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/$`))
+    })
   })
 
   describe('govuk-frontend-ie8-[version].min.css', () => {
+    let filename
     let stylesheet
 
     beforeAll(async () => {
-      stylesheet = await readFile(join(configPaths.dist, `govuk-frontend-ie8-${pkg.version}.min.css`), 'utf8')
+      filename = `govuk-frontend-ie8-${pkg.version}.min.css`
+      stylesheet = await readFile(join(configPaths.dist, filename), 'utf8')
     })
 
     it('should not contain current media query displayed on body element', () => {
       expect(stylesheet).not.toMatch(/body:before{content:/)
+    })
+
+    it('should contain source mapping URL', () => {
+      expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/$`))
     })
   })
 

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -50,14 +50,20 @@ describe('dist/', () => {
   })
 
   describe('govuk-frontend-[version].min.js', () => {
+    let filename
     let javascript
 
     beforeAll(async () => {
-      javascript = await readFile(join(configPaths.dist, `govuk-frontend-${pkg.version}.min.js`), 'utf8')
+      filename = `govuk-frontend-${pkg.version}.min.js`
+      javascript = await readFile(join(configPaths.dist, filename), 'utf8')
     })
 
     it('should have the correct version name', () => {
       expect(javascript).toBeTruthy()
+    })
+
+    it('should contain source mapping URL', () => {
+      expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map$`))
     })
   })
 })

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -51,7 +51,10 @@ describe('package/', () => {
         const importFilter = /^govuk(?!-)/
 
         // All source `**/*.mjs` files compiled to `**/*.js`
-        const output = [join(requirePath, `${name}.js`)]
+        const output = [
+          join(requirePath, `${name}.js`),
+          join(requirePath, `${name}.js.map`) // with source map
+        ]
 
         // Only source `./govuk/**/*.mjs` files copied to `./govuk-esm/**/*.mjs`
         if (importFilter.test(requirePath)) {

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -38,7 +38,9 @@ export function compileStylesheets () {
   if (isDist) {
     return merge(
       compileStylesheet(
-        gulp.src(`${slash(configPaths.src)}/govuk/all.scss`)
+        gulp.src(`${slash(configPaths.src)}/govuk/all.scss`, {
+          sourcemaps: true
+        })
           .pipe(rename({
             basename: 'govuk-frontend',
             suffix: `-${pkg.version}.min`,
@@ -46,34 +48,49 @@ export function compileStylesheets () {
           }))),
 
       compileStylesheet(
-        gulp.src(`${slash(configPaths.src)}/govuk/all-ie8.scss`)
+        gulp.src(`${slash(configPaths.src)}/govuk/all-ie8.scss`, {
+          sourcemaps: true
+        })
           .pipe(rename({
             basename: 'govuk-frontend-ie8',
             suffix: `-${pkg.version}.min`,
             extname: '.css'
           })))
     )
-      .pipe(gulp.dest(slash(destPath)))
+      .pipe(gulp.dest(slash(destPath), {
+        sourcemaps: '.'
+      }))
   }
 
   // Review application
   return merge(
     compileStylesheet(
-      gulp.src(`${slash(configPaths.app)}/assets/scss/app?(-ie8).scss`)),
+      gulp.src(`${slash(configPaths.app)}/assets/scss/app?(-ie8).scss`, {
+        sourcemaps: true
+      })),
 
     compileStylesheet(
-      gulp.src(`${slash(configPaths.app)}/assets/scss/app-legacy?(-ie8).scss`), {
-        includePaths: ['node_modules/govuk_frontend_toolkit/stylesheets', 'node_modules']
+      gulp.src(`${slash(configPaths.app)}/assets/scss/app-legacy?(-ie8).scss`, {
+        sourcemaps: true
+      }), {
+        includePaths: [
+          'node_modules/govuk_frontend_toolkit/stylesheets',
+          'node_modules'
+        ]
       }),
 
     compileStylesheet(
-      gulp.src(`${slash(configPaths.fullPageExamples)}/**/styles.scss`)
+      gulp.src(`${slash(configPaths.fullPageExamples)}/**/styles.scss`, {
+        sourcemaps: true
+      })
         .pipe(rename((path) => {
           path.basename = path.dirname
           path.dirname = 'full-page-examples'
         })))
   )
-    .pipe(gulp.dest(slash(destPath)))
+    .pipe(gulp.dest(slash(destPath), {
+      sourcemaps: '.'
+    }))
 }
 
 compileStylesheets.displayName = 'compile:scss'

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -1,4 +1,5 @@
 
+import { readFile } from 'fs/promises'
 import { join, parse } from 'path'
 
 import gulp from 'gulp'
@@ -21,6 +22,7 @@ import { componentNameToJavaScriptModuleName } from '../../lib/helper-functions.
 import { destination, isDev, isDist, isPackage } from '../task-arguments.mjs'
 
 const sass = gulpSass(nodeSass)
+const pkg = JSON.parse(await readFile(join(configPaths.package, 'package.json'), 'utf8'))
 
 /**
  * Compile Sass to CSS task
@@ -39,14 +41,16 @@ export function compileStylesheets () {
         gulp.src(`${slash(configPaths.src)}/govuk/all.scss`)
           .pipe(rename({
             basename: 'govuk-frontend',
-            extname: '.min.css'
+            suffix: `-${pkg.version}.min`,
+            extname: '.css'
           }))),
 
       compileStylesheet(
         gulp.src(`${slash(configPaths.src)}/govuk/all-ie8.scss`)
           .pipe(rename({
             basename: 'govuk-frontend-ie8',
-            extname: '.min.css'
+            suffix: `-${pkg.version}.min`,
+            extname: '.css'
           })))
     )
       .pipe(gulp.dest(slash(destPath)))
@@ -157,7 +161,7 @@ function compileJavaScript (stream, moduleName) {
     .pipe(gulpif(isDist,
       rename({
         basename: 'govuk-frontend',
-        extname: '.min.js'
+        suffix: `-${pkg.version}.min`
       })
     ))
     .pipe(rename({

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -121,8 +121,12 @@ export async function compileJavaScripts () {
       ? componentNameToJavaScriptModuleName(name)
       : 'GOVUKFrontend'
 
-    return compileJavaScript(gulp.src(slash(join(configPaths.src, file))), moduleName)
-      .pipe(gulp.dest(slash(join(destPath, modulePath))))
+    return compileJavaScript(gulp.src(slash(join(configPaths.src, file)), {
+      sourcemaps: true
+    }), moduleName)
+      .pipe(gulp.dest(slash(join(destPath, modulePath)), {
+        sourcemaps: '.'
+      }))
   }))
 }
 


### PR DESCRIPTION
This PR adds source maps to our compiled code

For example:

**govuk-frontend-4.4.0.min.js**
```js
//# sourceMappingURL=govuk-frontend-4.4.0.min.js.map
```

**govuk-frontend-4.4.0.min.css**
```css
/*# sourceMappingURL=govuk-frontend-4.4.0.min.css.map */
```

When browser developer tools are open the associated source map files are downloaded

## JavaScript source maps
See log messages and stack traces mapped to the `*.mjs` source code (with line numbers)

<img width="761" alt="JavaScript source maps" src="https://user-images.githubusercontent.com/415517/202737576-c6847615-2e67-47cc-876b-9bfbadc4fa7c.png">

Click through to the original source via the browser

<img width="761" alt="JavaScript source maps (code)" src="https://user-images.githubusercontent.com/415517/202737687-93647b53-05b2-40f2-87a0-ed314dda4238.png">

## CSS source maps
See styles mapped to the Sass `*.scss` source code (with line numbers)

<img width="1119" alt="CSS source maps" src="https://user-images.githubusercontent.com/415517/202737740-b8bad691-349b-4704-b501-f66ae8b9b9f1.png">
