### PR TITLE
Fix Safari `TypeError: 'handleEvent'` iFrame resizer error

### DIFF
--- a/app/views/component-preview.njk
+++ b/app/views/component-preview.njk
@@ -16,5 +16,5 @@
 {% endblock %}
 
 {% block scripts %}
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.contentWindow.min.js" integrity="sha256-4pHiLAYReL+uT1xGu9u8Afg9jkaV0vrdu/Dd0ax9Ak8=" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.contentWindow.min.js" integrity="sha256-4pHiLAYReL+uT1xGu9u8Afg9jkaV0vrdu/Dd0ax9Ak8=" crossorigin="anonymous"></script>
 {% endblock %}

--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -10,12 +10,13 @@
 
 {% block bodyEnd %}
   {{ super() }}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.min.js" integrity="sha256-NZjCYaMfryuJQRMgekHuC02c/Wv4sMRzHG2zyhrVwKU=" crossorigin="anonymous"></script>
-  <!--[if lte IE 8]>
-    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/ie8.polyfils.min.js"></script>
-  <![endif]-->
-  <script>
-    window.iFrameResize({}, '.js-component-preview')
-  </script>
-  {% block scripts %}{% endblock %}
+  {% block scripts %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.min.js" integrity="sha256-NZjCYaMfryuJQRMgekHuC02c/Wv4sMRzHG2zyhrVwKU=" crossorigin="anonymous"></script>
+    <!--[if lte IE 8]>
+      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/ie8.polyfils.min.js"></script>
+    <![endif]-->
+    <script>
+      window.iFrameResize({}, '.js-component-preview')
+    </script>
+  {% endblock %}
 {% endblock %}

--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -14,9 +14,8 @@
   <!--[if lte IE 8]>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/ie8.polyfils.min.js"></script>
   <![endif]-->
-  <script type="text/javascript">
-    var domReady = function(a,b,c){b=document,c='addEventListener';b[c]?b[c]('DOMContentLoaded',a):window.attachEvent('onload',a)}
-    domReady(iFrameResize({}, '.js-component-preview'))
+  <script>
+    window.iFrameResize({}, '.js-component-preview')
   </script>
   {% block scripts %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
This PR removes code that logs a error in Safari

```console
TypeError: 'handleEvent' property of event listener should be callable
```

## The issue

When an event listener is not callable Safari logs an error where other browsers stay silent.

We've got an example of this in our review app below, where the `iFrameResize()` function call returns an array of `<iframe>` elements. Safari logs an error because we use this array as our `DOMContentLoaded` handler.

This also shows we don't need `domReady()` as [iFrame Resizer](http://davidjbradshaw.github.io/iframe-resizer/) runs anyway

```js
<script type="text/javascript">
  var domReady = function(a,b,c){b=document,c='addEventListener';b[c]?b[c]('DOMContentLoaded',a):window.attachEvent('onload',a)}
  domReady(iFrameResize({}, '.js-component-preview'))
</script>
```

<img width="653" alt="TypeError 'handleEvent' in Safari" src="https://user-images.githubusercontent.com/415517/203004444-c3968775-8166-4c96-a36e-5da0fd7689df.png">

I've also included some other fixes:

1. **Remove `iframeResizer.min.js` **<script>** from `component-preview.njk`**
Preview iframes only need `iframeResizer.contentWindow.min.js`

2. ~**Upgrade to [iFrame Resizer v3.6.5](https://github.com/davidjbradshaw/iframe-resizer/releases/tag/v3.6.5)**~
~This is the last IE8 compatible release~