### PR TITLE
Skip “Percy screenshots” when secrets are unavailable on forks

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,34 @@
+name: Percy screenshots
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+   group: screenshots-${{ github.head_ref || github.run_id }}
+   cancel-in-progress: true
+
+jobs:
+  screenshots:
+    name: Send screenshots
+    runs-on: ubuntu-latest
+
+    env:
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+      PORT: 8888
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Build
+        uses: ./.github/workflows/actions/build
+
+      - name: Start review application
+        run: npm run serve &
+
+      - name: Send screenshots to Percy
+        run: npx percy exec -- npm run test:screenshots

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,3 +169,6 @@ jobs:
     # (after install and build have been cached)
     uses: ./.github/workflows/screenshots.yml
     secrets: inherit
+
+    # Skip when secrets are unavailable on forks
+    if: ${{ github.repository_owner == 'alphagov' }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,26 +162,10 @@ jobs:
         run: ${{ matrix.run }}
 
   regression:
-    name: Send screenshots to Percy
-    runs-on: ubuntu-latest
+    name: Percy
     needs: [install, build]
 
-    env:
-      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-      PORT: 8888
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Restore dependencies
-        uses: ./.github/workflows/actions/install-node
-
-      - name: Restore build
-        uses: ./.github/workflows/actions/build
-
-      - name: Start review application
-        run: npm run serve &
-
-      - name: Send screenshots to Percy
-        run: npx percy exec -- npm run test:screenshots
+    # Run existing "Percy screenshots" workflow
+    # (after install and build have been cached)
+    uses: ./.github/workflows/screenshots.yml
+    secrets: inherit


### PR DESCRIPTION
The Percy CLI requires `${{ secrets.PERCY_TOKEN }}` which forks won't necessarily have. We recently made our Percy npm script return an error code when the health check failed in:

* https://github.com/alphagov/govuk-frontend/pull/3009

This PR adds a condition to our **Send screenshots to Percy** job which makes it skippable

```yaml
# Skip when secrets are unavailable on forks
if: ${{ github.repository_owner == 'alphagov' }}
```

Where permissions allow you'll see we've now added a Dependabot `PERCY_TOKEN` secret too:
https://github.com/alphagov/govuk-frontend/settings/secrets/dependabot

### Reducing Percy runs in future
We may want to consider a ["paths" filter](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) in future so this PR also moves the Percy uploads to a separate GitHub Actions [`.github/workflows/screenshots.yml`](https://github.com/alphagov/govuk-frontend/blob/percy-secret-permissions/.github/workflows/screenshots.yml) workflow. More information in:

* https://github.com/alphagov/govuk-frontend/issues/2864
