### PR TITLE
Ensure npm scripts (via Gulp) emit errors

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -14,8 +14,8 @@ import { npmScriptTask } from './tasks/run.mjs'
  * Runs JavaScript code quality checks, documentation, compilation
  */
 gulp.task('scripts', gulp.series(
-  npmScriptTask('lint:js', ['--silent']),
-  npmScriptTask('build:jsdoc', ['--silent']),
+  npmScriptTask('lint:js'),
+  npmScriptTask('build:jsdoc'),
   compileJavaScripts
 ))
 
@@ -24,8 +24,8 @@ gulp.task('scripts', gulp.series(
  * Runs Sass code quality checks, documentation, compilation
  */
 gulp.task('styles', gulp.series(
-  npmScriptTask('lint:scss', ['--silent']),
-  npmScriptTask('build:sassdoc', ['--silent']),
+  npmScriptTask('lint:scss'),
+  npmScriptTask('build:sassdoc'),
   compileStylesheets
 ))
 
@@ -36,8 +36,8 @@ gulp.task('styles', gulp.series(
 gulp.task('compile', gulp.series(
   compileJavaScripts,
   compileStylesheets,
-  npmScriptTask('build:jsdoc', ['--silent']),
-  npmScriptTask('build:sassdoc', ['--silent'])
+  npmScriptTask('build:jsdoc'),
+  npmScriptTask('build:sassdoc')
 ))
 
 /**
@@ -48,7 +48,7 @@ gulp.task('dev', gulp.series(
   clean,
   'compile',
   watch,
-  npmScriptTask('serve', ['--silent', '--workspace', 'app'])
+  npmScriptTask('serve', ['--workspace', 'app'])
 ))
 
 /**

--- a/tasks/run.mjs
+++ b/tasks/run.mjs
@@ -12,7 +12,7 @@ export async function npmScript (name, args = []) {
   const command = process.platform === 'win32' ? 'npm.cmd' : 'npm'
 
   return new Promise((resolve, reject) => {
-    const script = spawn(command, ['run', name, ...args])
+    const script = spawn(command, ['run', name, '--silent', ...args])
 
     script.stdout.on('data', (data) => console.log(data.toString()))
     script.stderr.on('data', (data) => console.error(data.toString()))


### PR DESCRIPTION
This PR ensure npm scripts (via Gulp) emit errors

We currently ignore npm script crashes even when they write to `stderr` (which wasn't intentional)

I've also prevented the [**npm run**](https://docs.npmjs.com/cli/v9/commands/npm-run-script) `--silent` flag being logged to reduce Gulp CLI "log spam"

### Before
```console
[15:04:48] Starting 'npm run build:jsdoc --silent'...
[15:04:49] Finished 'npm run build:jsdoc --silent' after 1.22 s
[15:04:49] Starting 'npm run build:sassdoc --silent'...
[15:04:51] Finished 'npm run build:sassdoc --silent' after 1.51 s
```

### After
```console
[15:04:48] Starting 'npm run build:jsdoc'...
[15:04:49] Finished 'npm run build:jsdoc' after 1.22 s
[15:04:49] Starting 'npm run build:sassdoc'...
[15:04:51] Finished 'npm run build:sassdoc' after 1.51 s
```