### PR TITLE
Allow Sass compilation to restart after `gulp dev` errors

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -25,8 +25,8 @@ gulp.task('scripts', gulp.series(
  */
 gulp.task('styles', gulp.series(
   npmScriptTask('lint:scss'),
-  npmScriptTask('build:sassdoc'),
-  compileStylesheets
+  compileStylesheets,
+  npmScriptTask('build:sassdoc')
 ))
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "minimatch": "^5.1.0",
         "node-sass": "^8.0.0",
         "nunjucks": "^3.2.3",
+        "plugin-error": "^2.0.0",
         "postcss": "^8.4.19",
         "postcss-pseudo-classes": "^0.2.1",
         "postcss-scss": "^4.0.5",
@@ -10489,6 +10490,48 @@
         "vinyl-sourcemaps-apply": "^0.2.1"
       }
     },
+    "node_modules/gulp-better-rollup/node_modules/arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-better-rollup/node_modules/extend-shallow": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+      "integrity": "sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==",
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-better-rollup/node_modules/kind-of": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "integrity": "sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-better-rollup/node_modules/plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gulp-better-rollup/node_modules/replace-ext": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
@@ -10855,6 +10898,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/gulp-plumber/node_modules/arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/gulp-plumber/node_modules/chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -10865,6 +10916,40 @@
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-plumber/node_modules/extend-shallow": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+      "integrity": "sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==",
+      "dependencies": {
+        "kind-of": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-plumber/node_modules/kind-of": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+      "integrity": "sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-plumber/node_modules/plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==",
+      "dependencies": {
+        "ansi-cyan": "^0.1.1",
+        "ansi-red": "^0.1.1",
+        "arr-diff": "^1.0.1",
+        "arr-union": "^2.0.1",
+        "extend-shallow": "^1.1.2"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -17971,45 +18056,14 @@
       }
     },
     "node_modules/plugin-error": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
-      "integrity": "sha512-WzZHcm4+GO34sjFMxQMqZbsz3xiNEgonCskQ9v+IroMmYgk/tas8dG+Hr2D6IbRPybZ12oWpzE/w3cGJ6FJzOw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.0.tgz",
+      "integrity": "sha512-o4bwIOmuFwUg2MU6xt7plGEQY3YyENx6kvwaFZBrUpamA91FdS9w3U+pU0y4OuDoBQe+jf3RLGSfQebSRBEVsQ==",
       "dependencies": {
-        "ansi-cyan": "^0.1.1",
-        "ansi-red": "^0.1.1",
-        "arr-diff": "^1.0.1",
-        "arr-union": "^2.0.1",
-        "extend-shallow": "^1.1.2"
+        "ansi-colors": "^1.0.1"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/arr-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
-      "integrity": "sha512-t5db90jq+qdgk8aFnxEkjqta0B/GHrM1pxzuuZz2zWsOXc5nKu3t+76s/PQBA8FTcM/ipspIH9jWG4OxCBc2eA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/extend-shallow": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
-      "integrity": "sha512-L7AGmkO6jhDkEBBGWlLtftA80Xq8DipnrRPr0pyi7GQLXkaq9JYA4xF4z6qnadIC6euiTDKco0cGSU9muw+WTw==",
-      "dependencies": {
-        "kind-of": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/plugin-error/node_modules/kind-of": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-      "integrity": "sha512-aUH6ElPnMGon2/YkxRIigV32MOpTVcoXQ1Oo8aYn40s+sJ3j+0gFZsT8HKDcxNy7Fi9zuquWtGaGAahOdv5p/g==",
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/posix-character-classes": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "minimatch": "^5.1.0",
     "node-sass": "^8.0.0",
     "nunjucks": "^3.2.3",
+    "plugin-error": "^2.0.0",
     "postcss": "^8.4.19",
     "postcss-pseudo-classes": "^0.2.1",
     "postcss-scss": "^4.0.5",

--- a/tasks/task-arguments.mjs
+++ b/tasks/task-arguments.mjs
@@ -35,3 +35,4 @@ export const destination = destPath
 export const isPackage = target === 'package'
 export const isPublic = target === 'public'
 export const isDist = target === 'dist'
+export const isDev = isPublic && tasks.includes('dev')


### PR DESCRIPTION
This PR fixes an issue with our Sass compilation `compile:scss` Gulp task

1. Begin `npm start`
2. Make any Sass `*.scss` invalid, save it
3. Wait for `gulp.watch()` to kick in
4. Sass compilation `compile:scss` Gulp task shows error + hangs 🔥 
5. Uh oh, have to cancel and run `npm start` again 😭 

**Development:** we now `.emit('end')` for the Sass compiler to resume on next save
**Production:** we still `.emit('error')` for the Sass compiler to crash and break the build

Merge this PR and you can save, error, save, error, save, fix—all day long 😊 