### PR TITLE
Allow JavaScript compilation to restart after `gulp dev` errors

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -15,8 +15,8 @@ import { npmScriptTask } from './tasks/run.mjs'
  */
 gulp.task('scripts', gulp.series(
   npmScriptTask('lint:js'),
-  npmScriptTask('build:jsdoc'),
-  compileJavaScripts
+  compileJavaScripts,
+  npmScriptTask('build:jsdoc')
 ))
 
 /**

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -129,30 +129,45 @@ export async function compileJavaScripts () {
       ? componentNameToJavaScriptModuleName(name)
       : 'GOVUKFrontend'
 
-    return gulp.src(slash(join(configPaths.src, file)))
-      .pipe(rollup({
-        // Used to set the `window` global and UMD/AMD export name
-        // Component JavaScript is given a unique name to aid individual imports, e.g GOVUKFrontend.Accordion
-        name: moduleName,
-        // Legacy mode is required for IE8 support
-        legacy: true,
-        // UMD allows the published bundle to work in CommonJS and in the browser.
-        format: 'umd'
-      }))
-      .pipe(gulpif(isDist, uglify({
-        ie8: true
-      })))
-      .pipe(gulpif(isDist,
-        rename({
-          basename: 'govuk-frontend',
-          extname: '.min.js'
-        })
-      ))
-      .pipe(rename({
-        extname: '.js'
-      }))
+    return compileJavaScript(gulp.src(slash(join(configPaths.src, file))), moduleName)
       .pipe(gulp.dest(slash(join(destPath, modulePath))))
   }))
 }
 
 compileJavaScripts.displayName = 'compile:js'
+
+/**
+ * Compile JavaScript ESM to CommonJS helper
+ *
+ * @param {import('stream').Stream} stream - Input file stream
+ * @param {string} moduleName - Rollup module name
+ * @returns {import('stream').Stream} Output file stream
+ */
+function compileJavaScript (stream, moduleName) {
+  return stream
+    .pipe(rollup({
+      // Used to set the `window` global and UMD/AMD export name
+      // Component JavaScript is given a unique name to aid individual imports, e.g GOVUKFrontend.Accordion
+      name: moduleName,
+      // Legacy mode is required for IE8 support
+      legacy: true,
+      // UMD allows the published bundle to work in CommonJS and in the browser.
+      format: 'umd'
+    }))
+
+    // Minify
+    .pipe(gulpif(isDist, uglify({
+      ie8: true
+    })))
+
+    // Rename
+    .pipe(gulpif(isDist,
+      rename({
+        basename: 'govuk-frontend',
+        extname: '.min.js'
+      })
+    ))
+    .pipe(rename({
+      extname: '.js'
+    }))
+}


### PR DESCRIPTION
This PR closes https://github.com/alphagov/govuk-frontend/issues/2872

The changes enable friendly errors for our JavaScript compile (+ uglify) task

### Before
Gulp logs a super long and confusing `Unhandled 'error' event`

```console
[15:39:33] The following tasks did not complete: compile, compile:scss
[15:39:33] Did you forget to signal async completion?

node:events:491
      throw er; // Unhandled 'error' event
      ^
PluginError: Unexpected token

[… more]
```

### After
We use [`gulp-plumber`](https://github.com/floatdrop/gulp-plumber) to log the friendly error message (showing the faulty code):

```console
[15:38:10] Starting 'compile:scss'...
Error in plugin "gulp-better-rollup"
Message:
    Unexpected token
Details:
    code: PARSE_ERROR
    pos: 1256
    loc: [object Object]
    frame: 25:   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
26:   // Defaults to the entire document if nothing is set.
27:   var $scope = typeof config.scope !== 'undefined' ? config.scope document
                                                                      ^
28:
29:   var $accordions = $scope.querySelectorAll('[data-module="govuk-accordion"]')
```

Follows the same approach as:

* https://github.com/alphagov/govuk-frontend/pull/3034