### PR TITLE
Bug: Percy uploads should complete before “finalizing”

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,4 +31,7 @@ jobs:
         run: npm run serve &
 
       - name: Send screenshots to Percy
-        run: npx percy exec -- npm run test:screenshots
+        run: npx percy exec --parallel -- npm run test:screenshots
+
+      - name: Finalise Percy build
+        run: npx percy build:finalize

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       PORT: 8888
 


### PR DESCRIPTION
Looks like we have a Percy race condition which started recently and has caused a few flaky workflow runs

## The problem
Percy CLI is "finalizing" a build early when more uploads are yet to complete (also reported by others):

* https://github.com/percy/cli/discussions/1137

```console
[percy:client] Finalizing build XXXXXXXX... (0ms)
[percy:cli] Error: Finalizing build XXXXXXXX failed: cannot finalize before all snapshot resources are uploaded. This is likely a client error, please make sure that content for all SHAs in 'missing-resources' from the snapshot response are uploaded before calling finalize.
```

## The solution
1. Add the Percy `--parallel` flag so the door stays open for more uploads
2. Run the Percy `build:finalize` command when we know we're (really) complete

Potential related changes:

* https://github.com/alphagov/govuk-frontend/pull/2993
* https://github.com/alphagov/govuk-frontend/pull/3002
* https://github.com/alphagov/govuk-frontend/pull/3020
* https://github.com/alphagov/govuk-frontend/pull/3031

We may have also revealed this issue after adding [**Send Percy screenshots in batches** `93cde6f`](https://github.com/alphagov/govuk-frontend/pull/3009/commits/93cde6f7cf11450ea1cb635dc1fe99915b13939d) in:

* https://github.com/alphagov/govuk-frontend/pull/3009