### PR TITLE
Use native Fetch API in behaviour tests

### DIFF
--- a/app/app.test.js
+++ b/app/app.test.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio')
-const { Agent, fetch, setGlobalDispatcher } = require('undici')
 
 const configPaths = require('../config/paths')
 const { getDirectories } = require('../lib/file-helper')
@@ -17,12 +16,6 @@ const expectedPages = [
   '/examples/template-default',
   '/examples/template-custom'
 ]
-
-// Reduce test keep-alive
-setGlobalDispatcher(new Agent({
-  keepAliveTimeout: 10,
-  keepAliveMaxTimeout: 10
-}))
 
 // Returns Fetch API wrapper which applies these options by default
 const fetchPath = (path, options) => {

--- a/app/banner.test.js
+++ b/app/banner.test.js
@@ -1,14 +1,7 @@
 const cheerio = require('cheerio')
-const { Agent, fetch, setGlobalDispatcher } = require('undici')
 
 const configPaths = require('../config/paths')
 const PORT = configPaths.ports.test
-
-// Reduce test keep-alive timeouts
-setGlobalDispatcher(new Agent({
-  keepAliveTimeout: 10,
-  keepAliveMaxTimeout: 10
-}))
 
 // Returns Fetch API wrapper which applies these options by default
 const fetchPath = (path, options) => {

--- a/app/full-page-examples.test.js
+++ b/app/full-page-examples.test.js
@@ -1,5 +1,4 @@
 const cheerio = require('cheerio')
-const { Agent, fetch, setGlobalDispatcher } = require('undici')
 
 const configPaths = require('../config/paths')
 const PORT = configPaths.ports.test
@@ -20,12 +19,6 @@ const expectedPages = [
   'what-is-your-postcode',
   'what-was-the-last-country-you-visited'
 ]
-
-// Reduce test keep-alive timeouts
-setGlobalDispatcher(new Agent({
-  keepAliveTimeout: 10,
-  keepAliveMaxTimeout: 10
-}))
 
 // Returns Fetch API wrapper which applies these options by default
 const fetchPath = (path, options) => {

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,6 @@
     "shuffle-seed": "^1.1.6"
   },
   "devDependencies": {
-    "cheerio": "^1.0.0-rc.12",
-    "undici": "^5.12.0"
+    "cheerio": "^1.0.0-rc.12"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -12,15 +12,15 @@
     "start": "node start.js"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "express-validator": "^6.14.2",
     "body-parser": "^1.18.3",
     "cookie-parser": "^1.4.6",
+    "express": "^4.18.2",
+    "express-validator": "^6.14.2",
     "front-matter": "^4.0.2",
     "glob": "^8.0.3",
-    "govuk-elements-sass": "3.1.3",
     "govuk_frontend_toolkit": "^9.0.1",
     "govuk_template_jinja": "^0.26.0",
+    "govuk-elements-sass": "3.1.3",
     "html5shiv": "^3.7.3",
     "jquery": "1.12.4",
     "js-yaml": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,8 +109,7 @@
         "shuffle-seed": "^1.1.6"
       },
       "devDependencies": {
-        "cheerio": "^1.0.0-rc.12",
-        "undici": "^5.12.0"
+        "cheerio": "^1.0.0-rc.12"
       },
       "engines": {
         "node": "^18.12.0",
@@ -5214,18 +5213,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -22033,15 +22020,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/streamx": {
       "version": "2.12.5",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.12.5.tgz",
@@ -23545,18 +23523,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
       "integrity": "sha512-Ia0sQNrMPXXkqVFt6w6M1n1oKo3NfKs+mvaV811Jwir7vAk9a6PVV9VPYf6X3BU97QiLEmuW3uXH9u87zDFfdw=="
-    },
-    "node_modules/undici": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
-      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
-      "dev": true,
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
-      "engines": {
-        "node": ">=12.18"
-      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",


### PR DESCRIPTION
We temporarily used [`undici`](https://github.com/nodejs/undici) to prepare for the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) landing in Node.js 18:

* https://github.com/alphagov/govuk-frontend/pull/2858
* https://github.com/alphagov/govuk-frontend/pull/3018

Both PRs have now merged so we can remove [`undici`](https://github.com/nodejs/undici)

(Another package Dependabot doesn't need to worry about)