### PR TITLE
Run browser tests on minified code

### DIFF
--- a/app/app.test.js
+++ b/app/app.test.js
@@ -125,7 +125,7 @@ describe(`http://localhost:${PORT}`, () => {
       const response = await fetchPath(templatePath)
       const $ = cheerio.load(await response.text())
 
-      const $appStylesheet = $('link[href="/public/app.css"]')
+      const $appStylesheet = $('link[href="/public/app.min.css"]')
       expect($appStylesheet.length).toBe(1)
     })
 

--- a/app/views/examples/scoped-initialisation/index.njk
+++ b/app/views/examples/scoped-initialisation/index.njk
@@ -4,10 +4,10 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/public/app.css">
+    <link rel="stylesheet" href="/public/app.min.css">
   <!--<![endif]-->
   <!--[if IE 8]>
-    <link rel="stylesheet" href="/public/app-ie8.css">
+    <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
     <script src="/vendor/html5-shiv/html5shiv.js"></script>

--- a/app/views/examples/scoped-initialisation/index.njk
+++ b/app/views/examples/scoped-initialisation/index.njk
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <script src="/vendor/html5-shiv/html5shiv.min.js"></script>
   <![endif]-->
 {% endblock %}
 

--- a/app/views/examples/scoped-initialisation/index.njk
+++ b/app/views/examples/scoped-initialisation/index.njk
@@ -53,7 +53,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>
     var $scope = document.getElementById('scoped')
     window.GOVUKFrontend.initAll({

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -129,7 +129,7 @@
 
 {% block bodyEnd %}
   <!-- block:bodyEnd -->
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
   <!-- endblock:bodyEnd -->
 {% endblock %}

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -32,7 +32,7 @@
     <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <script src="/vendor/html5-shiv/html5shiv.min.js"></script>
   <![endif]-->
   <!-- endblock:head -->
 {% endblock %}

--- a/app/views/examples/template-custom/index.njk
+++ b/app/views/examples/template-custom/index.njk
@@ -26,10 +26,10 @@
 {% block head %}
   <!-- block:head -->
   <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/public/app.css">
+    <link rel="stylesheet" href="/public/app.min.css">
   <!--<![endif]-->
   <!--[if IE 8]>
-    <link rel="stylesheet" href="/public/app-ie8.css">
+    <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
     <script src="/vendor/html5-shiv/html5shiv.js"></script>

--- a/app/views/examples/template-default/index.njk
+++ b/app/views/examples/template-default/index.njk
@@ -2,10 +2,10 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/public/app.css">
+    <link rel="stylesheet" href="/public/app.min.css">
   <!--<![endif]-->
   <!--[if IE 8]>
-    <link rel="stylesheet" href="/public/app-ie8.css">
+    <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
     <script src="/vendor/html5-shiv/html5shiv.js"></script>

--- a/app/views/examples/template-default/index.njk
+++ b/app/views/examples/template-default/index.njk
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="/public/app-ie8.min.css">
   <![endif]-->
   <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <script src="/vendor/html5-shiv/html5shiv.min.js"></script>
   <![endif]-->
 {% endblock %}
 

--- a/app/views/examples/template-default/index.njk
+++ b/app/views/examples/template-default/index.njk
@@ -20,6 +20,6 @@
 
 
 {% block bodyEnd %}
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/app/views/examples/translated/index.njk
+++ b/app/views/examples/translated/index.njk
@@ -937,7 +937,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>
     window.GOVUKFrontend.initAll({
       accordion: {

--- a/app/views/full-page-examples/campaign-page/index.njk
+++ b/app/views/full-page-examples/campaign-page/index.njk
@@ -20,7 +20,7 @@ notes: >-
 
 {% block head %}
     {{ super() }}
-    <link rel="stylesheet" href="/public/full-page-examples/campaign-page.css">
+    <link rel="stylesheet" href="/public/full-page-examples/campaign-page.min.css">
 {% endblock %}
 
 {% block header %}

--- a/app/views/full-page-examples/search/index.njk
+++ b/app/views/full-page-examples/search/index.njk
@@ -32,7 +32,7 @@ notes: >-
 
 {% block head %}
   {{ super() }}
-  <link rel="stylesheet" href="/public/full-page-examples/search.css">
+  <link rel="stylesheet" href="/public/full-page-examples/search.min.css">
 {% endblock %}
 
 {% block beforeContent %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -50,6 +50,6 @@
     {% include "partials/legacyJavaScript.njk" %}
   {% endif %}
 
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -12,17 +12,17 @@
     <link rel="stylesheet" media="print" href="/vendor/govuk_template/stylesheets/govuk-template-print.css">
     <link rel="stylesheet" media="all" href="/vendor/govuk_template/stylesheets/fonts.css"/>
     <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="/public/app-legacy.css">
+      <link rel="stylesheet" href="/public/app-legacy.min.css">
     <!--<![endif]-->
     <!--[if IE 8]>
-      <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+      <link rel="stylesheet" href="/public/app-legacy-ie8.min.css">
     <![endif]-->
   {% else %}
     <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="/public/app.css">
+      <link rel="stylesheet" href="/public/app.min.css">
     <!--<![endif]-->
     <!--[if IE 8]>
-      <link rel="stylesheet" href="/public/app-ie8.css">
+      <link rel="stylesheet" href="/public/app-ie8.min.css">
     <![endif]-->
   {% endif %}
 

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -31,7 +31,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
   <!--<![endif]-->
   <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.js"></script>
+    <script src="/vendor/html5-shiv/html5shiv.min.js"></script>
   <![endif]-->
 
   {% block styles %}{% endblock %}

--- a/app/views/layouts/legacy.njk
+++ b/app/views/layouts/legacy.njk
@@ -9,10 +9,10 @@
 
 {% block head %}
   <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/public/app-legacy.css">
+    <link rel="stylesheet" href="/public/app-legacy.min.css">
   <!--<![endif]-->
   <!--[if IE 8]>
-    <link rel="stylesheet" href="/public/app-legacy-ie8.css">
+    <link rel="stylesheet" href="/public/app-legacy-ie8.min.css">
   <![endif]-->
 {% endblock %}
 

--- a/app/views/layouts/legacy.njk
+++ b/app/views/layouts/legacy.njk
@@ -22,6 +22,6 @@
 
 {% block body_end %}
   {% include "partials/legacyJavaScript.njk" %}
-  <script src="/public/all.js"></script>
+  <script src="/public/all.min.js"></script>
   <script>window.GOVUKFrontend.initAll()</script>
 {% endblock %}

--- a/app/views/tests/boilerplate.njk
+++ b/app/views/tests/boilerplate.njk
@@ -12,6 +12,6 @@
       Used during testing to inject rendered components and test specific configurations
     </p>
     <div id="slot"></div>
-    <script src="/public/all.js"></script>
+    <script src="/public/all.min.js"></script>
 	</body>
 </html>

--- a/app/views/tests/boilerplate.njk
+++ b/app/views/tests/boilerplate.njk
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8"/>
     <title>Test Boilerplate</title>
-    <link rel="stylesheet" href="/public/app.css">
+    <link rel="stylesheet" href="/public/app.min.css">
   </head>
   <body>
     <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>

--- a/docs/examples/webpack/index.html
+++ b/docs/examples/webpack/index.html
@@ -9,10 +9,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <!--[if !IE 8]><!-->
-      <link rel="stylesheet" href="/assets/stylesheets/app.css">
+      <link rel="stylesheet" href="/assets/stylesheets/app.min.css">
     <!--<![endif]-->
     <!--[if IE 8]>
-      <link rel="stylesheet" href="/assets/stylesheets/app-ie8.css">
+      <link rel="stylesheet" href="/assets/stylesheets/app-ie8.min.css">
     <![endif]-->
     <!--[if lt IE 9]>
       <script src="/assets/javascripts/html5shiv.min.js"></script>
@@ -29,6 +29,6 @@
       </main>
     </div>
 
-    <script src="/assets/javascripts/main.js"></script>
+    <script src="/assets/javascripts/main.min.js"></script>
   </body>
 </html>

--- a/docs/examples/webpack/webpack.config.js
+++ b/docs/examples/webpack/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
         generator: {
           outputPath: 'assets/stylesheets',
           publicPath: '/assets/stylesheets',
-          filename: '[name].css'
+          filename: '[name].min.css'
         },
         test: /\.scss$/,
         type: 'asset',
@@ -77,7 +77,7 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
 
   output: {
     clean: true,
-    filename: 'assets/javascripts/[name].js',
+    filename: 'assets/javascripts/[name].min.js',
     library: { type: 'umd' },
     path: resolve(__dirname, './public'),
     publicPath: '/'

--- a/tasks/compile-javascripts.mjs
+++ b/tasks/compile-javascripts.mjs
@@ -14,6 +14,9 @@ import { destination, isDist, isPackage } from './task-arguments.mjs'
 /**
  * Compile JavaScript ESM to CommonJS task
  *
+ * The 'all-in-one' JavaScript bundle (all.mjs)
+ * will be minified by default for 'dist' and 'public'
+ *
  * @returns {Promise<void>}
  */
 export async function compileJavaScripts () {
@@ -130,7 +133,7 @@ export async function getModuleEntries () {
     .map((modulePath) => ([modulePath, {
       srcPath,
       destPath,
-      minify: isDist
+      minify: !isPackage
     }]))
 }
 

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -35,9 +35,9 @@ export function compileStylesheets () {
         })
           .pipe(rename({
             basename: 'govuk-frontend',
-            suffix: `-${pkg.version}.min`,
-            extname: '.css'
-          }))),
+            suffix: `-${pkg.version}`
+          }))
+      ),
 
       compileStylesheet(
         gulp.src(`${slash(paths.src)}/govuk/all-ie8.scss`, {
@@ -45,9 +45,9 @@ export function compileStylesheets () {
         })
           .pipe(rename({
             basename: 'govuk-frontend-ie8',
-            suffix: `-${pkg.version}.min`,
-            extname: '.css'
-          })))
+            suffix: `-${pkg.version}`
+          }))
+      )
     )
       .pipe(gulp.dest(slash(destPath), {
         sourcemaps: '.'
@@ -78,7 +78,8 @@ export function compileStylesheets () {
         .pipe(rename((path) => {
           path.basename = path.dirname
           path.dirname = 'full-page-examples'
-        })))
+        }))
+    )
   )
     .pipe(gulp.dest(slash(destPath), {
       sourcemaps: '.'
@@ -98,6 +99,9 @@ function compileStylesheet (stream, options = {}) {
   return stream
     .pipe(plumber(errorHandler(stream, 'compile:scss')))
     .pipe(sass(options))
+    .pipe(rename({
+      extname: '.min.css'
+    }))
     .pipe(postcss())
     .pipe(plumber.stop())
 }


### PR DESCRIPTION
Quick proof of concept to:

1. Run the JS minifier on `all.mjs` (for **./dist** and **./public**)
2. Run the CSS minifier on all Sass files
3. Use minified files in the [review app](https://govuk-frontend-pr-3050.herokuapp.com)
4. Use `.min.*` extensions in webpack example

Discussed in:

* https://github.com/alphagov/govuk-frontend/issues/2886

### Why?
Ensures our browser tests (via the review app) run on minified code as minifiers can cause their own issues:

* https://github.com/mishoo/UglifyJS/pull/5033
* https://github.com/mishoo/UglifyJS/pull/5084
* https://github.com/mishoo/UglifyJS/pull/5207

Also gives us the confidence to swap to a modern ES6+ minifier:

* https://github.com/alphagov/govuk-frontend/pull/3013