### PR TITLE
Enhance the Accordion component with `hidden='until-found'`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### New features
+
+#### Search within accordion content on supporting browsers
+
+We've updated the Accordion component to use the new [`hidden="until-found"` attribute value](https://developer.chrome.com/articles/hidden-until-found/).
+
+This allows the browser's native 'find in page' functionality to search within and automatically open sections of the accordion. Currently, this functionality is only supported by recent versions of Google Chrome, Microsoft Edge and Samsung Internet.
+
+This was added in [pull request #3053: Enhance the Accordion component with `hidden='until-found'`](https://github.com/alphagov/govuk-frontend/pull/3053). 
+
 ### Fixes
 
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -46,7 +46,18 @@
       padding-top: 0;
     }
 
-    // Hide the body of collapsed sections
+    // Manually apply display: none to browsers that don't have a user agent
+    // style for it, but override it with content-visibility if the browser
+    // supports that instead.
+    .govuk-accordion__section-content[hidden] {
+      display: none;
+      @supports (content-visibility: hidden) {
+        content-visibility: hidden;
+        display: inherit;
+      }
+    }
+
+    // Hide the padding of collapsed sections
     .govuk-accordion__section--expanded .govuk-accordion__section-content {
       @include govuk-responsive-padding(8, "bottom");
       @include govuk-responsive-padding(3, "top");

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -47,15 +47,9 @@
     }
 
     // Hide the body of collapsed sections
-    .govuk-accordion__section-content {
-      display: none;
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
       @include govuk-responsive-padding(8, "bottom");
       @include govuk-responsive-padding(3, "top");
-    }
-
-    // Show the body of expanded sections
-    .govuk-accordion__section--expanded .govuk-accordion__section-content {
-      display: block;
     }
 
     .govuk-accordion__show-all {


### PR DESCRIPTION
`until-found` is a new value for the `hidden` attribute, that allows a user agent's find-in-page functionality to search the text inside of elements that are currently collapsed. It serves as a progressive enhancement to the existing `hidden` boolean attribute, falling back to the default behaviour in browsers that don't support the new value.

It was introduced at the same time as the `beforematch` JavaScript event, allowing us to see which element on the page the "found" text is contained within.

Currently the new attribute value and JavaScript event are only supported in Chromium-based browsers (including Google Chrome, Microsoft Edge, Opera, and Samsung Internet).

Linked to #2697. I previously did a small, hackier investigation into this at the start of August. See [my previous comment](https://github.com/alphagov/govuk-frontend/issues/2697#issuecomment-1203769281) for the outcome of that.

## Changes in this spike

- Replaces the hiding and showing of accordion sections via CSS, to instead conditionally add and remove the `hidden="until-found"` attribute using JavaScript.
  - This change means that the point that accordion content is hidden is slightly different. Formerly it was hidden (effectively) immediately, based on the presence of the `js-enabled` class. It now requires both the class and for the accordion's JavaScript to have been initialised before anything is hidden.
  - As a benefit, this is a little more resilient as it means the accordion's content is visible even when the accordion hasn't been initialised or errored whilst doing so, which wasn't the case previously. 
- Refactors the section content's padding to only apply when the section is expanded.
  - This is because an element with `hidden="until-found"` on it is not removed from the box model (it uses `content-visibility: hidden`, not `display: none` unlike boolean `hidden`) so the padding was always visible.
- Adds a `beforematch` event handler and function to correctly change the state, styles and button labels in the event of a match by the user agent.
  - Without this, the user agent would automatically remove the `hidden` attribute upon a match, but would not change any other parts of the accordion.

## Other thoughts

This would seem to be a non-breaking change in terms of service teams, unless a team has customised the styles of the section content box. As this element is no longer completely ignored when rendering the box model, any styles (such as borders, background colours, margins or padding) may become visible even when the section is collapsed.

~~This probably poses a larger issue for legacy Internet Explorer support. This is currently relying on user agent stylesheets to be clever and apply either `content-visibility: hidden` or `display: none` depending on the value (or lack) of the `hidden` attribute. IE 10 and below don't support the `hidden` attribute at all, so a `display: none` rule would need to be applied for those browsers without compromising those that support `hidden="until-found"`.~~ Resolved, see discussion below.

This functionality would seemingly want to be mirrored to the [Details component](https://design-system.service.gov.uk/components/details/), however we are relying solely on the user agent's own functionality to provide the expand/collapse feature in modern browsers. 