### PR TITLE
[SPIKE] Testing with Playwright

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,12 +23,7 @@ module.exports = {
       parserOptions: {
         ecmaVersion: 'latest'
       },
-      plugins: [
-        'import',
-        'jsdoc',
-        'n',
-        'promise'
-      ],
+      plugins: ['import', 'jsdoc', 'n', 'promise'],
       rules: {
         // Check import or require statements are A-Z ordered
         'import/order': [
@@ -54,14 +49,16 @@ module.exports = {
 
         // Add unknown @jest-environment tag name
         'jsdoc/check-tag-names': [
-          'warn', {
+          'warn',
+          {
             definedTags: ['jest-environment']
           }
         ],
 
         // Add missing .querySelectorAll() type
         'jsdoc/no-undefined-types': [
-          'error', {
+          'error',
+          {
             definedTypes: ['NodeListOf']
           }
         ]
@@ -103,6 +100,12 @@ module.exports = {
       files: ['**/*.test.{cjs,js,mjs}'],
       env: {
         jest: true
+      }
+    },
+    {
+      files: ['**/*.spec.{cjs,js,mjs}'],
+      parserOptions: {
+        ecmaVersion: 'latest'
       }
     }
   ]

--- a/.github/workflows/playwright-bulk.yml
+++ b/.github/workflows/playwright-bulk.yml
@@ -1,0 +1,41 @@
+name: Playwright - Bulk
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Browser test
+
+    strategy:
+      matrix:
+        suite:
+          - test: character-count/character-count
+          - test: checkboxes/template
+          - test: ""
+
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      uses: ./.github/workflows/actions/install-node
+
+    - name: Build
+      uses: ./.github/workflows/actions/build
+
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+
+    - name: Run Playwright tests
+      run: npx playwright test ${{matrix.suite.test}}
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright-matrix.yml
+++ b/.github/workflows/playwright-matrix.yml
@@ -1,4 +1,4 @@
-name: Playwright Tests
+name: Playwright Matrix
 on:
   workflow_call:
   workflow_dispatch:
@@ -8,15 +8,14 @@ jobs:
     name: Browser test
     strategy:
       matrix:
-        include:
-          - description: Chromium
-            name: chromium
-
-          - description: Firefox
-            name: firefox
-
-          - description: Webkit
-            name: webkit
+        suite:
+          - test: character-count/character-count
+          - test: checkboxes/template
+          - test: ""
+        browser:
+          - name: chromium
+          - name: firefox
+          - name: webkit
 
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -34,7 +33,7 @@ jobs:
       run: npx playwright install --with-deps
 
     - name: Run Playwright tests
-      run: npx playwright test --project ${{ matrix.name }}
+      run: npx playwright test --project=${{ matrix.browser.name }} ${{matrix.suite.test}}
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,27 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 16
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npx playwright test
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,24 +1,28 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+  workflow_call:
+  workflow_dispatch:
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Install dependencies
-      run: npm ci
+      uses: ./.github/workflows/actions/install-node
+
+    - name: Build
+      uses: ./.github/workflows/actions/build
+
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+
     - name: Run Playwright tests
       run: npx playwright test
+
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,19 @@ on:
 
 jobs:
   test:
+    name: Browser test
+    strategy:
+      matrix:
+        include:
+          - description: Chromium
+            name: chromium
+
+          - description: Firefox
+            name: firefox
+
+          - description: Webkit
+            name: webkit
+
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
@@ -21,7 +34,7 @@ jobs:
       run: npx playwright install --with-deps
 
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npx playwright test --project ${{ matrix.name }}
 
     - uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/puppeteer-comparison.yml
+++ b/.github/workflows/puppeteer-comparison.yml
@@ -1,0 +1,38 @@
+name: Puppeteer comparison
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Browser test
+
+    strategy:
+      matrix:
+        suite:
+          - test: character-count/character-count
+          - test: checkboxes/template
+          - test: "character-count/character-count checkboxes/template"
+
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install dependencies
+      uses: ./.github/workflows/actions/install-node
+
+    - name: Build
+      uses: ./.github/workflows/actions/build
+
+    - name: Test
+      run: npx jest --color --maxWorkers=2 --testLocationInResults ${{matrix.suite.test}}
+
+    - name: Save test coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.description }} coverage
+        path: coverage
+        if-no-files-found: ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,12 @@ jobs:
       - name: Run verify task
         run: ${{ matrix.run }}
 
+  playwright:
+    name: Playwright
+    needs: [install, build]
+
+    uses: ./.github/workflows/playwright.yml
+
   regression:
     name: Percy
     needs: [install, build]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,11 +161,23 @@ jobs:
       - name: Run verify task
         run: ${{ matrix.run }}
 
-  playwright:
-    name: Playwright
+  playwright-bulk:
+    name: Playwright - Bulk
     needs: [install, build]
 
-    uses: ./.github/workflows/playwright.yml
+    uses: ./.github/workflows/playwright-bulk.yml
+
+  playwright-matrix:
+    name: Playwright - Matrix
+    needs: [install, build]
+
+    uses: ./.github/workflows/playwright-matrix.yml
+
+  jest-puppeteer:
+    name: Puppeteer comparison
+    needs: [install, build]
+
+    uses: ./.github/workflows/puppeteer-comparison.yml
 
   regression:
     name: Percy

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ examples/**/package-lock.json
 jsdoc/
 sassdoc/
 .cache
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/lib/playwright-helpers.js
+++ b/lib/playwright-helpers.js
@@ -1,3 +1,6 @@
+const { componentNameToJavaScriptClassName } = require('./helper-functions.js')
+const { renderHtml } = require('./jest-helpers.js')
+
 async function goTo (page, path) {
   await page.goto(path)
   await page.bringToFront()
@@ -17,8 +20,41 @@ function goToComponent (page, componentName, { exampleName } = {}) {
   return goTo(page, componentPath)
 }
 
+async function renderAndInitialise (page, componentName, options = {}) {
+  await goTo(page, '/tests/boilerplate')
+
+  const html = renderHtml(componentName, options.nunjucksParams)
+
+  // Inject rendered HTML into the page
+  await page.$eval(
+    '#slot',
+    (slot, htmlForSlot) => {
+      slot.innerHTML = htmlForSlot
+    },
+    html
+  )
+
+  const initialiser =
+    options.initialiser ||
+    function ({ config, componentClassName }) {
+      const $component = document.querySelector('[data-module]')
+      new window.GOVUKFrontend[componentClassName]($component, config).init()
+    }
+
+  if (initialiser) {
+    // Run a script to init the JavaScript component
+    await page.evaluate(initialiser, {
+      config: options.javascriptConfig,
+      componentClassName: componentNameToJavaScriptClassName(componentName)
+    })
+  }
+
+  return page
+}
+
 module.exports = {
   goTo,
   goToComponent,
-  goToExample
+  goToExample,
+  renderAndInitialise
 }

--- a/lib/playwright-helpers.js
+++ b/lib/playwright-helpers.js
@@ -1,0 +1,24 @@
+async function goTo (page, path) {
+  await page.goto(path)
+  await page.bringToFront()
+
+  return page
+}
+
+function goToExample (page, exampleName, options) {
+  return goTo(page, `/examples/${exampleName}`, options)
+}
+
+function goToComponent (page, componentName, { exampleName } = {}) {
+  const componentPath = exampleName
+    ? `/components/${componentName}/${exampleName}/preview`
+    : `/components/${componentName}/preview`
+
+  return goTo(page, componentPath)
+}
+
+module.exports = {
+  goTo,
+  goToComponent,
+  goToExample
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@percy/cli": "^1.16.0",
         "@percy/puppeteer": "^2.0.2",
         "@percy/sdk-utils": "^1.16.0",
+        "@playwright/test": "^1.28.1",
         "babel-jest": "^29.3.1",
         "cheerio": "^1.0.0-rc.12",
         "eslint": "^8.29.0",
@@ -3045,6 +3046,22 @@
       "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.16.0.tgz",
       "integrity": "sha512-/nPyK4NCjFGYNVQ7vOivfuEYveOJhA4gWzB7w2PjCkw/Y3kCtu+axRpUiDPEybTz2H6RTvr+I526DbtUYguqVw==",
       "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
       "engines": {
         "node": ">=14"
       }
@@ -18745,6 +18762,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/plugin-error": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "yargs-parser": "^21.1.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.5.2",
         "@percy/cli": "^1.16.0",
         "@percy/puppeteer": "^2.0.2",
         "@percy/sdk-utils": "^1.16.0",
@@ -148,6 +149,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.5.2.tgz",
+      "integrity": "sha512-RXdnUeroQwLoIoxxZNKBy/2FsjOrgYsiIrSdZkRfVVWFudTgatncc9izyMZ40ou+nw/d1zi/WPCjrLUI6TZBBA==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.5.2"
+      },
+      "peerDependencies": {
+        "playwright": ">= 1.0.0"
+      }
+    },
+    "node_modules/@axe-core/playwright/node_modules/axe-core": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
+      "integrity": "sha512-u2MVsXfew5HBvjsczCv+xlwdNnB1oQR9HlAcsejZttNjKKSkeDNVwB1vMThIUIFI9GoT57Vtk8iQLwqOfAkboA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -18762,6 +18784,23 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.28.1.tgz",
+      "integrity": "sha512-92Sz6XBlfHlb9tK5UCDzIFAuIkHHpemA9zwUaqvo+w7sFMSmVMGmvKcbptof/eJObq63PGnMhM75x7qxhTR78Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "playwright-core": "1.28.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/playwright-core": {

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "yargs-parser": "^21.1.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.5.2",
     "@percy/cli": "^1.16.0",
     "@percy/puppeteer": "^2.0.2",
     "@percy/sdk-utils": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@percy/cli": "^1.16.0",
     "@percy/puppeteer": "^2.0.2",
     "@percy/sdk-utils": "^1.16.0",
+    "@playwright/test": "^1.28.1",
     "babel-jest": "^29.3.1",
     "cheerio": "^1.0.0-rc.12",
     "eslint": "^8.29.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,108 @@
+// @ts-check
+const { devices } = require('@playwright/test')
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ * @type {import('@playwright/test').PlaywrightTestConfig}
+ */
+const config = {
+  testDir: './tests',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry'
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome']
+      }
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox']
+      }
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari']
+      }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ]
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+}
+
+module.exports = config

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,7 @@ const config = {
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['html', { open: process.env.PW_REPORTER_HTML_OPEN }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,6 +14,7 @@ const { devices } = require('@playwright/test')
 const config = {
   testDir: '.',
   testMatch: '**/*.spec.{cjs,js,mjs}',
+  snapshotPathTemplate: '{testFileDir}/__pw_snapshots__/{testFileName}/{arg}{ext}',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -12,7 +12,8 @@ const { devices } = require('@playwright/test')
  * @type {import('@playwright/test').PlaywrightTestConfig}
  */
 const config = {
-  testDir: './tests',
+  testDir: '.',
+  testMatch: '**/*.spec.{cjs,js,mjs}',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -93,16 +94,16 @@ const config = {
     //     channel: 'chrome',
     //   },
     // },
-  ]
+  ],
 
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   port: 3000,
-  // },
+  webServer: {
+    command: 'npm start',
+    port: 3000
+  }
 }
 
 module.exports = config

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,7 +14,8 @@ const { devices } = require('@playwright/test')
 const config = {
   testDir: '.',
   testMatch: '**/*.spec.{cjs,js,mjs}',
-  snapshotPathTemplate: '{testFileDir}/__pw_snapshots__/{testFileName}/{arg}{ext}',
+  snapshotPathTemplate:
+    '{testFileDir}/__pw_snapshots__/{testFileName}/{arg}{ext}',
   /* Maximum time one test can run for. */
   timeout: 30 * 1000,
   expect: {
@@ -103,7 +104,8 @@ const config = {
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'npm start',
-    port: 3000
+    port: 3000,
+    reuseExistingServer: !process.env.CI
   }
 }
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -32,7 +32,7 @@ const config = {
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['html', { open: process.env.PW_REPORTER_HTML_OPEN }]],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */

--- a/src/govuk/components/character-count/character-count.spec.mjs
+++ b/src/govuk/components/character-count/character-count.spec.mjs
@@ -1,0 +1,42 @@
+// @ts-check
+import { test, expect } from '@playwright/test'
+
+import { goToComponent } from '../../../../lib/playwright-helpers.js'
+
+test.describe('Character Count', () => {
+  test.describe('when JavaScript is unavailable or fails', () => {
+    test.use({ javaScriptEnabled: false })
+
+    test('shows the textarea description', async ({ page }) => {
+      await goToComponent(page, 'character-count')
+
+      await expect(page.locator('.govuk-character-count__message')).toHaveText('You can enter up to 10 characters')
+    })
+  })
+
+  test.describe('when JavaScript is available', () => {
+    test.describe('on page load', () => {
+      test.beforeEach(async ({ page }) => {
+        await goToComponent(page, 'character-count')
+      })
+
+      test('injects the visual counter', async ({ page }) => {
+        const visualCounter = page.locator('.govuk-character-count__status')
+
+        await expect(visualCounter).toHaveText('You have 10 characters remaining')
+        await expect(visualCounter).toBeVisible()
+      })
+
+      test('injects the screen reader counter', async ({ page }) => {
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveClass(/govuk-visually-hidden/)
+      })
+
+      test('hides the textarea description', async ({ page }) => {
+        // The `.govuk-character-count__message` is used twice
+        // so we need to disambiguate and specify we want the one not displaying the count as people type
+        await expect(page.locator('.govuk-character-count__message:not(.govuk-character-count__status)'))
+          .toHaveClass(/govuk-visually-hidden/)
+      })
+    })
+  })
+})

--- a/src/govuk/components/character-count/character-count.spec.mjs
+++ b/src/govuk/components/character-count/character-count.spec.mjs
@@ -52,11 +52,8 @@ test.describe('Character Count', () => {
       test('shows the dynamic message', async ({ page }) => {
         await goToComponent(page, 'character-count')
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 10 characters remaining')
-
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 10 characters remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 10 characters remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 10 characters remaining')
       })
 
       test('shows the characters remaining if the field is pre-filled', async ({ page }) => {
@@ -64,11 +61,8 @@ test.describe('Character Count', () => {
           exampleName: 'with-default-value'
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 67 characters remaining')
-
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 67 characters remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 67 characters remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 67 characters remaining')
       })
 
       test('counts down to the character limit', async ({ page }) => {
@@ -76,29 +70,26 @@ test.describe('Character Count', () => {
 
         await page.type('.govuk-js-character-count', 'A')
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 9 characters remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 9 characters remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 9 characters remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 9 characters remaining')
       })
 
+      // TODO: Remove as this is unit tested already?
       test('uses the singular when there is only one character remaining', async ({ page }) => {
         await goToComponent(page, 'character-count')
 
         await page.type('.govuk-js-character-count', 'A'.repeat(9))
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 1 character remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 1 character remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 1 character remaining')
       })
 
       test.describe('when the character limit is exceeded', () => {
@@ -109,37 +100,31 @@ test.describe('Character Count', () => {
         })
 
         test('shows the number of characters over the limit', async ({ page }) => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 1 character too many')
         })
 
         test('uses the plural when the limit is exceeded by 2 or more', async ({ page }) => {
           await page.type('.govuk-js-character-count', 'A')
 
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 2 characters too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 2 characters too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 2 characters too many')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 2 characters too many')
         })
 
         test('adds error styles to the textarea', async ({ page }) => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
-          expect(textareaClasses).toContain('govuk-textarea--error')
+          await expect(page.locator('.govuk-js-character-count')).toHaveClass(/govuk-textarea--error/)
         })
 
         test('adds error styles to the count message', async ({ page }) => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
-          expect(messageClasses).toContain('govuk-error-message')
+          await expect(page.locator('.govuk-character-count__status')).toHaveClass(/govuk-error-message/)
         })
       })
 
@@ -151,21 +136,16 @@ test.describe('Character Count', () => {
         })
 
         test('shows the number of characters over the limit', async ({ page }) => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 23 characters too many')
-
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 23 characters too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 23 characters too many')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 23 characters too many')
         })
 
         test('adds error styles to the textarea', async ({ page }) => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
-          expect(textareaClasses).toContain('govuk-textarea--error')
+          await expect(page.locator('.govuk-js-character-count')).toHaveClass(/govuk-textarea--error/)
         })
 
         test('adds error styles to the count message', async ({ page }) => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
-          expect(messageClasses).toContain('govuk-error-message')
+          await expect(page.locator('.govuk-character-count__status')).toHaveClass(/govuk-error-message/)
         })
       })
 
@@ -177,29 +157,25 @@ test.describe('Character Count', () => {
         })
 
         test('does not show the limit until the threshold is reached', async ({ page }) => {
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
-          expect(visibility).toEqual('hidden')
+          expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'hidden')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
-          expect(ariaHidden).toEqual('true')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveAttribute('aria-hidden', 'true')
         })
 
         test('becomes visible once the threshold is reached', async ({ page }) => {
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
-          expect(visibility).toEqual('visible')
+          expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'visible')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
-          expect(ariaHidden).toBeFalsy()
+          // Ensure threshold is hidden for users of assistive technologies
+          await expect(page.locator('.govuk-character-count__sr-status').getAttribute('aria-hidden')).resolves.toBeNull()
         })
       })
 
@@ -212,11 +188,8 @@ test.describe('Character Count', () => {
         })
 
         test('still works correctly', async ({ page }) => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 10 characters remaining')
-
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 10 characters remaining')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 10 characters remaining')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 10 characters remaining')
         })
       })
 
@@ -228,11 +201,8 @@ test.describe('Character Count', () => {
         })
 
         test('still works correctly', async ({ page }) => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 10 characters remaining')
-
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 10 characters remaining')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 10 characters remaining')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 10 characters remaining')
         })
       })
 
@@ -244,8 +214,7 @@ test.describe('Character Count', () => {
         })
 
         test('should not have a maxlength attribute once the JS has run', async ({ page }) => {
-          const textareaMaxLength = await page.$eval('.govuk-textarea', el => el.getAttribute('maxlength'))
-          expect(textareaMaxLength).toBeNull()
+          await expect(page.locator('.govuk-textarea').getAttribute('maxlength')).resolves.toBeNull()
         })
       })
     })
@@ -256,11 +225,8 @@ test.describe('Character Count', () => {
           exampleName: 'with-word-count'
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 10 words remaining')
-
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 10 words remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 10 words remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 10 words remaining')
       })
 
       test('counts down to the word limit', async ({ page }) => {
@@ -270,14 +236,12 @@ test.describe('Character Count', () => {
 
         await page.type('.govuk-js-character-count', 'Hello world')
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 8 words remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 8 words remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 8 words remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 8 words remaining')
       })
 
       test('uses the singular when there is only one word remaining', async ({ page }) => {
@@ -287,14 +251,12 @@ test.describe('Character Count', () => {
 
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-        expect(message).toEqual('You have 1 word remaining')
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-        expect(srMessage).toEqual('You have 1 word remaining')
+        await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 1 word remaining')
       })
 
       test.describe('when the word limit is exceeded', () => {
@@ -307,37 +269,31 @@ test.describe('Character Count', () => {
         })
 
         test('shows the number of words over the limit', async ({ page }) => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 1 word too many')
         })
 
         test('uses the plural when the limit is exceeded by 2 or more', async ({ page }) => {
           await page.type('.govuk-js-character-count', 'World')
 
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
-          expect(message).toEqual('You have 2 words too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 2 words too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
-          expect(srMessage).toEqual('You have 2 words too many')
+          await expect(page.locator('.govuk-character-count__sr-status')).toHaveText('You have 2 words too many')
         })
 
         test('adds error styles to the textarea', async ({ page }) => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
-          expect(textareaClasses).toContain('govuk-textarea--error')
+          await expect(page.locator('.govuk-js-character-count')).toHaveClass(/govuk-textarea--error/)
         })
 
         test('adds error styles to the count message', async ({ page }) => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
-          expect(messageClasses).toContain('govuk-error-message')
+          await expect(page.locator('.govuk-character-count__status')).toHaveClass(/govuk-error-message/)
         })
       })
     })
@@ -354,11 +310,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character too many')
         })
 
         test('configures the number of words', async ({ page }) => {
@@ -371,11 +323,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word too many')
         })
 
         test('configures the threshold', async ({ page }) => {
@@ -387,10 +335,11 @@ test.describe('Character Count', () => {
             }
           })
 
+          await expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'hidden')
+
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
-          expect(visibility).toEqual('visible')
+          await expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'visible')
         })
 
         test('configures the description of the textarea', async ({ page }) => {
@@ -412,11 +361,8 @@ test.describe('Character Count', () => {
             }
           })
 
-          const message = await page.$eval(
-            '.govuk-character-count__message',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('No more than 10 characters')
+          await expect(page.locator('.govuk-character-count__message:not(.govuk-character-count__status)'))
+            .toHaveText('No more than 10 characters')
         })
       })
 
@@ -435,11 +381,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character too many')
         })
 
         test('configures the number of words', async ({ page }) => {
@@ -456,11 +398,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word too many')
         })
 
         test('configures the threshold', async ({ page }) => {
@@ -476,13 +414,11 @@ test.describe('Character Count', () => {
             }
           })
 
+          await expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'hidden')
+
           await page.type('.govuk-js-character-count', 'A'.repeat(8))
 
-          const visibility = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => window.getComputedStyle(el).visibility
-          )
-          expect(visibility).toEqual('visible')
+          await expect(page.locator('.govuk-character-count__status')).toHaveCSS('visibility', 'visible')
         })
       })
 
@@ -497,11 +433,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character too many')
         })
 
         test("uses `maxlength` data attribute instead of JS's `maxwords`", async ({ page }) => {
@@ -514,11 +446,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 character too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 character too many')
         })
 
         test('uses `maxwords` data attribute instead of the JS one', async ({ page }) => {
@@ -531,11 +459,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word too many')
         })
 
         test("uses `maxwords` data attribute instead of the JS's `maxlength`", async ({ page }) => {
@@ -548,11 +472,7 @@ test.describe('Character Count', () => {
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
 
-          const message = await page.$eval(
-            '.govuk-character-count__status',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('You have 1 word too many')
+          await expect(page.locator('.govuk-character-count__status')).toHaveText('You have 1 word too many')
         })
 
         test('interpolates the textarea description in data attributes with the maximum set in JavaScript', async ({ page }) => {
@@ -570,11 +490,8 @@ test.describe('Character Count', () => {
             }
           })
 
-          const message = await page.$eval(
-            '.govuk-character-count__message',
-            (el) => el.innerHTML.trim()
-          )
-          expect(message).toEqual('No more than 10 characters')
+          await expect(page.locator('.govuk-character-count__message:not(.govuk-character-count__status)'))
+            .toHaveText('No more than 10 characters')
         })
       })
     })
@@ -593,13 +510,7 @@ test.describe('Character Count', () => {
           }
         })
 
-        const message = await page.$eval(
-          '.govuk-character-count__status',
-          (el) => el.innerHTML.trim()
-        )
-        expect(message).toEqual(
-          '&lt;strong&gt;10&lt;/strong&gt; characters left'
-        )
+        await expect(page.locator('.govuk-character-count__status')).toHaveText('<strong>10</strong> characters left')
       })
     })
   })

--- a/src/govuk/components/character-count/character-count.spec.mjs
+++ b/src/govuk/components/character-count/character-count.spec.mjs
@@ -1,9 +1,18 @@
 // @ts-check
 import { test, expect } from '@playwright/test'
 
-import { goToComponent } from '../../../../lib/playwright-helpers.js'
+import { getExamples } from '../../../../lib/jest-helpers.js'
+import { goToComponent, renderAndInitialise } from '../../../../lib/playwright-helpers.js'
+
+const debouncedWaitTime = 2000
 
 test.describe('Character Count', () => {
+  let examples
+
+  test.beforeAll(async () => {
+    examples = await getExamples('character-count')
+  })
+
   test.describe('when JavaScript is unavailable or fails', () => {
     test.use({ javaScriptEnabled: false })
 
@@ -37,6 +46,594 @@ test.describe('Character Count', () => {
         await expect(page.locator('.govuk-character-count__message:not(.govuk-character-count__status)'))
           .toHaveClass(/govuk-visually-hidden/)
       })
+    })
+
+    test.describe('when counting characters', () => {
+      test('shows the dynamic message', async ({ page }) => {
+        await goToComponent(page, 'character-count')
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 10 characters remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 10 characters remaining')
+      })
+
+      test('shows the characters remaining if the field is pre-filled', async ({ page }) => {
+        await goToComponent(page, 'character-count', {
+          exampleName: 'with-default-value'
+        })
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 67 characters remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 67 characters remaining')
+      })
+
+      test('counts down to the character limit', async ({ page }) => {
+        await goToComponent(page, 'character-count')
+
+        await page.type('.govuk-js-character-count', 'A')
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 9 characters remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 9 characters remaining')
+      })
+
+      test('uses the singular when there is only one character remaining', async ({ page }) => {
+        await goToComponent(page, 'character-count')
+
+        await page.type('.govuk-js-character-count', 'A'.repeat(9))
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 1 character remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 1 character remaining')
+      })
+
+      test.describe('when the character limit is exceeded', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count')
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(11))
+        })
+
+        test('shows the number of characters over the limit', async ({ page }) => {
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 1 character too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 1 character too many')
+        })
+
+        test('uses the plural when the limit is exceeded by 2 or more', async ({ page }) => {
+          await page.type('.govuk-js-character-count', 'A')
+
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 2 characters too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 2 characters too many')
+        })
+
+        test('adds error styles to the textarea', async ({ page }) => {
+          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        test('adds error styles to the count message', async ({ page }) => {
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
+      })
+
+      test.describe('when the character limit is exceeded on page load', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-default-value-exceeding-limit'
+          })
+        })
+
+        test('shows the number of characters over the limit', async ({ page }) => {
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 23 characters too many')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 23 characters too many')
+        })
+
+        test('adds error styles to the textarea', async ({ page }) => {
+          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        test('adds error styles to the count message', async ({ page }) => {
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
+      })
+
+      test.describe('when a threshold is set', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-threshold'
+          })
+        })
+
+        test('does not show the limit until the threshold is reached', async ({ page }) => {
+          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          expect(visibility).toEqual('hidden')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          // Ensure threshold is hidden for users of assistive technologies
+          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
+          expect(ariaHidden).toEqual('true')
+        })
+
+        test('becomes visible once the threshold is reached', async ({ page }) => {
+          await page.type('.govuk-js-character-count', 'A'.repeat(8))
+
+          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          expect(visibility).toEqual('visible')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          // Ensure threshold is visible for users of assistive technologies
+          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
+          expect(ariaHidden).toBeFalsy()
+        })
+      })
+
+      // Errors logged to the console will cause these tests to fail
+      test.describe('when the textarea ID starts with a number', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-id-starting-with-number'
+          })
+        })
+
+        test('still works correctly', async ({ page }) => {
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 10 characters remaining')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 10 characters remaining')
+        })
+      })
+
+      test.describe('when the textarea ID contains CSS syntax characters', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-id-with-special-characters'
+          })
+        })
+
+        test('still works correctly', async ({ page }) => {
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 10 characters remaining')
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 10 characters remaining')
+        })
+      })
+
+      test.describe('when a maxlength attribute is specified on the textarea', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-textarea-maxlength-attribute'
+          })
+        })
+
+        test('should not have a maxlength attribute once the JS has run', async ({ page }) => {
+          const textareaMaxLength = await page.$eval('.govuk-textarea', el => el.getAttribute('maxlength'))
+          expect(textareaMaxLength).toBeNull()
+        })
+      })
+    })
+
+    test.describe('when counting words', () => {
+      test('shows the dynamic message', async ({ page }) => {
+        await goToComponent(page, 'character-count', {
+          exampleName: 'with-word-count'
+        })
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 10 words remaining')
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 10 words remaining')
+      })
+
+      test('counts down to the word limit', async ({ page }) => {
+        await goToComponent(page, 'character-count', {
+          exampleName: 'with-word-count'
+        })
+
+        await page.type('.govuk-js-character-count', 'Hello world')
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 8 words remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 8 words remaining')
+      })
+
+      test('uses the singular when there is only one word remaining', async ({ page }) => {
+        await goToComponent(page, 'character-count', {
+          exampleName: 'with-word-count'
+        })
+
+        await page.type('.govuk-js-character-count', 'Hello '.repeat(9))
+
+        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        expect(message).toEqual('You have 1 word remaining')
+
+        // Wait for debounced update to happen
+        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        expect(srMessage).toEqual('You have 1 word remaining')
+      })
+
+      test.describe('when the word limit is exceeded', () => {
+        test.beforeEach(async ({ page }) => {
+          await goToComponent(page, 'character-count', {
+            exampleName: 'with-word-count'
+          })
+
+          await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+        })
+
+        test('shows the number of words over the limit', async ({ page }) => {
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 1 word too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 1 word too many')
+        })
+
+        test('uses the plural when the limit is exceeded by 2 or more', async ({ page }) => {
+          await page.type('.govuk-js-character-count', 'World')
+
+          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          expect(message).toEqual('You have 2 words too many')
+
+          // Wait for debounced update to happen
+          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+
+          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          expect(srMessage).toEqual('You have 2 words too many')
+        })
+
+        test('adds error styles to the textarea', async ({ page }) => {
+          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          expect(textareaClasses).toContain('govuk-textarea--error')
+        })
+
+        test('adds error styles to the count message', async ({ page }) => {
+          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          expect(messageClasses).toContain('govuk-error-message')
+        })
+      })
+    })
+
+    test.describe('JavaScript configuration', () => {
+      test.describe('at instantiation', () => {
+        test('configures the number of characters', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            javascriptConfig: {
+              maxlength: 10
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 character too many')
+        })
+
+        test('configures the number of words', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            javascriptConfig: {
+              maxwords: 10
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 word too many')
+        })
+
+        test('configures the threshold', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            javascriptConfig: {
+              maxlength: 10,
+              threshold: 75
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(8))
+
+          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          expect(visibility).toEqual('visible')
+        })
+
+        test('configures the description of the textarea', async ({ page }) => {
+          // This tests that a description can be provided through JavaScript attributes
+          // and interpolated with the limit provided to the character count in JS.
+
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams:
+              examples[
+                'when neither maxlength/maxwords nor textarea description are set'
+              ],
+            javascriptConfig: {
+              maxlength: 10,
+              i18n: {
+                textareaDescription: {
+                  other: 'No more than %{count} characters'
+                }
+              }
+            }
+          })
+
+          const message = await page.$eval(
+            '.govuk-character-count__message',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('No more than 10 characters')
+        })
+      })
+
+      test.describe('via `initAll`', () => {
+        test('configures the number of characters', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            initialiser () {
+              window.GOVUKFrontend.initAll({
+                characterCount: {
+                  maxlength: 10
+                }
+              })
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 character too many')
+        })
+
+        test('configures the number of words', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            initialiser () {
+              window.GOVUKFrontend.initAll({
+                characterCount: {
+                  maxwords: 10
+                }
+              })
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 word too many')
+        })
+
+        test('configures the threshold', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['to configure in JavaScript'],
+            initialiser () {
+              window.GOVUKFrontend.initAll({
+                characterCount: {
+                  maxlength: 10,
+                  threshold: 75
+                }
+              })
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(8))
+
+          const visibility = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => window.getComputedStyle(el).visibility
+          )
+          expect(visibility).toEqual('visible')
+        })
+      })
+
+      test.describe('when data-attributes are present', () => {
+        test('uses `maxlength` data attribute instead of the JS one', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples.default,
+            javascriptConfig: {
+              maxlength: 12 // JS configuration that would tell 1 character remaining
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 character too many')
+        })
+
+        test("uses `maxlength` data attribute instead of JS's `maxwords`", async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples.default, // Default example counts characters
+            javascriptConfig: {
+              maxwords: 12
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'A'.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 character too many')
+        })
+
+        test('uses `maxwords` data attribute instead of the JS one', async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['with word count'],
+            javascriptConfig: {
+              maxwords: 12 // JS configuration that would tell 1 word remaining
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 word too many')
+        })
+
+        test("uses `maxwords` data attribute instead of the JS's `maxlength`", async ({ page }) => {
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams: examples['with word count'],
+            javascriptConfig: {
+              maxlength: 10
+            }
+          })
+
+          await page.type('.govuk-js-character-count', 'Hello '.repeat(11))
+
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('You have 1 word too many')
+        })
+
+        test('interpolates the textarea description in data attributes with the maximum set in JavaScript', async ({ page }) => {
+          // This tests that any textarea description provided through data-attributes
+          // (or the Nunjucks macro), waiting for a maximum to be provided in
+          // JavaScript config, will lead to the message being injected in the
+          // element holding the textarea's accessible description
+          // (and interpolated to replace `%{count}` with the maximum)
+
+          await renderAndInitialise(page, 'character-count', {
+            nunjucksParams:
+              examples['when neither maxlength nor maxwords are set'],
+            javascriptConfig: {
+              maxlength: 10
+            }
+          })
+
+          const message = await page.$eval(
+            '.govuk-character-count__message',
+            (el) => el.innerHTML.trim()
+          )
+          expect(message).toEqual('No more than 10 characters')
+        })
+      })
+    })
+
+    test.describe('Cross Side Scripting prevention', () => {
+      test('injects the localised strings as text not HTML', async ({ page }) => {
+        await renderAndInitialise(page, 'character-count', {
+          nunjucksParams: examples['to configure in JavaScript'],
+          javascriptConfig: {
+            maxlength: 10,
+            i18n: {
+              charactersUnderLimit: {
+                other: '<strong>%{count}</strong> characters left'
+              }
+            }
+          }
+        })
+
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
+        expect(message).toEqual(
+          '&lt;strong&gt;10&lt;/strong&gt; characters left'
+        )
+      })
+    })
+  })
+  test.describe('in mismatched locale', () => {
+    test('does not error', async ({ page }) => {
+      let pageErrorHappened = false
+      page.on('pageerror', () => { pageErrorHappened = true })
+
+      await renderAndInitialise(page, 'character-count', {
+        nunjucksParams: examples.default,
+        javascriptConfig: {
+          // Override maxlength to 10
+          maxlength: 10
+        },
+        initialiser: function ({ config }) {
+          const $component = document.querySelector('[data-module]')
+
+          // Set locale to Welsh, which expects translations for 'one', 'two',
+          // 'few' 'many' and 'other' forms – with the default English strings
+          // provided we only have translations for 'one' and 'other'.
+          //
+          // We want to make sure we handle this gracefully in case users have
+          // an existing character count inside an incorrect locale.
+          $component.setAttribute('lang', 'cy')
+          new window.GOVUKFrontend.CharacterCount($component, config).init()
+        }
+      })
+
+      // Type 10 characters so we go 'through' all the different forms as we
+      // approach 0 characters remaining.
+      await page.type('.govuk-js-character-count', 'A'.repeat(10))
+
+      // Expect the page error event not to have been fired
+      expect(pageErrorHappened).toBe(false)
     })
   })
 })

--- a/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-fieldset-params-without-breaking-1.txt
+++ b/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-fieldset-params-without-breaking-1.txt
@@ -1,0 +1,8 @@
+<fieldset class="govuk-fieldset app-fieldset--custom-modifier" aria-describedby="example-name-error" data-attribute="value" data-second-attribute="second-value">
+  <legend class="govuk-fieldset__legend">
+    What is your nationality?
+  </legend>
+  
+  
+
+</fieldset>

--- a/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-html-fieldset-params-without-breaking-1.txt
+++ b/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-html-fieldset-params-without-breaking-1.txt
@@ -1,0 +1,7 @@
+<fieldset class="govuk-fieldset">
+  <legend class="govuk-fieldset__legend">
+    What is your <b>nationality</b>?
+  </legend>
+  
+
+</fieldset>

--- a/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-label-params-without-breaking-1.txt
+++ b/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-nested-dependant-components-passes-through-label-params-without-breaking-1.txt
@@ -1,0 +1,3 @@
+<label class="govuk-label govuk-checkboxes__label" data-attribute="value" data-second-attribute="second-value" for="example-name">
+        <b>Option 1</b>
+      </label>

--- a/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-when-they-include-a-hint-renders-the-hint-1.txt
+++ b/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-when-they-include-a-hint-renders-the-hint-1.txt
@@ -1,0 +1,7 @@
+<div id="example-multiple-hints-hint" class="govuk-hint">
+    If you have dual nationality, select all options that are relevant to you.
+  </div><div id="example-multiple-hints-item-hint" class="govuk-hint govuk-checkboxes__hint">
+        Hint for british option here
+      </div><div id="example-multiple-hints-3-item-hint" class="govuk-hint govuk-checkboxes__hint">
+        Hint for other option here
+      </div>

--- a/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-when-they-include-an-error-message-renders-the-error-message-1.txt
+++ b/src/govuk/components/checkboxes/__pw_snapshots__/template.spec.mjs/Checkboxes-when-they-include-an-error-message-renders-the-error-message-1.txt
@@ -1,0 +1,3 @@
+<p id="waste-error" class="govuk-error-message">
+   Please select an option
+  </p>

--- a/src/govuk/components/checkboxes/template.spec.mjs
+++ b/src/govuk/components/checkboxes/template.spec.mjs
@@ -29,349 +29,223 @@ test.describe('Checkboxes', () => {
     expect(result.violations).toEqual([])
   })
 
-  test('render example with minimum required name and items', async () => {
-    await renderAndInitialise(page, 'checkboxes', {nunjucksParams: examples.default })
-    const $ = render('checkboxes', examples.default)
+  test('render example with minimum required name and items', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.default })
 
-    const $component = $('.govuk-checkboxes')
+    const component = page.locator('#slot > *').first()
+    const firstInput = component.getByRole('checkbox', { name: 'British' })
+    await expect(firstInput).toHaveValue('british')
+    await expect(firstInput).toHaveAttribute('name', 'nationality')
 
-    const $firstInput = $component.find(
-      '.govuk-checkboxes__item:first-child input'
-    )
-    const $firstLabel = $component.find(
-      '.govuk-checkboxes__item:first-child label'
-    )
-    expect($firstInput.attr('name')).toEqual('nationality')
-    expect($firstInput.val()).toEqual('british')
-    expect($firstLabel.text()).toContain('British')
-
-    const $lastInput = $component.find(
-      '.govuk-checkboxes__item:last-child input'
-    )
-    const $lastLabel = $component.find(
-      '.govuk-checkboxes__item:last-child label'
-    )
-    expect($lastInput.attr('name')).toEqual('nationality')
-    expect($lastInput.val()).toEqual('other')
-    expect($lastLabel.text()).toContain('Citizen of another country')
+    const lastInput = component.getByRole('checkbox', { name: 'Citizen of another country' })
+    await expect(lastInput).toHaveValue('other')
+    await expect(lastInput).toHaveAttribute('name', 'nationality')
   })
 
-  test('render example without falsely values', () => {
-    const $ = render('checkboxes', examples['with falsey values'])
+  test('render example without falsely values', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with falsey values'] })
+    const component = page.locator('#slot > *').first()
 
-    const $component = $('.govuk-checkboxes')
-    const $items = $component.find('.govuk-checkboxes__item')
-
-    expect($items.length).toEqual(2)
+    await expect(component.getByRole('checkbox')).toHaveCount(2)
   })
 
-  test('render example with a divider and ‘None’ checkbox with exclusive behaviour', () => {
-    const $ = render('checkboxes', examples['with divider and None'])
+  test('render example with a divider and ‘None’ checkbox with exclusive behaviour', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with divider and None'] })
+    const component = page.locator('#slot > *').first()
 
-    const $component = $('.govuk-checkboxes')
+    await expect(component.getByText('or', { exact: true })).toHaveClass(/govuk-checkboxes__divider/)
 
-    const $divider = $component.find('.govuk-checkboxes__divider').first()
-    expect($divider.text().trim()).toEqual('or')
-
-    const $items = $component.find('.govuk-checkboxes__item')
-    expect($items.length).toEqual(4)
-
-    const $orItemInput = $items.last().find('input').first()
-    expect($orItemInput.attr('data-behaviour')).toEqual('exclusive')
+    const checkboxes = component.getByRole('checkbox')
+    await expect(checkboxes).toHaveCount(4)
+    await expect(checkboxes.last()).toHaveAttribute('data-behaviour', 'exclusive')
   })
 
-  test('render additional label classes', () => {
-    const $ = render('checkboxes', examples['with label classes'])
+  test('render additional label classes', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with label classes'] })
+    const component = page.locator('#slot > *').first()
 
-    const $component = $('.govuk-checkboxes')
-    const $label = $component.find('.govuk-checkboxes__item label')
-    expect($label.hasClass('bold')).toBeTruthy()
+    await expect(component.locator('.govuk-checkboxes__item label')).toHaveClass(/bold/)
   })
 
-  test('render classes', () => {
-    const $ = render('checkboxes', examples.classes)
+  test('render classes', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.classes })
+    const component = page.locator('#slot > *').first()
 
-    const $component = $('.govuk-checkboxes')
-
-    expect($component.hasClass('app-checkboxes--custom-modifier')).toBeTruthy()
+    await expect(component.locator('.govuk-checkboxes')).toHaveClass(/app-checkboxes--custom-modifier/)
   })
 
-  test('renders initial aria-describedby on fieldset', () => {
-    const $ = render('checkboxes', examples['with fieldset describedBy'])
+  test('renders initial aria-describedby on fieldset', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with fieldset describedBy'] })
+    const component = page.locator('#slot > *').first()
 
-    const $fieldset = $('.govuk-fieldset')
-    expect($fieldset.attr('aria-describedby')).toMatch('some-id')
+    await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', /some-id/)
   })
 
-  test('render attributes', () => {
-    const $ = render('checkboxes', examples.attributes)
+  test('render attributes', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.attributes })
+    const component = page.locator('#slot > *').first()
 
-    const $component = $('.govuk-checkboxes')
-
-    expect($component.attr('data-attribute')).toEqual('value')
-    expect($component.attr('data-second-attribute')).toEqual('second-value')
+    const checkboxesWrapper = component.locator('.govuk-checkboxes')
+    await expect(checkboxesWrapper).toHaveAttribute('data-attribute', 'value')
+    await expect(checkboxesWrapper).toHaveAttribute('data-second-attribute', 'second-value')
   })
 
-  test('renders with a form group wrapper', () => {
-    const $ = render('checkboxes', examples.default)
+  test('renders with a form group wrapper', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.default })
+    const component = page.locator('#slot > *').first()
 
-    const $formGroup = $('.govuk-form-group')
-    expect($formGroup.length).toBeTruthy()
+    await expect(component).toHaveClass(/govuk-form-group/)
   })
 
-  test('render a custom class on the form group', () => {
-    const $ = render(
-      'checkboxes',
-      examples['with optional form-group classes showing group error']
-    )
+  test('render a custom class on the form group', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with optional form-group classes showing group error'] })
+    const component = page.locator('#slot > *').first()
 
-    const $formGroup = $('.govuk-form-group')
-    expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    await expect(component).toHaveClass(/govuk-form-group govuk-form-group--error/)
   })
 
   test.describe('items', () => {
-    test('render a matching label and input using name by default', () => {
-      const $ = render('checkboxes', examples.default)
+    test('render a matching label and input using name by default', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.default })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $firstInput = $component.find(
-        '.govuk-checkboxes__item:first-child input'
-      )
-      const $firstLabel = $component.find(
-        '.govuk-checkboxes__item:first-child label'
-      )
-      expect($firstInput.attr('id')).toEqual('nationality')
-      expect($firstLabel.attr('for')).toEqual('nationality')
-
-      const $lastInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      const $lastLabel = $component.find(
-        '.govuk-checkboxes__item:last-child label'
-      )
-      expect($lastInput.attr('id')).toEqual('nationality-3')
-      expect($lastLabel.attr('for')).toEqual('nationality-3')
+      await expect(component.getByRole('checkbox', { name: 'British' })).toHaveId('nationality')
+      await expect(component.getByRole('checkbox', { name: 'Citizen of another country' })).toHaveId('nationality-3')
     })
 
-    test('render a matching label and input using custom idPrefix', () => {
-      const $ = render('checkboxes', examples['with idPrefix'])
+    test('render a matching label and input using custom idPrefix', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with idPrefix'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $firstInput = $component.find(
-        '.govuk-checkboxes__item:first-child input'
-      )
-      const $firstLabel = $component.find(
-        '.govuk-checkboxes__item:first-child label'
-      )
-      expect($firstInput.attr('id')).toEqual('nationality')
-      expect($firstLabel.attr('for')).toEqual('nationality')
-
-      const $lastInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      const $lastLabel = $component.find(
-        '.govuk-checkboxes__item:last-child label'
-      )
-      expect($lastInput.attr('id')).toEqual('nationality-2')
-      expect($lastLabel.attr('for')).toEqual('nationality-2')
+      await expect(component.getByRole('checkbox', { name: 'Option 1' })).toHaveId('nationality')
+      await expect(component.getByRole('checkbox', { name: 'Option 2' })).toHaveId('nationality-2')
     })
 
-    test('render explicitly passed item ids', () => {
-      const $ = render('checkboxes', examples['with id and name'])
+    test('render explicitly passed item ids', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with id and name'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $lastInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      expect($lastInput.attr('id')).toBe('with-id-and-name-3')
-
-      const $firstInput = $component.find(
-        '.govuk-checkboxes__item:first-child input'
-      )
-      const $firstLabel = $component.find(
-        '.govuk-checkboxes__item:first-child label'
-      )
-      expect($firstInput.attr('id')).toBe('item_british')
-      expect($firstLabel.attr('for')).toEqual('item_british')
+      // First checkbox gets its ID from the id options in the item
+      await expect(component.getByRole('checkbox', { name: 'British' })).toHaveId('item_british')
+      // Last one doesn't have anything specified so gets its ID generated automatically
+      await expect(component.getByRole('checkbox', { name: 'Scottish' })).toHaveId('with-id-and-name-3')
     })
 
-    test('render explicitly passed item names', () => {
-      const $ = render('checkboxes', examples['with id and name'])
+    test('render explicitly passed item names', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with id and name'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $lastInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      expect($lastInput.attr('name')).toBe('custom-name-scottish')
+      // Last one doesn't have anything specified so gets its ID generated automatically
+      await expect(component.getByRole('checkbox', { name: 'Scottish' })).toHaveAttribute('name', 'custom-name-scottish')
     })
 
-    test('render disabled', () => {
-      const $ = render('checkboxes', examples['with disabled item'])
+    test('render disabled', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with disabled item'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $disabledInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      expect($disabledInput.attr('disabled')).toEqual('disabled')
+      await expect(component.getByRole('checkbox', { name: 'Sign in with GOV.UK Verify' })).toBeDisabled()
     })
 
-    test('render checked', () => {
-      const $ = render('checkboxes', examples['with checked item'])
+    test('render checked', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with checked item'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-      const $secondInput = $component.find(
-        '.govuk-checkboxes__item:nth-child(2) input'
-      )
-      const $lastInput = $component.find(
-        '.govuk-checkboxes__item:last-child input'
-      )
-      expect($secondInput.attr('checked')).toEqual('checked')
-      expect($lastInput.attr('checked')).toEqual('checked')
+      await expect(component.getByRole('checkbox', { name: 'Option 1' })).not.toBeChecked()
+      await expect(component.getByRole('checkbox', { name: 'Option 2' })).toBeChecked()
+      await expect(component.getByRole('checkbox', { name: 'Option 3' })).toBeChecked()
     })
 
-    test('checks the checkboxes in values', () => {
-      const $ = render('checkboxes', examples['with pre-checked values'])
+    test('checks the checkboxes in values', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with pre-checked values'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-      const $british = $component.find('input[value="british"]')
-      expect($british.attr('checked')).toEqual('checked')
-
-      const $other = $component.find('input[value="other"]')
-      expect($other.attr('checked')).toEqual('checked')
+      await expect(component.getByRole('checkbox', { name: 'British' })).toBeChecked()
+      await expect(component.getByRole('checkbox', { name: 'Other' })).toBeChecked()
     })
 
-    test('allows item.checked to override values', () => {
-      const $ = render('checkboxes', examples['item checked overrides values'])
+    test('allows item.checked to override values', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['item checked overrides values'] })
+      const component = page.locator('#slot > *').first()
 
-      const $green = $('.govuk-checkboxes').find('input[value="green"]')
-      expect($green.attr('checked')).toBeUndefined()
+      // Despite green being part of the values, the item is marked with
+      // `checked: false` so shouldn't render checked
+      await expect(component.getByRole('checkbox', { name: 'Green' })).not.toBeChecked()
     })
 
     test.describe('when they include attributes', () => {
-      test('it renders the attributes', () => {
-        const $ = render('checkboxes', examples['items with attributes'])
+      test('it renders the attributes', async ({ page }) => {
+        await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['items with attributes'] })
+        const component = page.locator('#slot > *').first()
 
-        const $component = $('.govuk-checkboxes')
+        const firstOption = component.getByRole('checkbox', { name: 'Option 1' })
+        await expect(firstOption).toHaveAttribute('data-attribute', 'ABC')
+        await expect(firstOption).toHaveAttribute('data-second-attribute', 'DEF')
 
-        const $firstInput = $component.find(
-          '.govuk-checkboxes__item:first-child input'
-        )
-        expect($firstInput.attr('data-attribute')).toEqual('ABC')
-        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
-
-        const $lastInput = $component.find(
-          '.govuk-checkboxes__item:last-child input'
-        )
-        expect($lastInput.attr('data-attribute')).toEqual('GHI')
-        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+        const secondOption = component.getByRole('checkbox', { name: 'Option 2' })
+        await expect(secondOption).toHaveAttribute('data-attribute', 'GHI')
+        await expect(secondOption).toHaveAttribute('data-second-attribute', 'JKL')
       })
     })
   })
 
   test.describe('when they include a hint', () => {
-    test('it renders the hint text', () => {
-      const $ = render('checkboxes', examples['with hints on items'])
+    test('it renders the hint text', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with hints on items'] })
+      const component = page.locator('#slot > *').first()
 
-      const $firstHint = $('.govuk-checkboxes__hint').first()
-      expect($firstHint.text().trim()).toContain(
-        "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
-      )
-    })
+      const descriptionId = await component.getByRole('checkbox', { name: 'Sign in with Government Gateway' }).getAttribute('aria-describedby')
+      const description = component.locator(`#${descriptionId}`)
 
-    test('it renders the correct id attribute for the hint', () => {
-      const $ = render('checkboxes', examples['with hints on items'])
-
-      expect($('.govuk-checkboxes__hint').attr('id')).toBe(
-        'government-gateway-item-hint'
-      )
-    })
-
-    test('the input describedBy attribute matches the item hint id', () => {
-      const $ = render('checkboxes', examples['with hints on items'])
-
-      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe(
-        'government-gateway-item-hint'
-      )
+      await expect(description).toHaveText("You'll have a user ID if you've registered for Self Assessment or filed a tax return online before.")
     })
   })
 
   test.describe('render conditionals', () => {
-    test('hidden by default when not checked', () => {
-      const $ = render('checkboxes', examples['with conditional items'])
+    test('hidden by default when not checked', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with conditional items'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $firstConditional = $component
-        .find('.govuk-checkboxes__conditional')
-        .first()
-      expect($firstConditional.text().trim()).toContain('Email address')
-      expect(
-        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
-      ).toBeTruthy()
+      const firstConditional = component.locator('.govuk-checkboxes__conditional').first()
+      await expect(firstConditional).toHaveText('Email address')
+      await expect(firstConditional).not.toBeVisible()
     })
-    test('visible by default when checked', () => {
-      const $ = render('checkboxes', examples['with conditional item checked'])
+    test('visible by default when checked', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with conditional item checked'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $firstConditional = $component
-        .find('.govuk-checkboxes__conditional')
-        .first()
-      expect($firstConditional.text().trim()).toContain('Email address')
-      expect(
-        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
-      ).toBeFalsy()
+      const firstConditional = component.locator('.govuk-checkboxes__conditional').first()
+      await expect(firstConditional).toHaveText('Email address')
+      await expect(firstConditional).toBeVisible()
     })
 
-    test('visible when checked with pre-checked values', () => {
-      const $ = render('checkboxes', examples['with pre-checked values'])
+    test('visible when checked with pre-checked values', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with pre-checked values'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-
-      const $firstConditional = $component
-        .find('.govuk-checkboxes__conditional')
-        .first()
-      expect($firstConditional.text().trim()).toContain('Country')
-      expect(
-        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
-      ).toBeFalsy()
+      const firstConditional = component.locator('.govuk-checkboxes__conditional').first()
+      await expect(firstConditional).toHaveText('Country')
+      await expect(firstConditional).toBeVisible()
     })
 
-    test('with association to the input they are controlled by', () => {
-      const $ = render('checkboxes', examples['with conditional items'])
+    test('with association to the input they are controlled by', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with conditional items'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
+      const checkbox = component.getByRole('checkbox', { name: 'Text message' })
+      // Move to `aria-controls` as the JavaScript is running for this test
+      const conditionalId = await checkbox.getAttribute('aria-controls')
+      const conditional = component.locator(`#${conditionalId}`)
 
-      const $lastInput = $component.find('.govuk-checkboxes__input').last()
-      const $lastConditional = $component
-        .find('.govuk-checkboxes__conditional')
-        .last()
-
-      expect($lastInput.attr('data-aria-controls')).toBe(
-        'conditional-how-contacted-3'
-      )
-      expect($lastConditional.attr('id')).toBe('conditional-how-contacted-3')
+      expect(conditionalId).toEqual('conditional-how-contacted-3')
+      await expect(conditional).toHaveCount(1)
     })
 
-    test('omits empty conditionals', () => {
-      const $ = render('checkboxes', examples['empty conditional'])
+    test('omits empty conditionals', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['empty conditional'] })
+      const component = page.locator('#slot > *').first()
 
-      const $component = $('.govuk-checkboxes')
-      expect($component.find('.govuk-checkboxes__conditional').length).toEqual(
-        0
-      )
-    })
-
-    test('does not associate checkboxes with empty conditionals', () => {
-      const $ = render('checkboxes', examples['empty conditional'])
-
-      const $input = $('.govuk-checkboxes__input').first()
-      expect($input.attr('data-aria-controls')).toBeFalsy()
+      await expect(component.locator('.govuk-checkboxes__conditional')).toHaveCount(0)
+      await expect(component.locator('input:is([aria-controls],[data-aria-controls])')).toHaveCount(0)
     })
   })
 
@@ -382,82 +256,70 @@ test.describe('Checkboxes', () => {
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
-    test('uses the idPrefix for the error message id if provided', () => {
-      const $ = render('checkboxes', examples['with error and idPrefix'])
+    test('uses the idPrefix for the error message id if provided', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error and idPrefix'] })
+      const component = page.locator('#slot > *').first()
 
-      const $errorMessage = $('.govuk-error-message')
-
-      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+      await expect(component.locator('.govuk-error-message')).toHaveId('id-prefix-error')
     })
 
-    test('falls back to using the name for the error message id', () => {
-      const $ = render('checkboxes', examples['with error message'])
+    test('falls back to using the name for the error message id', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error message'] })
+      const component = page.locator('#slot > *').first()
 
-      const $errorMessage = $('.govuk-error-message')
-
-      expect($errorMessage.attr('id')).toEqual('waste-error')
+      await expect(component.locator('.govuk-error-message')).toHaveId('waste-error')
     })
 
-    test('associates the fieldset as "described by" the error message', () => {
-      const $ = render(
-        'checkboxes',
-        examples['with fieldset and error message']
+    test('associates the fieldset as "described by" the error message', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with fieldset and error message'] })
+      const component = page.locator('#slot > *').first()
+
+      // A `toHaveDescription` matcher would be pretty useful here
+      const errorMessageId = await component.locator('.govuk-error-message').getAttribute('id')
+      const expectedAriaDescribedby = new RegExp(
+        WORD_BOUNDARY + errorMessageId + WORD_BOUNDARY
       )
 
-      const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
-      )
-
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
 
-    test('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples['with error message and fieldset describedBy']
-      )
+    test('associates the fieldset as "described by" the error message and parent fieldset', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error message and fieldset describedBy'] })
+      const component = page.locator('#slot > *').first()
 
-      const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
-
-      const errorMessageId = new RegExp(
+      const errorMessageId = await component.locator('.govuk-error-message').getAttribute('id')
+      const expectedAriaDescribedby = new RegExp(
         WORD_BOUNDARY +
-          'some-id' +
-          WHITESPACE +
-          $errorMessage.attr('id') +
-          WORD_BOUNDARY
+        'some-id' +
+        WHITESPACE +
+        errorMessageId +
+        WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
 
-    test('does not associate each input as "described by" the error message', () => {
-      const $ = render(
-        'checkboxes',
-        examples['with error message and hints on items']
-      )
+    test('does not associate each input as "described by" the error message', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error message and hints on items'] })
+      const component = page.locator('#slot > *').first()
 
-      const $inputs = $('input')
+      const checkboxes = component.getByRole('checkbox')
+      const ariaDescribedbyValues = await checkboxes.evaluateAll(inputs => inputs.map(element => element.getAttribute('aria-describedby')))
 
-      $inputs.each((index, input) => {
-        let expectedDescribedById = `waste-${index + 1}-item-hint`
-        if (index === 0) {
-          expectedDescribedById = 'waste-item-hint'
+      ariaDescribedbyValues.forEach((ariaDescribedbyValue, index) => {
+        if (index) {
+          expect(ariaDescribedbyValue).toEqual(`waste-${index + 1}-item-hint`)
+        } else {
+          expect(ariaDescribedbyValue).toEqual('waste-item-hint')
         }
-        expect($(input).attr('aria-describedby')).toEqual(
-          expectedDescribedById
-        )
       })
     })
 
-    test('renders with a form group wrapper that has an error state', () => {
-      const $ = render('checkboxes', examples['with error message'])
+    test('renders with a form group wrapper that has an error state', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error message'] })
+      const component = page.locator('#slot > *').first()
 
-      const $formGroup = $('.govuk-form-group')
-      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+      await expect(component).toHaveClass(/govuk-form-group--error/)
     })
   })
 
@@ -468,62 +330,60 @@ test.describe('Checkboxes', () => {
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
-    test('associates the fieldset as "described by" the hint', () => {
-      const $ = render('checkboxes', examples['with id and name'])
+    test('associates the fieldset as "described by" the hint', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with id and name'] })
+      const component = page.locator('#slot > *').first()
 
-      const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
-
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      // A `toHaveDescription` matcher would be pretty useful here
+      const errorMessageId = await component.locator('.govuk-hint').getAttribute('id')
+      const expectedAriaDescribedby = new RegExp(
+        WORD_BOUNDARY + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
 
-    test('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const $ = render('checkboxes', examples['with fieldset describedBy'])
-      const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
+    test('associates the fieldset as "described by" the hint and parent fieldset', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with fieldset describedBy'] })
+      const component = page.locator('#slot > *').first()
 
-      const hintId = new RegExp(
+      // A `toHaveDescription` matcher would be pretty useful here
+      const errorMessageId = await component.locator('.govuk-hint').getAttribute('id')
+      const expectedAriaDescribedby = new RegExp(
         WORD_BOUNDARY +
           'some-id' +
           WHITESPACE +
-          $hint.attr('id') +
+          errorMessageId +
           WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
   })
 
   test.describe('when they include both a hint and an error message', () => {
-    test('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = render('checkboxes', examples['with error message and hint'])
+    test('associates the fieldset as described by both the hint and the error message', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error message and hint'] })
+      const component = page.locator('#slot > *').first()
 
-      const $fieldset = $('.govuk-fieldset')
-      const errorMessageId = $('.govuk-error-message').attr('id')
-      const hintId = $('.govuk-hint').attr('id')
+      const errorMessageId = await component.locator('.govuk-error-message').getAttribute('id')
+      const hintId = await component.locator('.govuk-hint').getAttribute('id')
 
-      const combinedIds = new RegExp(
+      const expectedAriaDescribedby = new RegExp(
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
 
-    test('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples['with error, hint and fieldset describedBy']
-      )
+    test('associates the fieldset as described by the hint, error message and parent fieldset', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['with error, hint and fieldset describedBy'] })
+      const component = page.locator('#slot > *').first()
 
-      const $fieldset = $('.govuk-fieldset')
-      const errorMessageId = $('.govuk-error-message').attr('id')
-      const hintId = $('.govuk-hint').attr('id')
+      const errorMessageId = await component.locator('.govuk-error-message').getAttribute('id')
+      const hintId = await component.locator('.govuk-hint').getAttribute('id')
 
-      const combinedIds = new RegExp(
+      const expectedAriaDescribedby = new RegExp(
         WORD_BOUNDARY +
           'some-id' +
           WHITESPACE +
@@ -533,18 +393,15 @@ test.describe('Checkboxes', () => {
           WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      await expect(component.locator('.govuk-fieldset')).toHaveAttribute('aria-describedby', expectedAriaDescribedby)
     })
   })
 
   test.describe('nested dependant components', () => {
-    test('have correct nesting order', () => {
-      const $ = render('checkboxes', examples['fieldset params'])
+    test('have correct nesting order', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples['fieldset params'] })
 
-      const $component = $(
-        '.govuk-form-group > .govuk-fieldset > .govuk-checkboxes'
-      )
-      expect($component.length).toBeTruthy()
+      await expect(page.locator('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')).toBeVisible()
     })
 
     test('passes through label params without breaking', () => {
@@ -569,54 +426,42 @@ test.describe('Checkboxes', () => {
   })
 
   test.describe('single checkbox without a fieldset', () => {
-    test('adds aria-describedby to input if there is an error', () => {
-      const $ = render(
-        'checkboxes',
-        examples["with single option set 'aria-describedby' on input"]
-      )
-      const $input = $('input')
-      expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
+    test('adds aria-describedby to input if there is an error', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', {
+        nunjucksParams: examples["with single option set 'aria-describedby' on input"]
+      })
+      const component = page.locator('#slot > *').first()
+
+      await expect(component.getByRole('checkbox')).toHaveAttribute('aria-describedby', 't-and-c-error')
     })
 
-    test('adds aria-describedby to input if there is an error and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option set 'aria-describedby' on input, and describedBy"
-        ]
-      )
-      const $input = $('input')
+    test('adds aria-describedby to input if there is an error and parent fieldset', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', {
+        nunjucksParams: examples["with single option set 'aria-describedby' on input, and describedBy"]
+      })
+      const component = page.locator('#slot > *').first()
 
-      expect($input.attr('aria-describedby')).toMatch('some-id t-and-c-error')
+      await expect(component.getByRole('checkbox')).toHaveAttribute('aria-describedby', 'some-id t-and-c-error')
     })
   })
 
   test.describe('single checkbox (with hint) without a fieldset', () => {
-    test('adds aria-describedby to input if there is an error and a hint', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option (and hint) set 'aria-describedby' on input"
-        ]
-      )
-      const $input = $('input')
-      expect($input.attr('aria-describedby')).toMatch(
-        't-and-c-with-hint-error t-and-c-with-hint-item-hint'
-      )
+    test('adds aria-describedby to input if there is an error and a hint', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', {
+        nunjucksParams: examples["with single option (and hint) set 'aria-describedby' on input"]
+      })
+      const component = page.locator('#slot > *').first()
+
+      await expect(component.getByRole('checkbox')).toHaveAttribute('aria-describedby', 't-and-c-with-hint-error t-and-c-with-hint-item-hint')
     })
 
-    test('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option (and hint) set 'aria-describedby' on input, and describedBy"
-        ]
-      )
-      const $input = $('input')
+    test('adds aria-describedby to input if there is an error, hint and parent fieldset', async ({ page }) => {
+      await renderAndInitialise(page, 'checkboxes', {
+        nunjucksParams: examples["with single option (and hint) set 'aria-describedby' on input, and describedBy"]
+      })
+      const component = page.locator('#slot > *').first()
 
-      expect($input.attr('aria-describedby')).toMatch(
-        'some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint'
-      )
+      await expect(component.getByRole('checkbox')).toHaveAttribute('aria-describedby', 'some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint')
     })
   })
 })

--- a/src/govuk/components/checkboxes/template.spec.mjs
+++ b/src/govuk/components/checkboxes/template.spec.mjs
@@ -1,0 +1,622 @@
+import AxePlaywright from '@axe-core/playwright'
+import { test, expect } from '@playwright/test'
+
+import {
+  render,
+  getExamples,
+  htmlWithClassName
+} from '../../../../lib/jest-helpers.js'
+import { renderAndInitialise } from '../../../../lib/playwright-helpers.js'
+
+const AxeBuilder = AxePlaywright.default
+
+const WORD_BOUNDARY = '\\b'
+const WHITESPACE = '\\s'
+
+test.describe('Checkboxes', () => {
+  let examples
+
+  test.beforeAll(async () => {
+    examples = await getExamples('checkboxes')
+  })
+
+  test('default example passes accessibility tests', async ({ page }) => {
+    await renderAndInitialise(page, 'checkboxes', { nunjucksParams: examples.default })
+
+    // We need to restrict the check to the element that actually contains the component code
+    const result = await new AxeBuilder({ page }).include('#slot').analyze()
+    // And we'll likely want that encapsulated into a `toHaveNoViolations` helper
+    expect(result.violations).toEqual([])
+  })
+
+  test('render example with minimum required name and items', async () => {
+    await renderAndInitialise(page, 'checkboxes', {nunjucksParams: examples.default })
+    const $ = render('checkboxes', examples.default)
+
+    const $component = $('.govuk-checkboxes')
+
+    const $firstInput = $component.find(
+      '.govuk-checkboxes__item:first-child input'
+    )
+    const $firstLabel = $component.find(
+      '.govuk-checkboxes__item:first-child label'
+    )
+    expect($firstInput.attr('name')).toEqual('nationality')
+    expect($firstInput.val()).toEqual('british')
+    expect($firstLabel.text()).toContain('British')
+
+    const $lastInput = $component.find(
+      '.govuk-checkboxes__item:last-child input'
+    )
+    const $lastLabel = $component.find(
+      '.govuk-checkboxes__item:last-child label'
+    )
+    expect($lastInput.attr('name')).toEqual('nationality')
+    expect($lastInput.val()).toEqual('other')
+    expect($lastLabel.text()).toContain('Citizen of another country')
+  })
+
+  test('render example without falsely values', () => {
+    const $ = render('checkboxes', examples['with falsey values'])
+
+    const $component = $('.govuk-checkboxes')
+    const $items = $component.find('.govuk-checkboxes__item')
+
+    expect($items.length).toEqual(2)
+  })
+
+  test('render example with a divider and ‘None’ checkbox with exclusive behaviour', () => {
+    const $ = render('checkboxes', examples['with divider and None'])
+
+    const $component = $('.govuk-checkboxes')
+
+    const $divider = $component.find('.govuk-checkboxes__divider').first()
+    expect($divider.text().trim()).toEqual('or')
+
+    const $items = $component.find('.govuk-checkboxes__item')
+    expect($items.length).toEqual(4)
+
+    const $orItemInput = $items.last().find('input').first()
+    expect($orItemInput.attr('data-behaviour')).toEqual('exclusive')
+  })
+
+  test('render additional label classes', () => {
+    const $ = render('checkboxes', examples['with label classes'])
+
+    const $component = $('.govuk-checkboxes')
+    const $label = $component.find('.govuk-checkboxes__item label')
+    expect($label.hasClass('bold')).toBeTruthy()
+  })
+
+  test('render classes', () => {
+    const $ = render('checkboxes', examples.classes)
+
+    const $component = $('.govuk-checkboxes')
+
+    expect($component.hasClass('app-checkboxes--custom-modifier')).toBeTruthy()
+  })
+
+  test('renders initial aria-describedby on fieldset', () => {
+    const $ = render('checkboxes', examples['with fieldset describedBy'])
+
+    const $fieldset = $('.govuk-fieldset')
+    expect($fieldset.attr('aria-describedby')).toMatch('some-id')
+  })
+
+  test('render attributes', () => {
+    const $ = render('checkboxes', examples.attributes)
+
+    const $component = $('.govuk-checkboxes')
+
+    expect($component.attr('data-attribute')).toEqual('value')
+    expect($component.attr('data-second-attribute')).toEqual('second-value')
+  })
+
+  test('renders with a form group wrapper', () => {
+    const $ = render('checkboxes', examples.default)
+
+    const $formGroup = $('.govuk-form-group')
+    expect($formGroup.length).toBeTruthy()
+  })
+
+  test('render a custom class on the form group', () => {
+    const $ = render(
+      'checkboxes',
+      examples['with optional form-group classes showing group error']
+    )
+
+    const $formGroup = $('.govuk-form-group')
+    expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+  })
+
+  test.describe('items', () => {
+    test('render a matching label and input using name by default', () => {
+      const $ = render('checkboxes', examples.default)
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
+      expect($firstInput.attr('id')).toEqual('nationality')
+      expect($firstLabel.attr('for')).toEqual('nationality')
+
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      const $lastLabel = $component.find(
+        '.govuk-checkboxes__item:last-child label'
+      )
+      expect($lastInput.attr('id')).toEqual('nationality-3')
+      expect($lastLabel.attr('for')).toEqual('nationality-3')
+    })
+
+    test('render a matching label and input using custom idPrefix', () => {
+      const $ = render('checkboxes', examples['with idPrefix'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
+      expect($firstInput.attr('id')).toEqual('nationality')
+      expect($firstLabel.attr('for')).toEqual('nationality')
+
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      const $lastLabel = $component.find(
+        '.govuk-checkboxes__item:last-child label'
+      )
+      expect($lastInput.attr('id')).toEqual('nationality-2')
+      expect($lastLabel.attr('for')).toEqual('nationality-2')
+    })
+
+    test('render explicitly passed item ids', () => {
+      const $ = render('checkboxes', examples['with id and name'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      expect($lastInput.attr('id')).toBe('with-id-and-name-3')
+
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
+      expect($firstInput.attr('id')).toBe('item_british')
+      expect($firstLabel.attr('for')).toEqual('item_british')
+    })
+
+    test('render explicitly passed item names', () => {
+      const $ = render('checkboxes', examples['with id and name'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      expect($lastInput.attr('name')).toBe('custom-name-scottish')
+    })
+
+    test('render disabled', () => {
+      const $ = render('checkboxes', examples['with disabled item'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $disabledInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      expect($disabledInput.attr('disabled')).toEqual('disabled')
+    })
+
+    test('render checked', () => {
+      const $ = render('checkboxes', examples['with checked item'])
+
+      const $component = $('.govuk-checkboxes')
+      const $secondInput = $component.find(
+        '.govuk-checkboxes__item:nth-child(2) input'
+      )
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      expect($secondInput.attr('checked')).toEqual('checked')
+      expect($lastInput.attr('checked')).toEqual('checked')
+    })
+
+    test('checks the checkboxes in values', () => {
+      const $ = render('checkboxes', examples['with pre-checked values'])
+
+      const $component = $('.govuk-checkboxes')
+      const $british = $component.find('input[value="british"]')
+      expect($british.attr('checked')).toEqual('checked')
+
+      const $other = $component.find('input[value="other"]')
+      expect($other.attr('checked')).toEqual('checked')
+    })
+
+    test('allows item.checked to override values', () => {
+      const $ = render('checkboxes', examples['item checked overrides values'])
+
+      const $green = $('.govuk-checkboxes').find('input[value="green"]')
+      expect($green.attr('checked')).toBeUndefined()
+    })
+
+    test.describe('when they include attributes', () => {
+      test('it renders the attributes', () => {
+        const $ = render('checkboxes', examples['items with attributes'])
+
+        const $component = $('.govuk-checkboxes')
+
+        const $firstInput = $component.find(
+          '.govuk-checkboxes__item:first-child input'
+        )
+        expect($firstInput.attr('data-attribute')).toEqual('ABC')
+        expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
+
+        const $lastInput = $component.find(
+          '.govuk-checkboxes__item:last-child input'
+        )
+        expect($lastInput.attr('data-attribute')).toEqual('GHI')
+        expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
+      })
+    })
+  })
+
+  test.describe('when they include a hint', () => {
+    test('it renders the hint text', () => {
+      const $ = render('checkboxes', examples['with hints on items'])
+
+      const $firstHint = $('.govuk-checkboxes__hint').first()
+      expect($firstHint.text().trim()).toContain(
+        "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+      )
+    })
+
+    test('it renders the correct id attribute for the hint', () => {
+      const $ = render('checkboxes', examples['with hints on items'])
+
+      expect($('.govuk-checkboxes__hint').attr('id')).toBe(
+        'government-gateway-item-hint'
+      )
+    })
+
+    test('the input describedBy attribute matches the item hint id', () => {
+      const $ = render('checkboxes', examples['with hints on items'])
+
+      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe(
+        'government-gateway-item-hint'
+      )
+    })
+  })
+
+  test.describe('render conditionals', () => {
+    test('hidden by default when not checked', () => {
+      const $ = render('checkboxes', examples['with conditional items'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
+      expect($firstConditional.text().trim()).toContain('Email address')
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeTruthy()
+    })
+    test('visible by default when checked', () => {
+      const $ = render('checkboxes', examples['with conditional item checked'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
+      expect($firstConditional.text().trim()).toContain('Email address')
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeFalsy()
+    })
+
+    test('visible when checked with pre-checked values', () => {
+      const $ = render('checkboxes', examples['with pre-checked values'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
+      expect($firstConditional.text().trim()).toContain('Country')
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeFalsy()
+    })
+
+    test('with association to the input they are controlled by', () => {
+      const $ = render('checkboxes', examples['with conditional items'])
+
+      const $component = $('.govuk-checkboxes')
+
+      const $lastInput = $component.find('.govuk-checkboxes__input').last()
+      const $lastConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .last()
+
+      expect($lastInput.attr('data-aria-controls')).toBe(
+        'conditional-how-contacted-3'
+      )
+      expect($lastConditional.attr('id')).toBe('conditional-how-contacted-3')
+    })
+
+    test('omits empty conditionals', () => {
+      const $ = render('checkboxes', examples['empty conditional'])
+
+      const $component = $('.govuk-checkboxes')
+      expect($component.find('.govuk-checkboxes__conditional').length).toEqual(
+        0
+      )
+    })
+
+    test('does not associate checkboxes with empty conditionals', () => {
+      const $ = render('checkboxes', examples['empty conditional'])
+
+      const $input = $('.govuk-checkboxes__input').first()
+      expect($input.attr('data-aria-controls')).toBeFalsy()
+    })
+  })
+
+  test.describe('when they include an error message', () => {
+    test('renders the error message', () => {
+      const $ = render('checkboxes', examples['with error message'])
+
+      expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
+    })
+
+    test('uses the idPrefix for the error message id if provided', () => {
+      const $ = render('checkboxes', examples['with error and idPrefix'])
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+    })
+
+    test('falls back to using the name for the error message id', () => {
+      const $ = render('checkboxes', examples['with error message'])
+
+      const $errorMessage = $('.govuk-error-message')
+
+      expect($errorMessage.attr('id')).toEqual('waste-error')
+    })
+
+    test('associates the fieldset as "described by" the error message', () => {
+      const $ = render(
+        'checkboxes',
+        examples['with fieldset and error message']
+      )
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+    })
+
+    test('associates the fieldset as "described by" the error message and parent fieldset', () => {
+      const $ = render(
+        'checkboxes',
+        examples['with error message and fieldset describedBy']
+      )
+
+      const $fieldset = $('.govuk-fieldset')
+      const $errorMessage = $('.govuk-error-message')
+
+      const errorMessageId = new RegExp(
+        WORD_BOUNDARY +
+          'some-id' +
+          WHITESPACE +
+          $errorMessage.attr('id') +
+          WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+    })
+
+    test('does not associate each input as "described by" the error message', () => {
+      const $ = render(
+        'checkboxes',
+        examples['with error message and hints on items']
+      )
+
+      const $inputs = $('input')
+
+      $inputs.each((index, input) => {
+        let expectedDescribedById = `waste-${index + 1}-item-hint`
+        if (index === 0) {
+          expectedDescribedById = 'waste-item-hint'
+        }
+        expect($(input).attr('aria-describedby')).toEqual(
+          expectedDescribedById
+        )
+      })
+    })
+
+    test('renders with a form group wrapper that has an error state', () => {
+      const $ = render('checkboxes', examples['with error message'])
+
+      const $formGroup = $('.govuk-form-group')
+      expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
+    })
+  })
+
+  test.describe('when they include a hint', () => {
+    test('renders the hint', () => {
+      const $ = render('checkboxes', examples['multiple hints'])
+
+      expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
+    })
+
+    test('associates the fieldset as "described by" the hint', () => {
+      const $ = render('checkboxes', examples['with id and name'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+    })
+
+    test('associates the fieldset as "described by" the hint and parent fieldset', () => {
+      const $ = render('checkboxes', examples['with fieldset describedBy'])
+      const $fieldset = $('.govuk-fieldset')
+      const $hint = $('.govuk-hint')
+
+      const hintId = new RegExp(
+        WORD_BOUNDARY +
+          'some-id' +
+          WHITESPACE +
+          $hint.attr('id') +
+          WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+    })
+  })
+
+  test.describe('when they include both a hint and an error message', () => {
+    test('associates the fieldset as described by both the hint and the error message', () => {
+      const $ = render('checkboxes', examples['with error message and hint'])
+
+      const $fieldset = $('.govuk-fieldset')
+      const errorMessageId = $('.govuk-error-message').attr('id')
+      const hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+    })
+
+    test('associates the fieldset as described by the hint, error message and parent fieldset', () => {
+      const $ = render(
+        'checkboxes',
+        examples['with error, hint and fieldset describedBy']
+      )
+
+      const $fieldset = $('.govuk-fieldset')
+      const errorMessageId = $('.govuk-error-message').attr('id')
+      const hintId = $('.govuk-hint').attr('id')
+
+      const combinedIds = new RegExp(
+        WORD_BOUNDARY +
+          'some-id' +
+          WHITESPACE +
+          hintId +
+          WHITESPACE +
+          errorMessageId +
+          WORD_BOUNDARY
+      )
+
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+    })
+  })
+
+  test.describe('nested dependant components', () => {
+    test('have correct nesting order', () => {
+      const $ = render('checkboxes', examples['fieldset params'])
+
+      const $component = $(
+        '.govuk-form-group > .govuk-fieldset > .govuk-checkboxes'
+      )
+      expect($component.length).toBeTruthy()
+    })
+
+    test('passes through label params without breaking', () => {
+      const $ = render('checkboxes', examples['label with attributes'])
+
+      expect(
+        htmlWithClassName($, '.govuk-checkboxes__label')
+      ).toMatchSnapshot()
+    })
+
+    test('passes through fieldset params without breaking', () => {
+      const $ = render('checkboxes', examples['fieldset params'])
+
+      expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
+    })
+
+    test('passes through html fieldset params without breaking', () => {
+      const $ = render('checkboxes', examples['fieldset html params'])
+
+      expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
+    })
+  })
+
+  test.describe('single checkbox without a fieldset', () => {
+    test('adds aria-describedby to input if there is an error', () => {
+      const $ = render(
+        'checkboxes',
+        examples["with single option set 'aria-describedby' on input"]
+      )
+      const $input = $('input')
+      expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
+    })
+
+    test('adds aria-describedby to input if there is an error and parent fieldset', () => {
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option set 'aria-describedby' on input, and describedBy"
+        ]
+      )
+      const $input = $('input')
+
+      expect($input.attr('aria-describedby')).toMatch('some-id t-and-c-error')
+    })
+  })
+
+  test.describe('single checkbox (with hint) without a fieldset', () => {
+    test('adds aria-describedby to input if there is an error and a hint', () => {
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option (and hint) set 'aria-describedby' on input"
+        ]
+      )
+      const $input = $('input')
+      expect($input.attr('aria-describedby')).toMatch(
+        't-and-c-with-hint-error t-and-c-with-hint-item-hint'
+      )
+    })
+
+    test('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option (and hint) set 'aria-describedby' on input, and describedBy"
+        ]
+      )
+      const $input = $('input')
+
+      expect($input.attr('aria-describedby')).toMatch(
+        'some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint'
+      )
+    })
+  })
+})

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -31,7 +31,7 @@ describe('package/', () => {
   it('should contain the expected files', async () => {
     const filterPatterns = [
       '!**/.DS_Store',
-      '!**/*.test.*',
+      '!**/*.+(test|spec).*',
       '!**/__snapshots__/',
       '!**/__snapshots__/**',
       '!govuk/README.md'

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -121,7 +121,9 @@ export async function compileJavaScripts () {
     : destination
 
   // For dist/ folder we only want compiled 'all.js'
-  const fileLookup = isDist ? 'govuk/all.mjs' : 'govuk/**/!(*.test).mjs'
+  // For non dist/ folder we want to exclude test and spec files
+  // See https://github.com/micromatch/micromatch#extglobs for extglobs matching syntax
+  const fileLookup = isDist ? 'govuk/all.mjs' : 'govuk/**/!(*.+(test|spec)).mjs'
 
   // Perform a search and return an array of matching file names
   const srcFiles = await getListing(configPaths.src, fileLookup)

--- a/tasks/gulp/copy-to-destination.mjs
+++ b/tasks/gulp/copy-to-destination.mjs
@@ -41,7 +41,7 @@ export function copyFiles () {
      */
     gulp.src([
       `${slash(configPaths.src)}/govuk/**/*.mjs`,
-      `!${slash(configPaths.src)}/govuk/**/*.test.*`
+      `!${slash(configPaths.src)}/govuk/**/*.+(test|spec).*`
     ]).pipe(gulp.dest(slash(join(destination, 'govuk-esm')))),
 
     /**


### PR DESCRIPTION
Explores the use of [Playwright] as a potential replacement for Puppeteer to run our in-browser tests.

This should offer us [a wider range of browsers to test in](https://playwright.dev/docs/browsers), increasing our confidence that things run OK. It should offer a better debugging experience locally (viewing browser and pausing when querying its content), as well [as remotely][playwright-traces]

## Changes

The PR adds Playwrigh to the project and ports two tests to it:

1. the CharacterCount JavaScript component tests, as a way to see how different things would be from our current use of Puppeteer
2. the Checkboxes template test (except snapshot matching assertions for now) as a way to explore the tradeoffs of using Playwright's browser-oriented ways of [locating elements][playwright-locators] and [making expectations][playwright-assertions]

The PR also sets up Github workflows to compare the tests running:

a. using Jest
b. using Playwright, in a single run targeting all 3 available browsers
c. using Playwright, in parallel runs for each of the 3 available browsers

The workflows are set up to run either each file individually or both files in a single run. This is in the hope to highlight the cost of moving from Jest+Cheerio template tests to Playwright ones.

## Findings

### Running tests

Puppeteer is only about controlling the browser, we bind it to jest using jest-puppeteer. Playwright provides both the API for controlling the browser and the test runner. It can be bound to jest, but that's not the route recommended by the project.

The test runner API offers similar concept as Jest, but in a slightly different API: `test` instead of `it`, and the `describe`, `beforeAll`, `beforeEach` methods are accessed on that `test` object rather than as argument. It also uses a [slightly different API for configuring the use of JavaScript][playwright-disable-javascript]

Each test gets its [own isolated "BrowserContext", which includes a fresh page][playwright-browser-context], so that ensures tests don't leak from one to another as far as I understand. Gotcha is that the `page` is not accessible in `test.beforeAll`, though, as it is created for each test, so to be reserved for non in-browser initialisation. If some initialisation need to happen on the page, it'll need to be in `test.beforeEach` (or manually creating a shared page, which is also a possibility, but less ideal).

There's no global `page` variable. You get reference to the page through the arguments of the test function. This makes things quite neat and make sure test logic runs on the relevant page.

### Runner configuration

I've mostly stuck to the pre-configured default form the initialisation. They did the job to get looking at how things would work. They also configure some decent defaults, especially retrying and capturing trace for debugging on CI (more later).

The runner can be configured to automatically start a server, after checking if one is already running. It gives flexibility to `npm start` or not before running the tests. When configured to run a server, the API to control the browser will use it as base for resolving URLs, allowing us to not have to juggle with the server's port, which is nice.

### Working locally

[The runner doesn't have a watch mode, which is a major pain point for a test runner][playwright-watch-mode] 😭 Nothing that nodemon cannot fix though `PWDEBUG=0 PW_REPORTER_HTML_OPEN=never npx nodemon --watch "src/**/*.spec.{cjs,js,mjs}" --exec "npx playwright test --project chromium"`. We'll probably want that as an npm script though.

Unless told otherwise, the runner will automatically open an HTML report of the result if they fail when ran locally. I added some configuration to get some flexibility on that, as it can be a bit annoying and open lots of browser windows. The HTML reports are saved anyway and can be open with `npx playwright show-report`.

The test runner offers a debug mode (`PWDEBUG=1` or `--debug`) which will pause at each interaction with the browser (locating an element or actual interaction), allowing to go step by step locally.

The test runner can capture traces of the interactions with the browser to replay them afterwards. Not necessarily useful locally thanks to the debug mode, outside of sharing with another dev maybe. It's more something useful on CI to investigate test failures.

### Writing tests

The API for controlling browser is very very close to Puppeteer's. To the point that porting the tests could get started by [moving them across and replacing the test runner API only, mostly][port-tests].

[The API is able to control 3 different browser engines: Chromium, Firefox and Webkit][playwright-browsers]. Note the mention of Chromium and Webkit, not Chrome (though if Chrome/Edge is installed it can run against it) and Safari. It still gives us a wider target than Puppeteer.

Past that, Playwrights offers some neat additions that make the tests clearer:
  - [clear API to locate elements][playwright-locators]. Especially by roles and accessible name, providing a closer experience to what our users will do than CSS selectors.
  - [matchers designed to test frontend code][playwright-assertions]: `toBeVisible()`, `toHaveAttribute(attributeName, value)`, `toHaveCSS(propertyName, value)`, `toHaveId()`, `toHaveText()` and of course `toHaveClass()` (though that one is a little unfortunately implemented and does string comparison against the whole value rather than checking individual classes, though RegExp can alleviate that. Probably worth declaring our own `toContainClass` that abstracts that up).

Playwright supports snapshot matching. This would allow to check for regressions in the HTML of the component. **I didn't explore this further, leaving our snapshot tests still to rely on Cheerio**. One change is that snapshots are stored as individual files rather than a single file as of now. While Playwright points to Jest's `expect` API for its documentation, I couldn't figure a way to get them stored as a single file. 

[not explored] Playwright also offers a way to compare screenshots.

### On CI

Test reports report can be [uploaded as artifact of the Github action][playwright-github-artifact]. Once downloaded and unziped, they can be opened to access the report with `npx playwright show-report` like a local report. They'll contain the traces for failing tests which can be then investigated in the browser.

[Playwright also offers a Progressive Web App for loading the traces][playwright-traces-remote], that may smoothen the workflow if we upload only the traces as Github action artifacts.

Perf wise, the PR runs a good few workflow so we can compare running times inside Github actions (see the Changes for description). Clicking "Checks" than "Tests" will give a more palatable view than the list of checks at the bottom of this PR due to the long names.

First notable thing is that Playwright will download the 3 browsers and it takes a little bit. Something to keep in mind when looking at the different checks, as 40-ish seconds of the Playwright runs are down to installing browsers. Hopefully a bit of caching can speed that up. 

Even when running a single browser and using 2 workers (matching Github actions), Playwright does run slower than our tests with Puppeteer (comparing "Puppeteer Comparison" times with "Playwright - Matrix , Browser Test (chromium)"), whether it runs a both files or a single one. Goes from ~25s to ~35s with the two files, but hard to say how that will scale up with the number of files (is it the "launch" that's creating the increase and would be a one-off-ish thing, or each test running slower?).

Running multiple browsers unsurprisingly takes longer, especially as Playwright runs only a single worker (50% of available cores, I think), so we'd likely want to create a matrix to parallelise each browser run. 

The hardest perf impact is moving template tests from Cheerio to Playwright. Spinning up a browser moves from 6s to 20ish seconds. Again no idea how that would scale, so the gain from a more fluent API for writing the tests will have to be weighted against the performance. 


[Playwright]: https://playwright.dev
[playwright-traces]: https://playwright.dev/docs/trace-viewer
[playwright-traces-remote]: https://playwright.dev/docs/trace-viewer#viewing-remote-traces
[playwright-locators]: https://playwright.dev/docs/locators
[playwright-assertions]: https://playwright.dev/docs/test-assertions
[playwright-browser-context]: https://playwright.dev/docs/api/class-fixtures#fixtures-browser
[playwright-disable-javascript]: https://playwright.dev/docs/emulation#javascript-enabled
[playwright-github-artifact]: https://github.com/alphagov/govuk-frontend/actions/runs/3678474077
[playwright-browsers]: https://playwright.dev/docs/browsers#chromium
[playwright-watch-mode]: https://github.com/microsoft/playwright/issues/7035
[playwright-port-tests]: [alphagov/govuk-frontend@`c3ab8d2` (#3064)](https://github.com/alphagov/govuk-frontend/pull/3064/commits/c3ab8d24401c1bc4e13b94504f3b40619f8c6557)

## Steps trail

- [x] Set up Playwright in the repo
- [x] Port the CharacterCount JS component tests to Playwright
- [x] Tweak Github workflow configuration so it runs on Github similarly to the other test
		Adds 3 extra jobs to compare timings:
		  - Playwright Bulk to run all Playwright tests in one call
		  - Playwright Matrix that splits them per browser
		  - Puppeteer comparison which runs the CharacterCount tests in isolation for comparison
- [x] Port the Checkboxes Nunjucks test to Playwright
- [x] Port the CharacterCount JS code to Playwright locators/assertions rather than Puppeteer's
- [x] Add Github workflow test that only runs the CharacterCount JS and Checkboxes Nunjucks component tests with Puppeteer for timing comparison. We may want to look into using [Playwright's Docker container to have pre-installed browsers](https://playwright.dev/docs/docker)

Left out for now:

- [ ] Port Checkboxes snapshot tests to Playwright? Would require rewriting `htmlWithClassName`, that isolates the markup related to a component specifically using the element's classnames.
- [ ] Check how things go on Windows?