### PR TITLE
Skip “Percy screenshots” when secrets are unavailable on forks (fix)

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -18,7 +18,14 @@ jobs:
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
       PORT: 8888
 
+    # Skip when secrets are unavailable on forks
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+
     steps:
+      - name: Check secrets
+        if: ${{ !env.PERCY_TOKEN }}
+        run: echo "::warning title=GitHub Actions secrets::Workflow requires 'PERCY_TOKEN' secret"
+
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -169,6 +169,3 @@ jobs:
     # (after install and build have been cached)
     uses: ./.github/workflows/screenshots.yml
     secrets: inherit
-
-    # Skip when secrets are unavailable on forks
-    if: ${{ github.repository_owner == 'alphagov' }}


### PR DESCRIPTION
Looks like our "local branches only" check for Percy screenshots didn't work

I'd forgotten that workflows for fork PRs identify our repo making this check always pass: 🙈 

❌  **Use the `github.repository_owner` context**
```yaml
if: ${{ github.repository_owner == 'alphagov' }}
```

✅ **Use the `github.event` context to identify forks**
```yaml
if: ${{ !github.event.pull_request.head.repo.fork }}
```

For example, this PR (fork) has passed the incorrect check and tried to run Percy

* https://github.com/alphagov/govuk-frontend/pull/3074

But others (my fork) use the new check and Percy has been skipped:

* https://github.com/alphagov/govuk-frontend/pull/3129
* https://github.com/alphagov/govuk-frontend/pull/3131

Unlike the old fix, Percy is _not_ skipped when run directly from the fork:

* https://github.com/colinrotherham/govuk-frontend/actions/runs/3749530406
* https://github.com/colinrotherham/govuk-frontend/actions/runs/3749529213

This allows contributors to add their own `${{ secrets.PERCY_TOKEN }}` but with a warning if not provided:

<img width="356" alt="Percy secret warning" src="https://user-images.githubusercontent.com/415517/208912566-e1bc07ac-2b21-4665-a570-3bbb0b792275.png">
