### PR TITLE
Fix focus styles for links split over multiple lines in Chromium 108+ (Chrome 108+, Edge 108+, Opera 94+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Fixes
 
+We've made fixes to GOV.UK Frontend in the following pull requests:
+
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
-- [#3021 Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
+- [#3021: Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
+- [#3087: Fix focus styles for links split over multiple lines in Chromium 108+ (Chrome 108+, Edge 108+, Opera 94+)](https://github.com/alphagov/govuk-frontend/pull/3087)
 
 ## 4.4.0 (Feature release)
 

--- a/src/govuk/helpers/_focused.scss
+++ b/src/govuk/helpers/_focused.scss
@@ -25,4 +25,8 @@
   // When link is focussed, hide the default underline since the
   // box shadow adds the "underline"
   text-decoration: none;
+
+  // When a focused box is broken by e.g. a line break, ensure that the
+  // box-shadow is applied to each fragment independently.
+  box-decoration-break: clone;
 }


### PR DESCRIPTION
Chromium 108 includes [a change in behaviour for box decoration when a box is split over multiple lines, pages etc][1].

This change in theory brings Chromium in line with the [CSS Fragmentation Module Level 3 spec][2] but means that the box-shadow (which we rely on for colour contrast for the focus state) no longer appears on links that break over multiple lines.

This affects browsers based on Chromium 108 including Chrome 108, Edge 108 and Opera 94.

Add `box-decoration-break: clone` so that `box-shadow` is applied to each fragment independently, maintaining the existing behaviour in Chromium browsers.

## Before

<img width="668" alt="A link with long enough text that it wraps over two lines. The link is focused, and has a yellow background. It is missing a black bottom edge (box-shadow) which is present on single-line links." src="https://user-images.githubusercontent.com/121939/206696225-db528196-8829-45a9-bf58-fe0ce71908b8.png">

## After

<img width="668" alt="A link with long enough text that it wraps over two lines. The link is focused, and has a yellow background, and has a black bottom edge (box-shadow) which matches the style used on single-line links." src="https://user-images.githubusercontent.com/121939/206696222-b9764e4c-ff58-4a53-bd9f-2276e142d269.png">

Fixes #3085.

[1]: https://bugs.chromium.org/p/chromium/issues/detail?id=682173
[2]: https://www.w3.org/TR/css-break-3/#propdef-box-decoration-break