### PR TITLE
Add CHANGELOG entry for source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This allows the browser's native 'find in page' functionality to search within a
 
 This was added in [pull request #3053: Enhance the Accordion component with `hidden='until-found'`](https://github.com/alphagov/govuk-frontend/pull/3053). 
 
+#### Source maps for precompiled files
+
+You can now use [source maps](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html) to help identify errors and console messages that come from GOV.UK Frontend precompiled files.
+
+This was added in [pull request #3023: Add source maps to compiled JavaScript and CSS](https://github.com/alphagov/govuk-frontend/pull/3023).
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:


### PR DESCRIPTION
Adds a CHANGELOG entry for source maps

* https://github.com/alphagov/govuk-frontend/pull/3023

Worth documenting any of the other things we know about?

1. Source maps only work with Developer Tools™ open
2. Source maps only work when uploaded together with `*.js` and `*.css` files
3. Source maps useful for precompiled files like `govuk/**/*.js` UMD bundles (+ CSS, but not Sass)
4. Source maps might be discarded on build without [`rollup-plugin-sourcemaps`](https://www.npmjs.com/package/rollup-plugin-sourcemaps) or [`source-map-loader`](https://www.npmjs.com/package/source-map-loader) etc

**Note:** Our next "build" will include lots of `*.map` files in [package](https://github.com/alphagov/govuk-frontend/tree/main/package) and [dist](https://github.com/alphagov/govuk-frontend/tree/main/dist)