### PR TITLE
Accordion margin/padding fixes

### DIFF
--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -46,21 +46,25 @@
       padding-top: 0;
     }
 
+    .govuk-accordion__section-content {
+      @include govuk-responsive-padding(3, "top");
+      @include govuk-responsive-padding(8, "bottom");
+    }
+
     // Manually apply display: none to browsers that don't have a user agent
     // style for it, but override it with content-visibility if the browser
     // supports that instead.
     .govuk-accordion__section-content[hidden] {
       display: none;
+
       @supports (content-visibility: hidden) {
         content-visibility: hidden;
         display: inherit;
       }
-    }
 
-    // Hide the padding of collapsed sections
-    .govuk-accordion__section--expanded .govuk-accordion__section-content {
-      @include govuk-responsive-padding(8, "bottom");
-      @include govuk-responsive-padding(3, "top");
+      // Hide the padding of collapsed sections
+      padding-top: 0;
+      padding-bottom: 0;
     }
 
     .govuk-accordion__show-all {

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -79,7 +79,7 @@
       cursor: pointer;
       -webkit-appearance: none;
 
-      @include govuk-media-query ($from: desktop) {
+      @include govuk-media-query ($from: tablet) {
         margin-bottom: 14px;
       }
 
@@ -274,7 +274,7 @@
       padding-bottom: govuk-spacing(3);
       border-bottom: 0;
 
-      @include govuk-media-query ($from: desktop) {
+      @include govuk-media-query ($from: tablet) {
         padding-bottom: govuk-spacing(4);
       }
     }

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -271,8 +271,12 @@
     // relates to the content below. Adjust padding to maintain the height of the element.
     // See https://github.com/alphagov/govuk-frontend/pull/2257#issuecomment-951920798
     .govuk-accordion__section--expanded .govuk-accordion__section-button {
-      padding-bottom: govuk-spacing(4);
+      padding-bottom: govuk-spacing(3);
       border-bottom: 0;
+
+      @include govuk-media-query ($from: desktop) {
+        padding-bottom: govuk-spacing(4);
+      }
     }
 
     // As Chevron icon is vertically aligned it overlaps with the focus state bottom border

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -11,7 +11,7 @@
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}
-      <div class="govuk-accordion__section {% if item.expanded %}govuk-accordion__section--expanded{% endif %}">
+      <div class="govuk-accordion__section {%- if item.expanded %} govuk-accordion__section--expanded{% endif %}">
         <div class="govuk-accordion__section-header">
           <h{{ headingLevel }} class="govuk-accordion__section-heading">
             <span class="govuk-accordion__section-button" id="{{ id }}-heading-{{ loop.index }}">


### PR DESCRIPTION
Just a quick PR to fix a few tiny Accordion issues we've had for a long time in:

1. **"Show all" button `margin-bottom` fix applied too wide**
Moves [legacy bug fix](https://github.com/alphagov/govuk-frontend/commit/879e37c85e4ff1156e1febb609afacc4df9de1bd) to 'tablet' (from 'desktop') which align with font size

2. **Section button `padding-bottom` jumps 10px taller on mobile**
Notice how the section button height appears to get taller (unlike tablet, desktop) 

3. **Trailing space in `class` attribute**
Now using `{%-` to trim whitespace as we do elsewhere
```html
<div class="govuk-accordion__section ">
```

![Accordion height](https://user-images.githubusercontent.com/415517/207066997-4503b0bd-5fbb-4b53-b379-c0141491a972.png)


See original Accordion design PR

* https://github.com/alphagov/govuk-frontend/pull/2257

Plus a minor fix where accordion sections lack padding (during slow page loads) since:

* https://github.com/alphagov/govuk-frontend/pull/3053

## Reducing layout shift
Whilst we know additional layout shifts take place when the accordion controls and section headers are injected, I've shifted `.govuk-accordion__section-content` content padding so it's applied whilst the JavaScript loads

Our Accordion sections are now open during page load, where previously we only added padding when `[hidden]` was added by component `init()` but in preparation for the `--expanded` modifier being toggled

![Accordion section padding shown before and after component initialisation](https://user-images.githubusercontent.com/415517/207080836-0eb2942f-f937-4b41-b4bc-6dfdc6b53ae0.gif)
