### PR TITLE
Hide Accordion content (again) during `.js-enabled` page load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ We've updated the Accordion component to use the new [`hidden="until-found"` att
 
 This allows the browser's native 'find in page' functionality to search within and automatically open sections of the accordion. Currently, this functionality is only supported by recent versions of Google Chrome, Microsoft Edge and Samsung Internet.
 
-This was added in [pull request #3053: Enhance the Accordion component with `hidden='until-found'`](https://github.com/alphagov/govuk-frontend/pull/3053). 
+This was added in pull requests:
+
+- [#3053: Enhance the Accordion component with `hidden='until-found'`](https://github.com/alphagov/govuk-frontend/pull/3053)
+- [#3095: Hide Accordion content (again) during `.js-enabled` page load](https://github.com/alphagov/govuk-frontend/pull/3095)
 
 #### Source maps for precompiled files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 - [#3021: Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
 - [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
+- [#3094: Fix Accordion margin/padding inconsistencies](https://github.com/alphagov/govuk-frontend/pull/3094)
 - [#3150: Add missing `Event` polyfill to accordion component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3150)
 
 ## 4.4.1 (Fix release)

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -46,17 +46,18 @@
       padding-top: 0;
     }
 
+    // Hide the body of collapsed sections by default for browsers that lack
+    // support for `content-visibility` paired with [hidden=until-found]
     .govuk-accordion__section-content {
+      display: none;
+
       @include govuk-responsive-padding(3, "top");
       @include govuk-responsive-padding(8, "bottom");
     }
 
-    // Manually apply display: none to browsers that don't have a user agent
-    // style for it, but override it with content-visibility if the browser
-    // supports that instead.
+    // Hide the body of collapsed sections using `content-visibility` to enable
+    // page search within [hidden=until-found] regions where browser supported
     .govuk-accordion__section-content[hidden] {
-      display: none;
-
       @supports (content-visibility: hidden) {
         content-visibility: hidden;
         display: inherit;
@@ -65,6 +66,11 @@
       // Hide the padding of collapsed sections
       padding-top: 0;
       padding-bottom: 0;
+    }
+
+    // Show the body of expanded sections
+    .govuk-accordion__section--expanded .govuk-accordion__section-content {
+      display: block;
     }
 
     .govuk-accordion__show-all {


### PR DESCRIPTION
This PR investigates an Accordion change to avoid a visual layout shift

During a slow page load (with `js-enabled` class on **`<body>`**) we now see Accordion sections jump from open to closed after component initialisation. We're not sure if this is preferred for users.

For example, shown when adding a 500ms delay [before our code runs](https://github.com/alphagov/govuk-frontend/blob/main/app/views/layouts/_generic.njk#L53-L54)

```html
<script src="/public/all.js"></script>
<script>
  // Add 500ms delay before our code runs
  // (For example, analytics might run first !!)
  setTimeout(function () {
    window.GOVUKFrontend.initAll()
  }, 500)
</script>
```

For discussion, I've included a quick tweak which keeps all the enhancements from:

* https://github.com/alphagov/govuk-frontend/pull/3053

<img src="https://user-images.githubusercontent.com/415517/207064929-f407a9ad-5201-49d2-aed9-42f393763fd3.gif" width="50%" alt="Accordion loading delay">
