### PR TITLE
Configure ESLint to require JSDoc `@params` etc

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -7,7 +7,20 @@ module.exports = {
         browser: true
       },
       rules: {
-        'no-var': 'off'
+        'no-var': 'off',
+
+        // JSDoc blocks are mandatory
+        'jsdoc/require-jsdoc': [
+          'error', {
+            enableFixer: false,
+            require: {
+              ClassDeclaration: true,
+              ClassExpression: true,
+              FunctionExpression: true,
+              MethodDefinition: true
+            }
+          }
+        ]
       }
     },
     {

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,10 +1,8 @@
 module.exports = {
   overrides: [
     {
-      files: [
-        '!**/*.test.{cjs,js,mjs}',
-        '**/*.{cjs,js,mjs}'
-      ],
+      files: ['**/*.{cjs,js,mjs}'],
+      excludedFiles: ['**/*.test.{cjs,js,mjs}'],
       env: {
         browser: true
       },
@@ -13,9 +11,15 @@ module.exports = {
       }
     },
     {
+      // Matches 'JavaScript component tests' in jest.config.mjs
+      // to ignore unknown 'page' and 'browser' Puppeteer globals
       files: [
-        '!**/template.test.js',
-        '**/*.test.js'
+        '**/all.test.{js,mjs}',
+        '**/components/*/*.test.{js,mjs}'
+      ],
+      excludedFiles: [
+        '**/(*.)?template.test.{js,mjs}',
+        '**/*.unit.test.{js,mjs}'
       ],
       globals: {
         page: true,

--- a/src/govuk/all.test.mjs
+++ b/src/govuk/all.test.mjs
@@ -47,12 +47,12 @@ describe('GOV.UK Frontend', () => {
     it('exported Components have an init function', async () => {
       await goTo(page, '/')
 
-      var componentsWithoutInitFunctions = await page.evaluate(() => {
+      const componentsWithoutInitFunctions = await page.evaluate(() => {
         const components = Object.keys(window.GOVUKFrontend)
           .filter(method => !['initAll'].includes(method))
 
         return components.filter(component => {
-          var prototype = window.GOVUKFrontend[component].prototype
+          const prototype = window.GOVUKFrontend[component].prototype
           return typeof prototype.init !== 'function'
         })
       })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -17,8 +17,8 @@ describe('/components/accordion', () => {
 
         const numberOfExampleSections = 2
 
-        for (var i = 0; i < numberOfExampleSections; i++) {
-          var isContentVisible = await page.waitForSelector('.govuk-accordion .govuk-accordion__section:nth-of-type(' + (i + 1) + ') .govuk-accordion__section-content',
+        for (let i = 0; i < numberOfExampleSections; i++) {
+          const isContentVisible = await page.waitForSelector('.govuk-accordion .govuk-accordion__section:nth-of-type(' + (i + 1) + ') .govuk-accordion__section-content',
             { visible: true, timeout: 1000 }
           )
           expect(isContentVisible).toBeTruthy()
@@ -44,7 +44,7 @@ describe('/components/accordion', () => {
 
         const numberOfExampleSections = 2
 
-        for (var i = 0; i < numberOfExampleSections; i++) {
+        for (let i = 0; i < numberOfExampleSections; i++) {
           const sectionHeaderButtonExpanded = await page.evaluate(function (i) {
             return document.body.querySelector('.govuk-accordion .govuk-accordion__section:nth-of-type(' + (2 + i) + ') .govuk-accordion__section-button').getAttribute('aria-expanded')
           }, i)
@@ -86,7 +86,7 @@ describe('/components/accordion', () => {
 
         const numberOfExampleSections = 2
 
-        for (var i = 0; i < numberOfExampleSections; i++) {
+        for (let i = 0; i < numberOfExampleSections; i++) {
           const sectionHeaderButtonExpanded = await page.evaluate(function (i) {
             return document.body.querySelector('.govuk-accordion .govuk-accordion__section:nth-of-type(' + (2 + i) + ') .govuk-accordion__section-button').getAttribute('aria-expanded')
           }, i)

--- a/src/govuk/i18n.mjs
+++ b/src/govuk/i18n.mjs
@@ -293,6 +293,7 @@ I18n.pluralRulesMap = {
  * @type {Object<string, function(number): PluralRule>}
  */
 I18n.pluralRules = {
+  /* eslint-disable jsdoc/require-jsdoc */
   arabic: function (n) {
     if (n === 0) { return 'zero' }
     if (n === 1) { return 'one' }
@@ -346,6 +347,7 @@ I18n.pluralRules = {
     if (n === 6) { return 'many' }
     return 'other'
   }
+  /* eslint-enable jsdoc/require-jsdoc */
 }
 
 /**


### PR DESCRIPTION
This PR follows up https://github.com/alphagov/govuk-frontend/pull/2913 (optional JSDoc) by making `@param` tags mandatory for methods that use JSDoc

It also configures ESLint excluded files correctly using `excludedFiles`

Which continues work we started for v4.4.0:

* https://github.com/alphagov/govuk-frontend/pull/2913
* https://github.com/alphagov/govuk-frontend/pull/2997

To assist with code reviews I've split these changes into:

1. https://github.com/alphagov/govuk-frontend/pull/3102
2. https://github.com/alphagov/govuk-frontend/pull/3103
3. https://github.com/alphagov/govuk-frontend/pull/2987
4. https://github.com/alphagov/govuk-frontend/pull/3123
5. https://github.com/alphagov/govuk-frontend/pull/3104

Resolves https://github.com/alphagov/govuk-frontend/issues/2513