### PR TITLE
Remove unused `classList` polyfill from header component JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 - [#3021: Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
 - [#3087: Fix focus styles for links split over multiple lines in Chromium 108+ (Chrome 108+, Edge 108+, Opera 94+)](https://github.com/alphagov/govuk-frontend/pull/3087)
+- [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
 
 ## 4.4.0 (Feature release)
 

--- a/src/govuk/components/header/header.mjs
+++ b/src/govuk/components/header/header.mjs
@@ -1,4 +1,3 @@
-import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Event.mjs'
 import '../../vendor/polyfills/Function/prototype/bind.mjs'
 


### PR DESCRIPTION
The header imports the `Element.prototype.classList` polyfill but hasn’t actually called `classList` anywhere since we updated it to use the `hidden` attribute to toggle the menu visibility in 7217a7f (#2727).