### PR TITLE
Add version info from `package.json` to config

### DIFF
--- a/app/app.test.js
+++ b/app/app.test.js
@@ -1,9 +1,9 @@
 const cheerio = require('cheerio')
 
-const configPaths = require('../config/paths')
+const config = require('../config')
 const { getDirectories } = require('../lib/file-helper')
 
-const PORT = configPaths.ports.test
+const PORT = config.ports.test
 
 const expectedPages = [
   '/',
@@ -45,7 +45,7 @@ describe(`http://localhost:${PORT}`, () => {
       const response = await fetchPath('/')
       const $ = cheerio.load(await response.text())
 
-      const componentNames = await getDirectories(configPaths.components)
+      const componentNames = await getDirectories(config.paths.components)
       const componentsList = $('li a[href^="/components/"]').get()
 
       // Since we have an 'all' component link that renders the default example of all

--- a/app/banner.test.js
+++ b/app/banner.test.js
@@ -1,7 +1,7 @@
 const cheerio = require('cheerio')
 
-const configPaths = require('../config/paths')
-const PORT = configPaths.ports.test
+const config = require('../config')
+const PORT = config.ports.test
 
 // Returns Fetch API wrapper which applies these options by default
 const fetchPath = (path, options) => {

--- a/app/full-page-examples.test.js
+++ b/app/full-page-examples.test.js
@@ -1,7 +1,7 @@
 const cheerio = require('cheerio')
 
-const configPaths = require('../config/paths')
-const PORT = configPaths.ports.test
+const config = require('../config')
+const PORT = config.ports.test
 
 const expectedPages = [
   'bank-holidays',

--- a/app/start.js
+++ b/app/start.js
@@ -1,8 +1,8 @@
-const configPaths = require('../config/paths')
+const config = require('../config')
 
 const app = require('./app')
 
-const PORT = process.env.PORT || configPaths.ports.app
+const PORT = process.env.PORT || config.ports.app
 
 app()
   .then(server => server.listen(PORT, () =>

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,10 @@
+/**
+ * Config
+ */
+const paths = require('./paths')
+const ports = require('./ports')
+
+module.exports = {
+  paths,
+  ports
+}

--- a/config/index.js
+++ b/config/index.js
@@ -1,3 +1,5 @@
+const pkg = require('../package/package.json')
+
 /**
  * Config
  */
@@ -6,5 +8,6 @@ const ports = require('./ports')
 
 module.exports = {
   paths,
+  pkg,
   ports
 }

--- a/config/jest/server/start.mjs
+++ b/config/jest/server/start.mjs
@@ -1,11 +1,11 @@
 import { getServers, setup } from 'jest-dev-server'
 import waitOn from 'wait-on'
 
-import configPaths from '../../paths.js'
+import config from '../../index.js'
 
 import serverStop from './stop.mjs'
 
-const { PORT = configPaths.ports.test } = process.env
+const PORT = process.env.PORT || config.ports.test
 
 /**
  * Start web server

--- a/config/paths.js
+++ b/config/paths.js
@@ -38,11 +38,5 @@ module.exports = {
   views: join(configPaths.app, 'views'),
   examples: join(configPaths.app, 'views/examples'),
   fullPageExamples: join(configPaths.app, 'views/full-page-examples'),
-  layouts: join(configPaths.app, 'views/layouts'),
-
-  // Review application ports
-  ports: {
-    app: 3000,
-    test: 8888
-  }
+  layouts: join(configPaths.app, 'views/layouts')
 }

--- a/config/ports.js
+++ b/config/ports.js
@@ -1,0 +1,7 @@
+/**
+ * Review application ports
+ */
+module.exports = {
+  app: 3000,
+  test: 8888
+}

--- a/lib/puppeteer-helpers.js
+++ b/lib/puppeteer-helpers.js
@@ -1,9 +1,9 @@
-const configPaths = require('../config/paths')
+const config = require('../config')
 
 const { componentNameToJavaScriptClassName } = require('./helper-functions')
 const { renderHtml } = require('./jest-helpers')
 
-const PORT = process.env.PORT || configPaths.ports.test
+const PORT = process.env.PORT || config.ports.test
 
 /**
  * Render and initialise a component within test boilerplate HTML

--- a/tasks/asset-version.mjs
+++ b/tasks/asset-version.mjs
@@ -2,7 +2,7 @@ import { readFile, writeFile } from 'fs/promises'
 import { EOL } from 'os'
 import { join } from 'path'
 
-import configPaths from '../config/paths.js'
+import { paths } from '../config/index.js'
 
 import { destination, isDist } from './task-arguments.mjs'
 
@@ -13,7 +13,7 @@ import { destination, isDist } from './task-arguments.mjs'
  * @returns {Promise<void>}
  */
 export async function updateDistAssetsVersion () {
-  const pkg = JSON.parse(await readFile(join(configPaths.package, 'package.json'), 'utf8'))
+  const pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
 
   if (!isDist) {
     throw new Error('Asset version can only be applied to ./dist')

--- a/tasks/asset-version.mjs
+++ b/tasks/asset-version.mjs
@@ -1,8 +1,8 @@
-import { readFile, writeFile } from 'fs/promises'
+import { writeFile } from 'fs/promises'
 import { EOL } from 'os'
 import { join } from 'path'
 
-import { paths } from '../config/index.js'
+import { pkg } from '../config/index.js'
 
 import { destination, isDist } from './task-arguments.mjs'
 
@@ -13,8 +13,6 @@ import { destination, isDist } from './task-arguments.mjs'
  * @returns {Promise<void>}
  */
 export async function updateDistAssetsVersion () {
-  const pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
-
   if (!isDist) {
     throw new Error('Asset version can only be applied to ./dist')
   }

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
-import configPaths from '../../../config/paths.js'
+import { paths } from '../../../config/index.js'
 import { getListing } from '../../../lib/file-helper.js'
 
 describe('dist/', () => {
@@ -10,9 +10,9 @@ describe('dist/', () => {
   let listingDistAssets
 
   beforeAll(async () => {
-    pkg = JSON.parse(await readFile(join(configPaths.package, 'package.json'), 'utf8'))
-    listingSourceAssets = await getListing(configPaths.assets)
-    listingDistAssets = await getListing(join(configPaths.dist, 'assets'))
+    pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
+    listingSourceAssets = await getListing(paths.assets)
+    listingDistAssets = await getListing(join(paths.dist, 'assets'))
   })
 
   describe('assets/', () => {
@@ -27,7 +27,7 @@ describe('dist/', () => {
 
     beforeAll(async () => {
       filename = `govuk-frontend-${pkg.version}.min.css`
-      stylesheet = await readFile(join(configPaths.dist, filename), 'utf8')
+      stylesheet = await readFile(join(paths.dist, filename), 'utf8')
     })
 
     it('should not contain current media query displayed on body element', () => {
@@ -49,7 +49,7 @@ describe('dist/', () => {
 
     beforeAll(async () => {
       filename = `govuk-frontend-ie8-${pkg.version}.min.css`
-      stylesheet = await readFile(join(configPaths.dist, filename), 'utf8')
+      stylesheet = await readFile(join(paths.dist, filename), 'utf8')
     })
 
     it('should not contain current media query displayed on body element', () => {
@@ -67,7 +67,7 @@ describe('dist/', () => {
 
     beforeAll(async () => {
       filename = `govuk-frontend-${pkg.version}.min.js`
-      javascript = await readFile(join(configPaths.dist, filename), 'utf8')
+      javascript = await readFile(join(paths.dist, filename), 'utf8')
     })
 
     it('should have the correct version name', () => {

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -1,16 +1,14 @@
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
-import { paths } from '../../../config/index.js'
+import { paths, pkg } from '../../../config/index.js'
 import { getListing } from '../../../lib/file-helper.js'
 
 describe('dist/', () => {
-  let pkg
   let listingSourceAssets
   let listingDistAssets
 
   beforeAll(async () => {
-    pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
     listingSourceAssets = await getListing(paths.assets)
     listingDistAssets = await getListing(join(paths.dist, 'assets'))
   })

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -1,5 +1,4 @@
 
-import { readFile } from 'fs/promises'
 import { join, parse } from 'path'
 
 import gulp from 'gulp'
@@ -16,13 +15,12 @@ import nodeSass from 'node-sass'
 import PluginError from 'plugin-error'
 import slash from 'slash'
 
-import { paths } from '../../config/index.js'
+import { paths, pkg } from '../../config/index.js'
 import { getListing } from '../../lib/file-helper.js'
 import { componentNameToJavaScriptModuleName } from '../../lib/helper-functions.js'
 import { destination, isDev, isDist, isPackage } from '../task-arguments.mjs'
 
 const sass = gulpSass(nodeSass)
-const pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
 
 /**
  * Compile Sass to CSS task

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -16,13 +16,13 @@ import nodeSass from 'node-sass'
 import PluginError from 'plugin-error'
 import slash from 'slash'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 import { getListing } from '../../lib/file-helper.js'
 import { componentNameToJavaScriptModuleName } from '../../lib/helper-functions.js'
 import { destination, isDev, isDist, isPackage } from '../task-arguments.mjs'
 
 const sass = gulpSass(nodeSass)
-const pkg = JSON.parse(await readFile(join(configPaths.package, 'package.json'), 'utf8'))
+const pkg = JSON.parse(await readFile(join(paths.package, 'package.json'), 'utf8'))
 
 /**
  * Compile Sass to CSS task
@@ -38,7 +38,7 @@ export function compileStylesheets () {
   if (isDist) {
     return merge(
       compileStylesheet(
-        gulp.src(`${slash(configPaths.src)}/govuk/all.scss`, {
+        gulp.src(`${slash(paths.src)}/govuk/all.scss`, {
           sourcemaps: true
         })
           .pipe(rename({
@@ -48,7 +48,7 @@ export function compileStylesheets () {
           }))),
 
       compileStylesheet(
-        gulp.src(`${slash(configPaths.src)}/govuk/all-ie8.scss`, {
+        gulp.src(`${slash(paths.src)}/govuk/all-ie8.scss`, {
           sourcemaps: true
         })
           .pipe(rename({
@@ -65,12 +65,12 @@ export function compileStylesheets () {
   // Review application
   return merge(
     compileStylesheet(
-      gulp.src(`${slash(configPaths.app)}/assets/scss/app?(-ie8).scss`, {
+      gulp.src(`${slash(paths.app)}/assets/scss/app?(-ie8).scss`, {
         sourcemaps: true
       })),
 
     compileStylesheet(
-      gulp.src(`${slash(configPaths.app)}/assets/scss/app-legacy?(-ie8).scss`, {
+      gulp.src(`${slash(paths.app)}/assets/scss/app-legacy?(-ie8).scss`, {
         sourcemaps: true
       }), {
         includePaths: [
@@ -80,7 +80,7 @@ export function compileStylesheets () {
       }),
 
     compileStylesheet(
-      gulp.src(`${slash(configPaths.fullPageExamples)}/**/styles.scss`, {
+      gulp.src(`${slash(paths.fullPageExamples)}/**/styles.scss`, {
         sourcemaps: true
       })
         .pipe(rename((path) => {
@@ -124,7 +124,7 @@ export async function compileJavaScripts () {
   const fileLookup = isDist ? 'govuk/all.mjs' : 'govuk/**/!(*.test).mjs'
 
   // Perform a search and return an array of matching file names
-  const srcFiles = await getListing(configPaths.src, fileLookup)
+  const srcFiles = await getListing(paths.src, fileLookup)
 
   return merge(srcFiles.map((file) => {
     const { dir: srcPath, name } = parse(file)
@@ -138,7 +138,7 @@ export async function compileJavaScripts () {
       ? componentNameToJavaScriptModuleName(name)
       : 'GOVUKFrontend'
 
-    return compileJavaScript(gulp.src(slash(join(configPaths.src, file)), {
+    return compileJavaScript(gulp.src(slash(join(paths.src, file)), {
       sourcemaps: true
     }), moduleName)
       .pipe(gulp.dest(slash(join(destPath, modulePath)), {


### PR DESCRIPTION
Quick PR to split up our `configPaths` into separate parts:

```mjs
import { paths, pkg, ports } from './config/index.js'
```

(Seemed a bit odd that "ports" was inside `configPaths.ports`)