### PR TITLE
Ensure `VERSION.txt` task accepts `--destination` flag

### DIFF
--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -1,7 +1,7 @@
 import gulp from 'gulp'
 import taskListing from 'gulp-task-listing'
 
-import { updateDistAssetsVersion } from './tasks/asset-version.mjs'
+import { updateAssetsVersion } from './tasks/asset-version.mjs'
 import { clean } from './tasks/clean.mjs'
 import { compileJavaScripts, compileStylesheets } from './tasks/gulp/compile-assets.mjs'
 import { copyAssets, copyFiles } from './tasks/gulp/copy-to-destination.mjs'
@@ -70,7 +70,7 @@ gulp.task('build:dist', gulp.series(
   clean,
   'compile',
   copyAssets,
-  updateDistAssetsVersion
+  updateAssetsVersion
 ))
 
 /**

--- a/tasks/asset-version.mjs
+++ b/tasks/asset-version.mjs
@@ -4,7 +4,7 @@ import { join } from 'path'
 
 import { pkg } from '../config/index.js'
 
-import { destination, isDist } from './task-arguments.mjs'
+import { destination } from './task-arguments.mjs'
 
 /**
  * Write VERSION.txt
@@ -12,13 +12,8 @@ import { destination, isDist } from './task-arguments.mjs'
  *
  * @returns {Promise<void>}
  */
-export async function updateDistAssetsVersion () {
-  if (!isDist) {
-    throw new Error('Asset version can only be applied to ./dist')
-  }
-
-  // Write VERSION.txt file
+export async function updateAssetsVersion () {
   return writeFile(join(destination, 'VERSION.txt'), pkg.version + EOL)
 }
 
-updateDistAssetsVersion.displayName = 'update-dist-assets-version'
+updateAssetsVersion.displayName = 'update-assets-version'

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -1,4 +1,5 @@
 import { readFile } from 'fs/promises'
+import { EOL } from 'os'
 import { join } from 'path'
 
 import { paths, pkg } from '../../../config/index.js'
@@ -74,6 +75,20 @@ describe('dist/', () => {
 
     it('should contain source mapping URL', () => {
       expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map$`))
+    })
+  })
+
+  describe('VERSION.txt', () => {
+    let filename
+    let version
+
+    beforeAll(async () => {
+      filename = 'VERSION.txt'
+      version = await readFile(join(paths.dist, filename), 'utf8')
+    })
+
+    it('should contain the correct version', () => {
+      expect(version).toEqual(pkg.version + EOL)
     })
   })
 })

--- a/tasks/task-arguments.mjs
+++ b/tasks/task-arguments.mjs
@@ -5,10 +5,16 @@ import parser from 'yargs-parser'
 
 import configPaths from '../config/paths.js'
 
-export const argv = parser(process.argv)
+export const argv = parser(process.argv, {
+  string: ['destination']
+})
 
 // Defaults for known tasks
 const destinations = [
+  {
+    task: 'compile',
+    destination: 'public'
+  },
   {
     task: 'build:package',
     destination: 'package'


### PR DESCRIPTION
Noticed our **build:dist** task accepts `--destination` but errors when trying to target another directory

It can now be varied like the others:

```console
npx gulp compile --destination '123'
npx gulp build:dist --destination '456'
npx gulp build:package --destination '789'
```

I've added a [check for `VERSION.txt`](https://github.com/alphagov/govuk-frontend/pull/3114/files#diff-24cf4c47d61ad26051ad863d660f1db5b9760eac9cd0e6f4d6e3a6a494b51ab5) in `./dist` for `npm run postbuild:dist`