### PR TITLE
Updates to our releasing docs

### DIFF
--- a/docs/releasing/after-publishing-a-release.md
+++ b/docs/releasing/after-publishing-a-release.md
@@ -1,0 +1,47 @@
+# Tasks after publishing a new release of GOV.UK Frontend
+
+Once we've published a new release of GOV.UK Frontend there are a number of things we still need to do, such as informing our community and updating our own repos.
+
+## Update our repos to use the new release
+
+Developers should update [govuk-design-system](https://github.com/alphagov/govuk-design-system/issues/2024) and [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs) to use the new release. When updating the design system, you should also test any new or updated guidance that relate to the new release and publish them along with the version update.
+
+## Let the community know about the new release
+
+We now need to update or comms channels.
+
+### The mailing list
+
+The team should send out an email with the release comms drafted before publishing.
+
+The release email should:
+- give a summary of the update
+- explain on why teams should update
+- components or styles affected (if possible)
+- thanks to any major contributors (if possible, include name and organisation)
+
+A release email will typically end with a link to the version's [release notes](https://github.com/alphagov/govuk-frontend/releases), and a call-to-action button to the [update npm how-to page](https://frontend.design-system.service.gov.uk/updating-with-npm/#update-using-node-js-package-manager-npm).
+
+For example, see the [release email for GOV.UK Frontend 4.4.0](https://us1.admin.mailchimp.com/campaigns/show?id=10053738).
+
+### Slack
+
+We should update both internal and x-gov slack channels:
+
+- [GDS: govuk-design-system](https://gds.slack.com/archives/CAF8JA25U)
+- [GDS: digital-service-platforms](https://gds.slack.com/archives/C01E20X06JK)
+- [x-gov: govuk-design-system](https://ukgovernmentdigital.slack.com/archives/C6DMEH5R6)
+
+The message we send on Slack is usually a shorter version of the email.
+
+### Design System website
+
+We should update the "what's new" section on the homepage of the website. The content for this section can be found in [/views/partials/_whats-new.njk](https://github.com/alphagov/govuk-design-system/blob/main/views/partials/_whats-new.njk).
+
+## Clear the decks
+
+Finally, we should make sure that our issue list and sprint board are tidy by making sure:
+
+- issues created for this release are all complete, closed, and moved into the **Done** column on the [Design System sprint board](https://github.com/orgs/alphagov/projects/4)
+- that all the issues (on the same board) solved and/or published in this release have been moved from the **Ready to Release** column to **Done**
+- any associated milestones are closed

--- a/docs/releasing/before-publishing-a-release.md
+++ b/docs/releasing/before-publishing-a-release.md
@@ -1,0 +1,53 @@
+# Tasks before publishing a new release of GOV.UK Frontend
+
+When preparing to publish a release of GOV.UK Frontend we need to ensure we are following proper procedure to effectively track our work and are prepared to publish our new release.
+
+## Kick off the release
+
+Both squads should coordinate when either wants to publish a new release. Choose a team member to lead on the release, typically a developer.
+
+We next need to define a cutoff date for this release. Once the cutoff date passes, do not add any further major changes. We can still add small fixes before we publish as long as we notify the team. However, we should try to avoid adding too many fixes in this way, as it requires us to have to repeat steps of the release process.
+
+Optionally, we can also let the prototype kit know that we are coordinating a release. The prototype kit team have [their own release process](https://github.com/alphagov/govuk-prototype-kit/tree/main/internal_docs) and we don't need to run releases synchronously.
+
+## Raise release issues
+
+Those leading on the release should then raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-design-system](https://github.com/alphagov/govuk-design-system/issues/2024), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs) to track the following:
+
+- draft comms for the new release (example issue: [#2507](https://github.com/alphagov/govuk-frontend/issues/2507))
+- create release notes for the new release (example issue: [#2508](https://github.com/alphagov/govuk-frontend/issues/2508))
+- release the new version of GOV.UK Frontend to npm (example issue: [#2509](https://github.com/alphagov/govuk-frontend/issues/2509))
+- update the GOV.UK Design System to use the new release of GOV.UK Frontend (example issue: [#2024](https://github.com/alphagov/govuk-design-system/issues/2024)):
+  - bump the version of `govuk-frontend`
+  - update the "What's new" section on the home page
+  - update the "Recently shipped" section of the roadmap
+  - merge any other documentation PRs specific to the release
+- update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example issue: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184)):
+  - bump the version of `govuk-frontend`
+  - update the "Updating with npm" example for `package.json` with the current number
+  - merge any other documentation PRs specific to the release
+- post the comms and do tidy-up tasks (example issue: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
+
+Once the developers have created these issues, the person leading the release should add them to an epic (example issue: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)). All these issues should be added to the [Design System sprint board](https://github.com/orgs/alphagov/projects/4).
+
+## Draft comms and release notes for the community
+
+A content designer and/or tech writer should do the following:
+- write announcements for slack posts, email and to go on the design system website after we release GOV.UK Frontend (for example, [draft comms for the cookie banner component](https://docs.google.com/document/d/1jVyMB7i94NOeflWaf3kE4Q4APMXGfluK3rOh74IHO08/edit))
+- check who the release’s contributors are and if we have consent to include their name
+
+A technical writer should finalise draft of release notes. Release notes will require a 2i review by another technical writer, make sure the technical writer has time to coordinate this.
+
+If the technical writer is unavailable, ask for help in the [gds-technical-writing Slack channel](https://gds.slack.com/archives/CAD0R2NQG) or confer with a content designer.
+
+The team should also post a message on any relevant [issue discussions](https://github.com/orgs/alphagov/projects/43/views/1) with rationale for any decisions we've made.
+
+## Finalise the release
+
+At this stage, the person leading the release should agree the publishing date. Once the team agrees, this confirms a code and content freeze. Use the [#design-system-team-channel](https://gds.slack.com/app_redirect?channel=design-system-team-channel) to confirm sign-off from:
+
+- content designer, technical writer and designers for guidance, examples and community backlog decision rationale
+- technical writer and developers for Nunjucks macros
+- developers for changes to GOV.UK Frontend
+- technical writer for release notes
+- content designer, community manager and technical writer for announcements and engagement activities

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -6,9 +6,9 @@ Before you publish a pre-release, you need to have committed a code change to GO
 
 Use pre-releases when you:
 - [work on developing a component or pattern](https://design-system.service.gov.uk/community/develop-a-component-or-pattern/) for the GOV.UK Design System
-- want to trial an experimental feature (guidance on trialling experimental features is in development)
+- want to trial an experimental feature (guidance on trialing experimental features is in development)
 
-> :warning:Your projects should never depend on a pre-released GOV.UK Frontend package. This is because someone could remove the GitHub branch containing the pre-release package at any time. For this reason, never use a pre-released package in a production setting.
+:warning: Your projects should never depend on a pre-released GOV.UK Frontend package. This is because someone could remove the GitHub branch containing the pre-release package at any time. For this reason, never use a pre-released package in a production setting.
 
 ## What happens when you pre-release GOV.UK Frontend
 

--- a/docs/releasing/publishing-from-a-support-branch.md
+++ b/docs/releasing/publishing-from-a-support-branch.md
@@ -18,37 +18,7 @@ However, this approach has risks. For example, it creates a messy commit history
 
 ## Before you publish GOV.UK Frontend
 
-1. At stand-up, person leading the release (usually a developer) to tell the GOV.UK Design System team we are close to releasing.
-
-2. Developers to raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs), [govuk-prototype-kit](https://github.com/alphagov/govuk-prototype-kit)) to:
-    - create announcement draft for the new release (example issue: [#2108](https://github.com/alphagov/govuk-frontend/issues/2108))
-    - create release notes for the new release (example issue: [#1986](https://github.com/alphagov/govuk-frontend/issues/1986))
-    - create release notes for the new release of GOV.UK Prototype Kit (example issue: [#958](https://github.com/alphagov/govuk-prototype-kit/issues/958))
-    - create an issue for the new release of GOV.UK Frontend (example issue: [#1987](https://github.com/alphagov/govuk-frontend/issues/1987))
-    - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example issue: [#1347](https://github.com/alphagov/govuk-design-system/issues/1347))
-    - create an issue for the new release of GOV.UK Prototype Kit (example issue: [#917](https://github.com/alphagov/govuk-prototype-kit/issues/917))
-    - update the GOV.UK Prototype Kit to use the new release (example issue: [#923](https://github.com/alphagov/govuk-prototype-kit/issues/923))
-
-3. Person leading the release to add the issues to the [Design System sprint board](https://github.com/orgs/alphagov/projects/4).
-
-4. Content designer to:
-    - write announcements to post on Slack after we release:
-      - GOV.UK Frontend (for example, [draft comms for the cookie banner component](https://docs.google.com/document/d/1jVyMB7i94NOeflWaf3kE4Q4APMXGfluK3rOh74IHO08/edit))
-      - GOV.UK Prototype kit
-    - check who the release’s contributors are and if we have consent to include their name
-
-5. Technical writer to finalise draft of release notes and get 2i on them.
-
-6. Content designer or designer to update community backlog with rationale for any decisions we made.
-
-7. Person leading the release to coordinate the sign-off when they are ready to do the release. Once the team agrees, this confirms a code and content freeze. Use the [#design-system-team-channel](https://gds.slack.com/app_redirect?channel=design-system-team-channel) to confirm sign-off from:
-    - content designer, technical writer and designers for guidance, examples and community backlog decision rationale
-    - technical writer and developers for Nunjucks macros
-    - developers for changes to GOV.UK Frontend
-    - technical writer for release notes
-    - content designer, community manager or technical writer for announcements and engagement activities
-
-Note: Before you go on annual leave, tell the delivery manager who will be looking after your work. This will help us to complete sign-off.
+Read the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to ensure you are prepared to publish.
 
 ## Publish a new version of GOV.UK Frontend from the support branch
 
@@ -130,12 +100,7 @@ Note: Before you go on annual leave, tell the delivery manager who will be looki
 
 ## After you publish the new release
 
-1. Once you've updated the GOV.UK Design System, Prototype Kit and Frontend Docs, [post a short summary of the release in the cross-government and GDS #govuk-design-system Slack channels](https://github.com/alphagov/govuk-frontend/issues/2363).
-
-2. On the [Design System Kanban Board](https://github.com/orgs/alphagov/projects/4):
-
-    - move any relevant issues from the 'Ready to Release' column to 'Done'
-    - close any associated milestones
+Read the docs for [what to do after publishing a release](/docs/releasing/after-publishing-a-release.md).
 
 ## Update the `main` branch (optional)
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -1,44 +1,6 @@
 # Before you publish GOV.UK Frontend
 
-1. At stand up, person leading the release to tell the GOV.UK Design System team we are close to releasing so we can coordinate the final cutoff date. Once the cutoff date passes, do not add any further major changes to the release. We can still add small fixes before step 7 as long as we notify the content designer and technical writer. However, we should try to avoid adding too many fixes in this way, as it requires us to repeat some of steps 4-6.
-
-2. (optional step) Let the prototype kit know that we are coordinating a release. The prototype kit team have [their own release process](https://github.com/alphagov/govuk-prototype-kit/tree/main/internal_docs) and we don't need to run releases synchronously.
-
-3. Developers to raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-design-system](https://github.com/alphagov/govuk-design-system/issues/2024), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs) to:
-  - draft comms for the new release (example issue: [#2507](https://github.com/alphagov/govuk-frontend/issues/2507))
-  - create release notes for the new release (example issue: [#2508](https://github.com/alphagov/govuk-frontend/issues/2508))
-  - release the new version of GOV.UK Frontend to npm (example issue: [#2509](https://github.com/alphagov/govuk-frontend/issues/2509))
-  - update the GOV.UK Design System to use the new release of GOV.UK Frontend (example issue: [#2024](https://github.com/alphagov/govuk-design-system/issues/2024)):
-    - bump the version of `govuk-frontend`
-    - update the "What's new" section on the home page
-    - update the "Recently shipped" section of the roadmap
-    - merge any other documentation PRs specific to the release
-  - update the GOV.UK Frontend Docs to use the new release of GOV.UK Frontend (example issue: [#184](https://github.com/alphagov/govuk-frontend-docs/issues/184)):
-    - bump the version of `govuk-frontend`
-    - update the "Updating with npm" example for `package.json` with the current number
-    - merge any other documentation PRs specific to the release
-  - post the comms and do tidy-up tasks (example issue: [#2510](https://github.com/alphagov/govuk-frontend/issues/2510))
-
-  Once the developers have created these issues, the person leading the release should add them to an epic (example issue: [#2511](https://github.com/alphagov/govuk-frontend/issues/2511)).
-
-4. Person leading the release to add the issues to the [Design System kanban board](https://github.com/orgs/alphagov/projects/4).
-
-5. Content designer to:
-  - write announcements to post on Slack after we release GOV.UK Frontend (for example, [draft comms for the cookie banner component](https://docs.google.com/document/d/1jVyMB7i94NOeflWaf3kE4Q4APMXGfluK3rOh74IHO08/edit))
-  - check who the release’s contributors are and if we have consent to include their name
-
-6. Technical writer to finalise draft of release notes and get 2i on them. If the technical writer is unavailable, ask for help in the [gds-technical-writing Slack channel](https://gds.slack.com/archives/CAD0R2NQG).
-
-7. Content designer or designer to update community backlog with rationale for any decisions we made.
-
-8. Person leading the release to coordinate the sign-off when they are ready to do the release. Once the team agrees, this confirms a code and content freeze. Use the [#design-system-team-channel](https://gds.slack.com/app_redirect?channel=design-system-team-channel) to confirm sign-off from:
-  - content designer, technical writer and designers for guidance, examples and community backlog decision rationale
-  - technical writer and developers for Nunjucks macros
-  - developers for changes to GOV.UK Frontend
-  - technical writer for release notes
-  - content designer, community manager and technical writer for announcements and engagement activities
-
-> **Note:** Before you go on leave, tell the delivery manager who will be looking after your work. This will help us to complete sign-off without fuss.
+Read the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to ensure you are prepared to publish.
 
 # Publish a new version of GOV.UK Frontend
 
@@ -107,13 +69,4 @@ You can view the tag created during step 10 of creating the new version in the [
 
 # After you publish the new release
 
-1. Update the GOV.UK Design System and Frontend Docs to use a new release of GOV.UK Frontend
-
-2. Post announcements of the release to:
-  - GOV.UK Frontend in the govuk-design-system channels on [GDS Slack](https://gds.slack.com/app_redirect?channel=govuk-design-system) and [x-gov Slack](https://ukgovernmentdigital.slack.com/app_redirect?channel=govuk-design-system)
-  - let the team know they can post social comms
-  - let stakeholders know the release is live
-
-3. Move issues on the [Design System Kanban board](https://github.com/orgs/alphagov/projects/4) from the **Ready to Release** column to **Done**.
-
-4. Close any associated milestones.
+Read the docs for [what to do after publishing a release](/docs/releasing/after-publishing-a-release.md).


### PR DESCRIPTION
## What
Updates our docs on publishing new releases with the following:

- Adds dedicated before publishing and after publishing docs
- Removes quote blocks as warnings from our release docs
- Generally tidies up the content and adds more detail where we're able to

## Why
This was investigated in response to the recent 4.4.1 release where we noted it was unclear where tech writers could find the release notes for a given release to link in comms. From this I noticed that we duplicate content between `releasing` and `publishing-from-a-support-branch` and in fact the latter was out of date as we update the former eg: https://github.com/alphagov/govuk-frontend/pull/2741. This is an attempt to reduce the risk of the 2 release docs becoming out of sync and to simplify the content pertaining to pre and post publishing.

I queried our use of quote blocks as callout-esque patterns some months ago and didn't get a definitive answer. It looks like this was intended as a way to make the content standout in the absence of a callout pattern in markdown. However, this is a misuse of the quote pattern in markdown and it has pretty dodgy contrast for anyone using github dark mode. If folks think it should stay, I'll put it back.