### PR TITLE
Fix incorrect changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 - [#3021: Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
+- [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
 
 ## 4.4.1 (Fix release)
 
@@ -32,7 +33,6 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#3087: Fix focus styles for links split over multiple lines in Chromium 108+ (Chrome 108+, Edge 108+, Opera 94+)](https://github.com/alphagov/govuk-frontend/pull/3087)
-- [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
 
 ## 4.4.0 (Feature release)
 


### PR DESCRIPTION
We shipped 4.4.1 from the support/4.4.x branch without the other changes from main.

It looks like when #3112 was merged Git cleanly merged the changelog entry but it incorrectly ended up listed as part of v4.4.1.

Move the entry for this PR to the 'Unreleased' section.

(Thanks to @colinrotherham for spotting!)