### PR TITLE
Allow compile with lint errors in development

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,5 +105,6 @@ module.exports = {
         jest: true
       }
     }
-  ]
+  ],
+  root: true
 }

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -15,8 +15,10 @@ import { npmScriptTask } from './tasks/run.mjs'
  * Runs JavaScript code quality checks, documentation, compilation
  */
 gulp.task('scripts', gulp.series(
-  npmScriptTask('lint:js'),
-  compileJavaScripts,
+  gulp.parallel(
+    npmScriptTask('lint:js'),
+    compileJavaScripts
+  ),
   npmScriptTask('build:jsdoc')
 ))
 
@@ -25,8 +27,10 @@ gulp.task('scripts', gulp.series(
  * Runs Sass code quality checks, documentation, compilation
  */
 gulp.task('styles', gulp.series(
-  npmScriptTask('lint:scss'),
-  compileStylesheets,
+  gulp.parallel(
+    npmScriptTask('lint:scss'),
+    compileStylesheets
+  ),
   npmScriptTask('build:sassdoc')
 ))
 


### PR DESCRIPTION
This PR fixes a slightly frustrating side effect of making our linting stricter

### Steps to reproduce

1. Open a component `*.mjs` or `*.scss` file
2. Update or add some new code
3. Save the changes… ⏳
4. Linting error on invalid JSDoc or SassDoc etc 🚨

The problem? Code is blocked from being compiled

For example quickly commenting out some code to do a quick browser refresh but being blocked on:

> 'normaliseDataset' is defined but never used. eslint([no-unused-vars](https://eslint.org/docs/rules/no-unused-vars))

### The fix

In development we use **gulp.watch()** to trigger either [`gulp styles`](https://github.com/alphagov/govuk-frontend/blob/eslint-during-watch/gulpfile.mjs#L29) or [`gulp scripts`](https://github.com/alphagov/govuk-frontend/blob/eslint-during-watch/gulpfile.mjs#L17) but with this PR we've changed the task running order so lint/compile happens in parallel (not series). One doesn't block the other

For both releases and [GitHub **Tests** workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml) (or building locally) we use `gulp compile` which is unaffected