### PR TITLE
Set up `eslint-plugin-es-x` to check the syntax we use

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -92,14 +92,6 @@ module.exports = {
       }
     },
     {
-      files: ['**/govuk/components/**/*.{cjs,js,mjs}'],
-      excludedFiles: ['**/govuk/components/**/*.test.{cjs,js,mjs}'],
-      parserOptions: {
-        // Note: Allow ES6 for import/export syntax (although our code is ES3 for legacy browsers)
-        ecmaVersion: '2015'
-      }
-    },
-    {
       files: ['**/*.test.{cjs,js,mjs}'],
       env: {
         jest: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "cheerio": "^1.0.0-rc.12",
         "eslint": "^8.31.0",
         "eslint-config-standard": "^17.0.0",
+        "eslint-plugin-es-x": "^5.4.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jsdoc": "^39.6.4",
         "eslint-plugin-n": "^15.6.0",
@@ -8211,6 +8212,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-5.4.0.tgz",
+      "integrity": "sha512-6Mniw760Nhd6brnDy+rz857LD+icZe5wXmsvXSuJ84svM0Q53ulJxpMhTJmpqHaLzYh7fuGAJ8V62ohbmqF+jA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-utils": "^2.0.0 || ^3.0.0",
+        "regexpp": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
       },
       "peerDependencies": {
         "eslint": ">=4.19.1"
@@ -31746,6 +31766,16 @@
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
+      }
+    },
+    "eslint-plugin-es-x": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-5.4.0.tgz",
+      "integrity": "sha512-6Mniw760Nhd6brnDy+rz857LD+icZe5wXmsvXSuJ84svM0Q53ulJxpMhTJmpqHaLzYh7fuGAJ8V62ohbmqF+jA==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0 || ^3.0.0",
+        "regexpp": "^3.0.0"
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "cheerio": "^1.0.0-rc.12",
     "eslint": "^8.31.0",
     "eslint-config-standard": "^17.0.0",
+    "eslint-plugin-es-x": "^5.4.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^39.6.4",
     "eslint-plugin-n": "^15.6.0",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -24,6 +24,22 @@ module.exports = {
       }
     },
     {
+      files: ['govuk/**/*.mjs'],
+      excludedFiles: ['**/*.test.mjs'],
+      parserOptions: {
+        // Note: Allow ES6 for import/export syntax (although our code is ES3 for legacy browsers)
+        ecmaVersion: '2015'
+      },
+      plugins: ['es-x'],
+      extends: ['plugin:es-x/restrict-to-es3'],
+      rules: {
+        // Rollup transpiles modules to AMD export/define
+        'es-x/no-modules': 'off',
+        // Rollup plays fine with `export * from`
+        'es-x/no-export-ns-from': 'off'
+      }
+    },
+    {
       // Matches 'JavaScript component tests' in jest.config.mjs
       // to ignore unknown 'page' and 'browser' Puppeteer globals
       files: [

--- a/src/govuk/common/normalise-dataset.mjs
+++ b/src/govuk/common/normalise-dataset.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-string-prototype-trim -- Polyfill imported */
+
 import '../vendor/polyfills/Element/prototype/dataset.mjs'
 import '../vendor/polyfills/String/prototype/trim.mjs'
 

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -1,3 +1,6 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+/* eslint-disable es-x/no-string-prototype-trim -- Polyfill imported */
+
 import { nodeListForEach, mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { I18n } from '../../i18n.mjs'

--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import '../../vendor/polyfills/Event.mjs' // addEventListener, event.target normalization and DOMContentLoaded

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -1,3 +1,6 @@
+/* eslint-disable es-x/no-date-now -- Polyfill imported */
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { extractConfigByNamespace, mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'

--- a/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/src/govuk/components/checkboxes/checkboxes.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { nodeListForEach } from '../../common/index.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Event.mjs' // addEventListener, event.target normalization and DOMContentLoaded

--- a/src/govuk/components/radios/radios.mjs
+++ b/src/govuk/components/radios/radios.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { nodeListForEach } from '../../common/index.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Event.mjs' // addEventListener, event.target normalization and DOMContentLoaded

--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { nodeListForEach } from '../../common/index.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Element/prototype/nextElementSibling.mjs'


### PR DESCRIPTION
[`eslint-plugin-es-x`](https://eslint-community.github.io/eslint-plugin-es-x/) validates the use of features brought by specific ES version. This should give us a safety net that we're not including the modern features it can detect in our code. 

The setup sets the restrictions to ES3 features, due to our IE8 support. The rules matching the features we polyfills are deactivated to allow us using them.

We'll still need a bit of caution as it only have rules [against EcmaScript features not Browser API features](https://eslint-community.github.io/eslint-plugin-es-x/rules/).