### PR TITLE
Remove Chromium from GitHub Actions cache

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -10,7 +10,7 @@ runs:
 
       with:
         # Restore build cache (unless commit SHA changes)
-        key: build-cache-${{ github.sha }}
+        key: build-cache-${{ runner.os }}-${{ github.sha }}
         path: |
           jsdoc
           public

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -10,7 +10,7 @@ runs:
 
       with:
         # Restore `node_modules` cache (unless packages change)
-        key: npm-install-cache-${{ hashFiles('package-lock.json', '**/package.json') }}
+        key: npm-install-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
         path: node_modules
 
     - name: Setup Node.js

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -11,9 +11,7 @@ runs:
       with:
         # Restore `node_modules` cache (unless packages change)
         key: npm-install-cache-${{ hashFiles('package-lock.json', '**/package.json') }}
-        path: |
-          .cache/puppeteer
-          node_modules
+        path: node_modules
 
     - name: Setup Node.js
       uses: ./.github/workflows/actions/setup-node

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -32,6 +32,12 @@ jobs:
       - name: Install dependencies
         uses: ./.github/workflows/actions/install-node
 
+      - name: Cache browser download
+        uses: actions/cache@v3
+        with:
+          key: puppeteer-cache-${{ runner.os }}
+          path: .cache/puppeteer
+
       - name: Build
         uses: ./.github/workflows/actions/build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Cache linter
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache
+          key: ${{ matrix.name }}-cache-${{ runner.os }}
           path: ${{ matrix.cache }}
 
       - name: Run lint task
@@ -109,7 +109,7 @@ jobs:
         if: ${{ matrix.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache
+          key: ${{ matrix.name }}-cache-${{ runner.os }}
           path: ${{ matrix.cache }}
 
       - name: Run test task
@@ -166,7 +166,7 @@ jobs:
         if: ${{ matrix.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.name }}-cache
+          key: ${{ matrix.name }}-cache-${{ runner.os }}
           path: ${{ matrix.cache }}
 
       - name: Run verify task

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,9 @@ jobs:
     name: Install
     runs-on: ubuntu-latest
 
+    env:
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -145,7 +148,9 @@ jobs:
           - description: JavaScript component tests
             name: test-component
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
-            cache: .cache/jest
+            cache: |
+              .cache/jest
+              .cache/puppeteer
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,10 +88,12 @@ jobs:
           - description: Nunjucks macro tests
             name: test-macro
             run: npx jest --color --selectProjects "Nunjucks macro tests"
+            cache: .cache/jest
 
           - description: JavaScript unit tests
             name: test-unit
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript unit tests" --coverage --testLocationInResults
+            cache: .cache/jest
 
     steps:
       - name: Checkout
@@ -100,11 +102,12 @@ jobs:
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
 
-      - name: Cache Jest
+      - name: Cache task
+        if: ${{ matrix.cache }}
         uses: actions/cache@v3
         with:
           key: ${{ matrix.name }}-cache
-          path: .cache/jest
+          path: ${{ matrix.cache }}
 
       - name: Run test task
         run: ${{ matrix.run }}
@@ -137,10 +140,12 @@ jobs:
           - description: JavaScript behaviour tests
             name: test-behaviour
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
+            cache: .cache/jest
 
           - description: JavaScript component tests
             name: test-component
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
+            cache: .cache/jest
 
     steps:
       - name: Checkout
@@ -152,11 +157,12 @@ jobs:
       - name: Restore build
         uses: ./.github/workflows/actions/build
 
-      - name: Cache Jest
+      - name: Cache task
+        if: ${{ matrix.cache }}
         uses: actions/cache@v3
         with:
           key: ${{ matrix.name }}-cache
-          path: .cache/jest
+          path: ${{ matrix.cache }}
 
       - name: Run verify task
         run: ${{ matrix.run }}

--- a/config/jest/browser/open.mjs
+++ b/config/jest/browser/open.mjs
@@ -1,4 +1,5 @@
 import { setup } from 'jest-environment-puppeteer'
+import { downloadBrowser } from 'puppeteer/lib/esm/puppeteer/node/install.js'
 
 import serverStart from '../server/start.mjs'
 
@@ -18,6 +19,7 @@ export default async function browserOpen (jestConfig) {
     process.setMaxListeners(1 + maxWorkers)
   }
 
+  await downloadBrowser() // Download browser
   await serverStart() // Wait for web server
   await setup(jestConfig) // Open browser
 }

--- a/tasks/screenshot-components.mjs
+++ b/tasks/screenshot-components.mjs
@@ -3,6 +3,7 @@ import { join } from 'path'
 import percySnapshot from '@percy/puppeteer'
 import { isPercyEnabled } from '@percy/sdk-utils'
 import { launch } from 'puppeteer'
+import { downloadBrowser } from 'puppeteer/lib/esm/puppeteer/node/install.js'
 
 import configPaths from '../config/paths.js'
 import { getDirectories, getListing } from '../lib/file-helper.js'
@@ -67,4 +68,5 @@ if (!await isPercyEnabled()) {
   throw new Error('Percy healthcheck failed')
 }
 
+await downloadBrowser()
 await screenshotComponents()


### PR DESCRIPTION
Whilst investigating the [`puppeteer@19.5.0` update PR](https://github.com/alphagov/govuk-frontend/pull/3152) I noticed Chromium was ~283MB on disk (macOS) and we were saving and restoring it to each GitHub Actions workflow step

This is one of the reasons we've seen Windows test runs perform slowly in:

* https://github.com/alphagov/govuk-frontend/pull/2945

This PR defers the Puppeteer download (~137MB compressed) until Jest "**JavaScript component tests**" run

### Before
```
Cache Size: ~180 MB (188782653 B)
```

### After
```
Cache Size: ~42 MB (44379878 B)
```