### PR TITLE
Change Phase Banner's `tag` parameter to required

### DIFF
--- a/src/govuk/components/phase-banner/phase-banner.yaml
+++ b/src/govuk/components/phase-banner/phase-banner.yaml
@@ -9,7 +9,7 @@ params:
   description: If `text` is set, this is not required. HTML to use within the phase banner. If `html` is provided, the `text` option will be ignored.
 - name: tag
   type: object
-  required: false
+  required: true
   description: Options for the tag component.
   isComponent: true
 - name: classes


### PR DESCRIPTION
Updates the Phase Banner's params data to mark the `tag` parameter as required.

The tag parameter is not currently listed as being required, however the component does not render correctly if it's omitted—it still renders the tag, just without any text. 

![Screenshot](https://user-images.githubusercontent.com/1253214/213160358-15418d7a-c44b-4beb-9a86-7c922cbf97ef.png)

Closes #1930. 