### PR TITLE
Fix PostCSS condition for Review app “pseudo-classes” plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -38,6 +38,7 @@ module.exports = ({ env, file = '' }) => {
   // For example ':hover' and ':focus' classes to simulate form label states
   if (minimatch(dir, '**/app/assets/scss')) {
     plugins.push(pseudoclasses({
+      allCombinations: true,
       restrictTo: [
         ':link',
         ':visited',

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -29,11 +29,6 @@ module.exports = ({ env, file = '' }) => {
     autoprefixer({ env: isIE8 ? 'oldie' : env })
   ]
 
-  // Minify CSS
-  if (name.endsWith('.min')) {
-    plugins.push(cssnano())
-  }
-
   // Add review app auto-generated 'companion' classes for each pseudo-class
   // For example ':hover' and ':focus' classes to simulate form label states
   if (minimatch(dir, '**/app/assets/scss')) {
@@ -57,6 +52,9 @@ module.exports = ({ env, file = '' }) => {
       unrgba({ filter: true })
     )
   }
+
+  // Always minify CSS
+  plugins.push(cssnano())
 
   return {
     plugins

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -36,7 +36,7 @@ module.exports = ({ env, file = '' }) => {
 
   // Add review app auto-generated 'companion' classes for each pseudo-class
   // For example ':hover' and ':focus' classes to simulate form label states
-  if (minimatch(dir, '**/app/assets/scss') && (name === 'app' || name.startsWith('app-'))) {
+  if (minimatch(dir, '**/app/assets/scss')) {
     plugins.push(pseudoclasses({
       restrictTo: [
         ':link',

--- a/postcss.config.unit.test.js
+++ b/postcss.config.unit.test.js
@@ -84,7 +84,10 @@ describe('PostCSS config', () => {
           const config = configFn({ env, file })
 
           expect(getPluginNames(config))
-            .toEqual(['autoprefixer'])
+            .toEqual([
+              'autoprefixer',
+              'cssnano'
+            ])
         }
       })
     })
@@ -107,54 +110,8 @@ describe('PostCSS config', () => {
               'autoprefixer',
               'postcss-unmq',
               'postcss-unopacity',
-              'postcss-color-rgba-fallback'
-            ])
-        }
-      })
-    })
-
-    describe('Default + Minification', () => {
-      it.each(
-        [
-          { path: 'example.min.css' },
-          { path: 'example.min.scss' }
-        ]
-      )('Adds plugins for $path', ({ path }) => {
-        const input = new Vinyl({ path })
-
-        // Confirm plugins for both file object and path
-        for (const file of [input, input.path]) {
-          const config = configFn({ env, file })
-
-          expect(getPluginNames(config))
-            .toEqual([
-              'autoprefixer',
+              'postcss-color-rgba-fallback',
               'cssnano'
-            ])
-        }
-      })
-    })
-
-    describe('Default + Minification + IE8', () => {
-      it.each(
-        [
-          { path: 'example-ie8.min.css' },
-          { path: 'example-ie8.min.scss' }
-        ]
-      )('Adds plugins for $path', ({ path }) => {
-        const input = new Vinyl({ path })
-
-        // Confirm plugins for both file object and path
-        for (const file of [input, input.path]) {
-          const config = configFn({ env, file })
-
-          expect(getPluginNames(config))
-            .toEqual([
-              'autoprefixer',
-              'cssnano',
-              'postcss-unmq',
-              'postcss-unopacity',
-              'postcss-color-rgba-fallback'
             ])
         }
       })
@@ -176,7 +133,8 @@ describe('PostCSS config', () => {
           expect(getPluginNames(config))
             .toEqual([
               'autoprefixer',
-              'postcss-pseudo-classes'
+              'postcss-pseudo-classes',
+              'cssnano'
             ])
         }
       })
@@ -218,7 +176,8 @@ describe('PostCSS config', () => {
               'postcss-pseudo-classes',
               'postcss-unmq',
               'postcss-unopacity',
-              'postcss-color-rgba-fallback'
+              'postcss-color-rgba-fallback',
+              'cssnano'
             ])
         }
       })

--- a/postcss.config.unit.test.js
+++ b/postcss.config.unit.test.js
@@ -163,8 +163,8 @@ describe('PostCSS config', () => {
     describe('Review app only', () => {
       it.each(
         [
-          { path: 'app/assets/scss/app.scss' },
-          { path: 'app/assets/scss/app-legacy.scss' }
+          { path: 'app/assets/scss/app.css' },
+          { path: 'app/assets/scss/app-legacy.css' }
         ]
       )('Adds plugins for $path', ({ path }) => {
         const input = new Vinyl({ path })
@@ -180,13 +180,30 @@ describe('PostCSS config', () => {
             ])
         }
       })
+
+      it.each(
+        [
+          { path: 'app/views/full-page-examples/campaign-page/styles.css' },
+          { path: 'app/views/full-page-examples/search/styles.css' }
+        ]
+      )("Skips plugin 'pseudo-classes' for $path", ({ path }) => {
+        const input = new Vinyl({ path })
+
+        // Confirm plugin skipped for both file object and path
+        for (const file of [input, input.path]) {
+          const config = configFn({ env, file })
+
+          expect(getPluginNames(config))
+            .not.toContain('postcss-pseudo-classes')
+        }
+      })
     })
 
     describe('Review app only + IE8', () => {
       it.each(
         [
-          { path: 'app/assets/scss/app-ie8.scss' },
-          { path: 'app/assets/scss/app-legacy-ie8.scss' }
+          { path: 'app/assets/scss/app-ie8.css' },
+          { path: 'app/assets/scss/app-legacy-ie8.css' }
         ]
       )('Adds plugins for $path', ({ path }) => {
         const input = new Vinyl({ path })

--- a/tasks/gulp/compile-assets.mjs
+++ b/tasks/gulp/compile-assets.mjs
@@ -33,22 +33,25 @@ export function compileStylesheets () {
         gulp.src(`${slash(paths.src)}/govuk/all.scss`, {
           sourcemaps: true
         })
-          .pipe(rename({
-            basename: 'govuk-frontend',
-            suffix: `-${pkg.version}`
-          }))
-      ),
+      )
+        .pipe(rename({
+          basename: 'govuk-frontend'
+        })),
 
       compileStylesheet(
         gulp.src(`${slash(paths.src)}/govuk/all-ie8.scss`, {
           sourcemaps: true
         })
-          .pipe(rename({
-            basename: 'govuk-frontend-ie8',
-            suffix: `-${pkg.version}`
-          }))
       )
+        .pipe(rename({
+          basename: 'govuk-frontend-ie8'
+        }))
     )
+      .pipe(rename({
+        suffix: `-${pkg.version}`,
+        extname: '.min.css'
+      }))
+
       .pipe(gulp.dest(slash(destPath), {
         sourcemaps: '.'
       }))
@@ -75,12 +78,16 @@ export function compileStylesheets () {
       gulp.src(`${slash(paths.fullPageExamples)}/**/styles.scss`, {
         sourcemaps: true
       })
-        .pipe(rename((path) => {
-          path.basename = path.dirname
-          path.dirname = 'full-page-examples'
-        }))
     )
+      .pipe(rename((path) => {
+        path.basename = path.dirname
+        path.dirname = 'full-page-examples'
+      }))
   )
+    .pipe(rename({
+      extname: '.min.css'
+    }))
+
     .pipe(gulp.dest(slash(destPath), {
       sourcemaps: '.'
     }))
@@ -99,9 +106,6 @@ function compileStylesheet (stream, options = {}) {
   return stream
     .pipe(plumber(errorHandler(stream, 'compile:scss')))
     .pipe(sass(options))
-    .pipe(rename({
-      extname: '.min.css'
-    }))
     .pipe(postcss())
     .pipe(plumber.stop())
 }


### PR DESCRIPTION
This PR restores the [`postcss-pseudo-classes`](https://github.com/giuseppeg/postcss-pseudo-classes) PostCSS plugin for [review app](https://govuk-frontend-review.herokuapp.com) stylesheets

We use the plugin to generate classes (see below) for the following:

```
:link
:visited
:hover
:active
:focus
```

Unfortunately our config hasn't matched minified stylesheets (such as `app.min.css`) since merging:

* https://github.com/alphagov/govuk-frontend/pull/3050

<img width="307" alt="Pseudo classes on form elements" src="https://user-images.githubusercontent.com/415517/213426177-ee30849c-ad23-45af-b290-345301b7d8c7.png">

This PR includes:

1. **Fix PostCSS condition for Review app “pseudo-classes” plugin**
We can match all `'**/app/assets/scss'` child stylesheets regardless of name or extension

2. **Adjust Sass task to run PostCSS first before renaming**
For some Gulp streams we were renaming/moving files before PostCSS could check the path

3. **Move PostCSS `cssnano` to default plugins**
We minify our CSS by default so can simplify our tests