### PR TITLE
Add disabled styles for form controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+### New features
+
+#### Updated the appearance of disabled form controls
+
+The disabled state of Text Input, Textarea, Select and File Upload components has been updated to appear consistent across browsers and devices. They also now consistent with the existing disabled styles for Buttons, Checkboxes, and Radios.
+
+Disabled form controls appear with their opacity reduced by 50% and with an alternative cursor appearance when hovered over.
+
+This was added in [pull request #3187: Add disabled styles for form controls](https://github.com/alphagov/govuk-frontend/pull/3187).
+
+#### Added a top-level `disabled` parameter to form controls
+
+The Nunjucks macros for Text Input, Textarea, Select and File Upload components have been updated to include a top-level `disabled` parameter, making it easier to enable the disabled state for these controls.
+
+```nunjucks
+{{ govukInput({
+  id: "disabled-input",
+  name: "disabled-input",
+  value: "Unchangeable value",
+  disabled: true
+}) }}
+```
+
+Disabled form controls have poor contrast and can confuse some users, so avoid them if possible.
+
+Only use disabled form controls if research shows it makes the user interface easier to understand.
+
+This was added in [pull request #3187: Add disabled styles for form controls](https://github.com/alphagov/govuk-frontend/pull/3187).
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/app/views/examples/form-controls-states/index.njk
+++ b/app/views/examples/form-controls-states/index.njk
@@ -1,8 +1,33 @@
 {% extends "layout.njk" %}
 
 {% from "back-link/macro.njk" import govukBackLink %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "input/macro.njk" import govukInput %}
+{% from "select/macro.njk" import govukSelect %}
+{% from "textarea/macro.njk" import govukTextarea %}
+
+{% set examples = [
+  { name: "Initial" },
+  { name: "Hover", classes: ":hover" },
+  { name: "Focus", classes: ":focus" },
+  { name: "Hover, Focus", classes: ":hover :focus" },
+  { name: "Disabled", attributes: { "disabled": "disabled" } },
+  { name: "Disabled, Hover", classes: ":hover", attributes: { "disabled": "disabled" } },
+  { name: "Error", error: true },
+  { name: "Error, Hover", error: true, classes: ":hover" },
+  { name: "Error, Focus", error: true, classes: ":focus" },
+  { name: "Error, Hover, Focus", error: true, classes: ":hover :focus" }
+] %}
+
+{% set examplesTextInputs = examples.concat([
+  { name: "Readonly",attributes: { "readonly": "readonly" } },
+  { name: "Readonly, Hover", classes: ":hover", attributes: { "readonly": "readonly" } },
+  { name: "Readonly, Focus", classes: ":focus", attributes: { "readonly": "readonly" } },
+  { name: "Readonly, Hover, Focus", classes: ":hover :focus", attributes: { "readonly": "readonly" } },
+  { name: "X-Ray", xray: true }
+]) %}
+
+{% set examples = examples.concat([{ name: "X-Ray", xray: true }]) %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -16,7 +41,9 @@
   box-shadow: 0 0 0 3px rgba(175, 175, 175, 0.5);
 }
 
-.x-ray input {
+.x-ray input,
+.x-ray select,
+.x-ray textarea {
   opacity: 1 !important;
   box-shadow: 0 0 0 3px rgba(0, 0, 255, 0.5);
   -webkit-appearance: none;
@@ -26,6 +53,50 @@
   box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.5);
 }
 </style>
+
+<div class="govuk-grid-row">
+  {% for hasValue in [false, true] %}
+    <div class="govuk-grid-column-one-half">
+      {% for item in examplesTextInputs %}
+        {{ govukInput({
+          id: 'input-' + loop.index,
+          value: 'Bats are mammals of the order Chiroptera' if hasValue else '',
+          classes: item.classes if item.classes else '',
+          label: {
+            text: item.name
+          },
+          formGroup: { classes: 'x-ray' if item.xray else '' },
+          attributes: item.attributes if item.attributes else {},
+          errorMessage: item.error
+        }) }}
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  {% for hasValue in [false, true] %}
+    <div class="govuk-grid-column-one-half">
+      {% for item in examplesTextInputs %}
+        {{ govukTextarea({
+          id: 'textarea-' + loop.index,
+          value: "With their forelimbs adapted as wings, they are the only mammals capable of true and sustained flight. Bats are more agile in flight than most birds, flying with their very long spread-out digits covered with a thin membrane or patagium. The smallest bat, and arguably the smallest extant mammal, is Kitti's hog-nosed bat, which is 29–34 millimetres in length, 150 mm  across the wings and 2–2.6 g in mass. The largest bats are the flying foxes, with the giant golden-crowned flying fox, reaching a weight of 1.6 kg and having a wingspan of 1.7 m." if hasValue else '',
+          classes: item.classes if item.classes else '',
+          label: {
+            text: item.name
+          },
+          formGroup: { classes: 'x-ray' if item.xray else '' },
+          attributes: item.attributes if item.attributes else {},
+          errorMessage: item.error
+        }) }}
+      {% endfor %}
+    </div>
+  {% endfor %}
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
@@ -304,6 +375,53 @@
         </label>
       </div>
     </div>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    {% for item in examples %}
+      {{ govukSelect({
+        id: 'select-' + loop.index,
+        items: [
+          { value: 'Aethalops aequalis', text: 'Borneo fruit bat' },
+          { value: 'Pteropus mariannus mariannus', text: 'Guam Mariana fruit bat' },
+          { value: 'Ectophylla alba', text: 'Honduran white bat', selected: true },
+          { value: 'Pteropus medius', text: 'Indian flying fox' },
+          { value: 'Megaerops kusnotoi', text: 'Javan tailless fruit bat' },
+          { value: 'Pteropus rufus', text: 'Madagascan flying fox' },
+          { value: 'Myzopoda aurita', text: 'Madagascar sucker-footed bat' },
+          { value: 'Miniopterus mossambicus', text: 'Mozambique long-fingered bat' },
+          { value: 'Miniopterus paululus', text: 'Philippine long-fingered bat' },
+          { value: 'Myonycteris brachycephala', text: 'São Tomé collared fruit bat' },
+          { value: 'Pteropus seychellensis', text: 'Seychelles fruit bat' },
+          { value: 'Harpyionycteris celebensis', text: 'Sulawesi harpy fruit bat' }
+        ],
+        classes: item.classes if item.classes else '',
+        label: {
+          text: item.name
+        },
+        formGroup: { classes: 'x-ray' if item.xray else '' },
+        attributes: item.attributes if item.attributes else {},
+        errorMessage: item.error
+      }) }}
+    {% endfor %}
+  </div>
+  <div class="govuk-grid-column-one-half">
+    {% for item in examples %}
+      {{ govukFileUpload({
+        id: 'file-upload-' + loop.index,
+        classes: item.classes if item.classes else '',
+        label: {
+          text: item.name
+        },
+        formGroup: { classes: 'x-ray' if item.xray else '' },
+        attributes: item.attributes if item.attributes else {},
+        errorMessage: item.error
+      }) }}
+    {% endfor %}
   </div>
 </div>
 

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -173,7 +173,7 @@ $govuk-button-text-colour: govuk-colour("white") !default;
 
     &:hover {
       background-color: $govuk-button-colour;
-      cursor: default;
+      cursor: not-allowed;
     }
 
     &:active {

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -147,7 +147,7 @@
   // Disabled state
   .govuk-checkboxes__input:disabled,
   .govuk-checkboxes__input:disabled + .govuk-checkboxes__label {
-    cursor: default;
+    cursor: not-allowed;
   }
 
   .govuk-checkboxes__input:disabled + .govuk-checkboxes__label,

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -49,6 +49,7 @@
 
     &:disabled {
       opacity: .5;
+      cursor: not-allowed;
     }
   }
 }

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -46,5 +46,9 @@
 
       box-shadow: inset 0 0 0 4px $govuk-input-border-colour;
     }
+
+    &:disabled {
+      opacity: .5;
+    }
   }
 }

--- a/src/govuk/components/file-upload/file-upload.yaml
+++ b/src/govuk/components/file-upload/file-upload.yaml
@@ -11,6 +11,10 @@ params:
     type: string
     required: false
     description: Optional initial value of the input.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If `true`, file input will be disabled.
   - name: describedBy
     type: string
     required: false

--- a/src/govuk/components/file-upload/template.njk
+++ b/src/govuk/components/file-upload/template.njk
@@ -39,6 +39,7 @@
 {% endif %}
   <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
   {%- if params.value %} value="{{ params.value }}"{% endif %}
+  {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 </div>

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -44,6 +44,7 @@
       opacity: .5;
       color: inherit;
       background-color: transparent;
+      cursor: not-allowed;
     }
   }
 

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -39,6 +39,12 @@
         border-width: $govuk-border-width-form-element * 2;
       }
     }
+
+    &:disabled {
+      opacity: .5;
+      color: inherit;
+      background-color: transparent;
+    }
   }
 
   .govuk-input::-webkit-outer-spin-button,

--- a/src/govuk/components/input/input.yaml
+++ b/src/govuk/components/input/input.yaml
@@ -19,6 +19,10 @@ params:
     type: string
     required: false
     description: Optional initial value of the input.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If `true`, input will be disabled.
   - name: describedBy
     type: string
     required: false

--- a/src/govuk/components/input/template.njk
+++ b/src/govuk/components/input/template.njk
@@ -49,6 +49,7 @@
   <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.value %} value="{{ params.value}}"{% endif %}
+  {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- if params.pattern %} pattern="{{ params.pattern }}"{% endif %}

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -145,7 +145,7 @@
   // Disabled state
   .govuk-radios__input:disabled,
   .govuk-radios__input:disabled + .govuk-radios__label {
-    cursor: default;
+    cursor: not-allowed;
   }
 
   .govuk-radios__input:disabled + .govuk-radios__label,

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -45,6 +45,7 @@
     &:disabled {
       opacity: .5;
       color: inherit;
+      cursor: not-allowed;
     }
   }
 

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -41,6 +41,11 @@
         border-width: $govuk-border-width-form-element * 2;
       }
     }
+
+    &:disabled {
+      opacity: .5;
+      color: inherit;
+    }
   }
 
   .govuk-select option:active,

--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -36,6 +36,10 @@ params:
     type: string
     required: false
     description: Value for the option which should be selected. Use this as an alternative to setting the `selected` option on each individual item.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If `true`, select box will be disabled. Use the `disabled` option on each individual item to only disable certain options.
   - name: describedBy
     type: string
     required: false

--- a/src/govuk/components/select/template.njk
+++ b/src/govuk/components/select/template.njk
@@ -38,7 +38,10 @@
   }) | indent(2) | trim }}
 {% endif %}
   <select class="govuk-select
-    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %} {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+    {%- if params.classes %} {{ params.classes }}{% endif %}{%- if params.errorMessage %} govuk-select--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}"
+    {%- if params.disabled %} disabled{% endif %}
+    {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+    {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}
       <option value="{{ item.value }}"

--- a/src/govuk/components/textarea/_index.scss
+++ b/src/govuk/components/textarea/_index.scss
@@ -35,6 +35,12 @@
         border-width: $govuk-border-width-form-element * 2;
       }
     }
+
+    &:disabled {
+      opacity: .5;
+      color: inherit;
+      background-color: transparent;
+    }
   }
 
   .govuk-textarea--error {

--- a/src/govuk/components/textarea/_index.scss
+++ b/src/govuk/components/textarea/_index.scss
@@ -40,6 +40,7 @@
       opacity: .5;
       color: inherit;
       background-color: transparent;
+      cursor: not-allowed;
     }
   }
 

--- a/src/govuk/components/textarea/template.njk
+++ b/src/govuk/components/textarea/template.njk
@@ -39,6 +39,7 @@
 {% endif %}
   <textarea class="govuk-textarea {{- ' govuk-textarea--error' if params.errorMessage }} {{- ' ' + params.classes if params.classes}}" id="{{ params.id }}" name="{{ params.name }}" rows="{%if params.rows %} {{- params.rows -}} {% else %}5{%endif %}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
+  {%- if params.disabled %} disabled{% endif %}
   {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
   {%- if params.autocomplete %} autocomplete="{{ params.autocomplete}}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>{{ params.value }}</textarea>

--- a/src/govuk/components/textarea/textarea.yaml
+++ b/src/govuk/components/textarea/textarea.yaml
@@ -19,6 +19,10 @@ params:
     type: string
     required: false
     description: Optional initial value of the textarea.
+  - name: disabled
+    type: boolean
+    required: false
+    description: If `true`, textarea will be disabled.
   - name: describedBy
     type: string
     required: false


### PR DESCRIPTION
Currently we rely on user agent styles to indicate the `disabled` state of all form controls except for radio buttons and checkboxes. For these, we reduce the opacity of both the input and associated label by 50%.

In my research, [the user agent styles for disabled controls are wildly inconsistent](https://github.com/alphagov/govuk-frontend/issues/1713#issuecomment-1397048516), both between browsers and different input types. Some user agents don't visually differentiate between enabled and disabled inputs at all! For this reason, I think we should explicitly define disabled styles rather than relying on UA styles. 

Whilst we don't tend to encourage the use of disabled inputs, this feels like one of those things we should accommodate within Frontend for when they are used or needed. 

This change was requested in #1713. I've also added `disabled` parameters to our Nunjucks macros as a linked change as was requested in #1712, though this can be pulled into a separate piece if desired.

## Changes
- Adds `:disabled` styles to the text input, textarea, select and file upload components, mirroring the 50% opacity reduction that we use for radio buttons and checkboxes. The actual CSS used for each differs slightly, as [explained in this comment](https://github.com/alphagov/govuk-frontend/issues/1713#issuecomment-1397048516). 
- Adds the `not-allowed` cursor style to disabled form controls and buttons when they are hovered over.
- Adds a `disabled` Nunjucks parameter to the text input, textarea, select and file upload components, with associated documentation.
- Expands the "Forms controls states" example in the Frontend review app to include more form controls and more states (and more bats).

## Screenshots

### Text input / textarea

Textareas look pretty much identical to these, they're just taller and have a scrollbar, so I've not screenshotted them (sorry, there's just so many!) 

| |Before|After|
|:-|:-:|:-:|
|Chrome 109 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213485146-fb876b0a-d6ef-4ffa-8865-d7b9fcb5f6c3.png)|![image](https://user-images.githubusercontent.com/1253214/213485179-1401e604-80b7-441d-91b6-4ae845a507ca.png)|
|Safari 16.0 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213485249-c73b5988-fa83-4269-9e4e-bef3b0ef57f6.png)|![image](https://user-images.githubusercontent.com/1253214/213485212-58035b76-b6c1-4006-ac39-aa805e0397c8.png)|
|Safari 16.1 (iOS)| <img width="382" alt="image" src="https://user-images.githubusercontent.com/1253214/213486769-206f3feb-54b4-43dd-a1e6-69a56ff3719b.png">|<img width="383" alt="image" src="https://user-images.githubusercontent.com/1253214/213487092-2f1189f4-460e-4d19-bc09-693b1725f288.png">|
|Firefox 108 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213485628-fc259fe7-dad2-4fd2-8e45-a8cc0b22e5d8.png)|![image](https://user-images.githubusercontent.com/1253214/213485546-6cec40c2-87a1-419d-945a-bd1a17026f27.png)|
|IE 11 (Windows 10)|![image](https://user-images.githubusercontent.com/1253214/213486058-2fbdf090-275d-4c84-97da-207f0304f604.png)|![image](https://user-images.githubusercontent.com/1253214/213485932-18f37e2e-33fe-4366-b035-9f9d396d4919.png)|

### Select

| |Before|After|
|:-|:-:|:-:|
|Chrome 109 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213487791-c776b914-f1c6-4038-8e7b-f24c28ae5320.png)|![image](https://user-images.githubusercontent.com/1253214/213487711-2d1b875c-6d8c-40b0-a94d-09136c86ab0a.png)|
|Safari 16.0 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213487588-e1486cc7-d0a8-4033-8a00-02f5760ea858.png)|![image](https://user-images.githubusercontent.com/1253214/213487518-057c3435-a078-444e-a3b1-b860ceb08218.png)|
|Safari 16.1 (iOS)|<img width="314" alt="image" src="https://user-images.githubusercontent.com/1253214/213488494-0254647c-f916-462f-afce-918f5e774d5a.png">|<img width="311" alt="image" src="https://user-images.githubusercontent.com/1253214/213488333-888c102b-2e7c-428a-92b0-d20d032027b0.png">|
|Firefox 108 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213488219-06306cb0-6e8c-418a-90b3-3d60dec4a2c6.png)|![image](https://user-images.githubusercontent.com/1253214/213488157-138576b1-9b10-48fe-b487-a925864650b1.png)|
|IE 11 (Windows 10)|![image](https://user-images.githubusercontent.com/1253214/213487983-62f540b1-523a-477f-97c5-62d8916653b8.png)|![image](https://user-images.githubusercontent.com/1253214/213487888-007eae5f-a945-4934-aea6-45281bff17e1.png)|

### File upload

| |Before|After|
|:-|:-:|:-:|
|Chrome 109 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213489650-b45d0dd9-5494-4380-afd9-2bead87de875.png)|![image](https://user-images.githubusercontent.com/1253214/213489564-efb0cc3a-e705-421c-bd1d-552e03b45612.png)|
|Safari 16.0 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213489177-4ba0de4a-2c69-4d65-aac5-0e09642149f1.png)|![image](https://user-images.githubusercontent.com/1253214/213489126-15041d8c-b078-4584-bb6b-080840bc415a.png)|
|Safari 16.1 (iOS)|<img width="289" alt="image" src="https://user-images.githubusercontent.com/1253214/213488951-0091590b-6d93-409e-98f0-dca8a348660b.png">|<img width="298" alt="image" src="https://user-images.githubusercontent.com/1253214/213488812-5fc95b7e-e13a-4615-8f5a-5aae073bb231.png">|
|Firefox 108 (macOS)|![image](https://user-images.githubusercontent.com/1253214/213489369-23ce9cc8-431b-4d96-8c95-7314b7129658.png)|![image](https://user-images.githubusercontent.com/1253214/213489243-2f6836fb-f39d-427d-a01c-2f49014e784b.png)|
|IE 11 (Windows 10)|![image](https://user-images.githubusercontent.com/1253214/213489492-0673ff47-b321-48ae-9627-30ff24ae31f0.png)|![image](https://user-images.githubusercontent.com/1253214/213489430-7a0c1de4-bddf-42ce-9b06-06f901d00c4c.png)|

## Questions and concerns
### How well does this work in alternative colour modes (e.g. Windows High Contrast Mode)?
Windows HCM seems to universally apply a green border and text colour to disabled inputs, ignoring opacity-based styling entirely.

### How well does this work for users with low vision?
Disabled inputs do not need to meet the [3:1 non-text contrast ratio](https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html) or [4.5:1 text contrast ratio](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum) required by WCAG, but we may want to ensure a minimum level of contrast regardless.

### How well does this work for sighted users?
Of particular concern to me is empty text inputs and textareas, where the lighter border colour is the only indicator that the control is disabled. This difference may not be clear if there are no other inputs to compare against.

Arguably it's unlikely that the user will be presented with a disabled input with no other options to compare it against. This doesn't mean the disabled styling is _obvious_, however.

### Do we want to add back in a grey background? If so, should that be mirrored in the radio button and checkbox styles?
This feels like it would convey the affordance of 'this input is disabled' a bit clearer, but it couldn't be applied consistently without some bigger changes—particularly on File Upload components and Selects on macOS. 

### Should we use `[disabled]` or `:disabled` for our CSS selectors?
We use `:disabled` virtually everywhere in Frontend, with the exception of the Button component, which uses `[disabled]`. Unsure if there's a specific reason for the difference, as `:disabled` seems to also work on `<button>`s. 

IE 8, however, doesn't support the `:disabled` pseudo-selector.