### PR TITLE
Apply “Using Sass with Jest” environment guidance

### DIFF
--- a/config/jest/environment/node.mjs
+++ b/config/jest/environment/node.mjs
@@ -1,12 +1,15 @@
-import { TestEnvironment } from 'jest-environment-node'
+import SingleContextNodeEnvironment from 'jest-environment-node-single-context'
 
 import { globals } from '../globals.mjs'
 
 /**
- * Default Node.js environment
- * Adds shared test globals
+ * Single context Node.js environment
+ * Adds real Node.js test globals for Dart Sass
+ *
+ * {@link https://github.com/sass/dart-sass#using-sass-with-jest}
+ * {@link https://github.com/facebook/jest/issues/2549}
  */
-class NodeEnvironment extends TestEnvironment {
+class NodeEnvironment extends SingleContextNodeEnvironment {
   async setup () {
     await super.setup()
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -67,7 +67,7 @@ export default {
         '!**/*.unit.test.{js,mjs}',
 
         // Exclude other tests
-        '!**/all.test.{js,mjs}',
+        '!**/components/globals.test.mjs',
         '!**/components/*/**',
         '!**/gulp/**'
       ],
@@ -81,7 +81,7 @@ export default {
       displayName: 'JavaScript component tests',
       testEnvironment: './config/jest/environment/puppeteer.mjs',
       testMatch: [
-        '**/all.test.{js,mjs}',
+        '**/components/globals.test.mjs',
         '**/components/*/*.test.{js,mjs}',
 
         // Exclude macro/unit tests

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,5 +1,6 @@
 const config = {
   cacheDirectory: '<rootDir>/.cache/jest/',
+  clearMocks: true,
   coveragePathIgnorePatterns: [
     '.test.(js|mjs)',
     '.eslintrc.js',

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -9,12 +9,22 @@ const { outdent } = require('outdent')
 
 const sassRender = util.promisify(sass.render)
 
-const configPaths = require('../config/paths')
+const { paths } = require('../config/index.js')
 
 const { getComponentData } = require('./file-helper')
 const { componentNameToMacroName } = require('./helper-functions')
 
-const nunjucksEnv = nunjucks.configure([join(configPaths.src, 'govuk'), configPaths.components], {
+const sassPaths = [
+  join(paths.src, 'govuk'),
+  paths.node_modules
+]
+
+const nunjucksPaths = [
+  join(paths.src, 'govuk'),
+  paths.components
+]
+
+const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
   trimBlocks: true,
   lstripBlocks: true
 })
@@ -126,7 +136,7 @@ async function getExamples (componentName) {
  */
 function renderSass (options) {
   return sassRender({
-    includePaths: [join(configPaths.src, 'govuk')],
+    includePaths: sassPaths,
     ...options
   })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "jest-axe": "^7.0.0",
         "jest-dev-server": "^6.2.0",
         "jest-environment-jsdom": "^29.4.1",
-        "jest-environment-node": "^29.4.0",
+        "jest-environment-node-single-context": "^29.0.0",
         "jest-environment-puppeteer": "^6.2.0",
         "jest-serializer-html": "^7.1.0",
         "lint-staged": "^13.1.0",
@@ -13673,6 +13673,18 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-node-single-context": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node-single-context/-/jest-environment-node-single-context-29.0.0.tgz",
+      "integrity": "sha512-/XB09Hje38Kl5k9ISUpXNom3M4DQo5ifEsnELPFP5r3yrJDRyNQCEjL/9ScUN6z6UeF4FCNZUsiJIX/tGtTXNw==",
+      "dev": true,
+      "dependencies": {
+        "jest-environment-node": "^29.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/kayahr/jest-environment-node-single-context?sponsor=1"
       }
     },
     "node_modules/jest-environment-puppeteer": {
@@ -35801,6 +35813,15 @@
         "@types/node": "*",
         "jest-mock": "^29.4.1",
         "jest-util": "^29.4.1"
+      }
+    },
+    "jest-environment-node-single-context": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node-single-context/-/jest-environment-node-single-context-29.0.0.tgz",
+      "integrity": "sha512-/XB09Hje38Kl5k9ISUpXNom3M4DQo5ifEsnELPFP5r3yrJDRyNQCEjL/9ScUN6z6UeF4FCNZUsiJIX/tGtTXNw==",
+      "dev": true,
+      "requires": {
+        "jest-environment-node": "^29.0.1"
       }
     },
     "jest-environment-puppeteer": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "jest-axe": "^7.0.0",
     "jest-dev-server": "^6.2.0",
     "jest-environment-jsdom": "^29.4.1",
-    "jest-environment-node": "^29.4.0",
+    "jest-environment-node-single-context": "^29.0.0",
     "jest-environment-puppeteer": "^6.2.0",
     "jest-serializer-html": "^7.1.0",
     "lint-staged": "^13.1.0",

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -43,7 +43,7 @@ module.exports = {
       // Matches 'JavaScript component tests' in jest.config.mjs
       // to ignore unknown 'page' and 'browser' Puppeteer globals
       files: [
-        '**/all.test.{js,mjs}',
+        '**/components/globals.test.mjs',
         '**/components/*/*.test.{js,mjs}'
       ],
       excludedFiles: [

--- a/src/govuk/all.test.mjs
+++ b/src/govuk/all.test.mjs
@@ -3,85 +3,8 @@ import slash from 'slash'
 
 import configPaths from '../../config/paths.js'
 import { renderSass } from '../../lib/jest-helpers.js'
-import { goTo, goToExample } from '../../lib/puppeteer-helpers.js'
 
 describe('GOV.UK Frontend', () => {
-  describe('javascript', () => {
-    it('can be accessed via `GOVUKFrontend`', async () => {
-      await goTo(page, '/')
-
-      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
-
-      expect(typeof GOVUKFrontendGlobal).toBe('object')
-    })
-    it('exports `initAll` function', async () => {
-      await goTo(page, '/')
-
-      const typeofInitAll = await page.evaluate(() => typeof window.GOVUKFrontend.initAll)
-
-      expect(typeofInitAll).toEqual('function')
-    })
-    it('exports Components', async () => {
-      await goTo(page, '/')
-
-      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
-
-      const components = Object.keys(GOVUKFrontendGlobal)
-        .filter(method => !['initAll'].includes(method))
-
-      // Ensure GOV.UK Frontend exports the expected components
-      expect(components).toEqual([
-        'Accordion',
-        'Button',
-        'Details',
-        'CharacterCount',
-        'Checkboxes',
-        'ErrorSummary',
-        'Header',
-        'NotificationBanner',
-        'Radios',
-        'SkipLink',
-        'Tabs'
-      ])
-    })
-    it('exported Components have an init function', async () => {
-      await goTo(page, '/')
-
-      const componentsWithoutInitFunctions = await page.evaluate(() => {
-        const components = Object.keys(window.GOVUKFrontend)
-          .filter(method => !['initAll'].includes(method))
-
-        return components.filter(component => {
-          const prototype = window.GOVUKFrontend[component].prototype
-          return typeof prototype.init !== 'function'
-        })
-      })
-
-      expect(componentsWithoutInitFunctions).toEqual([])
-    })
-    it('can be initialised scoped to certain sections of the page', async () => {
-      await goToExample(page, 'scoped-initialisation')
-
-      // To test that certain parts of the page are scoped we have two similar components
-      // that we can interact with to check if they're interactive.
-
-      // Check that the conditional reveal component has a conditional section that would open if enhanced.
-      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
-
-      await page.click('[for="not-scoped"]')
-
-      // Check that when it is clicked that nothing opens, which shows that it has not been enhanced.
-      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
-
-      // Check the other conditional reveal which has been enhanced based on it's scope.
-      await page.waitForSelector('#conditional-scoped', { hidden: true })
-
-      await page.click('[for="scoped"]')
-
-      // Check that it has opened as expected.
-      await page.waitForSelector('#conditional-scoped', { hidden: false })
-    })
-  })
   describe('global styles', () => {
     it('are disabled by default', async () => {
       const sass = `

--- a/src/govuk/components/globals.test.mjs
+++ b/src/govuk/components/globals.test.mjs
@@ -1,0 +1,83 @@
+import { goTo, goToExample } from '../../../lib/puppeteer-helpers.js'
+
+describe('GOV.UK Frontend', () => {
+  describe('javascript', () => {
+    it('can be accessed via `GOVUKFrontend`', async () => {
+      await goTo(page, '/')
+
+      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
+
+      expect(typeof GOVUKFrontendGlobal).toBe('object')
+    })
+
+    it('exports `initAll` function', async () => {
+      await goTo(page, '/')
+
+      const typeofInitAll = await page.evaluate(() => typeof window.GOVUKFrontend.initAll)
+
+      expect(typeofInitAll).toEqual('function')
+    })
+
+    it('exports Components', async () => {
+      await goTo(page, '/')
+
+      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
+
+      const components = Object.keys(GOVUKFrontendGlobal)
+        .filter(method => !['initAll'].includes(method))
+
+      // Ensure GOV.UK Frontend exports the expected components
+      expect(components).toEqual([
+        'Accordion',
+        'Button',
+        'Details',
+        'CharacterCount',
+        'Checkboxes',
+        'ErrorSummary',
+        'Header',
+        'NotificationBanner',
+        'Radios',
+        'SkipLink',
+        'Tabs'
+      ])
+    })
+
+    it('exported Components have an init function', async () => {
+      await goTo(page, '/')
+
+      const componentsWithoutInitFunctions = await page.evaluate(() => {
+        const components = Object.keys(window.GOVUKFrontend)
+          .filter(method => !['initAll'].includes(method))
+
+        return components.filter(component => {
+          const prototype = window.GOVUKFrontend[component].prototype
+          return typeof prototype.init !== 'function'
+        })
+      })
+
+      expect(componentsWithoutInitFunctions).toEqual([])
+    })
+    it('can be initialised scoped to certain sections of the page', async () => {
+      await goToExample(page, 'scoped-initialisation')
+
+      // To test that certain parts of the page are scoped we have two similar components
+      // that we can interact with to check if they're interactive.
+
+      // Check that the conditional reveal component has a conditional section that would open if enhanced.
+      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
+
+      await page.click('[for="not-scoped"]')
+
+      // Check that when it is clicked that nothing opens, which shows that it has not been enhanced.
+      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
+
+      // Check the other conditional reveal which has been enhanced based on it's scope.
+      await page.waitForSelector('#conditional-scoped', { hidden: true })
+
+      await page.click('[for="scoped"]')
+
+      // Check that it has opened as expected.
+      await page.waitForSelector('#conditional-scoped', { hidden: false })
+    })
+  })
+})

--- a/src/govuk/settings/colours.test.js
+++ b/src/govuk/settings/colours.test.js
@@ -1,10 +1,6 @@
-const { join } = require('path')
-
-const configPaths = require('../../../config/paths')
 const { renderSass } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
-  includePaths: [join(configPaths.src, 'govuk'), 'node_modules/'],
   outputStyle: 'compressed'
 }
 

--- a/src/govuk/settings/warnings.test.js
+++ b/src/govuk/settings/warnings.test.js
@@ -17,10 +17,6 @@ const sassConfig = {
 describe('Warnings mixin', () => {
   const sassBootstrap = '@import "settings/warnings";'
 
-  afterEach(() => {
-    jest.clearAllMocks()
-  })
-
   it('Fires a @warn with the message plus the key suffix text', async () => {
     const sass = `
     ${sassBootstrap}


### PR DESCRIPTION
This PR adds some preparation work for Dart Sass

## Node.js globals
JavaScript compiled from Dart requires real Node.js globals which Jest doesn’t use

>### [Using Sass with Jest](https://github.com/sass/dart-sass#using-sass-with-jest)
>
>If you're using [Jest] to run your tests, be aware that it has a [longstanding bug] where its default test environment breaks JavaScript's built-in [`instanceof` operator]. Dart Sass's JS package uses `instanceof` fairly heavily, so in order to avoid breaking Sass you'll need to install [`jest-environment-node-single-context`] and add `testEnvironment: 'jest-environment-node-single-context'` to your Jest config.
>
>[Jest]: https://jestjs.io/
>[longstanding bug]: https://github.com/facebook/jest/issues/2549
>[`instanceof` operator]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof
>[`jest-environment-node-single-context`]: https://www.npmjs.com/package/jest-environment-node-single-context

Worth investigating Dart Sass [`sass` (slow, JS)](https://github.com/sass/dart-sass) vs [`sass-embedded` (fast, Dart executable)](https://github.com/sass/embedded-host-node)

## Puppeteer and Sass tests together
I've moved Jest browser global tests from `all.test.mjs` → **`globals.test.mjs`** which leaves the Sass tests in `all.test.mjs` to use the environment fix above. They didn’t need a Puppeteer browser test environment