### PR TITLE
Fix or suppress Dart Sass deprecation warnings

### DIFF
--- a/src/govuk/components/tag/_index.scss
+++ b/src/govuk/components/tag/_index.scss
@@ -35,47 +35,47 @@
   }
 
   .govuk-tag--grey {
-    color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30);
-    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90);
+    color: govuk-shade(govuk-colour("dark-grey", $legacy: "grey-1"), 30%);
+    background: govuk-tint(govuk-colour("dark-grey", $legacy: "grey-1"), 90%);
   }
 
   .govuk-tag--purple {
-    color: govuk-shade(govuk-colour("purple"), 20);
-    background: govuk-tint(govuk-colour("purple"), 80);
+    color: govuk-shade(govuk-colour("purple"), 20%);
+    background: govuk-tint(govuk-colour("purple"), 80%);
   }
 
   .govuk-tag--turquoise {
-    color: govuk-shade(govuk-colour("turquoise"), 60);
-    background: govuk-tint(govuk-colour("turquoise"), 70);
+    color: govuk-shade(govuk-colour("turquoise"), 60%);
+    background: govuk-tint(govuk-colour("turquoise"), 70%);
   }
 
   .govuk-tag--blue {
-    color: govuk-shade(govuk-colour("blue"), 30);
-    background: govuk-tint(govuk-colour("blue"), 80);
+    color: govuk-shade(govuk-colour("blue"), 30%);
+    background: govuk-tint(govuk-colour("blue"), 80%);
   }
 
   .govuk-tag--yellow {
-    color: govuk-shade(govuk-colour("yellow"), 65);
-    background: govuk-tint(govuk-colour("yellow"), 75);
+    color: govuk-shade(govuk-colour("yellow"), 65%);
+    background: govuk-tint(govuk-colour("yellow"), 75%);
   }
 
   .govuk-tag--orange {
-    color: govuk-shade(govuk-colour("orange"), 55);
-    background: govuk-tint(govuk-colour("orange"), 70);
+    color: govuk-shade(govuk-colour("orange"), 55%);
+    background: govuk-tint(govuk-colour("orange"), 70%);
   }
 
   .govuk-tag--red {
-    color: govuk-shade(govuk-colour("red"), 30);
-    background: govuk-tint(govuk-colour("red"), 80);
+    color: govuk-shade(govuk-colour("red"), 30%);
+    background: govuk-tint(govuk-colour("red"), 80%);
   }
 
   .govuk-tag--pink {
-    color: govuk-shade(govuk-colour("pink"), 40);
-    background: govuk-tint(govuk-colour("pink"), 80);
+    color: govuk-shade(govuk-colour("pink"), 40%);
+    background: govuk-tint(govuk-colour("pink"), 80%);
   }
 
   .govuk-tag--green {
-    color: govuk-shade(govuk-colour("green"), 20);
-    background: govuk-tint(govuk-colour("green"), 80);
+    color: govuk-shade(govuk-colour("green"), 20%);
+    background: govuk-tint(govuk-colour("green"), 80%);
   }
 }

--- a/src/govuk/helpers/_colour.scss
+++ b/src/govuk/helpers/_colour.scss
@@ -8,7 +8,7 @@
 
 /// Get colour
 ///
-/// @param {String} $colour - Name of colour from the colour palette
+/// @param {String | Colour} $colour - Name of colour from the colour palette
 ///   (`$govuk-colours`)
 /// @param {String} $legacy - Either the name of colour from the legacy palette
 ///   or a colour literal, to return instead when in 'legacy mode' - matching
@@ -36,7 +36,10 @@
     $colour: $legacy;
   }
 
-  $colour: quote($colour);
+  @if type-of($colour) == "color" {
+    // stylelint-disable-next-line scss/function-quote-no-quoted-strings-inside
+    $colour: quote("#{$colour}");
+  }
 
   @if not map-has-key($govuk-colours, $colour) {
     @error "Unknown colour `#{$colour}`";

--- a/tasks/compile-stylesheets.mjs
+++ b/tasks/compile-stylesheets.mjs
@@ -66,6 +66,9 @@ export async function compileStylesheet ([modulePath, { srcPath, destPath }]) {
       file: moduleSrcPath,
       outFile: moduleDestPath,
 
+      // Turn off dependency warnings
+      quietDeps: true,
+
       // Enable source maps
       sourceMap: true,
       sourceMapContents: true,


### PR DESCRIPTION
This PR fixes or suppresses all deprecation warnings that show up in Dart Sass

For forwards compatibility (LibSass, Node Sass, Dart Sass) not all deprecations can be resolved

## Breaking change fixes

### $string: red is not a string.

Dart Sass will throw when trying to `quote()` colour identifiers as it no longer treats them as unquoted strings. We can use interpolation `"#{$colour}"` so Dart Sass takes `red` (color) as `"red"` (string)

See “Heads up!” box on Strings (Unquoted) docs:
https://sass-lang.com/documentation/values/strings#unquoted

```console
Error: $string: red is not a string.
   ╷
39 │   $colour: quote($colour);
   │            ^^^^^^^^^^^^^^
   ╵
    helpers/_colour.scss 39:12  govuk-colour()
    - 13:16                     root stylesheet]
```

## Deprecations fixed

### $weight: Passing a number without unit % (30) is deprecated.

The fix? Add units where needed

```console
Deprecation Warning: $weight: Passing a number without unit % (30) is deprecated.

To preserve current behavior: $weight * 1%

More info: https://sass-lang.com/d/function-units

   ╷
83 │   @return mix(#000000, $colour, $percentage);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
    src/govuk/helpers/_colour.scss 83:11               govuk-shade()
    src/govuk/components/tag/_index.scss 38:12         @content
    src/govuk/tools/_exports.scss 29:5                 govuk-exports()
    src/govuk/components/tag/_index.scss 1:1           @import
    src/govuk/components/phase-banner/_index.scss 1:9  @import
    src/govuk/components/_all.scss 26:9                @import
    src/govuk/all.scss 6:9                             @import
    src/govuk/all-ie8.scss 6:9                         @import
    app/assets/scss/app-ie8.scss 1:9                   root stylesheet
```

## Deprecations suppressed

This PR previously recreated [`math.div()`](https://sass-lang.com/documentation/modules/math#other-functions) ([see implementation](https://github.com/alphagov/govuk-frontend/compare/main...dart-sass-fix-deprecations-division)) but we've now suppressed warnings for:

1. Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
2. Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

These suppressions have been moved to:

* https://github.com/alphagov/govuk-frontend/pull/3164#pullrequestreview-1297214229