### PR TITLE
Format Sass tests using `expanded` output style

### DIFF
--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -129,16 +129,25 @@ async function getExamples (componentName) {
 }
 
 /**
- * Render Sass
+ * Render Sass from file
  *
- * @param {import('node-sass').Options} options - Options to pass to sass.render
- * @returns {Promise<import('node-sass').Result>} Result of calling sass.render
+ * @param {string} path - Path to Sass file
+ * @param {import('node-sass').Options} [options] - Options to pass to Sass
+ * @returns {Promise<import('node-sass').Result>} Sass compile result
  */
-function renderSass (options) {
-  return sassRender({
-    includePaths: sassPaths,
-    ...options
-  })
+async function compileSassFile (path, options = {}) {
+  return sassRender({ file: path, includePaths: sassPaths, quietDeps: true, ...options })
+}
+
+/**
+ * Render Sass from string
+ *
+ * @param {string} source - Sass source string
+ * @param {import('node-sass').Options} [options] - Options to pass to Sass
+ * @returns {Promise<import('node-sass').Result>} Sass compile result
+ */
+async function compileSassString (source, options = {}) {
+  return sassRender({ data: source, includePaths: sassPaths, quietDeps: true, ...options })
 }
 
 /**
@@ -179,7 +188,8 @@ module.exports = {
   callMacro,
   render,
   renderHtml,
-  renderSass,
+  compileSassFile,
+  compileSassString,
   renderTemplate
 }
 

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -135,6 +135,7 @@ async function compileSassFile (path, options = {}) {
   const { css, map, stats } = sass.renderSync({
     file: path,
     includePaths: sassPaths,
+    outputStyle: 'expanded',
     quietDeps: true,
     ...options
   })
@@ -156,6 +157,7 @@ async function compileSassString (source, options = {}) {
   const { css, map, stats } = sass.renderSync({
     data: source,
     includePaths: sassPaths,
+    outputStyle: 'expanded',
     quietDeps: true,
     ...options
   })

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -1,13 +1,10 @@
 const { join } = require('path')
-const util = require('util')
 
 const cheerio = require('cheerio')
 const { configureAxe } = require('jest-axe')
 const sass = require('node-sass')
 const nunjucks = require('nunjucks')
 const { outdent } = require('outdent')
-
-const sassRender = util.promisify(sass.render)
 
 const { paths } = require('../config/index.js')
 
@@ -133,10 +130,20 @@ async function getExamples (componentName) {
  *
  * @param {string} path - Path to Sass file
  * @param {import('node-sass').Options} [options] - Options to pass to Sass
- * @returns {Promise<import('node-sass').Result>} Sass compile result
  */
 async function compileSassFile (path, options = {}) {
-  return sassRender({ file: path, includePaths: sassPaths, quietDeps: true, ...options })
+  const { css, map, stats } = sass.renderSync({
+    file: path,
+    includePaths: sassPaths,
+    quietDeps: true,
+    ...options
+  })
+
+  return {
+    css: css?.toString().trim(),
+    map: map?.toString().trim(),
+    stats
+  }
 }
 
 /**
@@ -144,10 +151,20 @@ async function compileSassFile (path, options = {}) {
  *
  * @param {string} source - Sass source string
  * @param {import('node-sass').Options} [options] - Options to pass to Sass
- * @returns {Promise<import('node-sass').Result>} Sass compile result
  */
 async function compileSassString (source, options = {}) {
-  return sassRender({ data: source, includePaths: sassPaths, quietDeps: true, ...options })
+  const { css, map, stats } = sass.renderSync({
+    data: source,
+    includePaths: sassPaths,
+    quietDeps: true,
+    ...options
+  })
+
+  return {
+    css: css?.toString().trim(),
+    map: map?.toString().trim(),
+    stats
+  }
 }
 
 /**

--- a/src/govuk/all.test.mjs
+++ b/src/govuk/all.test.mjs
@@ -10,18 +10,32 @@ describe('GOV.UK Frontend', () => {
       const sass = `
         @import "all";
       `
-      const results = await compileSassString(sass)
-      expect(results.css.toString()).not.toContain(', a {')
-      expect(results.css.toString()).not.toContain(', p {')
+      const results = compileSassString(sass)
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.not.stringContaining('.govuk-link, a {')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.not.stringContaining('.govuk-body-m, .govuk-body, p {')
+      })
     })
+
     it('are enabled if $global-styles variable is set to true', async () => {
       const sass = `
         $govuk-global-styles: true;
         @import "all";
       `
-      const results = await compileSassString(sass)
-      expect(results.css.toString()).toContain(', a {')
-      expect(results.css.toString()).toContain(', p {')
+
+      const results = compileSassString(sass)
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('.govuk-link, a {')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('.govuk-body-m, .govuk-body, p {')
+      })
     })
   })
 
@@ -58,12 +72,9 @@ describe('GOV.UK Frontend', () => {
   it('does not contain any unexpected govuk- function calls', async () => {
     const sass = '@import "all"'
 
-    const results = await compileSassString(sass)
-    const css = results.css.toString()
-
-    const functionCalls = css.match(/_?govuk-[\w-]+\(.*?\)/g)
-
-    expect(functionCalls).toBeNull()
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: expect.not.stringMatching(/_?govuk-[\w-]+\(.*?\)/g)
+    })
   })
 
   describe('Sass documentation', () => {

--- a/src/govuk/all.test.mjs
+++ b/src/govuk/all.test.mjs
@@ -2,7 +2,7 @@ import sassdoc from 'sassdoc'
 import slash from 'slash'
 
 import configPaths from '../../config/paths.js'
-import { renderSass } from '../../lib/jest-helpers.js'
+import { compileSassString } from '../../lib/jest-helpers.js'
 
 describe('GOV.UK Frontend', () => {
   describe('global styles', () => {
@@ -10,7 +10,7 @@ describe('GOV.UK Frontend', () => {
       const sass = `
         @import "all";
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
       expect(results.css.toString()).not.toContain(', a {')
       expect(results.css.toString()).not.toContain(', p {')
     })
@@ -19,7 +19,7 @@ describe('GOV.UK Frontend', () => {
         $govuk-global-styles: true;
         @import "all";
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
       expect(results.css.toString()).toContain(', a {')
       expect(results.css.toString()).toContain(', p {')
     })
@@ -58,7 +58,7 @@ describe('GOV.UK Frontend', () => {
   it('does not contain any unexpected govuk- function calls', async () => {
     const sass = '@import "all"'
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
     const css = results.css.toString()
 
     const functionCalls = css.match(/_?govuk-[\w-]+\(.*?\)/g)

--- a/src/govuk/components/components.test.js
+++ b/src/govuk/components/components.test.js
@@ -21,7 +21,7 @@ describe('Components', () => {
       const file = join(configPaths.components, '_all.scss')
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
-        css: expect.any(Object),
+        css: expect.any(String),
         stats: expect.any(Object)
       })
     })
@@ -31,7 +31,7 @@ describe('Components', () => {
         const file = join(configPaths.components, sassFilePath)
 
         return expect(compileSassFile(file)).resolves.toMatchObject({
-          css: expect.any(Object),
+          css: expect.any(String),
           stats: expect.any(Object)
         })
       })

--- a/src/govuk/components/components.test.js
+++ b/src/govuk/components/components.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const configPaths = require('../../../config/paths')
 const { getListing } = require('../../../lib/file-helper')
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassFile } = require('../../../lib/jest-helpers')
 
 describe('Components', () => {
   let sassFiles
@@ -20,24 +20,20 @@ describe('Components', () => {
     it('renders CSS for all components', () => {
       const file = join(configPaths.components, '_all.scss')
 
-      return expect(renderSass({ file })).resolves.toEqual(
-        expect.objectContaining({
-          css: expect.any(Object),
-          stats: expect.any(Object)
-        })
-      )
+      return expect(compileSassFile(file)).resolves.toMatchObject({
+        css: expect.any(Object),
+        stats: expect.any(Object)
+      })
     })
 
     it('renders CSS for each component', () => {
       const sassTasks = sassFiles.map((sassFilePath) => {
         const file = join(configPaths.components, sassFilePath)
 
-        return expect(renderSass({ file })).resolves.toEqual(
-          expect.objectContaining({
-            css: expect.any(Object),
-            stats: expect.any(Object)
-          })
-        )
+        return expect(compileSassFile(file)).resolves.toMatchObject({
+          css: expect.any(Object),
+          stats: expect.any(Object)
+        })
       })
 
       return Promise.all(sassTasks)

--- a/src/govuk/helpers/colour.test.js
+++ b/src/govuk/helpers/colour.test.js
@@ -35,11 +35,14 @@ describe('@function govuk-colour', () => {
 
       .foo {
         color: govuk-colour('red');
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo { color: #ff0000; }'
+      })
   })
 
   it('works with unquoted strings', async () => {
@@ -48,11 +51,14 @@ describe('@function govuk-colour', () => {
 
       .foo {
         color: govuk-colour(red);
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo { color: #ff0000; }'
+      })
   })
 
   it('throws an error if a non-existent colour is requested', async () => {
@@ -61,7 +67,8 @@ describe('@function govuk-colour', () => {
 
       .foo {
         color: govuk-colour('hooloovoo');
-      }`
+      }
+    `
 
     await expect(compileSassString(sass, sassConfig))
       .rejects
@@ -85,11 +92,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('red', $legacy: 'blue');
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #0000ff; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #0000ff; }'
+        })
     })
 
     it('returns the legacy literal if specified', async () => {
@@ -98,11 +108,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('red', $legacy: #BADA55);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #BADA55; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #BADA55; }'
+        })
     })
 
     it('does not error if the non-legacy colour does not exist', async () => {
@@ -111,11 +124,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('hooloovoo', $legacy: 'blue');
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #0000ff; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #0000ff; }'
+        })
     })
 
     it('throws an error if the legacy colour does not exist', async () => {
@@ -123,7 +139,8 @@ describe('@function govuk-colour', () => {
         ${sassBootstrap}
         .foo {
           color: govuk-colour('red', $legacy: 'hooloovoo');
-        }`
+        }
+      `
 
       await expect(compileSassString(sass, sassConfig))
         .rejects
@@ -135,16 +152,16 @@ describe('@function govuk-colour', () => {
     it('outputs a deprecation warning when set to true', async () => {
       const sass = `${sassBootstrap}`
 
-      await compileSassString(sass, sassConfig).then(() => {
-        // Expect our mocked @warn function to have been called once with a single
-        // argument, which should be the deprecation notice
-        return expect(mockWarnFunction.mock.calls[0][0].getValue())
-          .toEqual(
-            '$govuk-use-legacy-palette is deprecated. Only the modern colour ' +
+      await compileSassString(sass, sassConfig)
+
+      // Expect our mocked @warn function to have been called once with a single
+      // argument, which should be the deprecation notice
+      expect(mockWarnFunction.mock.calls[0][0].getValue())
+        .toEqual(
+          '$govuk-use-legacy-palette is deprecated. Only the modern colour ' +
             'palette will be supported from v5.0. To silence this warning, ' +
             'update $govuk-suppressed-warnings with key: "legacy-palette"'
-          )
-      })
+        )
     })
   })
 
@@ -162,11 +179,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('red', $legacy: 'blue');
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #ff0000; }'
+        })
     })
 
     it('does not returns the legacy literal when specified', async () => {
@@ -175,11 +195,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('red', $legacy: #BADA55);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #ff0000; }'
+        })
     })
 
     it('throws an error if the non-legacy colour does not exist', async () => {
@@ -188,7 +211,8 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('hooloovoo', $legacy: 'blue');
-        }`
+        }
+      `
 
       await expect(compileSassString(sass, sassConfig))
         .rejects
@@ -203,11 +227,14 @@ describe('@function govuk-colour', () => {
 
         .foo {
           color: govuk-colour('red', $legacy: 'hooloovoo');
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo { color: #ff0000; }'
+        })
     })
   })
 })
@@ -233,11 +260,14 @@ describe('@function govuk-organisation-colour', () => {
 
       .foo {
         color: govuk-organisation-colour('floo-network-authority');
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo { color: #9A00A8; }')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo { color: #9A00A8; }'
+      })
   })
 
   it('falls back to the default colour if a websafe colour is not explicitly defined', async () => {
@@ -246,11 +276,14 @@ describe('@function govuk-organisation-colour', () => {
 
       .foo {
         color: govuk-organisation-colour('broom-regulatory-control');
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo { color: #A81223; }')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo { color: #A81223; }'
+      })
   })
 
   it('can be overridden to return the non-websafe colour', async () => {
@@ -259,11 +292,14 @@ describe('@function govuk-organisation-colour', () => {
 
       .foo {
         border-color: govuk-organisation-colour('floo-network-authority', $websafe: false);
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo { border-color: #EC22FF; }')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo { border-color: #EC22FF; }'
+      })
   })
 
   it('throws an error if a non-existent organisation is requested', async () => {
@@ -272,7 +308,8 @@ describe('@function govuk-organisation-colour', () => {
 
       .foo {
         color: govuk-organisation-colour('muggle-born-registration-commission');
-      }`
+      }
+    `
 
     await expect(compileSassString(sass, sassConfig))
       .rejects

--- a/src/govuk/helpers/colour.test.js
+++ b/src/govuk/helpers/colour.test.js
@@ -1,6 +1,6 @@
 const sass = require('node-sass')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
@@ -37,7 +37,7 @@ describe('@function govuk-colour', () => {
         color: govuk-colour('red');
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
   })
@@ -50,7 +50,7 @@ describe('@function govuk-colour', () => {
         color: govuk-colour(red);
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
   })
@@ -63,7 +63,7 @@ describe('@function govuk-colour', () => {
         color: govuk-colour('hooloovoo');
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(compileSassString(sass, sassConfig))
       .rejects
       .toThrow(
         'Unknown colour `hooloovoo`'
@@ -87,7 +87,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: 'blue');
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #0000ff; }')
     })
@@ -100,7 +100,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: #BADA55);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #BADA55; }')
     })
@@ -113,7 +113,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('hooloovoo', $legacy: 'blue');
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #0000ff; }')
     })
@@ -125,7 +125,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: 'hooloovoo');
         }`
 
-      await expect(renderSass({ data: sass, ...sassConfig }))
+      await expect(compileSassString(sass, sassConfig))
         .rejects
         .toThrow(
           'Unknown colour `hooloovoo`'
@@ -135,7 +135,7 @@ describe('@function govuk-colour', () => {
     it('outputs a deprecation warning when set to true', async () => {
       const sass = `${sassBootstrap}`
 
-      await renderSass({ data: sass, ...sassConfig }).then(() => {
+      await compileSassString(sass, sassConfig).then(() => {
         // Expect our mocked @warn function to have been called once with a single
         // argument, which should be the deprecation notice
         return expect(mockWarnFunction.mock.calls[0][0].getValue())
@@ -164,7 +164,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: 'blue');
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
     })
@@ -177,7 +177,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: #BADA55);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
     })
@@ -190,7 +190,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('hooloovoo', $legacy: 'blue');
         }`
 
-      await expect(renderSass({ data: sass, ...sassConfig }))
+      await expect(compileSassString(sass, sassConfig))
         .rejects
         .toThrow(
           'Unknown colour `hooloovoo`'
@@ -205,7 +205,7 @@ describe('@function govuk-colour', () => {
           color: govuk-colour('red', $legacy: 'hooloovoo');
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo { color: #ff0000; }')
     })
@@ -235,7 +235,7 @@ describe('@function govuk-organisation-colour', () => {
         color: govuk-organisation-colour('floo-network-authority');
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo { color: #9A00A8; }')
   })
@@ -248,7 +248,7 @@ describe('@function govuk-organisation-colour', () => {
         color: govuk-organisation-colour('broom-regulatory-control');
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo { color: #A81223; }')
   })
@@ -261,7 +261,7 @@ describe('@function govuk-organisation-colour', () => {
         border-color: govuk-organisation-colour('floo-network-authority', $websafe: false);
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo { border-color: #EC22FF; }')
   })
@@ -274,7 +274,7 @@ describe('@function govuk-organisation-colour', () => {
         color: govuk-organisation-colour('muggle-born-registration-commission');
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(compileSassString(sass, sassConfig))
       .rejects
       .toThrow(
         'Unknown organisation `muggle-born-registration-commission`'

--- a/src/govuk/helpers/colour.test.js
+++ b/src/govuk/helpers/colour.test.js
@@ -1,4 +1,5 @@
 const sass = require('node-sass')
+const outdent = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 
@@ -8,7 +9,6 @@ const mockWarnFunction = jest.fn()
   .mockReturnValue(sass.NULL)
 
 const sassConfig = {
-  outputStyle: 'compact',
   functions: {
     '@warn': mockWarnFunction
   }
@@ -41,7 +41,11 @@ describe('@function govuk-colour', () => {
     await expect(compileSassString(sass, sassConfig))
       .resolves
       .toMatchObject({
-        css: '.foo { color: #ff0000; }'
+        css: outdent`
+          .foo {
+            color: #ff0000;
+          }
+        `
       })
   })
 
@@ -57,7 +61,11 @@ describe('@function govuk-colour', () => {
     await expect(compileSassString(sass, sassConfig))
       .resolves
       .toMatchObject({
-        css: '.foo { color: #ff0000; }'
+        css: outdent`
+          .foo {
+            color: #ff0000;
+          }
+        `
       })
   })
 
@@ -98,7 +106,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #0000ff; }'
+          css: outdent`
+            .foo {
+              color: #0000ff;
+            }
+          `
         })
     })
 
@@ -114,7 +126,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #BADA55; }'
+          css: outdent`
+            .foo {
+              color: #BADA55;
+            }
+          `
         })
     })
 
@@ -130,7 +146,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #0000ff; }'
+          css: outdent`
+            .foo {
+              color: #0000ff;
+            }
+          `
         })
     })
 
@@ -185,7 +205,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #ff0000; }'
+          css: outdent`
+            .foo {
+              color: #ff0000;
+            }
+          `
         })
     })
 
@@ -201,7 +225,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #ff0000; }'
+          css: outdent`
+            .foo {
+              color: #ff0000;
+            }
+          `
         })
     })
 
@@ -233,7 +261,11 @@ describe('@function govuk-colour', () => {
       await expect(compileSassString(sass, sassConfig))
         .resolves
         .toMatchObject({
-          css: '.foo { color: #ff0000; }'
+          css: outdent`
+            .foo {
+              color: #ff0000;
+            }
+          `
         })
     })
   })
@@ -266,7 +298,11 @@ describe('@function govuk-organisation-colour', () => {
     await expect(compileSassString(sass, sassConfig))
       .resolves
       .toMatchObject({
-        css: '.foo { color: #9A00A8; }'
+        css: outdent`
+          .foo {
+            color: #9A00A8;
+          }
+        `
       })
   })
 
@@ -282,7 +318,11 @@ describe('@function govuk-organisation-colour', () => {
     await expect(compileSassString(sass, sassConfig))
       .resolves
       .toMatchObject({
-        css: '.foo { color: #A81223; }'
+        css: outdent`
+          .foo {
+            color: #A81223;
+          }
+        `
       })
   })
 
@@ -298,7 +338,11 @@ describe('@function govuk-organisation-colour', () => {
     await expect(compileSassString(sass, sassConfig))
       .resolves
       .toMatchObject({
-        css: '.foo { border-color: #EC22FF; }'
+        css: outdent`
+          .foo {
+            border-color: #EC22FF;
+          }
+        `
       })
   })
 

--- a/src/govuk/helpers/grid.test.js
+++ b/src/govuk/helpers/grid.test.js
@@ -14,6 +14,7 @@ describe('grid system', () => {
 
     @import "tools/exports";
   `
+
   describe('govuk-grid-width function', () => {
     it('outputs the specified key value from the map of widths', async () => {
       const sass = `
@@ -21,13 +22,17 @@ describe('grid system', () => {
 
         .foo {
           content: govuk-grid-width(one-quarter);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        content: 25%; }`)
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
+            .foo {
+              content: 25%; }
+          `
+        })
     })
 
     it('throws an error that the specified key does not exist in the map of widths', async () => {
@@ -53,20 +58,20 @@ describe('grid system', () => {
         }
         `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-full {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .govuk-grid-column-full {
+              box-sizing: border-box;
               width: 100%;
-              float: left; } }`)
+              padding: 0 15px; }
+              @media (min-width: 40.0625em) {
+                .govuk-grid-column-full {
+                  width: 100%;
+                  float: left; } }
+          `
+        })
     })
 
     it('allows different widths to be specified using $width', async () => {
@@ -77,21 +82,21 @@ describe('grid system', () => {
           @include govuk-grid-column(two-thirds);
         }
       `
-      const results = await compileSassString(sass)
 
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-two-thirds {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .govuk-grid-column-two-thirds {
-              width: 66.66667%;
-              float: left; } }
-        `)
+              box-sizing: border-box;
+              width: 100%;
+              padding: 0 15px; }
+              @media (min-width: 40.0625em) {
+                .govuk-grid-column-two-thirds {
+                  width: 66.66667%;
+                  float: left; } }
+          `
+        })
     })
 
     it('allows predefined breakpoints to be specified using $at', async () => {
@@ -102,21 +107,21 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: desktop);
         }
       `
-      const results = await compileSassString(sass)
-
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-quarter-at-desktop {
-          box-sizing: border-box;
-          padding: 0 15px; }
-          @media (min-width: 48.0625em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .govuk-grid-column-one-quarter-at-desktop {
-              width: 25%;
-              float: left; } }
-        `)
+              box-sizing: border-box;
+              padding: 0 15px; }
+              @media (min-width: 48.0625em) {
+                .govuk-grid-column-one-quarter-at-desktop {
+                  width: 25%;
+                  float: left; } }
+          `
+        })
     })
+
     it('allows custom breakpoints to be specified using $at', async () => {
       const sass = `
         ${sassImports}
@@ -125,21 +130,21 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: 500px);
         }
       `
-      const results = await compileSassString(sass)
 
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-quarter-at-500px {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 31.25em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .govuk-grid-column-one-quarter-at-500px {
-              width: 25%;
-              float: left; } }
-        `)
+              box-sizing: border-box;
+              width: 100%;
+              padding: 0 15px; }
+              @media (min-width: 31.25em) {
+                .govuk-grid-column-one-quarter-at-500px {
+                  width: 25%;
+                  float: left; } }
+          `
+        })
     })
 
     it('allows columns to float right using $float: right', async () => {
@@ -150,21 +155,21 @@ describe('grid system', () => {
           @include govuk-grid-column(one-half, $float: right);
         }
       `
-      const results = await compileSassString(sass)
 
-      expect(results.css
-        .toString()
-        .trim())
-        .toBe(outdent`
-        .govuk-grid-column-one-half-right {
-          box-sizing: border-box;
-          width: 100%;
-          padding: 0 15px; }
-          @media (min-width: 40.0625em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .govuk-grid-column-one-half-right {
-              width: 50%;
-              float: right; } }
-        `)
+              box-sizing: border-box;
+              width: 100%;
+              padding: 0 15px; }
+              @media (min-width: 40.0625em) {
+                .govuk-grid-column-one-half-right {
+                  width: 50%;
+                  float: right; } }
+          `
+        })
     })
   })
 })

--- a/src/govuk/helpers/grid.test.js
+++ b/src/govuk/helpers/grid.test.js
@@ -1,6 +1,6 @@
 const { outdent } = require('outdent')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 describe('grid system', () => {
   const sassImports = `
@@ -23,7 +23,7 @@ describe('grid system', () => {
           content: govuk-grid-width(one-quarter);
         }`
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -37,7 +37,7 @@ describe('grid system', () => {
         $value: govuk-grid-width(seven-fifths);
         `
 
-      await expect(renderSass({ data: sass }))
+      await expect(compileSassString(sass))
         .rejects
         .toThrow('Unknown grid width `seven-fifths`')
     })
@@ -53,7 +53,7 @@ describe('grid system', () => {
         }
         `
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css
         .toString()
@@ -77,7 +77,7 @@ describe('grid system', () => {
           @include govuk-grid-column(two-thirds);
         }
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css
         .toString()
@@ -102,7 +102,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: desktop);
         }
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css
         .toString()
@@ -125,7 +125,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: 500px);
         }
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css
         .toString()
@@ -150,7 +150,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-half, $float: right);
         }
       `
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css
         .toString()

--- a/src/govuk/helpers/grid.test.js
+++ b/src/govuk/helpers/grid.test.js
@@ -2,10 +2,6 @@ const { outdent } = require('outdent')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 
-const sassConfig = {
-  outputStyle: 'nested'
-}
-
 describe('grid system', () => {
   const sassImports = `
     @import "settings/ie8";
@@ -27,7 +23,7 @@ describe('grid system', () => {
           content: govuk-grid-width(one-quarter);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -41,7 +37,7 @@ describe('grid system', () => {
         $value: govuk-grid-width(seven-fifths);
         `
 
-      await expect(renderSass({ data: sass, ...sassConfig }))
+      await expect(renderSass({ data: sass }))
         .rejects
         .toThrow('Unknown grid width `seven-fifths`')
     })
@@ -57,7 +53,7 @@ describe('grid system', () => {
         }
         `
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css
         .toString()
@@ -81,7 +77,7 @@ describe('grid system', () => {
           @include govuk-grid-column(two-thirds);
         }
       `
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css
         .toString()
@@ -106,7 +102,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: desktop);
         }
       `
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css
         .toString()
@@ -129,7 +125,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: 500px);
         }
       `
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css
         .toString()
@@ -154,7 +150,7 @@ describe('grid system', () => {
           @include govuk-grid-column(one-half, $float: right);
         }
       `
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css
         .toString()

--- a/src/govuk/helpers/grid.test.js
+++ b/src/govuk/helpers/grid.test.js
@@ -30,7 +30,8 @@ describe('grid system', () => {
         .toMatchObject({
           css: outdent`
             .foo {
-              content: 25%; }
+              content: 25%;
+            }
           `
         })
     })
@@ -65,11 +66,15 @@ describe('grid system', () => {
             .govuk-grid-column-full {
               box-sizing: border-box;
               width: 100%;
-              padding: 0 15px; }
-              @media (min-width: 40.0625em) {
-                .govuk-grid-column-full {
-                  width: 100%;
-                  float: left; } }
+              padding: 0 15px;
+            }
+
+            @media (min-width: 40.0625em) {
+              .govuk-grid-column-full {
+                width: 100%;
+                float: left;
+              }
+            }
           `
         })
     })
@@ -90,11 +95,15 @@ describe('grid system', () => {
             .govuk-grid-column-two-thirds {
               box-sizing: border-box;
               width: 100%;
-              padding: 0 15px; }
-              @media (min-width: 40.0625em) {
-                .govuk-grid-column-two-thirds {
-                  width: 66.66667%;
-                  float: left; } }
+              padding: 0 15px;
+            }
+
+            @media (min-width: 40.0625em) {
+              .govuk-grid-column-two-thirds {
+                width: 66.66667%;
+                float: left;
+              }
+            }
           `
         })
     })
@@ -113,11 +122,15 @@ describe('grid system', () => {
           css: outdent`
             .govuk-grid-column-one-quarter-at-desktop {
               box-sizing: border-box;
-              padding: 0 15px; }
-              @media (min-width: 48.0625em) {
-                .govuk-grid-column-one-quarter-at-desktop {
-                  width: 25%;
-                  float: left; } }
+              padding: 0 15px;
+            }
+
+            @media (min-width: 48.0625em) {
+              .govuk-grid-column-one-quarter-at-desktop {
+                width: 25%;
+                float: left;
+              }
+            }
           `
         })
     })
@@ -138,11 +151,15 @@ describe('grid system', () => {
             .govuk-grid-column-one-quarter-at-500px {
               box-sizing: border-box;
               width: 100%;
-              padding: 0 15px; }
-              @media (min-width: 31.25em) {
-                .govuk-grid-column-one-quarter-at-500px {
-                  width: 25%;
-                  float: left; } }
+              padding: 0 15px;
+            }
+
+            @media (min-width: 31.25em) {
+              .govuk-grid-column-one-quarter-at-500px {
+                width: 25%;
+                float: left;
+              }
+            }
           `
         })
     })
@@ -163,11 +180,15 @@ describe('grid system', () => {
             .govuk-grid-column-one-half-right {
               box-sizing: border-box;
               width: 100%;
-              padding: 0 15px; }
-              @media (min-width: 40.0625em) {
-                .govuk-grid-column-one-half-right {
-                  width: 50%;
-                  float: right; } }
+              padding: 0 15px;
+            }
+
+            @media (min-width: 40.0625em) {
+              .govuk-grid-column-one-half-right {
+                width: 50%;
+                float: right;
+              }
+            }
           `
         })
     })

--- a/src/govuk/helpers/helpers.test.js
+++ b/src/govuk/helpers/helpers.test.js
@@ -4,7 +4,7 @@ const sassdoc = require('sassdoc')
 
 const configPaths = require('../../../config/paths')
 const { getListing } = require('../../../lib/file-helper')
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassFile } = require('../../../lib/jest-helpers')
 
 describe('The helpers layer', () => {
   let sassFiles
@@ -16,22 +16,20 @@ describe('The helpers layer', () => {
   })
 
   it('should not output any CSS', async () => {
-    const helpers = join(configPaths.src, 'govuk/helpers/_all.scss')
+    const file = join(configPaths.src, 'govuk/helpers/_all.scss')
 
-    const output = await renderSass({ file: helpers })
-    expect(output.css.toString()).toEqual('')
+    const results = await compileSassFile(file)
+    expect(results.css.toString()).toEqual('')
   })
 
   it('renders CSS for all helpers', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
       const file = join(configPaths.src, sassFilePath)
 
-      return expect(renderSass({ file })).resolves.toEqual(
-        expect.objectContaining({
-          css: expect.any(Object),
-          stats: expect.any(Object)
-        })
-      )
+      return expect(compileSassFile(file)).resolves.toMatchObject({
+        css: expect.any(Object),
+        stats: expect.any(Object)
+      })
     })
 
     return Promise.all(sassTasks)

--- a/src/govuk/helpers/helpers.test.js
+++ b/src/govuk/helpers/helpers.test.js
@@ -17,9 +17,7 @@ describe('The helpers layer', () => {
 
   it('should not output any CSS', async () => {
     const file = join(configPaths.src, 'govuk/helpers/_all.scss')
-
-    const results = await compileSassFile(file)
-    expect(results.css.toString()).toEqual('')
+    await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all helpers', () => {
@@ -27,7 +25,7 @@ describe('The helpers layer', () => {
       const file = join(configPaths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
-        css: expect.any(Object),
+        css: expect.any(String),
         stats: expect.any(Object)
       })
     })

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -12,11 +12,12 @@ describe('@mixin govuk-link-decoration', () => {
 
         .foo {
           @include govuk-link-decoration;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('text-decoration-thickness')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.not.stringContaining('text-decoration-thickness')
+      })
     })
 
     it('does not set text-underline-offset', async () => {
@@ -25,11 +26,12 @@ describe('@mixin govuk-link-decoration', () => {
 
         .foo {
           @include govuk-link-decoration;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('text-underline-offset')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.not.stringContaining('text-underline-offset')
+      })
     })
   })
 
@@ -42,11 +44,12 @@ describe('@mixin govuk-link-decoration', () => {
 
         .foo {
           @include govuk-link-decoration;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).toContain('text-decoration-thickness: 1px;')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.stringContaining('text-decoration-thickness: 1px;')
+      })
     })
 
     it('sets text-underline-offset', async () => {
@@ -57,11 +60,12 @@ describe('@mixin govuk-link-decoration', () => {
 
         .foo {
           @include govuk-link-decoration;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.stringContaining('text-underline-offset: 0.1em;')
+      })
     })
 
     describe('when $govuk-link-underline-thickness is falsey', () => {
@@ -73,11 +77,12 @@ describe('@mixin govuk-link-decoration', () => {
 
           .foo {
             @include govuk-link-decoration;
-          }`
+          }
+        `
 
-        const results = await compileSassString(sass, sassConfig)
-
-        expect(results.css.toString()).not.toContain('text-decoration-thickness')
+        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+          css: expect.not.stringContaining('text-decoration-thickness')
+        })
       })
     })
 
@@ -90,11 +95,12 @@ describe('@mixin govuk-link-decoration', () => {
 
         .foo {
             @include govuk-link-decoration;
-        }`
+        }
+      `
 
-        const results = await compileSassString(sass, sassConfig)
-
-        expect(results.css.toString()).not.toContain('text-underline-offset')
+        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+          css: expect.not.stringContaining('text-underline-offset')
+        })
       })
     })
   })
@@ -110,11 +116,12 @@ describe('@mixin govuk-link-hover-decoration', () => {
       // is omitted from the CSS
       .foo:hover {
           @include govuk-link-hover-decoration;
-      }`
+      }
+    `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('.foo:hover')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.not.stringContaining('.foo:hover')
+      })
     })
   })
 
@@ -127,11 +134,12 @@ describe('@mixin govuk-link-hover-decoration', () => {
 
         .foo:hover {
           @include govuk-link-hover-decoration;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).toContain('.foo:hover')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.stringContaining('.foo:hover')
+      })
     })
 
     describe('when $govuk-link-hover-underline-thickness is falsey', () => {
@@ -145,11 +153,12 @@ describe('@mixin govuk-link-hover-decoration', () => {
         // is omitted from the CSS
         .foo:hover {
             @include govuk-link-hover-decoration;
-        }`
+        }
+      `
 
-        const results = await compileSassString(sass, sassConfig)
-
-        expect(results.css.toString()).not.toContain('.foo:hover')
+        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+          css: expect.not.stringContaining('.foo:hover')
+        })
       })
     })
   })
@@ -164,13 +173,22 @@ describe('@mixin govuk-link-style-text', () => {
 
         a {
             @include govuk-link-style-text;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
+      const results = compileSassString(sass, sassConfig)
 
-      expect(results.css.toString()).toContain(':hover')
-      expect(results.css.toString()).toContain('color:')
-      expect(results.css.toString()).toContain('rgba(')
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining(':hover')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('color:')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('rgba(')
+      })
     })
   })
 
@@ -182,11 +200,12 @@ describe('@mixin govuk-link-style-text', () => {
 
         a {
             @include govuk-link-style-text;
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('rgba(')
+      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        css: expect.not.stringContaining('rgba(')
+      })
     })
   })
 })

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compact'
@@ -14,7 +14,7 @@ describe('@mixin govuk-link-decoration', () => {
           @include govuk-link-decoration;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('text-decoration-thickness')
     })
@@ -27,7 +27,7 @@ describe('@mixin govuk-link-decoration', () => {
           @include govuk-link-decoration;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('text-underline-offset')
     })
@@ -44,7 +44,7 @@ describe('@mixin govuk-link-decoration', () => {
           @include govuk-link-decoration;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('text-decoration-thickness: 1px;')
     })
@@ -59,7 +59,7 @@ describe('@mixin govuk-link-decoration', () => {
           @include govuk-link-decoration;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('text-underline-offset: 0.1em;')
     })
@@ -75,7 +75,7 @@ describe('@mixin govuk-link-decoration', () => {
             @include govuk-link-decoration;
           }`
 
-        const results = await renderSass({ data: sass, ...sassConfig })
+        const results = await compileSassString(sass, sassConfig)
 
         expect(results.css.toString()).not.toContain('text-decoration-thickness')
       })
@@ -92,7 +92,7 @@ describe('@mixin govuk-link-decoration', () => {
             @include govuk-link-decoration;
         }`
 
-        const results = await renderSass({ data: sass, ...sassConfig })
+        const results = await compileSassString(sass, sassConfig)
 
         expect(results.css.toString()).not.toContain('text-underline-offset')
       })
@@ -112,7 +112,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
           @include govuk-link-hover-decoration;
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('.foo:hover')
     })
@@ -129,7 +129,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
           @include govuk-link-hover-decoration;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('.foo:hover')
     })
@@ -147,7 +147,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
             @include govuk-link-hover-decoration;
         }`
 
-        const results = await renderSass({ data: sass, ...sassConfig })
+        const results = await compileSassString(sass, sassConfig)
 
         expect(results.css.toString()).not.toContain('.foo:hover')
       })
@@ -166,7 +166,7 @@ describe('@mixin govuk-link-style-text', () => {
             @include govuk-link-style-text;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain(':hover')
       expect(results.css.toString()).toContain('color:')
@@ -184,7 +184,7 @@ describe('@mixin govuk-link-style-text', () => {
             @include govuk-link-style-text;
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('rgba(')
     })

--- a/src/govuk/helpers/links.test.js
+++ b/src/govuk/helpers/links.test.js
@@ -1,9 +1,5 @@
 const { compileSassString } = require('../../../lib/jest-helpers')
 
-const sassConfig = {
-  outputStyle: 'compact'
-}
-
 describe('@mixin govuk-link-decoration', () => {
   describe('by default', () => {
     it('does not set text-decoration-thickness', async () => {
@@ -15,7 +11,7 @@ describe('@mixin govuk-link-decoration', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.not.stringContaining('text-decoration-thickness')
       })
     })
@@ -29,7 +25,7 @@ describe('@mixin govuk-link-decoration', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.not.stringContaining('text-underline-offset')
       })
     })
@@ -47,7 +43,7 @@ describe('@mixin govuk-link-decoration', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.stringContaining('text-decoration-thickness: 1px;')
       })
     })
@@ -63,7 +59,7 @@ describe('@mixin govuk-link-decoration', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.stringContaining('text-underline-offset: 0.1em;')
       })
     })
@@ -80,7 +76,7 @@ describe('@mixin govuk-link-decoration', () => {
           }
         `
 
-        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        await expect(compileSassString(sass)).resolves.toMatchObject({
           css: expect.not.stringContaining('text-decoration-thickness')
         })
       })
@@ -98,7 +94,7 @@ describe('@mixin govuk-link-decoration', () => {
         }
       `
 
-        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        await expect(compileSassString(sass)).resolves.toMatchObject({
           css: expect.not.stringContaining('text-underline-offset')
         })
       })
@@ -119,7 +115,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
       }
     `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.not.stringContaining('.foo:hover')
       })
     })
@@ -137,7 +133,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.stringContaining('.foo:hover')
       })
     })
@@ -156,7 +152,7 @@ describe('@mixin govuk-link-hover-decoration', () => {
         }
       `
 
-        await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+        await expect(compileSassString(sass)).resolves.toMatchObject({
           css: expect.not.stringContaining('.foo:hover')
         })
       })
@@ -176,7 +172,7 @@ describe('@mixin govuk-link-style-text', () => {
         }
       `
 
-      const results = compileSassString(sass, sassConfig)
+      const results = compileSassString(sass)
 
       await expect(results).resolves.toMatchObject({
         css: expect.stringContaining(':hover')
@@ -203,7 +199,7 @@ describe('@mixin govuk-link-style-text', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      await expect(compileSassString(sass)).resolves.toMatchObject({
         css: expect.not.stringContaining('rgba(')
       })
     })

--- a/src/govuk/helpers/media-queries.test.js
+++ b/src/govuk/helpers/media-queries.test.js
@@ -1,8 +1,6 @@
-const { compileSassString } = require('../../../lib/jest-helpers')
+const outdent = require('outdent')
 
-const sassConfig = {
-  outputStyle: 'compressed'
-}
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassBootstrap = `
   $govuk-breakpoints: (
@@ -25,10 +23,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (min-width: 20em){.foo{color:red}}'
+        css: outdent`
+          @media (min-width: 20em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -44,10 +48,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (min-width: 20em){.foo{color:red}}'
+        css: outdent`
+          @media (min-width: 20em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -61,10 +71,16 @@ describe('@mixin govuk-media-query', () => {
         }
       }
     `
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (max-width: 20em){.foo{color:red}}'
+        css: outdent`
+          @media (max-width: 20em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -80,10 +96,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (max-width: 61.24em){.foo{color:red}}'
+        css: outdent`
+          @media (max-width: 61.24em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -98,10 +120,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (min-width: 20em) and (max-width: 40em){.foo{color:red}}'
+        css: outdent`
+          @media (min-width: 20em) and (max-width: 40em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -117,10 +145,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (min-width: 20em) and (max-width: 46.24em){.foo{color:red}}'
+        css: outdent`
+          @media (min-width: 20em) and (max-width: 46.24em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -135,10 +169,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media (max-width: 40em) and (orientation: landscape){.foo{color:red}}'
+        css: outdent`
+          @media (max-width: 40em) and (orientation: landscape) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -153,10 +193,16 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@media aural and (max-width: 40em){.foo{color:red}}'
+        css: outdent`
+          @media aural and (max-width: 40em) {
+            .foo {
+              color: red;
+            }
+          }
+        `
       })
   })
 
@@ -184,10 +230,14 @@ describe('@mixin govuk-media-query', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig))
+      await expect(compileSassString(sass))
         .resolves
         .toMatchObject({
-          css: '.foo{color:forestgreen}'
+          css: outdent`
+            .foo {
+              color: forestgreen;
+            }
+          `
         })
     })
 
@@ -206,10 +256,14 @@ describe('@mixin govuk-media-query', () => {
         }
       `
 
-      await expect(compileSassString(sass, sassConfig))
+      await expect(compileSassString(sass))
         .resolves
         .toMatchObject({
-          css: '.foo{color:blue}'
+          css: outdent`
+            .foo {
+              color: blue;
+            }
+          `
         })
     })
   })

--- a/src/govuk/helpers/media-queries.test.js
+++ b/src/govuk/helpers/media-queries.test.js
@@ -22,11 +22,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($from: 20em) {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (min-width: 20em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (min-width: 20em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target min-width using a predefined breakpoint', async () => {
@@ -38,11 +41,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($from: mobile) {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (min-width: 20em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (min-width: 20em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target max-width using a numeric value', async () => {
@@ -53,11 +59,13 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($until: 20em) {
           color: red;
         }
-      }`
-
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (max-width: 20em){.foo{color:red}}')
+      }
+    `
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (max-width: 20em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target max-width using a predefined breakpoint', async () => {
@@ -69,11 +77,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($until: desktop) {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (max-width: 61.24em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (max-width: 61.24em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target combined min-width and max-width using numeric values', async () => {
@@ -84,11 +95,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($from: 20em, $until: 40em) {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (min-width: 20em) and (max-width: 40em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (min-width: 20em) and (max-width: 40em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target combined min-width and max-width using predefined breakpoints', async () => {
@@ -100,11 +114,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($from: mobile, $until: tablet) {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (min-width: 20em) and (max-width: 46.24em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (min-width: 20em) and (max-width: 46.24em){.foo{color:red}}'
+      })
   })
 
   it('allows you to target using custom directives', async () => {
@@ -115,11 +132,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($until: 40em, $and: '(orientation: landscape)') {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media (max-width: 40em) and (orientation: landscape){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media (max-width: 40em) and (orientation: landscape){.foo{color:red}}'
+      })
   })
 
   it('allows you to target particular media types', async () => {
@@ -130,11 +150,14 @@ describe('@mixin govuk-media-query', () => {
         @include govuk-media-query($until: 40em, $media-type: 'aural') {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('@media aural and (max-width: 40em){.foo{color:red}}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@media aural and (max-width: 40em){.foo{color:red}}'
+      })
   })
 
   describe('when compiling a rasterized stylesheet for IE8', () => {
@@ -158,11 +181,14 @@ describe('@mixin govuk-media-query', () => {
           @include govuk-media-query($from: desktop) {
               color: forestgreen;
           }
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo{color:forestgreen}')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo{color:forestgreen}'
+        })
     })
 
     it('does not rasterize print queries', async () => {
@@ -177,11 +203,14 @@ describe('@mixin govuk-media-query', () => {
           @include govuk-media-query($media-type: 'print') {
             color: red;
           }
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe('.foo{color:blue}')
+      await expect(compileSassString(sass, sassConfig))
+        .resolves
+        .toMatchObject({
+          css: '.foo{color:blue}'
+        })
     })
   })
 })

--- a/src/govuk/helpers/media-queries.test.js
+++ b/src/govuk/helpers/media-queries.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compressed'
@@ -24,7 +24,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (min-width: 20em){.foo{color:red}}')
   })
@@ -40,7 +40,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (min-width: 20em){.foo{color:red}}')
   })
@@ -55,7 +55,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (max-width: 20em){.foo{color:red}}')
   })
@@ -71,7 +71,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (max-width: 61.24em){.foo{color:red}}')
   })
@@ -86,7 +86,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (min-width: 20em) and (max-width: 40em){.foo{color:red}}')
   })
@@ -102,7 +102,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (min-width: 20em) and (max-width: 46.24em){.foo{color:red}}')
   })
@@ -117,7 +117,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media (max-width: 40em) and (orientation: landscape){.foo{color:red}}')
   })
@@ -132,7 +132,7 @@ describe('@mixin govuk-media-query', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('@media aural and (max-width: 40em){.foo{color:red}}')
   })
@@ -160,7 +160,7 @@ describe('@mixin govuk-media-query', () => {
           }
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo{color:forestgreen}')
     })
@@ -179,7 +179,7 @@ describe('@mixin govuk-media-query', () => {
           }
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe('.foo{color:blue}')
     })

--- a/src/govuk/helpers/spacing.test.js
+++ b/src/govuk/helpers/spacing.test.js
@@ -1,6 +1,6 @@
 const { outdent } = require('outdent')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassBootstrap = `
   @import "settings/media-queries";
@@ -39,7 +39,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing($spacing-point)
       }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -54,7 +54,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-2)
       }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -69,7 +69,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing('margin')
       }`
 
-    await expect(renderSass({ data: sass }))
+    await expect(compileSassString(sass))
       .rejects
       .toThrow(
         'Expected a number (integer), but got a string.'
@@ -84,7 +84,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(999)
       }`
 
-    await expect(renderSass({ data: sass }))
+    await expect(compileSassString(sass))
       .rejects
       .toThrow(
         'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
@@ -99,7 +99,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-999)
       }`
 
-    await expect(renderSass({ data: sass }))
+    await expect(compileSassString(sass))
       .rejects
       .toThrow(
         'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
@@ -114,7 +114,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-0)
       }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -131,7 +131,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing($spacing-point, 'margin')
       }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -149,7 +149,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing($spacing-point, 'padding', 'top');
       }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -167,7 +167,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing(14px, 'margin')
       }`
 
-    await expect(renderSass({ data: sass }))
+    await expect(compileSassString(sass))
       .rejects
       .toThrow(
         'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
@@ -187,7 +187,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -210,7 +210,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -234,7 +234,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -257,7 +257,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass })
+      const results = await compileSassString(sass)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -278,7 +278,7 @@ describe('@mixin govuk-responsive-margin', () => {
           @include govuk-responsive-margin($spacing-point)
         }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -301,7 +301,7 @@ describe('@mixin govuk-responsive-margin', () => {
           )
         }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -321,7 +321,7 @@ describe('@mixin govuk-responsive-padding', () => {
           @include govuk-responsive-padding($spacing-point)
         }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -344,7 +344,7 @@ describe('@mixin govuk-responsive-padding', () => {
           )
         }`
 
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {

--- a/src/govuk/helpers/spacing.test.js
+++ b/src/govuk/helpers/spacing.test.js
@@ -37,13 +37,17 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing($spacing-point)
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        top: 15px; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            top: 15px; }
+        `
+      })
   })
 
   it('returns CSS for a property based on a negative spacing point', async () => {
@@ -52,13 +56,17 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing(-2)
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        top: -15px; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            top: -15px; }
+        `
+      })
   })
 
   it('throws an error when passed anything other than a number', async () => {
@@ -67,7 +75,8 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing('margin')
-      }`
+      }
+    `
 
     await expect(compileSassString(sass))
       .rejects
@@ -82,7 +91,8 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing(999)
-      }`
+      }
+    `
 
     await expect(compileSassString(sass))
       .rejects
@@ -97,7 +107,8 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing(-999)
-      }`
+      }
+    `
 
     await expect(compileSassString(sass))
       .rejects
@@ -112,13 +123,17 @@ describe('@function govuk-spacing', () => {
 
       .foo {
         top: govuk-spacing(-0)
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        top: 0; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            top: 0; }
+        `
+      })
   })
 })
 
@@ -129,16 +144,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       .foo {
         @include _govuk-responsive-spacing($spacing-point, 'margin')
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        margin: 15px; }
-        @media (min-width: 30em) {
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
           .foo {
-            margin: 25px; } }`)
+            margin: 15px; }
+            @media (min-width: 30em) {
+              .foo {
+                margin: 25px; } }
+        `
+      })
   })
 
   it('outputs CSS for a property and direction based on the spacing map', async () => {
@@ -147,16 +166,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       .foo {
         @include _govuk-responsive-spacing($spacing-point, 'padding', 'top');
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        padding-top: 15px; }
-        @media (min-width: 30em) {
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
           .foo {
-            padding-top: 25px; } }`)
+            padding-top: 15px; }
+            @media (min-width: 30em) {
+              .foo {
+                padding-top: 25px; } }
+        `
+      })
   })
 
   it('throws an exception when passed a non-existent point', async () => {
@@ -165,7 +188,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       .foo {
         @include _govuk-responsive-spacing(14px, 'margin')
-      }`
+      }
+    `
 
     await expect(compileSassString(sass))
       .rejects
@@ -185,16 +209,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
             'margin',
             $important: true
           )
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin: 15px !important; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              margin: 25px !important; } }`)
+              margin: 15px !important; }
+              @media (min-width: 30em) {
+                .foo {
+                  margin: 25px !important; } }
+          `
+        })
     })
 
     it('marks the rule as important for the property and direction', async () => {
@@ -208,16 +236,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
             'top',
             $important: true
           )
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin-top: 15px !important; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              margin-top: 25px !important; } }`)
+              margin-top: 15px !important; }
+              @media (min-width: 30em) {
+                .foo {
+                  margin-top: 25px !important; } }
+          `
+        })
     })
   })
 
@@ -232,16 +264,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
             'margin',
             $adjustment: 2px
           )
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin: 17px; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              margin: 27px; } }`)
+              margin: 17px; }
+              @media (min-width: 30em) {
+                .foo {
+                  margin: 27px; } }
+          `
+        })
     })
 
     it('adjusts the value for the property and direction', async () => {
@@ -255,16 +291,20 @@ describe('@mixin _govuk-responsive-spacing', () => {
             'top',
             $adjustment: 2px
           )
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin-top: 17px; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              margin-top: 27px; } }`)
+              margin-top: 17px; }
+              @media (min-width: 30em) {
+                .foo {
+                  margin-top: 27px; } }
+          `
+        })
     })
   })
 })
@@ -276,16 +316,20 @@ describe('@mixin govuk-responsive-margin', () => {
 
         .foo {
           @include govuk-responsive-margin($spacing-point)
-        }`
+        }
+      `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin: 15px; }
-          @media (min-width: 30em) {
-            .foo {
-              margin: 25px; } }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            margin: 15px; }
+            @media (min-width: 30em) {
+              .foo {
+                margin: 25px; } }
+        `
+      })
   })
 
   it('outputs extreme responsive margins', async () => {
@@ -299,16 +343,20 @@ describe('@mixin govuk-responsive-margin', () => {
             $important: true,
             $adjustment: 2px
           )
-        }`
+        }
+      `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          margin-top: 17px !important; }
-          @media (min-width: 30em) {
-            .foo {
-              margin-top: 27px !important; } }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            margin-top: 17px !important; }
+            @media (min-width: 30em) {
+              .foo {
+                margin-top: 27px !important; } }
+        `
+      })
   })
 })
 
@@ -319,16 +367,20 @@ describe('@mixin govuk-responsive-padding', () => {
 
         .foo {
           @include govuk-responsive-padding($spacing-point)
-        }`
+        }
+      `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          padding: 15px; }
-          @media (min-width: 30em) {
-            .foo {
-              padding: 25px; } }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            padding: 15px; }
+            @media (min-width: 30em) {
+              .foo {
+                padding: 25px; } }
+        `
+      })
   })
 
   it('outputs extreme responsive padding', async () => {
@@ -342,15 +394,19 @@ describe('@mixin govuk-responsive-padding', () => {
             $important: true,
             $adjustment: 2px
           )
-        }`
+        }
+      `
 
-    const results = await compileSassString(sass)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          padding-top: 17px !important; }
-          @media (min-width: 30em) {
-            .foo {
-              padding-top: 27px !important; } }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            padding-top: 17px !important; }
+            @media (min-width: 30em) {
+              .foo {
+                padding-top: 27px !important; } }
+        `
+      })
   })
 })

--- a/src/govuk/helpers/spacing.test.js
+++ b/src/govuk/helpers/spacing.test.js
@@ -2,10 +2,6 @@ const { outdent } = require('outdent')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 
-const sassConfig = {
-  outputStyle: 'nested'
-}
-
 const sassBootstrap = `
   @import "settings/media-queries";
   @import "settings/ie8";
@@ -43,7 +39,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing($spacing-point)
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -58,7 +54,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-2)
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -73,7 +69,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing('margin')
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(renderSass({ data: sass }))
       .rejects
       .toThrow(
         'Expected a number (integer), but got a string.'
@@ -88,7 +84,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(999)
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(renderSass({ data: sass }))
       .rejects
       .toThrow(
         'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
@@ -103,7 +99,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-999)
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(renderSass({ data: sass }))
       .rejects
       .toThrow(
         'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
@@ -118,7 +114,7 @@ describe('@function govuk-spacing', () => {
         top: govuk-spacing(-0)
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -135,7 +131,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing($spacing-point, 'margin')
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -153,7 +149,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing($spacing-point, 'padding', 'top');
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -171,7 +167,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
         @include _govuk-responsive-spacing(14px, 'margin')
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(renderSass({ data: sass }))
       .rejects
       .toThrow(
         'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
@@ -191,7 +187,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -214,7 +210,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -238,7 +234,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -261,7 +257,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
           )
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await renderSass({ data: sass })
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -282,7 +278,7 @@ describe('@mixin govuk-responsive-margin', () => {
           @include govuk-responsive-margin($spacing-point)
         }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -305,7 +301,7 @@ describe('@mixin govuk-responsive-margin', () => {
           )
         }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -325,7 +321,7 @@ describe('@mixin govuk-responsive-padding', () => {
           @include govuk-responsive-padding($spacing-point)
         }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -348,7 +344,7 @@ describe('@mixin govuk-responsive-padding', () => {
           )
         }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css.toString().trim()).toBe(outdent`
         .foo {

--- a/src/govuk/helpers/spacing.test.js
+++ b/src/govuk/helpers/spacing.test.js
@@ -45,7 +45,8 @@ describe('@function govuk-spacing', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            top: 15px; }
+            top: 15px;
+          }
         `
       })
   })
@@ -64,7 +65,8 @@ describe('@function govuk-spacing', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            top: -15px; }
+            top: -15px;
+          }
         `
       })
   })
@@ -131,7 +133,8 @@ describe('@function govuk-spacing', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            top: 0; }
+            top: 0;
+          }
         `
       })
   })
@@ -152,10 +155,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            margin: 15px; }
-            @media (min-width: 30em) {
-              .foo {
-                margin: 25px; } }
+            margin: 15px;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              margin: 25px;
+            }
+          }
         `
       })
   })
@@ -174,10 +181,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            padding-top: 15px; }
-            @media (min-width: 30em) {
-              .foo {
-                padding-top: 25px; } }
+            padding-top: 15px;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              padding-top: 25px;
+            }
+          }
         `
       })
   })
@@ -217,10 +228,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
         .toMatchObject({
           css: outdent`
             .foo {
-              margin: 15px !important; }
-              @media (min-width: 30em) {
-                .foo {
-                  margin: 25px !important; } }
+              margin: 15px !important;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                margin: 25px !important;
+              }
+            }
           `
         })
     })
@@ -244,10 +259,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
         .toMatchObject({
           css: outdent`
             .foo {
-              margin-top: 15px !important; }
-              @media (min-width: 30em) {
-                .foo {
-                  margin-top: 25px !important; } }
+              margin-top: 15px !important;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                margin-top: 25px !important;
+              }
+            }
           `
         })
     })
@@ -272,10 +291,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
         .toMatchObject({
           css: outdent`
             .foo {
-              margin: 17px; }
-              @media (min-width: 30em) {
-                .foo {
-                  margin: 27px; } }
+              margin: 17px;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                margin: 27px;
+              }
+            }
           `
         })
     })
@@ -299,10 +322,14 @@ describe('@mixin _govuk-responsive-spacing', () => {
         .toMatchObject({
           css: outdent`
             .foo {
-              margin-top: 17px; }
-              @media (min-width: 30em) {
-                .foo {
-                  margin-top: 27px; } }
+              margin-top: 17px;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                margin-top: 27px;
+              }
+            }
           `
         })
     })
@@ -324,10 +351,14 @@ describe('@mixin govuk-responsive-margin', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            margin: 15px; }
-            @media (min-width: 30em) {
-              .foo {
-                margin: 25px; } }
+            margin: 15px;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              margin: 25px;
+            }
+          }
         `
       })
   })
@@ -351,10 +382,14 @@ describe('@mixin govuk-responsive-margin', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            margin-top: 17px !important; }
-            @media (min-width: 30em) {
-              .foo {
-                margin-top: 27px !important; } }
+            margin-top: 17px !important;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              margin-top: 27px !important;
+            }
+          }
         `
       })
   })
@@ -375,10 +410,14 @@ describe('@mixin govuk-responsive-padding', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            padding: 15px; }
-            @media (min-width: 30em) {
-              .foo {
-                padding: 25px; } }
+            padding: 15px;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              padding: 25px;
+            }
+          }
         `
       })
   })
@@ -402,10 +441,14 @@ describe('@mixin govuk-responsive-padding', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            padding-top: 17px !important; }
-            @media (min-width: 30em) {
-              .foo {
-                padding-top: 27px !important; } }
+            padding-top: 17px !important;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              padding-top: 27px !important;
+            }
+          }
         `
       })
   })

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -198,7 +198,8 @@ describe('@function _govuk-line-height', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            line-height: 3.141; }
+            line-height: 3.141;
+          }
         `
       })
   })
@@ -217,7 +218,8 @@ describe('@function _govuk-line-height', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            line-height: 2em; }
+            line-height: 2em;
+          }
         `
       })
   })
@@ -236,7 +238,8 @@ describe('@function _govuk-line-height', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            line-height: 1.5; }
+            line-height: 1.5;
+          }
         `
       })
   })
@@ -259,12 +262,16 @@ describe('@mixin govuk-typography-responsive', () => {
           .foo {
             font-size: 12px;
             font-size: 0.75rem;
-            line-height: 1.25; }
-            @media (min-width: 30em) {
-              .foo {
-                font-size: 14px;
-                font-size: 0.875rem;
-                line-height: 1.42857; } }
+            line-height: 1.25;
+          }
+
+          @media (min-width: 30em) {
+            .foo {
+              font-size: 14px;
+              font-size: 0.875rem;
+              line-height: 1.42857;
+            }
+          }
         `
       })
   })
@@ -285,11 +292,15 @@ describe('@mixin govuk-typography-responsive', () => {
           .foo {
             font-size: 12px;
             font-size: 0.75rem;
-            line-height: 1.25; }
-            @media print {
-              .foo {
-                font-size: 14pt;
-                line-height: 1.5; } }
+            line-height: 1.25;
+          }
+
+          @media print {
+            .foo {
+              font-size: 14pt;
+              line-height: 1.5;
+            }
+          }
         `
       })
   })
@@ -327,12 +338,16 @@ describe('@mixin govuk-typography-responsive', () => {
             .foo {
               font-size: 12px !important;
               font-size: 0.75rem !important;
-              line-height: 1.25 !important; }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px !important;
-                  font-size: 0.875rem !important;
-                  line-height: 1.42857 !important; } }
+              line-height: 1.25 !important;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px !important;
+                font-size: 0.875rem !important;
+                line-height: 1.42857 !important;
+              }
+            }
           `
         })
     })
@@ -353,11 +368,15 @@ describe('@mixin govuk-typography-responsive', () => {
             .foo {
               font-size: 12px !important;
               font-size: 0.75rem !important;
-              line-height: 1.25 !important; }
-              @media print {
-                .foo {
-                  font-size: 14pt !important;
-                  line-height: 1.5 !important; } }
+              line-height: 1.25 !important;
+            }
+
+            @media print {
+              .foo {
+                font-size: 14pt !important;
+                line-height: 1.5 !important;
+              }
+            }
           `
         })
     })
@@ -380,12 +399,16 @@ describe('@mixin govuk-typography-responsive', () => {
             .foo {
               font-size: 12px;
               font-size: 0.75rem;
-              line-height: 1.75; }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px;
-                  font-size: 0.875rem;
-                  line-height: 1.5; } }
+              line-height: 1.75;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                font-size: 0.875rem;
+                line-height: 1.5;
+              }
+            }
           `
         })
     })
@@ -415,11 +438,15 @@ describe('@mixin govuk-typography-responsive', () => {
           css: outdent`
             .foo {
               font-size: 12px;
-              line-height: 1.25; }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px;
-                  line-height: 1.42857; } }
+              line-height: 1.25;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                line-height: 1.42857;
+              }
+            }
           `
         })
     })
@@ -441,11 +468,15 @@ describe('@mixin govuk-typography-responsive', () => {
           css: outdent`
             .foo {
               font-size: 12px;
-              line-height: 1.25; }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px;
-                  line-height: 1.42857; } }
+              line-height: 1.25;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                line-height: 1.42857;
+              }
+            }
           `
         })
     })
@@ -467,11 +498,15 @@ describe('@mixin govuk-typography-responsive', () => {
             css: outdent`
               .foo {
                 font-size: 12px !important;
-                line-height: 1.25 !important; }
-                @media (min-width: 30em) {
-                  .foo {
-                    font-size: 14px !important;
-                    line-height: 1.42857 !important; } }
+                line-height: 1.25 !important;
+              }
+
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px !important;
+                  line-height: 1.42857 !important;
+                }
+              }
             `
           })
       })
@@ -514,11 +549,15 @@ describe('@mixin govuk-typography-responsive', () => {
           css: outdent`
             .foo {
               font-size: 12px;
-              line-height: 1.25; }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px;
-                  line-height: 1.42857; } }
+              line-height: 1.25;
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                line-height: 1.42857;
+              }
+            }
           `
         })
     })
@@ -547,15 +586,22 @@ describe('@mixin govuk-typography-responsive', () => {
               font-weight: 400;
               font-size: 12px;
               font-size: 0.75rem;
-              line-height: 1.25; }
-              @media print {
-                .foo {
-                  font-family: sans-serif; } }
-              @media (min-width: 30em) {
-                .foo {
-                  font-size: 14px;
-                  font-size: 0.875rem;
-                  line-height: 1.42857; } }
+              line-height: 1.25;
+            }
+
+            @media print {
+              .foo {
+                font-family: sans-serif;
+              }
+            }
+
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                font-size: 0.875rem;
+                line-height: 1.42857;
+              }
+            }
           `
         })
     })
@@ -578,9 +624,11 @@ describe('@mixin govuk-typography-responsive', () => {
       await expect(results).resolves.toMatchObject({
         css: expect.stringContaining(outdent`
           @supports (font-variant-numeric: tabular-nums) {
-              .foo {
-                font-feature-settings: normal;
-                font-variant-numeric: tabular-nums; } }
+            .foo {
+              font-feature-settings: normal;
+              font-variant-numeric: tabular-nums;
+            }
+          }
         `)
       })
     })

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -2,7 +2,7 @@
 const sass = require('node-sass')
 const { outdent } = require('outdent')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
@@ -60,7 +60,7 @@ describe('@mixin govuk-typography-common', () => {
     }
     `
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
     const resultsString = results.css.toString()
 
     expect(resultsString).toContain('@font-face')
@@ -83,7 +83,7 @@ describe('@mixin govuk-typography-common', () => {
     }
     `
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
     const resultsString = results.css.toString()
 
     expect(resultsString).not.toContain('@font-face')
@@ -105,7 +105,7 @@ describe('@mixin govuk-typography-common', () => {
     }
     `
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
     const resultsString = results.css.toString()
 
     expect(resultsString).not.toContain('@font-face')
@@ -127,7 +127,7 @@ describe('@mixin govuk-typography-common', () => {
     }
     `
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
     const resultsString = results.css.toString()
 
     expect(resultsString).not.toContain('@font-face')
@@ -151,7 +151,7 @@ describe('@mixin govuk-typography-common', () => {
     }
     `
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
     const resultsString = results.css.toString()
 
     expect(resultsString).not.toContain('@font-face')
@@ -168,7 +168,7 @@ describe('@function _govuk-line-height', () => {
         line-height: _govuk-line-height($line-height: 3.141, $font-size: 20px);
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -183,7 +183,7 @@ describe('@function _govuk-line-height', () => {
         line-height: _govuk-line-height($line-height: 2em, $font-size: 20px);
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -198,7 +198,7 @@ describe('@function _govuk-line-height', () => {
         line-height: _govuk-line-height($line-height: 30px, $font-size: 20px);
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -215,7 +215,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-typography-responsive($size: 14)
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -237,7 +237,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-typography-responsive($size: 12)
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe(outdent`
       .foo {
@@ -258,7 +258,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-typography-responsive(3.14159265359)
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(compileSassString(sass, sassConfig))
       .rejects
       .toThrow(
         'Unknown font size `3.14159` - expected a point from the typography scale.'
@@ -274,7 +274,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 14, $important: true);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -296,7 +296,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 12, $important: true);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -319,7 +319,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 14, $override-line-height: 21px);
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -351,7 +351,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 14)
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -373,7 +373,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 14)
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -395,7 +395,7 @@ describe('@mixin govuk-typography-responsive', () => {
             @include govuk-typography-responsive($size: 14, $important: true);
           }`
 
-        const results = await renderSass({ data: sass, ...sassConfig })
+        const results = await compileSassString(sass, sassConfig)
 
         expect(results.css.toString().trim()).toBe(outdent`
           .foo {
@@ -413,7 +413,7 @@ describe('@mixin govuk-typography-responsive', () => {
         $govuk-typography-use-rem: false;
         ${sassBootstrap}`
 
-      await renderSass({ data: sass, ...sassConfig }).then(() => {
+      await compileSassString(sass, sassConfig).then(() => {
         // Get the argument of the last @warn call, which we expect to be the
         // deprecation notice
         return expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())
@@ -437,7 +437,7 @@ describe('@mixin govuk-typography-responsive', () => {
           @include govuk-typography-responsive($size: 14)
         }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -461,7 +461,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString().trim()).toBe(outdent`
         .foo {
@@ -490,7 +490,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $tabular: true)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
       const css = results.css.toString()
 
       expect(css).toContain('font-feature-settings: "tnum" 1;')
@@ -511,7 +511,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $tabular: true)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
       const css = results.css.toString()
 
       expect(css).toContain('font-family: "ntatabularnumbers"')
@@ -526,7 +526,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 12)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('font-size: 12px')
       expect(results.css.toString()).not.toContain('font-size: 14px')
@@ -540,7 +540,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: false)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('font-size')
     })
@@ -555,7 +555,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $weight: bold)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('font-weight: 700')
     })
@@ -570,7 +570,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $weight: false)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('font-weight')
     })
@@ -585,7 +585,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $weight: superdupermegabold)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).not.toContain('font-weight')
     })
@@ -600,7 +600,7 @@ describe('@mixin govuk-typography-responsive', () => {
         @include govuk-font($size: 14, $line-height: 1.337)
       }`
 
-      const results = await renderSass({ data: sass, ...sassConfig })
+      const results = await compileSassString(sass, sassConfig)
 
       expect(results.css.toString()).toContain('line-height: 1.337;')
     })
@@ -613,7 +613,7 @@ describe('$govuk-font-family-tabular value is specified', () => {
     $govuk-font-family-tabular: monospace;
       ${sassBootstrap}`
 
-    await renderSass({ data: sass, ...sassConfig }).then(() => {
+    await compileSassString(sass, sassConfig).then(() => {
       // Get the argument of the last @warn call, which we expect to be the
       // deprecation notice
       return expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -1,4 +1,3 @@
-
 const sass = require('node-sass')
 const { outdent } = require('outdent')
 
@@ -43,119 +42,144 @@ let sassBootstrap = `
     )
   );
 
-  @import "base";`
+  @import "base";
+`
 
 describe('@mixin govuk-typography-common', () => {
   it('should output a @font-face declaration by default', async () => {
     const sass = `
-    @import "settings/all";
-    @import "helpers/all";
-    @import "tools/ie8";
+      @import "settings/all";
+      @import "helpers/all";
+      @import "tools/ie8";
 
-    :root {
-      @include govuk-typography-common;
-    }
-    :root {
-      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
-    }
+      :root {
+        @include govuk-typography-common;
+      }
+      :root {
+        @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+      }
     `
 
-    const results = await compileSassString(sass, sassConfig)
-    const resultsString = results.css.toString()
+    const results = compileSassString(sass)
 
-    expect(resultsString).toContain('@font-face')
-    expect(resultsString).toContain('font-family: "GDS Transport"')
-    expect(resultsString).toContain('font-family: "GDS Transport"')
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('@font-face')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-family: "GDS Transport"')
+    })
   })
 
   it('should not output a @font-face declaration when the user has changed their font', async () => {
     const sass = `
-    $govuk-font-family: Helvetica, Arial, sans-serif;
-    $govuk-font-family-tabular: monospace;
-    @import "settings/all";
-    @import "helpers/all";
+      $govuk-font-family: Helvetica, Arial, sans-serif;
+      $govuk-font-family-tabular: monospace;
+      @import "settings/all";
+      @import "helpers/all";
 
-    :root {
-      @include govuk-typography-common;
-    }
-    :root {
-      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
-    }
+      :root {
+        @include govuk-typography-common;
+      }
+      :root {
+        @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+      }
     `
 
-    const results = await compileSassString(sass, sassConfig)
-    const resultsString = results.css.toString()
+    const results = compileSassString(sass)
 
-    expect(resultsString).not.toContain('@font-face')
-    expect(resultsString).not.toContain('font-family: "GDS Transport"')
-    expect(resultsString).not.toContain('font-family: "ntatabularnumbers"')
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('@font-face')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('font-family: "GDS Transport"')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('font-family: "ntatabularnumbers"')
+    })
   })
 
   it('should not output a @font-face declaration when the user wants compatibility with GOV.UK Template', async () => {
     const sass = `
-    $govuk-compatibility-govuktemplate: true;
-    @import "settings/all";
-    @import "helpers/all";
+      $govuk-compatibility-govuktemplate: true;
+      @import "settings/all";
+      @import "helpers/all";
 
-    :root {
-      @include govuk-typography-common;
-    }
-    :root {
-      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
-    }
+      :root {
+        @include govuk-typography-common;
+      }
+      :root {
+        @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+      }
     `
 
-    const results = await compileSassString(sass, sassConfig)
-    const resultsString = results.css.toString()
+    const results = compileSassString(sass)
 
-    expect(resultsString).not.toContain('@font-face')
-    expect(resultsString).toContain('font-family: "nta"')
-    expect(resultsString).toContain('font-family: "ntatabularnumbers"')
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('@font-face')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-family: "nta"')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-family: "ntatabularnumbers"')
+    })
   })
 
   it('should not output a @font-face declaration when the user has turned off this feature', async () => {
     const sass = `
-    $govuk-include-default-font-face: false;
-    @import "settings/all";
-    @import "helpers/all";
+      $govuk-include-default-font-face: false;
+      @import "settings/all";
+      @import "helpers/all";
 
-    :root {
-      @include govuk-typography-common;
-    }
-    :root {
-      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
-    }
+      :root {
+        @include govuk-typography-common;
+      }
+      :root {
+        @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+      }
     `
 
-    const results = await compileSassString(sass, sassConfig)
-    const resultsString = results.css.toString()
+    const results = compileSassString(sass)
 
-    expect(resultsString).not.toContain('@font-face')
-    expect(resultsString).toContain('font-family: "GDS Transport"')
-    expect(resultsString).toContain('font-family: "GDS Transport"')
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('@font-face')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-family: "GDS Transport"')
+    })
   })
 
   it('should not output a @font-face declaration when the browser is IE8', async () => {
     const sass = `
-    $govuk-is-ie8: true;
+      $govuk-is-ie8: true;
 
-    @import "settings/all";
-    @import "helpers/all";
-    @import "tools/ie8";
+      @import "settings/all";
+      @import "helpers/all";
+      @import "tools/ie8";
 
-    :root {
-      @include govuk-typography-common;
-    }
-    :root {
-      @include govuk-typography-common($font-family: $govuk-font-family-tabular);
-    }
+      :root {
+        @include govuk-typography-common;
+      }
+      :root {
+        @include govuk-typography-common($font-family: $govuk-font-family-tabular);
+      }
     `
 
-    const results = await compileSassString(sass, sassConfig)
-    const resultsString = results.css.toString()
+    const results = compileSassString(sass)
 
-    expect(resultsString).not.toContain('@font-face')
-    expect(resultsString).toContain('font-family: "GDS Transport"')
+    await expect(results).resolves.toMatchObject({
+      css: expect.not.stringContaining('@font-face')
+    })
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-family: "GDS Transport"')
+    })
   })
 })
 
@@ -166,13 +190,17 @@ describe('@function _govuk-line-height', () => {
 
       .foo {
         line-height: _govuk-line-height($line-height: 3.141, $font-size: 20px);
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        line-height: 3.141; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            line-height: 3.141; }
+        `
+      })
   })
 
   it('preserves line-height if using different units', async () => {
@@ -181,13 +209,17 @@ describe('@function _govuk-line-height', () => {
 
       .foo {
         line-height: _govuk-line-height($line-height: 2em, $font-size: 20px);
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        line-height: 2em; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            line-height: 2em; }
+        `
+      })
   })
 
   it('converts line-height to a relative number', async () => {
@@ -196,13 +228,17 @@ describe('@function _govuk-line-height', () => {
 
       .foo {
         line-height: _govuk-line-height($line-height: 30px, $font-size: 20px);
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        line-height: 1.5; }`)
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            line-height: 1.5; }
+        `
+      })
   })
 })
 
@@ -213,20 +249,24 @@ describe('@mixin govuk-typography-responsive', () => {
 
       .foo {
         @include govuk-typography-responsive($size: 14)
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        font-size: 12px;
-        font-size: 0.75rem;
-        line-height: 1.25; }
-        @media (min-width: 30em) {
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
           .foo {
-            font-size: 14px;
-            font-size: 0.875rem;
-            line-height: 1.42857; } }`)
+            font-size: 12px;
+            font-size: 0.75rem;
+            line-height: 1.25; }
+            @media (min-width: 30em) {
+              .foo {
+                font-size: 14px;
+                font-size: 0.875rem;
+                line-height: 1.42857; } }
+        `
+      })
   })
 
   it('outputs CSS with suitable media queries for print', async () => {
@@ -235,19 +275,23 @@ describe('@mixin govuk-typography-responsive', () => {
 
       .foo {
         @include govuk-typography-responsive($size: 12)
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe(outdent`
-      .foo {
-        font-size: 12px;
-        font-size: 0.75rem;
-        line-height: 1.25; }
-        @media print {
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
           .foo {
-            font-size: 14pt;
-            line-height: 1.5; } }`)
+            font-size: 12px;
+            font-size: 0.75rem;
+            line-height: 1.25; }
+            @media print {
+              .foo {
+                font-size: 14pt;
+                line-height: 1.5; } }
+        `
+      })
   })
 
   it('throws an exception when passed a size that is not in the scale', async () => {
@@ -256,7 +300,8 @@ describe('@mixin govuk-typography-responsive', () => {
 
       .foo {
         @include govuk-typography-responsive(3.14159265359)
-      }`
+      }
+    `
 
     await expect(compileSassString(sass, sassConfig))
       .rejects
@@ -272,20 +317,24 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 14, $important: true);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px !important;
-          font-size: 0.75rem !important;
-          line-height: 1.25 !important; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14px !important;
-              font-size: 0.875rem !important;
-              line-height: 1.42857 !important; } }`)
+              font-size: 12px !important;
+              font-size: 0.75rem !important;
+              line-height: 1.25 !important; }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px !important;
+                  font-size: 0.875rem !important;
+                  line-height: 1.42857 !important; } }
+          `
+        })
     })
 
     it('marks font-size and line-height as important for print media', async () => {
@@ -294,19 +343,23 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 12, $important: true);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px !important;
-          font-size: 0.75rem !important;
-          line-height: 1.25 !important; }
-          @media print {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14pt !important;
-              line-height: 1.5 !important; } }`)
+              font-size: 12px !important;
+              font-size: 0.75rem !important;
+              line-height: 1.25 !important; }
+              @media print {
+                .foo {
+                  font-size: 14pt !important;
+                  line-height: 1.5 !important; } }
+          `
+        })
     })
   })
 
@@ -317,20 +370,24 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 14, $override-line-height: 21px);
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px;
-          font-size: 0.75rem;
-          line-height: 1.75; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14px;
-              font-size: 0.875rem;
-              line-height: 1.5; } }`)
+              font-size: 12px;
+              font-size: 0.75rem;
+              line-height: 1.75; }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px;
+                  font-size: 0.875rem;
+                  line-height: 1.5; } }
+          `
+        })
     })
   })
 
@@ -349,18 +406,22 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 14)
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px;
-          line-height: 1.25; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14px;
-              line-height: 1.42857; } }`)
+              font-size: 12px;
+              line-height: 1.25; }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px;
+                  line-height: 1.42857; } }
+          `
+        })
     })
 
     it('adjusts rem values based on root font size', async () => {
@@ -371,18 +432,22 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 14)
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px;
-          line-height: 1.25; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14px;
-              line-height: 1.42857; } }`)
+              font-size: 12px;
+              line-height: 1.25; }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px;
+                  line-height: 1.42857; } }
+          `
+        })
     })
 
     describe('and $important is set to true', () => {
@@ -393,37 +458,42 @@ describe('@mixin govuk-typography-responsive', () => {
 
           .foo {
             @include govuk-typography-responsive($size: 14, $important: true);
-          }`
+          }
+        `
 
-        const results = await compileSassString(sass, sassConfig)
-
-        expect(results.css.toString().trim()).toBe(outdent`
-          .foo {
-            font-size: 12px !important;
-            line-height: 1.25 !important; }
-            @media (min-width: 30em) {
+        await expect(compileSassString(sass))
+          .resolves
+          .toMatchObject({
+            css: outdent`
               .foo {
-                font-size: 14px !important;
-                line-height: 1.42857 !important; } }`)
+                font-size: 12px !important;
+                line-height: 1.25 !important; }
+                @media (min-width: 30em) {
+                  .foo {
+                    font-size: 14px !important;
+                    line-height: 1.42857 !important; } }
+            `
+          })
       })
     })
 
     it('outputs a deprecation warning when set to false', async () => {
       const sass = `
         $govuk-typography-use-rem: false;
-        ${sassBootstrap}`
+        ${sassBootstrap}
+      `
 
-      await compileSassString(sass, sassConfig).then(() => {
-        // Get the argument of the last @warn call, which we expect to be the
-        // deprecation notice
-        return expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())
-          .toEqual(
-            '$govuk-typography-use-rem is deprecated. From version 5.0, ' +
-            'GOV.UK Frontend will not support disabling rem font sizes. To ' +
-            'silence this warning, update $govuk-suppressed-warnings with ' +
-            'key: "allow-not-using-rem"'
-          )
-      })
+      await compileSassString(sass, sassConfig)
+
+      // Get the argument of the last @warn call, which we expect to be the
+      // deprecation notice
+      return expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())
+        .toEqual(
+          '$govuk-typography-use-rem is deprecated. From version 5.0, ' +
+          'GOV.UK Frontend will not support disabling rem font sizes. To ' +
+          'silence this warning, update $govuk-suppressed-warnings with ' +
+          'key: "allow-not-using-rem"'
+        )
     })
   })
 
@@ -435,174 +505,203 @@ describe('@mixin govuk-typography-responsive', () => {
 
         .foo {
           @include govuk-typography-responsive($size: 14)
-        }`
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
-        .foo {
-          font-size: 12px;
-          line-height: 1.25; }
-          @media (min-width: 30em) {
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-size: 14px;
-              line-height: 1.42857; } }`)
+              font-size: 12px;
+              line-height: 1.25; }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px;
+                  line-height: 1.42857; } }
+          `
+        })
     })
   })
 
   describe('@mixin govuk-font', () => {
     it('outputs all required typographic CSS properties', async () => {
       const sass = `
-      // Avoid font face being output in tests
-      $govuk-include-default-font-face: false;
-      ${sassBootstrap}
+        // Avoid font face being output in tests
+        $govuk-include-default-font-face: false;
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14)
-      }`
-
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString().trim()).toBe(outdent`
         .foo {
-          font-family: "GDS Transport", arial, sans-serif;
-          -webkit-font-smoothing: antialiased;
-          -moz-osx-font-smoothing: grayscale;
-          font-weight: 400;
-          font-size: 12px;
-          font-size: 0.75rem;
-          line-height: 1.25; }
-          @media print {
+          @include govuk-font($size: 14)
+        }
+      `
+
+      await expect(compileSassString(sass))
+        .resolves
+        .toMatchObject({
+          css: outdent`
             .foo {
-              font-family: sans-serif; } }
-          @media (min-width: 30em) {
-            .foo {
-              font-size: 14px;
-              font-size: 0.875rem;
-              line-height: 1.42857; } }`)
+              font-family: "GDS Transport", arial, sans-serif;
+              -webkit-font-smoothing: antialiased;
+              -moz-osx-font-smoothing: grayscale;
+              font-weight: 400;
+              font-size: 12px;
+              font-size: 0.75rem;
+              line-height: 1.25; }
+              @media print {
+                .foo {
+                  font-family: sans-serif; } }
+              @media (min-width: 30em) {
+                .foo {
+                  font-size: 14px;
+                  font-size: 0.875rem;
+                  line-height: 1.42857; } }
+          `
+        })
     })
 
     it('enables tabular numbers opentype feature flags if $tabular: true', async () => {
       const sass = `
-      ${sassBootstrap}
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $tabular: true)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $tabular: true)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-      const css = results.css.toString()
+      const results = compileSassString(sass)
 
-      expect(css).toContain('font-feature-settings: "tnum" 1;')
-      expect(css).toContain(outdent`
-      ${outdent}
-        @supports (font-variant-numeric: tabular-nums) {
-          .foo {
-            font-feature-settings: normal;
-            font-variant-numeric: tabular-nums; } }`)
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('font-feature-settings: "tnum" 1;')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining(outdent`
+          @supports (font-variant-numeric: tabular-nums) {
+              .foo {
+                font-feature-settings: normal;
+                font-variant-numeric: tabular-nums; } }
+        `)
+      })
     })
 
     it('uses the tabular font instead if defined and $tabular: true', async () => {
       const sass = `
-      $govuk-font-family-tabular: "ntatabularnumbers";
-      ${sassBootstrap}
+        $govuk-font-family-tabular: "ntatabularnumbers";
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $tabular: true)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $tabular: true)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-      const css = results.css.toString()
+      const results = compileSassString(sass)
 
-      expect(css).toContain('font-family: "ntatabularnumbers"')
-      expect(css).not.toContain('font-feature-settings')
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('font-family: "ntatabularnumbers"')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.not.stringContaining('font-feature-settings')
+      })
     })
 
     it('sets font-size based on $size', async () => {
       const sass = `
-      ${sassBootstrap}
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 12)
-      }`
+        .foo {
+          @include govuk-font($size: 12)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
+      const results = compileSassString(sass)
 
-      expect(results.css.toString()).toContain('font-size: 12px')
-      expect(results.css.toString()).not.toContain('font-size: 14px')
+      await expect(results).resolves.toMatchObject({
+        css: expect.stringContaining('font-size: 12px')
+      })
+
+      await expect(results).resolves.toMatchObject({
+        css: expect.not.stringContaining('font-size: 14px')
+      })
     })
 
     it('does not output font-size if $size: false', async () => {
       const sass = `
-      ${sassBootstrap}
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: false)
-      }`
+        .foo {
+          @include govuk-font($size: false)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('font-size')
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: expect.not.stringContaining('font-size')
+      })
     })
 
     it('sets font-weight based on $weight', async () => {
       const sass = `
-      // Avoid font face being output in tests
-      $govuk-include-default-font-face: false;
-      ${sassBootstrap}
+        // Avoid font face being output in tests
+        $govuk-include-default-font-face: false;
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $weight: bold)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $weight: bold)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).toContain('font-weight: 700')
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: expect.stringContaining('font-weight: 700')
+      })
     })
 
     it('does not output font-weight if $weight: false', async () => {
       const sass = `
-      // Avoid font face being output in tests
-      $govuk-include-default-font-face: false;
-      ${sassBootstrap}
+        // Avoid font face being output in tests
+        $govuk-include-default-font-face: false;
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $weight: false)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $weight: false)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('font-weight')
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: expect.not.stringContaining('font-weight')
+      })
     })
 
     it('ignores undefined font-weights', async () => {
       const sass = `
-      // Avoid font face being output in tests
-      $govuk-include-default-font-face: false;
-      ${sassBootstrap}
+        // Avoid font face being output in tests
+        $govuk-include-default-font-face: false;
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $weight: superdupermegabold)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $weight: superdupermegabold)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).not.toContain('font-weight')
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: expect.not.stringContaining('font-weight')
+      })
     })
 
     it('sets line-height based on $line-height', async () => {
       const sass = `
-      // Avoid font face being output in tests
-      $govuk-include-default-font-face: false;
-      ${sassBootstrap}
+        // Avoid font face being output in tests
+        $govuk-include-default-font-face: false;
+        ${sassBootstrap}
 
-      .foo {
-        @include govuk-font($size: 14, $line-height: 1.337)
-      }`
+        .foo {
+          @include govuk-font($size: 14, $line-height: 1.337)
+        }
+      `
 
-      const results = await compileSassString(sass, sassConfig)
-
-      expect(results.css.toString()).toContain('line-height: 1.337;')
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: expect.stringContaining('line-height: 1.337;')
+      })
     })
   })
 })
@@ -610,19 +709,20 @@ describe('@mixin govuk-typography-responsive', () => {
 describe('$govuk-font-family-tabular value is specified', () => {
   it('outputs a deprecation warning when set', async () => {
     const sass = `
-    $govuk-font-family-tabular: monospace;
-      ${sassBootstrap}`
+      $govuk-font-family-tabular: monospace;
+      ${sassBootstrap}
+    `
 
-    await compileSassString(sass, sassConfig).then(() => {
-      // Get the argument of the last @warn call, which we expect to be the
-      // deprecation notice
-      return expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())
-        .toEqual(
-          '$govuk-font-family-tabular is deprecated. From version 5.0, ' +
-          'GOV.UK Frontend will not support using a separate font-face for ' +
-          'tabular numbers. To silence this warning, update ' +
-          '$govuk-suppressed-warnings with key: "tabular-font-face"'
-        )
-    })
+    await compileSassString(sass, sassConfig)
+
+    // Get the argument of the last @warn call, which we expect to be the
+    // deprecation notice
+    expect(mockWarnFunction.mock.calls.at(-1)[0].getValue())
+      .toEqual(
+        '$govuk-font-family-tabular is deprecated. From version 5.0, ' +
+        'GOV.UK Frontend will not support using a separate font-face for ' +
+        'tabular numbers. To silence this warning, update ' +
+        '$govuk-suppressed-warnings with key: "tabular-font-face"'
+      )
   })
 })

--- a/src/govuk/helpers/typography.test.js
+++ b/src/govuk/helpers/typography.test.js
@@ -10,7 +10,6 @@ const mockWarnFunction = jest.fn()
   .mockReturnValue(sass.NULL)
 
 const sassConfig = {
-  outputStyle: 'nested',
   functions: {
     '@warn': mockWarnFunction
   }

--- a/src/govuk/objects/objects.test.js
+++ b/src/govuk/objects/objects.test.js
@@ -20,7 +20,7 @@ describe('The objects layer', () => {
       const file = join(configPaths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
-        css: expect.any(Object),
+        css: expect.any(String),
         stats: expect.any(Object)
       })
     })

--- a/src/govuk/objects/objects.test.js
+++ b/src/govuk/objects/objects.test.js
@@ -4,7 +4,7 @@ const sassdoc = require('sassdoc')
 
 const configPaths = require('../../../config/paths')
 const { getListing } = require('../../../lib/file-helper')
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassFile } = require('../../../lib/jest-helpers')
 
 describe('The objects layer', () => {
   let sassFiles
@@ -19,12 +19,10 @@ describe('The objects layer', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
       const file = join(configPaths.src, sassFilePath)
 
-      return expect(renderSass({ file })).resolves.toEqual(
-        expect.objectContaining({
-          css: expect.any(Object),
-          stats: expect.any(Object)
-        })
-      )
+      return expect(compileSassFile(file)).resolves.toMatchObject({
+        css: expect.any(Object),
+        stats: expect.any(Object)
+      })
     })
 
     return Promise.all(sassTasks)

--- a/src/govuk/objects/width-container.test.js
+++ b/src/govuk/objects/width-container.test.js
@@ -11,36 +11,34 @@ describe('@mixin govuk-width-container', () => {
         @include govuk-width-container(1200px);
       }
     `
-    const results = await compileSassString(sass)
 
-    expect(results.css
-      .toString()
-      .trim())
-      .toContain(outdent`
-      .app-width-container--wide {
-        max-width: 1200px;
-        margin-right: 15px;
-        margin-left: 15px; }
-        @supports (margin: max(calc(0px))) {
-          .app-width-container--wide {
-            margin-right: max(15px, calc(15px + env(safe-area-inset-right)));
-            margin-left: max(15px, calc(15px + env(safe-area-inset-left))); } }
-        @media (min-width: 40.0625em) {
-          .app-width-container--wide {
-            margin-right: 30px;
-            margin-left: 30px; }
-            @supports (margin: max(calc(0px))) {
-              .app-width-container--wide {
-                margin-right: max(30px, calc(15px + env(safe-area-inset-right)));
-                margin-left: max(30px, calc(15px + env(safe-area-inset-left))); } } }
-        @media (min-width: 1260px) {
-          .app-width-container--wide {
-            margin-right: auto;
-            margin-left: auto; }
-            @supports (margin: max(calc(0px))) {
-              .app-width-container--wide {
-                margin-right: auto;
-                margin-left: auto; } } }
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: expect.stringContaining(outdent`
+        .app-width-container--wide {
+          max-width: 1200px;
+          margin-right: 15px;
+          margin-left: 15px; }
+          @supports (margin: max(calc(0px))) {
+            .app-width-container--wide {
+              margin-right: max(15px, calc(15px + env(safe-area-inset-right)));
+              margin-left: max(15px, calc(15px + env(safe-area-inset-left))); } }
+          @media (min-width: 40.0625em) {
+            .app-width-container--wide {
+              margin-right: 30px;
+              margin-left: 30px; }
+              @supports (margin: max(calc(0px))) {
+                .app-width-container--wide {
+                  margin-right: max(30px, calc(15px + env(safe-area-inset-right)));
+                  margin-left: max(30px, calc(15px + env(safe-area-inset-left))); } } }
+          @media (min-width: 1260px) {
+            .app-width-container--wide {
+              margin-right: auto;
+              margin-left: auto; }
+              @supports (margin: max(calc(0px))) {
+                .app-width-container--wide {
+                  margin-right: auto;
+                  margin-left: auto; } } }
       `)
+    })
   })
 })

--- a/src/govuk/objects/width-container.test.js
+++ b/src/govuk/objects/width-container.test.js
@@ -17,27 +17,41 @@ describe('@mixin govuk-width-container', () => {
         .app-width-container--wide {
           max-width: 1200px;
           margin-right: 15px;
-          margin-left: 15px; }
+          margin-left: 15px;
+        }
+
+        @supports (margin: max(calc(0px))) {
+          .app-width-container--wide {
+            margin-right: max(15px, calc(15px + env(safe-area-inset-right)));
+            margin-left: max(15px, calc(15px + env(safe-area-inset-left)));
+          }
+        }
+
+        @media (min-width: 40.0625em) {
+          .app-width-container--wide {
+            margin-right: 30px;
+            margin-left: 30px;
+          }
           @supports (margin: max(calc(0px))) {
             .app-width-container--wide {
-              margin-right: max(15px, calc(15px + env(safe-area-inset-right)));
-              margin-left: max(15px, calc(15px + env(safe-area-inset-left))); } }
-          @media (min-width: 40.0625em) {
-            .app-width-container--wide {
-              margin-right: 30px;
-              margin-left: 30px; }
-              @supports (margin: max(calc(0px))) {
-                .app-width-container--wide {
-                  margin-right: max(30px, calc(15px + env(safe-area-inset-right)));
-                  margin-left: max(30px, calc(15px + env(safe-area-inset-left))); } } }
-          @media (min-width: 1260px) {
+              margin-right: max(30px, calc(15px + env(safe-area-inset-right)));
+              margin-left: max(30px, calc(15px + env(safe-area-inset-left)));
+            }
+          }
+        }
+
+        @media (min-width: 1260px) {
+          .app-width-container--wide {
+            margin-right: auto;
+            margin-left: auto;
+          }
+          @supports (margin: max(calc(0px))) {
             .app-width-container--wide {
               margin-right: auto;
-              margin-left: auto; }
-              @supports (margin: max(calc(0px))) {
-                .app-width-container--wide {
-                  margin-right: auto;
-                  margin-left: auto; } } }
+              margin-left: auto;
+            }
+          }
+        }
       `)
     })
   })

--- a/src/govuk/objects/width-container.test.js
+++ b/src/govuk/objects/width-container.test.js
@@ -2,10 +2,6 @@ const { outdent } = require('outdent')
 
 const { renderSass } = require('../../../lib/jest-helpers')
 
-const sassConfig = {
-  outputStyle: 'nested'
-}
-
 describe('@mixin govuk-width-container', () => {
   it('allows different widths to be specified using $width', async () => {
     const sass = `
@@ -15,7 +11,7 @@ describe('@mixin govuk-width-container', () => {
         @include govuk-width-container(1200px);
       }
     `
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await renderSass({ data: sass })
 
     expect(results.css
       .toString()

--- a/src/govuk/objects/width-container.test.js
+++ b/src/govuk/objects/width-container.test.js
@@ -1,6 +1,6 @@
 const { outdent } = require('outdent')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 describe('@mixin govuk-width-container', () => {
   it('allows different widths to be specified using $width', async () => {
@@ -11,7 +11,7 @@ describe('@mixin govuk-width-container', () => {
         @include govuk-width-container(1200px);
       }
     `
-    const results = await renderSass({ data: sass })
+    const results = await compileSassString(sass)
 
     expect(results.css
       .toString()

--- a/src/govuk/settings/colours.test.js
+++ b/src/govuk/settings/colours.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compressed'
@@ -29,6 +29,6 @@ describe('Organisation colours', () => {
         }
       }`
 
-    await renderSass({ data: sass, ...sassConfig })
+    await compileSassString(sass, sassConfig)
   })
 })

--- a/src/govuk/settings/colours.test.js
+++ b/src/govuk/settings/colours.test.js
@@ -27,8 +27,9 @@ describe('Organisation colours', () => {
           + " #{$colour} on #{$govuk-body-background-colour} has a contrast of: #{$contrast}."
           + " Must be higher than #{$minimum-contrast} for WCAG AA support.";
         }
-      }`
+      }
+    `
 
-    await compileSassString(sass, sassConfig)
+    await expect(compileSassString(sass, sassConfig)).resolves
   })
 })

--- a/src/govuk/settings/colours.test.js
+++ b/src/govuk/settings/colours.test.js
@@ -1,9 +1,5 @@
 const { compileSassString } = require('../../../lib/jest-helpers')
 
-const sassConfig = {
-  outputStyle: 'compressed'
-}
-
 describe('Organisation colours', () => {
   it('should define websafe colours that meet contrast requirements', async () => {
     const sass = `
@@ -30,6 +26,6 @@ describe('Organisation colours', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig)).resolves
+    await expect(compileSassString(sass)).resolves
   })
 })

--- a/src/govuk/settings/settings.test.js
+++ b/src/govuk/settings/settings.test.js
@@ -4,7 +4,7 @@ const sassdoc = require('sassdoc')
 
 const configPaths = require('../../../config/paths')
 const { getListing } = require('../../../lib/file-helper')
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassFile } = require('../../../lib/jest-helpers')
 
 describe('The settings layer', () => {
   let sassFiles
@@ -16,22 +16,20 @@ describe('The settings layer', () => {
   })
 
   it('should not output any CSS', async () => {
-    const settings = join(configPaths.src, 'govuk/settings/_all.scss')
+    const file = join(configPaths.src, 'govuk/settings/_all.scss')
 
-    const output = await renderSass({ file: settings })
-    expect(output.css.toString()).toEqual('')
+    const results = await compileSassFile(file)
+    expect(results.css.toString()).toEqual('')
   })
 
   it('renders CSS for all settings', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
       const file = join(configPaths.src, sassFilePath)
 
-      return expect(renderSass({ file })).resolves.toEqual(
-        expect.objectContaining({
-          css: expect.any(Object),
-          stats: expect.any(Object)
-        })
-      )
+      return expect(compileSassFile(file)).resolves.toMatchObject({
+        css: expect.any(Object),
+        stats: expect.any(Object)
+      })
     })
 
     return Promise.all(sassTasks)

--- a/src/govuk/settings/settings.test.js
+++ b/src/govuk/settings/settings.test.js
@@ -17,9 +17,7 @@ describe('The settings layer', () => {
 
   it('should not output any CSS', async () => {
     const file = join(configPaths.src, 'govuk/settings/_all.scss')
-
-    const results = await compileSassFile(file)
-    expect(results.css.toString()).toEqual('')
+    await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all settings', () => {
@@ -27,7 +25,7 @@ describe('The settings layer', () => {
       const file = join(configPaths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
-        css: expect.any(Object),
+        css: expect.any(String),
         stats: expect.any(Object)
       })
     })

--- a/src/govuk/settings/warnings.test.js
+++ b/src/govuk/settings/warnings.test.js
@@ -8,7 +8,6 @@ const mockWarnFunction = jest.fn()
   .mockReturnValue(sass.NULL)
 
 const sassConfig = {
-  outputStyle: 'compressed',
   functions: {
     '@warn': mockWarnFunction
   }

--- a/src/govuk/settings/warnings.test.js
+++ b/src/govuk/settings/warnings.test.js
@@ -19,42 +19,44 @@ describe('Warnings mixin', () => {
 
   it('Fires a @warn with the message plus the key suffix text', async () => {
     const sass = `
-    ${sassBootstrap}
-    @include _warning('test', 'This is a warning.');`
+      ${sassBootstrap}
+      @include _warning('test', 'This is a warning.');
+    `
 
-    await compileSassString(sass, sassConfig).then(() => {
-      // Expect our mocked @warn function to have been called once with a single
-      // argument, which should be the test message
-      return expect(mockWarnFunction.mock.calls[0][0].getValue())
-        .toEqual(
-          'This is a warning. To silence this warning, update ' +
-          '$govuk-suppressed-warnings with key: "test"'
-        )
-    })
+    await compileSassString(sass, sassConfig)
+
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the test message
+    expect(mockWarnFunction.mock.calls[0][0].getValue())
+      .toEqual(
+        'This is a warning. To silence this warning, update ' +
+        '$govuk-suppressed-warnings with key: "test"'
+      )
   })
 
   it('Only fires one @warn per warning key', async () => {
     const sass = `
-    ${sassBootstrap}
-    @include _warning('test', 'This is a warning.');
-    @include _warning('test', 'This is a warning.');`
+      ${sassBootstrap}
+      @include _warning('test', 'This is a warning.');
+      @include _warning('test', 'This is a warning.');
+    `
 
-    await compileSassString(sass, sassConfig).then(() => {
-      // Expect our mocked @warn function to have been called once with a single
-      // argument, which should be the test message
-      return expect(mockWarnFunction.mock.calls.length).toEqual(1)
-    })
+    await compileSassString(sass, sassConfig)
+
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the test message
+    expect(mockWarnFunction.mock.calls.length).toEqual(1)
   })
 
   it('Does not fire a @warn if the key is already in $govuk-suppressed-warnings', async () => {
     const sass = `
-    ${sassBootstrap}
+      ${sassBootstrap}
 
-    $govuk-suppressed-warnings: append($govuk-suppressed-warnings, 'test');
-    @include _warning('test', 'This is a warning.');`
+      $govuk-suppressed-warnings: append($govuk-suppressed-warnings, 'test');
+      @include _warning('test', 'This is a warning.');
+    `
 
-    await compileSassString(sass, sassConfig).then(() => {
-      return expect(mockWarnFunction).not.toHaveBeenCalled()
-    })
+    await compileSassString(sass, sassConfig)
+    expect(mockWarnFunction).not.toHaveBeenCalled()
   })
 })

--- a/src/govuk/settings/warnings.test.js
+++ b/src/govuk/settings/warnings.test.js
@@ -1,6 +1,6 @@
 const sass = require('node-sass')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
@@ -22,7 +22,7 @@ describe('Warnings mixin', () => {
     ${sassBootstrap}
     @include _warning('test', 'This is a warning.');`
 
-    await renderSass({ data: sass, ...sassConfig }).then(() => {
+    await compileSassString(sass, sassConfig).then(() => {
       // Expect our mocked @warn function to have been called once with a single
       // argument, which should be the test message
       return expect(mockWarnFunction.mock.calls[0][0].getValue())
@@ -39,7 +39,7 @@ describe('Warnings mixin', () => {
     @include _warning('test', 'This is a warning.');
     @include _warning('test', 'This is a warning.');`
 
-    await renderSass({ data: sass, ...sassConfig }).then(() => {
+    await compileSassString(sass, sassConfig).then(() => {
       // Expect our mocked @warn function to have been called once with a single
       // argument, which should be the test message
       return expect(mockWarnFunction.mock.calls.length).toEqual(1)
@@ -53,7 +53,7 @@ describe('Warnings mixin', () => {
     $govuk-suppressed-warnings: append($govuk-suppressed-warnings, 'test');
     @include _warning('test', 'This is a warning.');`
 
-    await renderSass({ data: sass, ...sassConfig }).then(() => {
+    await compileSassString(sass, sassConfig).then(() => {
       return expect(mockWarnFunction).not.toHaveBeenCalled()
     })
   })

--- a/src/govuk/tools/compatibility.test.js
+++ b/src/govuk/tools/compatibility.test.js
@@ -1,4 +1,5 @@
 const sass = require('node-sass')
+const outdent = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 
@@ -30,11 +31,12 @@ describe('@mixin govuk-compatibility', () => {
         .foo {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString()).toEqual('')
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({ css: '' })
   })
 
   it('outputs if the app is not marked as included', async () => {
@@ -48,11 +50,17 @@ describe('@mixin govuk-compatibility', () => {
         .foo {
           color: red;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toBe('.foo{color:red}')
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            color: red; }
+        `
+      })
   })
 
   it('throws an exception if the app is not recognised', async () => {
@@ -66,7 +74,8 @@ describe('@mixin govuk-compatibility', () => {
         .foo {
           color: red;
         }
-      }`
+      }
+    `
 
     await expect(compileSassString(sass, sassConfig))
       .rejects
@@ -84,17 +93,18 @@ describe('@mixin govuk-compatibility', () => {
         .foo {
           color: red;
         }
-      }`
+      }
+    `
 
-    await compileSassString(sass, sassConfig).then(() => {
-      // Expect our mocked @warn function to have been called once with a single
-      // argument, which should be the deprecation notice
-      return expect(mockWarnFunction.mock.calls[0][0].getValue())
-        .toEqual(
-          'govuk-compatibility is deprecated. From version 5.0, GOV.UK Frontend ' +
-          'will not support compatibility mode. To silence this warning, ' +
-          'update $govuk-suppressed-warnings with key: "compatibility-helper"'
-        )
-    })
+    await compileSassString(sass, sassConfig)
+
+    // Expect our mocked @warn function to have been called once with a single
+    // argument, which should be the deprecation notice
+    expect(mockWarnFunction.mock.calls[0][0].getValue())
+      .toEqual(
+        'govuk-compatibility is deprecated. From version 5.0, GOV.UK Frontend ' +
+        'will not support compatibility mode. To silence this warning, ' +
+        'update $govuk-suppressed-warnings with key: "compatibility-helper"'
+      )
   })
 })

--- a/src/govuk/tools/compatibility.test.js
+++ b/src/govuk/tools/compatibility.test.js
@@ -9,7 +9,6 @@ const mockWarnFunction = jest.fn()
   .mockReturnValue(sass.NULL)
 
 const sassConfig = {
-  outputStyle: 'compressed',
   functions: {
     '@warn': mockWarnFunction
   }
@@ -58,7 +57,8 @@ describe('@mixin govuk-compatibility', () => {
       .toMatchObject({
         css: outdent`
           .foo {
-            color: red; }
+            color: red;
+          }
         `
       })
   })

--- a/src/govuk/tools/compatibility.test.js
+++ b/src/govuk/tools/compatibility.test.js
@@ -1,6 +1,6 @@
 const sass = require('node-sass')
 
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
@@ -32,7 +32,7 @@ describe('@mixin govuk-compatibility', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString()).toEqual('')
   })
@@ -50,7 +50,7 @@ describe('@mixin govuk-compatibility', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toBe('.foo{color:red}')
   })
@@ -68,7 +68,7 @@ describe('@mixin govuk-compatibility', () => {
         }
       }`
 
-    await expect(renderSass({ data: sass, ...sassConfig }))
+    await expect(compileSassString(sass, sassConfig))
       .rejects
       .toThrow('Non existent product \'non_existent_app\'')
   })
@@ -86,7 +86,7 @@ describe('@mixin govuk-compatibility', () => {
         }
       }`
 
-    await renderSass({ data: sass, ...sassConfig }).then(() => {
+    await compileSassString(sass, sassConfig).then(() => {
       // Expect our mocked @warn function to have been called once with a single
       // argument, which should be the deprecation notice
       return expect(mockWarnFunction.mock.calls[0][0].getValue())

--- a/src/govuk/tools/exports.test.js
+++ b/src/govuk/tools/exports.test.js
@@ -19,11 +19,14 @@ describe('@mixin govuk-exports', () => {
         .foo {
           color: blue;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual('.foo{color:red}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo{color:red}'
+      })
   })
 
   it('will export differently named sections', async () => {
@@ -40,11 +43,13 @@ describe('@mixin govuk-exports', () => {
         .bar {
           color: blue;
         }
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim())
-      .toEqual('.foo{color:red}.bar{color:blue}')
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo{color:red}.bar{color:blue}'
+      })
   })
 })

--- a/src/govuk/tools/exports.test.js
+++ b/src/govuk/tools/exports.test.js
@@ -1,8 +1,6 @@
-const { compileSassString } = require('../../../lib/jest-helpers')
+const outdent = require('outdent')
 
-const sassConfig = {
-  outputStyle: 'compressed'
-}
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 describe('@mixin govuk-exports', () => {
   it('will only output a named section once', async () => {
@@ -22,10 +20,14 @@ describe('@mixin govuk-exports', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '.foo{color:red}'
+        css: outdent`
+          .foo {
+            color: red;
+          }
+        `
       })
   })
 
@@ -46,10 +48,18 @@ describe('@mixin govuk-exports', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '.foo{color:red}.bar{color:blue}'
+        css: outdent`
+          .foo {
+            color: red;
+          }
+
+          .bar {
+            color: blue;
+          }
+        `
       })
   })
 })

--- a/src/govuk/tools/exports.test.js
+++ b/src/govuk/tools/exports.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compressed'
@@ -21,7 +21,7 @@ describe('@mixin govuk-exports', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual('.foo{color:red}')
   })
@@ -42,7 +42,7 @@ describe('@mixin govuk-exports', () => {
         }
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim())
       .toEqual('.foo{color:red}.bar{color:blue}')

--- a/src/govuk/tools/font-url.test.js
+++ b/src/govuk/tools/font-url.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compressed'
@@ -16,7 +16,7 @@ describe('@function font-url', () => {
         src: govuk-font-url("whatever.woff2");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '@font-face{font-family:"whatever";src:url("/path/to/fonts/whatever.woff2")}'
@@ -34,7 +34,7 @@ describe('@function font-url', () => {
         src: govuk-font-url("whatever.woff2");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '@font-face{font-family:"whatever";src:"WHATEVER.WOFF2"}'
@@ -57,7 +57,7 @@ describe('@function font-url', () => {
         src: govuk-font-url("whatever.woff2");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '@font-face{font-family:"whatever";src:url("/custom/whatever.woff2")}'

--- a/src/govuk/tools/font-url.test.js
+++ b/src/govuk/tools/font-url.test.js
@@ -1,8 +1,6 @@
-const { compileSassString } = require('../../../lib/jest-helpers')
+const outdent = require('outdent')
 
-const sassConfig = {
-  outputStyle: 'compressed'
-}
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 describe('@function font-url', () => {
   it('by default concatenates the font path and the filename', async () => {
@@ -17,10 +15,15 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@font-face{font-family:"whatever";src:url("/path/to/fonts/whatever.woff2")}'
+        css: outdent`
+          @font-face {
+            font-family: "whatever";
+            src: url("/path/to/fonts/whatever.woff2");
+          }
+        `
       })
   })
 
@@ -37,10 +40,15 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@font-face{font-family:"whatever";src:"WHATEVER.WOFF2"}'
+        css: outdent`
+          @font-face {
+            font-family: "whatever";
+            src: "WHATEVER.WOFF2";
+          }
+        `
       })
   })
 
@@ -61,10 +69,15 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '@font-face{font-family:"whatever";src:url("/custom/whatever.woff2")}'
+        css: outdent`
+          @font-face {
+            font-family: "whatever";
+            src: url("/custom/whatever.woff2");
+          }
+        `
       })
   })
 })

--- a/src/govuk/tools/font-url.test.js
+++ b/src/govuk/tools/font-url.test.js
@@ -27,6 +27,7 @@ describe('@function font-url', () => {
     const sass = `
       @import "tools/font-url";
 
+      $govuk-fonts-path: '/path/to/fonts/';
       $govuk-font-url-function: 'to_upper_case';
 
       @font-face {

--- a/src/govuk/tools/font-url.test.js
+++ b/src/govuk/tools/font-url.test.js
@@ -14,13 +14,14 @@ describe('@function font-url', () => {
       @font-face {
         font-family: "whatever";
         src: govuk-font-url("whatever.woff2");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '@font-face{font-family:"whatever";src:url("/path/to/fonts/whatever.woff2")}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@font-face{font-family:"whatever";src:url("/path/to/fonts/whatever.woff2")}'
+      })
   })
 
   it('can be overridden to use a defined Sass function', async () => {
@@ -33,13 +34,14 @@ describe('@function font-url', () => {
       @font-face {
         font-family: "whatever";
         src: govuk-font-url("whatever.woff2");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '@font-face{font-family:"whatever";src:"WHATEVER.WOFF2"}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@font-face{font-family:"whatever";src:"WHATEVER.WOFF2"}'
+      })
   })
 
   it('can be overridden to use a custom function', async () => {
@@ -56,12 +58,13 @@ describe('@function font-url', () => {
       @font-face {
         font-family: "whatever";
         src: govuk-font-url("whatever.woff2");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '@font-face{font-family:"whatever";src:url("/custom/whatever.woff2")}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '@font-face{font-family:"whatever";src:url("/custom/whatever.woff2")}'
+      })
   })
 })

--- a/src/govuk/tools/image-url.test.js
+++ b/src/govuk/tools/image-url.test.js
@@ -1,4 +1,4 @@
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 const sassConfig = {
   outputStyle: 'compressed'
@@ -15,7 +15,7 @@ describe('@function image-url', () => {
         background-image: govuk-image-url("baz.png");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '.foo{background-image:url("/path/to/images/baz.png")}'
@@ -32,7 +32,7 @@ describe('@function image-url', () => {
         background-image: govuk-image-url("baz.png");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '.foo{background-image:"BAZ.PNG"}'
@@ -54,7 +54,7 @@ describe('@function image-url', () => {
         background-image: govuk-image-url("baz.png");
       }`
 
-    const results = await renderSass({ data: sass, ...sassConfig })
+    const results = await compileSassString(sass, sassConfig)
 
     expect(results.css.toString().trim()).toEqual(
       '.foo{background-image:url("/custom/baz.png")}'

--- a/src/govuk/tools/image-url.test.js
+++ b/src/govuk/tools/image-url.test.js
@@ -1,8 +1,6 @@
-const { compileSassString } = require('../../../lib/jest-helpers')
+const outdent = require('outdent')
 
-const sassConfig = {
-  outputStyle: 'compressed'
-}
+const { compileSassString } = require('../../../lib/jest-helpers')
 
 describe('@function image-url', () => {
   it('by default concatenates the image path and the filename', async () => {
@@ -16,10 +14,14 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '.foo{background-image:url("/path/to/images/baz.png")}'
+        css: outdent`
+          .foo {
+            background-image: url("/path/to/images/baz.png");
+          }
+        `
       })
   })
 
@@ -34,10 +36,14 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '.foo{background-image:"BAZ.PNG"}'
+        css: outdent`
+          .foo {
+            background-image: "BAZ.PNG";
+          }
+        `
       })
   })
 
@@ -57,10 +63,14 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
+    await expect(compileSassString(sass))
       .resolves
       .toMatchObject({
-        css: '.foo{background-image:url("/custom/baz.png")}'
+        css: outdent`
+          .foo {
+            background-image: url("/custom/baz.png");
+          }
+        `
       })
   })
 })

--- a/src/govuk/tools/image-url.test.js
+++ b/src/govuk/tools/image-url.test.js
@@ -13,13 +13,14 @@ describe('@function image-url', () => {
 
       .foo {
         background-image: govuk-image-url("baz.png");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '.foo{background-image:url("/path/to/images/baz.png")}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo{background-image:url("/path/to/images/baz.png")}'
+      })
   })
 
   it('can be overridden to use a defined Sass function', async () => {
@@ -30,13 +31,14 @@ describe('@function image-url', () => {
 
       .foo {
         background-image: govuk-image-url("baz.png");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '.foo{background-image:"BAZ.PNG"}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo{background-image:"BAZ.PNG"}'
+      })
   })
 
   it('can be overridden to use a custom function', async () => {
@@ -52,12 +54,13 @@ describe('@function image-url', () => {
 
       .foo {
         background-image: govuk-image-url("baz.png");
-      }`
+      }
+    `
 
-    const results = await compileSassString(sass, sassConfig)
-
-    expect(results.css.toString().trim()).toEqual(
-      '.foo{background-image:url("/custom/baz.png")}'
-    )
+    await expect(compileSassString(sass, sassConfig))
+      .resolves
+      .toMatchObject({
+        css: '.foo{background-image:url("/custom/baz.png")}'
+      })
   })
 })

--- a/src/govuk/tools/tools.test.js
+++ b/src/govuk/tools/tools.test.js
@@ -17,9 +17,7 @@ describe('The tools layer', () => {
 
   it('should not output any CSS', async () => {
     const file = join(configPaths.src, 'govuk/tools/_all.scss')
-
-    const results = await compileSassFile(file)
-    expect(results.css.toString()).toEqual('')
+    await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all tools', () => {
@@ -27,7 +25,7 @@ describe('The tools layer', () => {
       const file = join(configPaths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
-        css: expect.any(Object),
+        css: expect.any(String),
         stats: expect.any(Object)
       })
     })

--- a/src/govuk/tools/tools.test.js
+++ b/src/govuk/tools/tools.test.js
@@ -4,7 +4,7 @@ const sassdoc = require('sassdoc')
 
 const configPaths = require('../../../config/paths')
 const { getListing } = require('../../../lib/file-helper')
-const { renderSass } = require('../../../lib/jest-helpers')
+const { compileSassFile } = require('../../../lib/jest-helpers')
 
 describe('The tools layer', () => {
   let sassFiles
@@ -16,22 +16,20 @@ describe('The tools layer', () => {
   })
 
   it('should not output any CSS', async () => {
-    const tools = join(configPaths.src, 'govuk/tools/_all.scss')
+    const file = join(configPaths.src, 'govuk/tools/_all.scss')
 
-    const output = await renderSass({ file: tools })
-    expect(output.css.toString()).toEqual('')
+    const results = await compileSassFile(file)
+    expect(results.css.toString()).toEqual('')
   })
 
   it('renders CSS for all tools', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
       const file = join(configPaths.src, sassFilePath)
 
-      return expect(renderSass({ file })).resolves.toEqual(
-        expect.objectContaining({
-          css: expect.any(Object),
-          stats: expect.any(Object)
-        })
-      )
+      return expect(compileSassFile(file)).resolves.toMatchObject({
+        css: expect.any(Object),
+        stats: expect.any(Object)
+      })
     })
 
     return Promise.all(sassTasks)

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -4,7 +4,7 @@ import { join } from 'path'
 import configPaths from '../../../config/paths.js'
 import { filterPath, getDirectories, getListing, mapPathTo } from '../../../lib/file-helper.js'
 import { componentNameToClassName, componentPathToModuleName } from '../../../lib/helper-functions.js'
-import { renderSass } from '../../../lib/jest-helpers.js'
+import { compileSassFile } from '../../../lib/jest-helpers.js'
 
 describe('package/', () => {
   let listingSource
@@ -94,8 +94,8 @@ describe('package/', () => {
 
   describe('all.scss', () => {
     it('should compile without throwing an exception', async () => {
-      const allScssFile = join(configPaths.package, 'govuk', 'all.scss')
-      await renderSass({ file: allScssFile })
+      const file = join(configPaths.package, 'govuk', 'all.scss')
+      await compileSassFile(file)
     })
   })
 

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -95,7 +95,7 @@ describe('package/', () => {
   describe('all.scss', () => {
     it('should compile without throwing an exception', async () => {
       const file = join(configPaths.package, 'govuk', 'all.scss')
-      await compileSassFile(file)
+      await expect(compileSassFile(file)).resolves
     })
   })
 


### PR DESCRIPTION
Output styles `nested` and `compact` will no longer be supported in Dart Sass

This PR also includes:

1. **Asynchronous test assertions**
By using `await expect()` we get improved Jest test failure output vs unhandled promise exceptions

2. **Run Sass tests with separate “file” and “string” helpers**
Preparation for Dart Sass separate `compileAsync()` and `compileStringAsync()` methods