### PR TITLE
Fix Sass rounding issues with width of grid columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,10 +38,10 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#2998: Refactor back link and breadcrumb chevrons to use ems](https://github.com/alphagov/govuk-frontend/pull/2998)
 - [#3021: Printing style for current page link in header](https://github.com/alphagov/govuk-frontend/pull/3021) - thanks to [Malcolm Butler](https://github.com/MalcolmVonMoJ) for the contribution
-- [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
 - [#3094: Fix Accordion margin/padding inconsistencies](https://github.com/alphagov/govuk-frontend/pull/3094)
+- [#3112: Remove unused `classList` polyfill from header component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3112)
 - [#3150: Add missing `Event` polyfill to accordion component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3150)
-- [Correcting incorrect closing double quotes in pagination Nunjucks](https://github.com/alphagov/govuk-frontend/pull/3156)
+- [#3156: Correcting incorrect closing double quotes in pagination Nunjucks](https://github.com/alphagov/govuk-frontend/pull/3156)
 - [#3199: Fix Sass rounding issues with width of grid columns](https://github.com/alphagov/govuk-frontend/pull/3199)
 
 ## 4.4.1 (Fix release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ We've made fixes to GOV.UK Frontend in the following pull requests:
 - [#3094: Fix Accordion margin/padding inconsistencies](https://github.com/alphagov/govuk-frontend/pull/3094)
 - [#3150: Add missing `Event` polyfill to accordion component JavaScript](https://github.com/alphagov/govuk-frontend/pull/3150)
 - [Correcting incorrect closing double quotes in pagination Nunjucks](https://github.com/alphagov/govuk-frontend/pull/3156)
+- [#3199: Fix Sass rounding issues with width of grid columns](https://github.com/alphagov/govuk-frontend/pull/3199)
 
 ## 4.4.1 (Fix release)
 

--- a/src/govuk/helpers/grid.test.js
+++ b/src/govuk/helpers/grid.test.js
@@ -93,7 +93,7 @@ describe('grid system', () => {
           padding: 0 15px; }
           @media (min-width: 40.0625em) {
             .govuk-grid-column-two-thirds {
-              width: 66.6666%;
+              width: 66.66667%;
               float: left; } }
         `)
     })

--- a/src/govuk/settings/_measurements.scss
+++ b/src/govuk/settings/_measurements.scss
@@ -19,11 +19,11 @@ $govuk-page-width: 960px !default;
 /// @access public
 
 $govuk-grid-widths: (
-  one-quarter: 25%,
-  one-third: 33.3333%,
-  one-half: 50%,
-  two-thirds: 66.6666%,
-  three-quarters: 75%,
+  one-quarter: (100% / 4),
+  one-third: (100% / 3),
+  one-half: (100% / 2),
+  two-thirds: (200% / 3),
+  three-quarters: (300% / 4),
   full: 100%
 ) !default;
 


### PR DESCRIPTION
This PR changes our grid column percentage sizes so they're rounded to the maximum precision available to Sass

By rounding ⅔ to ~`66.6666%`~ **`66.6667%`** (note the 67 _not_ 66) we see browsers render our `one-third` and `two-thirds` grid column widths to whole pixels, which fixes https://github.com/alphagov/govuk-frontend/issues/2361

It appears that no change in `node-sass` decimal precision is necessary 🎉 

![Grid column rounding](https://user-images.githubusercontent.com/415517/214102127-2c3629fd-4ec7-4587-93ed-cef778474e89.png)

But we can go further by calculating `two-thirds: (200% / 3)` to add another decimal place:

### Before
```scss
.govuk-grid-column-two-thirds {
  width: 66.6666%;
  float: left;
}
```

### After
```scss
.govuk-grid-column-two-thirds {
  width: 66.66667%;
  float: left;
}
```

**Note:** Unlike [LibSass](https://sass-lang.com/libsass) (and `node-sass`) [Dart Sass](https://sass-lang.com/dart-sass) will output `66.6666666667%` with 10 decimal places of precision