### PR TITLE
Use consistent ignore patterns for Git, ESLint and Stylelint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,15 @@
 module.exports = {
   extends: 'standard',
   ignorePatterns: [
+    '**/dist/**',
+    '**/package/**',
+    '**/public/**',
+    '**/vendor/**',
+
+    // Enable dotfile linting
     '!.*',
-    'dist/**/*',
     'node_modules',
-    'node_modules/.*',
-    'package-lock.json',
-    'package/**/*',
-    'public/**/*',
-    'src/govuk/vendor/polyfills/**/*'
+    'node_modules/.*'
   ],
   overrides: [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,23 @@
+# Temporary only
+.cache/
+.tmp/
+
+# Node.js modules
 node_modules/
-npm-debug.log
-.DS_Store
-preview/
-tmp/
-axeReports/
+
+# Test coverage
 coverage/
-public/
-package/package-lock.json
-examples/**/package-lock.json
-*.zip
+
+# Build output
 jsdoc/
+public/
 sassdoc/
-.cache
+
+# Files to ignore
+.DS_Store
+*.zip
+*.log
+
+# Project lockfile only
+package-lock.json
+!/package-lock.json

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -12,7 +12,7 @@ module.exports = {
   //
   // https://github.com/okonet/lint-staged#how-can-i-ignore-files-from-eslintignore
   '*.{cjs,js,mjs}': filterTask('npm run lint:js:cli -- --fix'),
-  '*.scss': filterTask('npm run lint:scss:cli -- --fix')
+  '*.scss': 'npm run lint:scss:cli -- --fix --allow-empty-input'
 }
 
 // Configure paths to ignore

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -1,11 +1,13 @@
 module.exports = {
   extends: 'stylelint-config-gds/scss',
   ignoreFiles: [
-    '**/?(.)*.{cjs,js,mjs}',
-    'dist/**/*',
-    'package/**/*',
-    'public/**/*',
-    'src/govuk/vendor/**/*'
+    '**/dist/**',
+    '**/package/**',
+    '**/public/**',
+    '**/vendor/**',
+
+    // Ignore CSS-in-JS (including dotfiles)
+    '**/?(.)*.{cjs,js,mjs}'
   ],
   overrides: [
     {


### PR DESCRIPTION
This PR includes:

1. Remove unused `.gitignore` entries
2. Ignore pattern review for Git, ESLint and Stylelint
3. Ignore “build-but-committed” directories such as **./dist** and **./package**

We're making these changes because committing `*.scss` files into **./package** throws:

```console
✖ npm run lint:scss:cli -- --fix:
Error: All input files were ignored because of the ignore pattern. Either change your input, ignore pattern or use "--allow-empty-input" to allow no inputs
```

We've fixed this by adding the `--allow-empty-input` flag to skip already-ignored files

This was a lot easier than the fix for ESLint:

* https://github.com/alphagov/govuk-frontend/pull/3186

Which we've now consolidated into `filterTask()` should other linters need to ignore files in future