### PR TITLE
Tie Exit this Page skiplink into ghost page functionality

### DIFF
--- a/app/views/examples/exit-this-page-with-skiplink/index.njk
+++ b/app/views/examples/exit-this-page-with-skiplink/index.njk
@@ -6,7 +6,7 @@
 {% block skipLink %}
   {{ super() }}
   {{ govukSkipLink({
-    href: "#",
+    href: "https://www.gov.uk/",
     text: "Exit this page",
     classes: "govuk-js-exit-this-page-skiplink"
   }) }}
@@ -15,6 +15,6 @@
 {% block content %}
   {{ govukExitThisPage({
     text: "Exit this page",
-    redirectUrl: "#"
+    redirectUrl: "https://www.gov.uk/"
   }) }}
 {% endblock %}

--- a/app/views/examples/exit-this-page-with-skiplink/index.njk
+++ b/app/views/examples/exit-this-page-with-skiplink/index.njk
@@ -1,0 +1,20 @@
+{% extends "layout.njk" %}
+
+{% from "exit-this-page/macro.njk" import govukExitThisPage %}
+{% from "skip-link/macro.njk" import govukSkipLink %}
+
+{% block skipLink %}
+  {{ super() }}
+  {{ govukSkipLink({
+    href: "#",
+    text: "Exit this page",
+    classes: "govuk-js-exit-this-page-skiplink"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  {{ govukExitThisPage({
+    text: "Exit this page",
+    redirectUrl: "#"
+  }) }}
+{% endblock %}

--- a/app/views/full-page-examples/child-maintenance/index.njk
+++ b/app/views/full-page-examples/child-maintenance/index.njk
@@ -33,9 +33,9 @@ scenario: >-
 {% block skipLink %}
   {{ super() }}
   {{ govukSkipLink({
-    href: 'https://www.google.com/',
+    href: 'https://bbc.co.uk/weather/',
     text: 'Exit this page',
-    classes: 'govuk-js-exit-this-page-button'
+    classes: 'govuk-js-exit-this-page-skiplink'
   }) }}
 {% endblock %}
 

--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
 
+
 import { nodeListForEach } from '../../common.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Element/prototype/dataset.mjs'
@@ -14,6 +15,7 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
 function ExitThisPage ($module) {
   this.$module = $module
   this.$button = $module.querySelector('.govuk-exit-this-page__button')
+  this.$skiplinkButton = document.querySelector('.govuk-js-exit-this-page-skiplink')
   this.$updateSpan = null
   this.$indicatorContainer = null
   this.$overlay = null
@@ -35,10 +37,16 @@ ExitThisPage.prototype.initUpdateSpan = function () {
 }
 
 /**
- * Create button click handler.
+ * Create button click handlers.
  */
 ExitThisPage.prototype.initButtonClickHandler = function () {
+  // Main EtP button
   this.$button.addEventListener('click', this.exitPage.bind(this))
+
+  // EtP skiplink
+  if (this.$skiplinkButton) {
+    this.$skiplinkButton.addEventListener('click', this.exitPage.bind(this))
+  }
 }
 
 /**
@@ -105,8 +113,11 @@ ExitThisPage.prototype.updateIndicator = function () {
  * @param {MouseEvent} [e] - mouse click event
  */
 ExitThisPage.prototype.exitPage = function (e) {
+  var redirectUrl = this.$button.href
+
   if (typeof e !== 'undefined' && e.target) {
     e.preventDefault()
+    redirectUrl = e.target.href
   }
 
   // Blank the page
@@ -114,7 +125,7 @@ ExitThisPage.prototype.exitPage = function (e) {
   this.$overlay.className = 'govuk-exit-this-page__overlay'
   document.body.appendChild(this.$overlay)
 
-  window.location.href = this.$button.href
+  window.location.href = redirectUrl
 }
 
 /**

--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,6 +1,5 @@
 /* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
 
-
 import { nodeListForEach } from '../../common.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Element/prototype/dataset.mjs'

--- a/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -116,19 +116,5 @@ describe('/components/exit-this-page', () => {
       const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
       expect(ghostOverlay).not.toBeNull()
     })
-
-    it('hides the ghost page when the user navigates back in history', async () => {
-      await goToExample(page, 'exit-this-page-with-skiplink')
-
-      await Promise.all([
-        page.waitForNavigation(),
-        page.click(buttonClass)
-      ])
-
-      await page.goBack()
-
-      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
-      expect(ghostOverlay).toBeNull()
-    })
   })
 })

--- a/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -116,5 +116,19 @@ describe('/components/exit-this-page', () => {
       const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
       expect(ghostOverlay).not.toBeNull()
     })
+
+    it('hides the ghost page when the user navigates back in history', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(buttonClass)
+      ])
+
+      await page.goBack()
+
+      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      expect(ghostOverlay).toBeNull()
+    })
   })
 })

--- a/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -2,38 +2,119 @@
  * @jest-environment puppeteer
  */
 
-const { goToComponent } = require('../../../../lib/puppeteer-helpers')
+const { goToComponent, goToExample } = require('../../../../lib/puppeteer-helpers')
 
 const buttonClass = '.govuk-js-exit-this-page-button'
+const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
+const overlayClass = '.govuk-exit-this-page__overlay'
 
 describe('/components/exit-this-page', () => {
-  beforeEach(async () => {
-    await goToComponent(page, 'exit-this-page')
+  describe('when JavaScript is unavailable or fails', () => {
+    beforeAll(async () => {
+      await page.setJavaScriptEnabled(false)
+    })
+
+    afterAll(async () => {
+      await page.setJavaScriptEnabled(true)
+    })
+
+    it('navigates to the href of the button', async () => {
+      await goToComponent(page, 'exit-this-page')
+
+      const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(buttonClass)
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
+
+    it('navigates to the href of the skiplink', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      const href = await page.evaluate((skiplinkClass) => document.querySelector(skiplinkClass).href, skiplinkClass)
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
   })
 
-  it('navigates to the href of the button', async () => {
-    const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
+  describe('when JavaScript is available', () => {
+    it('navigates to the href of the button', async () => {
+      await goToComponent(page, 'exit-this-page')
 
-    await Promise.all([
-      page.waitForNavigation(),
-      page.click(buttonClass)
-    ])
+      const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
 
-    const url = await page.url()
-    expect(url).toBe(href)
-  })
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(buttonClass)
+      ])
 
-  it('activates the button functionality when the Shift key is pressed 3 times', async () => {
-    const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
 
-    await Promise.all([
-      page.keyboard.press('Shift'),
-      page.keyboard.press('Shift'),
-      page.keyboard.press('Shift'),
-      page.waitForNavigation()
-    ])
+    it('navigates to the href of the skiplink', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
 
-    const url = await page.url()
-    expect(url).toBe(href)
+      const href = await page.evaluate((skiplinkClass) => document.querySelector(skiplinkClass).href, skiplinkClass)
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
+
+    it('activates the button functionality when the Shift key is pressed 3 times', async () => {
+      await goToComponent(page, 'exit-this-page')
+
+      const href = await page.evaluate((buttonClass) => document.querySelector(buttonClass).href, buttonClass)
+
+      await Promise.all([
+        page.keyboard.press('Shift'),
+        page.keyboard.press('Shift'),
+        page.keyboard.press('Shift'),
+        page.waitForNavigation()
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
+
+    it('shows the ghost page when the EtP button is clicked', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      // Make the button not navigate away from the current page
+      await page.evaluate((buttonClass) => document.body.querySelector(buttonClass).setAttribute('href', '#'), buttonClass)
+      await page.click(buttonClass)
+
+      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      expect(ghostOverlay).not.toBeNull()
+    })
+
+    it('shows the ghost page when the skiplink is clicked', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      // Make the button not navigate away from the current page
+      await page.evaluate((skiplinkClass) => document.body.querySelector(skiplinkClass).setAttribute('href', '#'), skiplinkClass)
+      await page.focus(skiplinkClass)
+      await page.click(skiplinkClass)
+
+      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      expect(ghostOverlay).not.toBeNull()
+    })
   })
 })


### PR DESCRIPTION
Adds a little JS so that skiplinks are tied into the EtP component's `exitPage` function, allowing the skiplink to activate the 'ghost page' function. `exitPage` has been updated so that it redirects to the href of the activated link, rather than being hardcoded to the href of the main EtP button.

Keyboard-based functionality operates on a page-wide basis, and thus does not need to be separately enabled for the skiplink. This leaves only the 'ghost page' overlay needing to work across both components. 

## Issues
- Writing Jest tests that play nicely with the `syncOverlayVisibility` function in our JS is proving elusive. This might be because we use `pageshow` as one of the event hooks for it, but this is never triggered when the tests are ran headlessly. 
  - That said, the test still fails when Jest/Puppeteer is ran in headed mode.
  - This uses the same event hooks as the functionality that restores the state of conditional checkboxes and radio buttons, which also lacks Jest tests. Maybe this is just a no go? 