### PR TITLE
Fix linting issue with bind function on Exit This Page

### DIFF
--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,3 +1,5 @@
+/* eslint-disable es-x/no-function-prototype-bind -- Polyfill imported */
+
 import { nodeListForEach } from '../../common.mjs'
 import '../../vendor/polyfills/Element/prototype/classList.mjs'
 import '../../vendor/polyfills/Element/prototype/dataset.mjs'


### PR DESCRIPTION
## What/Why

Fix a linting issue with Exit This Page with our use of `bind`. `es-x` doesn't like that we're using `bind` as it isn't supported in IE8. We just need to ignore the warning as we've imported the polyfill.