### PR TITLE
Ensure review app can run offline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
         update-types: ['version-update:semver-major']
 
       # Always ignore legacy packages
+      - dependency-name: iframe-resizer
       - dependency-name: jquery
       - dependency-name: rollup
 

--- a/app/middleware/vendor.js
+++ b/app/middleware/vendor.js
@@ -17,6 +17,8 @@ router.use('/html5-shiv/', express.static(packageNameToPath('html5shiv', 'dist')
 router.use('/govuk_template/', express.static(packageNameToPath('govuk_template_jinja', 'assets')))
 router.use('/govuk_frontend_toolkit/assets', express.static(packageNameToPath('govuk_frontend_toolkit', 'images')))
 router.use('/govuk_frontend_toolkit/', express.static(packageNameToPath('govuk_frontend_toolkit', 'javascripts/govuk')))
+router.use('/iframe-resizer/', express.static(packageNameToPath('iframe-resizer', 'js')))
 router.use('/jquery/', express.static(packageNameToPath('jquery', 'dist')))
+router.use('/prismjs/', express.static(packageNameToPath('prismjs')))
 
 module.exports = router

--- a/app/package.json
+++ b/app/package.json
@@ -22,12 +22,14 @@
     "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "3.1.3",
     "html5shiv": "^3.7.3",
+    "iframe-resizer": "3.5.15",
     "jquery": "1.12.4",
     "js-yaml": "^4.1.0",
     "marked": "^4.2.12",
     "minimatch": "^6.1.6",
     "nodemon": "^2.0.20",
     "nunjucks": "^3.2.3",
+    "prismjs": "^1.29.0",
     "shuffle-seed": "^1.1.6"
   },
   "devDependencies": {

--- a/app/views/component-preview.njk
+++ b/app/views/component-preview.njk
@@ -16,5 +16,8 @@
 {% endblock %}
 
 {% block scripts %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.contentWindow.min.js" integrity="sha256-4pHiLAYReL+uT1xGu9u8Afg9jkaV0vrdu/Dd0ax9Ak8=" crossorigin="anonymous"></script>
+  <!--[if lt IE 9]>
+    <script src="/vendor/iframe-resizer/ie8.polyfils.min.js"></script>
+  <![endif]-->
+  <script src="/vendor/iframe-resizer/iframeResizer.contentWindow.min.js"></script>
 {% endblock %}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -27,8 +27,9 @@
   {% endif %}
 
   <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/themes/prism.min.css" integrity="sha256-vtR0hSWRc3Tb26iuN2oZHt3KRUomwTufNIf5/4oeCyg=" crossorigin="anonymous" />
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/prism.min.js" integrity="sha256-Zb9yKJ/cfs+jG/zIOFL0QEuXr2CDKF7FR5YBJY3No+c=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="/vendor/prismjs/themes/prism.min.css">
+    <script src="/vendor/prismjs/components/prism-core.min.js"></script>
+    <script src="/vendor/prismjs/plugins/autoloader/prism-autoloader.min.js"></script>
   <!--<![endif]-->
   <!--[if lt IE 9]>
     <script src="/vendor/html5-shiv/html5shiv.min.js"></script>

--- a/app/views/layouts/layout.njk
+++ b/app/views/layouts/layout.njk
@@ -11,10 +11,10 @@
 {% block bodyEnd %}
   {{ super() }}
   {% block scripts %}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/iframeResizer.min.js" integrity="sha256-NZjCYaMfryuJQRMgekHuC02c/Wv4sMRzHG2zyhrVwKU=" crossorigin="anonymous"></script>
-    <!--[if lte IE 8]>
-      <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/ie8.polyfils.min.js"></script>
+    <!--[if lt IE 9]>
+      <script src="/vendor/iframe-resizer/ie8.polyfils.min.js"></script>
     <![endif]-->
+    <script src="/vendor/iframe-resizer/iframeResizer.min.js"></script>
     <script>
       window.iFrameResize({}, '.js-component-preview')
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,12 +102,14 @@
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "3.1.3",
         "html5shiv": "^3.7.3",
+        "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
         "js-yaml": "^4.1.0",
         "marked": "^4.2.12",
         "minimatch": "^6.1.6",
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
+        "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6"
       },
       "devDependencies": {
@@ -11957,6 +11959,14 @@
         }
       ]
     },
+    "node_modules/iframe-resizer": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-3.5.15.tgz",
+      "integrity": "sha512-ZdmPmqafz5Vy2ooUW38LTl6ACcArfK53FQPtR8gOwb74nXiMRkuOV4Vr4w1LHu/YDVlnB1D7qONVX6BUD5DbHA==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
@@ -20123,6 +20133,14 @@
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/process-nextick-args": {
@@ -33626,12 +33644,14 @@
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "3.1.3",
         "html5shiv": "^3.7.3",
+        "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
         "js-yaml": "^4.1.0",
         "marked": "^4.2.12",
         "minimatch": "^6.1.6",
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
+        "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6"
       }
     },
@@ -34533,6 +34553,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
+    },
+    "iframe-resizer": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-3.5.15.tgz",
+      "integrity": "sha512-ZdmPmqafz5Vy2ooUW38LTl6ACcArfK53FQPtR8gOwb74nXiMRkuOV4Vr4w1LHu/YDVlnB1D7qONVX6BUD5DbHA=="
     },
     "ignore": {
       "version": "5.2.1",
@@ -40638,6 +40663,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
+    },
+    "prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "process-nextick-args": {
       "version": "2.0.1",


### PR DESCRIPTION
Quick bug fix PR from last week as I couldn't run the review app on the train 😆 

This PR now loads `prismjs` and `iframe-resizer` from **/vendor** not:

```console
https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/3.5.15/*
https://cdnjs.cloudflare.com/ajax/libs/prism/1.6.0/*
```

Same approach with jQuery, we don’t need 3rd party hosting to slow our browser tests down