### PR TITLE
Use `highlight.js` (server-side) code syntax highlighting

### DIFF
--- a/app/common/middleware/vendor.js
+++ b/app/common/middleware/vendor.js
@@ -19,6 +19,5 @@ router.use('/govuk_frontend_toolkit/assets', express.static(packageNameToPath('g
 router.use('/govuk_frontend_toolkit/', express.static(packageNameToPath('govuk_frontend_toolkit', 'javascripts/govuk')))
 router.use('/iframe-resizer/', express.static(packageNameToPath('iframe-resizer', 'js')))
 router.use('/jquery/', express.static(packageNameToPath('jquery', 'dist')))
-router.use('/prismjs/', express.static(packageNameToPath('prismjs')))
 
 module.exports = router

--- a/app/common/nunjucks/filters/highlight.js
+++ b/app/common/nunjucks/filters/highlight.js
@@ -1,0 +1,14 @@
+const hljs = require('highlight.js')
+
+/**
+ * Format code with syntax highlighting
+ *
+ * @param {string} code - Code in plain text
+ * @param {string} [language] - Code programming language
+ * @returns {string} Code with syntax highlighting
+ */
+function highlight (code, language) {
+  return hljs.highlight(code.trim(), { language: language || 'plaintext' }).value
+}
+
+module.exports = highlight

--- a/app/common/nunjucks/filters/index.js
+++ b/app/common/nunjucks/filters/index.js
@@ -1,8 +1,11 @@
+const { componentNameToMacroName } = require('../../../../lib/helper-functions.js')
+
 /**
  * Nunjucks filters
  */
-const { componentNameToMacroName } = require('../../../../lib/helper-functions.js')
+const highlight = require('./highlight')
 
 module.exports = {
-  componentNameToMacroName
+  componentNameToMacroName,
+  highlight
 }

--- a/app/common/nunjucks/filters/index.js
+++ b/app/common/nunjucks/filters/index.js
@@ -1,0 +1,8 @@
+/**
+ * Nunjucks filters
+ */
+const { componentNameToMacroName } = require('../../../../lib/helper-functions.js')
+
+module.exports = {
+  componentNameToMacroName
+}

--- a/app/common/nunjucks/globals/get-html-code.js
+++ b/app/common/nunjucks/globals/get-html-code.js
@@ -1,0 +1,34 @@
+const { join } = require('path')
+
+const beautify = require('js-beautify')
+
+const { paths } = require('../../../../config/index.js')
+
+/**
+ * Component HTML code (formatted)
+ *
+ * @param {string} componentName - Component name
+ * @param {unknown} params - Component macro params
+ * @returns {string} Nunjucks code
+ */
+function getHTMLCode (componentName, params) {
+  const templatePath = join(paths.components, componentName, 'template.njk')
+
+  // Render to HTML
+  const html = this.env.render(templatePath, { params }).trim()
+
+  // Default beautify options
+  const options = beautify.html.defaultOptions()
+
+  return beautify.html(html, {
+    indent_size: 2,
+    // Ensure nested labels in headings are indented properly
+    inline: options.inline.filter((tag) => !['label'].includes(tag)),
+    // Remove blank lines
+    max_preserve_newlines: 0,
+    // Ensure attribute wrapping in header SVG is preserved
+    wrap_attributes: 'preserve'
+  })
+}
+
+module.exports = getHTMLCode

--- a/app/common/nunjucks/globals/get-nunjucks-code.js
+++ b/app/common/nunjucks/globals/get-nunjucks-code.js
@@ -1,0 +1,24 @@
+const { outdent } = require('outdent')
+
+const { componentNameToMacroName } = require('../filters/index')
+
+/**
+ * Component Nunjucks code (formatted)
+ *
+ * @param {string} componentName - Component name
+ * @param {unknown} params - Component macro params
+ * @returns {string} Nunjucks code
+ */
+function getNunjucksCode (componentName, params) {
+  const macroName = componentNameToMacroName(componentName)
+
+  return outdent`
+    {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
+
+    {{ ${macroName}(${
+      JSON.stringify(params, undefined, 2)
+    }) }}
+  `
+}
+
+module.exports = getNunjucksCode

--- a/app/common/nunjucks/globals/index.js
+++ b/app/common/nunjucks/globals/index.js
@@ -1,0 +1,8 @@
+/**
+ * Nunjucks globals
+ */
+const markdown = require('marked')
+
+module.exports = {
+  markdown
+}

--- a/app/common/nunjucks/globals/index.js
+++ b/app/common/nunjucks/globals/index.js
@@ -1,8 +1,13 @@
+const markdown = require('marked')
+
 /**
  * Nunjucks globals
  */
-const markdown = require('marked')
+const getHTMLCode = require('./get-html-code.js')
+const getNunjucksCode = require('./get-nunjucks-code.js')
 
 module.exports = {
+  getHTMLCode,
+  getNunjucksCode,
   markdown
 }

--- a/app/common/nunjucks/index.js
+++ b/app/common/nunjucks/index.js
@@ -1,0 +1,49 @@
+
+const { join } = require('path')
+
+const nunjucks = require('nunjucks')
+
+const { paths } = require('../../../config/index.js')
+
+const filters = require('./filters/index.js')
+const globals = require('./globals/index.js')
+
+function renderer (app) {
+  const appViews = [
+    paths.layouts,
+    paths.views,
+    paths.components,
+    join(paths.src, 'govuk'),
+    join(paths.node_modules, 'govuk_template_jinja')
+  ]
+
+  // Initialise nunjucks environment
+  const env = nunjucks.configure(appViews, {
+    autoescape: true, // output with dangerous characters are escaped automatically
+    express: app, // the express app that nunjucks should install to
+    noCache: true, // never use a cache and recompile templates each time
+    trimBlocks: true, // automatically remove trailing newlines from a block/tag
+    lstripBlocks: true, // automatically remove leading whitespace from a block/tag
+    watch: true // reload templates when they are changed. needs chokidar dependency to be installed
+  })
+
+  // Set view engine
+  app.set('view engine', 'njk')
+
+  // Share feature flags with middleware
+  env.addGlobal('flags', app.get('flags'))
+
+  // Custom filters
+  for (const key in filters) {
+    env.addFilter(key, filters[key])
+  }
+
+  // Custom globals
+  for (const key in globals) {
+    env.addGlobal(key, globals[key])
+  }
+
+  return env
+}
+
+module.exports.renderer = renderer

--- a/app/package.json
+++ b/app/package.json
@@ -31,7 +31,6 @@
     "nodemon": "^2.0.20",
     "nunjucks": "^3.2.3",
     "outdent": "^0.8.0",
-    "prismjs": "^1.29.0",
     "shuffle-seed": "^1.1.6"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -23,11 +23,13 @@
     "html5shiv": "^3.7.3",
     "iframe-resizer": "3.5.15",
     "jquery": "1.12.4",
+    "js-beautify": "^1.14.7",
     "js-yaml": "^4.1.0",
     "marked": "^4.2.12",
     "minimatch": "^7.0.1",
     "nodemon": "^2.0.20",
     "nunjucks": "^3.2.3",
+    "outdent": "^0.8.0",
     "prismjs": "^1.29.0",
     "shuffle-seed": "^1.1.6"
   },

--- a/app/package.json
+++ b/app/package.json
@@ -20,6 +20,7 @@
     "govuk_frontend_toolkit": "^9.0.1",
     "govuk_template_jinja": "^0.26.0",
     "govuk-elements-sass": "3.1.3",
+    "highlight.js": "^11.7.0",
     "html5shiv": "^3.7.3",
     "iframe-resizer": "3.5.15",
     "jquery": "1.12.4",

--- a/app/stylesheets/app.scss
+++ b/app/stylesheets/app.scss
@@ -3,5 +3,6 @@ $govuk-new-link-styles: true;
 
 @import "../../src/govuk/all";
 @import "partials/app";
+@import "partials/code";
 @import "partials/banner";
 @import "partials/prose";

--- a/app/stylesheets/partials/_code.scss
+++ b/app/stylesheets/partials/_code.scss
@@ -1,0 +1,21 @@
+@import "highlight.js/scss/github";
+
+.app-code {
+  @include govuk-responsive-margin(6, "bottom");
+}
+
+.app-code__container {
+  display: block;
+  margin: 0;
+  padding: govuk-spacing(4);
+  overflow-x: auto;
+  border: $govuk-focus-width solid transparent;
+  outline: 1px solid transparent;
+  background-color: govuk-colour("light-grey", $legacy: "grey-3");
+  @include govuk-responsive-margin(4, "bottom");
+
+  &:focus {
+    border: $govuk-focus-width solid $govuk-input-border-colour;
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+  }
+}

--- a/app/stylesheets/partials/_code.scss
+++ b/app/stylesheets/partials/_code.scss
@@ -1,4 +1,4 @@
-@import "highlight.js/scss/github";
+@import "highlight";
 
 .app-code {
   @include govuk-responsive-margin(6, "bottom");

--- a/app/stylesheets/partials/_highlight.scss
+++ b/app/stylesheets/partials/_highlight.scss
@@ -1,0 +1,87 @@
+// GitHub code highlight
+
+.hljs-comment,
+.hljs-quote {
+  color: #545555;
+  font-style: italic;
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+  color: #333333;
+  font-weight: bold;
+}
+
+.hljs-number,
+.hljs-literal,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-tag .hljs-attr {
+  color: #00703c;
+}
+
+.hljs-string,
+.hljs-doctag {
+  color: #d13118;
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+  color: #990000;
+  font-weight: bold;
+}
+
+.hljs-subst {
+  font-weight: normal;
+}
+
+.hljs-type,
+.hljs-class .hljs-title {
+  color: #445588;
+  font-weight: bold;
+}
+
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+  color: #003078;
+  font-weight: normal;
+}
+
+.hljs-regexp,
+.hljs-link {
+  color: #008020;
+}
+
+.hljs-symbol,
+.hljs-bullet {
+  color: #990073;
+}
+
+.hljs-builtin,
+.hljs-builtin-name {
+  color: #017ba5;
+}
+
+.hljs-meta {
+  color: #545555;
+  font-weight: bold;
+}
+
+.hljs-deletion {
+  background: #ffdddd;
+}
+
+.hljs-addition {
+  background: #ddffdd;
+}
+
+.hljs-emphasis {
+  font-style: italic;
+}
+
+.hljs-strong {
+  font-weight: bold;
+}

--- a/app/views/layouts/_generic.njk
+++ b/app/views/layouts/_generic.njk
@@ -26,15 +26,6 @@
     <![endif]-->
   {% endif %}
 
-  <!--[if !IE 8]><!-->
-    <link rel="stylesheet" href="/vendor/prismjs/themes/prism.min.css">
-    <script src="/vendor/prismjs/components/prism-core.min.js"></script>
-    <script src="/vendor/prismjs/plugins/autoloader/prism-autoloader.min.js"></script>
-  <!--<![endif]-->
-  <!--[if lt IE 9]>
-    <script src="/vendor/html5-shiv/html5shiv.min.js"></script>
-  <![endif]-->
-
   {% block styles %}{% endblock %}
 {% endblock %}
 

--- a/app/views/macros/loadComponentTemplate.njk
+++ b/app/views/macros/loadComponentTemplate.njk
@@ -1,3 +1,0 @@
-{% macro loadComponentTemplate(componentName, params) %}
-  {%- include componentName + "/template.njk" -%}
-{% endmacro %}

--- a/app/views/partials/code.njk
+++ b/app/views/partials/code.njk
@@ -1,9 +1,9 @@
 <h4 class="govuk-heading-s">Markup</h4>
-<pre><code class="govuk-!-font-size-16">
-  {{- getHTMLCode(componentSlug, example.data) | safe -}}
+<pre class="app-code"><code tabindex="0" class="app-code__container hljs language-html">
+  {{- getHTMLCode(componentSlug, example.data) | highlight("html") | safe -}}
 </code></pre>
 
 <h4 class="govuk-heading-s">Macro</h4>
-<pre class="govuk-!-margin-bottom-0 govuk-!-font-size-16"><code>
-  {{- getNunjucksCode(componentSlug, example.data) | safe -}}
+<pre class="app-code"><code tabindex="0" class="app-code__container hljs language-js">
+  {{- getNunjucksCode(componentSlug, example.data) | highlight("js") | safe -}}
 </code></pre>

--- a/app/views/partials/code.njk
+++ b/app/views/partials/code.njk
@@ -1,12 +1,9 @@
-{% from "macros/loadComponentTemplate.njk" import loadComponentTemplate %}
-
 <h4 class="govuk-heading-s">Markup</h4>
-{% set componentHtml %}{{ loadComponentTemplate(componentSlug, example.data) }}{% endset %}
-<pre><code class="govuk-!-font-size-16">{{- componentHtml | e -}}</code></pre>
+<pre><code class="govuk-!-font-size-16">
+  {{- getHTMLCode(componentSlug, example.data) | safe -}}
+</code></pre>
 
 <h4 class="govuk-heading-s">Macro</h4>
-<pre class="govuk-!-margin-bottom-0 govuk-!-font-size-16"><code>{% raw %}{%{% endraw %} from "{{ componentSlug }}/macro.njk" import {{ componentSlug | componentNameToMacroName }} {% raw %}%}{% endraw %}
-
-{% raw %}{{ {% endraw %}{{ componentSlug | componentNameToMacroName }}(
-  {{- example.data | dump(2) -}}
-  ){% raw %} }}{% endraw %}</code></pre>
+<pre class="govuk-!-margin-bottom-0 govuk-!-font-size-16"><code>
+  {{- getNunjucksCode(componentSlug, example.data) | safe -}}
+</code></pre>

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "govuk_frontend_toolkit": "^9.0.1",
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "3.1.3",
+        "highlight.js": "^11.7.0",
         "html5shiv": "^3.7.3",
         "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
@@ -11282,6 +11283,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
+      "integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/homedir-polyfill": {
@@ -32262,6 +32271,7 @@
         "govuk_frontend_toolkit": "^9.0.1",
         "govuk_template_jinja": "^0.26.0",
         "govuk-elements-sass": "3.1.3",
+        "highlight.js": "^11.7.0",
         "html5shiv": "^3.7.3",
         "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
@@ -32742,6 +32752,11 @@
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
       "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
+    },
+    "highlight.js": {
+      "version": "11.7.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
+      "integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ=="
     },
     "homedir-polyfill": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,6 @@
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
         "outdent": "^0.8.0",
-        "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6"
       },
       "devDependencies": {
@@ -18913,14 +18912,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -32282,7 +32273,6 @@
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
         "outdent": "^0.8.0",
-        "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6",
         "supertest": "^6.3.3"
       },
@@ -38333,11 +38323,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A=="
-    },
-    "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "process-nextick-args": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,11 +98,13 @@
         "html5shiv": "^3.7.3",
         "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
+        "js-beautify": "^1.14.7",
         "js-yaml": "^4.1.0",
         "marked": "^4.2.12",
         "minimatch": "^7.0.1",
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
+        "outdent": "^0.8.0",
         "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6"
       },
@@ -6458,6 +6460,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -7625,6 +7636,20 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
     },
+    "node_modules/editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      }
+    },
     "node_modules/editorconfig-checker": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/editorconfig-checker/-/editorconfig-checker-5.0.1.tgz",
@@ -7638,6 +7663,33 @@
         "type": "buymeacoffee",
         "url": "https://www.buymeacoffee.com/mstruebing"
       }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "node_modules/editorconfig/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/editorconfig/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/editorconfig/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -14503,6 +14555,39 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
     },
+    "node_modules/js-beautify": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-beautify/node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -17611,8 +17696,7 @@
     "node_modules/outdent": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
-      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
-      "dev": true
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
@@ -18898,6 +18982,11 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -18915,6 +19004,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "node_modules/psl": {
       "version": "1.9.0",
@@ -20705,6 +20799,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -28920,6 +29019,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "requires": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "configstore": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
@@ -29778,6 +29886,43 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true
+    },
+    "editorconfig": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+      "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
+      "requires": {
+        "commander": "^2.19.0",
+        "lru-cache": "^4.1.5",
+        "semver": "^5.6.0",
+        "sigmund": "^1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A=="
+        }
+      }
     },
     "editorconfig-checker": {
       "version": "5.0.1",
@@ -32120,11 +32265,13 @@
         "html5shiv": "^3.7.3",
         "iframe-resizer": "3.5.15",
         "jquery": "1.12.4",
+        "js-beautify": "^1.14.7",
         "js-yaml": "^4.1.0",
         "marked": "^4.2.12",
         "minimatch": "^7.0.1",
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
+        "outdent": "^0.8.0",
         "prismjs": "^1.29.0",
         "shuffle-seed": "^1.1.6",
         "supertest": "^6.3.3"
@@ -34993,6 +35140,27 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
     },
+    "js-beautify": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.7.tgz",
+      "integrity": "sha512-5SOX1KXPFKx+5f6ZrPsIPEY7NwKeQz47n3jm2i+XeHx9MoRsfQenlOP13FQhWvg8JRS0+XLO6XYUQ2GX+q+T9A==",
+      "requires": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^0.15.3",
+        "glob": "^8.0.3",
+        "nopt": "^6.0.0"
+      },
+      "dependencies": {
+        "nopt": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+          "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+          "requires": {
+            "abbrev": "^1.0.0"
+          }
+        }
+      }
+    },
     "js-sdsl": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
@@ -37367,8 +37535,7 @@
     "outdent": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
-      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
-      "dev": true
+      "integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A=="
     },
     "p-cancelable": {
       "version": "2.1.1",
@@ -38219,6 +38386,11 @@
         }
       }
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -38233,6 +38405,11 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ=="
     },
     "psl": {
       "version": "1.9.0",
@@ -39644,6 +39821,11 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g=="
     },
     "signal-exit": {
       "version": "3.0.7",


### PR DESCRIPTION
This PR replaces [**Prism** (client-side)](https://www.npmjs.com/package/prismjs) code highlighting with [**Highlight.js** (server-side)](https://www.npmjs.com/package/highlight.js)

The review app now matches the GOV.UK Design System code syntax highlighting:

* https://github.com/alphagov/govuk-design-system/pull/2562
* https://github.com/alphagov/govuk-design-system/pull/2566

Plus we've now got Nunjucks highlighting turned enabled where we previously didn't

<img width="1003" alt="Syntax highlighting enabled for both Nunjucks macro and HTML markup" src="https://user-images.githubusercontent.com/415517/215593067-c4c3f5d5-9fb8-491b-866e-a3a20a0a7b82.png">
