### PR TITLE
Fix dangling angle bracket in compiled cookie banner

### DIFF
--- a/src/govuk/components/cookie-banner/template.njk
+++ b/src/govuk/components/cookie-banner/template.njk
@@ -12,7 +12,7 @@
 
     <div class="{{classNames}}" {%- if message.role %} role="{{message.role}}"{% endif %}
     {%- for attribute, value in message.attributes %} {{attribute}}="{{value}}"{% endfor %}
-    {% if message.hidden %} hidden{% endif %}>
+    {%- if message.hidden %} hidden{% endif %}>
 
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
Noticed this while reviewing https://github.com/alphagov/govuk-design-system/pull/2565

Quite a bit of the diff in that PR comes from the Cookie Banner component, with one of the more eye-twitchy examples being this dangling bracket.

So a teeny tiny fix for that.