### PR TITLE
[SPIKE] Collecting performance information

### DIFF
--- a/.github/workflows/actions/build-dist/action.yml
+++ b/.github/workflows/actions/build-dist/action.yml
@@ -1,0 +1,30 @@
+name: Build `dist`
+
+runs:
+  using: composite
+
+  steps:
+    - name: Cache build
+      uses: actions/cache@v3
+      id: build-cache
+
+      with:
+        # Restore build cache (unless commit SHA changes)
+        key: build-dist-cache-${{ github.sha }}
+        path: |
+          dist
+
+    - name: Install dependencies
+      uses: ./.github/workflows/actions/install-node
+
+      # Skip install when build is already cached
+      if: steps.build-cache.outputs.cache-hit != 'true'
+
+    - name: Build
+      id: build
+
+      # Skip build when we’ve built this SHA before
+      if: steps.build-cache.outputs.cache-hit != 'true'
+      shell: bash
+
+      run: npm run build:dist

--- a/.github/workflows/actions/build-package/action.yml
+++ b/.github/workflows/actions/build-package/action.yml
@@ -1,0 +1,30 @@
+name: Build package
+
+runs:
+  using: composite
+
+  steps:
+    - name: Cache build
+      uses: actions/cache@v3
+      id: build-cache
+
+      with:
+        # Restore build cache (unless commit SHA changes)
+        key: build-package-cache-${{ github.sha }}
+        path: |
+          package
+
+    - name: Install dependencies
+      uses: ./.github/workflows/actions/install-node
+
+      # Skip install when build is already cached
+      if: steps.build-cache.outputs.cache-hit != 'true'
+
+    - name: Build
+      id: build
+
+      # Skip build when we’ve built this SHA before
+      if: steps.build-cache.outputs.cache-hit != 'true'
+      shell: bash
+
+      run: npm run build:compile

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -13,7 +13,7 @@ runs:
         key: npm-install-cache-${{ hashFiles('package-lock.json', '**/package.json') }}
         path: |
           .cache/puppeteer
-          node_modules
+          **/node_modules
 
     - name: Setup Node.js
       uses: ./.github/workflows/actions/setup-node

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,19 +191,51 @@ jobs:
       - name: Collects stats
         run: npm start --workspace stats
 
+      # TODO: Cache comment ID in a `.stats-comment-id` file
+      # If the cached file is present
+
       - name: Add comment to PR
         uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const commentText = 'Test comment'
 
-            github.rest.issues.createComment({
+            const COMMENT_MARKER = "\n File stats"
+
+            const issueParameters = {
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentText
-            })
+              repo: context.repo.repo
+            }
+
+            const commentText = 'Test comment '+ new Date().toISOString()
+
+            const commentId = await findStatsCommentId()
+
+            if (commentId) {
+              github.rest.issues.updateComment({
+                ...issueParameters,
+                comment_id: commentId,
+                body: commentText + COMMENT_MARKER
+              })
+            } else {
+              github.rest.issues.createComment({
+                ...issueParameters,
+                body: commentText + COMMENT_MARKER
+              })
+            }
+
+            // Based on https://github.com/peter-evans/find-comment/blob/main/src/find.ts
+            async function findStatsCommentId() {
+              for await (const {data: comments} of github.paginate.iterator(
+                github.rest.issues.listComments,
+                issueParameters
+              )) {
+                const comment = comments.find(comment => comment.body.includes(COMMENT_MARKER))
+
+                if (comment) return comment.id;
+              }
+            }
         if: github.event_name == 'pull_request'
 
       - name: Save test coverage

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,11 @@ on:
       - main
       - 'feature/**'
       - 'support/**'
-      - 'rollup-plugin-visualiser-gh-action'
 
   workflow_dispatch:
+
+permissions:
+  pull-requests: write
 
 concurrency:
   group: tests-${{ github.head_ref || github.run_id }}
@@ -188,6 +190,21 @@ jobs:
 
       - name: Collects stats
         run: npm start --workspace stats
+
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const commentText = 'Test comment'
+
+            github.rest.issues.createComment({
+              issue_number: context.payload.pull_request.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentText
+            })
+        if: github.event_name == 'pull_request'
 
       - name: Save test coverage
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -194,53 +194,21 @@ jobs:
       # TODO: Cache comment ID in a `.stats-comment-id` file
       # If the cached file is present
 
-      - name: Add comment to PR
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-
-            const COMMENT_MARKER = "\n File stats"
-
-            const issueParameters = {
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-
-            const commentText = 'Test comment '+ new Date().toISOString()
-
-            const commentId = await findStatsCommentId()
-
-            if (commentId) {
-              github.rest.issues.updateComment({
-                ...issueParameters,
-                comment_id: commentId,
-                body: commentText + COMMENT_MARKER
-              })
-            } else {
-              github.rest.issues.createComment({
-                ...issueParameters,
-                body: commentText + COMMENT_MARKER
-              })
-            }
-
-            // Based on https://github.com/peter-evans/find-comment/blob/main/src/find.ts
-            async function findStatsCommentId() {
-              for await (const {data: comments} of github.paginate.iterator(
-                github.rest.issues.listComments,
-                issueParameters
-              )) {
-                const comment = comments.find(comment => comment.body.includes(COMMENT_MARKER))
-
-                if (comment) return comment.id;
-              }
-            }
-        if: github.event_name == 'pull_request'
-
       - name: Save test coverage
         uses: actions/upload-artifact@v3
         with:
           name: File stats
           path: stats/public/all/stats-sunburst.html
           if-no-files-found: ignore
+
+      - name: Add comment to PR
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const commentOnPr = require('./stats/comment-on-pr.js');
+            await commentOnPr({github,context})
+
+        if: github.event_name == 'pull_request'
+
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ on:
       - main
       - 'feature/**'
       - 'support/**'
+      - 'rollup-plugin-visualiser-gh-action'
 
   workflow_dispatch:
 
@@ -172,3 +173,25 @@ jobs:
 
     # Skip when secrets are unavailable on forks
     if: ${{ github.repository_owner == 'alphagov' }}
+
+  stats:
+    name: Stats
+    needs: [install, build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Collects stats
+        run: npm start --workspace stats
+
+      - name: Save test coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: File stats
+          path: stats/public/all/stats-sunburst.html
+          if-no-files-found: ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,14 +129,6 @@ jobs:
 
       matrix:
         include:
-          - description: Verify package build
-            name: test-build-package
-            run: npm run build:package
-
-          - description: Verify distribution build
-            name: test-build-dist
-            run: npm run build:dist
-
           - description: JavaScript behaviour tests
             name: test-behaviour
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
@@ -176,9 +168,9 @@ jobs:
     # Skip when secrets are unavailable on forks
     if: ${{ github.repository_owner == 'alphagov' }}
 
-  stats:
-    name: Stats
-    needs: [install, build]
+  build_dist:
+    name: Build dist
+    needs: [install]
     runs-on: ubuntu-latest
 
     steps:
@@ -188,13 +180,46 @@ jobs:
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
 
+      - name: Build dist
+        uses: ./.github/workflows/actions/build-dist
+
+  build_package:
+    name: Build package
+    needs: [install]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Build package
+        uses: ./.github/workflows/actions/build-package
+
+  stats:
+    name: Stats
+    needs: [build_dist,build_package]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Restore dist
+        uses: ./.github/workflows/actions/build-dist
+
+      - name: Restore package
+        uses: ./.github/workflows/actions/build-package
+
       - name: Collects stats
         run: npm start --workspace stats
 
-      # TODO: Cache comment ID in a `.stats-comment-id` file
-      # If the cached file is present
-
-      - name: Save test coverage
+      - name: Save stats
         uses: actions/upload-artifact@v3
         with:
           name: File stats

--- a/app/app.js
+++ b/app/app.js
@@ -84,6 +84,7 @@ module.exports = async (options) => {
   app.use(middleware.assets)
   app.use('/docs', middleware.docs)
   app.use('/vendor', middleware.vendor)
+  app.use('/stats', middleware.stats)
 
   // Turn form POSTs into data that can be used for validation.
   app.use(bodyParser.urlencoded({ extended: true }))

--- a/app/middleware/index.js
+++ b/app/middleware/index.js
@@ -3,10 +3,12 @@
  */
 const assets = require('./assets')
 const docs = require('./docs')
+const stats = require('./stats')
 const vendor = require('./vendor')
 
 module.exports = {
   assets,
   docs,
-  vendor
+  vendor,
+  stats
 }

--- a/app/middleware/stats.js
+++ b/app/middleware/stats.js
@@ -1,0 +1,12 @@
+const express = require('express')
+const serveIndex = require('serve-index')
+
+const configPaths = require('../../config/paths')
+const router = express.Router()
+
+// Serve the files themselves
+router.use(express.static(configPaths.stats))
+// Serve the directory listings, to allow navigating to the files
+router.use(serveIndex(configPaths.stats))
+
+module.exports = router

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "minimatch": "^5.1.1",
     "nodemon": "^2.0.20",
     "nunjucks": "^3.2.3",
+    "serve-index": "^1.9.1",
     "shuffle-seed": "^1.1.6"
   },
   "devDependencies": {

--- a/config/paths.js
+++ b/config/paths.js
@@ -24,7 +24,10 @@ const configPaths = {
 
   // Documentation
   jsdoc: join(rootPath, 'jsdoc'),
-  sassdoc: join(rootPath, 'sassdoc')
+  sassdoc: join(rootPath, 'sassdoc'),
+
+  // Performance
+  stats: join(rootPath, 'stats', 'public')
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9404,6 +9404,14 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
     },
+    "node_modules/filesize": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.0.6.tgz",
+      "integrity": "sha512-rzpOZ4C9vMFDqOa6dNpog92CoLYjD79dnjLk2TYDDtImRIyLTOzqojCb05Opd1WuiWjs+fshhCgTd8cl7y5t+g==",
+      "engines": {
+        "node": ">= 10.4.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -25749,8 +25757,12 @@
       "dependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",
         "@rollup/plugin-virtual": "^3.0.1",
+        "filesize": "^10.0.6",
         "rollup": "^3.7.4",
         "rollup-plugin-visualizer": "^5.8.3"
+      },
+      "engines": {
+        "node": "^18.12.0"
       }
     },
     "stats/node_modules/@rollup/plugin-node-resolve": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,6 +109,7 @@
         "minimatch": "^5.1.1",
         "nodemon": "^2.0.20",
         "nunjucks": "^3.2.3",
+        "serve-index": "^1.9.1",
         "shuffle-seed": "^1.1.6"
       },
       "devDependencies": {
@@ -4942,8 +4943,7 @@
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
-      "dev": true
+      "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -21977,7 +21977,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
       "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
-      "dev": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "batch": "0.6.1",
@@ -21995,7 +21994,6 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -22004,7 +22002,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -22013,7 +22010,6 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
-      "dev": true,
       "dependencies": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -22027,26 +22023,22 @@
     "node_modules/serve-index/node_modules/inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-      "dev": true
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/serve-index/node_modules/setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-      "dev": true
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "node_modules/serve-index/node_modules/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "npm ls --depth=0",
     "start": "gulp dev",
     "serve": "npm run serve --workspace app",
-    "heroku": "npm run build:compile && npm start --workspace app",
+    "heroku": "npm run build:compile && npm start --workspace stats && npm start --workspace app",
     "build-release": "./bin/build-release.sh",
     "publish-release": "./bin/publish-release.sh",
     "pre-release": "./bin/pre-release.sh",

--- a/stats/comment-on-pr.js
+++ b/stats/comment-on-pr.js
@@ -1,23 +1,23 @@
+const generateStatsMessage = require('./generate-stats-message.js')
+
+const DOWNLOAD_LINK_TEXT =
+  "Interactive visualisation can be downloaded from the build's artifacts"
+
+const COMMENT_MARKER = `[${DOWNLOAD_LINK_TEXT}]`
+
 module.exports = async function ({ github, context }) {
-  const DOWNLOAD_LINK_TEXT =
-    "Interactive visualisation can be downloaded from the build's artifacts"
-
-  const COMMENT_MARKER = `[${DOWNLOAD_LINK_TEXT}]`
-
   const issueParameters = {
     issue_number: context.payload.pull_request.number,
     owner: context.repo.owner,
     repo: context.repo.repo
   }
 
-  let body = 'TODO: Fill this section with actual stats!'
+  const body = `${generateStatsMessage()}
 
-  body += `\n[${DOWNLOAD_LINK_TEXT}](${githubActionArtifactsUrl(
-    context.runId
-  )})`
+[${DOWNLOAD_LINK_TEXT}](${githubActionArtifactsUrl(context.runId)})`
 
   const comment = await findFirstIssueCommentMatching(
-    comment => comment.body.includes(COMMENT_MARKER),
+    (comment) => comment.body.includes(COMMENT_MARKER),
     {
       github,
       issueParameters
@@ -63,7 +63,10 @@ function githubActionArtifactsUrl (runId) {
  * @returns {object | undefined} -- Found comment or underfined if no comment satisfying the matcher is found
  */
 // Based on https://github.com/peter-evans/find-comment/blob/main/src/find.ts
-async function findFirstIssueCommentMatching (matcher, { github, issueParameters }) {
+async function findFirstIssueCommentMatching (
+  matcher,
+  { github, issueParameters }
+) {
   for await (const { data: comments } of github.paginate.iterator(
     github.rest.issues.listComments,
     issueParameters

--- a/stats/comment-on-pr.js
+++ b/stats/comment-on-pr.js
@@ -14,6 +14,10 @@ module.exports = async function ({ github, context }) {
 
   const body = `${generateStatsMessage()}
 
+[View stats on the review app](${reviewAppUrl(
+    context.payload.pull_request.number
+  )})
+
 [${DOWNLOAD_LINK_TEXT}](${githubActionArtifactsUrl(context.runId)})`
 
   const comment = await findFirstIssueCommentMatching(
@@ -36,6 +40,10 @@ module.exports = async function ({ github, context }) {
       body
     })
   }
+}
+
+function reviewAppUrl (prNumber) {
+  return `https://govuk-frontend-pr-${prNumber}.herokuapp.com/stats/`
 }
 
 /**

--- a/stats/comment-on-pr.js
+++ b/stats/comment-on-pr.js
@@ -1,0 +1,75 @@
+module.exports = async function ({ github, context }) {
+  const DOWNLOAD_LINK_TEXT =
+    "Interactive visualisation can be downloaded from the build's artifacts"
+
+  const COMMENT_MARKER = `[${DOWNLOAD_LINK_TEXT}]`
+
+  const issueParameters = {
+    issue_number: context.payload.pull_request.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo
+  }
+
+  let body = 'TODO: Fill this section with actual stats!'
+
+  body += `\n[${DOWNLOAD_LINK_TEXT}](${githubActionArtifactsUrl(
+    context.runId
+  )})`
+
+  const comment = await findFirstIssueCommentMatching(
+    comment => comment.body.includes(COMMENT_MARKER),
+    {
+      github,
+      issueParameters
+    }
+  )
+
+  if (comment) {
+    return github.rest.issues.updateComment({
+      ...issueParameters,
+      comment_id: comment.id,
+      body
+    })
+  } else {
+    return github.rest.issues.createComment({
+      ...issueParameters,
+      body
+    })
+  }
+}
+
+/**
+ * Generates a URL to the "Artifacts" section of a Github action run
+ *
+ * Unfortunately the best we can do here is a link to the "Artifacts" section as
+ * [the upload-artifact action doesn't provide
+ * the public URL](https://github.com/actions/upload-artifact/issues/50) :'(
+ *
+ *
+ * @param {string|number} runId -- The ID of the Github action run
+ * @returns {string} The URL to the "Artifacts" section of the given run
+ */
+function githubActionArtifactsUrl (runId) {
+  return `https://github.com/alphagov/govuk-frontend/actions/runs/${runId}/#artifacts`
+}
+
+/**
+ * Finds the first issue comment for with the `matcher` function returns `true`
+ *
+ * @param {function(object):boolean} matcher -- Function evaluated on each comment
+ * @param {object} options
+ * @param {*} options.github -- Instance of the Github rest API available in script
+ * @param {object} options.issueParameters -- REST parameters identifying the issue to find the comment in
+ * @returns {object | undefined} -- Found comment or underfined if no comment satisfying the matcher is found
+ */
+// Based on https://github.com/peter-evans/find-comment/blob/main/src/find.ts
+async function findFirstIssueCommentMatching (matcher, { github, issueParameters }) {
+  for await (const { data: comments } of github.paginate.iterator(
+    github.rest.issues.listComments,
+    issueParameters
+  )) {
+    const comment = comments.find(matcher)
+
+    if (comment) return comment
+  }
+}

--- a/stats/comment-on-pr.js
+++ b/stats/comment-on-pr.js
@@ -12,7 +12,7 @@ module.exports = async function ({ github, context }) {
     repo: context.repo.repo
   }
 
-  const body = `${generateStatsMessage()}
+  const body = `${await generateStatsMessage()}
 
 [View stats on the review app](${reviewAppUrl(
     context.payload.pull_request.number

--- a/stats/generate-stats-message.js
+++ b/stats/generate-stats-message.js
@@ -1,0 +1,94 @@
+const { relative } = require('node:path')
+
+const { filesize } = require('filesize')
+
+module.exports = function generateStatsMessage () {
+  const statsConfig = require('./stats.config.js')
+
+  return Object.entries(statsConfig)
+    // .filter((o, i) => !i)
+    // First extract the information we need from the configuration
+    .map(([statsId, [modulePath, statsExport]]) => {
+      // Load the stats generated for that specific file
+      const stats = require(`./public/${statsId}/stats-raw-data.json`)
+
+      // TODO: Confirm I understood correctly
+      // We'll be traversing the `tree` in the stats, whose node Uid represent moduleParts.
+      // As far as I understand, those represent the parts of the module that actually get
+      // into each file of the bundle. Potentially, these are not the full module,
+      // as some of the file may have been tree-shaken away.
+      //
+      // These Uid are the ones used in `stats.moduleParts`, which reference the size each of each part
+      //
+      // However `nodeMetas`, providing the filename and the imports of each module is indexed against Uids
+      // representing the entirety of the modules (so not matching the moduleParts Uids)
+      //
+      // To speed up access when traversing the tree, this creates an index of the `nodeMetas`
+      // by name of the bundle file and module part
+      const nodeMetasByRootAndModulePartUid = {}
+      for (const meta of Object.values(stats.nodeMetas)) {
+        for (const [modulePartName, moduleUidInPart] of Object.entries(meta.moduleParts)) {
+          if (!nodeMetasByRootAndModulePartUid[modulePartName]) {
+            nodeMetasByRootAndModulePartUid[modulePartName] = {}
+          }
+
+          nodeMetasByRootAndModulePartUid[modulePartName][moduleUidInPart] = meta
+        }
+      }
+
+      let totalSize = 0
+      const partsLength = {}
+      for (const part of stats.tree.children) {
+        const rootPartName = part.name
+        traverse(part, (node) => {
+          if (rootPartName) {
+            if (node.uid) {
+            // The root node doesn't have a uid...
+              const nodePart = stats.nodeParts[node.uid]
+              totalSize += nodePart.renderedLength
+
+              const nodeMetas =
+                nodeMetasByRootAndModulePartUid[rootPartName]?.[node.uid]
+
+              // The virtual entry used to import doesn't have any meta
+              if (nodeMetas) {
+                partsLength[nodeMetas.id] = nodePart.renderedLength
+              }
+            }
+          }
+        })
+      }
+
+      return `## ${statsTitle(modulePath, statsExport)}: ${filesize(totalSize, { base: 2 })}, ${Object.keys(partsLength).length} modules` +
+        '\n\n' +
+        `
+|Module Path|Size|Percentage|
+|-----------|----|----------|` + '\n' +
+      Object.entries(partsLength).map(([modulePath, renderedLength]) => {
+        // Ignore the virtual entry
+        if (renderedLength) {
+          const shortPath = relative(process.cwd(), modulePath)
+          return `| ${shortPath} | ${filesize(renderedLength, { base: 2 })} | ${(renderedLength / totalSize * 100).toFixed(2)}% |`
+        }
+
+        return ''
+      }).join('\n')
+    })
+    .join('\n\n')
+}
+
+function traverse (node, callback) {
+  callback(node)
+  if (node.children) {
+    node.children.forEach((childNode) => traverse(childNode, callback))
+  }
+}
+
+function statsTitle (modulePath, statsExport) {
+  // If we're not importing only part of the module, just return the module path
+  if (!statsExport || statsExport === '*') {
+    return modulePath
+  }
+
+  return `${modulePath} (\`${statsExport}\`)`
+}

--- a/stats/generate-stats-message.js
+++ b/stats/generate-stats-message.js
@@ -1,31 +1,75 @@
-const { relative } = require('node:path')
+const { stat, readFile } = require('node:fs/promises')
+const { relative, join } = require('node:path')
 
 const { filesize } = require('filesize')
 
+const configPaths = require('../config/paths.js')
+
 const extractRelevantStats = require('./lib/rollup-plugin-visualiser-stats.js')
 
-module.exports = function generateStatsMessage () {
+module.exports = async function generateStatsMessage () {
+  return `
+## Dist
+
+File sizes represent **minified** code.
+
+${await generateDistStatsMessage()}
+
+## Modules
+
+File sizes represent **non-minified** code.
+
+${generateModuleStatsMessage()}
+  `
+}
+
+async function generateDistStatsMessage () {
+  const pkg = JSON.parse(
+    await readFile(join(configPaths.package, 'package.json'), 'utf8')
+  )
+
+  const [js, css, ie8] = await Promise.all([
+    stat(join(configPaths.dist, `govuk-frontend-${pkg.version}.min.js`)),
+    stat(join(configPaths.dist, `govuk-frontend-${pkg.version}.min.css`)),
+    stat(join(configPaths.dist, `govuk-frontend-ie8-${pkg.version}.min.css`))
+  ])
+
+  return `
+- JavaScript: ${filesize(js.size, { base: 2 })}
+- CSS: ${filesize(css.size, { base: 2 })}
+- CSS (IE8): ${filesize(ie8.size, { base: 2 })}
+  `
+}
+
+function generateModuleStatsMessage () {
   const statsConfig = require('./stats.config.js')
 
-  return Object.entries(statsConfig)
-    // Uncomment following line to only process the first entry, for debugging
-    // .filter((o, i) => !i)
-    // First extract the information we need from the configuration
-    .map(([statsId, [modulePath, statsExport]]) => {
-      // Load the stats generated for that specific file
-      const rawStats = require(`./public/${statsId}/stats-raw-data.json`)
+  return (
+    Object.entries(statsConfig)
+      // Uncomment following line to only process the first entry, for debugging
+      // .filter((o, i) => !i)
+      // First extract the information we need from the configuration
+      .map(([statsId, [modulePath, statsExport]]) => {
+        // Load the stats generated for that specific file
+        const rawStats = require(`./public/${statsId}/stats-raw-data.json`)
 
-      const { partsLength, totalSize } = extractRelevantStats(rawStats)
+        const { partsLength, totalSize } = extractRelevantStats(rawStats)
 
-      return `<details><summary><strong>${statsTitle(modulePath, statsExport)}: ${filesize(totalSize, { base: 2 })}, ${Object.keys(partsLength).length} modules</strong></summary>
+        return `<details><summary><strong>${statsTitle(
+          modulePath,
+          statsExport
+        )}: ${filesize(totalSize, { base: 2 })}, ${
+          Object.keys(partsLength).length
+        } modules</strong></summary>
 
 |Module Path|Size|Percentage|
 |-----------|----|----------|
 ${tableRows(partsLength, totalSize)}
 
 </details>`
-    })
-    .join('\n\n')
+      })
+      .join('\n\n')
+  )
 }
 
 function tableRows (partsLength, totalSize) {
@@ -45,5 +89,5 @@ function statsTitle (modulePath, statsExport) {
     return modulePath
   }
 
-  return `${modulePath} (\`${statsExport}\`)`
+  return `${modulePath} (<code>import ${statsExport}</code>)`
 }

--- a/stats/generate-stats-message.js
+++ b/stats/generate-stats-message.js
@@ -59,22 +59,26 @@ module.exports = function generateStatsMessage () {
         })
       }
 
-      return `## ${statsTitle(modulePath, statsExport)}: ${filesize(totalSize, { base: 2 })}, ${Object.keys(partsLength).length} modules` +
-        '\n\n' +
-        `
-|Module Path|Size|Percentage|
-|-----------|----|----------|` + '\n' +
-      Object.entries(partsLength).map(([modulePath, renderedLength]) => {
-        // Ignore the virtual entry
-        if (renderedLength) {
-          const shortPath = relative(process.cwd(), modulePath)
-          return `| ${shortPath} | ${filesize(renderedLength, { base: 2 })} | ${(renderedLength / totalSize * 100).toFixed(2)}% |`
-        }
+      return `<details><summary><strong>${statsTitle(modulePath, statsExport)}: ${filesize(totalSize, { base: 2 })}, ${Object.keys(partsLength).length} modules</strong></summary>
 
-        return ''
-      }).join('\n')
+|Module Path|Size|Percentage|
+|-----------|----|----------|
+${tableRows(partsLength, totalSize)}
+
+</details>`
     })
     .join('\n\n')
+}
+
+function tableRows (partsLength, totalSize) {
+  return Object.entries(partsLength)
+    .filter(([modulePath, renderedLength]) => !!renderedLength)
+    .map(([modulePath, renderedLength]) => {
+      // Ignore the virtual entry
+      const shortPath = relative(process.cwd(), modulePath)
+      return `|${shortPath}|${filesize(renderedLength, { base: 2 })}|${((renderedLength / totalSize) * 100).toFixed(2)}%|`
+    })
+    .join('\n')
 }
 
 function traverse (node, callback) {

--- a/stats/generate-stats-message.js
+++ b/stats/generate-stats-message.js
@@ -2,62 +2,20 @@ const { relative } = require('node:path')
 
 const { filesize } = require('filesize')
 
+const extractRelevantStats = require('./lib/rollup-plugin-visualiser-stats.js')
+
 module.exports = function generateStatsMessage () {
   const statsConfig = require('./stats.config.js')
 
   return Object.entries(statsConfig)
+    // Uncomment following line to only process the first entry, for debugging
     // .filter((o, i) => !i)
     // First extract the information we need from the configuration
     .map(([statsId, [modulePath, statsExport]]) => {
       // Load the stats generated for that specific file
-      const stats = require(`./public/${statsId}/stats-raw-data.json`)
+      const rawStats = require(`./public/${statsId}/stats-raw-data.json`)
 
-      // TODO: Confirm I understood correctly
-      // We'll be traversing the `tree` in the stats, whose node Uid represent moduleParts.
-      // As far as I understand, those represent the parts of the module that actually get
-      // into each file of the bundle. Potentially, these are not the full module,
-      // as some of the file may have been tree-shaken away.
-      //
-      // These Uid are the ones used in `stats.moduleParts`, which reference the size each of each part
-      //
-      // However `nodeMetas`, providing the filename and the imports of each module is indexed against Uids
-      // representing the entirety of the modules (so not matching the moduleParts Uids)
-      //
-      // To speed up access when traversing the tree, this creates an index of the `nodeMetas`
-      // by name of the bundle file and module part
-      const nodeMetasByRootAndModulePartUid = {}
-      for (const meta of Object.values(stats.nodeMetas)) {
-        for (const [modulePartName, moduleUidInPart] of Object.entries(meta.moduleParts)) {
-          if (!nodeMetasByRootAndModulePartUid[modulePartName]) {
-            nodeMetasByRootAndModulePartUid[modulePartName] = {}
-          }
-
-          nodeMetasByRootAndModulePartUid[modulePartName][moduleUidInPart] = meta
-        }
-      }
-
-      let totalSize = 0
-      const partsLength = {}
-      for (const part of stats.tree.children) {
-        const rootPartName = part.name
-        traverse(part, (node) => {
-          if (rootPartName) {
-            if (node.uid) {
-            // The root node doesn't have a uid...
-              const nodePart = stats.nodeParts[node.uid]
-              totalSize += nodePart.renderedLength
-
-              const nodeMetas =
-                nodeMetasByRootAndModulePartUid[rootPartName]?.[node.uid]
-
-              // The virtual entry used to import doesn't have any meta
-              if (nodeMetas) {
-                partsLength[nodeMetas.id] = nodePart.renderedLength
-              }
-            }
-          }
-        })
-      }
+      const { partsLength, totalSize } = extractRelevantStats(rawStats)
 
       return `<details><summary><strong>${statsTitle(modulePath, statsExport)}: ${filesize(totalSize, { base: 2 })}, ${Object.keys(partsLength).length} modules</strong></summary>
 
@@ -79,13 +37,6 @@ function tableRows (partsLength, totalSize) {
       return `|${shortPath}|${filesize(renderedLength, { base: 2 })}|${((renderedLength / totalSize) * 100).toFixed(2)}%|`
     })
     .join('\n')
-}
-
-function traverse (node, callback) {
-  callback(node)
-  if (node.children) {
-    node.children.forEach((childNode) => traverse(childNode, callback))
-  }
 }
 
 function statsTitle (modulePath, statsExport) {

--- a/stats/generate-stats-message.unit.test.mjs
+++ b/stats/generate-stats-message.unit.test.mjs
@@ -1,7 +1,7 @@
 import generateStatsMessage from './generate-stats-message.js'
 
 // Not really a test but a way to run generateMessage again and again
-describe('generateStatsMessage', () => {
+describe.skip('generateStatsMessage', () => {
   it('Generates a message', () => {
     console.log(generateStatsMessage())
   })

--- a/stats/generate-stats-message.unit.test.mjs
+++ b/stats/generate-stats-message.unit.test.mjs
@@ -1,0 +1,8 @@
+import generateStatsMessage from './generate-stats-message.js'
+
+// Not really a test but a way to run generateMessage again and again
+describe('generateStatsMessage', () => {
+  it('Generates a message', () => {
+    console.log(generateStatsMessage())
+  })
+})

--- a/stats/lib/rollup-plugin-visualiser-stats.js
+++ b/stats/lib/rollup-plugin-visualiser-stats.js
@@ -1,0 +1,78 @@
+module.exports = function extractRelevantStats (rawStats) {
+  const nodeMetasByRootAndModulePartUid = indexStatsByRootAndModuleParts(rawStats)
+
+  const result = {
+    totalSize: 0,
+    partsLength: {}
+  }
+
+  for (const part of rawStats.tree.children) {
+    const rootPartName = part.name
+    traverse(part, (node) => {
+      if (rootPartName) {
+        if (node.uid) {
+        // The root node doesn't have a uid...
+          const nodePart = rawStats.nodeParts[node.uid]
+          result.totalSize += nodePart.renderedLength
+
+          const nodeMetas =
+            nodeMetasByRootAndModulePartUid[rootPartName]?.[node.uid]
+
+          // The virtual entry used to import doesn't have any meta
+          if (nodeMetas) {
+            result.partsLength[nodeMetas.id] = nodePart.renderedLength
+          }
+        }
+      }
+    })
+  }
+
+  return result
+}
+
+/**
+ * We'll be traversing the `tree` in the stats, whose node Uid represent moduleParts.
+ * As far as I understand, those represent the parts of the module that actually get
+ * into each file of the bundle. Potentially, these are not the full module,
+ * as some of the file may have been tree-shaken away.
+ *
+ * These Uid are the ones used in `rawStats.moduleParts`, which reference the size each of each part
+ *
+ * However `nodeMetas`, providing the filename and the imports of each module is indexed against Uids
+ * representing the entirety of the modules (so not matching the moduleParts Uids)
+ *
+ * To speed up access when traversing the tree, this creates an index of the `nodeMetas`
+ * by name of the bundle file and module part
+ *
+ * @param {object} rawStats -- JSON stats emited by rollup-plugin-visualizer
+ * @returns {object} Node metadatas indexed by root and module part Uid
+ */
+function indexStatsByRootAndModuleParts (rawStats) {
+  const nodeMetasByRootAndModulePartUid = {}
+
+  for (const meta of Object.values(rawStats.nodeMetas)) {
+    for (const [modulePartName, moduleUidInPart] of Object.entries(meta.moduleParts)) {
+      if (!nodeMetasByRootAndModulePartUid[modulePartName]) {
+        nodeMetasByRootAndModulePartUid[modulePartName] = {}
+      }
+
+      nodeMetasByRootAndModulePartUid[modulePartName][moduleUidInPart] = meta
+    }
+  }
+
+  return nodeMetasByRootAndModulePartUid
+}
+
+/**
+ * Traverses a tree structure, where child nodes are listed in a `.children` `Array` property,
+ * calling `callback` when entering each node
+ *
+ * @param {{children?:Array}} node -- The root node to start the traversing from
+ * @param {Function} callback -- The callback to execute
+ */
+function traverse (node, callback) {
+  callback(node)
+  if (node.children) {
+    node.children.forEach((childNode) => traverse(childNode, callback))
+  }
+}

--- a/stats/package.json
+++ b/stats/package.json
@@ -8,9 +8,10 @@
     "start": "rollup -c './rollup.config.js'"
   },
   "dependencies": {
+    "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-virtual": "^3.0.1",
+    "filesize": "^10.0.6",
     "rollup": "^3.7.4",
-    "rollup-plugin-visualizer": "^5.8.3",
-    "@rollup/plugin-node-resolve": "^15.0.1"
+    "rollup-plugin-visualizer": "^5.8.3"
   }
 }

--- a/stats/package.json
+++ b/stats/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "name": "govuk-frontend-stats",
+  "engines": {
+    "node": "^18.12.0"
+  },
   "scripts": {
     "start": "rollup -c './rollup.config.js'"
   },

--- a/stats/rollup.config.js
+++ b/stats/rollup.config.js
@@ -4,20 +4,7 @@ const { nodeResolve } = require('@rollup/plugin-node-resolve')
 const virtual = require('@rollup/plugin-virtual')
 const visualizer = require('rollup-plugin-visualizer')
 
-/**
- * Lists the files to analyse in a `name` => `options` map,
- * where `options` is an array that contains:
- *
- * 1. the path to import (mandatory)
- * 2. the name of the import (optional, if missing will consider that you're trying to import `default`)
- *
- * @type {Object<string,Array<string>>}
- */
-const TO_ANALYSE = {
-  all: ['all.mjs', '*'],
-  'all-accordion': ['all.mjs', '{Accordion}'],
-  'component-accordion': ['components/accordion/accordion.mjs']
-}
+const TO_ANALYSE = require('./stats.config.js')
 
 const ESM_ROOT = resolve(__dirname, '../package/govuk-esm')
 

--- a/stats/stats.config.js
+++ b/stats/stats.config.js
@@ -1,0 +1,14 @@
+/**
+ * Lists the files to analyse in a `name` => `options` map,
+ * where `options` is an array that contains:
+ *
+ * 1. the path to import (mandatory)
+ * 2. the name of the import (optional, if missing will consider that you're trying to import `default`)
+ *
+ * @type {Object<string,Array<string>>}
+ */
+module.exports = {
+  all: ['all.mjs', '*'],
+  'all-accordion': ['all.mjs', '{Accordion}'],
+  'component-accordion': ['components/accordion/accordion.mjs']
+}


### PR DESCRIPTION
This PR explores how we may collect stats about the size of our built files, as well as different ways we can access these stats. It looks at two sets of files:

1. the minified builds in `dist`, that'll likely be loaded in a browser straight away
2. the ES modules provided in `package`, likely to be consumed by a bundler to build the final JS app

> **Warning** The code in this PR needs to be thrown away and re-built tidily, this is just a proof of concept!

## Collecting the stats

### `fs.stat`

Use Node to get the size of the file on disk using `fs.stat`.

This is the method used for assessing the files in `dist` as each Kb in these files is a Kb the browser will load.

Getting more information like the number of modules in the bundles didn't feel useful for the files in `dist` as they bundle the entirety of the library anyway.

### rollup-plugin-visualizer

[rollup-plugin-visualizer](https://www.npmjs.com/package/rollup-plugin-visualizer) is a plugin that collects statistics during a Rollup build and outputs them, either as interactive HTML visualisations or raw data (YAML or JSON).

This method is used for scrutinising the ES Modules. It allows us to get a more information than the file on disk. By bundling a file that `export`s the module we want information on, it can let us know which other modules will get included, as well as how much each will contribute (accounting for tree-shaking). It also accounts for tree-shaking, when only part of a module would end up in the final bundle.

Unlike `fs.stats` which looks at the minified size on disk, this looks at the unminified code (even with `@rollup/plugin-terser` in the build). 

> **Note** The plugin could also be added to our own build process as we bundle the files in `package/govuk`. However this would have to wait until we're no longer stuck on an old version of Rollup.

## Accessing the stats

The PR updates the `test` workflow to add a stat collection job upon PR. It also extracts the steps that were building `dist` and `package` to their own jobs as those are pre-requisite to collecting the stats.

> **Note** The organisation of the jobs and steps is completely up for grabs, I just did what I could to make things work

### On the PR as comment

To get quick access to the information, the workflow adds a comment on the PR with the information it collected. It'll reuse the same comment if new pushes are made on the PR (using specific content in the comment to identify it)

For the modules, we can extract quite a lot of information from the raw data exported by `rollup-plugin-visualizer` and format it however we want. We'll likely want to use a few `<details>` element to not have that comment be too overwhelming. We'll also have to keep in mind [the 65536 characters limit for comments on Github](https://github.com/alphagov/govuk-frontend/issues/3229).

### Downloadable archive

Besides the raw data we can format on the PR comment, `rollup-plugin-visualizer` also creates HTML visualisations. Those are zipped and attached to the Github action's artifacts so they can be downloaded.

To speed up access, the PR also adds a link in the comment.

### Visualisation in the review app

The PR also adds access to the visualisations in the review app. It adds the stats collection to the Procfile so it runs before startup and serves them under `/stats`.

A link to the stats is added to the PR comment as well (and `serve-index` provides a cheap way to browse the files).

> **Warning** I forgot to add the rebuild of `dist` and `package`, so that would need being added when we do it properly. The PR still shows how this may work  in terms of UX, should we want it.

## How it works

The work for collecting the ES module stats and commenting on Github is isolated in its own npm workspace, inside the `stats` folder.

The collection of file sizes for the `dist` folder happens in the script doing the comment itself, as it's only `fs.stats` calls. We could look to extract it in its own function come the time to properly implement things.

### ES modules stats collection

You can run the stats collection with `npm start --workspace stats` from the root of the project.

The stats end up in `stats/public`, with naming conventions based on the file being looked at and what was asked to be exported.

`rollup.config.js` controls the Rollup build that'll output the statistics. It creates one entry to build per item in the `stats.config.js` file.

Those entries are purely virtual, not files on disk, (thanks to `@rollup/plugin-virtual`) and `export` either the whole module under scrutiny or specific exports from that module, so we can check tree-shaking.

Rollup outputs the built file to stdout. It's a bit verbose in the console, so we could either ignore it (`> /dev/null`) or could build into the `tmp` folder at the root of the project.

### Stats serving in the review app

The review app adds a new middleware for `/stats` that serves the files themselves using `express-static` and uses `serve-index` to let us navigate between the different files exported.

### CI workflow

The CI workflow, running after `dist` and `package` are built:

- collects the stats
- uploads the generated visualisation as an artifact of the action
- comments on the PR

The commenting of the PR is split between:

- `comment-on-pr.js`, the entry point exporting the function run by the [GitHub Script action](https://github.com/marketplace/actions/github-script). It's mostly code for interacting with Github API, delegating the bulk of rendering the comment to `generateStatsMessage()`
- `generate-stats-message.js` contains the code generating the comment with the stats. 
- `lib/rollup-plugin-visualiser-stats.js` contains the logic parsing the raw data from rollup-plugin-visualiser and aggregating it in a way that suits us

## Thoughts and questions

- The code in this PR needs to be thrown away and re-built tidily, this is just a proof of concept! Especially the workflow, which I wasn't quite sure how to organise so `dist` and `package` are re-built beforehand.
- This PR shows what's feasible, but we don't necessarily need to do it all in one go. We could start by only looking at on-disk file size before diving deeper into analysing modules.
- Looking at the ES module stats, we'll need to decide on some sorting and organisation for the content (bearing in mind we're limited to 65536 characters, we may want to put some info in the review app?)
- The file sizes represent different things for `dist` and `package`. For the former, they're the actual size on disc. For the later, the size of the source. Not a bad thing, especially as they're relevant to what happens to each kind of files, but something to keep in mind.
- `rollup-plugin-visualizer` will integrate with our build once we move to Rollup 3, so we could collect stats without making 1 build per file we want to look at. Making a new build is closer to how our files will be consumed though.
- The file sizes returned by `rollup-plugin-visualizer` include the weight of the comments. In a way this makes sense as there's no guarantee that a bundler loading our file will have a minifier stripping comments, so these comments would contribute to the bundle size after all.
- the raw data format exported from `rollup-plugin-visualiser` is not as well specified as [that of Webpack](https://webpack.js.org/api/stats/). The project is also a much smaller scale. This may explain why many stats project rely on Webpack 🤔 
- The PR doesn't look into comparing the stats across branches, that's something we can look into separately.

Kind of tangential thought as well (and quite a heavy piece of work). We have 3 ways to build the project (`build:compile`, `build:dist`, `build:package`). This means the build runs 3 times on CI.
Could things be split up differently so we build only once, and then gather the results of the build in whichever way we want to ship them (ie. a "build" and then a "packaging" step?