### PR TITLE
Fix Exit this Page indicator colours not being suitable for hover/focus 

### DIFF
--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -28,8 +28,7 @@
     @include govuk-responsive-padding(2);
     display: none;
     padding-bottom: 0;
-    color: govuk-colour("white");
-    background-color: govuk-colour("red");
+    color: inherit;
     line-height: 0; // removes extra negative space below the indicators
     text-align: center;
     pointer-events: none;
@@ -44,12 +43,27 @@
     width: .5em;
     height: .5em;
     margin: 0 .125em;
-    border: 2px solid govuk-colour("white");
+    border-width: 2px;
+    border-style: solid;
     border-radius: 50%;
+
+    @include govuk-not-ie8 {
+      border-color: currentcolor;
+    }
+
+    @include govuk-if-ie8 {
+      border-color: govuk-colour("white");
+    }
   }
 
   .govuk-exit-this-page__indicator-light--on {
-    background-color: govuk-colour("white");
+    @include govuk-not-ie8 {
+      background-color: currentcolor;
+    }
+
+    @include govuk-if-ie8 {
+      background-color: govuk-colour("white");
+    }
   }
 
   @media only print {


### PR DESCRIPTION
Removes the background-color from the indicator dot container, as we want it to use whatever the button background colour is, including when hovering or focused.

Changes the indicator dots to use `inherit`/`currentcolor` so that the dots remain visible on the button's focus state. Still maintains the explicit colour definitions for IE8 as it doesn't support the `currentcolor` keyword.

Fixes #3246. 