### PR TITLE
Tweak tab clicks to use `event.currentTarget`

### DIFF
--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -260,19 +260,14 @@ Tabs.prototype.unsetAttributes = function ($tab) {
  * Handle tab link clicks
  *
  * @param {MouseEvent} event - Mouse click event
- * @returns {void | false} Returns void, or false within tab link
+ * @returns {void} Returns void
  */
 Tabs.prototype.onTabClick = function (event) {
   var $currentTab = this.getCurrentTab()
-  var $nextTab = event.target
+  var $nextTab = event.currentTarget
 
   if (!$currentTab || !$nextTab) {
     return
-  }
-
-  // Allow events on child DOM elements to bubble up to tab parent
-  if (!$nextTab.classList.contains('govuk-tabs__tab')) {
-    return false
   }
 
   event.preventDefault()


### PR DESCRIPTION
A few minor tweaks to **Tabs** to simplify our code in places

1. **Find the tab link using `event.currentTarget`**
Prevents us having to check for child elements getting the click

2. ~**Move Tab bound handlers to constructor**~
~We were recreating handlers multiple times per tab~

**Update:** Commit for 2) has been merged via:

* https://github.com/alphagov/govuk-frontend/pull/2987