### PR TITLE
Exit this Page - high contrast mode fixes

### DIFF
--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -1,6 +1,8 @@
 @import "../button/index";
 
 @include govuk-exports("govuk/component/exit-this-page") {
+  $indicator-size: .75em;
+
   .govuk-exit-this-page {
     z-index: 1000;
     top: 0;
@@ -39,9 +41,10 @@
   }
 
   .govuk-exit-this-page__indicator-light {
+    box-sizing: border-box;
     display: inline-block;
-    width: .5em;
-    height: .5em;
+    width: $indicator-size;
+    height: $indicator-size;
     margin: 0 .125em;
     border-width: 2px;
     border-style: solid;
@@ -57,13 +60,7 @@
   }
 
   .govuk-exit-this-page__indicator-light--on {
-    @include govuk-not-ie8 {
-      background-color: currentcolor;
-    }
-
-    @include govuk-if-ie8 {
-      background-color: govuk-colour("white");
-    }
+    border-width: $indicator-size / 2;
   }
 
   @media only print {


### PR DESCRIPTION
@36degrees noted on #3247 that our current EtP indicators were not visible on forced colour modes (aka, high contrast mode), as the `background-color` is typically overridden in that scenario. This PR refactors the indicators so that the border is used to indicate 'lit' status, rather than a background colour. 

## Screenshots
|Browser / OS|Screenshot|
|:-|:-:|
|Chrome 109 / macOS 13.2|![image](https://user-images.githubusercontent.com/1253214/217770781-bf7bf561-2288-411e-9498-039f1e968a1e.png)|
|Firefox 109 / macOS 13.2|![image](https://user-images.githubusercontent.com/1253214/217770258-1e2d1b40-12e3-4868-af49-569a0d22ce1e.png)|
|Safari 16.3 / macOS 13.2|![image](https://user-images.githubusercontent.com/1253214/217770679-d08a76c5-d872-4493-bd09-fc518faedd5e.png)|
|IE 11 / Windows 10|![image](https://user-images.githubusercontent.com/1253214/217771024-ae90064e-33a8-46e8-b536-f4c36570bbc6.png)|
|IE 8 / Windows 7|![image](https://user-images.githubusercontent.com/1253214/217770484-11705d73-93c8-49d2-ad6e-b2d00da346d8.png)|
|Edge 108 / Windows 10<br>(High Contrast Mode)|![image](https://user-images.githubusercontent.com/1253214/217771377-3dfaa82d-ddb0-4a55-b63d-4f443cedc626.png)|

## Changes
- Changes the way we 'light' indicators. Rather than setting a background colour, the border width is increased in a manner that makes it appear to fill the indicator. 