### PR TITLE
Exit this page: Add attached keyboard help text

### DIFF
--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -82,6 +82,7 @@
       border-radius: 4px;
       background-color: govuk-colour("white");
       box-shadow: 0 1px 0 govuk-colour("white"), 0 2px 0 $govuk-border-colour;
+      white-space: nowrap;
     }
 
     @include govuk-media-query($from: tablet) {

--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -6,7 +6,6 @@
     z-index: 1000;
     top: 0;
     left: 0;
-    width: 100%;
 
     @include govuk-media-query($from: tablet) {
       right: 0;
@@ -78,7 +77,6 @@
 
     kbd {
       @include govuk-font($size: 16);
-      display: inline-block;
       padding: 0 govuk-spacing(1);
       border: 1px solid $govuk-border-colour;
       border-radius: 4px;

--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -13,6 +13,8 @@
 
     @include govuk-media-query($from: tablet) {
       display: inline-block;
+      display: inline-flex;
+      flex-direction: column;
       right: 0;
       left: auto;
       width: auto;
@@ -63,6 +65,28 @@
 
     @include govuk-if-ie8 {
       background-color: govuk-colour("white");
+    }
+  }
+
+  .govuk-exit-this-page__help {
+    @include govuk-responsive-padding(2);
+    @include govuk-font($size: 16);
+    display: none;
+    border: 1px solid $govuk-border-colour;
+    border-top: none;
+    background-color: govuk-colour("white");
+    text-align: center;
+
+    kbd {
+      @include govuk-font($size: 16);
+      display: inline-block;
+      padding: 0 govuk-spacing(1);
+      border: 1px solid $govuk-border-colour;
+      border-radius: 4px;
+    }
+
+    @include mq($from: tablet) {
+      display: block;
     }
   }
 

--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -82,6 +82,8 @@
       padding: 0 govuk-spacing(1);
       border: 1px solid $govuk-border-colour;
       border-radius: 4px;
+      background-color: govuk-colour("white");
+      box-shadow: 0 1px 0 govuk-colour("white"), 0 2px 0 $govuk-border-colour;
     }
 
     @include govuk-media-query($from: tablet) {

--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -2,27 +2,26 @@
 
 @include govuk-exports("govuk/component/exit-this-page") {
   .govuk-exit-this-page {
+    @include govuk-responsive-padding(8, "bottom");
     z-index: 1000;
     top: 0;
     left: 0;
     width: 100%;
-    @supports (position: sticky) {
-      @include govuk-responsive-padding(8, "bottom");
-      position: sticky;
-    }
 
     @include govuk-media-query($from: tablet) {
-      display: inline-block;
-      display: inline-flex;
-      flex-direction: column;
       right: 0;
       left: auto;
       width: auto;
       float: right;
     }
+
+    @supports (position: sticky) {
+      position: sticky;
+    }
   }
 
   .govuk-exit-this-page__button {
+    width: 100%;
     margin-bottom: 0;
   }
 
@@ -85,7 +84,7 @@
       border-radius: 4px;
     }
 
-    @include mq($from: tablet) {
+    @include govuk-media-query($from: tablet) {
       display: block;
     }
   }

--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -16,7 +16,7 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
 var EXIT_THIS_PAGE_TRANSLATIONS = {
   keypressProgress: 'Exit this Page key press %{press} of 3',
   keypressComplete: 'Exit this page activated',
-  helpText: 'press <kbd>Shift</kbd> 3 times <span class="govuk-visually-hidden">to exit the page</span>'
+  helpText: 'Or press <kbd>&#8679; Shift</kbd> key 3 times <span class="govuk-visually-hidden">to exit the page</span>'
 }
 
 /**

--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -16,7 +16,7 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
 var EXIT_THIS_PAGE_TRANSLATIONS = {
   keypressProgress: 'Exit this Page key press %{press} of 3',
   keypressComplete: 'Exit this page activated',
-  helpText: 'press <kbd>Shift</kbd> 3 times<span class="govuk-visually-hidden"> to exit the page</span>'
+  helpText: 'press <kbd>Shift</kbd> 3 times <span class="govuk-visually-hidden">to exit the page</span>'
 }
 
 /**


### PR DESCRIPTION
Re-introduces having keyboard instructions "Press <kbd>Shift</kbd> 3 times" adjacent to the Exit this Page button, as per investigation #3267. 

This is done on the hypothesis that having that guidance next to the button is clearer to an end user than having the equivalent instructions on a separate guidance page. 

## Changes

![image](https://user-images.githubusercontent.com/1253214/217868744-3dc7cfa9-39e5-43ef-84db-bc4f487c0820.png)

- Adds help text displayed below the EtP button.
  - This text is injected as part of JavaScript initialisation and does not appear if JavaScript (and thus the keyboard-related functionality) is unavailable. 
  - This text remains 'stuck' to the viewport with the button when the user scrolls.
  - The help text is hidden on narrow screens, on the basis that screen real estate is more valuable and the vast majority of users are unlikely to be using a physical keyboard at this size.
- Implements our Frontend-wide localisation library into the EtP component's JavaScript for good measure.

## Things to consider

- The wording of the text. Currently this uses visually-hidden text to provide more context for screen readers. The full text being: "press <kbd>Shift</kbd> 3 times [to exit the page]"
  - Does it read better as "**or** press <kbd>Shift</kbd> 3 times"?
  - Is there liable to be confusion between pressing a key on a keyboard and 'pressing' something on a screen (aka, clicking)? 
- I've styled the word "Shift" differently to try and make it clearer that we mean Shift the key on a keyboard, not some other kind of Shift. This seems to be vaguely common practice, including on GitHub → <kbd>Shift</kbd>.
  - I'm not sure if there could be confusion here, as not all keyboards actually show the word "Shift" on the Shift key, using an upwards pointing arrow (⇧) instead, but I was worried this could be confused for the top arrow key.
  - Currently none of the help text, <kbd>Shift</kbd> included, is clickable. Should it be? 
- Hiding the help text on narrow screens also means that it disappears on high zoom levels. In this case, the point about screen real estate still applies, but the user is much more likely to be using a keyboard. 