### PR TITLE
Add PRs labelled `dependabot` to the project board

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -1,0 +1,21 @@
+name: Triage pull requests
+
+on:
+  pull_request:
+    types:
+      - labeled
+      - opened
+
+jobs:
+  add-to-project:
+    name: Triage pull requests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to project
+        uses: actions/add-to-project@v0.4.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Add to 'Design System Sprint Board'
+          project-url: https://github.com/orgs/alphagov/projects/53
+          labeled: dependabot


### PR DESCRIPTION
This PR configures Dependabot PRs to be added automatically to our project board

It uses the [Add to GitHub Projects](https://github.com/marketplace/actions/add-to-github-projects) action mentioned in:

* https://github.com/alphagov/govuk-frontend/pull/2950#issuecomment-1301931845

The official GitHub Action is quite limited but 3rd party alternatives are available should non-default columns be needed: https://docs.github.com/en/actions/managing-issues-and-pull-requests/moving-assigned-issues-on-project-boards