### PR TITLE
Remove redundant Jest "port available" checks

### DIFF
--- a/config/jest/browser/close.mjs
+++ b/config/jest/browser/close.mjs
@@ -1,13 +1,8 @@
 import { teardown } from 'jest-environment-puppeteer'
 
-import serverStop from '../server/stop.mjs'
-
 /**
  * Close browser
  */
 export default async function browserClose () {
-  await Promise.all([
-    serverStop(), // Stop web server
-    teardown() // Close browser
-  ])
+  await teardown() // Close browser, stop server
 }

--- a/config/jest/browser/close.mjs
+++ b/config/jest/browser/close.mjs
@@ -1,8 +1,4 @@
 import { teardown } from 'jest-environment-puppeteer'
 
-/**
- * Close browser
- */
-export default async function browserClose () {
-  await teardown() // Close browser, stop server
-}
+// Close browser, stop server
+export default () => teardown()

--- a/config/jest/browser/open.mjs
+++ b/config/jest/browser/open.mjs
@@ -19,5 +19,5 @@ export default async function browserOpen (jestConfig) {
   }
 
   await download() // Download browser
-  await setup(jestConfig) // Open browser, start server
+  return setup(jestConfig) // Open browser, start server
 }

--- a/config/jest/browser/open.mjs
+++ b/config/jest/browser/open.mjs
@@ -1,7 +1,6 @@
 import { setup } from 'jest-environment-puppeteer'
 
 import { download } from '../../../tasks/browser/download.mjs'
-import serverStart from '../server/start.mjs'
 
 /**
  * Open browser
@@ -20,6 +19,5 @@ export default async function browserOpen (jestConfig) {
   }
 
   await download() // Download browser
-  await serverStart() // Wait for web server
-  await setup(jestConfig) // Open browser
+  await setup(jestConfig) // Open browser, start server
 }

--- a/config/jest/server/start.mjs
+++ b/config/jest/server/start.mjs
@@ -2,9 +2,5 @@ import { setup } from 'jest-dev-server'
 
 import config from '../../../jest-dev-server.config.js'
 
-/**
- * Start web server
- */
-export default async function serverStart () {
-  await setup(config)
-}
+// Start web server
+export default () => setup(config)

--- a/config/jest/server/start.mjs
+++ b/config/jest/server/start.mjs
@@ -1,42 +1,10 @@
-import { getServers, setup } from 'jest-dev-server'
-import waitOn from 'wait-on'
+import { setup } from 'jest-dev-server'
 
-import config from '../../index.js'
-
-import serverStop from './stop.mjs'
-
-const PORT = process.env.PORT || config.ports.test
+import config from '../../../jest-dev-server.config.js'
 
 /**
  * Start web server
  */
 export default async function serverStart () {
-  const servers = await getServers()
-
-  // Server start timeout
-  let timeout = 1000
-
-  // Server stopping?
-  if (servers.some(({ signalCode }) => signalCode === 'SIGTERM')) {
-    await serverStop() // Wait for server to stop
-    timeout = 0 // No need to wait for start
-  }
-
-  // Wait until ready check
-  const ready = ({ timeout = 30000 } = {}) => waitOn({
-    resources: [`tcp:${PORT}`],
-    timeout
-  })
-
-  // Wait until ready (or start up)
-  try {
-    await ready({ timeout })
-  } catch (error) {
-    await setup({
-      // Ensure PORT works (on Windows) + SIGINT/SIGTERM signal events
-      command: `cross-env-shell PORT=${PORT} node app/start.js`,
-      port: PORT
-    })
-    await ready()
-  }
+  await setup(config)
 }

--- a/config/jest/server/stop.mjs
+++ b/config/jest/server/stop.mjs
@@ -1,8 +1,4 @@
 import { teardown } from 'jest-dev-server'
 
-/**
- * Stop web server
- */
-export default async function serverStop () {
-  await teardown()
-}
+// Stop web server
+export default () => teardown()

--- a/jest-dev-server.config.js
+++ b/jest-dev-server.config.js
@@ -1,0 +1,15 @@
+const { ports } = require('./config/index.js')
+
+const PORT = process.env.PORT || ports.test
+
+/**
+ * @type {import('jest-dev-server').JestDevServerOptions}
+ */
+module.exports = {
+  // Ensure PORT works (on Windows) + SIGINT/SIGTERM signal events
+  command: `cross-env-shell PORT=${PORT} node app/start.js`,
+  port: PORT,
+
+  // Skip when already running
+  usedPortAction: 'ignore'
+}

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,3 +1,5 @@
+const devServerOptions = require('./jest-dev-server.config.js')
+
 module.exports = {
   browserContext: 'incognito',
   browserPerWorker: true,
@@ -9,6 +11,8 @@ module.exports = {
   exitOnPageError: false,
 
   /**
+   * Puppeteer launch options
+   *
    * @type {import('puppeteer').PuppeteerLaunchOptions}
    */
   launch: {
@@ -27,5 +31,10 @@ module.exports = {
       '--no-startup-window'
     ],
     waitForInitialPage: false
-  }
+  },
+
+  /**
+   * Development server options
+   */
+  server: devServerOptions
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "husky": "^8.0.3",
         "jest": "^29.4.3",
         "jest-axe": "^7.0.0",
-        "jest-dev-server": "^7.0.0",
+        "jest-dev-server": "^7.0.1",
         "jest-environment-jsdom": "^29.4.3",
         "jest-environment-node-single-context": "^29.0.0",
         "jest-environment-puppeteer": "^7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,8 +76,7 @@
         "standard": "^17.0.0",
         "stylelint": "^14.16.1",
         "stylelint-config-gds": "^0.2.0",
-        "stylelint-order": "^6.0.2",
-        "wait-on": "^7.0.1"
+        "stylelint-order": "^6.0.2"
       },
       "engines": {
         "node": "^18.12.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "husky": "^8.0.3",
     "jest": "^29.4.3",
     "jest-axe": "^7.0.0",
-    "jest-dev-server": "^7.0.0",
+    "jest-dev-server": "^7.0.1",
     "jest-environment-jsdom": "^29.4.3",
     "jest-environment-node-single-context": "^29.0.0",
     "jest-environment-puppeteer": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,7 @@
     "standard": "^17.0.0",
     "stylelint": "^14.16.1",
     "stylelint-config-gds": "^0.2.0",
-    "stylelint-order": "^6.0.2",
-    "wait-on": "^7.0.1"
+    "stylelint-order": "^6.0.2"
   },
   "overrides": {
     "chokidar@^2": {


### PR DESCRIPTION
The following Dependabot update includes [`jest-dev-server@7.0.1`](https://github.com/argos-ci/jest-puppeteer/blob/main/packages/jest-dev-server/CHANGELOG.md#701-2023-02-15)

* https://github.com/alphagov/govuk-frontend/pull/3298

With "dev server" port detection on macOS now fixed we can remove all our workaround code 🙌

Much easier to run training sessions on code that isn't there 😊 

#### Dependencies removed

```console
wait-on
```