### PR TITLE
Exit this Page: Add text to the "ghost page" button feature

### DIFF
--- a/src/govuk/components/exit-this-page/_index.scss
+++ b/src/govuk/components/exit-this-page/_index.scss
@@ -67,7 +67,7 @@
     }
   }
 
-  .govuk-exit-this-page__overlay {
+  .govuk-exit-this-page-overlay {
     position: fixed;
     z-index: 9999;
     top: 0;
@@ -75,5 +75,22 @@
     bottom: 0;
     left: 0;
     background-color: govuk-colour("white");
+  }
+
+  // This class is added to the body when the Exit This Page button is activated
+  // in addition to the overlay to both block the entire screen and hide everything
+  // underneath it.
+  //
+  // We do this to ensure that users don't risk interacting with the page underneath
+  // the overlay between activating the button and navigating to the next page.
+  .govuk-exit-this-page-hide-content {
+    // stylelint-disable declaration-no-important
+    * {
+      display: none !important;
+    }
+
+    .govuk-exit-this-page-overlay {
+      display: block !important;
+    }
   }
 }

--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -14,7 +14,7 @@ import '../../vendor/polyfills/Function/prototype/bind.mjs'
  * @default
  */
 var EXIT_THIS_PAGE_TRANSLATIONS = {
-  activated: 'Exiting page.',
+  activated: 'Loading.',
   timedOut: 'Exit this page expired.',
   pressTwoMoreTimes: 'Shift, press 2 more times to exit.',
   pressOneMoreTime: 'Shift, press 1 more time to exit.'
@@ -132,7 +132,7 @@ ExitThisPage.prototype.updateIndicator = function () {
 
 /**
  * Initiates the redirection away from the current page.
- * Includes the 'ghost page' functionality, which covers the current page with a
+ * Includes the loading overlay functionality, which covers the current page with a
  * white overlay so that the contents are not visible during the loading
  * process. This is particularly important on slow network connections.
  *
@@ -146,10 +146,19 @@ ExitThisPage.prototype.exitPage = function (e) {
     redirectUrl = e.target.href
   }
 
+  this.$updateSpan.innerText = ''
+
   // Blank the page
+  // As well as creating an overlay with text, we also set the body to hidden
+  // to prevent screen reader and sequential navigation users potentially
+  // navigating through the page behind the overlay during loading
+  document.body.classList.add('govuk-exit-this-page-hide-content')
   this.$overlay = document.createElement('div')
-  this.$overlay.className = 'govuk-exit-this-page__overlay'
+  this.$overlay.className = 'govuk-exit-this-page-overlay'
+  this.$overlay.setAttribute('role', 'alert')
+
   document.body.appendChild(this.$overlay)
+  this.$overlay.innerText = this.i18n.t('activated')
 
   window.location.href = redirectUrl
 }
@@ -186,11 +195,9 @@ ExitThisPage.prototype.handleEscKeypress = function (e) {
 
     if (this.escCounter >= 3) {
       this.escCounter = 0
+
       clearTimeout(this.keypressTimeoutId)
       this.keypressTimeoutId = null
-
-      this.$updateSpan.setAttribute('role', 'alert')
-      this.$updateSpan.innerText = this.i18n.t('activated')
 
       this.exitPage()
     } else {
@@ -254,6 +261,8 @@ ExitThisPage.prototype.resetEscTimer = function () {
  */
 ExitThisPage.prototype.resetPage = function () {
   // If an overlay is set, remove it and reset the value
+  document.body.classList.remove('govuk-exit-this-page-hide-content')
+
   if (this.$overlay) {
     this.$overlay.remove()
     this.$overlay = null

--- a/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -6,7 +6,7 @@ const { goToComponent, goToExample } = require('../../../../lib/puppeteer-helper
 
 const buttonClass = '.govuk-js-exit-this-page-button'
 const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
-const overlayClass = '.govuk-exit-this-page__overlay'
+const overlayClass = '.govuk-exit-this-page-overlay'
 
 describe('/components/exit-this-page', () => {
   describe('when JavaScript is unavailable or fails', () => {
@@ -147,8 +147,8 @@ describe('/components/exit-this-page', () => {
         await page.keyboard.press('Shift')
         await page.keyboard.press('Shift')
 
-        const message = await page.evaluate((buttonClass) => document.querySelector(buttonClass).nextElementSibling.innerText, buttonClass)
-        expect(message).toBe('Exiting page.')
+        const message = await page.evaluate((overlayClass) => document.querySelector(overlayClass).innerText, overlayClass)
+        expect(message).toBe('Loading.')
       })
 
       it('announces when the keyboard shortcut has timed out', async () => {
@@ -156,8 +156,8 @@ describe('/components/exit-this-page', () => {
 
         await page.keyboard.press('Shift')
 
-        // Wait for 5 seconds
-        await new Promise((resolve) => setTimeout(resolve, 5000))
+        // Wait for 6 seconds (one full second over the 5 second limit)
+        await new Promise((resolve) => setTimeout(resolve, 6000))
 
         const message = await page.evaluate((buttonClass) => document.querySelector(buttonClass).nextElementSibling.innerText, buttonClass)
         expect(message).toBe('Exit this page expired.')


### PR DESCRIPTION
## What/Why
Adds text to the "ghost page" feature of the exit this page button so that we can revisit if this has a positive or negative impact on users. The text is unbranded and unstyled.

Additionally this change moves the button activation announcement for screen readers to the ghost page itself as opposed to the announcement `span` being used currently.

Closes https://github.com/alphagov/govuk-frontend/issues/3266

## Notes
From a quick screen reader test, as I've been finding whilst working on https://github.com/alphagov/govuk-frontend/issues/3061, there is an inconsistency in the button activation alert being announced before the screen reader "beats" the announcement and starts instead announcing navigation and the new page.