### PR TITLE
Re-enable complete hover link styles on the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#3272: Add empty alt attribute to logo IE8 fallback PNG](https://github.com/alphagov/govuk-frontend/pull/3272)
+- [#3306: Re-enable complete hover link styles on the footer](https://github.com/alphagov/govuk-frontend/pull/3306)
 
 ## 4.5.0 (Feature release)
 

--- a/src/govuk/components/footer/_index.scss
+++ b/src/govuk/components/footer/_index.scss
@@ -162,13 +162,6 @@
     padding: 0;
     list-style: none;
     column-gap: $govuk-gutter; // Support: Columns
-
-    // Disable thicker underlines on hover because of a bug in Chromium
-    // affecting links within columns
-    // https://bugs.chromium.org/p/chromium/issues/detail?id=1190987
-    .govuk-footer__link:hover {
-      text-decoration-thickness: auto;
-    }
   }
 
   @include govuk-media-query ($from: desktop) {


### PR DESCRIPTION
Remove the override we put in the footer to get around a Chrome bug.

Fixes: https://github.com/alphagov/govuk-frontend/issues/2660 (More details in the issue).