### PR TITLE
Add default value for warning text icon fallback attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#3272: Add empty alt attribute to logo IE8 fallback PNG](https://github.com/alphagov/govuk-frontend/pull/3272)
 - [#3306: Re-enable complete hover link styles on the footer](https://github.com/alphagov/govuk-frontend/pull/3306)
+- [#3312: Add default value for warning text icon fallback attribute](https://github.com/alphagov/govuk-frontend/pull/3312)
 
 ## 4.5.0 (Feature release)
 

--- a/src/govuk/components/warning-text/template.njk
+++ b/src/govuk/components/warning-text/template.njk
@@ -3,7 +3,7 @@
   >
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">{{ params.iconFallbackText }}</span>
+    <span class="govuk-warning-text__assistive">{{ params.iconFallbackText | default("Warning") }}</span>
     {{ params.html | safe if params.html else params.text }}
   </strong>
 </div>

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -22,7 +22,7 @@ describe('Warning text', () => {
       expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
     })
 
-    it('renders with assistive text', () => {
+    it('renders with default assistive text', () => {
       const $ = render('warning-text', examples.default)
 
       const $assistiveText = $('.govuk-warning-text__assistive')

--- a/src/govuk/components/warning-text/warning-text.yaml
+++ b/src/govuk/components/warning-text/warning-text.yaml
@@ -9,8 +9,8 @@ params:
     description: If `text` is set, this is not required. HTML to use within the warning text component. If `html` is provided, the `text` option will be ignored.
   - name: iconFallbackText
     type: string
-    required: true
-    description: The fallback text for the icon.
+    required: false
+    description: The fallback text for the icon. Defaults to 'Warning'
   - name: classes
     type: string
     required: false
@@ -35,7 +35,6 @@ examples:
     hidden: true
     data:
       text: You can be fined up to £5,000 if you don’t register.
-      iconFallbackText: Warning
       attributes:
         id: my-warning-text
         data-test: attribute
@@ -43,20 +42,21 @@ examples:
     hidden: true
     data:
       text: Warning text
-      iconFallbackText: Warning
       classes: govuk-warning-text--custom-class
   - name: html
     hidden: true
     data:
       text: You can be fined up to £5,000 if you don’t register.
-      iconFallbackText: Warning
       html: <span>Some custom warning text</span>
   - name: html as text
     hidden: true
     data:
-      iconFallbackText: Warning
       text: <span>Some custom warning text</span>
   - name: icon fallback text only
     hidden: true
     data:
       iconFallbackText: Some custom fallback text
+  - name: no icon fallback text
+    hidden: true
+    data:
+      text: This is a warning


### PR DESCRIPTION
## What/Why
Adds the default text 'Warning' to the `iconFallbackText` option for the [warning text component](https://design-system.service.gov.uk/components/warning-text/).

As we're now setting a default value, I've also set this to no longer be a required attribute. I couldn't find any evidence in commit history that there's a risk in setting a default and not setting this as required and we use the word 'Warning' for this value in all our review app examples and our code example on the website, therefore I don't think this change is controversial.

Fixes https://github.com/alphagov/govuk-frontend/issues/2693