### PR TITLE
Triage PRs labelled 'dependencies'

### DIFF
--- a/.github/workflows/triage-pull-requests.yml
+++ b/.github/workflows/triage-pull-requests.yml
@@ -18,4 +18,4 @@ jobs:
 
           # Add to 'Design System Sprint Board'
           project-url: https://github.com/orgs/alphagov/projects/53
-          labeled: dependabot
+          labeled: dependencies


### PR DESCRIPTION
We want to auto-triage dependabot PRs, which are labelled with the `dependencies` tag.

See https://github.com/alphagov/govuk-frontend/pull/3277