### PR TITLE
Add “Text alignment” and “Typography” pages to Percy

### DIFF
--- a/tasks/screenshot-components.mjs
+++ b/tasks/screenshot-components.mjs
@@ -82,7 +82,15 @@ export async function screenshotComponent (page, componentName) {
 export async function screenshotExample (page, exampleName) {
   await goToExample(page, exampleName)
 
+  // Dismiss app banner
+  await page.setCookie({
+    name: 'dismissed-app-banner',
+    value: 'yes',
+    url: page.url()
+  })
+
   // Screenshot preview page
+  await page.reload({ waitUntil: 'load' })
   await percySnapshot(page, `js: ${exampleName} (example)`)
 
   // Close page


### PR DESCRIPTION
This PR includes two review app "Example" pages for Percy visual regression:

* [Text alignment](https://govuk-frontend-review.herokuapp.com/examples/text-alignment)
* [Typography](https://govuk-frontend-review.herokuapp.com/examples/typography)

This helps assess `font-size` and `line-height` decimal place precision changes etc in:

* https://github.com/alphagov/govuk-frontend/issues/2239

But will also be useful for:

* https://github.com/alphagov/govuk-design-system/issues/2289

## Text alignment example
See review app [**Text alignment** example](https://govuk-frontend-review.herokuapp.com/examples/text-alignment) page

![Text alignment](https://user-images.githubusercontent.com/415517/220875130-2d25d8c6-405f-4fc9-83b5-ae249955ab71.png)

## Typography example
See review app [**Typography** example](https://govuk-frontend-review.herokuapp.com/examples/typography) page

![Typography](https://user-images.githubusercontent.com/415517/220875173-3d68aff3-34a2-4455-a6ad-3795559d9ee1.png)
