### PR TITLE
Fix select component fixture having two selected values

### DIFF
--- a/src/govuk/components/select/select.yaml
+++ b/src/govuk/components/select/select.yaml
@@ -111,11 +111,10 @@ examples:
           text: GOV.UK frontend option 1
         - value: 2
           text: GOV.UK frontend option 2
-          selected: true
         - value: 3
           text: GOV.UK frontend option 3
           disabled: true
-      value: 3
+      value: 2
   - name: with hint text and error message
     data:
       id: select-2


### PR DESCRIPTION
The Select component's "with selected value" fixture/example had two values that were selected: one at the item level and one at the component level.

Based on [the related test](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/select/template.test.js#L62-L67), only item 2 is expected to be selected, so I've changed the fixture to only select item 2.

This is based on the assumption that having two items selected wasn't a purposeful decision — i.e. to see if the two methods of selecting a value can be used in tandem, but given there isn't a test for this, it doesn't seem like that was the intention. 

Raised in #3317. 

