### PR TITLE
Add option to disable sessionState in Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,16 @@ Only use disabled form controls if research shows it makes the user interface ea
 
 This was added in [pull request #3187: Add disabled styles for form controls](https://github.com/alphagov/govuk-frontend/pull/3187).
 
+#### Configure whether the Accordion remembers and restores sessions
+
+By default, when a user leaves a page, the [Accordion](https://design-system.service.gov.uk/components/accordion/) will remember the layout of expanded and collapsed sections selected by the user. If the user returns to the page, this layout will be restored and override any sections manually set as `expanded` in code.
+
+You can now disable this functionality by using the `rememberExpanded` option in the `govukAccordion` Nunjucks macro.
+
+If you're not using the Nunjucks macro, you can disable it using the `data-remember-expanded` HTML attribute.
+
+This was added in [pull request #3342: Add option to disable sessionState in Accordion](https://github.com/alphagov/govuk-frontend/pull/3342).
+
 ### Deprecated features
 
 #### Stop using the `govuk-button--disabled` class on buttons

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -49,8 +49,8 @@ function Accordion ($module, config) {
   this.$module = $module
 
   var defaultConfig = {
-    rememberExpanded: true,
-    i18n: ACCORDION_TRANSLATIONS
+    i18n: ACCORDION_TRANSLATIONS,
+    rememberExpanded: true
   }
 
   /** @type {AccordionConfig} */
@@ -531,8 +531,8 @@ export default Accordion
  *
  * @typedef {object} AccordionConfig
  * @property {AccordionTranslations} [i18n = ACCORDION_TRANSLATIONS] - See constant {@link ACCORDION_TRANSLATIONS}
- * @property {boolean} [rememberExpanded] - Whether to remember the expanded and
- *   collapsed state of each section is remembered and restored when navigating.
+ * @property {boolean} [rememberExpanded] - Whether the expanded and collapsed
+ *   state of each section is remembered and restored when navigating.
  */
 
 /**

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -49,6 +49,7 @@ function Accordion ($module, config) {
   this.$module = $module
 
   var defaultConfig = {
+    rememberExpanded: true,
     i18n: ACCORDION_TRANSLATIONS
   }
 
@@ -469,7 +470,7 @@ var helper = {
  * @param {Element} $section - Section element
  */
 Accordion.prototype.storeState = function ($section) {
-  if (this.browserSupportsSessionStorage) {
+  if (this.browserSupportsSessionStorage && this.config.rememberExpanded) {
     // We need a unique way of identifying each content in the Accordion. Since
     // an `#id` should be unique and an `id` is required for `aria-` attributes
     // `id` can be safely used.
@@ -493,7 +494,7 @@ Accordion.prototype.storeState = function ($section) {
  * @param {Element} $section - Section element
  */
 Accordion.prototype.setInitialState = function ($section) {
-  if (this.browserSupportsSessionStorage) {
+  if (this.browserSupportsSessionStorage && this.config.rememberExpanded) {
     var $button = $section.querySelector('.' + this.sectionButtonClass)
 
     if ($button) {
@@ -530,6 +531,8 @@ export default Accordion
  *
  * @typedef {object} AccordionConfig
  * @property {AccordionTranslations} [i18n = ACCORDION_TRANSLATIONS] - See constant {@link ACCORDION_TRANSLATIONS}
+ * @property {boolean} [rememberExpanded] - Whether to remember the expanded and
+ *   collapsed state of each section is remembered and restored when navigating.
  */
 
 /**

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -120,6 +120,29 @@ describe('/components/accordion', () => {
         expect(expandedState).toEqual(expandedStateAfterRefresh)
       })
 
+      it('should not maintain the expanded state after a page refresh, if configured', async () => {
+        const sectionHeaderButton = '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
+
+        await goToComponent(page, 'accordion', {
+          exampleName: 'with-remember-expanded-off'
+        })
+        await page.click(sectionHeaderButton)
+
+        const expandedState = await page.evaluate((sectionHeaderButton) => {
+          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
+        }, sectionHeaderButton)
+
+        await page.reload({
+          waitUntil: 'load'
+        })
+
+        const expandedStateAfterRefresh = await page.evaluate((sectionHeaderButton) => {
+          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
+        }, sectionHeaderButton)
+
+        expect(expandedState).not.toEqual(expandedStateAfterRefresh)
+      })
+
       it('should transform the button span to <button>', async () => {
         await goToComponent(page, 'accordion')
 

--- a/src/govuk/components/accordion/accordion.yaml
+++ b/src/govuk/components/accordion/accordion.yaml
@@ -2,7 +2,7 @@ params:
   - name: id
     type: string
     required: true
-    description: Must be unique across the domain of your service (as the expanded state of individual instances of the component persists across page loads using [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-labelledby` and `aria-control` attributes.
+    description: Must be unique across the domain of your service if `rememberExpanded` is `true` (as the expanded state of individual instances of the component persists across page loads using [`sessionStorage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)). Used as an `id` in the HTML for the accordion as a whole, and also as a prefix for the `id`s of the section contents and the buttons that open them, so that those `id`s can be the target of `aria-labelledby` and `aria-control` attributes.
   - name: headingLevel
     type: integer
     required: false
@@ -15,6 +15,10 @@ params:
     type: object
     required: false
     description: HTML attributes (for example data attributes) to add to the accordion.
+  - name: rememberExpanded
+    type: boolean
+    required: false
+    description: Whether the expanded/collapsed state of the accordion should be saved when a user leaves the page and restored when they return. Default is `true`.
   - name: hideAllSectionsText
     type: string
     required: false
@@ -270,5 +274,15 @@ examples:
         - null
         - heading:
             text: Section B
+          content:
+            text: Some content
+  - name: with remember expanded off
+    hidden: true
+    data:
+      id: accordion-remember-expanded-off
+      rememberExpanded: false
+      items:
+        - heading:
+            text: Section A
           content:
             text: Some content

--- a/src/govuk/components/accordion/template.njk
+++ b/src/govuk/components/accordion/template.njk
@@ -8,6 +8,7 @@
   {%- if params.showAllSectionsText %} data-i18n.show-all-sections="{{ params.showAllSectionsText | escape }}"{% endif %}
   {%- if params.showSectionText %} data-i18n.show-section="{{ params.showSectionText | escape }}"{% endif %}
   {%- if params.showSectionAriaLabelText %} data-i18n.show-section-aria-label="{{ params.showSectionAriaLabelText | escape }}"{% endif %}
+  {%- if params.rememberExpanded !== undefined %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}
     {% if item %}

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -107,5 +107,12 @@ describe('Accordion', () => {
       expect($component.attr('data-i18n.show-section')).toEqual('Expand')
       expect($component.attr('data-i18n.show-section-aria-label')).toEqual('Expand this section')
     })
+
+    it('renders with remember expanded data attribute', () => {
+      const $ = render('accordion', examples['with remember expanded off'])
+      const $component = $('.govuk-accordion')
+
+      expect($component.attr('data-remember-expanded')).toEqual('false')
+    })
   })
 })


### PR DESCRIPTION
Adds a new configuration option to the Accordion component, allowing users to explicitly disable (or enable) the session storage and restoration functionality.

Some developers have expressed a desire to disable this function, which currently can only be done by separately clearing `sessionStorage` or randomising the `id` of accordions, as described in #3182.

## Option naming

My understanding of good naming is that boolean options, like checkboxes, should always be labelled using affirmative, opt-in kind of language: yes, remember my password; yes, allow analytics cookies; yes, I want disposable cutlery; and so forth.

As such, the parameter is named affirmatively—`rememberExpanded` in JS and Nunjucks APIs and `data-remember-expanded` in the HTML API.

I opted for this name as it's shorter and more self-explanatory (or maybe, less technical-sounding) than others I thought of (e.g. `rememberExpandedSections`, `rememberSectionState`, `enableStateRemembering`), but I'm not tied to it and am open to suggestions. It also feels more congruent with the existing `expanded` option available to each section.

However, this means that the default value for this setting is `true` (enabled) with the typical use case being developers setting it to `false` (disabled), which might be a bit unintuitive. 

## Usage

Like internationalisation options, the configuration can be provided via JavaScript initialisation, in HTML using a `data-*` attribute, or via a parameter on the `govukAccordion` Nunjucks macro.

JavaScript example:

```js
new window.GOVUKFrontend.Accordion(document.getElementById('accordion'), {
  rememberExpanded: false
}).init()
```

Nunjucks example:
```nunjucks
{{ govukAccordion({
  id: "accordion",
  rememberExpanded: false,
  items: […]
)} }}
```

HTML example:
```html
<div class="govuk-accordion" data-module="govuk-accordion" id="accordion" data-remember-expanded="false">
 […]
</div>
```

## Changes

- The Accordion's default configuration has a new default: `rememberExpanded: true`.
- The `setInitialState` and `storeState` methods of the Accordion's JS now check that `rememberExpanded` is `true` in addition to ensuring that `sessionState` is available.
- The Accordion template now looks for and uses `rememberExpanded` if it's provided. 
- Added documentation for the `rememberExpanded` Nunjucks parameter. Also tweaked the `id` parameter documentation.
- Added example and tests for the existence of the `data-*` attribute in the template and for the functionality itself.