### PR TITLE
Deprecate IE8 related settings and tools

### DIFF
--- a/app/stylesheets/app-legacy-ie8.scss
+++ b/app/stylesheets/app-legacy-ie8.scss
@@ -10,7 +10,8 @@ $govuk-compatibility-govukelements: true;
 
 // Suppress compatibility mode deprecation warnings locally
 $govuk-suppressed-warnings: (
-  "compatibility-mode"
+  "compatibility-mode",
+  "ie8"
 );
 
 // Set Elements assets path

--- a/app/stylesheets/partials/_app.scss
+++ b/app/stylesheets/partials/_app.scss
@@ -23,7 +23,7 @@
     clear: both;
     box-shadow: 0 0 0 5px $app-preview-border-colour;
 
-    @include govuk-if-ie8 {
+    @include _govuk-if-ie8 {
       outline: 5px solid $app-preview-border-colour;
     }
   }

--- a/src/govuk/all-ie8.scss
+++ b/src/govuk/all-ie8.scss
@@ -1,3 +1,11 @@
+// Ignore IE8 related warnings whilst we continue to generate IE8 specific
+// stylesheets for the review app or dist versions of GOV.UK Frontend
+$govuk-suppressed-warnings: if(
+  variable-exists(govuk-suppressed-warnings),
+  append($govuk-suppressed-warnings, "ie8"),
+  ("ie8")
+);
+
 // By setting $govuk-is-ie8 to true, we create a version of the stylesheet that
 // targets IE8 – e.g. conditionally including or excluding styles, and
 // rasterizing media queries.

--- a/src/govuk/components/accordion/_index.scss
+++ b/src/govuk/components/accordion/_index.scss
@@ -155,7 +155,7 @@
       vertical-align: middle;
 
       // IE8 fallback of icon
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         display: inline-block;
         max-height: 20px;
         line-height: 1;
@@ -180,7 +180,7 @@
         border-right: govuk-px-to-rem(2px) solid;
 
         // IE8 fallback of icon with HTML symbol
-        @include govuk-if-ie8 {
+        @include _govuk-if-ie8 {
           content: "\25B2"; // "▲"
           position: relative;
           border: 0;
@@ -193,7 +193,7 @@
       transform: rotate(180deg);
 
       // IE8 fallback of arrow icon
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         &:after {
           content: "\25BC"; // "▼"
           transform: none;

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -67,7 +67,7 @@
     }
 
     // Fall back to a less than sign for IE8
-    @include govuk-if-ie8 {
+    @include _govuk-if-ie8 {
       content: "\003c"; // Less than sign (<)
       width: auto;
       height: auto;

--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -89,7 +89,7 @@
       }
 
       // Fall back to a greater than sign for IE8
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         content: "\003e"; // Greater than sign (>)
         width: auto;
         height: auto;

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -61,7 +61,7 @@ $govuk-button-text-colour: govuk-colour("white") !default;
     cursor: pointer;
     -webkit-appearance: none;
 
-    @include govuk-if-ie8 {
+    @include _govuk-if-ie8 {
       border-bottom: $button-shadow-size solid $govuk-button-shadow-colour;
     }
 
@@ -92,7 +92,7 @@ $govuk-button-text-colour: govuk-colour("white") !default;
       // Bump the button down so it looks like its being pressed in
       top: $button-shadow-size;
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         border-bottom-width: 0;
       }
     }
@@ -103,11 +103,11 @@ $govuk-button-text-colour: govuk-colour("white") !default;
       // backgrounds and box-shadows disappear, so we need to ensure there's a
       // transparent outline which will be set to a visible colour.
       // Since Internet Explorer 8 does not support box-shadow, we want to force the user-agent outlines
-      @include govuk-not-ie8 {
+      @include _govuk-not-ie8 {
         outline: $govuk-focus-width solid transparent;
       }
       // Since Internet Explorer does not support `:not()` we set a clearer focus style to match user-agent outlines.
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         color: $govuk-focus-text-colour;
         background-color: $govuk-focus-colour;
       }
@@ -181,7 +181,7 @@ $govuk-button-text-colour: govuk-colour("white") !default;
     &:active {
       top: 0;
       box-shadow: 0 $button-shadow-size 0 $govuk-button-shadow-colour; // s0
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         border-bottom: $button-shadow-size solid $govuk-button-shadow-colour; // s0
       }
     }

--- a/src/govuk/components/checkboxes/_index.scss
+++ b/src/govuk/components/checkboxes/_index.scss
@@ -36,7 +36,7 @@
 
     // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
     // elements there.
-    @include govuk-not-ie8 {
+    @include _govuk-not-ie8 {
       position: absolute;
 
       z-index: 1;
@@ -50,7 +50,7 @@
       opacity: 0;
     }
 
-    @include govuk-if-ie8 {
+    @include _govuk-if-ie8 {
       margin-top: 10px;
       margin-right: $govuk-checkboxes-size / -2;
       margin-left: $govuk-checkboxes-size / -2;
@@ -72,7 +72,7 @@
     touch-action: manipulation;
   }
 
-  @include govuk-not-ie8 {
+  @include _govuk-not-ie8 {
     // [ ] Check box
     .govuk-checkboxes__label:before {
       content: "";
@@ -224,11 +224,11 @@
     //  ▲┆└─ Check box pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
     .govuk-checkboxes__input {
-      @include govuk-not-ie8 {
+      @include _govuk-not-ie8 {
         left: $input-offset * -1;
       }
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         margin-left: $govuk-small-checkboxes-size * -1;
       }
     }

--- a/src/govuk/components/file-upload/_index.scss
+++ b/src/govuk/components/file-upload/_index.scss
@@ -30,7 +30,7 @@
       // yellow focus state.
       box-shadow: inset 0 0 0 4px $govuk-input-border-colour;
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         // IE8 doesn't support `box-shadow` so add an actual border
         border: 4px solid $govuk-input-border-colour;
       }

--- a/src/govuk/components/input/_index.scss
+++ b/src/govuk/components/input/_index.scss
@@ -33,7 +33,7 @@
       // here as it is already used for the yellow focus state.
       box-shadow: inset 0 0 0 $govuk-border-width-form-element;
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         // IE8 doesn't support `box-shadow` so double the border with
         // `border-width`.
         border-width: $govuk-border-width-form-element * 2;
@@ -163,7 +163,7 @@
       border-bottom: 0;
     }
     @include govuk-media-query($from: mobile) {
-      @include govuk-not-ie8 {
+      @include _govuk-not-ie8 {
         border-right: 0;
       }
     }
@@ -175,7 +175,7 @@
       border-top: 0;
     }
     @include govuk-media-query($from: mobile) {
-      @include govuk-not-ie8 {
+      @include _govuk-not-ie8 {
         border-left: 0;
       }
     }

--- a/src/govuk/components/radios/_index.scss
+++ b/src/govuk/components/radios/_index.scss
@@ -39,7 +39,7 @@
 
     // IE8 doesn’t support pseudo-elements, so we don’t want to hide native
     // elements there.
-    @include govuk-not-ie8 {
+    @include _govuk-not-ie8 {
       position: absolute;
 
       z-index: 1;
@@ -53,7 +53,7 @@
       opacity: 0;
     }
 
-    @include govuk-if-ie8 {
+    @include _govuk-if-ie8 {
       margin-top: 10px;
       margin-right: $govuk-radios-size / -2;
       margin-left: $govuk-radios-size / -2;
@@ -238,11 +238,11 @@
     //  ▲┆└─ Radio pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
     .govuk-radios__input {
-      @include govuk-not-ie8 {
+      @include _govuk-not-ie8 {
         left: $input-offset * -1;
       }
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         margin-left: $govuk-small-radios-size * -1;
       }
     }

--- a/src/govuk/components/select/_index.scss
+++ b/src/govuk/components/select/_index.scss
@@ -35,7 +35,7 @@
       // since `outline` is already used for the yellow focus state.
       box-shadow: inset 0 0 0 $govuk-border-width-form-element;
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         // IE8 doesn't support `box-shadow` so double the border with
         // `border-width`.
         border-width: $govuk-border-width-form-element * 2;

--- a/src/govuk/components/textarea/_index.scss
+++ b/src/govuk/components/textarea/_index.scss
@@ -29,7 +29,7 @@
       // since `outline` is already used for the yellow focus state.
       box-shadow: inset 0 0 0 $govuk-border-width-form-element;
 
-      @include govuk-if-ie8 {
+      @include _govuk-if-ie8 {
         // IE8 doesn't support `box-shadow` so double the border with
         // `border-width`.
         border-width: $govuk-border-width-form-element * 2;

--- a/src/govuk/helpers/_focused.scss
+++ b/src/govuk/helpers/_focused.scss
@@ -16,7 +16,7 @@
 
   // Since Internet Explorer 8 does not support box-shadow, we want to force the
   // user-agent outlines
-  @include govuk-not-ie8 {
+  @include _govuk-not-ie8 {
     outline: $govuk-focus-width solid transparent;
   }
   color: $govuk-focus-text-colour;

--- a/src/govuk/helpers/_font-faces.scss
+++ b/src/govuk/helpers/_font-faces.scss
@@ -12,7 +12,7 @@
 /// @access private
 
 @mixin _govuk-font-face-gds-transport {
-  @include govuk-not-ie8 { // In IE8, which cannot render WOFF format, we fall back to system fonts
+  @include _govuk-not-ie8 { // In IE8, which cannot render WOFF format, we fall back to system fonts
     @include govuk-exports("govuk/helpers/font-faces") {
       @at-root {
         /*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */ /* stylelint-disable-line scss/comment-no-loud  */

--- a/src/govuk/objects/_width-container.scss
+++ b/src/govuk/objects/_width-container.scss
@@ -68,7 +68,7 @@
     }
   }
 
-  @include govuk-if-ie8 {
+  @include _govuk-if-ie8 {
     width: $width;
     // Since media queries are not supported in IE8,
     // we need to duplicate this margin that centers the page.

--- a/src/govuk/settings/_ie8.scss
+++ b/src/govuk/settings/_ie8.scss
@@ -6,13 +6,29 @@
 ///
 /// @type Boolean
 /// @access public
+/// @deprecated Will be removed in v5.0
 
 $govuk-is-ie8: false !default;
+
+@if $govuk-is-ie8 == true {
+  @include _warning(
+    ie8,
+    "The $govuk-is-ie8 setting is deprecated and will be removed in v5.0."
+  );
+}
 
 /// The name of the breakpoint to use as the target when rasterizing media
 /// queries
 ///
 /// @type String
 /// @access public
+/// @deprecated Will be removed in v5.0
 
 $govuk-ie8-breakpoint: desktop !default;
+
+@if not $govuk-ie8-breakpoint == desktop {
+  @include _warning(
+    ie8,
+    "The $govuk-ie8-breakpoint setting is deprecated and will be removed in v5.0."
+  );
+}

--- a/src/govuk/tools/_ie8.scss
+++ b/src/govuk/tools/_ie8.scss
@@ -1,6 +1,19 @@
+@import "../settings/warnings";
+
 ////
 /// @group tools/internet-explorer-8
 ////
+
+/// A private version of the govuk-if-ie8 mixin to avoid deprecation
+/// warnings where we use it internally
+///
+/// @access private
+
+@mixin _govuk-if-ie8 {
+  @if $govuk-is-ie8 {
+    @content;
+  }
+}
 
 /// Conditionally include rules only for IE8
 ///
@@ -18,9 +31,26 @@
 ///   }
 ///
 /// @access public
+/// @deprecated Will be removed in v5.0
 
 @mixin govuk-if-ie8 {
-  @if $govuk-is-ie8 {
+  @include _warning(
+    ie8,
+    "The govuk-if-ie8 mixin is deprecated and will be removed in v5.0."
+  );
+
+  @include _govuk-if-ie8 {
+    @content;
+  }
+}
+
+/// A private version of the govuk-not-ie8 mixin to avoid deprecation
+/// warnings where we use it internally
+///
+/// @access private
+
+@mixin _govuk-not-ie8 {
+  @if not $govuk-is-ie8 {
     @content;
   }
 }
@@ -43,9 +73,15 @@
 ///   }
 ///
 /// @access public
+/// @deprecated Will be removed in v5.0
 
 @mixin govuk-not-ie8 {
-  @if not $govuk-is-ie8 {
+  @include _warning(
+    ie8,
+    "The govuk-not-ie8 mixin is deprecated and will be removed in v5.0."
+  );
+
+  @include _govuk-not-ie8 {
     @content;
   }
 }

--- a/src/govuk/tools/ie8.test.js
+++ b/src/govuk/tools/ie8.test.js
@@ -1,0 +1,87 @@
+const outdent = require('outdent')
+
+const { compileSassString } = require('../../../lib/jest-helpers')
+
+describe('@mixin govuk-if-ie8', () => {
+  it('outputs @content when $govuk-is-ie8 is true', async () => {
+    const sass = `
+      $govuk-is-ie8: true;
+      @import "tools/ie8";
+
+      @include govuk-if-ie8 {
+        .foo {
+          color: red;
+        }
+      }
+    `
+
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            color: red;
+          }
+        `
+      })
+  })
+
+  it('does not output @content when $govuk-is-ie8 is false', async () => {
+    const sass = `
+      $govuk-is-ie8: false;
+      @import "tools/ie8";
+
+      @include govuk-if-ie8 {
+        .foo {
+          color: red;
+        }
+      }
+    `
+
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({ css: '' })
+  })
+})
+
+describe('@mixin govuk-not-ie8', () => {
+  it('outputs @content when $govuk-is-ie8 is false', async () => {
+    const sass = `
+      $govuk-is-ie8: false;
+      @import "tools/ie8";
+
+      @include govuk-not-ie8 {
+        .foo {
+          color: red;
+        }
+      }
+    `
+
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({
+        css: outdent`
+          .foo {
+            color: red;
+          }
+        `
+      })
+  })
+
+  it('does not output @content when $govuk-is-ie8 is true', async () => {
+    const sass = `
+      $govuk-is-ie8: true;
+      @import "tools/ie8";
+
+      @include govuk-not-ie8 {
+        .foo {
+          color: red;
+        }
+      }
+    `
+
+    await expect(compileSassString(sass))
+      .resolves
+      .toMatchObject({ css: '' })
+  })
+})


### PR DESCRIPTION
We'll be removing IE8 support in v5.0. Following our guidance for [deprecating and removing features](https://github.com/alphagov/govuk-frontend/blob/63cc49f19114ac1f249bad35500ab41094f27af7/docs/contributing/managing-change.md#deprecating-and-removing-features), deprecate the Sass settings and mixins used for building IE8 specific stylesheets:

- the `$govuk-is-ie8` setting
- the `$govuk-ie8-breakpoint` setting
- the `govuk-if-ie8` mixin
- the `govuk-not-ie8` mixin

Update references to the mixins within GOV.UK Frontend so that they do not generate warnings – we only want warnings to be generated where service teams are using the `govuk-if-ie8` and `govuk-not-ie8` mixins in their own code.

Suppress IE8 related warnings when generating the IE8 stylesheets for the review app or for the `dist` version of GOV.UK Frontend.

Deprecating these features communicates this intent to service teams and allows them to make changes ahead of time, reducing the effort involved in upgrading to the next major version.

Closes #3163 