### PR TITLE
Integrate I18n into Exit this Page component

### DIFF
--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -58,17 +58,17 @@ function initAll (config) {
     new ErrorSummary($errorSummary, config.errorSummary).init()
   }
 
+  var $exitThisPageButtons = $scope.querySelectorAll('[data-module="govuk-exit-this-page"]')
+  if ($exitThisPageButtons.length > 0) {
+    nodeListForEach($exitThisPageButtons, function ($button) {
+      new ExitThisPage($button, config.exitThisPage).init()
+    })
+  }
+
   // Find first header module to enhance.
   var $header = $scope.querySelector('[data-module="govuk-header"]')
   if ($header) {
     new Header($header).init()
-  }
-
-  var $exitThisPageButtons = $scope.querySelectorAll('[data-module="govuk-exit-this-page"]')
-  if ($exitThisPageButtons.length > 0) {
-    nodeListForEach($exitThisPageButtons, function ($button) {
-      new ExitThisPage($button).init()
-    })
   }
 
   var $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')

--- a/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -148,7 +148,7 @@ describe('/components/exit-this-page', () => {
         await page.keyboard.press('Shift')
 
         const message = await page.evaluate((buttonClass) => document.querySelector(buttonClass).nextElementSibling.innerText, buttonClass)
-        expect(message).toBe('Exiting page')
+        expect(message).toBe('Exiting page.')
       })
 
       it('announces when the keyboard shortcut has timed out', async () => {
@@ -160,7 +160,7 @@ describe('/components/exit-this-page', () => {
         await new Promise((resolve) => setTimeout(resolve, 5000))
 
         const message = await page.evaluate((buttonClass) => document.querySelector(buttonClass).nextElementSibling.innerText, buttonClass)
-        expect(message).toBe('Exit this page expired')
+        expect(message).toBe('Exit this page expired.')
       })
     })
   })

--- a/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -2,7 +2,7 @@ params:
 - name: text
   type: string
   required: false
-  description: Text for the link. Defaults to `Hide this page`.
+  description: Text for the link. Defaults to `Exit this page`.
 - name: redirectUrl
   type: string
   required: false
@@ -19,6 +19,22 @@ params:
   type: object
   required: false
   description: HTML attributes (for example data attributes) to add to the exit this page container.
+- name: activatedText
+  type: string
+  required: false
+  description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Exiting page.'
+- name: timedOutText
+  type: string
+  required: false
+  description: Text announced by screen readers when the keyboard shortcut has timed out without successful activation. Defaults to 'Exit this page expired.'
+- name: pressTwoMoreTimesText
+  type: string
+  required: false
+  description: Text announced by screen readers when the user must press <kbd>Shift</kbd> two more times to activate the button. Defaults to 'Shift, press 2 more times to exit.'
+- name: pressOneMoreTimeText
+  type: string
+  required: false
+  description: Text announced by screen readers when the user must press <kbd>Shift</kbd> one more time to activate the button. Defaults to 'Shift, press 1 more time to exit.'
 
 examples:
 - name: default  
@@ -29,6 +45,13 @@ examples:
     classes: null
     attributes:
       {}
+- name: translated
+  data:
+    text: "Gadael y dudalen"
+    activatedText: "Tudalen ymadael"
+    timedOutText: "Wedi'i amseru"
+    pressTwoMoreTimesText: "Pwyswch 'Shift' 2 gwaith arall"
+    pressOneMoreTimeText: "Pwyswch 'Shift' 1 mwy o amser"
 
 # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
 - name: testing

--- a/src/govuk/components/exit-this-page/template.njk
+++ b/src/govuk/components/exit-this-page/template.njk
@@ -5,6 +5,10 @@
   {%- if params.id %} id="{{ params.id }}"{% endif %}
   class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}"
   data-module="govuk-exit-this-page" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+  {%- if params.activatedText %} data-i18n.activated="{{ params.activatedText | escape }}"{% endif %}
+  {%- if params.timedOutText %} data-i18n.timed-out="{{ params.timedOutText | escape }}"{% endif %}
+  {%- if params.pressTwoMoreTimesText %} data-i18n.press-two-more-times="{{ params.pressTwoMoreTimesText | escape }}"{% endif %}
+  {%- if params.pressOneMoreTimeText %} data-i18n.press-one-more-time="{{ params.pressOneMoreTimeText | escape }}"{% endif %}
 >
   {{ govukButton({
     text: params.text,

--- a/src/govuk/components/exit-this-page/template.test.js
+++ b/src/govuk/components/exit-this-page/template.test.js
@@ -66,4 +66,16 @@ describe('Exit this page', () => {
       expect($component.attr('test-attribute')).toBe('true')
     })
   })
+
+  describe('Translated', () => {
+    it('renders with translation data attributes', () => {
+      const $ = render('exit-this-page', examples.translated)
+      const $component = $('.govuk-exit-this-page')
+
+      expect($component.attr('data-i18n.activated')).toBe('Tudalen ymadael')
+      expect($component.attr('data-i18n.timed-out')).toBe("Wedi'i amseru")
+      expect($component.attr('data-i18n.press-two-more-times')).toBe("Pwyswch 'Shift' 2 gwaith arall")
+      expect($component.attr('data-i18n.press-one-more-time')).toBe("Pwyswch 'Shift' 1 mwy o amser")
+    })
+  })
 })


### PR DESCRIPTION
Integrates internationalisation functions into the Exit this Page component. Pulled out from #3268. 

## Changes
- Integrates the `I18n` JS functionality into EtP.
- Updates Nunjucks template to add support for new parameters and `data-*` attributes relating to i18n.
- Adds a test to ensure that `data-*` attributes are added.
- Adds a translated example of the EtP button to the review app (complete with Google Translated Welsh).
- Fixes a tiny bit of outdated parameter documentation. 

Does not include tests to ensure that the correct text is injected during each of the one press/two press/activated/expired stages, as they aren't strictly i18n related—these tests can be carried out against the English language strings. 