### PR TITLE
Fix conflict in ESLint rules about object shorthands

### DIFF
--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -40,6 +40,8 @@ module.exports = {
       ],
       extends: ['plugin:es-x/restrict-to-es3'],
       rules: {
+        // Object shorthands are not available in ES3
+        'object-shorthand': 'off',
         // Rollup transpiles modules to AMD export/define
         'es-x/no-modules': 'off'
       }


### PR DESCRIPTION
## What

Disables ESLint's object-shortand rule for our source files

## Why

[Standard's configuration requires object shorthands](https://github.com/standard/eslint-config-standard/blob/80b9734d817a9babc2d02bb30cfbc98265299a00/.eslintrc.json#L29) (via <https://eslint.org/docs/latest/rules/object-shorthand>) but eslint-plugin-x requires them unavailable as we're linting to limit to ES3 features (via <https://eslint-community.github.io/eslint-plugin-es-x/rules/no-property-shorthands.html>)

## Who needs to work on this

Developers

## Who needs to review this

Developers

## Done when

- [ ] Standard's rule has been disabled for our source files (but not the rest of the project that don't need to be ES3)