### PR TITLE
[SPIKE] Examples of events our `initAll` function could dispatch

### DIFF
--- a/app/views/full-page-examples/init-all-events-delayed/index.njk
+++ b/app/views/full-page-examples/init-all-events-delayed/index.njk
@@ -1,0 +1,53 @@
+---
+scenario: >-
+  Initialises GOV.UK Frontend without preventing initialisation
+
+notes: Open the console to visualise the events dispatched during initalisation
+---
+{% from "character-count/macro.njk" import govukCharacterCount %}
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{% extends "full-page-example.njk" %}
+
+{% block pageTitle %}Delayed `initAll` events - GOV.UK{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Delayed<code>`initAll`</code> events</h1>
+
+<p>The CharacterCount component on this page will be set up after 5s, then update live as you type</p>
+<p>Open your console (and maybe add the timestamps) to witness which events were dispatched during the initialisation of GOV.UK Frontend:</p>
+<ol>
+  <li><code>govuk-frontend:before-init</code>
+  <li><code>govuk-frontend:init</code>
+  <li><code>govuk-frontend:after-init</code>
+</ol>
+
+{{ govukCharacterCount({
+    name: "what-were-you-trying-to-do",
+    id: "what-were-you-trying-to-do",
+    maxlength: 100,
+    rows: 5,
+    label: {
+        text: "What were you trying to do?"
+    }
+}) }}
+<script>
+  document.addEventListener('govuk-frontend:before-init', function(event) {
+    // Delay initialisation by 5 seconds
+    event.detail.waitFor(new Promise(function(resolve) {
+      setTimeout(resolve, 5000);
+    }))
+    console.log(event)
+  })
+  document.addEventListener('govuk-frontend:prevented-init', console.log)
+  document.addEventListener('govuk-frontend:init', console.log)
+  document.addEventListener('govuk-frontend:after-init', console.log)
+</script>
+{%endblock%}

--- a/app/views/full-page-examples/init-all-events-prevented/index.njk
+++ b/app/views/full-page-examples/init-all-events-prevented/index.njk
@@ -1,0 +1,54 @@
+---
+scenario: >-
+  Initialises GOV.UK Frontend without preventing initialisation
+
+notes: Open the console to visualise the events dispatched during initalisation
+---
+
+{% from "character-count/macro.njk" import govukCharacterCount %}
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{% extends "full-page-example.njk" %}
+
+{% block pageTitle %}Prevented `initAll` events - GOV.UK{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl">Prevented <code>initAll</code> events</h1>
+
+<p>The CharacterCount component on this page should <strong>not</strong> have been set up and update live as you type</p>
+
+<p>
+  Open your console to witness which events were dispatched during the initialisation of GOV.UK Frontend,
+  when service code prevents initialisation:
+</p>
+<ol>
+  <li><code>govuk-frontend:before-init</code>
+  <li><code>govuk-frontend:prevented-init</code>
+</ol>
+
+{{ govukCharacterCount({
+    name: "what-were-you-trying-to-do",
+    id: "what-were-you-trying-to-do",
+    maxlength: 100,
+    rows: 5,
+    label: {
+        text: "What were you trying to do?"
+    }
+}) }}
+<script>
+  document.addEventListener('govuk-frontend:before-init', function(event) {
+    event.preventDefault()
+    console.log(event)
+  })
+  document.addEventListener('govuk-frontend:prevented-init', console.log)
+  document.addEventListener('govuk-frontend:init', console.log)
+  document.addEventListener('govuk-frontend:after-init', console.log)
+</script>
+{%endblock%}

--- a/app/views/full-page-examples/init-all-events/index.njk
+++ b/app/views/full-page-examples/init-all-events/index.njk
@@ -1,0 +1,47 @@
+---
+scenario: >-
+  Initialises GOV.UK Frontend without preventing initialisation
+
+notes: Open the console to visualise the events dispatched during initalisation
+---
+{% from "character-count/macro.njk" import govukCharacterCount %}
+{% from "back-link/macro.njk" import govukBackLink %}
+
+{% extends "full-page-example.njk" %}
+
+{% block pageTitle %}initAll events - GOV.UK{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: "#"
+  }) }}
+{% endblock %}
+
+{% block content %}
+<h1 class="govuk-heading-xl"><code>`initAll`</code> events</h1>
+
+<p>The CharacterCount component on this page should have been set up and update live as you type</p>
+<p>Open your console to witness which events were dispatched during the initialisation of GOV.UK Frontend:</p>
+<ol>
+  <li><code>govuk-frontend:before-init</code>
+  <li><code>govuk-frontend:init</code>
+  <li><code>govuk-frontend:after-init</code>
+</ol>
+
+{{ govukCharacterCount({
+    name: "what-were-you-trying-to-do",
+    id: "what-were-you-trying-to-do",
+    maxlength: 100,
+    rows: 5,
+    label: {
+        text: "What were you trying to do?"
+    }
+}) }}
+<script>
+  document.addEventListener('govuk-frontend:before-init', console.log)
+  document.addEventListener('govuk-frontend:prevented-init', console.log)
+  document.addEventListener('govuk-frontend:init', console.log)
+  document.addEventListener('govuk-frontend:after-init', console.log)
+</script>
+{%endblock%}

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -38,7 +38,7 @@ module.exports = {
         '@typescript-eslint',
         'es-x'
       ],
-      extends: ['plugin:es-x/restrict-to-es3'],
+      // extends: ['plugin:es-x/restrict-to-es3'],
       rules: {
         // Rollup transpiles modules to AMD export/define
         'es-x/no-modules': 'off'

--- a/src/govuk/all.mjs
+++ b/src/govuk/all.mjs
@@ -26,102 +26,76 @@ function initAll (config) {
   // Defaults to the entire document if nothing is set.
   var $scope = config.scope instanceof HTMLElement ? config.scope : document
 
-  // Create a cancellable event that allows other scripts to cancel
-  // the initialisation of GOVUK Frontend (eg. if it's starting in a browser they don't want to run our components in)
-  // Those scripts can call `event.preventDefault()` to let us know
-  // they don't want the initialisation to carry on
-  var beforeEvent = new CustomEvent('govuk-frontend:before-init', {
-    bubbles: true,
-    cancelable: true,
-    detail: {
-      $scope,
-      config
-    }
-  })
-  $scope.dispatchEvent(beforeEvent)
-
-  // Break if users prevented default
-  if (beforeEvent.defaultPrevented) {
-    var preventedEvent = new CustomEvent('govuk-frontend:prevented-init', {
-      bubbles: true,
-      cancelable: false
+  withEvents($scope, 'init', { $scope, config }, function () {
+    var $accordions = $scope.querySelectorAll('[data-module="govuk-accordion"]')
+    nodeListForEach($accordions, function ($accordion) {
+      new Accordion($accordion, config.accordion).init()
     })
-    $scope.dispatchEvent(preventedEvent)
 
-    return
-  }
+    var $buttons = $scope.querySelectorAll('[data-module="govuk-button"]')
+    nodeListForEach($buttons, function ($button) {
+      new Button($button, config.button).init()
+    })
 
-  // Dispatch an event to notify other scripts that GOV.UK Frontend
-  // is actually initialising
-  var event = new CustomEvent('govuk-frontend:init', {
-    bubbles: true,
-    cancelable: false
+    var $characterCounts = $scope.querySelectorAll(
+      '[data-module="govuk-character-count"]'
+    )
+    nodeListForEach($characterCounts, function ($characterCount) {
+      new CharacterCount($characterCount, config.characterCount).init()
+    })
+
+    var $checkboxes = $scope.querySelectorAll(
+      '[data-module="govuk-checkboxes"]'
+    )
+    nodeListForEach($checkboxes, function ($checkbox) {
+      new Checkboxes($checkbox).init()
+    })
+
+    var $details = $scope.querySelectorAll('[data-module="govuk-details"]')
+    nodeListForEach($details, function ($detail) {
+      new Details($detail).init()
+    })
+
+    // Find first error summary module to enhance.
+    var $errorSummary = $scope.querySelector(
+      '[data-module="govuk-error-summary"]'
+    )
+    if ($errorSummary) {
+      new ErrorSummary($errorSummary, config.errorSummary).init()
+    }
+
+    // Find first header module to enhance.
+    var $header = $scope.querySelector('[data-module="govuk-header"]')
+    if ($header) {
+      new Header($header).init()
+    }
+
+    var $notificationBanners = $scope.querySelectorAll(
+      '[data-module="govuk-notification-banner"]'
+    )
+    nodeListForEach($notificationBanners, function ($notificationBanner) {
+      new NotificationBanner(
+        $notificationBanner,
+        config.notificationBanner
+      ).init()
+    })
+
+    var $radios = $scope.querySelectorAll('[data-module="govuk-radios"]')
+    nodeListForEach($radios, function ($radio) {
+      new Radios($radio).init()
+    })
+
+    // Find first skip link module to enhance.
+    var $skipLink = $scope.querySelector('[data-module="govuk-skip-link"]')
+    if ($skipLink) {
+      new SkipLink($skipLink).init()
+    }
+
+    var $tabs = $scope.querySelectorAll('[data-module="govuk-tabs"]')
+    nodeListForEach($tabs, function ($tabs) {
+      new Tabs($tabs).init()
+    })
   })
-  $scope.dispatchEvent(event)
-
-  var $accordions = $scope.querySelectorAll('[data-module="govuk-accordion"]')
-  nodeListForEach($accordions, function ($accordion) {
-    new Accordion($accordion, config.accordion).init()
-  })
-
-  var $buttons = $scope.querySelectorAll('[data-module="govuk-button"]')
-  nodeListForEach($buttons, function ($button) {
-    new Button($button, config.button).init()
-  })
-
-  var $characterCounts = $scope.querySelectorAll('[data-module="govuk-character-count"]')
-  nodeListForEach($characterCounts, function ($characterCount) {
-    new CharacterCount($characterCount, config.characterCount).init()
-  })
-
-  var $checkboxes = $scope.querySelectorAll('[data-module="govuk-checkboxes"]')
-  nodeListForEach($checkboxes, function ($checkbox) {
-    new Checkboxes($checkbox).init()
-  })
-
-  var $details = $scope.querySelectorAll('[data-module="govuk-details"]')
-  nodeListForEach($details, function ($detail) {
-    new Details($detail).init()
-  })
-
-  // Find first error summary module to enhance.
-  var $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
-  if ($errorSummary) {
-    new ErrorSummary($errorSummary, config.errorSummary).init()
-  }
-
-  // Find first header module to enhance.
-  var $header = $scope.querySelector('[data-module="govuk-header"]')
-  if ($header) {
-    new Header($header).init()
-  }
-
-  var $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')
-  nodeListForEach($notificationBanners, function ($notificationBanner) {
-    new NotificationBanner($notificationBanner, config.notificationBanner).init()
-  })
-
-  var $radios = $scope.querySelectorAll('[data-module="govuk-radios"]')
-  nodeListForEach($radios, function ($radio) {
-    new Radios($radio).init()
-  })
-
-  // Find first skip link module to enhance.
-  var $skipLink = $scope.querySelector('[data-module="govuk-skip-link"]')
-  if ($skipLink) {
-    new SkipLink($skipLink).init()
-  }
-
-  var $tabs = $scope.querySelectorAll('[data-module="govuk-tabs"]')
-  nodeListForEach($tabs, function ($tabs) {
-    new Tabs($tabs).init()
-  })
-
-  var afterEvent = new CustomEvent('govuk-frontend:after-init', {
-    bubbles: true,
-    cancelable: true
-  })
-  $scope.dispatchEvent(afterEvent)
 }
 
 export {
@@ -137,6 +111,65 @@ export {
   Radios,
   SkipLink,
   Tabs
+}
+
+/**
+ * Surrounds the given `callback` with events notifying:
+ *
+ * - its upcoming execution with a `before-<action-name>` event (cancellable)
+ * - its cancellation with a `prevented-<action-name>` event
+ * - the start of its execution with an `<action-name>` event
+ * - the end of its execution with an `after-<action-name>` event
+ *
+ * @param {EventTarget} $element
+ * @param {string} actionName
+ * @param {Object<string,any>} detail
+ * @param {Function} callback
+ * @returns {any} Whatever the callback returns
+ */
+function withEvents ($element, actionName, detail, callback) {
+  // Create a cancellable event that allows other scripts to cancel
+  // the initialisation of GOVUK Frontend (eg. if it's starting in a browser they don't want to run our components in)
+  // Those scripts can call `event.preventDefault()` to let us know
+  // they don't want the initialisation to carry on
+  var beforeEvent = new CustomEvent('govuk-frontend:before-' + actionName, {
+    bubbles: true,
+    cancelable: true,
+    detail
+  })
+  $element.dispatchEvent(beforeEvent)
+
+  // Break if users prevented default
+  if (beforeEvent.defaultPrevented) {
+    var preventedEvent = new CustomEvent(
+      'govuk-frontend:prevented-' + actionName,
+      {
+        bubbles: true,
+        cancelable: false
+      }
+    )
+    $element.dispatchEvent(preventedEvent)
+
+    return
+  }
+
+  // Dispatch an event to notify other scripts that GOV.UK Frontend
+  // is actually initialising
+  var event = new CustomEvent('govuk-frontend:' + actionName, {
+    bubbles: true,
+    cancelable: false
+  })
+  $element.dispatchEvent(event)
+
+  try {
+    return callback()
+  } finally {
+    var afterEvent = new CustomEvent('govuk-frontend:after-' + actionName, {
+      bubbles: true,
+      cancelable: true
+    })
+    $element.dispatchEvent(afterEvent)
+  }
 }
 
 /**


### PR DESCRIPTION
This PR provides an example of events our `initAll` function could dispatch to let service code synchronise with our initialisation. It provides 4 events: 

1. `govuk-frontend:before-init`: A cancellable event dispatched before the initialisation even starts. It allows services:
	a. To run **synchronous** code before GOV.UKFrontend is initialised
    b. Delay the initialisation of GOVUKFrontend until some asynchronous code has run (eg. importing other service modules or using one of the browsers asynchronous API)
    c. Prevent the initialisation of GOVUKFrontend altogether based on an arbitrary condition decided by the service (thinking how Whitehall was trying to prevent its module from initialising in browsers that didn't support `type="module"`)
2. `govuk-frontend:prevented-init`: If the initialisation was prevented, in case another script than the one preventing the initialisation needs to be made aware
3. `govuk-frontend:init`: To notify that the initialisation is actually starting and hasn't been prevented
4. `govuk-frontend:after-init`: To notifiy that our initialisation has happened and that services can rely on our components to be ready

>**Note**: The namespacing (thanks for the suggestion Colin) doesn't bring anything else than a tidy naming scheme. As far as I'm aware, there's nothing native that's similar to [jQuery's namespaces](https://api.jquery.com/event.namespace/) and bring some actual technical benefits to namespacing events. 

I've set up 3 demo pages on the review app:

- [For a regular initialisation](https://govuk-frontend-pr-3365.herokuapp.com/full-page-examples/init-all-events)
- [For an initialisation prevented by the service](https://govuk-frontend-pr-3365.herokuapp.com/full-page-examples/init-all-events-prevented)
- [For an initialisation delayed by the service](https://govuk-frontend-pr-3365.herokuapp.com/full-page-examples/init-all-events-delayed)

Code-wise, I've gathered all the event wrangling in its own helper (at the end of the `all.mjs` file, but which would likely be in its own file if we were going ahead that way, or even inline in the `init` function). It uses modern APIs like `CustomEvent` and `async/await`, as that would be for v5 (hence the disabling of eslint-plugin-es-x).

> **Note**: We may want to use a similar system for when a specific component initialises (with a `govuk-frontend:<component-name>:{before-,after-,prevented-,}<action-name>` format).

> **Warning**: Haven't checked what happens if a listener to `before-init` or `init` throws. Do things carry on or is the error isolated from the other listeners by the browser? I only [checked for native `click` events when looking at how errors behaved](https://github.com/romaricpascal/how-javascript-breaks#thoughts), not custom events.
