### PR TITLE
Build tasks: Clearly show subdirectory paths

### DIFF
--- a/app/src/app.mjs
+++ b/app/src/app.mjs
@@ -2,7 +2,7 @@ import { join } from 'path'
 
 import express from 'express'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 import { getDirectories, getComponentsData, getFullPageExamples } from '../../lib/file-helper.js'
 import { componentNameToMacroName } from '../../lib/helper-functions.js'
 
@@ -16,8 +16,8 @@ export default async () => {
   // Cache mapped components and examples
   const [componentsData, componentNames, exampleNames, fullPageExamples] = await Promise.all([
     getComponentsData(),
-    getDirectories(join(configPaths.src, 'govuk/components')),
-    getDirectories(join(configPaths.app, 'src/views/examples')),
+    getDirectories(join(paths.src, 'govuk/components')),
+    getDirectories(join(paths.app, 'src/views/examples')),
     getFullPageExamples()
   ])
 

--- a/app/src/app.mjs
+++ b/app/src/app.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import express from 'express'
 
 import configPaths from '../../config/paths.js'
@@ -14,8 +16,8 @@ export default async () => {
   // Cache mapped components and examples
   const [componentsData, componentNames, exampleNames, fullPageExamples] = await Promise.all([
     getComponentsData(),
-    getDirectories(configPaths.components),
-    getDirectories(configPaths.examples),
+    getDirectories(join(configPaths.src, 'govuk/components')),
+    getDirectories(join(configPaths.app, 'src/views/examples')),
     getFullPageExamples()
   ])
 

--- a/app/src/app.test.mjs
+++ b/app/src/app.test.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import { load } from 'cheerio'
 
 import { paths, ports } from '../../config/index.js'
@@ -45,7 +47,7 @@ describe(`http://localhost:${ports.app}`, () => {
       const response = await fetchPath('/')
       const $ = load(await response.text())
 
-      const componentNames = await getDirectories(paths.components)
+      const componentNames = await getDirectories(join(paths.src, 'govuk/components'))
       const componentsList = $('li a[href^="/components/"]').get()
 
       // Since we have an 'all' component link that renders the default example of all

--- a/app/src/common/middleware/assets.mjs
+++ b/app/src/common/middleware/assets.mjs
@@ -2,15 +2,15 @@ import { join } from 'path'
 
 import express from 'express'
 
-import configPaths from '../../../../config/paths.js'
+import { paths } from '../../../../config/index.js'
 
 const router = express.Router()
 
 /**
  * Add middleware to serve static assets
  */
-router.use('/assets', express.static(join(configPaths.public, 'assets')))
-router.use('/javascripts', express.static(join(configPaths.public, 'javascripts')))
-router.use('/stylesheets', express.static(join(configPaths.public, 'stylesheets')))
+router.use('/assets', express.static(join(paths.public, 'assets')))
+router.use('/javascripts', express.static(join(paths.public, 'javascripts')))
+router.use('/stylesheets', express.static(join(paths.public, 'stylesheets')))
 
 export default router

--- a/app/src/common/middleware/docs.mjs
+++ b/app/src/common/middleware/docs.mjs
@@ -1,6 +1,6 @@
 import express from 'express'
 
-import configPaths from '../../../../config/paths.js'
+import { paths } from '../../../../config/index.js'
 
 const router = express.Router()
 
@@ -27,7 +27,7 @@ router.use('/sass', ({ app }, res, next) => {
 /**
  * Add middleware
  */
-router.use('/sass', express.static(configPaths.sassdoc))
-router.use('/javascript', express.static(configPaths.jsdoc))
+router.use('/sass', express.static(paths.sassdoc))
+router.use('/javascript', express.static(paths.jsdoc))
 
 export default router

--- a/app/src/common/nunjucks/globals/get-html-code.mjs
+++ b/app/src/common/nunjucks/globals/get-html-code.mjs
@@ -12,7 +12,7 @@ import { paths } from '../../../../../config/index.js'
  * @returns {string} Nunjucks code
  */
 export function getHTMLCode (componentName, params) {
-  const templatePath = join(paths.components, componentName, 'template.njk')
+  const templatePath = join(paths.src, 'govuk/components', componentName, 'template.njk')
 
   // Render to HTML
   const html = this.env.render(templatePath, { params }).trim()

--- a/app/src/common/nunjucks/index.mjs
+++ b/app/src/common/nunjucks/index.mjs
@@ -10,11 +10,11 @@ import * as globals from './globals/index.mjs'
 
 export function renderer (app) {
   const appViews = [
-    paths.layouts,
-    paths.views,
-    paths.components,
+    join(paths.app, 'src/views/layouts'),
+    join(paths.app, 'src/views'),
+    join(paths.src, 'govuk/components'),
     join(paths.src, 'govuk'),
-    join(paths.node_modules, 'govuk_template_jinja')
+    join(paths.root, 'node_modules/govuk_template_jinja')
   ]
 
   // Initialise nunjucks environment

--- a/config/jest/globals.mjs
+++ b/config/jest/globals.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import { getDirectories, getComponentsData } from '../../lib/file-helper.js'
 import configPaths from '../paths.js'
 
@@ -9,10 +11,10 @@ const store = new Map()
 /**
  * Cache frequently used paths
  */
-const paths = [
-  configPaths.components,
-  configPaths.examples,
-  configPaths.fullPageExamples
+const cachePaths = [
+  join(configPaths.src, 'govuk/components'),
+  join(configPaths.app, 'src/views/examples'),
+  join(configPaths.app, 'src/views/full-page-examples')
 ]
 
 /**
@@ -23,7 +25,7 @@ export async function globals () {
     const componentsData = await getComponentsData()
 
     // Run directory lookups
-    const directoryEntries = await Promise.all(paths.map(
+    const directoryEntries = await Promise.all(cachePaths.map(
       async (path) => [path, await getDirectories(path)]
     ))
 

--- a/config/jest/globals.mjs
+++ b/config/jest/globals.mjs
@@ -1,7 +1,7 @@
 import { join } from 'path'
 
 import { getDirectories, getComponentsData } from '../../lib/file-helper.js'
-import configPaths from '../paths.js'
+import { paths } from '../index.js'
 
 /**
  * Cache store
@@ -12,9 +12,9 @@ const store = new Map()
  * Cache frequently used paths
  */
 const cachePaths = [
-  join(configPaths.src, 'govuk/components'),
-  join(configPaths.app, 'src/views/examples'),
-  join(configPaths.app, 'src/views/full-page-examples')
+  join(paths.src, 'govuk/components'),
+  join(paths.app, 'src/views/examples'),
+  join(paths.app, 'src/views/full-page-examples')
 ]
 
 /**

--- a/config/paths.js
+++ b/config/paths.js
@@ -4,13 +4,11 @@ const { dirname, join } = require('path')
 const rootPath = dirname(__dirname)
 
 /**
- * Config root paths
+ * Config paths
  */
-const configPaths = {
+module.exports = {
   root: rootPath,
   src: join(rootPath, 'src'),
-  config: join(rootPath, 'config'),
-  node_modules: join(rootPath, 'node_modules'),
 
   // Build: Release distribution
   dist: join(rootPath, 'dist'),
@@ -25,18 +23,4 @@ const configPaths = {
   // Documentation
   jsdoc: join(rootPath, 'jsdoc'),
   sassdoc: join(rootPath, 'sassdoc')
-}
-
-module.exports = {
-  ...configPaths,
-
-  // Source paths
-  assets: join(configPaths.src, 'govuk/assets'),
-  components: join(configPaths.src, 'govuk/components'),
-
-  // Review application views
-  views: join(configPaths.app, 'src/views'),
-  examples: join(configPaths.app, 'src/views/examples'),
-  fullPageExamples: join(configPaths.app, 'src/views/full-page-examples'),
-  layouts: join(configPaths.app, 'src/views/layouts')
 }

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -110,7 +110,7 @@ const getComponentData = async (componentName) => {
   }
 
   // Read from disk
-  const yamlPath = join(configPaths.components, componentName, `${componentName}.yaml`)
+  const yamlPath = join(configPaths.src, 'govuk/components', componentName, `${componentName}.yaml`)
   const yamlData = yaml.load(await readFile(yamlPath, 'utf8'), { json: true })
 
   return {
@@ -130,7 +130,7 @@ const getComponentsData = async () => {
   }
 
   // Read from disk
-  const componentNames = await getDirectories(configPaths.components)
+  const componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
   return Promise.all(componentNames.map(getComponentData))
 }
 
@@ -140,11 +140,11 @@ const getComponentsData = async () => {
  * @returns {Promise<FullPageExample[]>} Full page examples
  */
 const getFullPageExamples = async () => {
-  const directories = await getDirectories(configPaths.fullPageExamples)
+  const directories = await getDirectories(join(configPaths.app, 'src/views/full-page-examples'))
 
   // Add metadata (front matter) to each example
   const examples = await Promise.all(directories.map(async (exampleName) => {
-    const templatePath = join(configPaths.fullPageExamples, exampleName, 'index.njk')
+    const templatePath = join(configPaths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
 
     // @ts-expect-error "This expression is not callable" due to incorrect types
     const { attributes } = fm(await readFile(templatePath, 'utf8'))

--- a/lib/file-helper.js
+++ b/lib/file-helper.js
@@ -6,7 +6,7 @@ const { glob } = require('glob')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
 
-const configPaths = require('../config/paths')
+const { paths } = require('../config')
 
 /**
  * Test environment globals
@@ -110,7 +110,7 @@ const getComponentData = async (componentName) => {
   }
 
   // Read from disk
-  const yamlPath = join(configPaths.src, 'govuk/components', componentName, `${componentName}.yaml`)
+  const yamlPath = join(paths.src, 'govuk/components', componentName, `${componentName}.yaml`)
   const yamlData = yaml.load(await readFile(yamlPath, 'utf8'), { json: true })
 
   return {
@@ -130,7 +130,7 @@ const getComponentsData = async () => {
   }
 
   // Read from disk
-  const componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
+  const componentNames = await getDirectories(join(paths.src, 'govuk/components'))
   return Promise.all(componentNames.map(getComponentData))
 }
 
@@ -140,11 +140,11 @@ const getComponentsData = async () => {
  * @returns {Promise<FullPageExample[]>} Full page examples
  */
 const getFullPageExamples = async () => {
-  const directories = await getDirectories(join(configPaths.app, 'src/views/full-page-examples'))
+  const directories = await getDirectories(join(paths.app, 'src/views/full-page-examples'))
 
   // Add metadata (front matter) to each example
   const examples = await Promise.all(directories.map(async (exampleName) => {
-    const templatePath = join(configPaths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
+    const templatePath = join(paths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
 
     // @ts-expect-error "This expression is not callable" due to incorrect types
     const { attributes } = fm(await readFile(templatePath, 'utf8'))

--- a/lib/helper-functions.unit.test.mjs
+++ b/lib/helper-functions.unit.test.mjs
@@ -1,6 +1,6 @@
 import { join, relative } from 'path'
 
-import config from '../config/index.js'
+import { paths } from '../config/index.js'
 
 import {
   componentNameToClassName,
@@ -89,11 +89,11 @@ describe('componentPathToModuleName', () => {
   ]
 
   it.each(components)("transforms '$path' to '$moduleName'", ({ path, moduleName }) => {
-    const srcPath = join(config.paths.src, 'govuk')
+    const srcPath = join(paths.src, 'govuk')
 
     // Path variations
     const pathAbsolute = join(srcPath, path)
-    const pathRelativeToRoot = relative(config.paths.root, pathAbsolute)
+    const pathRelativeToRoot = relative(paths.root, pathAbsolute)
     const pathRelativeToSource = relative(srcPath, pathAbsolute)
 
     // Absolute path
@@ -113,11 +113,11 @@ describe('componentPathToModuleName', () => {
   })
 
   it.each(others)("transforms unknown components to 'GOVUKFrontend'", (path) => {
-    const srcPath = join(config.paths.src, 'govuk')
+    const srcPath = join(paths.src, 'govuk')
 
     // Path variations
     const pathAbsolute = join(srcPath, path)
-    const pathRelativeToRoot = relative(config.paths.root, pathAbsolute)
+    const pathRelativeToRoot = relative(paths.root, pathAbsolute)
     const pathRelativeToSource = relative(srcPath, pathAbsolute)
 
     // Unknown components always named 'GOVUKFrontend'
@@ -131,19 +131,19 @@ describe('packageNameToPath', () => {
   const packages = [
     {
       name: 'html5shiv',
-      path: join(config.paths.root, 'node_modules/html5shiv')
+      path: join(paths.root, 'node_modules/html5shiv')
     },
     {
       name: 'govuk_template_jinja',
-      path: join(config.paths.root, 'node_modules/govuk_template_jinja')
+      path: join(paths.root, 'node_modules/govuk_template_jinja')
     },
     {
       name: 'govuk_frontend_toolkit',
-      path: join(config.paths.root, 'node_modules/govuk_frontend_toolkit')
+      path: join(paths.root, 'node_modules/govuk_frontend_toolkit')
     },
     {
       name: 'jquery',
-      path: join(config.paths.root, 'node_modules/jquery')
+      path: join(paths.root, 'node_modules/jquery')
     }
   ]
 

--- a/lib/helper-functions.unit.test.mjs
+++ b/lib/helper-functions.unit.test.mjs
@@ -131,19 +131,19 @@ describe('packageNameToPath', () => {
   const packages = [
     {
       name: 'html5shiv',
-      path: join(config.paths.node_modules, 'html5shiv')
+      path: join(config.paths.root, 'node_modules/html5shiv')
     },
     {
       name: 'govuk_template_jinja',
-      path: join(config.paths.node_modules, 'govuk_template_jinja')
+      path: join(config.paths.root, 'node_modules/govuk_template_jinja')
     },
     {
       name: 'govuk_frontend_toolkit',
-      path: join(config.paths.node_modules, 'govuk_frontend_toolkit')
+      path: join(config.paths.root, 'node_modules/govuk_frontend_toolkit')
     },
     {
       name: 'jquery',
-      path: join(config.paths.node_modules, 'jquery')
+      path: join(config.paths.root, 'node_modules/jquery')
     }
   ]
 

--- a/lib/jest-helpers.js
+++ b/lib/jest-helpers.js
@@ -13,12 +13,12 @@ const { componentNameToMacroName } = require('./helper-functions')
 
 const sassPaths = [
   join(paths.src, 'govuk'),
-  paths.node_modules
+  join(paths.root, 'node_modules')
 ]
 
 const nunjucksPaths = [
   join(paths.src, 'govuk'),
-  paths.components
+  join(paths.src, 'govuk/components')
 ]
 
 const nunjucksEnv = nunjucks.configure(nunjucksPaths, {

--- a/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -2,7 +2,7 @@ import { join } from 'path'
 
 import slash from 'slash'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 import { filterPath, getDirectories, getListing } from '../../lib/file-helper.js'
 import { componentNameToMacroName } from '../../lib/helper-functions.js'
 
@@ -10,8 +10,8 @@ import { componentNameToMacroName } from '../../lib/helper-functions.js'
  * GOV.UK Prototype Kit config builder
  */
 export default async () => {
-  const componentsFiles = await getListing(join(configPaths.src, 'govuk/components'))
-  const componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
+  const componentsFiles = await getListing(join(paths.src, 'govuk/components'))
+  const componentNames = await getDirectories(join(paths.src, 'govuk/components'))
 
   // Build array of macros
   const nunjucksMacros = componentNames

--- a/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -1,4 +1,4 @@
-import { join, relative } from 'path'
+import { join } from 'path'
 
 import slash from 'slash'
 
@@ -10,8 +10,8 @@ import { componentNameToMacroName } from '../../lib/helper-functions.js'
  * GOV.UK Prototype Kit config builder
  */
 export default async () => {
-  const componentsFiles = await getListing(configPaths.components)
-  const componentNames = await getDirectories(configPaths.components)
+  const componentsFiles = await getListing(join(configPaths.src, 'govuk/components'))
+  const componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
 
   // Build array of macros
   const nunjucksMacros = componentNames
@@ -20,7 +20,7 @@ export default async () => {
         .filter(filterPath([`${componentName}/macro.njk`]))
 
       return {
-        importFrom: slash(relative(configPaths.src, join(configPaths.components, macroPath))),
+        importFrom: slash(join('govuk/components', macroPath)),
         macroName: componentNameToMacroName(componentName)
       }
     })

--- a/src/govuk/all.test.mjs
+++ b/src/govuk/all.test.mjs
@@ -1,7 +1,7 @@
 import sassdoc from 'sassdoc'
 import slash from 'slash'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 import { compileSassString } from '../../lib/jest-helpers.js'
 
 describe('GOV.UK Frontend', () => {
@@ -80,8 +80,8 @@ describe('GOV.UK Frontend', () => {
   describe('Sass documentation', () => {
     it('associates everything with a group', async () => {
       return sassdoc.parse([
-        `${slash(configPaths.src)}/govuk/**/*.scss`,
-        `!${slash(configPaths.src)}/govuk/vendor/*.scss`
+        `${slash(paths.src)}/govuk/**/*.scss`,
+        `!${slash(paths.src)}/govuk/vendor/*.scss`
       ])
         .then(docs => docs.forEach(doc => {
           return expect(doc).toMatchObject({

--- a/src/govuk/components/components.template.test.js
+++ b/src/govuk/components/components.template.test.js
@@ -22,7 +22,7 @@ describe('Components', () => {
     nunjucksEnvDefault = nunjucksEnv
 
     // Components list
-    componentNames = await getDirectories(configPaths.components)
+    componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
   })
 
   describe('Nunjucks environment', () => {

--- a/src/govuk/components/components.template.test.js
+++ b/src/govuk/components/components.template.test.js
@@ -5,7 +5,7 @@ const { HtmlValidate } = require('html-validate')
 // over the nunjucks environment.
 const nunjucks = require('nunjucks')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getDirectories, getComponentsData } = require('../../../lib/file-helper')
 const { nunjucksEnv, renderHtml } = require('../../../lib/jest-helpers')
 
@@ -18,11 +18,11 @@ describe('Components', () => {
   beforeAll(async () => {
     // Create a new Nunjucks environment that uses the src directory as its
     // base path, rather than the components folder itself
-    nunjucksEnvCustom = nunjucks.configure(join(configPaths.src, 'govuk'))
+    nunjucksEnvCustom = nunjucks.configure(join(paths.src, 'govuk'))
     nunjucksEnvDefault = nunjucksEnv
 
     // Components list
-    componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
+    componentNames = await getDirectories(join(paths.src, 'govuk/components'))
   })
 
   describe('Nunjucks environment', () => {

--- a/src/govuk/components/components.test.js
+++ b/src/govuk/components/components.test.js
@@ -1,6 +1,6 @@
 const { join } = require('path')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getListing } = require('../../../lib/file-helper')
 const { compileSassFile } = require('../../../lib/jest-helpers')
 
@@ -8,7 +8,7 @@ describe('Components', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(join(configPaths.src, 'govuk/components'), '**/*.scss', {
+    sassFiles = await getListing(join(paths.src, 'govuk/components'), '**/*.scss', {
       ignore: [
         '**/_all.scss',
         '**/_index.scss'
@@ -18,7 +18,7 @@ describe('Components', () => {
 
   describe('Sass render', () => {
     it('renders CSS for all components', () => {
-      const file = join(configPaths.src, 'govuk/components/_all.scss')
+      const file = join(paths.src, 'govuk/components/_all.scss')
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -28,7 +28,7 @@ describe('Components', () => {
 
     it('renders CSS for each component', () => {
       const sassTasks = sassFiles.map((sassFilePath) => {
-        const file = join(configPaths.src, 'govuk/components', sassFilePath)
+        const file = join(paths.src, 'govuk/components', sassFilePath)
 
         return expect(compileSassFile(file)).resolves.toMatchObject({
           css: expect.any(String),

--- a/src/govuk/components/components.test.js
+++ b/src/govuk/components/components.test.js
@@ -8,7 +8,7 @@ describe('Components', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.components, '**/*.scss', {
+    sassFiles = await getListing(join(configPaths.src, 'govuk/components'), '**/*.scss', {
       ignore: [
         '**/_all.scss',
         '**/_index.scss'
@@ -18,7 +18,7 @@ describe('Components', () => {
 
   describe('Sass render', () => {
     it('renders CSS for all components', () => {
-      const file = join(configPaths.components, '_all.scss')
+      const file = join(configPaths.src, 'govuk/components/_all.scss')
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -28,7 +28,7 @@ describe('Components', () => {
 
     it('renders CSS for each component', () => {
       const sassTasks = sassFiles.map((sassFilePath) => {
-        const file = join(configPaths.components, sassFilePath)
+        const file = join(configPaths.src, 'govuk/components', sassFilePath)
 
         return expect(compileSassFile(file)).resolves.toMatchObject({
           css: expect.any(String),

--- a/src/govuk/helpers/helpers.test.js
+++ b/src/govuk/helpers/helpers.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const sassdoc = require('sassdoc')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getListing } = require('../../../lib/file-helper')
 const { compileSassFile } = require('../../../lib/jest-helpers')
 
@@ -10,19 +10,19 @@ describe('The helpers layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'govuk/helpers/**/*.scss', {
+    sassFiles = await getListing(paths.src, 'govuk/helpers/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(configPaths.src, 'govuk/helpers/_all.scss')
+    const file = join(paths.src, 'govuk/helpers/_all.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all helpers', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
-      const file = join(configPaths.src, sassFilePath)
+      const file = join(paths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -35,7 +35,7 @@ describe('The helpers layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "helpers" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/helpers/**/*.scss'))
+      const docs = await sassdoc.parse(join(paths.src, 'govuk/helpers/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/objects/objects.test.js
+++ b/src/govuk/objects/objects.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const sassdoc = require('sassdoc')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getListing } = require('../../../lib/file-helper')
 const { compileSassFile } = require('../../../lib/jest-helpers')
 
@@ -10,14 +10,14 @@ describe('The objects layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'govuk/objects/**/*.scss', {
+    sassFiles = await getListing(paths.src, 'govuk/objects/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('renders CSS for all objects', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
-      const file = join(configPaths.src, sassFilePath)
+      const file = join(paths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -30,7 +30,7 @@ describe('The objects layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "objects" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/objects/**/*.scss'))
+      const docs = await sassdoc.parse(join(paths.src, 'govuk/objects/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/settings/settings.test.js
+++ b/src/govuk/settings/settings.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const sassdoc = require('sassdoc')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getListing } = require('../../../lib/file-helper')
 const { compileSassFile } = require('../../../lib/jest-helpers')
 
@@ -10,19 +10,19 @@ describe('The settings layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'govuk/settings/**/*.scss', {
+    sassFiles = await getListing(paths.src, 'govuk/settings/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(configPaths.src, 'govuk/settings/_all.scss')
+    const file = join(paths.src, 'govuk/settings/_all.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all settings', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
-      const file = join(configPaths.src, sassFilePath)
+      const file = join(paths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -35,7 +35,7 @@ describe('The settings layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "settings" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/settings/**/*.scss'))
+      const docs = await sassdoc.parse(join(paths.src, 'govuk/settings/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -3,13 +3,13 @@ const { join } = require('path')
 
 const nunjucks = require('nunjucks')
 
-const configPaths = require('../../config/paths')
+const { paths } = require('../../config')
 const { renderTemplate } = require('../../lib/jest-helpers')
 
 describe('Template', () => {
   describe('with default nunjucks configuration', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(join(configPaths.src, 'govuk'))
+      nunjucks.configure(join(paths.src, 'govuk'))
       const output = nunjucks.render('./template.njk')
       expect(output.charAt(0)).toEqual('<')
     })
@@ -17,7 +17,7 @@ describe('Template', () => {
 
   describe('with nunjucks block trimming enabled', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(join(configPaths.src, 'govuk'), {
+      nunjucks.configure(join(paths.src, 'govuk'), {
         trimBlocks: true,
         lstripBlocks: true
       })

--- a/src/govuk/tools/tools.test.js
+++ b/src/govuk/tools/tools.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const sassdoc = require('sassdoc')
 
-const configPaths = require('../../../config/paths')
+const { paths } = require('../../../config')
 const { getListing } = require('../../../lib/file-helper')
 const { compileSassFile } = require('../../../lib/jest-helpers')
 
@@ -10,19 +10,19 @@ describe('The tools layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(configPaths.src, 'govuk/tools/**/*.scss', {
+    sassFiles = await getListing(paths.src, 'govuk/tools/**/*.scss', {
       ignore: ['**/_all.scss']
     })
   })
 
   it('should not output any CSS', async () => {
-    const file = join(configPaths.src, 'govuk/tools/_all.scss')
+    const file = join(paths.src, 'govuk/tools/_all.scss')
     await expect(compileSassFile(file)).resolves.toMatchObject({ css: '' })
   })
 
   it('renders CSS for all tools', () => {
     const sassTasks = sassFiles.map((sassFilePath) => {
-      const file = join(configPaths.src, sassFilePath)
+      const file = join(paths.src, sassFilePath)
 
       return expect(compileSassFile(file)).resolves.toMatchObject({
         css: expect.any(String),
@@ -35,7 +35,7 @@ describe('The tools layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "tools" group', async () => {
-      const docs = await sassdoc.parse(join(configPaths.src, 'govuk/tools/**/*.scss'))
+      const docs = await sassdoc.parse(join(paths.src, 'govuk/tools/**/*.scss'))
 
       for (const doc of docs) {
         expect(doc).toMatchObject({

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,6 +4,7 @@
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
+    "resolveJsonModule": true,
     "target": "ES2015",
     "types": ["node", "typed-query-selector"]
   }

--- a/tasks/compile-stylesheets.mjs
+++ b/tasks/compile-stylesheets.mjs
@@ -71,8 +71,8 @@ export async function compileStylesheet ([modulePath, { srcPath, destPath }]) {
 
       // Resolve @imports via
       loadPaths: [
-        join(paths.node_modules, 'govuk_frontend_toolkit/stylesheets'),
-        paths.node_modules
+        join(paths.root, 'node_modules/govuk_frontend_toolkit/stylesheets'),
+        join(paths.root, 'node_modules')
       ],
 
       // Sass custom logger

--- a/tasks/gulp/__tests__/after-build-dist.test.mjs
+++ b/tasks/gulp/__tests__/after-build-dist.test.mjs
@@ -10,7 +10,7 @@ describe('dist/', () => {
   let listingDistAssets
 
   beforeAll(async () => {
-    listingSourceAssets = await getListing(paths.assets)
+    listingSourceAssets = await getListing(join(paths.src, 'govuk/assets'))
     listingDistAssets = await getListing(join(paths.dist, 'assets'))
   })
 

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -20,12 +20,12 @@ describe('package/', () => {
     listingSource = await getListing(configPaths.src)
     listingPackage = await getListing(configPaths.package)
 
-    componentsFilesSource = await getListing(configPaths.components)
+    componentsFilesSource = await getListing(join(configPaths.src, 'govuk/components'))
     componentsFilesPackage = await getListing(join(configPaths.package, 'govuk/components'))
     componentsFilesPackageESM = await getListing(join(configPaths.package, 'govuk-esm/components'))
 
     // Components list
-    componentNames = await getDirectories(configPaths.components)
+    componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
   })
 
   it('should contain the expected files', async () => {
@@ -186,7 +186,7 @@ describe('package/', () => {
         const [modulePathESM] = componentPackageESM
           .filter(filterPath([`**/${componentName}.mjs`]))
 
-        const moduleName = componentPathToModuleName(join(configPaths.components, modulePath))
+        const moduleName = componentPathToModuleName(join(join(configPaths.src, 'govuk/components'), modulePath))
         const moduleText = await readFile(join(configPaths.package, 'govuk/components', modulePath), 'utf8')
         const moduleTextESM = await readFile(join(configPaths.package, 'govuk-esm/components', modulePathESM), 'utf8')
 

--- a/tasks/gulp/__tests__/after-build-package.test.mjs
+++ b/tasks/gulp/__tests__/after-build-package.test.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
-import configPaths from '../../../config/paths.js'
+import { paths } from '../../../config/index.js'
 import { filterPath, getDirectories, getListing, mapPathTo } from '../../../lib/file-helper.js'
 import { componentNameToClassName, componentPathToModuleName } from '../../../lib/helper-functions.js'
 import { compileSassFile } from '../../../lib/jest-helpers.js'
@@ -17,15 +17,15 @@ describe('package/', () => {
   let componentNames
 
   beforeAll(async () => {
-    listingSource = await getListing(configPaths.src)
-    listingPackage = await getListing(configPaths.package)
+    listingSource = await getListing(paths.src)
+    listingPackage = await getListing(paths.package)
 
-    componentsFilesSource = await getListing(join(configPaths.src, 'govuk/components'))
-    componentsFilesPackage = await getListing(join(configPaths.package, 'govuk/components'))
-    componentsFilesPackageESM = await getListing(join(configPaths.package, 'govuk-esm/components'))
+    componentsFilesSource = await getListing(join(paths.src, 'govuk/components'))
+    componentsFilesPackage = await getListing(join(paths.package, 'govuk/components'))
+    componentsFilesPackageESM = await getListing(join(paths.package, 'govuk-esm/components'))
 
     // Components list
-    componentNames = await getDirectories(join(configPaths.src, 'govuk/components'))
+    componentNames = await getDirectories(join(paths.src, 'govuk/components'))
   })
 
   it('should contain the expected files', async () => {
@@ -86,7 +86,7 @@ describe('package/', () => {
 
   describe('README.md', () => {
     it('is not overwritten', async () => {
-      const contents = await readFile(join(configPaths.package, 'README.md'), 'utf8')
+      const contents = await readFile(join(paths.package, 'README.md'), 'utf8')
 
       // Look for H1 matching 'GOV.UK Frontend' from existing README
       expect(contents).toMatch(/^# GOV.UK Frontend/)
@@ -95,14 +95,14 @@ describe('package/', () => {
 
   describe('all.scss', () => {
     it('should compile without throwing an exception', async () => {
-      const file = join(configPaths.package, 'govuk', 'all.scss')
+      const file = join(paths.package, 'govuk', 'all.scss')
       await expect(compileSassFile(file)).resolves
     })
   })
 
   describe('all.js', () => {
     it('should have correct module name', async () => {
-      const contents = await readFile(join(configPaths.package, 'govuk', 'all.js'), 'utf8')
+      const contents = await readFile(join(paths.package, 'govuk', 'all.js'), 'utf8')
 
       // Look for AMD module definition for 'GOVUKFrontend'
       expect(contents).toContain("typeof define === 'function' && define.amd ? define('GOVUKFrontend', ['exports'], factory)")
@@ -129,7 +129,7 @@ describe('package/', () => {
           .filter(filterPath(['**/macro-options.json']))
 
         // Component options
-        const options = JSON.parse(await readFile(join(configPaths.package, 'govuk/components', optionsPath), 'utf8'))
+        const options = JSON.parse(await readFile(join(paths.package, 'govuk/components', optionsPath), 'utf8'))
         expect(options).toBeInstanceOf(Array)
 
         // Component options requirements
@@ -186,9 +186,9 @@ describe('package/', () => {
         const [modulePathESM] = componentPackageESM
           .filter(filterPath([`**/${componentName}.mjs`]))
 
-        const moduleName = componentPathToModuleName(join(join(configPaths.src, 'govuk/components'), modulePath))
-        const moduleText = await readFile(join(configPaths.package, 'govuk/components', modulePath), 'utf8')
-        const moduleTextESM = await readFile(join(configPaths.package, 'govuk-esm/components', modulePathESM), 'utf8')
+        const moduleName = componentPathToModuleName(join(join(paths.src, 'govuk/components'), modulePath))
+        const moduleText = await readFile(join(paths.package, 'govuk/components', modulePath), 'utf8')
+        const moduleTextESM = await readFile(join(paths.package, 'govuk-esm/components', modulePathESM), 'utf8')
 
         expect(moduleText).toContain(`typeof define === 'function' && define.amd ? define('${moduleName}', factory)`)
         expect(moduleTextESM).toContain(`export default ${componentNameToClassName(componentName)}`)
@@ -219,7 +219,7 @@ describe('package/', () => {
           .filter(filterPath([`${componentName}/fixtures.json`]))
 
         // Component fixtures
-        const { component, fixtures } = JSON.parse(await readFile(join(configPaths.package, 'govuk/components', fixturesPath), 'utf8'))
+        const { component, fixtures } = JSON.parse(await readFile(join(paths.package, 'govuk/components', fixturesPath), 'utf8'))
         expect(component).toEqual(componentName)
         expect(fixtures).toBeInstanceOf(Array)
 

--- a/tasks/gulp/copy-to-destination.mjs
+++ b/tasks/gulp/copy-to-destination.mjs
@@ -8,7 +8,7 @@ import merge from 'merge-stream'
 import nunjucks from 'nunjucks'
 import slash from 'slash'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 import { destination } from '../task-arguments.mjs'
 
 /**
@@ -18,7 +18,7 @@ import { destination } from '../task-arguments.mjs'
  * @returns {import('stream').Stream} Output file stream
  */
 export function copyAssets () {
-  return gulp.src(`${slash(configPaths.src)}/govuk/assets/**/*`)
+  return gulp.src(`${slash(paths.src)}/govuk/assets/**/*`)
     .pipe(gulp.dest(slash(join(destination, 'assets'))))
 }
 
@@ -37,8 +37,8 @@ export function copyFiles () {
      * Includes only source JavaScript ECMAScript (ES) modules
      */
     gulp.src([
-      `${slash(configPaths.src)}/govuk/**/*.mjs`,
-      `!${slash(configPaths.src)}/govuk/**/*.test.*`
+      `${slash(paths.src)}/govuk/**/*.mjs`,
+      `!${slash(paths.src)}/govuk/**/*.test.*`
     ]).pipe(gulp.dest(slash(join(destination, 'govuk-esm')))),
 
     /**
@@ -47,7 +47,7 @@ export function copyFiles () {
      */
     merge(
       gulp.src([
-        `${slash(configPaths.src)}/**/*`,
+        `${slash(paths.src)}/**/*`,
 
         // Exclude files we don't want to publish
         '!**/.DS_Store',
@@ -59,18 +59,18 @@ export function copyFiles () {
 
         // Preserve destination README when copying to ./package
         // https://github.com/alphagov/govuk-frontend/tree/main/package#readme
-        `!${slash(configPaths.src)}/govuk/README.md`,
+        `!${slash(paths.src)}/govuk/README.md`,
 
         // Exclude Sass files handled by Gulp 'compile:scss'
-        `!${slash(configPaths.src)}/**/*.scss`,
+        `!${slash(paths.src)}/**/*.scss`,
 
         // Exclude source YAML handled by JSON streams below
-        `!${slash(configPaths.src)}/govuk/components/**/*.yaml`
+        `!${slash(paths.src)}/govuk/components/**/*.yaml`
       ]),
 
       // Generate fixtures.json from ${componentName}.yaml
-      gulp.src(`${slash(configPaths.src)}/govuk/components/**/*.yaml`, {
-        base: slash(configPaths.src)
+      gulp.src(`${slash(paths.src)}/govuk/components/**/*.yaml`, {
+        base: slash(paths.src)
       })
         .pipe(map(async (file, done) => {
           try {
@@ -85,8 +85,8 @@ export function copyFiles () {
         })),
 
       // Generate macro-options.json from ${componentName}.yaml
-      gulp.src(`${slash(configPaths.src)}/govuk/components/**/*.yaml`, {
-        base: slash(configPaths.src)
+      gulp.src(`${slash(paths.src)}/govuk/components/**/*.yaml`, {
+        base: slash(paths.src)
       })
         .pipe(map(async (file, done) => {
           try {
@@ -120,7 +120,7 @@ async function generateFixtures (file) {
 
   // Nunjucks template
   const componentName = basename(file.dirname)
-  const template = join(configPaths.src, 'govuk/components', componentName, 'template.njk')
+  const template = join(paths.src, 'govuk/components', componentName, 'template.njk')
 
   // Loop examples
   const examples = json.examples.map(async (example) => {

--- a/tasks/gulp/copy-to-destination.mjs
+++ b/tasks/gulp/copy-to-destination.mjs
@@ -18,7 +18,7 @@ import { destination } from '../task-arguments.mjs'
  * @returns {import('stream').Stream} Output file stream
  */
 export function copyAssets () {
-  return gulp.src(`${slash(configPaths.assets)}/**/*`)
+  return gulp.src(`${slash(configPaths.src)}/govuk/assets/**/*`)
     .pipe(gulp.dest(slash(join(destination, 'assets'))))
 }
 
@@ -65,11 +65,11 @@ export function copyFiles () {
         `!${slash(configPaths.src)}/**/*.scss`,
 
         // Exclude source YAML handled by JSON streams below
-        `!${slash(configPaths.components)}/**/*.yaml`
+        `!${slash(configPaths.src)}/govuk/components/**/*.yaml`
       ]),
 
       // Generate fixtures.json from ${componentName}.yaml
-      gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
+      gulp.src(`${slash(configPaths.src)}/govuk/components/**/*.yaml`, {
         base: slash(configPaths.src)
       })
         .pipe(map(async (file, done) => {
@@ -85,7 +85,7 @@ export function copyFiles () {
         })),
 
       // Generate macro-options.json from ${componentName}.yaml
-      gulp.src(`${slash(configPaths.components)}/**/*.yaml`, {
+      gulp.src(`${slash(configPaths.src)}/govuk/components/**/*.yaml`, {
         base: slash(configPaths.src)
       })
         .pipe(map(async (file, done) => {
@@ -120,7 +120,7 @@ async function generateFixtures (file) {
 
   // Nunjucks template
   const componentName = basename(file.dirname)
-  const template = join(configPaths.components, componentName, 'template.njk')
+  const template = join(configPaths.src, 'govuk/components', componentName, 'template.njk')
 
   // Loop examples
   const examples = json.examples.map(async (example) => {

--- a/tasks/gulp/watch.mjs
+++ b/tasks/gulp/watch.mjs
@@ -1,7 +1,7 @@
 import gulp from 'gulp'
 import slash from 'slash'
 
-import configPaths from '../../config/paths.js'
+import { paths } from '../../config/index.js'
 
 /**
  * Watch task
@@ -15,14 +15,14 @@ export function watch () {
   return Promise.all([
     gulp.watch([
       'sassdoc.config.yaml',
-      `${slash(configPaths.app)}/src/**/*.scss`,
-      `${slash(configPaths.src)}/govuk/**/*.scss`,
-      `!${slash(configPaths.src)}/govuk/vendor/*`
+      `${slash(paths.app)}/src/**/*.scss`,
+      `${slash(paths.src)}/govuk/**/*.scss`,
+      `!${slash(paths.src)}/govuk/vendor/*`
     ], gulp.series('styles')),
 
     gulp.watch([
       'jsdoc.config.js',
-      `${slash(configPaths.src)}/govuk/**/*.mjs`
+      `${slash(paths.src)}/govuk/**/*.mjs`
     ], gulp.series('scripts'))
   ])
 }

--- a/tasks/screenshot-components.mjs
+++ b/tasks/screenshot-components.mjs
@@ -4,7 +4,7 @@ import percySnapshot from '@percy/puppeteer'
 import { isPercyEnabled } from '@percy/sdk-utils'
 import { launch } from 'puppeteer'
 
-import configPaths from '../config/paths.js'
+import { paths } from '../config/index.js'
 import { filterPath, getDirectories, getListing } from '../lib/file-helper.js'
 import { goToComponent, goToExample } from '../lib/puppeteer-helpers.js'
 
@@ -104,8 +104,8 @@ if (!await isPercyEnabled()) {
 }
 
 const [componentNames, componentsFiles] = await Promise.all([
-  getDirectories(join(configPaths.src, 'govuk/components')),
-  getListing(join(configPaths.src, 'govuk/components')),
+  getDirectories(join(paths.src, 'govuk/components')),
+  getListing(join(paths.src, 'govuk/components')),
   download() // Download browser
 ])
 

--- a/tasks/screenshot-components.mjs
+++ b/tasks/screenshot-components.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import percySnapshot from '@percy/puppeteer'
 import { isPercyEnabled } from '@percy/sdk-utils'
 import { launch } from 'puppeteer'
@@ -102,8 +104,8 @@ if (!await isPercyEnabled()) {
 }
 
 const [componentNames, componentsFiles] = await Promise.all([
-  getDirectories(configPaths.components),
-  getListing(configPaths.components),
+  getDirectories(join(configPaths.src, 'govuk/components')),
+  getListing(join(configPaths.src, 'govuk/components')),
   download() // Download browser
 ])
 

--- a/tasks/task-arguments.mjs
+++ b/tasks/task-arguments.mjs
@@ -3,7 +3,7 @@ import { resolve } from 'path'
 import slash from 'slash'
 import parser from 'yargs-parser'
 
-import configPaths from '../config/paths.js'
+import { paths } from '../config/index.js'
 
 export const argv = parser(process.argv, {
   string: ['destination']
@@ -32,7 +32,7 @@ const { _: tasks } = argv
 const target = argv.destination || (destinations
   .filter(({ task }) => tasks.includes(task))[0]?.destination ?? 'public')
 
-const destPath = resolve(configPaths.root, slash(target))
+const destPath = resolve(paths.root, slash(target))
 
 // Absolute path to destination
 export const destination = destPath

--- a/tasks/task-arguments.unit.test.mjs
+++ b/tasks/task-arguments.unit.test.mjs
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import { cwd } from 'process'
 
-import configPaths from '../config/paths.js'
+import { paths } from '../config/index.js'
 
 describe('Task arguments', () => {
   let args
@@ -33,44 +33,44 @@ describe('Task arguments', () => {
           process.argv = [...argv]
 
           const { destination } = await import('./task-arguments.mjs')
-          expect(destination).toEqual(configPaths.public)
+          expect(destination).toEqual(paths.public)
         })
 
         it('defaults to ./public for "gulp build:compile"', async () => {
           process.argv = [...argv, 'build:compile']
 
           const { destination } = await import('./task-arguments.mjs')
-          expect(destination).toEqual(configPaths.public)
+          expect(destination).toEqual(paths.public)
         })
 
         it('defaults to ./package for "gulp build:package"', async () => {
           process.argv = [...argv, 'build:package']
 
           const { destination } = await import('./task-arguments.mjs')
-          expect(destination).toEqual(configPaths.package)
+          expect(destination).toEqual(paths.package)
         })
 
         it('defaults to ./dist for "gulp build:dist"', async () => {
           process.argv = [...argv, 'build:dist']
 
           const { destination } = await import('./task-arguments.mjs')
-          expect(destination).toEqual(configPaths.dist)
+          expect(destination).toEqual(paths.dist)
         })
       })
 
       describe.each(
         [
           // Override to public
-          { flag: 'public', destination: configPaths.public },
-          { flag: './public', destination: configPaths.public },
+          { flag: 'public', destination: paths.public },
+          { flag: './public', destination: paths.public },
 
           // Override to package
-          { flag: 'package', destination: configPaths.package },
-          { flag: './package', destination: configPaths.package },
+          { flag: 'package', destination: paths.package },
+          { flag: './package', destination: paths.package },
 
           // Override to dist
-          { flag: 'dist', destination: configPaths.dist },
-          { flag: './dist', destination: configPaths.dist },
+          { flag: 'dist', destination: paths.dist },
+          { flag: './dist', destination: paths.dist },
 
           // Override to custom
           { flag: 'custom/location/here', destination: join(cwd(), 'custom/location/here') },


### PR DESCRIPTION
This PR helps to clearly show our build paths as part of:

* https://github.com/alphagov/govuk-frontend/issues/2711
* https://github.com/alphagov/govuk-frontend/issues/2886

Whilst pairing on https://github.com/alphagov/govuk-frontend/pull/3318 it wasn't obvious which areas of the repo are being copied, written or built from config paths

For example, what's the difference between these three?

1. `configPaths.components`
2. `join(configPaths.package, 'govuk/components')`
3. `join(configPaths.package, 'govuk-esm/components')`

I've ensured that only top-level paths are found in [config/**paths.js**](https://github.com/alphagov/govuk-frontend/blob/main/config/paths.js) so their locations are clear:


### Top level
```js
join(paths.root, 'config')
join(paths.root, 'node_modules')
```

### Source
```js
join(paths.src, 'govuk/assets')
join(paths.src, 'govuk/components')
```

### Review app
```js
join(paths.app, 'views')
join(paths.app, 'views/examples')
join(paths.app, 'views/full-page-examples')
join(paths.app, 'views/layouts')
```
