### PR TITLE
Ensure Nunjucks global `markdown()` renders correctly

### DIFF
--- a/app/app.test.js
+++ b/app/app.test.js
@@ -12,7 +12,9 @@ const expectedPages = [
   '/examples/links',
   '/examples/typography',
   '/examples/template-default',
-  '/examples/template-custom'
+  '/examples/template-custom',
+  '/full-page-examples',
+  '/full-page-examples/announcements'
 ]
 
 // Returns Fetch API wrapper which applies these options by default

--- a/app/common/nunjucks/globals/index.js
+++ b/app/common/nunjucks/globals/index.js
@@ -1,10 +1,11 @@
-const markdown = require('marked')
+const marked = require('marked')
 
 /**
  * Nunjucks globals
  */
 const getHTMLCode = require('./get-html-code.js')
 const getNunjucksCode = require('./get-nunjucks-code.js')
+const markdown = (content) => marked.parse(content)
 
 module.exports = {
   getHTMLCode,


### PR DESCRIPTION
Go to https://govuk-frontend-review.herokuapp.com/full-page-examples, it blows up.

After this change, no blow up.

This broke when updating marked to version 4 where the parse method was introduced:

https://github.com/markedjs/marked/releases/tag/v4.0.0