### PR TITLE
Build tasks: Move review app files into `app/dist`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
   ignorePatterns: [
     '**/dist/**',
     '**/package/**',
-    '**/public/**',
     '**/vendor/**',
 
     // Enable dotfile linting

--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -12,8 +12,8 @@ runs:
         # Restore build cache (unless commit SHA changes)
         key: build-cache-${{ runner.os }}-${{ github.sha }}
         path: |
+          app/dist
           jsdoc
-          public
           sassdoc
 
     - name: Install dependencies

--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -11,10 +11,7 @@ runs:
       with:
         # Restore build cache (unless commit SHA changes)
         key: build-cache-${{ runner.os }}-${{ github.sha }}
-        path: |
-          app/dist
-          jsdoc
-          sassdoc
+        path: app/dist
 
     - name: Install dependencies
       uses: ./.github/workflows/actions/install-node

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@ node_modules/
 coverage/
 
 # Build output
+dist/
 jsdoc/
-public/
 sassdoc/
+
+# Build output (committed)
+!/dist
 
 # Files to ignore
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ coverage/
 
 # Build output
 dist/
-jsdoc/
-sassdoc/
 
 # Build output (committed)
 !/dist

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,13 +9,12 @@ node_modules/
 coverage/
 
 # Build output
+dist/
 jsdoc/
-public/
 sassdoc/
 
 # Build output (committed)
-dist/
-package/
+/package
 
 # 3rd party vendor code
 vendor/

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,8 +10,6 @@ coverage/
 
 # Build output
 dist/
-jsdoc/
-sassdoc/
 
 # Build output (committed)
 /package

--- a/app/src/common/middleware/assets.mjs
+++ b/app/src/common/middleware/assets.mjs
@@ -9,8 +9,8 @@ const router = express.Router()
 /**
  * Add middleware to serve static assets
  */
-router.use('/assets', express.static(join(paths.public, 'assets')))
-router.use('/javascripts', express.static(join(paths.public, 'javascripts')))
-router.use('/stylesheets', express.static(join(paths.public, 'stylesheets')))
+router.use('/assets', express.static(join(paths.app, 'dist/assets')))
+router.use('/javascripts', express.static(join(paths.app, 'dist/javascripts')))
+router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 
 export default router

--- a/app/src/common/middleware/docs.mjs
+++ b/app/src/common/middleware/docs.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import express from 'express'
 
 import { paths } from '../../../../config/index.js'
@@ -27,7 +29,7 @@ router.use('/sass', ({ app }, res, next) => {
 /**
  * Add middleware
  */
-router.use('/sass', express.static(paths.sassdoc))
-router.use('/javascript', express.static(paths.jsdoc))
+router.use('/sass', express.static(join(paths.app, 'dist/docs/sassdoc')))
+router.use('/javascript', express.static(join(paths.app, 'dist/docs/jsdoc')))
 
 export default router

--- a/config/paths.js
+++ b/config/paths.js
@@ -18,7 +18,6 @@ module.exports = {
 
   // Review application
   app: join(rootPath, 'app'),
-  public: join(rootPath, 'public'),
 
   // Documentation
   jsdoc: join(rootPath, 'jsdoc'),

--- a/config/paths.js
+++ b/config/paths.js
@@ -17,9 +17,5 @@ module.exports = {
   package: join(rootPath, 'package'),
 
   // Review application
-  app: join(rootPath, 'app'),
-
-  // Documentation
-  jsdoc: join(rootPath, 'jsdoc'),
-  sassdoc: join(rootPath, 'sassdoc')
+  app: join(rootPath, 'app')
 }

--- a/docs/contributing/application-architecture.md
+++ b/docs/contributing/application-architecture.md
@@ -2,27 +2,7 @@
 
 - `app/`
 
-  [Express](https://github.com/expressjs/express) application to preview components; also referred to as _preview app_.
-
-  - `assets/`
-
-    App-specific assets.
-
-  - `views/`
-
-    [Nunjucks](https://github.com/mozilla/nunjucks) template files.
-
-    - `examples/`
-
-      Examples of components usage in various contexts. You can access these examples from the home page of the preview app.
-
-    - `layouts/`
-
-      Generic layout templates used to render preview app pages.
-
-    - `partials/`
-
-      Reusable blocks of template code.
+  [Express](https://github.com/expressjs/express) application to preview components; also referred to as the _review app_.
 
 - `bin/`
 
@@ -30,7 +10,7 @@
 
 - `config/`
 
-  Configuration files for the preview app and [Jest](https://github.com/facebook/jest).
+  Configuration files for the review app and [Jest](https://github.com/facebook/jest).
 
 - `dist/` **contains auto-generated files**
 
@@ -56,9 +36,3 @@
 - `tasks/`
 
   Application modules and helpers. See [tasks](tasks.md) for more information about the tasks.
-
-### Auto-generated directories
-
-- `public/`
-
-  Assets built for the preview app.

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -38,8 +38,8 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - copy fonts and images
 - run sub tasks from `gulp styles` without StyleLint code quality checks
 - run sub tasks from `gulp scripts` without ESLint code quality checks
-- compile Sass documentation into `./sassdoc`
-- compile JavaScript documentation into `./jsdoc`
+- compile Sass documentation into `./app/dist/docs/sassdoc`
+- compile JavaScript documentation into `./app/dist/docs/jsdoc`
 
 **`npm run build:package` will do the following:**
 
@@ -77,7 +77,7 @@ This task will:
 
 - check Sass code quality via Stylelint (`npm run lint:scss`)
 - compile Sass to CSS into `./app/dist/stylesheets`
-- compile Sass documentation into `./sassdoc`
+- compile Sass documentation into `./app/dist/docs/sassdoc`
 
 **`gulp scripts`**
 
@@ -85,7 +85,7 @@ This task will:
 
 - check JavaScript code quality via ESLint (`npm run lint:js`) (using JavaScript Standard Style)
 - compile JavaScript ESM to CommonJS into `./app/dist/javascripts`
-- compile JavaScript documentation into `./jsdoc`
+- compile JavaScript documentation into `./app/dist/docs/jsdoc`
 
 ## Express app only
 

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -10,7 +10,7 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 
 **`npm start` will trigger `gulp dev` that will:**
 
-- clean the `./public` folder
+- clean the `./app/dist` folder
 - copy fonts and images
 - compile JavaScript and Sass, including documentation
 - compile again when `.scss` and `.mjs` files change
@@ -33,8 +33,8 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 
 **`npm run build:app` will do the following:**
 
-- clean the `./public` folder
-- output files into `./public`
+- clean the `./app/dist` folder
+- output files into `./app/dist`
 - copy fonts and images
 - run sub tasks from `gulp styles` without StyleLint code quality checks
 - run sub tasks from `gulp scripts` without ESLint code quality checks
@@ -76,7 +76,7 @@ This task will:
 This task will:
 
 - check Sass code quality via Stylelint (`npm run lint:scss`)
-- compile Sass to CSS into `./public`
+- compile Sass to CSS into `./app/dist/stylesheets`
 - compile Sass documentation into `./sassdoc`
 
 **`gulp scripts`**
@@ -84,7 +84,7 @@ This task will:
 This task will:
 
 - check JavaScript code quality via ESLint (`npm run lint:js`) (using JavaScript Standard Style)
-- compile JavaScript ESM to CommonJS into `./public`
+- compile JavaScript ESM to CommonJS into `./app/dist/javascripts`
 - compile JavaScript documentation into `./jsdoc`
 
 ## Express app only

--- a/gulpfile.mjs
+++ b/gulpfile.mjs
@@ -13,7 +13,7 @@ import { browser, files, scripts, styles, npm } from './tasks/index.mjs'
 gulp.task('scripts', gulp.series(
   scripts.compile('all.mjs', {
     srcPath: join(paths.src, 'govuk'),
-    destPath: join(paths.public, 'javascripts'),
+    destPath: join(paths.app, 'dist/javascripts'),
 
     filePath (file) {
       return join(file.dir, `${file.name}.min.js`)
@@ -30,7 +30,7 @@ gulp.task('scripts', gulp.series(
 gulp.task('styles', gulp.series(
   styles.compile('**/[!_]*.scss', {
     srcPath: join(paths.app, 'src/stylesheets'),
-    destPath: join(paths.public, 'stylesheets'),
+    destPath: join(paths.app, 'dist/stylesheets'),
 
     filePath (file) {
       return join(file.dir, `${file.name}.min.css`)

--- a/jsdoc.config.js
+++ b/jsdoc.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   opts: {
-    destination: './jsdoc',
+    destination: './app/dist/docs/jsdoc',
     recurse: true
   },
   plugins: [

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -36,7 +36,7 @@ export default ({ from = '', to = '', env = 'production' }) => {
 
   // Add review app auto-generated 'companion' classes for each pseudo-class
   // For example ':hover' and ':focus' classes to simulate form label states
-  if (minimatch(from, '**/app/stylesheets/*')) {
+  if (minimatch(from, '**/app/src/stylesheets/*')) {
     config.plugins.push(pseudoclasses({
       allCombinations: true,
       restrictTo: [

--- a/postcss.config.unit.test.mjs
+++ b/postcss.config.unit.test.mjs
@@ -178,8 +178,8 @@ describe('PostCSS config', () => {
     describe('Review app only', () => {
       it.each([
         {
-          from: 'app/stylesheets/app.scss',
-          to: 'public/stylesheets/app.min.css'
+          from: 'app/src/stylesheets/app.scss',
+          to: 'app/dist/stylesheets/app.min.css'
         }
       ])('Adds plugins for $from', ({ from, to }) => {
         const config = configFn({ env, from, to })
@@ -221,12 +221,12 @@ describe('PostCSS config', () => {
 
       it.each([
         {
-          from: 'app/stylesheets/full-page-examples/campaign-page.scss',
-          to: 'public/stylesheets/full-page-examples/campaign-page.min.css'
+          from: 'app/src/stylesheets/full-page-examples/campaign-page.scss',
+          to: 'app/dist/stylesheets/full-page-examples/campaign-page.min.css'
         },
         {
-          from: 'app/stylesheets/full-page-examples/search.scss',
-          to: 'public/stylesheets/full-page-examples/search.min.css'
+          from: 'app/src/stylesheets/full-page-examples/search.scss',
+          to: 'app/dist/stylesheets/full-page-examples/search.min.css'
         }
       ])("Skips plugin 'pseudo-classes' for $from", ({ from, to }) => {
         const config = configFn({ env, from, to })
@@ -239,12 +239,12 @@ describe('PostCSS config', () => {
     describe('Review app only + IE8', () => {
       it.each([
         {
-          from: 'app/stylesheets/app-ie8.scss',
-          to: 'public/stylesheets/app-ie8.min.css'
+          from: 'app/src/stylesheets/app-ie8.scss',
+          to: 'app/dist/stylesheets/app-ie8.min.css'
         },
         {
-          from: 'app/stylesheets/app-legacy-ie8.scss',
-          to: 'public/stylesheets/app-legacy-ie8.min.css'
+          from: 'app/src/stylesheets/app-legacy-ie8.scss',
+          to: 'app/dist/stylesheets/app-legacy-ie8.min.css'
         }
       ])('Adds plugins for $from', ({ from, to }) => {
         const config = configFn({ env, from, to })

--- a/sassdoc.config.yaml
+++ b/sassdoc.config.yaml
@@ -1,3 +1,4 @@
+dest: app/dist/docs/sassdoc
 exclude:
   - vendor/*
 

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -3,7 +3,6 @@ module.exports = {
   ignoreFiles: [
     '**/dist/**',
     '**/package/**',
-    '**/public/**',
     '**/vendor/**',
 
     // Ignore CSS-in-JS (including dotfiles)

--- a/tasks/build/app.mjs
+++ b/tasks/build/app.mjs
@@ -7,19 +7,19 @@ import { files } from '../index.mjs'
 
 /**
  * Build review app task
- * Prepare public folder for review app
+ * Prepare dist folder for review app
  *
  * @returns {() => import('gulp').TaskFunction} Task function
  */
 export default () => gulp.series(
   files.clean('**/*', {
-    destPath: paths.public
+    destPath: join(paths.app, 'dist')
   }),
 
   // Copy GOV.UK Frontend static assets
   files.copy('**/*', {
     srcPath: join(paths.src, 'govuk/assets'),
-    destPath: join(paths.public, 'assets')
+    destPath: join(paths.app, 'dist/assets')
   }),
 
   'scripts',


### PR DESCRIPTION
This PR builds "Review app" files into `app/dist` as part of:

* https://github.com/alphagov/govuk-frontend/issues/2886

We can now clearly distinguish review app files under `app/public` including:

1. `public` → **`app/dist`**
1. `jsdoc` → **`app/dist/docs/jsdoc`**
1. `sassdoc` → **`app/dist/docs/sassdoc`**

## Before
```console
├── app
│   └── src
│       ├── common
│       ├── routes
│       ├── stylesheets
│       └── views
├── jsdoc
├── public
│   ├── assets
│   ├── javascripts
│   └── stylesheets
└── sassdoc
```

## After
```console
└── app
    ├── dist
    │   ├── assets
    │   ├── docs
    │   │   ├── jsdoc
    │   │   └── sassdoc
    │   ├── javascripts
    │   └── stylesheets
    └── src
        ├── common
        ├── routes
        ├── stylesheets
        └── views
```

Review app tasks will be moved in another PR:

* https://github.com/alphagov/govuk-frontend/pull/3384