### PR TITLE
Webpack example: Suppress IE8 deprecation warnings

### DIFF
--- a/docs/examples/webpack/assets/stylesheets/app-ie8.scss
+++ b/docs/examples/webpack/assets/stylesheets/app-ie8.scss
@@ -1,3 +1,1 @@
-$govuk-is-ie8: true;
-
-@import "app";
+@import "govuk-frontend/govuk/all-ie8";


### PR DESCRIPTION
For the webpack example, we'll want to suppress the new IE8 deprecation warnings:

* https://github.com/alphagov/govuk-frontend/pull/3343