### PR TITLE
Fix typos in overLimitText macro option names

### DIFF
--- a/src/govuk/components/character-count/character-count.yaml
+++ b/src/govuk/components/character-count/character-count.yaml
@@ -84,7 +84,7 @@ params:
     type: string
     required: false
     description: Message displayed when the number of characters reaches the configured maximum, `maxlength`. This message is displayed visually and through assistive technologies.
-  - name: charactersUnderLimitText
+  - name: charactersOverLimitText
     type: object
     required: false
     description: Message displayed when the number of characters is over the configured maximum, `maxlength`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of characters above the maximum. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).
@@ -96,7 +96,7 @@ params:
     type: string
     required: false
     description: Message displayed when the number of words reaches the configured maximum, `maxwords`. This message is displayed visually and through assistive technologies.
-  - name: wordsUnderLimitText
+  - name: wordsOverLimitText
     type: object
     required: false
     description: Message displayed when the number of words is over the configured maximum, `maxwords`. This message is displayed visually and through assistive technologies. The component will replace the `%{count}` placeholder with the number of characters above the maximum. This is a [pluralised list of messages](https://frontend.design-system.service.gov.uk/localise-govuk-frontend).


### PR DESCRIPTION
I noticed that the names of two options in the [character count documentation](https://design-system.service.gov.uk/components/character-count/#options-character-count-example) were wrong (probably a copy/paste error) - characters**Over**LimitText is shown as characters**Under**LimitText, and words**Over**LimitText as words**Under**LimitText:

![Screenshot showing documentation of Nunjucks macro options. Two of them have the name charactersUnderLimitText](https://user-images.githubusercontent.com/1935173/225864550-8d789f17-865c-43f3-9ad0-582b50bfb322.png)

This change just fixes those typos. Didn't think it needed a changelog entry but let me know if it does.