### PR TITLE
Fix typo in GitHub Actions linter cache check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache linter
-        if: ${{ matrix.cache }}
+        if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
           key: ${{ matrix.task.name }}-cache-${{ runner.os }}


### PR DESCRIPTION
This PR fixes a typo preventing lint tasks from being cached in GitHub Actions

Looks like it was missed in:

* https://github.com/alphagov/govuk-frontend/pull/3325