### PR TITLE
Support government changes - Update the labelling

### DIFF
--- a/src/govuk/settings/_colours-organisations.scss
+++ b/src/govuk/settings/_colours-organisations.scss
@@ -54,6 +54,10 @@ $govuk-colours-organisations: (
     colour: #cf102d,
     colour-websafe: #005ea5
   ),
+  "department-for-business-and-trade": (
+    colour: #cf102d,
+    colour-websafe: #005ea5
+  ),
   "department-for-levelling-up-housing-and-communities": (
     colour: #012169,
   ),


### PR DESCRIPTION
This change is to update labelling of Department of International Trade to Department for Business & Trade.

[Trello card](https://trello.com/c/rtK4IWUx/1206-update-department-of-business-trade-branding-labels-in-publishing-components)

