### PR TITLE
Fix argument count in deprecated `this.mql.addListener()`

### DIFF
--- a/src/govuk/components/header/header.mjs
+++ b/src/govuk/components/header/header.mjs
@@ -52,14 +52,15 @@ Header.prototype.init = function () {
     // Set the matchMedia to the govuk-frontend desktop breakpoint
     this.mql = window.matchMedia('(min-width: 48.0625em)')
 
-    var listenerMethod = 'addEventListener' in this.mql
-      ? 'addEventListener'
-      : 'addListener'
-
-    // addListener is a deprecated function, however addEventListener
-    // isn't supported by IE or Safari. We therefore add this in as
-    // a fallback for those browsers
-    this.mql[listenerMethod]('change', this.syncState.bind(this))
+    if ('addEventListener' in this.mql) {
+      this.mql.addEventListener('change', this.syncState.bind(this))
+    } else {
+      // addListener is a deprecated function, however addEventListener
+      // isn't supported by IE or Safari < 14. We therefore add this in as
+      // a fallback for those browsers
+      // @ts-expect-error Property 'addListener' does not exist
+      this.mql.addListener(this.syncState.bind(this))
+    }
 
     this.syncState()
     this.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind(this))


### PR DESCRIPTION
This PR partially reverts an unreleased change from https://github.com/alphagov/govuk-frontend/commit/0663ab3373736943e1b29fcf95473205ec382d17#diff-bcd43b95b8acddb0071fa9f557046160278bb06b55b12a58bf76b6c0a2bbb17aR57

Browser testing in Safari 9.1 correctly spotted some recent MediaQueryList argument changes:

```js
var mql = window.matchMedia('(min-width: 48.0625em)')

mql.addEventListener('change', handler)
mql.addListener(handler) // Legacy IE and Safari
```