### PR TITLE
Update default link underline offset setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ The [Button](https://design-system.service.gov.uk/components/button/) Nunjucks m
 
 This was added in [pull request #3344: Adding optional id attribute to button component](https://github.com/alphagov/govuk-frontend/pull/3344). Thanks to [Tom Billington](https://github.com/TomBillingtonUK) for this contribution.
 
-### Added a modifier for text input styles that accept sequences of digits
+#### Added a modifier for text input styles that accept sequences of digits
 
 We've added a new `.govuk-input--extra-letter-spacing` class for [Text Input](https://design-system.service.gov.uk/components/text-input/). This increases readability of text inputs that receive sequences of digits (like security codes, references or phone numbers).
 
@@ -96,6 +96,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#3306: Re-enable complete hover link styles on the footer](https://github.com/alphagov/govuk-frontend/pull/3306)
 - [#3312: Add default value for warning text icon fallback attribute](https://github.com/alphagov/govuk-frontend/pull/3312)
 - [#3426: Add organisation brand colour for Department for Business & Trade](https://github.com/alphagov/govuk-frontend/pull/3426) - thanks to [Barbara Slawinska](https://github.com/baisa) for contributing this change
+- [#3454: Update default link underline offset setting](https://github.com/alphagov/govuk-frontend/pull/3454)
 
 ## 4.5.0 (Feature release)
 

--- a/src/govuk/settings/_links.scss
+++ b/src/govuk/settings/_links.scss
@@ -38,12 +38,16 @@ $govuk-link-underline-thickness: unquote("max(1px, .0625rem)") !default;
 
 /// Offset of link underlines from text baseline
 ///
+/// The default is 3px expressed as ems, as calculated against the default body
+/// font size (on desktop) of 19px.
+/// 3 ÷ 19 = 0.1578
+///
 /// Set this variable to `false` to avoid setting an offset.
 ///
 /// @type Number
 /// @access public
 
-$govuk-link-underline-offset: .1em !default;
+$govuk-link-underline-offset: .1578em !default;
 
 /// Thickness of link underlines in hover state
 ///


### PR DESCRIPTION
We introduced new link styles in #2183 ([GOV.UK Frontend v3.12.0](https://github.com/alphagov/govuk-frontend/releases/tag/v3.12.0)), however were forced to compromise on the underline offset due to [a bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1251634) in the Chromium rendering engine. 

That bug was fixed in May 2022, was released in Chrome 104/Edge 104, and is now widely available. As such, we are updating the default link underline offset to achieve the originally intended appearance. 

Closes #2743.