### PR TITLE
Refactor file copying tasks to remove Gulp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,12 +29,10 @@
         "glob": "^10.0.0",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
-        "gulp-rename": "^2.0.0",
         "jest-axe": "^7.0.1",
         "js-yaml": "^4.1.0",
         "jsdoc": "^4.0.2",
         "jsdoc-tsimport-plugin": "^1.0.5",
-        "map-stream": "^0.0.7",
         "minimatch": "^8.0.3",
         "nunjucks": "^3.2.3",
         "outdent": "^0.8.0",
@@ -85,8 +83,7 @@
         "stylelint-config-gds": "^0.2.0",
         "stylelint-order": "^6.0.3",
         "typed-query-selector": "^2.9.2",
-        "typescript": "^5.0.3",
-        "vinyl": "^3.0.0"
+        "typescript": "^5.0.3"
       },
       "engines": {
         "node": "^18.12.0",
@@ -10354,12 +10351,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "node_modules/fast-fifo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.1.0.tgz",
-      "integrity": "sha512-Kl29QoNbNvn4nhDsLYjyIAaIqaJB6rBx5p3sL9VjaefJ+eMFBWVZiaoguaoZfzEKr5RhAti0UgM8703akGPJ6g==",
-      "dev": true
-    },
     "node_modules/fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -12156,14 +12147,6 @@
       "dependencies": {
         "camelcase": "^3.0.0",
         "object.assign": "^4.1.0"
-      }
-    },
-    "node_modules/gulp-rename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
-      "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/gulplog": {
@@ -16792,11 +16775,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/map-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
-      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ=="
-    },
     "node_modules/map-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
@@ -20499,12 +20477,6 @@
         }
       ]
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
-    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -20945,15 +20917,6 @@
       "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/replace-ext": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/replace-homedir": {
@@ -22934,16 +22897,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
-    "node_modules/streamx": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.13.2.tgz",
-      "integrity": "sha512-+TWqixPhGDXEG9L/XczSbhfkmwAtGs3BJX5QNU6cvno+pOLKeszByWcnaTu6dg8efsTYqR8ZZuXWHhZfgrxMvA==",
-      "dev": true,
-      "dependencies": {
-        "fast-fifo": "^1.1.0",
-        "queue-tick": "^1.0.1"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -23603,15 +23556,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "dev": true,
-      "dependencies": {
-        "streamx": "^2.12.5"
       }
     },
     "node_modules/term-size": {
@@ -24826,22 +24770,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vinyl": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-3.0.0.tgz",
-      "integrity": "sha512-rC2VRfAVVCGEgjnxHUnpIVh3AGuk62rP3tqVrn+yab0YH7UULisC085+NYH+mnqf3Wx4SpSi1RQMwudL89N03g==",
-      "dev": true,
-      "dependencies": {
-        "clone": "^2.1.2",
-        "clone-stats": "^1.0.0",
-        "remove-trailing-separator": "^1.1.0",
-        "replace-ext": "^2.0.0",
-        "teex": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/vinyl-fs": {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,10 @@
     "glob": "^10.0.0",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
-    "gulp-rename": "^2.0.0",
     "jest-axe": "^7.0.1",
     "js-yaml": "^4.1.0",
     "jsdoc": "^4.0.2",
     "jsdoc-tsimport-plugin": "^1.0.5",
-    "map-stream": "^0.0.7",
     "minimatch": "^8.0.3",
     "nunjucks": "^3.2.3",
     "outdent": "^0.8.0",
@@ -113,8 +111,7 @@
     "stylelint-config-gds": "^0.2.0",
     "stylelint-order": "^6.0.3",
     "typed-query-selector": "^2.9.2",
-    "typescript": "^5.0.3",
-    "vinyl": "^3.0.0"
+    "typescript": "^5.0.3"
   },
   "overrides": {
     "chokidar@^2": {

--- a/tasks/assets.mjs
+++ b/tasks/assets.mjs
@@ -40,16 +40,25 @@ export async function write (filePath, result) {
  * @typedef {object} AssetOptions
  * @property {string} [srcPath] - Input directory
  * @property {string} [destPath] - Output directory
- * @property {AssetFormatter} [filePath] - File path formatter
+ * @property {PathFormatter} [filePath] - File path formatter
+ * @property {TextFormatter} [fileContents] - File contents formatter
  * @property {string[]} [ignore] - File path patterns to ignore
  */
 
 /**
  * Asset path formatter
  *
- * @callback AssetFormatter
+ * @callback PathFormatter
  * @param {import('path').ParsedPath} file - Parsed file path
  * @returns {string} Formatted file path
+ */
+
+/**
+ * Asset contents formatter
+ *
+ * @callback TextFormatter
+ * @param {string} [contents] - Parsed file contents
+ * @returns {Promise<string>} Formatted file contents
  */
 
 /**

--- a/tasks/build/package.mjs
+++ b/tasks/build/package.mjs
@@ -3,7 +3,7 @@ import { join } from 'path'
 import gulp from 'gulp'
 
 import { paths } from '../../config/index.js'
-import { configs, files, scripts, styles, task } from '../index.mjs'
+import { components, configs, files, scripts, styles, task } from '../index.mjs'
 
 /**
  * Build package task
@@ -42,7 +42,7 @@ export default gulp.series(
 
   // Generate GOV.UK Frontend fixtures.json from ${componentName}.yaml
   task.name('copy:fixtures', () =>
-    files.generateFixtures({
+    components.generateFixtures({
       srcPath: paths.src,
       destPath: paths.package
     })
@@ -50,7 +50,7 @@ export default gulp.series(
 
   // Generate GOV.UK Frontend macro-options.json from ${componentName}.yaml
   task.name('copy:macro-options', () =>
-    files.generateMacroOptions({
+    components.generateMacroOptions({
       srcPath: paths.src,
       destPath: paths.package
     })

--- a/tasks/build/package.mjs
+++ b/tasks/build/package.mjs
@@ -41,18 +41,18 @@ export default gulp.series(
   ),
 
   // Generate GOV.UK Frontend fixtures.json from ${componentName}.yaml
-  task.name('copy:fixtures', () =>
-    components.generateFixtures({
-      srcPath: paths.src,
-      destPath: paths.package
+  task.name('compile:fixtures', () =>
+    components.generateFixtures('**/*.yaml', {
+      srcPath: join(paths.src, 'govuk/components'),
+      destPath: join(paths.package, 'govuk/components')
     })
   ),
 
   // Generate GOV.UK Frontend macro-options.json from ${componentName}.yaml
-  task.name('copy:macro-options', () =>
-    components.generateMacroOptions({
-      srcPath: paths.src,
-      destPath: paths.package
+  task.name('compile:macro-options', () =>
+    components.generateMacroOptions('**/*.yaml', {
+      srcPath: join(paths.src, 'govuk/components'),
+      destPath: join(paths.package, 'govuk/components')
     })
   ),
 

--- a/tasks/components.mjs
+++ b/tasks/components.mjs
@@ -7,7 +7,7 @@ import map from 'map-stream'
 import nunjucks from 'nunjucks'
 import slash from 'slash'
 
-import { paths } from '../../config/index.js'
+import { paths } from '../config/index.js'
 
 /**
  * Generate fixtures.json from ${componentName}.yaml
@@ -129,5 +129,5 @@ async function convertYamlToJson (file) {
 }
 
 /**
- * @typedef {import('../assets.mjs').AssetEntry} AssetEntry
+ * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
  */

--- a/tasks/configs.mjs
+++ b/tasks/configs.mjs
@@ -1,7 +1,7 @@
 
-import { writeFile } from 'fs/promises'
-import { EOL } from 'os'
-import { parse, join } from 'path'
+import { join } from 'path'
+
+import { files } from './index.mjs'
 
 /**
  * Write config to JSON
@@ -10,13 +10,18 @@ import { parse, join } from 'path'
  * @param {AssetEntry[1]} options - Asset options
  * @returns {Promise<void>}
  */
-export async function compile (modulePath, { srcPath, destPath, filePath }) {
-  const configPath = join(destPath, filePath ? filePath(parse(modulePath)) : modulePath)
+export async function compile (modulePath, options) {
+  const { default: configFn } = await import(join(options.srcPath, modulePath))
 
-  const { default: configFn } = await import(join(srcPath, modulePath))
+  // Write to destination
+  return files.write(modulePath, {
+    ...options,
 
-  // Write JSON config file
-  return writeFile(configPath, JSON.stringify(await configFn(), null, 2) + EOL)
+    // Format config as JSON
+    async fileContents () {
+      return JSON.stringify(await configFn(), undefined, 2)
+    }
+  })
 }
 
 /**

--- a/tasks/files.mjs
+++ b/tasks/files.mjs
@@ -1,6 +1,6 @@
 import { writeFile } from 'fs/promises'
 import { EOL } from 'os'
-import { join } from 'path'
+import { join, parse } from 'path'
 
 import cpy from 'cpy'
 import { deleteAsync } from 'del'
@@ -24,8 +24,30 @@ export async function clean (pattern, { destPath, ignore }) {
  * @param {AssetEntry[0]} assetPath - File path to asset
  * @param {AssetEntry[1]} options - Asset options
  */
-export async function version (assetPath, { destPath }) {
-  await writeFile(join(destPath, assetPath), pkg.version + EOL)
+export async function version (assetPath, options) {
+  return write(assetPath, {
+    ...options,
+
+    async fileContents () {
+      return pkg.version
+    }
+  })
+}
+
+/**
+ * Write file task
+ *
+ * @param {AssetEntry[0]} assetPath - File path to asset
+ * @param {AssetEntry[1]} options - Asset options
+ */
+export async function write (assetPath, { destPath, filePath, fileContents }) {
+  const assetDestPath = join(destPath, filePath ? filePath(parse(assetPath)) : assetPath)
+
+  if (!fileContents) {
+    throw new Error("Option 'fileContents' required")
+  }
+
+  return writeFile(assetDestPath, await fileContents() + EOL)
 }
 
 /**

--- a/tasks/files.mjs
+++ b/tasks/files.mjs
@@ -64,9 +64,6 @@ export async function copy (pattern, { srcPath, destPath, ignore = [] }) {
   await cpy(srcPatterns, destPath, { cwd: srcPath })
 }
 
-// Include Gulp legacy file tasks
-export { generateFixtures, generateMacroOptions } from './gulp/copy-to-destination.mjs'
-
 /**
  * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
  */

--- a/tasks/index.mjs
+++ b/tasks/index.mjs
@@ -3,6 +3,7 @@
  */
 export * as assets from './assets.mjs'
 export * as browser from './browser.mjs'
+export * as components from './components.mjs'
 export * as configs from './configs.mjs'
 export * as files from './files.mjs'
 export * as npm from './npm.mjs'

--- a/tasks/task.mjs
+++ b/tasks/task.mjs
@@ -3,7 +3,7 @@
  *
  * {@link https://gulpjs.com/docs/en/api/task#task-metadata}
  *
- * @template {(function(): Promise<void> | import('stream').Stream) & { displayName?: string }} TaskFunction
+ * @template {(function(): Promise<void>) & { displayName?: string }} TaskFunction
  * @param {string} displayName - Task name for Gulp CLI
  * @param {TaskFunction} taskFn - Task function to wrap
  * @returns {TaskFunction} Script run


### PR DESCRIPTION
This PR removes Gulp from the `generateFixtures()` `generateMacroOptions()` tasks to complete:

* https://github.com/alphagov/govuk-frontend/issues/2711