### PR TITLE
Bump minimum Ruby Sass v3.4.0 test bundler version (again)

### DIFF
--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -123,8 +123,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler: 1.12 # Avoid RubyGems.org Dependency API deprecation
-          ruby-version: 2.1.9 # Oldest version available on ruby/setup-ruby
+          ruby-version: 2.3 # Oldest version supported by Bundler v2
 
       - name: Install gem
         run: |


### PR DESCRIPTION
Today we're seeing all-day phased downtime from this announcement:

**RubyGems.org Dependency API Deprecation**
https://blog.rubygems.org/2023/02/22/dependency-api-deprecation.html

We've previously tried `bundler@1.12` to work around the issue:

* https://github.com/alphagov/govuk-frontend/pull/3455

But we're still affected so this PR bumps our Ruby Sass v3.4.0 test to Ruby v2.3 (includes `bundler@2.3.26`)

For more information on how the GitHub Action [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby) picks a Bundler and API versions see https://github.com/ruby/setup-ruby/blob/master/bundler.js#L127