### PR TITLE
Change EtP keyboard shortcut expiry methodology

### DIFF
--- a/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -221,13 +221,21 @@ ExitThisPage.prototype.handleKeypress = function (e) {
 
 /**
  * Starts the 'quick escape' keyboard sequence timer.
+ *
+ * This can be invoked several times. We want this to be possible so that the
+ * timer is restarted each time the shortcut key is pressed (e.g. the user has
+ * up to n seconds between each keypress, rather than n seconds to invoke the
+ * entire sequence.)
  */
 ExitThisPage.prototype.setKeypressTimer = function () {
-  if (this.keypressTimeoutId === null) {
-    this.keypressTimeoutId = setTimeout(function () {
-      this.resetKeypressTimer()
-    }.bind(this), this.timeoutTime)
-  }
+  // Clear any existing timeout. This is so only one timer is running even if
+  // there are multiple keypresses in quick succession.
+  clearTimeout(this.keypressTimeoutId)
+
+  // Set a fresh timeout
+  this.keypressTimeoutId = setTimeout(function () {
+    this.resetKeypressTimer()
+  }.bind(this), this.timeoutTime)
 }
 
 /**


### PR DESCRIPTION
Changes the method that the EtP keyboard shortcut self-expires. 

Currently, the user must complete all 3 keypresses within a 5 second time period, starting with the first keypress. This can pose a problem for screen reader users, as the associated announcements can collectively take 5 seconds (or longer) to be fully read out. 

This changes the methodology so that the 5 second timer is restarted after each keypress, allowing up to 10 seconds to achieve the needed 3 keypresses. 

## Changes

- Removes the check that only ran `setKeypressTimer` if `keypressTimeoutId` was null, as this prevented any keypresses after the first from setting the timer. 
- Clears `keypressTimeoutId` when `setKeypressTimer` is invoked, so that only one timer is running at any one time. 

## Thoughts

- Now that the timer resets with each keypress, can the timer be shorter than 5 seconds? 
- https://github.com/alphagov/govuk-design-system/pull/2721 will need updating if this is merged.