### PR TITLE
Add (optional) type declaration checks in all files

### DIFF
--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["**/*.mjs", "**/*.json"],
-  "exclude": ["./dist/**"],
-  "compilerOptions": {
-    "resolveJsonModule": true
-  }
+  "include": ["**/*.js", "**/*.mjs", "../config", "../lib", "../tasks"],
+  "exclude": ["./dist/**"]
 }

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.base.json",
   "include": ["**/*.mjs", "**/*.json"],
-  "exclude": ["**/*.test.*", "./dist/**"],
+  "exclude": ["./dist/**"],
   "compilerOptions": {
     "resolveJsonModule": true
   }

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.js", "**/*.mjs"]
+}

--- a/lib/puppeteer-helpers.js
+++ b/lib/puppeteer-helpers.js
@@ -18,37 +18,41 @@ const { renderHtml } = require('./jest-helpers')
  * @param {import('puppeteer').Page} page - Puppeteer page object
  * @param {string} componentName - The kebab-cased name of the component
  * @param {object} options - Render and initialise options
- * @param {object} options.nunjucksParams - Params passed to the Nunjucks macro
- * @param {object} [options.javascriptConfig] - The configuration hash passed
- *   to the component's class for initialisation
+ * @param {object} options.params - Nunjucks macro params
+ * @param {object} [options.config] - Component instantiation config
  * @param {initialiseCallback} [options.initialiser] - A function that'll run in the
  *   browser to execute arbitrary initialisation. Receives an object with the
- *   passed configuration as `config` and the PascalCased component name as
- *   `componentClassName`
+ *   passed configuration as `config` and the GOVUKFrontend global as `namespace`
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
 async function renderAndInitialise (page, componentName, options) {
   await goTo(page, '/tests/boilerplate')
 
-  const html = renderHtml(componentName, options.nunjucksParams)
+  const html = renderHtml(componentName, options.params)
 
   // Inject rendered HTML into the page
   await page.$eval('#slot', (slot, htmlForSlot) => {
     slot.innerHTML = htmlForSlot
   }, html)
 
-  const initialiser = options.initialiser || function ({ config, componentClassName }) {
+  // Run a script to init the JavaScript component
+  await page.evaluate((componentClassName, options) => {
     const $component = document.querySelector('[data-module]')
-    new window.GOVUKFrontend[componentClassName]($component, config).init()
-  }
 
-  if (initialiser) {
-    // Run a script to init the JavaScript component
-    await page.evaluate(initialiser, {
-      config: options.javascriptConfig,
-      componentClassName: componentNameToClassName(componentName)
-    })
-  }
+    // Check for window global
+    if (!('GOVUKFrontend' in window) || !window.GOVUKFrontend[componentClassName]) {
+      throw new Error(`Global 'window.GOVUKFrontend.${componentClassName}' not found`)
+    }
+
+    if (options.initialiser) {
+      return options.initialiser({
+        config: options.config,
+        namespace: window.GOVUKFrontend
+      })
+    }
+
+    new window.GOVUKFrontend[componentClassName]($component, options.config).init()
+  }, componentNameToClassName(componentName), options)
 
   return page
 }
@@ -161,5 +165,5 @@ module.exports = {
 
 /**
  * @callback initialiseCallback
- * @param {{ config: object, componentClassName: string }} context - Initialiser context
+ * @param {{ config: object, namespace: object }} context - Initialiser context
  */

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.js", "**/*.mjs", "../config"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,8 +55,6 @@
       },
       "devDependencies": {
         "@percy/cli": "^1.21.0",
-        "@types/gulp": "^4.0.10",
-        "@types/node": "^18.15.11",
         "@typescript-eslint/eslint-plugin": "^5.57.0",
         "@typescript-eslint/parser": "^5.57.1",
         "editorconfig-checker": "^5.0.1",
@@ -74,6 +72,7 @@
         "jest-environment-jsdom": "^29.5.0",
         "jest-environment-node-single-context": "^29.0.0",
         "jest-environment-puppeteer": "^8.0.6",
+        "jest-puppeteer": "^8.0.6",
         "jest-serializer-html": "^7.1.0",
         "lint-staged": "^13.2.0",
         "prettier": "^2.8.7",
@@ -88,6 +87,13 @@
       "engines": {
         "node": "^18.12.0",
         "npm": "^8.1.0 || ^9.1.0"
+      },
+      "optionalDependencies": {
+        "@jest/environment": "^29.5.0",
+        "@types/gulp": "^4.0.10",
+        "@types/jest": "^29.5.0",
+        "@types/jest-axe": "^3.5.5",
+        "@types/node": "^18.15.11"
       }
     },
     "app": {
@@ -2560,7 +2566,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.5.0.tgz",
       "integrity": "sha512-5FXw2+wD29YU1d4I2htpRX7jYnAyTRjP2CsXQdo9SAM8g3ifxWPSV0HnClSn71xwctr0U3oZIIH+dtbfmnbXVQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/fake-timers": "^29.5.0",
         "@jest/types": "^29.5.0",
@@ -2588,7 +2594,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.5.0.tgz",
       "integrity": "sha512-fmKzsidoXQT2KwnrwE0SQq3uj8Z763vzR8LnLBwC2qYWEFpjX8daRsk6rHUM1QvNlEW/UJXNXm59ztmJJWs2Mg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "jest-get-type": "^29.4.3"
       },
@@ -2600,7 +2606,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.5.0.tgz",
       "integrity": "sha512-9ARvuAAQcBwDAqOnglWq2zwNIRUDtk/SCkp/ToGEhFv5r86K21l+VEs0qNTaXtyiY0lEePl3kylijSYJQqdbDg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.5.0",
         "@sinonjs/fake-timers": "^10.0.2",
@@ -2971,7 +2977,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.5.0.tgz",
       "integrity": "sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/schemas": "^29.4.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2988,7 +2994,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3003,7 +3009,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3019,7 +3025,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3031,13 +3037,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@jest/types/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3046,7 +3052,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3945,7 +3951,7 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
       "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
@@ -3954,7 +3960,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "type-detect": "4.0.8"
       }
@@ -4134,7 +4140,7 @@
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/@types/expect/-/expect-1.20.4.tgz",
       "integrity": "sha512-Q5Vn3yjTDyCMV50TB6VRIbQNxSE4OmZR86VSbGaNpfUolm0iePBB4KdEEHmxoY5sT2+2DIvXW0rvMDP2nHZ4Mg==",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/express": {
       "version": "4.17.17",
@@ -4163,7 +4169,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
       "integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/minimatch": "^5.1.2",
         "@types/node": "*"
@@ -4173,7 +4179,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob-stream/-/glob-stream-6.1.1.tgz",
       "integrity": "sha512-AGOUTsTdbPkRS0qDeyeS+6KypmfVpbT5j23SN8UPG63qjKXNKjXn6V9wZUr8Fin0m9l8oGYaPK8b2WUMF8xI1A==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -4192,7 +4198,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@types/gulp/-/gulp-4.0.10.tgz",
       "integrity": "sha512-spgZHJFqiEJGwqGlf7T/k4nkBpBcLgP7T0EfN6G2vvnhUfvd4uO1h8RwpXOE8x/54DVYUs1XCAtBHkX/R3axAQ==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/undertaker": ">=1.2.6",
         "@types/vinyl-fs": "*",
@@ -4217,13 +4223,13 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
       "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -4232,9 +4238,38 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.0.tgz",
+      "integrity": "sha512-3Emr5VOl/aoBwnWcH/EFQvlSAmjV+XtV9GGu5mwdYew5vhQh0IUZx/60x0TzHDu09Bi7HMx10t/namdJw5QIcg==",
+      "optional": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jest-axe": {
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest-axe/-/jest-axe-3.5.5.tgz",
+      "integrity": "sha512-b8WDIdoeKtr/JDJ2+QjFXMuS8UhfdMA6+15Z5KjjIie3jQrSXD9KZWMSQxc0nPtx7L9rIFKdiDpQk+m7s4a/8w==",
+      "optional": true,
+      "dependencies": {
+        "@types/jest": "*",
+        "axe-core": "^3.5.5"
+      }
+    },
+    "node_modules/@types/jest-axe/node_modules/axe-core": {
+      "version": "3.5.6",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.6.tgz",
+      "integrity": "sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@types/jsdom": {
@@ -4297,7 +4332,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
       "integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -4358,7 +4393,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.5.tgz",
       "integrity": "sha512-YyP+VfeaqAyFmXoTh3HChxOQMyjByRMsHU7kc5KOJkSlXudhMhQIALbYV7rHh/l8d2lX3VUQzprrcAgWdRuU8g==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -4402,7 +4437,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.2",
@@ -4414,7 +4449,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@types/undertaker/-/undertaker-1.2.8.tgz",
       "integrity": "sha512-gW3PRqCHYpo45XFQHJBhch7L6hytPsIe0QeLujlnFsjHPnXLhJcPdN6a9368d7aIQgH2I/dUTPFBlGeSNA3qOg==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/node": "*",
         "@types/undertaker-registry": "*",
@@ -4425,13 +4460,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
       "integrity": "sha512-Z4TYuEKn9+RbNVk1Ll2SS4x1JeLHecolIbM/a8gveaHsW0Hr+RQMraZACwTO2VD7JvepgA6UO1A1VrbktQrIbQ==",
-      "dev": true
+      "optional": true
     },
     "node_modules/@types/vinyl": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.7.tgz",
       "integrity": "sha512-4UqPv+2567NhMQuMLdKAyK4yzrfCqwaTt6bLhHEs8PFcxbHILsrxaY63n4wgE/BRLDWDQeI+WcTmkXKExh9hQg==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/expect": "^1.20.4",
         "@types/node": "*"
@@ -4441,7 +4476,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/vinyl-fs/-/vinyl-fs-3.0.1.tgz",
       "integrity": "sha512-me2Gcxw23pZp62oqPoiTDDMz/txEmtEZzXM/D/VTr+xUX4LiNA+nQPs38SSPu5KHnsaEER4HEtzWU5qJRXigfA==",
-      "dev": true,
+      "optional": true,
       "dependencies": {
         "@types/glob-stream": "*",
         "@types/node": "*",
@@ -4462,7 +4497,7 @@
       "version": "17.0.13",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
       "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -4471,7 +4506,7 @@
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.0",
@@ -6927,7 +6962,7 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
       "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cjs-module-lexer": {
       "version": "1.2.2",
@@ -10047,7 +10082,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.5.0.tgz",
       "integrity": "sha512-yM7xqUrCO2JdpFo4XpM82t+PJBFybdqoQuJLDGeDX2ij8NZzqRHyu3Hp188/JX7SWqud+7t4MUdvcgGBICMHZg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/expect-utils": "^29.5.0",
         "jest-get-type": "^29.4.3",
@@ -10059,11 +10094,20 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/expect-puppeteer": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-8.0.5.tgz",
+      "integrity": "sha512-PtJ/HKYdt/SqoGIWYninAENrSRxRSDb+5I78Pke73+Nxp/nzX05yUU2B+ULUro7wPG4VdD5caKi8UN2NPkpvBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/expect/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -10078,7 +10122,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -10094,7 +10138,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -10106,13 +10150,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/expect/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -10121,7 +10165,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.5.0.tgz",
       "integrity": "sha512-lecRtgm/rjIK0CQ7LPQwzCs2VwW6WAahA55YBuI+xqmhm7LAaxokSB8C97yJeYyT+HvQkH741StzpU41wohhWw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.5.0",
@@ -10136,7 +10180,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14589,7 +14633,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.5.0.tgz",
       "integrity": "sha512-Kijeg9Dag6CKtIDA7O21zNTACqD5MD/8HfIV8pdD94vFyFuer52SigdC3IQMhab3vACxXMiFk+yMHNdbqtyTGA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.5.0",
@@ -14609,7 +14653,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -14624,7 +14668,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -14640,7 +14684,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -14652,13 +14696,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/jest-message-util/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -14667,7 +14711,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -14676,7 +14720,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -14688,7 +14732,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.5.0.tgz",
       "integrity": "sha512-GqOzvdWDE4fAV2bWQLQCkujxYWL7RxjCnj71b5VhDAGOevB3qj3Ovg26A5NI84ZpODxyzaozXLOh2NCgkbvyaw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.5.0",
         "@types/node": "*",
@@ -14713,6 +14757,22 @@
         "jest-resolve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-puppeteer": {
+      "version": "8.0.6",
+      "resolved": "https://registry.npmjs.org/jest-puppeteer/-/jest-puppeteer-8.0.6.tgz",
+      "integrity": "sha512-3ZakfoyYfTEtHRWWXZGi14706LGxtP0nVVvoPGry3x4YEV+tyaspGJ295JSgaE3Abxub0p2F1OKVxVo9Oy0fMA==",
+      "dev": true,
+      "dependencies": {
+        "expect-puppeteer": "^8.0.5",
+        "jest-environment-puppeteer": "^8.0.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "puppeteer": ">=19"
       }
     },
     "node_modules/jest-regex-util": {
@@ -15239,7 +15299,7 @@
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.5.0.tgz",
       "integrity": "sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jest/types": "^29.5.0",
         "@types/node": "*",
@@ -15256,7 +15316,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -15271,7 +15331,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15287,7 +15347,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -15299,13 +15359,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/jest-util/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -15314,7 +15374,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -22762,7 +22822,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -22774,7 +22834,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -24221,7 +24281,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4"
       }

--- a/package.json
+++ b/package.json
@@ -83,8 +83,6 @@
   },
   "devDependencies": {
     "@percy/cli": "^1.21.0",
-    "@types/gulp": "^4.0.10",
-    "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": "^5.57.0",
     "@typescript-eslint/parser": "^5.57.1",
     "editorconfig-checker": "^5.0.1",
@@ -102,6 +100,7 @@
     "jest-environment-jsdom": "^29.5.0",
     "jest-environment-node-single-context": "^29.0.0",
     "jest-environment-puppeteer": "^8.0.6",
+    "jest-puppeteer": "^8.0.6",
     "jest-serializer-html": "^7.1.0",
     "lint-staged": "^13.2.0",
     "prettier": "^2.8.7",
@@ -112,6 +111,13 @@
     "stylelint-order": "^6.0.3",
     "typed-query-selector": "^2.9.2",
     "typescript": "^5.0.3"
+  },
+  "optionalDependencies": {
+    "@jest/environment": "^29.5.0",
+    "@types/gulp": "^4.0.10",
+    "@types/jest": "^29.5.0",
+    "@types/jest-axe": "^3.5.5",
+    "@types/node": "^18.15.11"
   },
   "overrides": {
     "chokidar@^2": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build:app": "npm run build --workspace app",
     "build:package": "gulp build:package",
     "build:dist": "gulp build:dist",
-    "build:types": "tsc --build",
+    "build:types": "tsc --build tsconfig.build.json",
     "postbuild:package": "jest --color --selectProjects \"Build tasks\" --testMatch \"**/*package.test*\"",
     "postbuild:dist": "jest --color --selectProjects \"Build tasks\" --testMatch \"**/*dist.test*\"",
     "pretest": "npm run build:app",

--- a/src/govuk-prototype-kit/init.js
+++ b/src/govuk-prototype-kit/init.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 if (window.GOVUKPrototypeKit &&
   window.GOVUKPrototypeKit.documentReady &&
   window.GOVUKPrototypeKit.majorVersion >= 13) {

--- a/src/govuk/common/closest-attribute-value.unit.test.mjs
+++ b/src/govuk/common/closest-attribute-value.unit.test.mjs
@@ -19,9 +19,8 @@ describe('closestAttributeValue', () => {
           </div>
         </div>
       `
-    const dom = template.content.cloneNode(true)
-    const $element = dom.querySelector('.target')
 
+    const $element = template.content.querySelector('.target')
     expect(closestAttributeValue($element, 'lang')).toEqual('en-GB')
   })
 

--- a/src/govuk/common/index.unit.test.mjs
+++ b/src/govuk/common/index.unit.test.mjs
@@ -105,10 +105,12 @@ describe('Common JS utilities', () => {
     })
 
     it('throws an error if no `configObject` is provided', () => {
+      // @ts-expect-error Parameter 'configObject' not provided
       expect(() => extractConfigByNamespace()).toThrow()
     })
 
     it('throws an error if no `namespace` is provided', () => {
+      // @ts-expect-error Parameter 'namespace' not provided
       expect(() => extractConfigByNamespace(flattenedConfig)).toThrow()
     })
   })

--- a/src/govuk/common/normalise-dataset.unit.test.mjs
+++ b/src/govuk/common/normalise-dataset.unit.test.mjs
@@ -2,9 +2,13 @@ import { normaliseDataset, normaliseString } from './normalise-dataset.mjs'
 
 describe('normaliseString', () => {
   it('does not normalise non-strings', () => {
+    // @ts-expect-error Parameter 'value' not a string
     expect(normaliseString(100)).toEqual(100)
+    // @ts-expect-error Parameter 'value' not a string
     expect(normaliseString(false)).toEqual(false)
+    // @ts-expect-error Parameter 'value' not a string
     expect(normaliseString({})).toEqual({})
+    // @ts-expect-error Parameter 'value' not a string
     expect(normaliseString(NaN)).toEqual(NaN)
   })
 

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -482,8 +482,8 @@ describe('/components/accordion', () => {
 
           it('injects the localised strings as text not HTML', async () => {
             await renderAndInitialise(page, 'accordion', {
-              nunjucksParams: examples.default,
-              javascriptConfig: {
+              params: examples.default,
+              config: {
                 i18n: {
                   showAllSections: 'Show <strong>all sections</strong>',
                   showSection: 'Show <strong>this section</strong>'

--- a/src/govuk/components/button/button.test.js
+++ b/src/govuk/components/button/button.test.js
@@ -61,7 +61,7 @@ describe('/components/button', () => {
      * Examples don't do this and we need it to have something to submit
      *
      * @param {import('puppeteer').Page} page - Puppeteer page object
-     * @returns {Promise<undefined>}
+     * @returns {Promise<void>}
      */
     function trackClicks (page) {
       return page.evaluate(() => {
@@ -70,9 +70,9 @@ describe('/components/button', () => {
         $button.parentNode.appendChild($form)
         $form.appendChild($button)
 
-        window.__SUBMIT_EVENTS = 0
+        globalThis.__SUBMIT_EVENTS = 0
         $form.addEventListener('submit', (event) => {
-          window.__SUBMIT_EVENTS++
+          globalThis.__SUBMIT_EVENTS++
           // Don't refresh the page, which will destroy the context to test against.
           event.preventDefault()
         })
@@ -83,10 +83,10 @@ describe('/components/button', () => {
      * Gets the number of times the form was submitted
      *
      * @param {import('puppeteer').Page} page - Puppeteer page object
-     * @returns {number} Number of times the form was submitted
+     * @returns {Promise<number>} Number of times the form was submitted
      */
     function getClicksCount (page) {
-      return page.evaluate(() => window.__SUBMIT_EVENTS)
+      return page.evaluate(() => globalThis.__SUBMIT_EVENTS)
     }
 
     describe('not enabled', () => {

--- a/src/govuk/components/button/button.test.js
+++ b/src/govuk/components/button/button.test.js
@@ -12,14 +12,18 @@ describe('/components/button', () => {
     it('does not prevent further JavaScript from running', async () => {
       await goTo(page, '/tests/boilerplate')
 
-      const result = await page.evaluate(() => {
+      const result = await page.evaluate((component) => {
+        const namespace = 'GOVUKFrontend' in window
+          ? window.GOVUKFrontend
+          : {}
+
         // `undefined` simulates the element being missing,
         // from an unchecked `document.querySelector` for example
-        new window.GOVUKFrontend.Button(undefined).init()
+        new namespace[component](undefined).init()
 
         // If our component initialisation breaks, this won't run
         return true
-      })
+      }, 'Button')
 
       expect(result).toBe(true)
     })
@@ -152,8 +156,8 @@ describe('/components/button', () => {
     describe('using JavaScript configuration', () => {
       beforeEach(async () => {
         await renderAndInitialise(page, 'button', {
-          nunjucksParams: examples.default,
-          javascriptConfig: {
+          params: examples.default,
+          config: {
             preventDoubleClick: true
           }
         })
@@ -200,8 +204,8 @@ describe('/components/button', () => {
     describe('using JavaScript configuration, but cancelled by data-attributes', () => {
       beforeEach(async () => {
         await renderAndInitialise(page, 'button', {
-          nunjucksParams: examples["don't prevent double click"],
-          javascriptConfig: {
+          params: examples["don't prevent double click"],
+          config: {
             preventDoubleClick: true
           }
         })
@@ -222,13 +226,9 @@ describe('/components/button', () => {
     describe('using `initAll`', () => {
       beforeEach(async () => {
         await renderAndInitialise(page, 'button', {
-          nunjucksParams: examples.default,
-          initialiser () {
-            window.GOVUKFrontend.initAll({
-              button: {
-                preventDoubleClick: true
-              }
-            })
+          params: examples.default,
+          config: {
+            preventDoubleClick: true
           }
         })
 

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -377,8 +377,8 @@ describe('Character count', () => {
       describe('at instantiation', () => {
         it('configures the number of characters', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            javascriptConfig: {
+            params: examples['to configure in JavaScript'],
+            config: {
               maxlength: 10
             }
           })
@@ -396,8 +396,8 @@ describe('Character count', () => {
 
         it('configures the number of words', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            javascriptConfig: {
+            params: examples['to configure in JavaScript'],
+            config: {
               maxwords: 10
             }
           })
@@ -415,8 +415,8 @@ describe('Character count', () => {
 
         it('configures the threshold', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            javascriptConfig: {
+            params: examples['to configure in JavaScript'],
+            config: {
               maxlength: 10,
               threshold: 75
             }
@@ -435,11 +435,11 @@ describe('Character count', () => {
           // and interpolated with the limit provided to the character count in JS.
 
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams:
+            params:
               examples[
                 'when neither maxlength/maxwords nor textarea description are set'
               ],
-            javascriptConfig: {
+            config: {
               maxlength: 10,
               i18n: {
                 textareaDescription: {
@@ -460,13 +460,9 @@ describe('Character count', () => {
       describe('via `initAll`', () => {
         it('configures the number of characters', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            initialiser () {
-              window.GOVUKFrontend.initAll({
-                characterCount: {
-                  maxlength: 10
-                }
-              })
+            params: examples['to configure in JavaScript'],
+            config: {
+              maxlength: 10
             }
           })
 
@@ -483,13 +479,9 @@ describe('Character count', () => {
 
         it('configures the number of words', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            initialiser () {
-              window.GOVUKFrontend.initAll({
-                characterCount: {
-                  maxwords: 10
-                }
-              })
+            params: examples['to configure in JavaScript'],
+            config: {
+              maxwords: 10
             }
           })
 
@@ -506,14 +498,10 @@ describe('Character count', () => {
 
         it('configures the threshold', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['to configure in JavaScript'],
-            initialiser () {
-              window.GOVUKFrontend.initAll({
-                characterCount: {
-                  maxlength: 10,
-                  threshold: 75
-                }
-              })
+            params: examples['to configure in JavaScript'],
+            config: {
+              maxlength: 10,
+              threshold: 75
             }
           })
 
@@ -532,8 +520,8 @@ describe('Character count', () => {
       describe('when data-attributes are present', () => {
         it('uses `maxlength` data attribute instead of the JS one', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples.default,
-            javascriptConfig: {
+            params: examples.default,
+            config: {
               maxlength: 12 // JS configuration that would tell 1 character remaining
             }
           })
@@ -551,8 +539,8 @@ describe('Character count', () => {
 
         it("uses `maxlength` data attribute instead of JS's `maxwords`", async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples.default, // Default example counts characters
-            javascriptConfig: {
+            params: examples.default, // Default example counts characters
+            config: {
               maxwords: 12
             }
           })
@@ -570,8 +558,8 @@ describe('Character count', () => {
 
         it('uses `maxwords` data attribute instead of the JS one', async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['with word count'],
-            javascriptConfig: {
+            params: examples['with word count'],
+            config: {
               maxwords: 12 // JS configuration that would tell 1 word remaining
             }
           })
@@ -589,8 +577,8 @@ describe('Character count', () => {
 
         it("uses `maxwords` data attribute instead of the JS's `maxlength`", async () => {
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams: examples['with word count'],
-            javascriptConfig: {
+            params: examples['with word count'],
+            config: {
               maxlength: 10
             }
           })
@@ -614,9 +602,9 @@ describe('Character count', () => {
           // (and interpolated to replace `%{count}` with the maximum)
 
           await renderAndInitialise(page, 'character-count', {
-            nunjucksParams:
+            params:
               examples['when neither maxlength nor maxwords are set'],
-            javascriptConfig: {
+            config: {
               maxlength: 10
             }
           })
@@ -633,8 +621,8 @@ describe('Character count', () => {
     describe('Cross Side Scripting prevention', () => {
       it('injects the localised strings as text not HTML', async () => {
         await renderAndInitialise(page, 'character-count', {
-          nunjucksParams: examples['to configure in JavaScript'],
-          javascriptConfig: {
+          params: examples['to configure in JavaScript'],
+          config: {
             maxlength: 10,
             i18n: {
               charactersUnderLimit: {
@@ -662,12 +650,12 @@ describe('Character count', () => {
       page.on('pageerror', pageErrorListener)
 
       await renderAndInitialise(page, 'character-count', {
-        nunjucksParams: examples.default,
-        javascriptConfig: {
+        params: examples.default,
+        config: {
           // Override maxlength to 10
           maxlength: 10
         },
-        initialiser: function ({ config }) {
+        initialiser ({ config, namespace }) {
           const $component = document.querySelector('[data-module]')
 
           // Set locale to Welsh, which expects translations for 'one', 'two',
@@ -677,7 +665,7 @@ describe('Character count', () => {
           // We want to make sure we handle this gracefully in case users have
           // an existing character count inside an incorrect locale.
           $component.setAttribute('lang', 'cy')
-          new window.GOVUKFrontend.CharacterCount($component, config).init()
+          new namespace.CharacterCount($component, config).init()
         }
       })
 

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -56,8 +56,8 @@ describe('Error Summary', () => {
     describe('using JavaScript configuration', () => {
       beforeAll(async () => {
         await renderAndInitialise(page, 'error-summary', {
-          nunjucksParams: examples.default,
-          javascriptConfig: {
+          params: examples.default,
+          config: {
             disableAutoFocus: true
           }
         })
@@ -82,14 +82,18 @@ describe('Error Summary', () => {
 
     describe('using JavaScript configuration, with no elements on the page', () => {
       it('does not prevent further JavaScript from running', async () => {
-        const result = await page.evaluate(() => {
+        const result = await page.evaluate((component) => {
+          const namespace = 'GOVUKFrontend' in window
+            ? window.GOVUKFrontend
+            : {}
+
           // `undefined` simulates the element being missing,
           // from an unchecked `document.querySelector` for example
-          new window.GOVUKFrontend.ErrorSummary(undefined).init()
+          new namespace[component](undefined).init()
 
           // If our component initialisation breaks, this won't run
           return true
-        })
+        }, 'ErrorSummary')
 
         expect(result).toBe(true)
       })
@@ -98,7 +102,7 @@ describe('Error Summary', () => {
     describe('using JavaScript configuration, but enabled via data-attributes', () => {
       beforeAll(async () => {
         await renderAndInitialise(page, 'error-summary', {
-          nunjucksParams: examples['autofocus explicitly enabled']
+          params: examples['autofocus explicitly enabled']
         })
       })
 
@@ -120,13 +124,9 @@ describe('Error Summary', () => {
     describe('using `initAll`', () => {
       beforeAll(async () => {
         await renderAndInitialise(page, 'error-summary', {
-          nunjucksParams: examples.default,
-          initialiser () {
-            window.GOVUKFrontend.initAll({
-              errorSummary: {
-                disableAutoFocus: true
-              }
-            })
+          params: examples.default,
+          config: {
+            disableAutoFocus: true
           }
         })
       })

--- a/src/govuk/components/error-summary/error-summary.test.js
+++ b/src/govuk/components/error-summary/error-summary.test.js
@@ -16,13 +16,13 @@ describe('Error Summary', () => {
 
   it('is automatically focused when the page loads', async () => {
     await goToComponent(page, 'error-summary')
-    const moduleName = await page.evaluate(() => document.activeElement.dataset.module)
+    const moduleName = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
     expect(moduleName).toBe('govuk-error-summary')
   })
 
   it('removes the tabindex attribute on blur', async () => {
     await goToComponent(page, 'error-summary')
-    await page.$eval('.govuk-error-summary', el => el.blur())
+    await page.$eval('.govuk-error-summary', el => el instanceof window.HTMLElement && el.blur())
 
     const tabindex = await page.$eval('.govuk-error-summary', el => el.getAttribute('tabindex'))
     expect(tabindex).toBeNull()
@@ -46,7 +46,7 @@ describe('Error Summary', () => {
 
       it('does not focus on page load', async () => {
         const activeElement = await page.evaluate(
-          () => document.activeElement.dataset.module
+          () => document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')
@@ -73,7 +73,7 @@ describe('Error Summary', () => {
 
       it('does not focus on page load', async () => {
         const activeElement = await page.evaluate(
-          () => document.activeElement.dataset.module
+          () => document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')
@@ -111,7 +111,7 @@ describe('Error Summary', () => {
 
       it('is automatically focused when the page loads', async () => {
         const moduleName = await page.evaluate(
-          () => document.activeElement.dataset.module
+          () => document.activeElement.getAttribute('data-module')
         )
         expect(moduleName).toBe('govuk-error-summary')
       })
@@ -141,7 +141,7 @@ describe('Error Summary', () => {
 
       it('does not focus on page load', async () => {
         const activeElement = await page.evaluate(
-          () => document.activeElement.dataset.module
+          () => document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')

--- a/src/govuk/components/globals.test.mjs
+++ b/src/govuk/components/globals.test.mjs
@@ -2,28 +2,34 @@ import { goTo, goToExample } from '../../../lib/puppeteer-helpers.js'
 
 describe('GOV.UK Frontend', () => {
   describe('javascript', () => {
-    it('can be accessed via `GOVUKFrontend`', async () => {
+    let exported
+
+    beforeEach(async () => {
       await goTo(page, '/')
 
-      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
-
-      expect(typeof GOVUKFrontendGlobal).toBe('object')
+      // Exported via global (e.g GOVUKFrontend.initAll)
+      exported = await page.evaluate(() => 'GOVUKFrontend' in window
+        ? Object.keys(window.GOVUKFrontend)
+        : undefined
+      )
     })
 
     it('exports `initAll` function', async () => {
       await goTo(page, '/')
 
-      const typeofInitAll = await page.evaluate(() => typeof window.GOVUKFrontend.initAll)
+      const typeofInitAll = await page.evaluate((utility) => {
+        const namespace = 'GOVUKFrontend' in window
+          ? window.GOVUKFrontend
+          : {}
+
+        return typeof namespace[utility]
+      }, 'initAll')
 
       expect(typeofInitAll).toEqual('function')
     })
 
     it('exports Components', async () => {
-      await goTo(page, '/')
-
-      const GOVUKFrontendGlobal = await page.evaluate(() => window.GOVUKFrontend)
-
-      const components = Object.keys(GOVUKFrontendGlobal)
+      const components = exported
         .filter(method => !['initAll', 'version'].includes(method))
 
       // Ensure GOV.UK Frontend exports the expected components
@@ -43,20 +49,23 @@ describe('GOV.UK Frontend', () => {
     })
 
     it('exported Components have an init function', async () => {
-      await goTo(page, '/')
+      const components = exported
+        .filter(method => !['initAll', 'version'].includes(method))
 
-      const componentsWithoutInitFunctions = await page.evaluate(() => {
-        const components = Object.keys(window.GOVUKFrontend)
-          .filter(method => !['initAll', 'version'].includes(method))
+      const componentsWithoutInitFunctions = await page.evaluate((components) => {
+        const namespace = 'GOVUKFrontend' in window
+          ? window.GOVUKFrontend
+          : {}
 
         return components.filter(component => {
-          const prototype = window.GOVUKFrontend[component].prototype
+          const prototype = namespace[component].prototype
           return typeof prototype.init !== 'function'
         })
-      })
+      }, components)
 
       expect(componentsWithoutInitFunctions).toEqual([])
     })
+
     it('can be initialised scoped to certain sections of the page', async () => {
       await goToExample(page, 'scoped-initialisation')
 

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -62,8 +62,8 @@ describe('Notification banner, when type is set to "success"', () => {
   describe('and auto-focus is disabled using JavaScript configuration', () => {
     beforeAll(async () => {
       await renderAndInitialise(page, 'notification-banner', {
-        nunjucksParams: examples['with type as success'],
-        javascriptConfig: {
+        params: examples['with type as success'],
+        config: {
           disableAutoFocus: true
         }
       })
@@ -85,13 +85,9 @@ describe('Notification banner, when type is set to "success"', () => {
   describe('and auto-focus is disabled using options passed to initAll', () => {
     beforeAll(async () => {
       await renderAndInitialise(page, 'notification-banner', {
-        nunjucksParams: examples['with type as success'],
-        initialiser () {
-          window.GOVUKFrontend.initAll({
-            notificationBanner: {
-              disableAutoFocus: true
-            }
-          })
+        params: examples['with type as success'],
+        config: {
+          disableAutoFocus: true
         }
       })
     })
@@ -112,8 +108,8 @@ describe('Notification banner, when type is set to "success"', () => {
   describe('and autofocus is disabled in JS but enabled in data attributes', () => {
     beforeAll(async () => {
       await renderAndInitialise(page, 'notification-banner', {
-        nunjucksParams: examples['auto-focus explicitly enabled, with type as success'],
-        javascriptConfig: {
+        params: examples['auto-focus explicitly enabled, with type as success'],
+        config: {
           disableAutoFocus: true
         }
       })

--- a/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/src/govuk/components/notification-banner/notification-banner.test.js
@@ -23,7 +23,7 @@ describe('Notification banner, when type is set to "success"', () => {
       exampleName: 'with-type-as-success'
     })
 
-    const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+    const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
     expect(activeElement).toBe('govuk-notification-banner')
   })
@@ -33,7 +33,7 @@ describe('Notification banner, when type is set to "success"', () => {
       exampleName: 'with-type-as-success'
     })
 
-    await page.$eval('.govuk-notification-banner', el => el.blur())
+    await page.$eval('.govuk-notification-banner', el => el instanceof window.HTMLElement && el.blur())
 
     const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
     expect(tabindex).toBeNull()
@@ -53,7 +53,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -76,7 +76,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -103,7 +103,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -126,7 +126,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('is automatically focused when the page loads', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
       expect(activeElement).toBe('govuk-notification-banner')
     })
@@ -146,7 +146,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.dataset.module)
+      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -160,7 +160,7 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not remove the tabindex attribute on blur', async () => {
-      await page.$eval('.govuk-notification-banner', el => el.blur())
+      await page.$eval('.govuk-notification-banner', el => el instanceof window.HTMLElement && el.blur())
 
       const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
       expect(tabindex).toEqual('2')

--- a/src/govuk/components/skip-link/skip-link.test.js
+++ b/src/govuk/components/skip-link/skip-link.test.js
@@ -27,7 +27,7 @@ describe('/examples/template-default', () => {
     })
 
     it('removes the tabindex attribute from the linked element on blur', async () => {
-      await page.$eval('.govuk-main-wrapper', el => el.blur())
+      await page.$eval('.govuk-main-wrapper', el => el instanceof window.HTMLElement && el.blur())
 
       const tabindex = await page.$eval('.govuk-main-wrapper', el => el.getAttribute('tabindex'))
 
@@ -35,7 +35,7 @@ describe('/examples/template-default', () => {
     })
 
     it('removes the class for removing the native focus style from the linked element on blur', async () => {
-      await page.$eval('.govuk-main-wrapper', el => el.blur())
+      await page.$eval('.govuk-main-wrapper', el => el instanceof window.HTMLElement && el.blur())
 
       const cssClass = await page.$eval('.govuk-main-wrapper', el => el.getAttribute('class'))
 

--- a/src/govuk/helpers/colour.test.js
+++ b/src/govuk/helpers/colour.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 const { sassNull } = require('sass-embedded')
 
 const { compileSassString } = require('../../../lib/jest-helpers')

--- a/src/govuk/helpers/media-queries.test.js
+++ b/src/govuk/helpers/media-queries.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -312,11 +312,12 @@ describe('I18n', () => {
   describe('.selectPluralFormUsingFallbackRules', () => {
     // The locales we want to test, with numbers for any 'special cases' in
     // those locales we want to ensure are handled correctly
+    /** @type {[string, number[]][]} */
     const locales = [
       ['ar', [105, 125]],
-      ['zh'],
-      ['fr'],
-      ['de'],
+      ['zh', []],
+      ['fr', []],
+      ['de', []],
       ['ga', [9]],
       ['ru', [3, 13, 101]],
       ['gd', [15]],
@@ -324,7 +325,7 @@ describe('I18n', () => {
       ['cy', [3, 6]]
     ]
 
-    it.each(locales)('matches `Intl.PluralRules.select()` for %s locale', (locale, localeNumbers = []) => {
+    it.each(locales)('matches `Intl.PluralRules.select()` for %s locale', (locale, localeNumbers) => {
       const i18n = new I18n({}, { locale })
       const intl = new Intl.PluralRules(locale)
 

--- a/src/govuk/i18n.unit.test.mjs
+++ b/src/govuk/i18n.unit.test.mjs
@@ -32,6 +32,8 @@ describe('I18n', () => {
 
     it('throws an error if no lookup key is provided', () => {
       const i18n = new I18n(translations)
+
+      // @ts-expect-error Parameter 'lookupKey' not provided
       expect(() => i18n.t()).toThrow('i18n: lookup key missing')
     })
 
@@ -282,6 +284,7 @@ describe('I18n', () => {
         locale: 'en'
       })
 
+      // @ts-expect-error Parameter 'count' not a number
       expect(i18n.getPluralSuffix('test', 'nonsense')).toBe('other')
     })
   })

--- a/src/govuk/tools/compatibility.test.js
+++ b/src/govuk/tools/compatibility.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 const { sassNull } = require('sass-embedded')
 
 const { compileSassString } = require('../../../lib/jest-helpers')

--- a/src/govuk/tools/exports.test.js
+++ b/src/govuk/tools/exports.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 

--- a/src/govuk/tools/font-url.test.js
+++ b/src/govuk/tools/font-url.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 

--- a/src/govuk/tools/ie8.test.js
+++ b/src/govuk/tools/ie8.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 const { sassNull } = require('sass-embedded')
 
 const { compileSassString } = require('../../../lib/jest-helpers')

--- a/src/govuk/tools/image-url.test.js
+++ b/src/govuk/tools/image-url.test.js
@@ -1,4 +1,4 @@
-const outdent = require('outdent')
+const { outdent } = require('outdent')
 
 const { compileSassString } = require('../../../lib/jest-helpers')
 

--- a/src/tsconfig.build.json
+++ b/src/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.mjs"],
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "lib": ["ESNext", "DOM"],
+    "target": "ES2015",
+    "types": ["node", "typed-query-selector"]
+  }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["**/*.mjs"],
+  "include": ["**/*.js", "**/*.mjs", "../config", "../lib"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
-    "resolveJsonModule": true,
     "target": "ES2015",
     "types": [
       "jest",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -6,6 +6,12 @@
     "lib": ["ESNext", "DOM"],
     "resolveJsonModule": true,
     "target": "ES2015",
-    "types": ["node", "typed-query-selector"]
+    "types": [
+      "jest",
+      "jest-axe",
+      "jest-puppeteer",
+      "node",
+      "typed-query-selector"
+    ]
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../tsconfig.base.json",
   "include": ["**/*.mjs"],
-  "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "resolveJsonModule": true,

--- a/tasks/browser.mjs
+++ b/tasks/browser.mjs
@@ -17,12 +17,14 @@ export async function download () {
     path: join(configPuppeteer.cacheDirectory, 'chrome')
   })
 
-  // Downloaded versions
+  // Available versions
+  // @ts-expect-error 'defaultBrowserRevision' is marked @internal
+  const latest = puppeteer.defaultBrowserRevision
   const versions = fetcher.localRevisions()
 
   // Download latest browser (unless cached)
-  if (!versions.includes(puppeteer.defaultBrowserRevision)) {
-    await fetcher.download(puppeteer.defaultBrowserRevision)
+  if (!versions.includes(latest)) {
+    await fetcher.download(latest)
 
     // Remove outdated browser versions
     for (const version of versions) {

--- a/tasks/browser.unit.test.mjs
+++ b/tasks/browser.unit.test.mjs
@@ -18,11 +18,11 @@ describe('Browser tasks: Puppeteer browser downloader', () => {
     }
 
     // Mock browser version
+    // @ts-expect-error 'defaultBrowserRevision' is marked @internal
     puppeteer.defaultBrowserRevision = 'new-version'
 
     // Mock browser fetcher
-    puppeteer.createBrowserFetcher
-      .mockReturnValue(browserFetcher)
+    puppeteer.createBrowserFetcher = jest.fn(() => browserFetcher)
   })
 
   it('downloads by default', async () => {

--- a/tasks/build/package.test.mjs
+++ b/tasks/build/package.test.mjs
@@ -34,7 +34,7 @@ describe('package/', () => {
       '!**/*.test.*',
       '!**/__snapshots__/',
       '!**/__snapshots__/**',
-      '!**/tsconfig.json',
+      '!**/tsconfig?(.build).json',
       '!govuk/README.md'
     ]
 

--- a/tasks/scripts.mjs
+++ b/tasks/scripts.mjs
@@ -46,7 +46,6 @@ export async function compileJavaScript ([modulePath, { srcPath, destPath, fileP
 
   if (!isDev) {
     // Add GOV.UK Frontend release version
-    // @ts-expect-error "This expression is not callable" due to incorrect types
     plugins.push(replace({
       include: join(srcPath, 'common/govuk-frontend-version.mjs'),
       values: { development: pkg.version }
@@ -113,7 +112,7 @@ export function minifyJavaScript (modulePath, result) {
 
     // Include source maps
     sourceMap: {
-      content: result.map,
+      content: result.map.toString(),
       filename: result.map.file,
       url: `${result.map.file}.map`,
       includeSources: true

--- a/tasks/styles.mjs
+++ b/tasks/styles.mjs
@@ -95,7 +95,6 @@ export async function compileStylesheet ([modulePath, { srcPath, destPath, fileP
   const config = await postcssrc(options)
 
   // Transform with PostCSS
-  // @ts-expect-error "This expression is not callable" due to incorrect types
   const result = await postcss(config.plugins)
     .process(css, { ...options, ...config.options })
 

--- a/tasks/tsconfig.json
+++ b/tasks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["**/*.js", "**/*.mjs", "../config", "../lib"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,8 +2,9 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "lib": ["ESNext"],
-    "module": "NodeNext",
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
     "noEmit": true,
     "strict": false,
     "strictBindCallApply": true,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,6 @@
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "target": "ESNext",
-    "types": ["node"]
+    "types": ["jest", "jest-axe", "jest-puppeteer", "node"]
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "noEmit": true,
+    "resolveJsonModule": true,
     "strict": false,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    {
+      "path": "./src/tsconfig.build.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,16 @@
       "path": "./app"
     },
     {
+      "path": "./config"
+    },
+    {
+      "path": "./lib"
+    },
+    {
       "path": "./src"
+    },
+    {
+      "path": "./tasks"
     }
   ]
 }


### PR DESCRIPTION
This is a follow to:

* https://github.com/alphagov/govuk-frontend/pull/3104

This PR adds `tsconfig.json` files into **config**, **lib**, **tasks** with coverage now on `*.test.*` files

These checks are still optional but JSDoc type autocomplete (to helps spot issues) works all files

It was split out from https://github.com/alphagov/govuk-frontend/pull/3399