### PR TITLE
Use letter spacing modifier for passport example

### DIFF
--- a/app/src/views/full-page-examples/passport-details/index.njk
+++ b/app/src/views/full-page-examples/passport-details/index.njk
@@ -49,7 +49,7 @@ scenario: >-
           hint: {
             text: "For example, 502135326"
           },
-          classes: "govuk-input--width-10",
+          classes: "govuk-input--width-10 govuk-input--extra-letter-spacing",
           id: "passport-number",
           name: "passport-number",
           value: values["passport-number"],


### PR DESCRIPTION
Update the ['Passport details' full page example](http://govuk-frontend-review.herokuapp.com/full-page-examples/passport-details) in the review app to use the new extra letter spacing modifier for text inputs introduced in #2230.

## Before

![Screenshot of example page, with passport number displayed as normal text](https://user-images.githubusercontent.com/121939/231164228-40d0a7a8-ee7b-4b5d-8ee2-968d287d0290.png)

## After

![Screenshot of example page, with passport number displayed with tabular numbers and extra spacing between each character](https://user-images.githubusercontent.com/121939/231164222-8ac6c5ec-8b88-4359-afe8-bd72627c6386.png)