### PR TITLE
Deprecate all JavaScript instance properties the except `init` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,14 @@ This was added in [pull request #2230: Add extra letter spacing modifier for inp
 
 ### Deprecated features
 
+#### Stop using JavaScript API properties other than the `init` method
+
+We have deprecated all of the JavaScript properties in the API, except for the `init` method for each component. We will make all of the deprecated JavaScript properties private in v5.0.
+
+Please [let us know if you're using parts of the API other than the `init` method by filling in this form](https://docs.google.com/forms/d/e/1FAIpQLSfmH2AitMeouXqB0FWC5p5e6y1TSiFCjmJ8DrVuwfmpRGCaWw/viewform?usp=sf_link). We'll use this information when prioritising future additions to the public API.
+
+This was added in [pull request #3499: Deprecate all JavaScript instance properties the except `init` method](https://github.com/alphagov/govuk-frontend/pull/3499).
+
 #### Stop using the `govuk-button--disabled` class on buttons
 
 The `govuk-button--disabled` class is deprecated and will be removed in the next major release.

--- a/src/govuk/common/closest-attribute-value.mjs
+++ b/src/govuk/common/closest-attribute-value.mjs
@@ -3,6 +3,7 @@ import '../vendor/polyfills/Element/prototype/closest.mjs'
 /**
  * Returns the value of the given attribute closest to the given element (including itself)
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $element - The element to start walking the DOM tree up
  * @param {string} attributeName - The name of the attribute
  * @returns {string | null} Attribute value

--- a/src/govuk/common/index.mjs
+++ b/src/govuk/common/index.mjs
@@ -13,6 +13,7 @@
  * This seems to fail in IE8, requires more investigation.
  * See: https://github.com/imagitama/nodelist-foreach-polyfill
  *
+ * @deprecated Will be made private in v5.0
  * @template {Node} ElementType
  * @param {NodeListOf<ElementType>} nodes - NodeList from querySelectorAll()
  * @param {nodeListIterator<ElementType>} callback - Callback function to run for each node
@@ -32,6 +33,7 @@ export function nodeListForEach (nodes, callback) {
  * without them conflicting with each other.
  * https://stackoverflow.com/a/8809472
  *
+ * @deprecated Will be made private in v5.0
  * @returns {string} Unique ID
  */
 export function generateUniqueID () {
@@ -53,6 +55,7 @@ export function generateUniqueID () {
  * (e.g. {'i18n.showSection': 'Show section'}) and combines them together, with
  * greatest priority on the LAST item passed in.
  *
+ * @deprecated Will be made private in v5.0
  * @returns {Object<string, unknown>} A flattened object of key-value pairs.
  */
 export function mergeConfigs (/* configObject1, configObject2, ...configObjects */) {
@@ -126,6 +129,7 @@ export function mergeConfigs (/* configObject1, configObject2, ...configObjects 
  * Extracts keys starting with a particular namespace from a flattened config
  * object, removing the namespace in the process.
  *
+ * @deprecated Will be made private in v5.0
  * @param {Object<string, unknown>} configObject - The object to extract key-value pairs from.
  * @param {string} namespace - The namespace to filter keys with.
  * @returns {Object<string, unknown>} Flattened object with dot-separated key namespace removed

--- a/src/govuk/common/normalise-dataset.mjs
+++ b/src/govuk/common/normalise-dataset.mjs
@@ -14,6 +14,7 @@ import '../vendor/polyfills/String/prototype/trim.mjs'
  * Designed to be used to convert config passed via data attributes (which are
  * always strings) into something sensible.
  *
+ * @deprecated Will be made private in v5.0
  * @param {string} value - The value to normalise
  * @returns {string | boolean | number | undefined} Normalised data
  */
@@ -46,6 +47,7 @@ export function normaliseString (value) {
  *
  * Loop over an object and normalise each value using normaliseData function
  *
+ * @deprecated Will be made private in v5.0
  * @param {DOMStringMap} dataset - HTML element dataset
  * @returns {Object<string, unknown>} Normalised dataset
  */

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -46,6 +46,7 @@ function Accordion ($module, config) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
 
   var defaultConfig = {
@@ -53,36 +54,74 @@ function Accordion ($module, config) {
     rememberExpanded: true
   }
 
-  /** @type {AccordionConfig} */
+  /**
+   * @deprecated Will be made private in v5.0
+   * @type {AccordionConfig}
+   */
   this.config = mergeConfigs(
     defaultConfig,
     config || {},
     normaliseDataset($module.dataset)
   )
 
+  /** @deprecated Will be made private in v5.0 */
   this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
 
+  /** @deprecated Will be made private in v5.0 */
   this.controlsClass = 'govuk-accordion__controls'
+
+  /** @deprecated Will be made private in v5.0 */
   this.showAllClass = 'govuk-accordion__show-all'
+
+  /** @deprecated Will be made private in v5.0 */
   this.showAllTextClass = 'govuk-accordion__show-all-text'
 
+  /** @deprecated Will be made private in v5.0 */
   this.sectionClass = 'govuk-accordion__section'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionExpandedClass = 'govuk-accordion__section--expanded'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionButtonClass = 'govuk-accordion__section-button'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionHeaderClass = 'govuk-accordion__section-header'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionHeadingClass = 'govuk-accordion__section-heading'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionHeadingDividerClass = 'govuk-accordion__section-heading-divider'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionHeadingTextClass = 'govuk-accordion__section-heading-text'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionHeadingTextFocusClass = 'govuk-accordion__section-heading-text-focus'
 
+  /** @deprecated Will be made private in v5.0 */
   this.sectionShowHideToggleClass = 'govuk-accordion__section-toggle'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionShowHideToggleFocusClass = 'govuk-accordion__section-toggle-focus'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionShowHideTextClass = 'govuk-accordion__section-toggle-text'
+
+  /** @deprecated Will be made private in v5.0 */
   this.upChevronIconClass = 'govuk-accordion-nav__chevron'
+
+  /** @deprecated Will be made private in v5.0 */
   this.downChevronIconClass = 'govuk-accordion-nav__chevron--down'
 
+  /** @deprecated Will be made private in v5.0 */
   this.sectionSummaryClass = 'govuk-accordion__section-summary'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionSummaryFocusClass = 'govuk-accordion__section-summary-focus'
+
+  /** @deprecated Will be made private in v5.0 */
   this.sectionContentClass = 'govuk-accordion__section-content'
 
   var $sections = this.$module.querySelectorAll('.' + this.sectionClass)
@@ -90,7 +129,10 @@ function Accordion ($module, config) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$sections = $sections
+
+  /** @deprecated Will be made private in v5.0 */
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
 }
 

--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -113,6 +113,8 @@ Accordion.prototype.init = function () {
 
 /**
  * Initialise controls and set attributes
+ *
+ * @deprecated Will be made private in v5.0
  */
 Accordion.prototype.initControls = function () {
   // Create "Show all" button and set attributes
@@ -148,6 +150,8 @@ Accordion.prototype.initControls = function () {
 
 /**
  * Initialise section headers
+ *
+ * @deprecated Will be made private in v5.0
  */
 Accordion.prototype.initSectionHeaders = function () {
   var $component = this
@@ -176,6 +180,7 @@ Accordion.prototype.initSectionHeaders = function () {
 /**
  * Construct section header
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $header - Section header
  * @param {number} index - Section index
  */
@@ -282,6 +287,7 @@ Accordion.prototype.constructHeaderMarkup = function ($header, index) {
 /**
  * When a section is opened by the user agent via the 'beforematch' event
  *
+ * @deprecated Will be made private in v5.0
  * @param {Event} event - Generic event
  */
 Accordion.prototype.onBeforeMatch = function (event) {
@@ -302,6 +308,7 @@ Accordion.prototype.onBeforeMatch = function (event) {
 /**
  * When section toggled, set and store state
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $section - Section element
  */
 Accordion.prototype.onSectionToggle = function ($section) {
@@ -314,6 +321,8 @@ Accordion.prototype.onSectionToggle = function ($section) {
 
 /**
  * When Open/Close All toggled, set and store state
+ *
+ * @deprecated Will be made private in v5.0
  */
 Accordion.prototype.onShowOrHideAllToggle = function () {
   var $component = this
@@ -334,6 +343,7 @@ Accordion.prototype.onShowOrHideAllToggle = function () {
 /**
  * Set section attributes when opened/closed
  *
+ * @deprecated Will be made private in v5.0
  * @param {boolean} expanded - Section expanded
  * @param {Element} $section - Section element
  */
@@ -401,6 +411,7 @@ Accordion.prototype.setExpanded = function (expanded, $section) {
 /**
  * Get state of section
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $section - Section element
  * @returns {boolean} True if expanded
  */
@@ -411,6 +422,7 @@ Accordion.prototype.isExpanded = function ($section) {
 /**
  * Check if all sections are open
  *
+ * @deprecated Will be made private in v5.0
  * @returns {boolean} True if all sections are open
  */
 Accordion.prototype.checkIfAllSectionsOpen = function () {
@@ -426,6 +438,7 @@ Accordion.prototype.checkIfAllSectionsOpen = function () {
 /**
  * Update "Show all sections" button
  *
+ * @deprecated Will be made private in v5.0
  * @param {boolean} expanded - Section expanded
  */
 Accordion.prototype.updateShowAllButton = function (expanded) {
@@ -467,6 +480,7 @@ var helper = {
 /**
  * Set the state of the accordions in sessionStorage
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $section - Section element
  */
 Accordion.prototype.storeState = function ($section) {
@@ -491,6 +505,7 @@ Accordion.prototype.storeState = function ($section) {
 /**
  * Read the state of the accordions from sessionStorage
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $section - Section element
  */
 Accordion.prototype.setInitialState = function ($section) {
@@ -515,6 +530,7 @@ Accordion.prototype.setInitialState = function ($section) {
  * into thematic chunks.
  * See https://github.com/alphagov/govuk-frontend/issues/2327#issuecomment-922957442
  *
+ * @deprecated Will be made private in v5.0
  * @returns {Element} DOM element
  */
 Accordion.prototype.getButtonPunctuationEl = function () {

--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -56,6 +56,7 @@ Button.prototype.init = function () {
  *
  * See https://github.com/alphagov/govuk_elements/pull/272#issuecomment-233028270
  *
+ * @deprecated Will be made private in v5.0
  * @param {KeyboardEvent} event - Keydown event
  */
 Button.prototype.handleKeyDown = function (event) {
@@ -80,6 +81,7 @@ Button.prototype.handleKeyDown = function (event) {
  * stops people accidentally causing multiple form submissions by double
  * clicking buttons.
  *
+ * @deprecated Will be made private in v5.0
  * @param {MouseEvent} event - Mouse click event
  * @returns {undefined | false} Returns undefined, or false when debounced
  */

--- a/src/govuk/components/button/button.mjs
+++ b/src/govuk/components/button/button.mjs
@@ -20,14 +20,20 @@ function Button ($module, config) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.debounceFormSubmitTimer = null
 
   var defaultConfig = {
     preventDoubleClick: false
   }
 
-  /** @type {ButtonConfig} */
+  /**
+   * @deprecated Will be made private in v5.0
+   * @type {ButtonConfig}
+   */
   this.config = mergeConfigs(
     defaultConfig,
     config || {},

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -88,7 +88,10 @@ function CharacterCount ($module, config) {
     }
   }
 
-  /** @type {CharacterCountConfig} */
+  /**
+   * @deprecated Will be made private in v5.0
+   * @type {CharacterCountConfig}
+   */
   this.config = mergeConfigs(
     defaultConfig,
     config || {},
@@ -96,6 +99,7 @@ function CharacterCount ($module, config) {
     datasetConfig
   )
 
+  /** @deprecated Will be made private in v5.0 */
   this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
     // Read the fallback if necessary rather than have it set in the defaults
     locale: closestAttributeValue($module, 'lang')
@@ -110,12 +114,22 @@ function CharacterCount ($module, config) {
     return
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$textarea = $textarea
+
+  /** @deprecated Will be made private in v5.0 */
   this.$visibleCountMessage = null
+
+  /** @deprecated Will be made private in v5.0 */
   this.$screenReaderCountMessage = null
 
+  /** @deprecated Will be made private in v5.0 */
   this.lastInputTimestamp = null
+
+  /** @deprecated Will be made private in v5.0 */
   this.lastInputValue = ''
 }
 

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -188,6 +188,8 @@ CharacterCount.prototype.init = function () {
  *
  * Set up event listeners on the $textarea so that the count messages update
  * when the user types.
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.bindChangeEvents = function () {
   var $textarea = this.$textarea
@@ -203,6 +205,8 @@ CharacterCount.prototype.bindChangeEvents = function () {
  *
  * Update the visible character counter and keep track of when the last update
  * happened for each keypress
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.handleKeyUp = function () {
   this.updateVisibleCountMessage()
@@ -221,6 +225,8 @@ CharacterCount.prototype.handleKeyUp = function () {
  *
  * This is so that the update triggered by the manual comparison doesn't
  * conflict with debounced KeyboardEvent updates.
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.handleFocus = function () {
   this.valueChecker = setInterval(function () {
@@ -234,6 +240,8 @@ CharacterCount.prototype.handleFocus = function () {
  * Handle blur event
  *
  * Stop checking the textarea value once the textarea no longer has focus
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.handleBlur = function () {
   // Cancel value checking on blur
@@ -242,6 +250,8 @@ CharacterCount.prototype.handleBlur = function () {
 
 /**
  * Update count message if textarea value has changed
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.updateIfValueChanged = function () {
   if (this.$textarea.value !== this.lastInputValue) {
@@ -255,6 +265,8 @@ CharacterCount.prototype.updateIfValueChanged = function () {
  *
  * Helper function to update both the visible and screen reader-specific
  * counters simultaneously (e.g. on init)
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.updateCountMessage = function () {
   this.updateVisibleCountMessage()
@@ -263,6 +275,8 @@ CharacterCount.prototype.updateCountMessage = function () {
 
 /**
  * Update visible count message
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.updateVisibleCountMessage = function () {
   var $textarea = this.$textarea
@@ -294,6 +308,8 @@ CharacterCount.prototype.updateVisibleCountMessage = function () {
 
 /**
  * Update screen reader count message
+ *
+ * @deprecated Will be made private in v5.0
  */
 CharacterCount.prototype.updateScreenReaderCountMessage = function () {
   var $screenReaderCountMessage = this.$screenReaderCountMessage
@@ -314,6 +330,7 @@ CharacterCount.prototype.updateScreenReaderCountMessage = function () {
  * Count the number of characters (or words, if `config.maxwords` is set)
  * in the given text
  *
+ * @deprecated Will be made private in v5.0
  * @param {string} text - The text to count the characters of
  * @returns {number} the number of characters (or words) in the text
  */
@@ -329,6 +346,7 @@ CharacterCount.prototype.count = function (text) {
 /**
  * Get count message
  *
+ * @deprecated Will be made private in v5.0
  * @returns {string} Status message
  */
 CharacterCount.prototype.getCountMessage = function () {
@@ -342,6 +360,7 @@ CharacterCount.prototype.getCountMessage = function () {
  * Formats the message shown to users according to what's counted
  * and how many remain
  *
+ * @deprecated Will be made private in v5.0
  * @param {number} remainingNumber - The number of words/characaters remaining
  * @param {string} countType - "words" or "characters"
  * @returns {string} Status message
@@ -363,6 +382,7 @@ CharacterCount.prototype.formatCountMessage = function (remainingNumber, countTy
  * If there is no configured threshold, it is set to 0 and this function will
  * always return true.
  *
+ * @deprecated Will be made private in v5.0
  * @returns {boolean} true if the current count is over the config.threshold
  *   (or no threshold is set)
  */

--- a/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/src/govuk/components/checkboxes/checkboxes.mjs
@@ -21,7 +21,10 @@ function Checkboxes ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$inputs = $inputs
 }
 

--- a/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/src/govuk/components/checkboxes/checkboxes.mjs
@@ -83,6 +83,8 @@ Checkboxes.prototype.init = function () {
 
 /**
  * Sync the conditional reveal states for all checkboxes in this $module.
+ *
+ * @deprecated Will be made private in v5.0
  */
 Checkboxes.prototype.syncAllConditionalReveals = function () {
   nodeListForEach(this.$inputs, this.syncConditionalRevealWithInputState.bind(this))
@@ -94,6 +96,7 @@ Checkboxes.prototype.syncAllConditionalReveals = function () {
  * Synchronise the visibility of the conditional reveal, and its accessible
  * state, with the input's checked state.
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLInputElement} $input - Checkbox input
  */
 Checkboxes.prototype.syncConditionalRevealWithInputState = function ($input) {
@@ -117,6 +120,7 @@ Checkboxes.prototype.syncConditionalRevealWithInputState = function ($input) {
  * Find any other checkbox inputs with the same name value, and uncheck them.
  * This is useful for when a “None of these" checkbox is checked.
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLInputElement} $input - Checkbox input
  */
 Checkboxes.prototype.unCheckAllInputsExcept = function ($input) {
@@ -144,6 +148,7 @@ Checkboxes.prototype.unCheckAllInputsExcept = function ($input) {
  * and uncheck them. This helps prevent someone checking both a regular checkbox and a
  * "None of these" checkbox in the same fieldset.
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLInputElement} $input - Checkbox input
  */
 Checkboxes.prototype.unCheckExclusiveInputs = function ($input) {
@@ -170,6 +175,7 @@ Checkboxes.prototype.unCheckExclusiveInputs = function ($input) {
  * Handle a click within the $module – if the click occurred on a checkbox, sync
  * the state of any associated conditional reveal with the checkbox state.
  *
+ * @deprecated Will be made private in v5.0
  * @param {MouseEvent} event - Click event
  */
 Checkboxes.prototype.handleClick = function (event) {

--- a/src/govuk/components/details/details.mjs
+++ b/src/govuk/components/details/details.mjs
@@ -47,6 +47,8 @@ Details.prototype.init = function () {
 
 /**
  * Polyfill component in older browsers
+ *
+ * @deprecated Will be made private in v5.0
  */
 Details.prototype.polyfillDetails = function () {
   var $module = this.$module
@@ -97,6 +99,7 @@ Details.prototype.polyfillDetails = function () {
 /**
  * Define a statechange function that updates aria-expanded and style.display
  *
+ * @deprecated Will be made private in v5.0
  * @returns {boolean} Returns true
  */
 Details.prototype.polyfillSetAttributes = function () {
@@ -116,6 +119,7 @@ Details.prototype.polyfillSetAttributes = function () {
 /**
  * Handle cross-modal click events
  *
+ * @deprecated Will be made private in v5.0
  * @param {polyfillHandleInputsCallback} callback - function
  */
 Details.prototype.polyfillHandleInputs = function (callback) {

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -60,6 +60,8 @@ ErrorSummary.prototype.init = function () {
 
 /**
  * Focus the error summary
+ *
+ * @deprecated Will be made private in v5.0
  */
 ErrorSummary.prototype.setFocus = function () {
   var $module = this.$module
@@ -82,6 +84,7 @@ ErrorSummary.prototype.setFocus = function () {
 /**
  * Click event handler
  *
+ * @deprecated Will be made private in v5.0
  * @param {MouseEvent} event - Click event
  */
 ErrorSummary.prototype.handleClick = function (event) {
@@ -106,6 +109,7 @@ ErrorSummary.prototype.handleClick = function (event) {
  * NVDA (as tested in 2018.3.2) - without this only the field type is announced
  * (e.g. "Edit, has autocomplete").
  *
+ * @deprecated Will be made private in v5.0
  * @param {EventTarget} $target - Event target
  * @returns {boolean} True if the target was able to be focussed
  */
@@ -145,6 +149,7 @@ ErrorSummary.prototype.focusTarget = function ($target) {
  * Extract the fragment (everything after the hash) from a URL, but not including
  * the hash.
  *
+ * @deprecated Will be made private in v5.0
  * @param {string} url - URL
  * @returns {string | undefined} Fragment from URL, without the hash
  */
@@ -167,6 +172,7 @@ ErrorSummary.prototype.getFragmentFromUrl = function (url) {
  * - The first `<label>` that is associated with the input using for="inputId"
  * - The closest parent `<label>`
  *
+ * @deprecated Will be made private in v5.0
  * @param {Element} $input - The input
  * @returns {Element | null} Associated legend or label, or null if no associated
  *   legend or label can be found

--- a/src/govuk/components/error-summary/error-summary.mjs
+++ b/src/govuk/components/error-summary/error-summary.mjs
@@ -29,13 +29,17 @@ function ErrorSummary ($module, config) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
 
   var defaultConfig = {
     disableAutoFocus: false
   }
 
-  /** @type {ErrorSummaryConfig} */
+  /**
+   * @deprecated Will be made private in v5.0
+   * @type {ErrorSummaryConfig}
+   */
   this.config = mergeConfigs(
     defaultConfig,
     config || {},

--- a/src/govuk/components/header/header.mjs
+++ b/src/govuk/components/header/header.mjs
@@ -14,21 +14,34 @@ function Header ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$menuButton = $module.querySelector('.govuk-js-header-toggle')
+
+  /** @deprecated Will be made private in v5.0 */
   this.$menu = this.$menuButton && $module.querySelector(
     '#' + this.$menuButton.getAttribute('aria-controls')
   )
 
-  // Save the opened/closed state for the nav in memory so that we can
-  // accurately maintain state when the screen is changed from small to
-  // big and back to small
+  /**
+   * Save the opened/closed state for the nav in memory so that we can
+   * accurately maintain state when the screen is changed from small to
+   * big and back to small
+   *
+   * @deprecated Will be made private in v5.0
+   */
   this.menuIsOpen = false
 
-  // A global const for storing a matchMedia instance which we'll use to
-  // detect when a screen size change happens. We set this later during the
-  // init function and rely on it being null if the feature isn't available
-  // to initially apply hidden attributes
+  /**
+   * A global const for storing a matchMedia instance which we'll use to
+   * detect when a screen size change happens. We set this later during the
+   * init function and rely on it being null if the feature isn't available
+   * to initially apply hidden attributes
+   *
+   * @deprecated Will be made private in v5.0
+   */
   this.mql = null
 }
 

--- a/src/govuk/components/header/header.mjs
+++ b/src/govuk/components/header/header.mjs
@@ -76,6 +76,8 @@ Header.prototype.init = function () {
  * visual states of the menu and the menu button.
  * Additionally will force the menu to be visible and the menu button to be
  * hidden if the matchMedia is triggered to desktop.
+ *
+ * @deprecated Will be made private in v5.0
  */
 Header.prototype.syncState = function () {
   if (this.mql.matches) {
@@ -98,6 +100,8 @@ Header.prototype.syncState = function () {
  *
  * When the menu button is clicked, change the visibility of the menu and then
  * sync the accessibility state and menu button state
+ *
+ * @deprecated Will be made private in v5.0
  */
 Header.prototype.handleMenuButtonClick = function () {
   this.menuIsOpen = !this.menuIsOpen

--- a/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/src/govuk/components/notification-banner/notification-banner.mjs
@@ -49,6 +49,8 @@ NotificationBanner.prototype.init = function () {
  * You can turn off the auto-focus functionality by setting `data-disable-auto-focus="true"` in the
  * component HTML. You might wish to do this based on user research findings, or to avoid a clash
  * with another element which should be focused when the page loads.
+ *
+ * @deprecated Will be made private in v5.0
  */
 NotificationBanner.prototype.setFocus = function () {
   var $module = this.$module

--- a/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/src/govuk/components/notification-banner/notification-banner.mjs
@@ -14,13 +14,17 @@ function NotificationBanner ($module, config) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
 
   var defaultConfig = {
     disableAutoFocus: false
   }
 
-  /** @type {NotificationBannerConfig} */
+  /**
+   * @deprecated Will be made private in v5.0
+   * @type {NotificationBannerConfig}
+   */
   this.config = mergeConfigs(
     defaultConfig,
     config || {},

--- a/src/govuk/components/radios/radios.mjs
+++ b/src/govuk/components/radios/radios.mjs
@@ -83,6 +83,8 @@ Radios.prototype.init = function () {
 
 /**
  * Sync the conditional reveal states for all radio buttons in this $module.
+ *
+ * @deprecated Will be made private in v5.0
  */
 Radios.prototype.syncAllConditionalReveals = function () {
   nodeListForEach(this.$inputs, this.syncConditionalRevealWithInputState.bind(this))
@@ -94,6 +96,7 @@ Radios.prototype.syncAllConditionalReveals = function () {
  * Synchronise the visibility of the conditional reveal, and its accessible
  * state, with the input's checked state.
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLInputElement} $input - Radio input
  */
 Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
@@ -119,6 +122,7 @@ Radios.prototype.syncConditionalRevealWithInputState = function ($input) {
  * with the same name (because checking one radio could have un-checked a radio
  * in another $module)
  *
+ * @deprecated Will be made private in v5.0
  * @param {MouseEvent} event - Click event
  */
 Radios.prototype.handleClick = function (event) {

--- a/src/govuk/components/radios/radios.mjs
+++ b/src/govuk/components/radios/radios.mjs
@@ -21,7 +21,10 @@ function Radios ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$inputs = $inputs
 }
 

--- a/src/govuk/components/skip-link/skip-link.mjs
+++ b/src/govuk/components/skip-link/skip-link.mjs
@@ -42,6 +42,7 @@ SkipLink.prototype.init = function () {
 /**
  * Get linked element
  *
+ * @deprecated Will be made private in v5.0
  * @returns {HTMLElement | null} $linkedElement - DOM element linked to from the skip link
  */
 SkipLink.prototype.getLinkedElement = function () {
@@ -57,6 +58,8 @@ SkipLink.prototype.getLinkedElement = function () {
  * Focus the linked element
  *
  * Set tabindex and helper CSS class. Set listener to remove them on blur.
+ *
+ * @deprecated Will be made private in v5.0
  */
 SkipLink.prototype.focusLinkedElement = function () {
   var $linkedElement = this.$linkedElement
@@ -81,6 +84,8 @@ SkipLink.prototype.focusLinkedElement = function () {
  * focusable until it has received programmatic focus and a screen reader has announced it.
  *
  * Remove the CSS class that removes the native focus styles.
+ *
+ * @deprecated Will be made private in v5.0
  */
 SkipLink.prototype.removeFocusProperties = function () {
   this.$linkedElement.removeAttribute('tabindex')
@@ -93,6 +98,7 @@ SkipLink.prototype.removeFocusProperties = function () {
  * Extract the fragment (everything after the hash symbol) from a URL, but not including
  * the symbol.
  *
+ * @deprecated Will be made private in v5.0
  * @returns {string | undefined} Fragment from URL, without the hash symbol
  */
 SkipLink.prototype.getFragmentFromUrl = function () {

--- a/src/govuk/components/skip-link/skip-link.mjs
+++ b/src/govuk/components/skip-link/skip-link.mjs
@@ -15,8 +15,13 @@ function SkipLink ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$linkedElement = null
+
+  /** @deprecated Will be made private in v5.0 */
   this.linkedElementListener = false
 }
 

--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -23,15 +23,27 @@ function Tabs ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
   this.$tabs = $tabs
 
+  /** @deprecated Will be made private in v5.0 */
   this.keys = { left: 37, right: 39, up: 38, down: 40 }
+
+  /** @deprecated Will be made private in v5.0 */
   this.jsHiddenClass = 'govuk-tabs__panel--hidden'
 
   // Save bounded functions to use when removing event listeners during teardown
+
+  /** @deprecated Will be made private in v5.0 */
   this.boundTabClick = this.onTabClick.bind(this)
+
+  /** @deprecated Will be made private in v5.0 */
   this.boundTabKeydown = this.onTabKeydown.bind(this)
+
+  /** @deprecated Will be made private in v5.0 */
   this.boundOnHashChange = this.onHashChange.bind(this)
 }
 
@@ -57,6 +69,7 @@ Tabs.prototype.init = function () {
  * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.setupResponsiveChecks = function () {
+  /** @deprecated Will be made private in v5.0 */
   this.mql = window.matchMedia('(min-width: 40.0625em)')
   this.mql.addListener(this.checkMode.bind(this))
   this.checkMode()

--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -53,6 +53,8 @@ Tabs.prototype.init = function () {
 
 /**
  * Setup viewport resize check
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.setupResponsiveChecks = function () {
   this.mql = window.matchMedia('(min-width: 40.0625em)')
@@ -62,6 +64,8 @@ Tabs.prototype.setupResponsiveChecks = function () {
 
 /**
  * Setup or teardown handler for viewport resize check
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.checkMode = function () {
   if (this.mql.matches) {
@@ -73,6 +77,8 @@ Tabs.prototype.checkMode = function () {
 
 /**
  * Setup tab component
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.setup = function () {
   var $component = this
@@ -117,6 +123,8 @@ Tabs.prototype.setup = function () {
 
 /**
  * Teardown tab component
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.teardown = function () {
   var $component = this
@@ -151,6 +159,7 @@ Tabs.prototype.teardown = function () {
 /**
  * Handle hashchange event
  *
+ * @deprecated Will be made private in v5.0
  * @returns {void | undefined} Returns void, or undefined when prevented
  */
 Tabs.prototype.onHashChange = function () {
@@ -180,6 +189,7 @@ Tabs.prototype.onHashChange = function () {
 /**
  * Hide panel for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.hideTab = function ($tab) {
@@ -190,6 +200,7 @@ Tabs.prototype.hideTab = function ($tab) {
 /**
  * Show panel for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.showTab = function ($tab) {
@@ -200,6 +211,7 @@ Tabs.prototype.showTab = function ($tab) {
 /**
  * Get tab link by hash
  *
+ * @deprecated Will be made private in v5.0
  * @param {string} hash - Hash fragment including #
  * @returns {HTMLAnchorElement | null} Tab link
  */
@@ -211,6 +223,7 @@ Tabs.prototype.getTab = function (hash) {
 /**
  * Set tab link and panel attributes
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.setAttributes = function ($tab) {
@@ -236,6 +249,7 @@ Tabs.prototype.setAttributes = function ($tab) {
 /**
  * Unset tab link and panel attributes
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.unsetAttributes = function ($tab) {
@@ -260,6 +274,7 @@ Tabs.prototype.unsetAttributes = function ($tab) {
 /**
  * Handle tab link clicks
  *
+ * @deprecated Will be made private in v5.0
  * @param {MouseEvent} event - Mouse click event
  * @returns {void} Returns void
  */
@@ -284,6 +299,7 @@ Tabs.prototype.onTabClick = function (event) {
  * - Allows back/forward to navigate tabs
  * - Avoids page jump when hash changes
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.createHistoryEntry = function ($tab) {
@@ -307,6 +323,7 @@ Tabs.prototype.createHistoryEntry = function ($tab) {
  * - Press right/down arrow for next tab
  * - Press left/up arrow for previous tab
  *
+ * @deprecated Will be made private in v5.0
  * @param {KeyboardEvent} event - Keydown event
  */
 Tabs.prototype.onTabKeydown = function (event) {
@@ -326,6 +343,8 @@ Tabs.prototype.onTabKeydown = function (event) {
 
 /**
  * Activate next tab
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.activateNextTab = function () {
   var $currentTab = this.getCurrentTab()
@@ -351,6 +370,8 @@ Tabs.prototype.activateNextTab = function () {
 
 /**
  * Activate previous tab
+ *
+ * @deprecated Will be made private in v5.0
  */
 Tabs.prototype.activatePreviousTab = function () {
   var $currentTab = this.getCurrentTab()
@@ -377,6 +398,7 @@ Tabs.prototype.activatePreviousTab = function () {
 /**
  * Get tab panel for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  * @returns {Element | null} Tab panel
  */
@@ -387,6 +409,7 @@ Tabs.prototype.getPanel = function ($tab) {
 /**
  * Show tab panel for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.showPanel = function ($tab) {
@@ -401,6 +424,7 @@ Tabs.prototype.showPanel = function ($tab) {
 /**
  * Hide tab panel for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.hidePanel = function ($tab) {
@@ -415,6 +439,7 @@ Tabs.prototype.hidePanel = function ($tab) {
 /**
  * Unset 'selected' state for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.unhighlightTab = function ($tab) {
@@ -430,6 +455,7 @@ Tabs.prototype.unhighlightTab = function ($tab) {
 /**
  * Set 'selected' state for tab link
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  */
 Tabs.prototype.highlightTab = function ($tab) {
@@ -445,6 +471,7 @@ Tabs.prototype.highlightTab = function ($tab) {
 /**
  * Get current tab link
  *
+ * @deprecated Will be made private in v5.0
  * @returns {HTMLAnchorElement | null} Tab link
  */
 Tabs.prototype.getCurrentTab = function () {
@@ -458,6 +485,7 @@ Tabs.prototype.getCurrentTab = function () {
  * should be a utility function most prob
  * {@link http://labs.thesedays.com/blog/2010/01/08/getting-the-href-value-with-jquery-in-ie/}
  *
+ * @deprecated Will be made private in v5.0
  * @param {HTMLAnchorElement} $tab - Tab link
  * @returns {string} Hash fragment including #
  */


### PR DESCRIPTION
We'll be clarifying our public API in v5, which means we will either not support or prevent access to some of the properties currently available on our components.

Deprecate everything except the `init` method to make people aware of this ahead of time to give them as much time as possible to anticipate the change.

Closes #3473.