### PR TITLE
Return `render()` and `renderTemplate()` helpers via cheerio

### DIFF
--- a/app/src/app.mjs
+++ b/app/src/app.mjs
@@ -4,6 +4,7 @@ import express from 'express'
 import { paths } from 'govuk-frontend-config'
 import { getDirectories, getComponentsData, getFullPageExamples } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName } from 'govuk-frontend-lib/names'
+import { outdent } from 'outdent'
 
 import * as middleware from './common/middleware/index.mjs'
 import * as nunjucks from './common/nunjucks/index.mjs'
@@ -115,10 +116,10 @@ export default async () => {
     const macroName = componentNameToMacroName(componentName)
     const macroParameters = JSON.stringify(exampleConfig.data, null, '\t')
 
-    res.locals.componentView = env.renderString(
-      `{% from '${componentName}/macro.njk' import ${macroName} %}
-      {{ ${macroName}(${macroParameters}) }}`
-    )
+    res.locals.componentView = env.renderString(outdent`
+      {% from '${componentName}/macro.njk' import ${macroName} %}
+      {{ ${macroName}(${macroParameters}) }}
+    `, {})
 
     let bodyClasses = ''
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,8 @@
         "@types/gulp": "^4.0.10",
         "@types/jest": "^29.5.0",
         "@types/jest-axe": "^3.5.5",
-        "@types/node": "^18.15.11"
+        "@types/node": "^18.15.11",
+        "@types/nunjucks": "^3.2.2"
       }
     },
     "app": {
@@ -4539,6 +4540,12 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.2.tgz",
+      "integrity": "sha512-qarGBZOVxv1pF6BxQHwYHYYxim/TCm3aXF8BUt/kyF/+xi/DXMoj1Bhw3hXVBl2Yov+w47reDldm0iXXFZTotA==",
+      "optional": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "@types/gulp": "^4.0.10",
     "@types/jest": "^29.5.0",
     "@types/jest-axe": "^3.5.5",
-    "@types/node": "^18.15.11"
+    "@types/node": "^18.15.11",
+    "@types/nunjucks": "^3.2.2"
   },
   "overrides": {
     "chokidar@^2": {

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -1,7 +1,7 @@
 const { ports } = require('govuk-frontend-config')
 const { componentNameToClassName } = require('govuk-frontend-lib/names')
 
-const { render } = require('./nunjucks')
+const { renderHTML } = require('./nunjucks')
 
 /**
  * Render and initialise a component within test boilerplate HTML
@@ -28,7 +28,7 @@ const { render } = require('./nunjucks')
 async function renderAndInitialise (page, componentName, options) {
   await goTo(page, '/tests/boilerplate')
 
-  const html = render(componentName, options.params)
+  const html = renderHTML(componentName, options.params)
 
   // Inject rendered HTML into the page
   await page.$eval('#slot', (slot, htmlForSlot) => {

--- a/src/govuk/components/accordion/template.test.js
+++ b/src/govuk/components/accordion/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,21 +11,21 @@ describe('Accordion', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('accordion', examples.default))
+      const $ = render('accordion', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with heading button text', () => {
-      const $ = cheerio.load(render('accordion', examples.default))
+      const $ = render('accordion', examples.default)
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
       expect($componentHeadingButton.html().trim()).toEqual('Section A')
     })
 
     it('renders with content as text, wrapped in styled paragraph', () => {
-      const $ = cheerio.load(render('accordion', examples.default))
+      const $ = render('accordion', examples.default)
       const $componentContent = $('.govuk-accordion__section-content').first()
 
       expect($componentContent.find('p').hasClass('govuk-body')).toBeTruthy()
@@ -34,7 +33,7 @@ describe('Accordion', () => {
     })
 
     it('renders with content as html', () => {
-      const $ = cheerio.load(render('accordion', examples.default))
+      const $ = render('accordion', examples.default)
       const $componentContent = $('.govuk-accordion__section-content').last()
 
       expect($componentContent.find('p.gvouk-body').length).toEqual(0)
@@ -42,7 +41,7 @@ describe('Accordion', () => {
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('accordion', examples.default))
+      const $ = render('accordion', examples.default)
 
       const $component = $('.govuk-accordion')
       expect($component.attr('id')).toEqual('default-example')
@@ -51,48 +50,48 @@ describe('Accordion', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('accordion', examples.classes))
+      const $ = render('accordion', examples.classes)
 
       const $component = $('.govuk-accordion')
       expect($component.hasClass('myClass')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('accordion', examples.attributes))
+      const $ = render('accordion', examples.attributes)
       const $component = $('.govuk-accordion')
       expect($component.attr('data-attribute')).toEqual('value')
     })
 
     it('renders with specified heading level', () => {
-      const $ = cheerio.load(render('accordion', examples['custom heading level']))
+      const $ = render('accordion', examples['custom heading level'])
       const $componentHeading = $('.govuk-accordion__section-heading')
 
       expect($componentHeading.get(0).tagName).toEqual('h3')
     })
 
     it('renders with heading button html', () => {
-      const $ = cheerio.load(render('accordion', examples['heading html']))
+      const $ = render('accordion', examples['heading html'])
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
       expect($componentHeadingButton.html().trim()).toEqual('<span class="myClass">Section A</span>')
     })
 
     it('renders with section expanded class', () => {
-      const $ = cheerio.load(render('accordion', examples['with one section open']))
+      const $ = render('accordion', examples['with one section open'])
       const $componentSection = $('.govuk-accordion__section').first()
 
       expect($componentSection.hasClass('govuk-accordion__section--expanded')).toBeTruthy()
     })
 
     it('renders with summary', () => {
-      const $ = cheerio.load(render('accordion', examples['with additional descriptions']))
+      const $ = render('accordion', examples['with additional descriptions'])
       const $componentSummary = $('.govuk-accordion__section-summary').first()
 
       expect($componentSummary.text().trim()).toEqual('Additional description')
     })
 
     it('renders list without falsely values', () => {
-      const $ = cheerio.load(render('accordion', examples['with falsey values']))
+      const $ = render('accordion', examples['with falsey values'])
       const $component = $('.govuk-accordion')
       const $items = $component.find('.govuk-accordion__section')
 
@@ -100,7 +99,7 @@ describe('Accordion', () => {
     })
 
     it('renders with localisation data attributes', () => {
-      const $ = cheerio.load(render('accordion', examples['with translations']))
+      const $ = render('accordion', examples['with translations'])
       const $component = $('.govuk-accordion')
 
       expect($component.attr('data-i18n.hide-all-sections')).toEqual('Collapse all sections')
@@ -112,7 +111,7 @@ describe('Accordion', () => {
     })
 
     it('renders with remember expanded data attribute', () => {
-      const $ = cheerio.load(render('accordion', examples['with remember expanded off']))
+      const $ = render('accordion', examples['with remember expanded off'])
       const $component = $('.govuk-accordion')
 
       expect($component.attr('data-remember-expanded')).toEqual('false')

--- a/src/govuk/components/back-link/template.test.js
+++ b/src/govuk/components/back-link/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,14 +10,14 @@ describe('back-link component', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('back-link', examples.default))
+    const $ = render('back-link', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('renders the default example with an anchor, href and text correctly', () => {
-    const $ = cheerio.load(render('back-link', examples.default))
+    const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-back-link')
     expect($component.get(0).tagName).toEqual('a')
@@ -27,42 +26,42 @@ describe('back-link component', () => {
   })
 
   it('renders classes correctly', () => {
-    const $ = cheerio.load(render('back-link', examples.classes))
+    const $ = render('back-link', examples.classes)
 
     const $component = $('.govuk-back-link')
     expect($component.hasClass('app-back-link--custom-class')).toBeTruthy()
   })
 
   it('renders custom text correctly', () => {
-    const $ = cheerio.load(render('back-link', examples['with custom text']))
+    const $ = render('back-link', examples['with custom text'])
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('Back to home')
   })
 
   it('renders escaped html when passed to text', () => {
-    const $ = cheerio.load(render('back-link', examples['html as text']))
+    const $ = render('back-link', examples['html as text'])
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('&lt;b&gt;Home&lt;/b&gt;')
   })
 
   it('renders html correctly', () => {
-    const $ = cheerio.load(render('back-link', examples.html))
+    const $ = render('back-link', examples.html)
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('<b>Back</b>')
   })
 
   it('renders default text correctly', () => {
-    const $ = cheerio.load(render('back-link', examples.default))
+    const $ = render('back-link', examples.default)
 
     const $component = $('.govuk-back-link')
     expect($component.html()).toEqual('Back')
   })
 
   it('renders attributes correctly', () => {
-    const $ = cheerio.load(render('back-link', examples.attributes))
+    const $ = render('back-link', examples.attributes)
 
     const $component = $('.govuk-back-link')
     expect($component.attr('data-test')).toEqual('attribute')

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,27 +11,27 @@ describe('Breadcrumbs', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.default))
+      const $ = render('breadcrumbs', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with items', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.default))
+      const $ = render('breadcrumbs', examples.default)
 
       const $items = $('.govuk-breadcrumbs__list-item')
       expect($items.length).toEqual(2)
     })
 
     it('renders 2 items', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.default))
+      const $ = render('breadcrumbs', examples.default)
       const $items = $('.govuk-breadcrumbs__list-item')
       expect($items.length).toEqual(2)
     })
 
     it('renders item with anchor', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.default))
+      const $ = render('breadcrumbs', examples.default)
 
       const $anchor = $('.govuk-breadcrumbs__list-item a').first()
       expect($anchor.get(0).tagName).toEqual('a')
@@ -44,35 +43,35 @@ describe('Breadcrumbs', () => {
 
   describe('custom options', () => {
     it('renders item with text', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples['with last breadcrumb as current page']))
+      const $ = render('breadcrumbs', examples['with last breadcrumb as current page'])
 
       const $item = $('.govuk-breadcrumbs__list-item').last()
       expect($item.text()).toEqual('Travel abroad')
     })
 
     it('renders item with escaped entities in text', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples['html as text']))
+      const $ = render('breadcrumbs', examples['html as text'])
 
       const $item = $('.govuk-breadcrumbs__list-item')
       expect($item.html()).toEqual('&lt;span&gt;Section 1&lt;/span&gt;')
     })
 
     it('renders item with html', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.html))
+      const $ = render('breadcrumbs', examples.html)
 
       const $item = $('.govuk-breadcrumbs__list-item').first()
       expect($item.html()).toEqual('<em>Section 1</em>')
     })
 
     it('renders item with html inside anchor', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.html))
+      const $ = render('breadcrumbs', examples.html)
 
       const $anchor = $('.govuk-breadcrumbs__list-item a').last()
       expect($anchor.html()).toEqual('<em>Section 2</em>')
     })
 
     it('renders item anchor with attributes', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples['item attributes']))
+      const $ = render('breadcrumbs', examples['item attributes'])
 
       const $breadcrumbLink = $('.govuk-breadcrumbs__link')
       expect($breadcrumbLink.attr('data-attribute')).toEqual('my-attribute')
@@ -80,14 +79,14 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.classes))
+      const $ = render('breadcrumbs', examples.classes)
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('app-breadcrumbs--custom-modifier')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples.attributes))
+      const $ = render('breadcrumbs', examples.attributes)
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.attr('id')).toEqual('my-navigation')
@@ -95,7 +94,7 @@ describe('Breadcrumbs', () => {
     })
 
     it('renders item as collapse on mobile if specified', () => {
-      const $ = cheerio.load(render('breadcrumbs', examples['with collapse on mobile']))
+      const $ = render('breadcrumbs', examples['with collapse on mobile'])
 
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()

--- a/src/govuk/components/button/template.test.js
+++ b/src/govuk/components/button/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,14 +11,14 @@ describe('Button', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('button', examples.default))
+      const $ = render('button', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders the default example', () => {
-      const $ = cheerio.load(render('button', examples.default))
+      const $ = render('button', examples.default)
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('button')
@@ -29,7 +28,7 @@ describe('Button', () => {
 
   describe('custom options', () => {
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('button', examples.attributes))
+      const $ = render('button', examples.attributes)
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -37,14 +36,14 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('button', examples.classes))
+      const $ = render('button', examples.classes)
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
     })
 
     it('renders with disabled', () => {
-      const $ = cheerio.load(render('button', examples.disabled))
+      const $ = render('button', examples.disabled)
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-disabled')).toEqual('true')
@@ -53,35 +52,35 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('button', examples.name))
+      const $ = render('button', examples.name)
 
       const $component = $('.govuk-button')
       expect($component.attr('name')).toEqual('start-now')
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('button', examples.id))
+      const $ = render('button', examples.id)
 
       const $component = $('.govuk-button')
       expect($component.attr('id')).toEqual('submit')
     })
 
     it('renders with value', () => {
-      const $ = cheerio.load(render('button', examples.value))
+      const $ = render('button', examples.value)
 
       const $component = $('.govuk-button')
       expect($component.attr('value')).toEqual('start')
     })
 
     it('renders with type', () => {
-      const $ = cheerio.load(render('button', examples.type))
+      const $ = render('button', examples.type)
 
       const $component = $('.govuk-button')
       expect($component.attr('type')).toEqual('button')
     })
 
     it('renders with html', () => {
-      const $ = cheerio.load(render('button', examples.html))
+      const $ = render('button', examples.html)
 
       const $component = $('.govuk-button')
       expect($component.html()).toContain('Start <em>now</em>')
@@ -89,21 +88,21 @@ describe('Button', () => {
 
     describe('preventDoubleClick', () => {
       it('does not render the attribute if not set', () => {
-        const $ = cheerio.load(render('button', examples['no data-prevent-double-click']))
+        const $ = render('button', examples['no data-prevent-double-click'])
 
         const $component = $('.govuk-button')
         expect($component.attr('data-prevent-double-click')).toBeUndefined()
       })
 
       it('renders with preventDoubleClick attribute set to true', () => {
-        const $ = cheerio.load(render('button', examples['prevent double click']))
+        const $ = render('button', examples['prevent double click'])
 
         const $component = $('.govuk-button')
         expect($component.attr('data-prevent-double-click')).toEqual('true')
       })
 
       it('renders with preventDoubleClick attribute set to false', () => {
-        const $ = cheerio.load(render('button', examples["don't prevent double click"]))
+        const $ = render('button', examples["don't prevent double click"])
 
         const $component = $('.govuk-button')
         expect($component.attr('data-prevent-double-click')).toEqual('false')
@@ -113,7 +112,7 @@ describe('Button', () => {
 
   describe('link', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const $ = cheerio.load(render('button', examples['explicit link']))
+      const $ = render('button', examples['explicit link'])
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('a')
@@ -123,14 +122,14 @@ describe('Button', () => {
     })
 
     it('renders with hash href if no href passed', () => {
-      const $ = cheerio.load(render('button', examples['no href']))
+      const $ = render('button', examples['no href'])
 
       const $component = $('.govuk-button')
       expect($component.attr('href')).toEqual('#')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('button', examples['link attributes']))
+      const $ = render('button', examples['link attributes'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -138,14 +137,14 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('button', examples['link classes']))
+      const $ = render('button', examples['link classes'])
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
     })
 
     it('renders with disabled', () => {
-      const $ = cheerio.load(render('button', examples['link disabled']))
+      const $ = render('button', examples['link disabled'])
 
       const $component = $('.govuk-button')
       expect($component.hasClass('govuk-button--disabled')).toBeTruthy()
@@ -154,7 +153,7 @@ describe('Button', () => {
 
   describe('with explicit input button set by "element"', () => {
     it('renders with anchor, href and an accessible role of button', () => {
-      const $ = cheerio.load(render('button', examples.input))
+      const $ = render('button', examples.input)
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('input')
@@ -162,7 +161,7 @@ describe('Button', () => {
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('button', examples['input attributes']))
+      const $ = render('button', examples['input attributes'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-controls')).toEqual('example-id')
@@ -170,14 +169,14 @@ describe('Button', () => {
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('button', examples['input classes']))
+      const $ = render('button', examples['input classes'])
 
       const $component = $('.govuk-button')
       expect($component.hasClass('app-button--custom-modifier')).toBeTruthy()
     })
 
     it('renders with disabled', () => {
-      const $ = cheerio.load(render('button', examples['input disabled']))
+      const $ = render('button', examples['input disabled'])
 
       const $component = $('.govuk-button')
       expect($component.attr('aria-disabled')).toEqual('true')
@@ -186,14 +185,14 @@ describe('Button', () => {
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('button', examples.input))
+      const $ = render('button', examples.input)
 
       const $component = $('.govuk-button')
       expect($component.attr('name')).toEqual('start-now')
     })
 
     it('renders with type', () => {
-      const $ = cheerio.load(render('button', examples['input type']))
+      const $ = render('button', examples['input type'])
 
       const $component = $('.govuk-button')
       expect($component.attr('type')).toEqual('button')
@@ -202,14 +201,14 @@ describe('Button', () => {
 
   describe('implicitly as no "element" param is set', () => {
     it('renders a link if you pass an href', () => {
-      const $ = cheerio.load(render('button', examples.link))
+      const $ = render('button', examples.link)
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('a')
     })
 
     it('renders a button if you don\'t pass anything', () => {
-      const $ = cheerio.load(render('button', examples['no type']))
+      const $ = render('button', examples['no type'])
 
       const $component = $('.govuk-button')
       expect($component.get(0).tagName).toEqual('button')
@@ -218,7 +217,7 @@ describe('Button', () => {
 
   describe('Start button', () => {
     it('renders a svg', () => {
-      const $ = cheerio.load(render('button', examples['start link']))
+      const $ = render('button', examples['start link'])
 
       const $component = $('.govuk-button .govuk-button__start-icon')
       expect($component.get(0).tagName).toEqual('svg')

--- a/src/govuk/components/character-count/template.test.js
+++ b/src/govuk/components/character-count/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -14,28 +13,28 @@ describe('Character count', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('id')).toEqual('more-detail')
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('name')).toEqual('more-detail')
     })
 
     it('renders with default number of rows', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('rows')).toEqual('5')
@@ -44,35 +43,35 @@ describe('Character count', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('character-count', examples.classes))
+      const $ = render('character-count', examples.classes)
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
     })
 
     it('renders with rows', () => {
-      const $ = cheerio.load(render('character-count', examples['with custom rows']))
+      const $ = render('character-count', examples['with custom rows'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('rows')).toEqual('8')
     })
 
     it('renders with value', () => {
-      const $ = cheerio.load(render('character-count', examples['with default value']))
+      const $ = render('character-count', examples['with default value'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('character-count', examples.attributes))
+      const $ = render('character-count', examples.attributes)
 
       const $component = $('.govuk-js-character-count')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with formGroup', () => {
-      const $ = cheerio.load(render('character-count', examples['formGroup with classes']))
+      const $ = render('character-count', examples['formGroup with classes'])
 
       const $component = $('.govuk-form-group')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
@@ -81,21 +80,21 @@ describe('Character count', () => {
 
   describe('count message', () => {
     it('renders with the amount of characters expected', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.text()).toContain('You can enter up to 10 characters')
     })
 
     it('renders with the amount of words expected', () => {
-      const $ = cheerio.load(render('character-count', examples['with word count']))
+      const $ = render('character-count', examples['with word count'])
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.text()).toContain('You can enter up to 10 words')
     })
 
     it('is associated with the textarea', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $textarea = $('.govuk-js-character-count')
       const $countMessage = $('.govuk-character-count__message')
@@ -109,7 +108,7 @@ describe('Character count', () => {
     })
 
     it('renders with custom classes', () => {
-      const $ = cheerio.load(render('character-count', examples['custom classes on countMessage']))
+      const $ = render('character-count', examples['custom classes on countMessage'])
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.hasClass('app-custom-count-message')).toBeTruthy()
@@ -118,21 +117,21 @@ describe('Character count', () => {
 
   describe('when it has the spellcheck attribute', () => {
     it('renders the textarea with spellcheck attribute set to true', () => {
-      const $ = cheerio.load(render('character-count', examples['spellcheck enabled']))
+      const $ = render('character-count', examples['spellcheck enabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders the textarea with spellcheck attribute set to false', () => {
-      const $ = cheerio.load(render('character-count', examples['spellcheck disabled']))
+      const $ = render('character-count', examples['spellcheck disabled'])
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders the textarea without spellcheck attribute by default', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $component = $('.govuk-character-count .govuk-textarea')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -141,13 +140,13 @@ describe('Character count', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = cheerio.load(render('character-count', examples['with hint']))
+      const $ = render('character-count', examples['with hint'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the character count as "described by" the hint', () => {
-      const $ = cheerio.load(render('character-count', examples['with hint']))
+      const $ = render('character-count', examples['with hint'])
 
       const $textarea = $('.govuk-js-character-count')
       const $hint = $('.govuk-hint')
@@ -163,13 +162,13 @@ describe('Character count', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = cheerio.load(render('character-count', examples['with default value exceeding limit']))
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the character-count as "described by" the error message', () => {
-      const $ = cheerio.load(render('character-count', examples['with default value exceeding limit']))
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-js-character-count')
       const $errorMessage = $('.govuk-error-message')
@@ -183,14 +182,14 @@ describe('Character count', () => {
     })
 
     it('adds the error class to the character-count', () => {
-      const $ = cheerio.load(render('character-count', examples['with default value exceeding limit']))
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('character-count', examples['custom classes with error message']))
+      const $ = render('character-count', examples['custom classes with error message'])
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
@@ -199,20 +198,20 @@ describe('Character count', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('character-count', examples['with default value exceeding limit']))
+      const $ = render('character-count', examples['with default value exceeding limit'])
 
       const $component = $('.govuk-form-group > .govuk-js-character-count')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the character count "id"', () => {
-      const $ = cheerio.load(render('character-count', examples.default))
+      const $ = render('character-count', examples.default)
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('more-detail')
@@ -221,7 +220,7 @@ describe('Character count', () => {
 
   describe('with threshold', () => {
     it('hides the count to start with', () => {
-      const $ = cheerio.load(render('character-count', examples['with threshold']))
+      const $ = render('character-count', examples['with threshold'])
 
       const $component = $('.govuk-character-count')
       expect($component.attr('data-threshold')).toEqual('75')
@@ -230,7 +229,7 @@ describe('Character count', () => {
 
   describe('with custom textarea description', () => {
     it('allows customisation of the textarea description', () => {
-      const $ = cheerio.load(render('character-count', examples['with custom textarea description']))
+      const $ = render('character-count', examples['with custom textarea description'])
 
       const message = $('.govuk-character-count__message').text().trim()
       expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
@@ -239,7 +238,7 @@ describe('Character count', () => {
 
   describe('translations', () => {
     it('renders with translation data attributes', () => {
-      const $ = cheerio.load(render('character-count', examples['with translations']))
+      const $ = render('character-count', examples['with translations'])
 
       const $component = $('[data-module]')
 
@@ -266,7 +265,7 @@ describe('Character count', () => {
       // it needs to pass down any textarea description to the JavaScript
       // so it can inject the limit it may have received at instantiation
       it('renders the textarea description as a data attribute', () => {
-        const $ = cheerio.load(render('character-count', examples['when neither maxlength nor maxwords are set']))
+        const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
 
         // Fallback hint is passed as data attribute
         const $component = $('[data-module]')
@@ -281,10 +280,10 @@ describe('Character count', () => {
 
     describe('without textarea description', () => {
       it('does not render a textarea description data attribute', () => {
-        const $ = cheerio.load(render(
+        const $ = render(
           'character-count',
           examples['when neither maxlength/maxwords nor textarea description are set']
-        ))
+        )
 
         const $component = $('[data-module]')
         expect($component.attr('data-i18n.textarea-description.other')).toBeFalsy()

--- a/src/govuk/components/checkboxes/template.test.js
+++ b/src/govuk/components/checkboxes/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -14,14 +13,14 @@ describe('Checkboxes', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('checkboxes', examples.default))
+    const $ = render('checkboxes', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = cheerio.load(render('checkboxes', examples.default))
+    const $ = render('checkboxes', examples.default)
 
     const $component = $('.govuk-checkboxes')
 
@@ -39,7 +38,7 @@ describe('Checkboxes', () => {
   })
 
   it('render example without falsely values', () => {
-    const $ = cheerio.load(render('checkboxes', examples['with falsey values']))
+    const $ = render('checkboxes', examples['with falsey values'])
 
     const $component = $('.govuk-checkboxes')
     const $items = $component.find('.govuk-checkboxes__item')
@@ -48,7 +47,7 @@ describe('Checkboxes', () => {
   })
 
   it('render example with a divider and ‘None’ checkbox with exclusive behaviour', () => {
-    const $ = cheerio.load(render('checkboxes', examples['with divider and None']))
+    const $ = render('checkboxes', examples['with divider and None'])
 
     const $component = $('.govuk-checkboxes')
 
@@ -63,7 +62,7 @@ describe('Checkboxes', () => {
   })
 
   it('render additional label classes', () => {
-    const $ = cheerio.load(render('checkboxes', examples['with label classes']))
+    const $ = render('checkboxes', examples['with label classes'])
 
     const $component = $('.govuk-checkboxes')
     const $label = $component.find('.govuk-checkboxes__item label')
@@ -71,7 +70,7 @@ describe('Checkboxes', () => {
   })
 
   it('render classes', () => {
-    const $ = cheerio.load(render('checkboxes', examples.classes))
+    const $ = render('checkboxes', examples.classes)
 
     const $component = $('.govuk-checkboxes')
 
@@ -79,14 +78,14 @@ describe('Checkboxes', () => {
   })
 
   it('renders initial aria-describedby on fieldset', () => {
-    const $ = cheerio.load(render('checkboxes', examples['with fieldset describedBy']))
+    const $ = render('checkboxes', examples['with fieldset describedBy'])
 
     const $fieldset = $('.govuk-fieldset')
     expect($fieldset.attr('aria-describedby')).toMatch('some-id')
   })
 
   it('render attributes', () => {
-    const $ = cheerio.load(render('checkboxes', examples.attributes))
+    const $ = render('checkboxes', examples.attributes)
 
     const $component = $('.govuk-checkboxes')
 
@@ -95,14 +94,14 @@ describe('Checkboxes', () => {
   })
 
   it('renders with a form group wrapper', () => {
-    const $ = cheerio.load(render('checkboxes', examples.default))
+    const $ = render('checkboxes', examples.default)
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.length).toBeTruthy()
   })
 
   it('render a custom class on the form group', () => {
-    const $ = cheerio.load(render('checkboxes', examples['with optional form-group classes showing group error']))
+    const $ = render('checkboxes', examples['with optional form-group classes showing group error'])
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -110,7 +109,7 @@ describe('Checkboxes', () => {
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const $ = cheerio.load(render('checkboxes', examples.default))
+      const $ = render('checkboxes', examples.default)
 
       const $component = $('.govuk-checkboxes')
 
@@ -126,7 +125,7 @@ describe('Checkboxes', () => {
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with idPrefix']))
+      const $ = render('checkboxes', examples['with idPrefix'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -142,7 +141,7 @@ describe('Checkboxes', () => {
     })
 
     it('render explicitly passed item ids', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with id and name']))
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -156,7 +155,7 @@ describe('Checkboxes', () => {
     })
 
     it('render explicitly passed item names', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with id and name']))
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -165,7 +164,7 @@ describe('Checkboxes', () => {
     })
 
     it('render disabled', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with disabled item']))
+      const $ = render('checkboxes', examples['with disabled item'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -174,7 +173,7 @@ describe('Checkboxes', () => {
     })
 
     it('render checked', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with checked item']))
+      const $ = render('checkboxes', examples['with checked item'])
 
       const $component = $('.govuk-checkboxes')
       const $secondInput = $component.find('.govuk-checkboxes__item:nth-child(2) input')
@@ -184,7 +183,7 @@ describe('Checkboxes', () => {
     })
 
     it('checks the checkboxes in values', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with pre-checked values']))
+      const $ = render('checkboxes', examples['with pre-checked values'])
 
       const $component = $('.govuk-checkboxes')
       const $british = $component.find('input[value="british"]')
@@ -195,7 +194,7 @@ describe('Checkboxes', () => {
     })
 
     it('allows item.checked to override values', () => {
-      const $ = cheerio.load(render('checkboxes', examples['item checked overrides values']))
+      const $ = render('checkboxes', examples['item checked overrides values'])
 
       const $green = $('.govuk-checkboxes').find('input[value="green"]')
       expect($green.attr('checked')).toBeUndefined()
@@ -203,7 +202,7 @@ describe('Checkboxes', () => {
 
     describe('when they include attributes', () => {
       it('it renders the attributes', () => {
-        const $ = cheerio.load(render('checkboxes', examples['items with attributes']))
+        const $ = render('checkboxes', examples['items with attributes'])
 
         const $component = $('.govuk-checkboxes')
 
@@ -220,20 +219,20 @@ describe('Checkboxes', () => {
 
   describe('when they include a hint', () => {
     it('it renders the hint text', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with hints on items']))
+      const $ = render('checkboxes', examples['with hints on items'])
 
       const $firstHint = $('.govuk-checkboxes__hint').first()
       expect($firstHint.text().trim()).toContain('You\'ll have a user ID if you\'ve registered for Self Assessment or filed a tax return online before.')
     })
 
     it('it renders the correct id attribute for the hint', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with hints on items']))
+      const $ = render('checkboxes', examples['with hints on items'])
 
       expect($('.govuk-checkboxes__hint').attr('id')).toBe('government-gateway-item-hint')
     })
 
     it('the input describedBy attribute matches the item hint id', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with hints on items']))
+      const $ = render('checkboxes', examples['with hints on items'])
 
       expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe('government-gateway-item-hint')
     })
@@ -241,7 +240,7 @@ describe('Checkboxes', () => {
 
   describe('render conditionals', () => {
     it('hidden by default when not checked', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with conditional items']))
+      const $ = render('checkboxes', examples['with conditional items'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -250,7 +249,7 @@ describe('Checkboxes', () => {
       expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeTruthy()
     })
     it('visible by default when checked', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with conditional item checked']))
+      const $ = render('checkboxes', examples['with conditional item checked'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -260,7 +259,7 @@ describe('Checkboxes', () => {
     })
 
     it('visible when checked with pre-checked values', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with pre-checked values']))
+      const $ = render('checkboxes', examples['with pre-checked values'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -270,7 +269,7 @@ describe('Checkboxes', () => {
     })
 
     it('with association to the input they are controlled by', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with conditional items']))
+      const $ = render('checkboxes', examples['with conditional items'])
 
       const $component = $('.govuk-checkboxes')
 
@@ -282,14 +281,14 @@ describe('Checkboxes', () => {
     })
 
     it('omits empty conditionals', () => {
-      const $ = cheerio.load(render('checkboxes', examples['empty conditional']))
+      const $ = render('checkboxes', examples['empty conditional'])
 
       const $component = $('.govuk-checkboxes')
       expect($component.find('.govuk-checkboxes__conditional').length).toEqual(0)
     })
 
     it('does not associate checkboxes with empty conditionals', () => {
-      const $ = cheerio.load(render('checkboxes', examples['empty conditional']))
+      const $ = render('checkboxes', examples['empty conditional'])
 
       const $input = $('.govuk-checkboxes__input').first()
       expect($input.attr('data-aria-controls')).toBeFalsy()
@@ -298,13 +297,13 @@ describe('Checkboxes', () => {
 
   describe('when they include an error message', () => {
     it('renders the error message', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message']))
+      const $ = render('checkboxes', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the idPrefix for the error message id if provided', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error and idPrefix']))
+      const $ = render('checkboxes', examples['with error and idPrefix'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -312,7 +311,7 @@ describe('Checkboxes', () => {
     })
 
     it('falls back to using the name for the error message id', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message']))
+      const $ = render('checkboxes', examples['with error message'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -320,7 +319,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with fieldset and error message']))
+      const $ = render('checkboxes', examples['with fieldset and error message'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -334,7 +333,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message and fieldset describedBy']))
+      const $ = render('checkboxes', examples['with error message and fieldset describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -348,7 +347,7 @@ describe('Checkboxes', () => {
     })
 
     it('does not associate each input as "described by" the error message', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message and hints on items']))
+      const $ = render('checkboxes', examples['with error message and hints on items'])
 
       const $inputs = $('input')
 
@@ -362,7 +361,7 @@ describe('Checkboxes', () => {
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message']))
+      const $ = render('checkboxes', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -371,13 +370,13 @@ describe('Checkboxes', () => {
 
   describe('when they include a hint', () => {
     it('renders the hint', () => {
-      const $ = cheerio.load(render('checkboxes', examples['multiple hints']))
+      const $ = render('checkboxes', examples['multiple hints'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with id and name']))
+      const $ = render('checkboxes', examples['with id and name'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -390,7 +389,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with fieldset describedBy']))
+      const $ = render('checkboxes', examples['with fieldset describedBy'])
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
 
@@ -404,7 +403,7 @@ describe('Checkboxes', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error message and hint']))
+      const $ = render('checkboxes', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -419,7 +418,7 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('checkboxes', examples['with error, hint and fieldset describedBy']))
+      const $ = render('checkboxes', examples['with error, hint and fieldset describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -436,26 +435,26 @@ describe('Checkboxes', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('checkboxes', examples['fieldset params']))
+      const $ = render('checkboxes', examples['fieldset params'])
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
       expect($component.length).toBeTruthy()
     })
 
     it('passes through label params without breaking', () => {
-      const $ = cheerio.load(render('checkboxes', examples['label with attributes']))
+      const $ = render('checkboxes', examples['label with attributes'])
 
       expect(htmlWithClassName($, '.govuk-checkboxes__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = cheerio.load(render('checkboxes', examples['fieldset params']))
+      const $ = render('checkboxes', examples['fieldset params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 
     it('passes through html fieldset params without breaking', () => {
-      const $ = cheerio.load(render('checkboxes', examples['fieldset html params']))
+      const $ = render('checkboxes', examples['fieldset html params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
@@ -463,13 +462,13 @@ describe('Checkboxes', () => {
 
   describe('single checkbox without a fieldset', () => {
     it('adds aria-describedby to input if there is an error', () => {
-      const $ = cheerio.load(render('checkboxes', examples["with single option set 'aria-describedby' on input"]))
+      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input"])
       const $input = $('input')
       expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
     })
 
     it('adds aria-describedby to input if there is an error and parent fieldset', () => {
-      const $ = cheerio.load(render('checkboxes', examples["with single option set 'aria-describedby' on input, and describedBy"]))
+      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input, and describedBy"])
       const $input = $('input')
 
       expect($input.attr('aria-describedby'))
@@ -479,13 +478,13 @@ describe('Checkboxes', () => {
 
   describe('single checkbox (with hint) without a fieldset', () => {
     it('adds aria-describedby to input if there is an error and a hint', () => {
-      const $ = cheerio.load(render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input"]))
+      const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input"])
       const $input = $('input')
       expect($input.attr('aria-describedby')).toMatch('t-and-c-with-hint-error t-and-c-with-hint-item-hint')
     })
 
     it('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
-      const $ = cheerio.load(render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input, and describedBy"]))
+      const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input, and describedBy"])
       const $input = $('input')
 
       expect($input.attr('aria-describedby'))

--- a/src/govuk/components/components.template.test.js
+++ b/src/govuk/components/components.template.test.js
@@ -1,7 +1,7 @@
 const { join } = require('path')
 
 const { paths } = require('govuk-frontend-config')
-const { nunjucksEnv, render } = require('govuk-frontend-helpers/nunjucks')
+const { nunjucksEnv, renderHTML } = require('govuk-frontend-helpers/nunjucks')
 const { getDirectories, getComponentsData } = require('govuk-frontend-lib/files')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control
@@ -118,7 +118,7 @@ describe('Components', () => {
       // Validate component examples
       for (const { name: componentName, examples } of componentsData) {
         const exampleTasks = examples.map(async ({ name: exampleName, data }) => {
-          const html = render(componentName, data)
+          const html = renderHTML(componentName, data)
 
           // Validate HTML
           return expect({ componentName, exampleName, report: validator.validateString(html) })

--- a/src/govuk/components/cookie-banner/template.test.js
+++ b/src/govuk/components/cookie-banner/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,49 +11,49 @@ describe('Cookie Banner', () => {
 
   describe('question banner', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders a heading', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $heading = $('.govuk-cookie-banner__heading')
       expect($heading.text()).toEqual('Cookies on this government service')
     })
 
     it('renders heading as escaped html when passed as text', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['heading html as text']))
+      const $ = render('cookie-banner', examples['heading html as text'])
 
       const $heading = $('.govuk-cookie-banner__heading')
       expect($heading.html().trim()).toEqual('Cookies on &lt;span&gt;my service&lt;/span&gt;')
     })
 
     it('renders heading html', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['heading html']))
+      const $ = render('cookie-banner', examples['heading html'])
 
       const $heading = $('.govuk-cookie-banner__heading')
       expect($heading.html().trim()).toEqual('Cookies on <span>my service</span>')
     })
 
     it('renders main content text', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $content = $('.govuk-cookie-banner__content')
       expect($content.text()).toEqual('We use analytics cookies to help understand how users use our service.')
     })
 
     it('renders main content html', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.html))
+      const $ = render('cookie-banner', examples.html)
 
       const $content = $('.govuk-cookie-banner__content')
       expect($content.html().trim()).toEqual('<p class="govuk-body">We use cookies in <span>our service</span>.</p>')
     })
 
     it('renders classes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.classes))
+      const $ = render('cookie-banner', examples.classes)
 
       const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__message')
 
@@ -62,7 +61,7 @@ describe('Cookie Banner', () => {
     })
 
     it('renders attributes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.attributes))
+      const $ = render('cookie-banner', examples.attributes)
 
       const $banner = $('.govuk-cookie-banner .govuk-cookie-banner__message')
 
@@ -72,21 +71,21 @@ describe('Cookie Banner', () => {
 
   describe('role and aria attributes', () => {
     it('has a role of region', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
       expect($component.attr('role')).toEqual('region')
     })
 
     it('has a default aria-label', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
       expect($component.attr('aria-label')).toEqual('Cookie banner')
     })
 
     it('renders a custom aria label', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['custom aria label']))
+      const $ = render('cookie-banner', examples['custom aria label'])
 
       const $component = $('.govuk-cookie-banner')
       expect($component.attr('aria-label')).toEqual('Cookies on GOV.UK')
@@ -95,14 +94,14 @@ describe('Cookie Banner', () => {
 
   describe('confirmation banner', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('cookie-banner', examples['accepted confirmation banner']))
+      const $ = render('cookie-banner', examples['accepted confirmation banner'])
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('role alert not set by default', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $component = $('.govuk-cookie-banner')
       const $banner = $component.find('.govuk-cookie-banner__message')
@@ -110,7 +109,7 @@ describe('Cookie Banner', () => {
     })
 
     it('sets role attribute when role provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['accepted confirmation banner']))
+      const $ = render('cookie-banner', examples['accepted confirmation banner'])
 
       const $component = $('.govuk-cookie-banner')
       const $banner = $component.find('.govuk-cookie-banner__message')
@@ -118,14 +117,14 @@ describe('Cookie Banner', () => {
     })
 
     it('hides banner if hidden option set to true', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.hidden))
+      const $ = render('cookie-banner', examples.hidden)
 
       const $component = $('.govuk-cookie-banner__message')
       expect($component.attr('hidden')).toBeTruthy()
     })
 
     it('does not hide banner if hidden option set to false', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['hidden false']))
+      const $ = render('cookie-banner', examples['hidden false'])
 
       const $component = $('.govuk-cookie-banner__message')
       expect($component.attr('hidden')).toBeUndefined()
@@ -134,21 +133,21 @@ describe('Cookie Banner', () => {
 
   describe('action', () => {
     it('renders as button by default', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['default action']))
+      const $ = render('cookie-banner', examples['default action'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.get(0).tagName).toEqual('button')
     })
 
     it('renders as a link if href provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.link))
+      const $ = render('cookie-banner', examples.link)
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.get(0).tagName).toEqual('a')
     })
 
     it('ignores other button options if href provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['link with false button options']))
+      const $ = render('cookie-banner', examples['link with false button options'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.get(0).tagName).toEqual('a')
@@ -160,7 +159,7 @@ describe('Cookie Banner', () => {
     })
 
     it('renders as a link button if href and type=button provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['link as a button']))
+      const $ = render('cookie-banner', examples['link as a button'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.get(0).tagName).toEqual('a')
@@ -170,49 +169,49 @@ describe('Cookie Banner', () => {
     })
 
     it('renders button text', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['default action']))
+      const $ = render('cookie-banner', examples['default action'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.text().trim()).toEqual('This is a button')
     })
 
     it('renders button with custom type', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.type))
+      const $ = render('cookie-banner', examples.type)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.attr('type')).toEqual('button')
     })
 
     it('renders button with name', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.attr('name')).toEqual('cookies')
     })
 
     it('renders button with value', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.default))
+      const $ = render('cookie-banner', examples.default)
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.attr('value')).toEqual('accept')
     })
 
     it('renders button with additional classes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['button classes']))
+      const $ = render('cookie-banner', examples['button classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.attr('class')).toEqual('govuk-button my-button-class app-button-class')
     })
 
     it('renders button with custom attributes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['button attributes']))
+      const $ = render('cookie-banner', examples['button attributes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
       expect($actions.attr('data-button-attribute')).toEqual('my-value')
     })
 
     it('renders link text and href', () => {
-      const $ = cheerio.load(render('cookie-banner', examples.link))
+      const $ = render('cookie-banner', examples.link)
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.text()).toEqual('This is a link')
@@ -220,14 +219,14 @@ describe('Cookie Banner', () => {
     })
 
     it('renders link with additional classes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['link classes']))
+      const $ = render('cookie-banner', examples['link classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.attr('class')).toEqual('govuk-link my-link-class app-link-class')
     })
 
     it('renders link with custom attributes', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['link attributes']))
+      const $ = render('cookie-banner', examples['link attributes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.attr('data-link-attribute')).toEqual('my-value')
@@ -236,21 +235,21 @@ describe('Cookie Banner', () => {
 
   describe('client-side implementation example', () => {
     it('renders 3 banners', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['client-side implementation']))
+      const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $actions = $('.govuk-cookie-banner__message')
       expect($actions.length).toEqual(3)
     })
 
     it('2 banners are hidden', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['client-side implementation']))
+      const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $actions = $('.govuk-cookie-banner__message[hidden]')
       expect($actions.length).toEqual(2)
     })
 
     it('has a data-nosnippet attribute to hide it from search result snippets', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['client-side implementation']))
+      const $ = render('cookie-banner', examples['client-side implementation'])
 
       const $parentContainer = $('.govuk-cookie-banner')
       expect($parentContainer.attr('data-nosnippet')).toEqual('')
@@ -259,28 +258,28 @@ describe('Cookie Banner', () => {
 
   describe('full cookie banner hidden', () => {
     it('HTML for 3 banners is present', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['full banner hidden']))
+      const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $messages = $('.govuk-cookie-banner__message')
       expect($messages.length).toEqual(3)
     })
 
     it('parent banner is hidden', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['full banner hidden']))
+      const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $cookieBanner = $('.govuk-cookie-banner[hidden]')
       expect($cookieBanner.length).toEqual(1)
     })
 
     it('adds classes to parent container when provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['full banner hidden']))
+      const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $cookieBanner = $('.govuk-cookie-banner')
       expect($cookieBanner.hasClass('hide-cookie-banner')).toBeTruthy()
     })
 
     it('adds attributes to parent container when provided', () => {
-      const $ = cheerio.load(render('cookie-banner', examples['full banner hidden']))
+      const $ = render('cookie-banner', examples['full banner hidden'])
 
       const $cookieBanner = $('.govuk-cookie-banner')
       expect($cookieBanner.attr('data-hide-cookie-banner')).toEqual('true')

--- a/src/govuk/components/date-input/template.test.js
+++ b/src/govuk/components/date-input/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -15,63 +14,63 @@ describe('Date input', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $component = $('.govuk-date-input')
       expect($component.attr('id')).toEqual('dob')
     })
 
     it('renders default inputs', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
       expect($items.length).toEqual(3)
     })
 
     it('renders item with capitalised label text', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $firstItems = $('.govuk-date-input__item:first-child')
       expect($firstItems.text().trim()).toEqual('Day')
     })
 
     it('renders inputs with type="text"', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('type')).toEqual('text')
     })
 
     it('renders inputs with inputmode="numeric"', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('inputmode')).toEqual('numeric')
     })
 
     it('renders item with implicit class for label', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $firstItems = $('.govuk-date-input__item:first-child label')
       expect($firstItems.hasClass('govuk-date-input__label')).toBeTruthy()
     })
 
     it('renders item with implicit class for input', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.hasClass('govuk-date-input__input')).toBeTruthy()
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -80,14 +79,14 @@ describe('Date input', () => {
 
   describe('items', () => {
     it('renders defaults when an empty item array is provided', () => {
-      const $ = cheerio.load(render('date-input', examples['with empty items']))
+      const $ = render('date-input', examples['with empty items'])
 
       const $items = $('.govuk-date-input__item')
       expect($items.length).toEqual(3)
     })
 
     it('renders with default items', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
       const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
@@ -97,28 +96,28 @@ describe('Date input', () => {
     })
 
     it('renders item with suffixed name for input', () => {
-      const $ = cheerio.load(render('date-input', examples['complete question']))
+      const $ = render('date-input', examples['complete question'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('name')).toEqual('dob-day')
     })
 
     it('renders items with id', () => {
-      const $ = cheerio.load(render('date-input', examples['with id on items']))
+      const $ = render('date-input', examples['with id on items'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('id')).toEqual('day')
     })
 
     it('renders item with suffixed id for input', () => {
-      const $ = cheerio.load(render('date-input', examples['suffixed id']))
+      const $ = render('date-input', examples['suffixed id'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('id')).toEqual('my-date-input-day')
     })
 
     it('renders items with value', () => {
-      const $ = cheerio.load(render('date-input', examples['with values']))
+      const $ = render('date-input', examples['with values'])
 
       const $lastItems = $('.govuk-date-input__item:last-child input')
       expect($lastItems.val()).toEqual('2018')
@@ -127,21 +126,21 @@ describe('Date input', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('date-input', examples.classes))
+      const $ = render('date-input', examples.classes)
 
       const $component = $('.govuk-date-input')
       expect($component.hasClass('app-date-input--custom-modifier')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('date-input', examples.attributes))
+      const $ = render('date-input', examples.attributes)
 
       const $component = $('.govuk-date-input')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with item attributes', () => {
-      const $ = cheerio.load(render('date-input', examples['with input attributes']))
+      const $ = render('date-input', examples['with input attributes'])
 
       const $input1 = $('.govuk-date-input__item:nth-of-type(1) input')
       const $input2 = $('.govuk-date-input__item:nth-of-type(2) input')
@@ -153,28 +152,28 @@ describe('Date input', () => {
     })
 
     it('renders items with name', () => {
-      const $ = cheerio.load(render('date-input', examples['with nested name']))
+      const $ = render('date-input', examples['with nested name'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('name')).toEqual('day[dd]')
     })
 
     it('renders inputs with custom pattern attribute', () => {
-      const $ = cheerio.load(render('date-input', examples['custom pattern']))
+      const $ = render('date-input', examples['custom pattern'])
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('pattern')).toEqual('[0-8]*')
     })
 
     it('renders inputs with custom inputmode="text"', () => {
-      const $ = cheerio.load(render('date-input', examples['custom inputmode']))
+      const $ = render('date-input', examples['custom inputmode'])
 
       const $firstInput = $('.govuk-date-input__item:first-child input')
       expect($firstInput.attr('inputmode')).toEqual('text')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = cheerio.load(render('date-input', examples['with optional form-group classes']))
+      const $ = render('date-input', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -183,12 +182,12 @@ describe('Date input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = cheerio.load(render('date-input', examples['complete question']))
+      const $ = render('date-input', examples['complete question'])
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = cheerio.load(render('date-input', examples['complete question']))
+      const $ = render('date-input', examples['complete question'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -202,7 +201,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('date-input', examples['with hint and describedBy']))
+      const $ = render('date-input', examples['with hint and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $hint = $('.govuk-hint')
@@ -218,12 +217,12 @@ describe('Date input', () => {
 
   describe('when it includes an error message', () => {
     it('renders the error message', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors only']))
+      const $ = render('date-input', examples['with errors only'])
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the id as a prefix for the error message id', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors only']))
+      const $ = render('date-input', examples['with errors only'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -231,7 +230,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors only']))
+      const $ = render('date-input', examples['with errors only'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -245,7 +244,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('date-input', examples['with error and describedBy']))
+      const $ = render('date-input', examples['with error and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -254,7 +253,7 @@ describe('Date input', () => {
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors only']))
+      const $ = render('date-input', examples['with errors only'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -263,7 +262,7 @@ describe('Date input', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('sets the `group` role on the fieldset to force JAWS18 to announce the hint and error message', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors and hint']))
+      const $ = render('date-input', examples['with errors and hint'])
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -271,7 +270,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors and hint']))
+      const $ = render('date-input', examples['with errors and hint'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -286,7 +285,7 @@ describe('Date input', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('date-input', examples['with errors and hint']))
+      const $ = render('date-input', examples['with errors and hint'])
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -297,33 +296,33 @@ describe('Date input', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('date-input', examples['complete question']))
+      const $ = render('date-input', examples['complete question'])
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-date-input')
       expect($component.length).toBeTruthy()
     })
 
     it('passes through label params without breaking', () => {
-      const $ = cheerio.load(render('date-input', examples.default))
+      const $ = render('date-input', examples.default)
 
       expect(htmlWithClassName($, '.govuk-date-input__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = cheerio.load(render('date-input', examples['complete question']))
+      const $ = render('date-input', examples['complete question'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
   })
 
   it('passes through html fieldset params without breaking', () => {
-    const $ = cheerio.load(render('date-input', examples['fieldset html']))
+    const $ = render('date-input', examples['fieldset html'])
 
     expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
   })
 
   it('can have classes for individual items', () => {
-    const $ = cheerio.load(render('date-input', examples['items with classes']))
+    const $ = render('date-input', examples['items with classes'])
 
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
@@ -334,7 +333,7 @@ describe('Date input', () => {
   })
 
   it('does not set classes as undefined if none are defined', () => {
-    const $ = cheerio.load(render('date-input', examples['items without classes']))
+    const $ = render('date-input', examples['items without classes'])
 
     const $dayInput = $('[name="day"]')
     const $monthInput = $('[name="month"]')
@@ -346,7 +345,7 @@ describe('Date input', () => {
 
   describe('when it includes autocomplete attributes', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = cheerio.load(render('date-input', examples['with autocomplete values']))
+      const $ = render('date-input', examples['with autocomplete values'])
 
       const $firstItems = $('.govuk-date-input__item:first-child input')
       expect($firstItems.attr('autocomplete')).toEqual('bday-day')

--- a/src/govuk/components/details/template.test.js
+++ b/src/govuk/components/details/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,42 +10,42 @@ describe('Details', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('details', examples.default))
+    const $ = render('details', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('renders a details element', () => {
-    const $ = cheerio.load(render('details', examples.default))
+    const $ = render('details', examples.default)
 
     const $component = $('.govuk-details')
     expect($component.get(0).tagName).toEqual('details')
   })
 
   it('renders with a custom id', () => {
-    const $ = cheerio.load(render('details', examples.id))
+    const $ = render('details', examples.id)
 
     const $component = $('.govuk-details')
     expect($component.attr('id')).toEqual('my-details-element')
   })
 
   it('is collapsed by default', () => {
-    const $ = cheerio.load(render('details', examples.default))
+    const $ = render('details', examples.default)
 
     const $component = $('.govuk-details')
     expect($component.attr('open')).toBeFalsy()
   })
 
   it('can be opened by default', () => {
-    const $ = cheerio.load(render('details', examples.expanded))
+    const $ = render('details', examples.expanded)
 
     const $component = $('.govuk-details')
     expect($component.attr('open')).toBeTruthy()
   })
 
   it('includes a nested summary', () => {
-    const $ = cheerio.load(render('details', examples.default))
+    const $ = render('details', examples.default)
 
     // Look for the summary element _within_ the details element
     const $summary = $('.govuk-details .govuk-details__summary')
@@ -54,48 +53,48 @@ describe('Details', () => {
   })
 
   it('renders nested components using `call`', () => {
-    const $ = cheerio.load(render('details', {}, '<div class="app-nested-component"></div>'))
+    const $ = render('details', {}, '<div class="app-nested-component"></div>')
 
     expect($('.govuk-details .app-nested-component').length).toBeTruthy()
   })
 
   it('allows text to be passed whilst escaping HTML entities', () => {
-    const $ = cheerio.load(render('details', examples['html as text']))
+    const $ = render('details', examples['html as text'])
 
     const detailsText = $('.govuk-details__text').html().trim()
     expect(detailsText).toEqual('More about the greater than symbol (&gt;)')
   })
 
   it('allows HTML to be passed un-escaped', () => {
-    const $ = cheerio.load(render('details', examples.html))
+    const $ = render('details', examples.html)
 
     const detailsText = $('.govuk-details__text').html().trim()
     expect(detailsText).toEqual('More about <b>bold text</b>')
   })
 
   it('allows summary text to be passed whilst escaping HTML entities', () => {
-    const $ = cheerio.load(render('details', examples['summary html as text']))
+    const $ = render('details', examples['summary html as text'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
     expect(detailsText).toEqual('The greater than symbol (&gt;) is the best')
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
-    const $ = cheerio.load(render('details', examples['summary html']))
+    const $ = render('details', examples['summary html'])
 
     const detailsText = $('.govuk-details__summary-text').html().trim()
     expect(detailsText).toEqual('Use <b>bold text</b> sparingly')
   })
 
   it('allows additional classes to be added to the details element', () => {
-    const $ = cheerio.load(render('details', examples.classes))
+    const $ = render('details', examples.classes)
 
     const $component = $('.govuk-details')
     expect($component.hasClass('some-additional-class')).toBeTruthy()
   })
 
   it('allows additional attributes to be added to the details element', () => {
-    const $ = cheerio.load(render('details', examples.attributes))
+    const $ = render('details', examples.attributes)
 
     const $component = $('.govuk-details')
     expect($component.attr('data-some-data-attribute')).toEqual('i-love-data')

--- a/src/govuk/components/error-message/template.test.js
+++ b/src/govuk/components/error-message/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,42 +10,42 @@ describe('Error message', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('error-message', examples.default))
+    const $ = render('error-message', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('renders with a custom id', () => {
-    const $ = cheerio.load(render('error-message', examples.id))
+    const $ = render('error-message', examples.id)
 
     const $component = $('.govuk-error-message')
     expect($component.attr('id')).toEqual('my-error-message-id')
   })
 
   it('allows additional classes to specified', () => {
-    const $ = cheerio.load(render('error-message', examples.classes))
+    const $ = render('error-message', examples.classes)
 
     const $component = $('.govuk-error-message')
     expect($component.hasClass('custom-class')).toBeTruthy()
   })
 
   it('allows text to be passed whilst escaping HTML entities', () => {
-    const $ = cheerio.load(render('error-message', examples['html as text']))
+    const $ = render('error-message', examples['html as text'])
 
     const content = $('.govuk-error-message').html().trim()
     expect(content).toContain('Unexpected &gt; in body')
   })
 
   it('allows summary HTML to be passed un-escaped', () => {
-    const $ = cheerio.load(render('error-message', examples.html))
+    const $ = render('error-message', examples.html)
 
     const content = $('.govuk-error-message').html().trim()
     expect(content).toContain('Unexpected <b>bold text</b> in body copy')
   })
 
   it('allows additional attributes to be specified', () => {
-    const $ = cheerio.load(render('error-message', examples.attributes))
+    const $ = render('error-message', examples.attributes)
 
     const $component = $('.govuk-error-message')
     expect($component.attr('data-test')).toEqual('attribute')
@@ -54,28 +53,28 @@ describe('Error message', () => {
   })
 
   it('includes a visually hidden "Error" prefix by default', () => {
-    const $ = cheerio.load(render('error-message', examples.default))
+    const $ = render('error-message', examples.default)
 
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('Error: Error message about full name goes here')
   })
 
   it('allows the visually hidden prefix to be customised', () => {
-    const $ = cheerio.load(render('error-message', examples['with visually hidden text']))
+    const $ = render('error-message', examples['with visually hidden text'])
 
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('Gwall: Rhowch eich enw llawn')
   })
 
   it('allows the visually hidden prefix to be removed', () => {
-    const $ = cheerio.load(render('error-message', examples['visually hidden text removed']))
+    const $ = render('error-message', examples['visually hidden text removed'])
 
     const $component = $('.govuk-error-message')
     expect($component.text().trim()).toEqual('There is an error on line 42')
   })
 
   it('allows the visually hidden prefix to be removed and then manually added with HTML', () => {
-    const $ = cheerio.load(render('error-message', examples.translated))
+    const $ = render('error-message', examples.translated)
 
     const $component = $('.govuk-error-message')
     expect($component.html().trim()).toContain('<span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma')

--- a/src/govuk/components/error-summary/template.test.js
+++ b/src/govuk/components/error-summary/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,42 +11,42 @@ describe('Error-summary', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('has a child container with the role=alert attribute', () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
       const childRoleAttr = $('.govuk-error-summary div:first-child').attr('role')
 
       expect(childRoleAttr).toEqual('alert')
     })
 
     it('renders title text', () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
       const summaryTitle = $('.govuk-error-summary__title').text().trim()
 
       expect(summaryTitle).toEqual('There is a problem')
     })
 
     it('number of error items matches the number of items specified', () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
       const errorList = $('.govuk-error-summary .govuk-error-summary__list li')
 
       expect(errorList).toHaveLength(2)
     })
 
     it('error list item is an anchor tag if href attribute is specified', () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
 
       const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child')
       expect(errorItem.children().get(0).tagName).toEqual('a')
     })
 
     it('render anchor tag href attribute is correctly', () => {
-      const $ = cheerio.load(render('error-summary', examples.default))
+      const $ = render('error-summary', examples.default)
 
       const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child a')
       expect(errorItem.attr('href')).toEqual('#example-error-1')
@@ -56,55 +55,55 @@ describe('Error-summary', () => {
 
   describe('custom options', () => {
     it('allows title text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('error-summary', examples['html as titleText']))
+      const $ = render('error-summary', examples['html as titleText'])
 
       const summaryTitle = $('.govuk-error-summary__title').html().trim()
       expect(summaryTitle).toEqual('Alert, &lt;em&gt;alert&lt;/em&gt;')
     })
 
     it('allows title HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('error-summary', examples['title html']))
+      const $ = render('error-summary', examples['title html'])
 
       const summaryTitle = $('.govuk-error-summary__title').html().trim()
       expect(summaryTitle).toEqual('Alert, <em>alert</em>')
     })
 
     it('renders description text', () => {
-      const $ = cheerio.load(render('error-summary', examples.description))
+      const $ = render('error-summary', examples.description)
       const summaryDescription = $('.govuk-error-summary__body p').text().trim()
 
       expect(summaryDescription).toEqual('Lorem ipsum')
     })
 
     it('allows description text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('error-summary', examples['html as descriptionText']))
+      const $ = render('error-summary', examples['html as descriptionText'])
 
       const summaryDescription = $('.govuk-error-summary__body p').html().trim()
       expect(summaryDescription).toEqual('See errors below (&gt;)')
     })
 
     it('allows description HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('error-summary', examples['description html']))
+      const $ = render('error-summary', examples['description html'])
 
       const summaryDescription = $('.govuk-error-summary__body p').html().trim()
       expect(summaryDescription).toEqual('See <span>errors</span> below')
     })
 
     it('renders nested components in description using `call`', () => {
-      const $ = cheerio.load(render('error-summary', {}, '<div class="app-nested-component"></div>'))
+      const $ = render('error-summary', {}, '<div class="app-nested-component"></div>')
 
       expect($('.govuk-error-summary .app-nested-component').length).toBeTruthy()
     })
 
     it('allows additional classes to be added to the error-summary component', () => {
-      const $ = cheerio.load(render('error-summary', examples.classes))
+      const $ = render('error-summary', examples.classes)
 
       const $component = $('.govuk-error-summary')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('allows additional attributes to be added to the error-summary component', () => {
-      const $ = cheerio.load(render('error-summary', examples.attributes))
+      const $ = render('error-summary', examples.attributes)
 
       const $component = $('.govuk-error-summary')
       expect($component.attr('first-attribute')).toEqual('foo')
@@ -112,7 +111,7 @@ describe('Error-summary', () => {
     })
 
     it('renders anchor tag with attributes', () => {
-      const $ = cheerio.load(render('error-summary', examples['error list with attributes']))
+      const $ = render('error-summary', examples['error list with attributes'])
 
       const $component = $('.govuk-error-summary__list a')
       expect($component.attr('data-attribute')).toEqual('my-attribute')
@@ -120,14 +119,14 @@ describe('Error-summary', () => {
     })
 
     it('renders error item text', () => {
-      const $ = cheerio.load(render('error-summary', examples['without links']))
+      const $ = render('error-summary', examples['without links'])
       const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()
 
       expect(errorItemText).toEqual('Invalid username or password')
     })
 
     it('allows error item HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('error-summary', examples['error list with html']))
+      const $ = render('error-summary', examples['error list with html'])
 
       const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
@@ -135,7 +134,7 @@ describe('Error-summary', () => {
     })
 
     it('allows error item text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('error-summary', examples['error list with html as text']))
+      const $ = render('error-summary', examples['error list with html as text'])
 
       const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
 
@@ -143,7 +142,7 @@ describe('Error-summary', () => {
     })
 
     it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
-      const $ = cheerio.load(render('error-summary', examples['error list with html link']))
+      const $ = render('error-summary', examples['error list with html link'])
 
       const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 
@@ -151,7 +150,7 @@ describe('Error-summary', () => {
     })
 
     it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('error-summary', examples['error list with html as text link']))
+      const $ = render('error-summary', examples['error list with html as text link'])
 
       const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
 
@@ -159,14 +158,14 @@ describe('Error-summary', () => {
     })
 
     it('allows to disable autofocus', () => {
-      const $ = cheerio.load(render('error-summary', examples['autofocus disabled']))
+      const $ = render('error-summary', examples['autofocus disabled'])
 
       const $component = $('.govuk-error-summary')
       expect($component.attr('data-disable-auto-focus')).toBe('true')
     })
 
     it('allows to explicitely enable autofocus', () => {
-      const $ = cheerio.load(render('error-summary', examples['autofocus explicitly enabled']))
+      const $ = render('error-summary', examples['autofocus explicitly enabled'])
 
       const $component = $('.govuk-error-summary')
       expect($component.attr('data-disable-auto-focus')).toBe('false')

--- a/src/govuk/components/fieldset/template.test.js
+++ b/src/govuk/components/fieldset/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,103 +10,103 @@ describe('fieldset', () => {
   })
 
   it('passes accessibility tests', async () => {
-    const $ = cheerio.load(render('fieldset', examples.default))
+    const $ = render('fieldset', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('creates a fieldset', () => {
-    const $ = cheerio.load(render('fieldset', examples.default))
+    const $ = render('fieldset', examples.default)
 
     const $component = $('fieldset.govuk-fieldset')
     expect($component.get(0).tagName).toContain('fieldset')
   })
 
   it('includes a legend element which captions the fieldset', () => {
-    const $ = cheerio.load(render('fieldset', examples.default))
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.get(0).tagName).toEqual('legend')
   })
 
   it('nests the legend within the fieldset', () => {
-    const $ = cheerio.load(render('fieldset', examples.default))
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.parent().get(0).tagName).toEqual('fieldset')
   })
 
   it('allows you to set the legend text', () => {
-    const $ = cheerio.load(render('fieldset', examples.default))
+    const $ = render('fieldset', examples.default)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.text().trim()).toEqual('What is your address?')
   })
 
   it('allows you to set the aria-describedby attribute', () => {
-    const $ = cheerio.load(render('fieldset', examples['with describedBy']))
+    const $ = render('fieldset', examples['with describedBy'])
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('aria-describedby')).toEqual('some-id')
   })
 
   it('escapes HTML in the text argument', () => {
-    const $ = cheerio.load(render('fieldset', examples['html as text']))
+    const $ = render('fieldset', examples['html as text'])
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.html()).toContain('&lt;b&gt;your&lt;/b&gt;')
   })
 
   it('does not escape HTML in the html argument', () => {
-    const $ = cheerio.load(render('fieldset', examples.html))
+    const $ = render('fieldset', examples.html)
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.html()).toContain('<b>your</b>')
   })
 
   it('nests the legend text in an H1 if the legend is a page heading', () => {
-    const $ = cheerio.load(render('fieldset', examples['as page heading l']))
+    const $ = render('fieldset', examples['as page heading l'])
 
     const $headingInsideLegend = $('.govuk-fieldset__legend > h1')
     expect($headingInsideLegend.text().trim()).toBe('What is your address?')
   })
 
   it('renders html when passed as fieldset content', () => {
-    const $ = cheerio.load(render('fieldset', examples['html fieldset content']))
+    const $ = render('fieldset', examples['html fieldset content'])
 
     expect($('.govuk-fieldset .my-content').text().trim()).toEqual('This is some content to put inside the fieldset')
   })
 
   it('renders nested components using `call`', () => {
-    const $ = cheerio.load(render('fieldset', {}, '<div class="app-nested-component"></div>'))
+    const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
 
     expect($('.govuk-fieldset .app-nested-component').length).toBeTruthy()
   })
 
   it('can have additional classes on the legend', () => {
-    const $ = cheerio.load(render('fieldset', examples['legend classes']))
+    const $ = render('fieldset', examples['legend classes'])
 
     const $legend = $('.govuk-fieldset__legend')
     expect($legend.hasClass('my-custom-class')).toBeTruthy()
   })
 
   it('can have additional classes on the fieldset', () => {
-    const $ = cheerio.load(render('fieldset', examples.classes))
+    const $ = render('fieldset', examples.classes)
 
     const $component = $('.govuk-fieldset')
     expect($component.hasClass('app-fieldset--custom-modifier')).toBeTruthy()
   })
 
   it('can have an explicit role', () => {
-    const $ = cheerio.load(render('fieldset', examples.role))
+    const $ = render('fieldset', examples.role)
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('role')).toEqual('group')
   })
 
   it('can have additional attributes', () => {
-    const $ = cheerio.load(render('fieldset', examples.attributes))
+    const $ = render('fieldset', examples.attributes)
 
     const $component = $('.govuk-fieldset')
     expect($component.attr('data-attribute')).toEqual('value')

--- a/src/govuk/components/file-upload/template.test.js
+++ b/src/govuk/components/file-upload/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -15,28 +14,28 @@ describe('File upload', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('id')).toEqual('file-upload-1')
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('name')).toEqual('file-upload-1')
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -45,35 +44,35 @@ describe('File upload', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('file-upload', examples.classes))
+      const $ = render('file-upload', examples.classes)
 
       const $component = $('.govuk-file-upload')
       expect($component.hasClass('app-file-upload--custom-modifier')).toBeTruthy()
     })
 
     it('renders with value', () => {
-      const $ = cheerio.load(render('file-upload', examples['with value']))
+      const $ = render('file-upload', examples['with value'])
 
       const $component = $('.govuk-file-upload')
       expect($component.val()).toEqual('C:\\fakepath\\myphoto.jpg')
     })
 
     it('renders with aria-describedby', () => {
-      const $ = cheerio.load(render('file-upload', examples['with describedBy']))
+      const $ = render('file-upload', examples['with describedBy'])
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('file-upload', examples.attributes))
+      const $ = render('file-upload', examples.attributes)
 
       const $component = $('.govuk-file-upload')
       expect($component.attr('accept')).toEqual('.jpg, .jpeg, .png')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = cheerio.load(render('file-upload', examples['with optional form-group classes']))
+      const $ = render('file-upload', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -82,13 +81,13 @@ describe('File upload', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = cheerio.load(render('file-upload', examples['with hint text']))
+      const $ = render('file-upload', examples['with hint text'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the hint', () => {
-      const $ = cheerio.load(render('file-upload', examples['with hint text']))
+      const $ = render('file-upload', examples['with hint text'])
 
       const $component = $('.govuk-file-upload')
       const $hint = $('.govuk-hint')
@@ -102,7 +101,7 @@ describe('File upload', () => {
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('file-upload', examples['with hint and describedBy']))
+      const $ = render('file-upload', examples['with hint and describedBy'])
 
       const $component = $('.govuk-file-upload')
       const $hint = $('.govuk-hint')
@@ -118,13 +117,13 @@ describe('File upload', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = cheerio.load(render('file-upload', examples.error))
+      const $ = render('file-upload', examples.error)
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the error message', () => {
-      const $ = cheerio.load(render('file-upload', examples.error))
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-file-upload')
       const $errorMessage = $('.govuk-error-message')
@@ -138,7 +137,7 @@ describe('File upload', () => {
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('file-upload', examples['with error and describedBy']))
+      const $ = render('file-upload', examples['with error and describedBy'])
 
       const $component = $('.govuk-file-upload')
       const $errorMessage = $('.govuk-error-message')
@@ -152,14 +151,14 @@ describe('File upload', () => {
     })
 
     it('includes the error class on the component', () => {
-      const $ = cheerio.load(render('file-upload', examples.error))
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-file-upload')
       expect($component.hasClass('govuk-file-upload--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('file-upload', examples.error))
+      const $ = render('file-upload', examples.error)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -168,7 +167,7 @@ describe('File upload', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the input as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('file-upload', examples['with error message and hint']))
+      const $ = render('file-upload', examples['with error message and hint'])
 
       const $component = $('.govuk-file-upload')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -185,7 +184,7 @@ describe('File upload', () => {
     it('associates the input as described by the hint, error message and parent fieldset', () => {
       const describedById = 'some-id'
 
-      const $ = cheerio.load(render('file-upload', examples['with error, describedBy and hint']))
+      const $ = render('file-upload', examples['with error, describedBy and hint'])
 
       const $component = $('.govuk-file-upload')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -202,20 +201,20 @@ describe('File upload', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('file-upload', examples.error))
+      const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-form-group > .govuk-file-upload')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the file-upload "id"', () => {
-      const $ = cheerio.load(render('file-upload', examples.default))
+      const $ = render('file-upload', examples.default)
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('file-upload-1')

--- a/src/govuk/components/footer/template.test.js
+++ b/src/govuk/components/footer/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,21 +10,21 @@ describe('footer', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('footer', examples.default))
+    const $ = render('footer', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('entire component must have a role of `contentinfo`', () => {
-    const $ = cheerio.load(render('footer', examples.default))
+    const $ = render('footer', examples.default)
 
     const $component = $('.govuk-footer')
     expect($component.attr('role')).toEqual('contentinfo')
   })
 
   it('renders attributes correctly', () => {
-    const $ = cheerio.load(render('footer', examples.attributes))
+    const $ = render('footer', examples.attributes)
 
     const $component = $('.govuk-footer')
     expect($component.attr('data-test-attribute')).toEqual('value')
@@ -33,14 +32,14 @@ describe('footer', () => {
   })
 
   it('renders classes', () => {
-    const $ = cheerio.load(render('footer', examples.classes))
+    const $ = render('footer', examples.classes)
 
     const $component = $('.govuk-footer')
     expect($component.hasClass('app-footer--custom-modifier')).toBeTruthy()
   })
 
   it('renders custom container classes', () => {
-    const $ = cheerio.load(render('footer', examples['with container classes']))
+    const $ = render('footer', examples['with container classes'])
 
     const $component = $('.govuk-footer')
     const $container = $component.find('.govuk-width-container')
@@ -50,14 +49,14 @@ describe('footer', () => {
 
   describe('meta', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('footer', examples['with meta']))
+      const $ = render('footer', examples['with meta'])
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders heading', () => {
-      const $ = cheerio.load(render('footer', examples['with meta']))
+      const $ = render('footer', examples['with meta'])
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
@@ -65,7 +64,7 @@ describe('footer', () => {
     })
 
     it('renders default heading when none supplied', () => {
-      const $ = cheerio.load(render('footer', examples['with empty meta']))
+      const $ = render('footer', examples['with empty meta'])
 
       const $component = $('.govuk-footer')
       const $heading = $component.find('h2.govuk-visually-hidden')
@@ -73,13 +72,13 @@ describe('footer', () => {
     })
 
     it('doesn\'t render footer link list when no items are provided', () => {
-      const $ = cheerio.load(render('footer', examples['with empty meta items']))
+      const $ = render('footer', examples['with empty meta items'])
 
       expect($('.govuk-footer__inline-list').length).toEqual(0)
     })
 
     it('renders links', () => {
-      const $ = cheerio.load(render('footer', examples['with meta']))
+      const $ = render('footer', examples['with meta'])
 
       const $list = $('ul.govuk-footer__inline-list')
       const $items = $list.find('li.govuk-footer__inline-list-item')
@@ -90,28 +89,28 @@ describe('footer', () => {
     })
 
     it('renders custom meta text', () => {
-      const $ = cheerio.load(render('footer', examples['with custom meta']))
+      const $ = render('footer', examples['with custom meta'])
 
       const $custom = $('.govuk-footer__meta-custom')
       expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
     })
 
     it('renders custom meta html as text', () => {
-      const $ = cheerio.load(render('footer', examples['meta html as text']))
+      const $ = render('footer', examples['meta html as text'])
 
       const $custom = $('.govuk-footer__meta-custom')
       expect($custom.text()).toContain('GOV.UK Prototype Kit <strong>v7.0.1</strong>')
     })
 
     it('renders custom meta html', () => {
-      const $ = cheerio.load(render('footer', examples['with meta html']))
+      const $ = render('footer', examples['with meta html'])
 
       const $custom = $('.govuk-footer__meta-custom')
       expect($custom.text()).toContain('GOV.UK Prototype Kit v7.0.1')
     })
 
     it('renders attributes on meta links', () => {
-      const $ = cheerio.load(render('footer', examples['with meta item attributes']))
+      const $ = render('footer', examples['with meta item attributes'])
 
       const $metaLink = $('.govuk-footer__meta .govuk-footer__link')
       expect($metaLink.attr('data-attribute')).toEqual('my-attribute')
@@ -121,20 +120,20 @@ describe('footer', () => {
 
   describe('navigation', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('no items displayed when no item array is provided', () => {
-      const $ = cheerio.load(render('footer', examples['with empty navigation']))
+      const $ = render('footer', examples['with empty navigation'])
 
       expect($('.govuk-footer__navigation').length).toEqual(0)
     })
 
     it('renders headings', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const $firstSection = $('.govuk-footer__section:first-child')
       const $lastSection = $('.govuk-footer__section:last-child')
@@ -145,7 +144,7 @@ describe('footer', () => {
     })
 
     it('renders lists of links', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const $list = $('ul.govuk-footer__list')
       const $items = $list.find('li.govuk-footer__list-item')
@@ -156,7 +155,7 @@ describe('footer', () => {
     })
 
     it('renders attributes on links', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation item attributes']))
+      const $ = render('footer', examples['with navigation item attributes'])
 
       const $navigationLink = $('.govuk-footer__list .govuk-footer__link')
       expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
@@ -164,28 +163,28 @@ describe('footer', () => {
     })
 
     it('renders lists in columns', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const $list = $('ul.govuk-footer__list')
       expect($list.hasClass('govuk-footer__list--columns-2')).toBeTruthy()
     })
 
     it('renders one-column section full width by default', () => {
-      const $ = cheerio.load(render('footer', examples['with default width navigation (one column)']))
+      const $ = render('footer', examples['with default width navigation (one column)'])
 
       const $section = $('.govuk-footer__section')
       expect($section.hasClass('govuk-grid-column-full')).toBeTruthy()
     })
 
     it('renders two-column section full width by default', () => {
-      const $ = cheerio.load(render('footer', examples['with default width navigation (two columns)']))
+      const $ = render('footer', examples['with default width navigation (two columns)'])
 
       const $section = $('.govuk-footer__section')
       expect($section.hasClass('govuk-grid-column-full')).toBeTruthy()
     })
 
     it('renders section custom width when width specified', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const $section = $('.govuk-footer__section')
       expect($section.hasClass('govuk-grid-column-two-thirds')).toBeTruthy()
@@ -194,14 +193,14 @@ describe('footer', () => {
 
   describe('section break', () => {
     it('renders when there is a navigation', () => {
-      const $ = cheerio.load(render('footer', examples['with navigation']))
+      const $ = render('footer', examples['with navigation'])
 
       const $sectionBreak = $('hr.govuk-footer__section-break')
       expect($sectionBreak.length).toBeTruthy()
     })
 
     it('renders nothing when there is only meta', () => {
-      const $ = cheerio.load(render('footer', examples['with meta']))
+      const $ = render('footer', examples['with meta'])
 
       const $sectionBreak = $('hr.govuk-footer__section-break')
       expect($sectionBreak.length).toBeFalsy()
@@ -210,28 +209,28 @@ describe('footer', () => {
 
   describe('content licence', () => {
     it('is visible', () => {
-      const $ = cheerio.load(render('footer', examples.default))
+      const $ = render('footer', examples.default)
 
       const $licenceMessage = $('.govuk-footer__licence-description')
       expect($licenceMessage.text()).toContain('Open Government Licence v3.0')
     })
 
     it('can be customised with `text` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with custom text content licence and copyright notice']))
+      const $ = render('footer', examples['with custom text content licence and copyright notice'])
 
       const $licenceMessage = $('.govuk-footer__licence-description')
       expect($licenceMessage.text()).toContain('Drwydded y Llywodraeth Agored v3.0')
     })
 
     it('can be customised with `html` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with custom HTML content licence and copyright notice']))
+      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
 
       const $licenceMessage = $('.govuk-footer__licence-description')
       expect($licenceMessage.html()).toContain('<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>')
     })
 
     it('escapes HTML in the `text` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with HTML passed as text content']))
+      const $ = render('footer', examples['with HTML passed as text content'])
 
       const $licenceMessage = $('.govuk-footer__licence-description')
       expect($licenceMessage.html()).toContain('&lt;a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license"&gt;Drwydded y Llywodraeth Agored v3.0&lt;/a&gt;')
@@ -240,28 +239,28 @@ describe('footer', () => {
 
   describe('crown copyright', () => {
     it('is visible', () => {
-      const $ = cheerio.load(render('footer', examples.default))
+      const $ = render('footer', examples.default)
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
       expect($copyrightMessage.text()).toContain('© Crown copyright')
     })
 
     it('can be customised with `text` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with custom text content licence and copyright notice']))
+      const $ = render('footer', examples['with custom text content licence and copyright notice'])
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
       expect($copyrightMessage.text()).toContain('© Hawlfraint y Goron')
     })
 
     it('can be customised with `html` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with custom HTML content licence and copyright notice']))
+      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
       expect($copyrightMessage.html()).toContain('<span>Hawlfraint y Goron</span>')
     })
 
     it('escapes HTML in the `text` parameter', () => {
-      const $ = cheerio.load(render('footer', examples['with HTML passed as text content']))
+      const $ = render('footer', examples['with HTML passed as text content'])
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
       expect($copyrightMessage.html()).toContain('&lt;span&gt;Hawlfraint y Goron&lt;/span&gt;')

--- a/src/govuk/components/header/template.test.js
+++ b/src/govuk/components/header/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,14 +11,14 @@ describe('header', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('header', examples.default))
+      const $ = render('header', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('has a role of `banner`', () => {
-      const $ = cheerio.load(render('header', examples.default))
+      const $ = render('header', examples.default)
 
       const $component = $('.govuk-header')
       expect($component.attr('role')).toEqual('banner')
@@ -28,7 +27,7 @@ describe('header', () => {
 
   describe('custom options', () => {
     it('renders attributes correctly', () => {
-      const $ = cheerio.load(render('header', examples.attributes))
+      const $ = render('header', examples.attributes)
 
       const $component = $('.govuk-header')
       expect($component.attr('data-test-attribute')).toEqual('value')
@@ -36,14 +35,14 @@ describe('header', () => {
     })
 
     it('renders classes', () => {
-      const $ = cheerio.load(render('header', examples.classes))
+      const $ = render('header', examples.classes)
 
       const $component = $('.govuk-header')
       expect($component.hasClass('app-header--custom-modifier')).toBeTruthy()
     })
 
     it('renders custom container classes', () => {
-      const $ = cheerio.load(render('header', examples['full width']))
+      const $ = render('header', examples['full width'])
 
       const $component = $('.govuk-header')
       const $container = $component.find('.govuk-header__container')
@@ -52,7 +51,7 @@ describe('header', () => {
     })
 
     it('renders custom navigation classes', () => {
-      const $ = cheerio.load(render('header', examples['full width with navigation']))
+      const $ = render('header', examples['full width with navigation'])
 
       const $component = $('.govuk-header')
       const $container = $component.find('.govuk-header__navigation')
@@ -61,7 +60,7 @@ describe('header', () => {
     })
 
     it('renders home page URL', () => {
-      const $ = cheerio.load(render('header', examples['custom homepage url']))
+      const $ = render('header', examples['custom homepage url'])
 
       const $component = $('.govuk-header')
       const $homepageLink = $component.find('.govuk-header__link--homepage')
@@ -71,7 +70,7 @@ describe('header', () => {
 
   describe('with product name', () => {
     it('renders product name', () => {
-      const $ = cheerio.load(render('header', examples['with product name']))
+      const $ = render('header', examples['with product name'])
 
       const $component = $('.govuk-header')
       const $productName = $component.find('.govuk-header__product-name')
@@ -81,7 +80,7 @@ describe('header', () => {
 
   describe('with service name', () => {
     it('renders service name', () => {
-      const $ = cheerio.load(render('header', examples['with service name']))
+      const $ = render('header', examples['with service name'])
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
@@ -89,7 +88,7 @@ describe('header', () => {
     })
 
     it('wraps the service name with a link when a url is provided', () => {
-      const $ = cheerio.load(render('header', examples['with service name']))
+      const $ = render('header', examples['with service name'])
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
@@ -98,7 +97,7 @@ describe('header', () => {
     })
 
     it('does not use a link when no service url is provided', () => {
-      const $ = cheerio.load(render('header', examples['with service name but no service url']))
+      const $ = render('header', examples['with service name but no service url'])
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
@@ -109,14 +108,14 @@ describe('header', () => {
 
   describe('with navigation', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('header', examples['with navigation']))
+      const $ = render('header', examples['with navigation'])
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders navigation', () => {
-      const $ = cheerio.load(render('header', examples['with navigation']))
+      const $ = render('header', examples['with navigation'])
 
       const $component = $('.govuk-header')
       const $list = $component.find('ul.govuk-header__navigation-list')
@@ -128,7 +127,7 @@ describe('header', () => {
     })
 
     it('renders navigation default label correctly', () => {
-      const $ = cheerio.load(render('header', examples['with navigation']))
+      const $ = render('header', examples['with navigation'])
 
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
@@ -137,7 +136,7 @@ describe('header', () => {
     })
 
     it('renders navigation label correctly when custom menu button text is set', () => {
-      const $ = cheerio.load(render('header', examples['with custom menu button text']))
+      const $ = render('header', examples['with custom menu button text'])
 
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
@@ -146,7 +145,7 @@ describe('header', () => {
     })
 
     it('allows navigation label to be customised', () => {
-      const $ = cheerio.load(render('header', examples['with custom navigation label']))
+      const $ = render('header', examples['with custom navigation label'])
 
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
@@ -155,7 +154,7 @@ describe('header', () => {
     })
 
     it('renders navigation label and menu button text when these are both set', () => {
-      const $ = cheerio.load(render('header', examples['with custom navigation label and custom menu button text']))
+      const $ = render('header', examples['with custom navigation label and custom menu button text'])
 
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
@@ -166,42 +165,42 @@ describe('header', () => {
     })
 
     it('renders navigation with active item', () => {
-      const $ = cheerio.load(render('header', examples['with navigation']))
+      const $ = render('header', examples['with navigation'])
 
       const $activeItem = $('li.govuk-header__navigation-item:first-child')
       expect($activeItem.hasClass('govuk-header__navigation-item--active')).toBeTruthy()
     })
 
     it('allows navigation item text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('header', examples['navigation item with html as text']))
+      const $ = render('header', examples['navigation item with html as text'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
       expect($navigationLink.html()).toContain('&lt;em&gt;Navigation item 1&lt;/em&gt;')
     })
 
     it('allows navigation item HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('header', examples['navigation item with html']))
+      const $ = render('header', examples['navigation item with html'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
       expect($navigationLink.html()).toContain('<em>Navigation item 1</em>')
     })
 
     it('renders navigation item with text without a link', () => {
-      const $ = cheerio.load(render('header', examples['navigation item with text without link']))
+      const $ = render('header', examples['navigation item with text without link'])
 
       const $navigationItem = $('.govuk-header__navigation-item')
       expect($navigationItem.html().trim()).toEqual('Navigation item 1')
     })
 
     it('renders navigation item with html without a link', () => {
-      const $ = cheerio.load(render('header', examples['navigation item with html without link']))
+      const $ = render('header', examples['navigation item with html without link'])
 
       const $navigationItem = $('.govuk-header__navigation-item')
       expect($navigationItem.html()).toContain('<em>Navigation item 1</em>')
     })
 
     it('renders navigation item anchor with attributes', () => {
-      const $ = cheerio.load(render('header', examples['navigation item with attributes']))
+      const $ = render('header', examples['navigation item with attributes'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
       expect($navigationLink.attr('data-attribute')).toEqual('my-attribute')
@@ -210,42 +209,42 @@ describe('header', () => {
 
     describe('menu button', () => {
       it('has an explicit type="button" so it does not act as a submit button', () => {
-        const $ = cheerio.load(render('header', examples['with navigation']))
+        const $ = render('header', examples['with navigation'])
 
         const $button = $('.govuk-header__menu-button')
 
         expect($button.attr('type')).toEqual('button')
       })
       it('has a hidden attribute on load so that it does not show an unusable button without js', () => {
-        const $ = cheerio.load(render('header', examples['with navigation']))
+        const $ = render('header', examples['with navigation'])
 
         const $button = $('.govuk-header__menu-button')
 
         expect($button.attr('hidden')).toBeTruthy()
       })
       it('renders default label correctly', () => {
-        const $ = cheerio.load(render('header', examples['with navigation']))
+        const $ = render('header', examples['with navigation'])
 
         const $button = $('.govuk-header__menu-button')
 
         expect($button.attr('aria-label')).toEqual('Show or hide menu')
       })
       it('allows label to be customised', () => {
-        const $ = cheerio.load(render('header', examples['with custom menu button label']))
+        const $ = render('header', examples['with custom menu button label'])
 
         const $button = $('.govuk-header__menu-button')
 
         expect($button.attr('aria-label')).toEqual('Custom button label')
       })
       it('renders default text correctly', () => {
-        const $ = cheerio.load(render('header', examples['with navigation']))
+        const $ = render('header', examples['with navigation'])
 
         const $button = $('.govuk-header__menu-button')
 
         expect($button.text()).toEqual('Menu')
       })
       it('allows text to be customised', () => {
-        const $ = cheerio.load(render('header', examples['with custom menu button text']))
+        const $ = render('header', examples['with custom menu button text'])
 
         const $button = $('.govuk-header__menu-button')
 
@@ -259,7 +258,7 @@ describe('header', () => {
     let $svg
 
     beforeAll(() => {
-      $ = cheerio.load(render('header', examples.default))
+      $ = render('header', examples.default)
       $svg = $('.govuk-header__logotype-crown')
     })
 

--- a/src/govuk/components/hint/template.test.js
+++ b/src/govuk/components/hint/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,49 +11,49 @@ describe('Hint', () => {
 
   describe('by default', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('hint', examples.default))
+      const $ = render('hint', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with text', () => {
-      const $ = cheerio.load(render('hint', examples.default))
+      const $ = render('hint', examples.default)
 
       const content = $('.govuk-hint').text()
       expect(content).toEqual('\n  It\'s on your National Insurance card, benefit letter, payslip or P60.\nFor example, \'QQ 12 34 56 C\'.\n\n')
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('hint', examples.classes))
+      const $ = render('hint', examples.classes)
 
       const $component = $('.govuk-hint')
       expect($component.hasClass('app-hint--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('hint', examples.id))
+      const $ = render('hint', examples.id)
 
       const $component = $('.govuk-hint')
       expect($component.attr('id')).toEqual('my-hint')
     })
 
     it('allows text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('hint', examples['html as text']))
+      const $ = render('hint', examples['html as text'])
 
       const content = $('.govuk-hint').html().trim()
       expect(content).toEqual('Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body')
     })
 
     it('allows HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('hint', examples['with html']))
+      const $ = render('hint', examples['with html'])
 
       const content = $('.govuk-hint').html().trim()
       expect(content).toEqual('It\'s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.\nFor example, \'QQ 12 34 56 C\'.')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('hint', examples.attributes))
+      const $ = render('hint', examples.attributes)
 
       const $component = $('.govuk-hint')
       expect($component.attr('data-attribute')).toEqual('my data value')

--- a/src/govuk/components/input/template.test.js
+++ b/src/govuk/components/input/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -15,35 +14,35 @@ describe('Input', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('id')).toEqual('input-example')
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('name')).toEqual('test-name')
     })
 
     it('renders with type="text" by default', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('type')).toEqual('text')
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -52,56 +51,56 @@ describe('Input', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('input', examples.classes))
+      const $ = render('input', examples.classes)
 
       const $component = $('.govuk-input')
       expect($component.hasClass('app-input--custom-modifier')).toBeTruthy()
     })
 
     it('allows you to override the type', () => {
-      const $ = cheerio.load(render('input', examples['custom type']))
+      const $ = render('input', examples['custom type'])
 
       const $component = $('.govuk-input')
       expect($component.attr('type')).toEqual('number')
     })
 
     it('renders with pattern attribute', () => {
-      const $ = cheerio.load(render('input', examples['with pattern attribute']))
+      const $ = render('input', examples['with pattern attribute'])
 
       const $component = $('.govuk-input')
       expect($component.attr('pattern')).toEqual('[0-9]*')
     })
 
     it('renders with value', () => {
-      const $ = cheerio.load(render('input', examples.value))
+      const $ = render('input', examples.value)
 
       const $component = $('.govuk-input')
       expect($component.val()).toEqual('QQ 12 34 56 C')
     })
 
     it('renders with aria-describedby', () => {
-      const $ = cheerio.load(render('input', examples['with describedBy']))
+      const $ = render('input', examples['with describedBy'])
 
       const $component = $('.govuk-input')
       expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('input', examples.attributes))
+      const $ = render('input', examples.attributes)
 
       const $component = $('.govuk-input')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = cheerio.load(render('input', examples['with optional form-group classes']))
+      const $ = render('input', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
     })
 
     it('doesn\'t render the input wrapper', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $wrapper = $('.govuk-form-group > .govuk-input__wrapper')
       expect($wrapper.length).toBeFalsy()
@@ -110,13 +109,13 @@ describe('Input', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = cheerio.load(render('input', examples['with hint text']))
+      const $ = render('input', examples['with hint text'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the hint', () => {
-      const $ = cheerio.load(render('input', examples['with hint text']))
+      const $ = render('input', examples['with hint text'])
 
       const $input = $('.govuk-input')
       const $hint = $('.govuk-hint')
@@ -130,7 +129,7 @@ describe('Input', () => {
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('input', examples['hint with describedBy']))
+      const $ = render('input', examples['hint with describedBy'])
 
       const $input = $('.govuk-input')
       const $hint = $('.govuk-hint')
@@ -146,13 +145,13 @@ describe('Input', () => {
 
   describe('when it includes an error message', () => {
     it('renders the error message', () => {
-      const $ = cheerio.load(render('input', examples['with error message']))
+      const $ = render('input', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the input as "described by" the error message', () => {
-      const $ = cheerio.load(render('input', examples['with error message']))
+      const $ = render('input', examples['with error message'])
 
       const $input = $('.govuk-input')
       const $errorMessage = $('.govuk-error-message')
@@ -166,7 +165,7 @@ describe('Input', () => {
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('input', examples['error with describedBy']))
+      const $ = render('input', examples['error with describedBy'])
 
       const $input = $('.govuk-input')
       const $errorMessage = $('.govuk-error-message')
@@ -180,14 +179,14 @@ describe('Input', () => {
     })
 
     it('includes the error class on the input', () => {
-      const $ = cheerio.load(render('input', examples['with error message']))
+      const $ = render('input', examples['with error message'])
 
       const $component = $('.govuk-input')
       expect($component.hasClass('govuk-input--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('input', examples['with error message']))
+      const $ = render('input', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -196,21 +195,21 @@ describe('Input', () => {
 
   describe('when it has the spellcheck attribute', () => {
     it('renders with spellcheck attribute set to true', () => {
-      const $ = cheerio.load(render('input', examples['with spellcheck enabled']))
+      const $ = render('input', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
-      const $ = cheerio.load(render('input', examples['with spellcheck disabled']))
+      const $ = render('input', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-input')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -219,7 +218,7 @@ describe('Input', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the input as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('input', examples['with error and hint']))
+      const $ = render('input', examples['with error and hint'])
 
       const $component = $('.govuk-input')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -234,7 +233,7 @@ describe('Input', () => {
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('input', examples['with error, hint and describedBy']))
+      const $ = render('input', examples['with error, hint and describedBy'])
 
       const $component = $('.govuk-input')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -251,20 +250,20 @@ describe('Input', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-input')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the input "id"', () => {
-      const $ = cheerio.load(render('input', examples.default))
+      const $ = render('input', examples.default)
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('input-example')
@@ -273,7 +272,7 @@ describe('Input', () => {
 
   describe('when it includes an autocomplete attribute', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = cheerio.load(render('input', examples['with autocomplete attribute']))
+      const $ = render('input', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-input')
       expect($component.attr('autocomplete')).toEqual('postal-code')
@@ -282,7 +281,7 @@ describe('Input', () => {
 
   describe('when it includes an inputmode', () => {
     it('renders with an inputmode attached to the input', () => {
-      const $ = cheerio.load(render('input', examples.inputmode))
+      const $ = render('input', examples.inputmode)
 
       const $component = $('.govuk-form-group > .govuk-input')
       expect($component.attr('inputmode')).toEqual('decimal')
@@ -291,21 +290,21 @@ describe('Input', () => {
 
   describe('when it includes a prefix', () => {
     it('renders the input wrapper', () => {
-      const $ = cheerio.load(render('input', examples['with prefix']))
+      const $ = render('input', examples['with prefix'])
 
       const $wrapper = $('.govuk-form-group > .govuk-input__wrapper')
       expect($wrapper.length).toBeTruthy()
     })
 
     it('renders the prefix inside the wrapper', () => {
-      const $ = cheerio.load(render('input', examples['with prefix']))
+      const $ = render('input', examples['with prefix'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
       expect($prefix.length).toBeTruthy()
     })
 
     it('renders the text in the prefix', () => {
-      const $ = cheerio.load(render('input', examples['with prefix']))
+      const $ = render('input', examples['with prefix'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
 
@@ -313,7 +312,7 @@ describe('Input', () => {
     })
 
     it('allows prefix text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('input', examples['with prefix with html as text']))
+      const $ = render('input', examples['with prefix with html as text'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
 
@@ -321,7 +320,7 @@ describe('Input', () => {
     })
 
     it('allows prefix HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('input', examples['with prefix with html']))
+      const $ = render('input', examples['with prefix with html'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
 
@@ -329,21 +328,21 @@ describe('Input', () => {
     })
 
     it('hides the prefix from screen readers using the aria-hidden attribute', () => {
-      const $ = cheerio.load(render('input', examples['with prefix']))
+      const $ = render('input', examples['with prefix'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
       expect($prefix.attr('aria-hidden')).toEqual('true')
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('input', examples['with prefix with classes']))
+      const $ = render('input', examples['with prefix with classes'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
       expect($prefix.hasClass('app-input__prefix--custom-modifier')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('input', examples['with prefix with attributes']))
+      const $ = render('input', examples['with prefix with attributes'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
       expect($prefix.attr('data-attribute')).toEqual('value')
@@ -352,21 +351,21 @@ describe('Input', () => {
 
   describe('when it includes a suffix', () => {
     it('renders the input wrapper', () => {
-      const $ = cheerio.load(render('input', examples['with suffix']))
+      const $ = render('input', examples['with suffix'])
 
       const $wrapper = $('.govuk-form-group > .govuk-input__wrapper')
       expect($wrapper.length).toBeTruthy()
     })
 
     it('renders the suffix inside the wrapper', () => {
-      const $ = cheerio.load(render('input', examples['with suffix']))
+      const $ = render('input', examples['with suffix'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
       expect($suffix.length).toBeTruthy()
     })
 
     it('renders the text in the prefix', () => {
-      const $ = cheerio.load(render('input', examples['with prefix']))
+      const $ = render('input', examples['with prefix'])
 
       const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
 
@@ -374,7 +373,7 @@ describe('Input', () => {
     })
 
     it('allows suffix text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('input', examples['with suffix with html as text']))
+      const $ = render('input', examples['with suffix with html as text'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
 
@@ -382,7 +381,7 @@ describe('Input', () => {
     })
 
     it('allows suffix HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('input', examples['with suffix with html']))
+      const $ = render('input', examples['with suffix with html'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
 
@@ -390,21 +389,21 @@ describe('Input', () => {
     })
 
     it('hides the suffix from screen readers using the aria-hidden attribute', () => {
-      const $ = cheerio.load(render('input', examples['with suffix']))
+      const $ = render('input', examples['with suffix'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
       expect($suffix.attr('aria-hidden')).toEqual('true')
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('input', examples['with suffix with classes']))
+      const $ = render('input', examples['with suffix with classes'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
       expect($suffix.hasClass('app-input__suffix--custom-modifier')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('input', examples['with suffix with attributes']))
+      const $ = render('input', examples['with suffix with attributes'])
 
       const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
       expect($suffix.attr('data-attribute')).toEqual('value')
@@ -413,7 +412,7 @@ describe('Input', () => {
 
   describe('when it includes both a prefix and a suffix', () => {
     it('renders the prefix before the suffix', () => {
-      const $ = cheerio.load(render('input', examples['with prefix and suffix']))
+      const $ = render('input', examples['with prefix and suffix'])
 
       const $prefixBeforeSuffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix ~ .govuk-input__suffix')
       expect($prefixBeforeSuffix.length).toBeTruthy()

--- a/src/govuk/components/inset-text/template.test.js
+++ b/src/govuk/components/inset-text/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,41 +11,41 @@ describe('Inset text', () => {
 
   describe('by default', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('inset-text', examples.default))
+      const $ = render('inset-text', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with classes', () => {
-      const $ = cheerio.load(render('inset-text', examples.classes))
+      const $ = render('inset-text', examples.classes)
 
       const $component = $('.govuk-inset-text')
       expect($component.hasClass('app-inset-text--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('inset-text', examples.id))
+      const $ = render('inset-text', examples.id)
 
       const $component = $('.govuk-inset-text')
       expect($component.attr('id')).toEqual('my-inset-text')
     })
 
     it('renders nested components using `call`', () => {
-      const $ = cheerio.load(render('inset-text', {}, '<div class="app-nested-component"></div>'))
+      const $ = render('inset-text', {}, '<div class="app-nested-component"></div>')
 
       expect($('.govuk-inset-text .app-nested-component').length).toBeTruthy()
     })
 
     it('allows text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('inset-text', examples['html as text']))
+      const $ = render('inset-text', examples['html as text'])
 
       const content = $('.govuk-inset-text').html().trim()
       expect(content).toEqual('It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.')
     })
 
     it('allows HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('inset-text', examples['with html']))
+      const $ = render('inset-text', examples['with html'])
 
       const mainContent = $('.govuk-inset-text .govuk-body:first-child').text().trim()
       const warningContent = $('.govuk-inset-text .govuk-warning-text__text').text().trim()
@@ -55,7 +54,7 @@ describe('Inset text', () => {
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('inset-text', examples.attributes))
+      const $ = render('inset-text', examples.attributes)
 
       const $component = $('.govuk-inset-text')
       expect($component.attr('data-attribute')).toEqual('my data value')

--- a/src/govuk/components/label/template.test.js
+++ b/src/govuk/components/label/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,21 +11,21 @@ describe('Label', () => {
 
   describe('by default', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('label', examples.default))
+      const $ = render('label', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders a label element', () => {
-      const $ = cheerio.load(render('label', examples.default))
+      const $ = render('label', examples.default)
 
       const $component = $('.govuk-label')
       expect($component.get(0).tagName).toEqual('label')
     })
 
     it('does not output anything if no html or text is provided', () => {
-      const $ = cheerio.load(render('label', examples.empty))
+      const $ = render('label', examples.empty)
 
       const $component = $('.govuk-label')
 
@@ -34,49 +33,49 @@ describe('Label', () => {
     })
 
     it('allows additional classes to be added to the component', () => {
-      const $ = cheerio.load(render('label', examples.classes))
+      const $ = render('label', examples.classes)
 
       const $component = $('.govuk-label')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('renders label text', () => {
-      const $ = cheerio.load(render('label', examples.default))
+      const $ = render('label', examples.default)
       const labelText = $('.govuk-label').text().trim()
 
       expect(labelText).toEqual('National Insurance number')
     })
 
     it('allows label text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('label', examples['html as text']))
+      const $ = render('label', examples['html as text'])
 
       const labelText = $('.govuk-label').html().trim()
       expect(labelText).toEqual('National Insurance number, &lt;em&gt;NINO&lt;/em&gt;')
     })
 
     it('allows label HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('label', examples.html))
+      const $ = render('label', examples.html)
 
       const labelText = $('.govuk-label').html().trim()
       expect(labelText).toEqual('National Insurance number <em>NINO</em>')
     })
 
     it('renders for attribute if specified', () => {
-      const $ = cheerio.load(render('label', examples.for))
+      const $ = render('label', examples.for)
 
       const labelForAttr = $('.govuk-label').attr('for')
       expect(labelForAttr).toEqual('#dummy-input')
     })
 
     it('can be nested inside an H1 using isPageHeading', () => {
-      const $ = cheerio.load(render('label', examples['as page heading l']))
+      const $ = render('label', examples['as page heading l'])
 
       const $selector = $('h1 > .govuk-label')
       expect($selector.length).toBeTruthy()
     })
 
     it('allows additional attributes to be added to the component', () => {
-      const $ = cheerio.load(render('label', examples.attributes))
+      const $ = render('label', examples.attributes)
 
       const $component = $('.govuk-label')
       expect($component.attr('first-attribute')).toEqual('foo')

--- a/src/govuk/components/notification-banner/template.test.js
+++ b/src/govuk/components/notification-banner/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,14 +11,14 @@ describe('Notification-banner', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('aria-labelledby attribute matches the title id', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
       const titleId = $('.govuk-notification-banner__title').attr('id')
 
@@ -27,42 +26,42 @@ describe('Notification-banner', () => {
     })
 
     it('has role=region attribute', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('role')).toEqual('region')
     })
 
     it('has data-module attribute to initialise JavaScript', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('data-module')).toEqual('govuk-notification-banner')
     })
 
     it('renders header container', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $header = $('.govuk-notification-banner__header')
 
       expect($header.length).toBeTruthy()
     })
 
     it('renders default heading level', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.get(0).tagName).toEqual('h2')
     })
 
     it('renders default title text', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.html().trim()).toEqual('Important')
     })
 
     it('renders content', () => {
-      const $ = cheerio.load(render('notification-banner', examples.default))
+      const $ = render('notification-banner', examples.default)
       const $content = $('.govuk-notification-banner__heading')
 
       expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
@@ -71,35 +70,35 @@ describe('Notification-banner', () => {
 
   describe('custom options', () => {
     it('renders custom title', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom title']))
+      const $ = render('notification-banner', examples['custom title'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.html().trim()).toEqual('Important information')
     })
 
     it('renders custom content', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom text']))
+      const $ = render('notification-banner', examples['custom text'])
       const $content = $('.govuk-notification-banner__heading')
 
       expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
     })
 
     it('renders custom heading level', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom title heading level']))
+      const $ = render('notification-banner', examples['custom title heading level'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.get(0).tagName).toEqual('h3')
     })
 
     it('renders custom role', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom role']))
+      const $ = render('notification-banner', examples['custom role'])
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('role')).toEqual('banner')
     })
 
     it('renders aria-labelledby attribute matching the title id when role overridden to region', () => {
-      const $ = cheerio.load(render('notification-banner', examples['role=alert overridden to role=region, with type as success']))
+      const $ = render('notification-banner', examples['role=alert overridden to role=region, with type as success'])
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
       const titleId = $('.govuk-notification-banner__title').attr('id')
 
@@ -107,42 +106,42 @@ describe('Notification-banner', () => {
     })
 
     it('renders custom title id', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom title id']))
+      const $ = render('notification-banner', examples['custom title id'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.attr('id')).toEqual('my-id')
     })
 
     it('has an aria-labelledby attribute matching the title id', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom title id']))
+      const $ = render('notification-banner', examples['custom title id'])
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
 
       expect(ariaAttr).toEqual('my-id')
     })
 
     it('adds data-disable-auto-focus="true" if disableAutoFocus is true', () => {
-      const $ = cheerio.load(render('notification-banner', examples['auto-focus disabled, with type as success']))
+      const $ = render('notification-banner', examples['auto-focus disabled, with type as success'])
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('data-disable-auto-focus')).toBe('true')
     })
 
     it('adds data-disable-auto-focus="false" if disableAutoFocus is false', () => {
-      const $ = cheerio.load(render('notification-banner', examples['auto-focus explicitly enabled, with type as success']))
+      const $ = render('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('data-disable-auto-focus')).toBe('false')
     })
 
     it('renders classes', () => {
-      const $ = cheerio.load(render('notification-banner', examples.classes))
+      const $ = render('notification-banner', examples.classes)
 
       const $component = $('.govuk-notification-banner')
       expect($component.hasClass('app-my-class')).toBeTruthy()
     })
 
     it('renders attributes', () => {
-      const $ = cheerio.load(render('notification-banner', examples.attributes))
+      const $ = render('notification-banner', examples.attributes)
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('my-attribute')).toEqual('value')
@@ -151,34 +150,34 @@ describe('Notification-banner', () => {
 
   describe('html', () => {
     it('renders title as escaped html when passed as text', () => {
-      const $ = cheerio.load(render('notification-banner', examples['title html as text']))
+      const $ = render('notification-banner', examples['title html as text'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.html().trim()).toEqual('&lt;span&gt;Important information&lt;/span&gt;')
     })
 
     it('renders nested components using `call`', () => {
-      const $ = cheerio.load(render('notification-banner', {}, '<div class="app-nested-component"></div>'))
+      const $ = render('notification-banner', {}, '<div class="app-nested-component"></div>')
 
       expect($('.govuk-notification-banner .app-nested-component').length).toBeTruthy()
     })
 
     it('renders title as html', () => {
-      const $ = cheerio.load(render('notification-banner', examples['title as html']))
+      const $ = render('notification-banner', examples['title as html'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.html().trim()).toEqual('<span>Important information</span>')
     })
 
     it('renders content as escaped html when passed as text', () => {
-      const $ = cheerio.load(render('notification-banner', examples['html as text']))
+      const $ = render('notification-banner', examples['html as text'])
       const $content = $('.govuk-notification-banner__content')
 
       expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>')
     })
 
     it('renders content as html', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with text as html']))
+      const $ = render('notification-banner', examples['with text as html'])
       const $contentHtml = $('.govuk-notification-banner__content')
 
       expect($contentHtml.html().trim()).toEqual('<h3 class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014</h3><p class="govuk-body">Archived and replaced by the <a href="#" class="govuk-notification-banner__link">new planning guidance</a> launched 6 March 2014 on an external website</p>')
@@ -187,42 +186,42 @@ describe('Notification-banner', () => {
 
   describe('when success type is passed', () => {
     it('renders with appropriate class', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with type as success']))
+      const $ = render('notification-banner', examples['with type as success'])
 
       const $component = $('.govuk-notification-banner')
       expect($component.hasClass('govuk-notification-banner--success')).toBeTruthy()
     })
 
     it('has role=alert attribute', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with type as success']))
+      const $ = render('notification-banner', examples['with type as success'])
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('role')).toEqual('alert')
     })
 
     it('does render aria-labelledby', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with type as success']))
+      const $ = render('notification-banner', examples['with type as success'])
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('aria-labelledby')).toEqual('govuk-notification-banner-title')
     })
 
     it('renders a title id for aria-labelledby', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with type as success']))
+      const $ = render('notification-banner', examples['with type as success'])
       const $component = $('.govuk-notification-banner__title')
 
       expect($component.attr('id')).toEqual('govuk-notification-banner-title')
     })
 
     it('renders default success title text', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with type as success']))
+      const $ = render('notification-banner', examples['with type as success'])
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.html().trim()).toEqual('Success')
     })
 
     it('renders custom title id and aria-labelledby', () => {
-      const $ = cheerio.load(render('notification-banner', examples['custom title id with type as success']))
+      const $ = render('notification-banner', examples['custom title id with type as success'])
       const $component = $('.govuk-notification-banner')
       const $title = $('.govuk-notification-banner__title')
 
@@ -233,14 +232,14 @@ describe('Notification-banner', () => {
 
   describe('when type that is invalid is passed', () => {
     it('has role=region attribute', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with invalid type']))
+      const $ = render('notification-banner', examples['with invalid type'])
       const $component = $('.govuk-notification-banner')
 
       expect($component.attr('role')).toEqual('region')
     })
 
     it('aria-labelledby attribute matches the title id', () => {
-      const $ = cheerio.load(render('notification-banner', examples['with invalid type']))
+      const $ = render('notification-banner', examples['with invalid type'])
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
       const titleId = $('.govuk-notification-banner__title').attr('id')
 

--- a/src/govuk/components/pagination/template.test.js
+++ b/src/govuk/components/pagination/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,14 +11,14 @@ describe('Pagination', () => {
 
   describe('default examples', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders the correct URLs for each link', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $previous = $('.govuk-pagination__prev .govuk-pagination__link')
       const $next = $('.govuk-pagination__next .govuk-pagination__link')
       const $firstNumber = $('.govuk-pagination__item:first-child .govuk-pagination__link')
@@ -34,7 +33,7 @@ describe('Pagination', () => {
     })
 
     it('renders the correct number within each pagination item', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $firstNumber = $('.govuk-pagination__item:first-child')
       const $secondNumber = $('.govuk-pagination__item:nth-child(2)')
       const $thirdNumber = $('.govuk-pagination__item:last-child')
@@ -48,7 +47,7 @@ describe('Pagination', () => {
     // Instead of the aria-label solution used for the links in the pagination because of issues caused
     // by aria-label on non-interactive elements like li's
     it('marks up the current item correctly', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $currentNumber = $('.govuk-pagination__item--current')
       const $currentNumberLink = $currentNumber.find('.govuk-pagination__link')
 
@@ -56,7 +55,7 @@ describe('Pagination', () => {
     })
 
     it('marks up pagination items as ellipses when specified', () => {
-      const $ = cheerio.load(render('pagination', examples['with many pages']))
+      const $ = render('pagination', examples['with many pages'])
       const $firstEllipsis = $('.govuk-pagination__item:nth-child(2).govuk-pagination__item--ellipses')
 
       expect($firstEllipsis).toBeTruthy()
@@ -67,14 +66,14 @@ describe('Pagination', () => {
 
   describe('with custom text, labels and landmarks', () => {
     it('renders a custom navigation landmark', () => {
-      const $ = cheerio.load(render('pagination', examples['with custom navigation landmark']))
+      const $ = render('pagination', examples['with custom navigation landmark'])
       const $nav = $('.govuk-pagination')
 
       expect($nav.attr('aria-label')).toEqual('search')
     })
 
     it('renders custom pagination item and prev/next link text', () => {
-      const $ = cheerio.load(render('pagination', examples['with custom link and item text']))
+      const $ = render('pagination', examples['with custom link and item text'])
       const $previous = $('.govuk-pagination__prev')
       const $next = $('.govuk-pagination__next')
       const $firstNumber = $('.govuk-pagination__item:first-child')
@@ -89,7 +88,7 @@ describe('Pagination', () => {
     })
 
     it('renders custom accessible labels for pagination items', () => {
-      const $ = cheerio.load(render('pagination', examples['with custom accessible labels on item links']))
+      const $ = render('pagination', examples['with custom accessible labels on item links'])
       const $firstNumber = $('.govuk-pagination__item:first-child .govuk-pagination__link')
       const $secondNumber = $('.govuk-pagination__item:nth-child(2) .govuk-pagination__link')
       const $thirdNumber = $('.govuk-pagination__item:last-child .govuk-pagination__link')
@@ -102,7 +101,7 @@ describe('Pagination', () => {
 
   describe('previous and next links', () => {
     it('applies the correct rel attribute to each link so that they communicate to search engines the intent of the links', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $previous = $('.govuk-pagination__prev .govuk-pagination__link')
       const $next = $('.govuk-pagination__next .govuk-pagination__link')
 
@@ -111,7 +110,7 @@ describe('Pagination', () => {
     })
 
     it('sets aria-hidden="true" to each link so that they are ignored by assistive technology', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $previousSvg = $('.govuk-pagination__icon--prev')
       const $nextSvg = $('.govuk-pagination__icon--next')
 
@@ -120,7 +119,7 @@ describe('Pagination', () => {
     })
 
     it('sets focusable="false" so that IE does not treat it as an interactive element', () => {
-      const $ = cheerio.load(render('pagination', examples.default))
+      const $ = render('pagination', examples.default)
       const $previousSvg = $('.govuk-pagination__icon--prev')
       const $nextSvg = $('.govuk-pagination__icon--next')
 
@@ -131,7 +130,7 @@ describe('Pagination', () => {
 
   describe('prev/next only view', () => {
     it('changes the display to prev/next only if no items are provided', () => {
-      const $ = cheerio.load(render('pagination', examples['with prev and next only']))
+      const $ = render('pagination', examples['with prev and next only'])
       const $blockNav = $('.govuk-pagination--block')
       const $previous = $('.govuk-pagination__prev')
       const $next = $('.govuk-pagination__next')
@@ -142,7 +141,7 @@ describe('Pagination', () => {
     })
 
     it('applies labels when provided', () => {
-      const $ = cheerio.load(render('pagination', examples['with prev and next only and labels']))
+      const $ = render('pagination', examples['with prev and next only and labels'])
       const $prevLabel = $('.govuk-pagination__prev .govuk-pagination__link-label')
       const $nextLabel = $('.govuk-pagination__next .govuk-pagination__link-label')
 
@@ -154,7 +153,7 @@ describe('Pagination', () => {
     // We apply a decoration class and add a hover state to the main link text instead
     // of the label so that there's a clear underline hover state on the link
     it('adds the decoration class to the link title if no label is present', () => {
-      const $ = cheerio.load(render('pagination', examples['with prev and next only']))
+      const $ = render('pagination', examples['with prev and next only'])
       const $decoratedPreviousLinkTitle = $('.govuk-pagination__prev .govuk-pagination__link-title--decorated')
       const $decoratedNextLinkTitle = $('.govuk-pagination__next .govuk-pagination__link-title--decorated')
 
@@ -165,13 +164,13 @@ describe('Pagination', () => {
 
   describe('custom classes and attributes', () => {
     it('renders with custom additional classes', () => {
-      const $ = cheerio.load(render('pagination', examples['with custom classes']))
+      const $ = render('pagination', examples['with custom classes'])
 
       expect($('.govuk-pagination').hasClass('my-custom-class')).toBeTruthy()
     })
 
     it('renders with custom attributes', () => {
-      const $ = cheerio.load(render('pagination', examples['with custom attributes']))
+      const $ = render('pagination', examples['with custom attributes'])
       const $nav = $('.govuk-pagination')
 
       expect($nav.attr('data-attribute-1')).toEqual('value-1')

--- a/src/govuk/components/panel/template.test.js
+++ b/src/govuk/components/panel/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,35 +11,35 @@ describe('Panel', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('panel', examples.default))
+      const $ = render('panel', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders title text', () => {
-      const $ = cheerio.load(render('panel', examples.default))
+      const $ = render('panel', examples.default)
       const panelTitle = $('.govuk-panel__title').text().trim()
 
       expect(panelTitle).toEqual('Application complete')
     })
 
     it('renders title as h1 (as the default heading level)', () => {
-      const $ = cheerio.load(render('panel', examples.default))
+      const $ = render('panel', examples.default)
       const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
       expect(panelTitleHeadingLevel).toEqual('h1')
     })
 
     it('renders body text', () => {
-      const $ = cheerio.load(render('panel', examples.default))
+      const $ = render('panel', examples.default)
       const panelBodyText = $('.govuk-panel__body').text().trim()
 
       expect(panelBodyText).toEqual('Your reference number: HDJ2123F')
     })
 
     it('doesnt render panel body if no body text is passed', () => {
-      const $ = cheerio.load(render('panel', examples['title with no body text']))
+      const $ = render('panel', examples['title with no body text'])
       const panelBody = $('.govuk-panel__body').length
 
       expect(panelBody).toBeFalsy()
@@ -49,55 +48,55 @@ describe('Panel', () => {
 
   describe('custom options', () => {
     it('allows title text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('panel', examples['title html as text']))
+      const $ = render('panel', examples['title html as text'])
 
       const panelTitle = $('.govuk-panel__title').html().trim()
       expect(panelTitle).toEqual('Application &lt;strong&gt;not&lt;/strong&gt; complete')
     })
 
     it('renders title as specified heading level', () => {
-      const $ = cheerio.load(render('panel', examples['custom heading level']))
+      const $ = render('panel', examples['custom heading level'])
       const panelTitleHeadingLevel = $('.govuk-panel__title')[0].name
 
       expect(panelTitleHeadingLevel).toEqual('h2')
     })
 
     it('allows title HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('panel', examples['title html']))
+      const $ = render('panel', examples['title html'])
 
       const panelTitle = $('.govuk-panel__title').html().trim()
       expect(panelTitle).toEqual('Application <strong>not</strong> complete')
     })
 
     it('renders nested components using `call`', () => {
-      const $ = cheerio.load(render('panel', {}, '<div class="app-nested-component"></div>'))
+      const $ = render('panel', {}, '<div class="app-nested-component"></div>')
 
       expect($('.govuk-panel .app-nested-component').length).toBeTruthy()
     })
 
     it('allows body text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('panel', examples['body html as text']))
+      const $ = render('panel', examples['body html as text'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
       expect(panelBodyText).toEqual('Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;')
     })
 
     it('allows body HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('panel', examples['body html']))
+      const $ = render('panel', examples['body html'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
       expect(panelBodyText).toEqual('Your reference number<br><strong>HDJ2123F</strong>')
     })
 
     it('allows additional classes to be added to the component', () => {
-      const $ = cheerio.load(render('panel', examples.classes))
+      const $ = render('panel', examples.classes)
 
       const $component = $('.govuk-panel')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('allows additional attributes to be added to the component', () => {
-      const $ = cheerio.load(render('panel', examples.attributes))
+      const $ = render('panel', examples.attributes)
 
       const $component = $('.govuk-panel')
       expect($component.attr('first-attribute')).toEqual('foo')

--- a/src/govuk/components/phase-banner/template.test.js
+++ b/src/govuk/components/phase-banner/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,42 +11,42 @@ describe('Phase banner', () => {
 
   describe('by default', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('phase-banner', examples.default))
+      const $ = render('phase-banner', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('allows additional classes to be added to the component', () => {
-      const $ = cheerio.load(render('phase-banner', examples.classes))
+      const $ = render('phase-banner', examples.classes)
 
       const $component = $('.govuk-phase-banner')
       expect($component.hasClass('extra-class one-more-class')).toBeTruthy()
     })
 
     it('renders banner text', () => {
-      const $ = cheerio.load(render('phase-banner', examples.text))
+      const $ = render('phase-banner', examples.text)
       const phaseBannerText = $('.govuk-phase-banner__text').text().trim()
 
       expect(phaseBannerText).toEqual('This is a new service – your feedback will help us to improve it')
     })
 
     it('allows body text to be passed whilst escaping HTML entities', () => {
-      const $ = cheerio.load(render('phase-banner', examples['html as text']))
+      const $ = render('phase-banner', examples['html as text'])
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
       expect(phaseBannerText).toEqual('This is a new service - your &lt;a href="#" class="govuk-link"&gt;feedback&lt;/a&gt; will help us to improve it.')
     })
 
     it('allows body HTML to be passed un-escaped', () => {
-      const $ = cheerio.load(render('phase-banner', examples.default))
+      const $ = render('phase-banner', examples.default)
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
       expect(phaseBannerText).toEqual('This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.')
     })
 
     it('allows additional attributes to be added to the component', () => {
-      const $ = cheerio.load(render('phase-banner', examples.attributes))
+      const $ = render('phase-banner', examples.attributes)
 
       const $component = $('.govuk-phase-banner')
       expect($component.attr('first-attribute')).toEqual('foo')
@@ -57,19 +56,19 @@ describe('Phase banner', () => {
 
   describe('with dependant components', () => {
     it('renders the tag component text', () => {
-      const $ = cheerio.load(render('phase-banner', examples.default))
+      const $ = render('phase-banner', examples.default)
 
       expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
     })
 
     it('renders the tag component html', () => {
-      const $ = cheerio.load(render('phase-banner', examples['tag html']))
+      const $ = render('phase-banner', examples['tag html'])
 
       expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
     })
 
     it('renders the tag component classes', () => {
-      const $ = cheerio.load(render('phase-banner', examples['tag classes']))
+      const $ = render('phase-banner', examples['tag classes'])
 
       expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
     })

--- a/src/govuk/components/radios/template.test.js
+++ b/src/govuk/components/radios/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -14,14 +13,14 @@ describe('Radios', () => {
   })
 
   it('default example passes accessibility tests', async () => {
-    const $ = cheerio.load(render('radios', examples.default))
+    const $ = render('radios', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('render example with minimum required name and items', () => {
-    const $ = cheerio.load(render('radios', examples.default))
+    const $ = render('radios', examples.default)
 
     const $component = $('.govuk-radios')
 
@@ -39,7 +38,7 @@ describe('Radios', () => {
   })
 
   it('renders without falsely items', () => {
-    const $ = cheerio.load(render('radios', examples['with falsey items']))
+    const $ = render('radios', examples['with falsey items'])
 
     const $component = $('.govuk-radios')
     const $items = $component.find('.govuk-radios__item input')
@@ -47,7 +46,7 @@ describe('Radios', () => {
   })
 
   it('render classes', () => {
-    const $ = cheerio.load(render('radios', examples.inline))
+    const $ = render('radios', examples.inline)
 
     const $component = $('.govuk-radios')
 
@@ -57,14 +56,14 @@ describe('Radios', () => {
   it('renders initial aria-describedby on fieldset', () => {
     const describedById = 'some-id'
 
-    const $ = cheerio.load(render('radios', examples['fieldset with describedBy']))
+    const $ = render('radios', examples['fieldset with describedBy'])
 
     const $fieldset = $('.govuk-fieldset')
     expect($fieldset.attr('aria-describedby')).toMatch(describedById)
   })
 
   it('render attributes', () => {
-    const $ = cheerio.load(render('radios', examples.attributes))
+    const $ = render('radios', examples.attributes)
 
     const $component = $('.govuk-radios')
 
@@ -73,7 +72,7 @@ describe('Radios', () => {
   })
 
   it('render a custom class on the form group', () => {
-    const $ = cheerio.load(render('radios', examples['with optional form-group classes showing group error']))
+    const $ = render('radios', examples['with optional form-group classes showing group error'])
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -81,7 +80,7 @@ describe('Radios', () => {
 
   describe('items', () => {
     it('render a matching label and input using name by default', () => {
-      const $ = cheerio.load(render('radios', examples.default))
+      const $ = render('radios', examples.default)
 
       const $component = $('.govuk-radios')
 
@@ -97,7 +96,7 @@ describe('Radios', () => {
     })
 
     it('render a matching label and input using custom idPrefix', () => {
-      const $ = cheerio.load(render('radios', examples['with idPrefix']))
+      const $ = render('radios', examples['with idPrefix'])
 
       const $component = $('.govuk-radios')
 
@@ -113,7 +112,7 @@ describe('Radios', () => {
     })
 
     it('render disabled', () => {
-      const $ = cheerio.load(render('radios', examples['with disabled']))
+      const $ = render('radios', examples['with disabled'])
 
       const $component = $('.govuk-radios')
 
@@ -122,7 +121,7 @@ describe('Radios', () => {
     })
 
     it('render checked', () => {
-      const $ = cheerio.load(render('radios', examples.prechecked))
+      const $ = render('radios', examples.prechecked)
 
       const $component = $('.govuk-radios')
       const $lastInput = $component.find('.govuk-radios__item:last-child input')
@@ -130,7 +129,7 @@ describe('Radios', () => {
     })
 
     it('checks the radio that matches value', () => {
-      const $ = cheerio.load(render('radios', examples['prechecked using value']))
+      const $ = render('radios', examples['prechecked using value'])
 
       const $component = $('.govuk-radios')
       const $lastInput = $component.find('input[value="no"]')
@@ -138,7 +137,7 @@ describe('Radios', () => {
     })
 
     it('allows item.checked to override value', () => {
-      const $ = cheerio.load(render('radios', examples['item checked overrides value']))
+      const $ = render('radios', examples['item checked overrides value'])
 
       const $green = $('.govuk-radios').find('input[value="green"]')
       expect($green.attr('checked')).toBeUndefined()
@@ -146,7 +145,7 @@ describe('Radios', () => {
 
     describe('when they include attributes', () => {
       it('it renders the attributes', () => {
-        const $ = cheerio.load(render('radios', examples['items with attributes']))
+        const $ = render('radios', examples['items with attributes'])
 
         const $component = $('.govuk-radios')
 
@@ -162,20 +161,20 @@ describe('Radios', () => {
 
     describe('when they include a hint', () => {
       it('it renders the hint text', () => {
-        const $ = cheerio.load(render('radios', examples['with hints on items']))
+        const $ = render('radios', examples['with hints on items'])
 
         expect($('.govuk-radios__hint').text())
           .toContain('You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.')
       })
 
       it('it renders the correct id attribute for the hint', () => {
-        const $ = cheerio.load(render('radios', examples['with hints on items']))
+        const $ = render('radios', examples['with hints on items'])
 
         expect($('.govuk-radios__hint').attr('id')).toBe('gateway-item-hint')
       })
 
       it('the input describedBy attribute matches the item hint id', () => {
-        const $ = cheerio.load(render('radios', examples['with hints on items']))
+        const $ = render('radios', examples['with hints on items'])
 
         expect($('.govuk-radios__input').attr('aria-describedby')).toBe('gateway-item-hint')
       })
@@ -183,7 +182,7 @@ describe('Radios', () => {
 
     describe('render conditionals', () => {
       it('hidden by default when not checked', () => {
-        const $ = cheerio.load(render('radios', examples['with conditional items']))
+        const $ = render('radios', examples['with conditional items'])
 
         const $component = $('.govuk-radios')
 
@@ -193,7 +192,7 @@ describe('Radios', () => {
       })
 
       it('visible when checked because of checkedValue', () => {
-        const $ = cheerio.load(render('radios', examples['with conditional items and pre-checked value']))
+        const $ = render('radios', examples['with conditional items and pre-checked value'])
 
         const $conditional = $('.govuk-radios__conditional').last()
         expect($conditional.text()).toContain('Mobile phone number')
@@ -201,7 +200,7 @@ describe('Radios', () => {
       })
 
       it('visible by default when checked', () => {
-        const $ = cheerio.load(render('radios', examples['with conditional item checked']))
+        const $ = render('radios', examples['with conditional item checked'])
 
         const $component = $('.govuk-radios')
 
@@ -211,7 +210,7 @@ describe('Radios', () => {
       })
 
       it('with association to the input they are controlled by', () => {
-        const $ = cheerio.load(render('radios', examples['with conditional items']))
+        const $ = render('radios', examples['with conditional items'])
 
         const $component = $('.govuk-radios')
 
@@ -223,14 +222,14 @@ describe('Radios', () => {
       })
 
       it('omits empty conditionals', () => {
-        const $ = cheerio.load(render('radios', examples['with empty conditional']))
+        const $ = render('radios', examples['with empty conditional'])
 
         const $component = $('.govuk-radios')
         expect($component.find('.govuk-radios__conditional').length).toEqual(0)
       })
 
       it('does not associate radios with empty conditionals', () => {
-        const $ = cheerio.load(render('radios', examples['with empty conditional']))
+        const $ = render('radios', examples['with empty conditional'])
 
         const $input = $('.govuk-radios__input').first()
         expect($input.attr('data-aria-controls')).toBeFalsy()
@@ -238,7 +237,7 @@ describe('Radios', () => {
     })
 
     it('render divider', () => {
-      const $ = cheerio.load(render('radios', examples['with a divider']))
+      const $ = render('radios', examples['with a divider'])
 
       const $component = $('.govuk-radios')
       const $divider = $component.find('.govuk-radios__divider')
@@ -246,7 +245,7 @@ describe('Radios', () => {
     })
 
     it('render additional label classes', () => {
-      const $ = cheerio.load(render('radios', examples['label with classes']))
+      const $ = render('radios', examples['label with classes'])
 
       const $component = $('.govuk-radios')
       const $label = $component.find('.govuk-radios__item label')
@@ -254,7 +253,7 @@ describe('Radios', () => {
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('radios', examples.default))
+      const $ = render('radios', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -263,13 +262,13 @@ describe('Radios', () => {
 
   describe('when they include a hint', () => {
     it('renders the hint', () => {
-      const $ = cheerio.load(render('radios', examples['with hints on parent and items']))
+      const $ = render('radios', examples['with hints on parent and items'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the fieldset as "described by" the hint', () => {
-      const $ = cheerio.load(render('radios', examples['with hints on parent and items']))
+      const $ = render('radios', examples['with hints on parent and items'])
 
       const $fieldset = $('.govuk-fieldset')
 
@@ -277,7 +276,7 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('radios', examples['with describedBy and hint']))
+      const $ = render('radios', examples['with describedBy and hint'])
       const $fieldset = $('.govuk-fieldset')
 
       expect($fieldset.attr('aria-describedby')).toMatch('some-id')
@@ -286,20 +285,20 @@ describe('Radios', () => {
 
   describe('when they include an error message', () => {
     it('renders the error message', () => {
-      const $ = cheerio.load(render('radios', examples['with error message']))
+      const $ = render('radios', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('uses the idPrefix for the error message id if provided', () => {
-      const $ = cheerio.load(render('radios', examples['with error message and idPrefix']))
+      const $ = render('radios', examples['with error message and idPrefix'])
       const $errorMessage = $('.govuk-error-message')
 
       expect($errorMessage.attr('id')).toEqual('id-prefix-error')
     })
 
     it('falls back to using the name for the error message id', () => {
-      const $ = cheerio.load(render('radios', examples['with error message']))
+      const $ = render('radios', examples['with error message'])
 
       const $errorMessage = $('.govuk-error-message')
 
@@ -307,7 +306,7 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = cheerio.load(render('radios', examples['with fieldset and error message']))
+      const $ = render('radios', examples['with fieldset and error message'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -321,7 +320,7 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('radios', examples['with fieldset, error message and describedBy']))
+      const $ = render('radios', examples['with fieldset, error message and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -335,7 +334,7 @@ describe('Radios', () => {
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('radios', examples['with error message']))
+      const $ = render('radios', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -344,7 +343,7 @@ describe('Radios', () => {
 
   describe('when they include both a hint and an error message', () => {
     it('associates the fieldset as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('radios', examples['with hint and error message']))
+      const $ = render('radios', examples['with hint and error message'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -359,7 +358,7 @@ describe('Radios', () => {
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('radios', examples['with hint, error message and describedBy']))
+      const $ = render('radios', examples['with hint, error message and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -376,26 +375,26 @@ describe('Radios', () => {
 
   describe('nested dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('radios', examples.inline))
+      const $ = render('radios', examples.inline)
 
       const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
       expect($component.length).toBeTruthy()
     })
 
     it('passes through label params without breaking', () => {
-      const $ = cheerio.load(render('radios', examples['label with attributes']))
+      const $ = render('radios', examples['label with attributes'])
 
       expect(htmlWithClassName($, '.govuk-radios__label')).toMatchSnapshot()
     })
 
     it('passes through fieldset params without breaking', () => {
-      const $ = cheerio.load(render('radios', examples['fieldset params']))
+      const $ = render('radios', examples['fieldset params'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })
 
     it('passes through html fieldset params without breaking', () => {
-      const $ = cheerio.load(render('radios', examples['fieldset with html']))
+      const $ = render('radios', examples['fieldset with html'])
 
       expect(htmlWithClassName($, '.govuk-fieldset')).toMatchSnapshot()
     })

--- a/src/govuk/components/select/template.test.js
+++ b/src/govuk/components/select/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -15,90 +14,90 @@ describe('Select', () => {
 
   describe('by default', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
       expect($component.attr('id')).toEqual('select-1')
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $component = $('.govuk-select')
       expect($component.attr('name')).toEqual('select-1')
     })
 
     it('renders with items', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
       const $items = $('.govuk-select option')
       expect($items.length).toEqual(3)
     })
 
     it('renders item with value', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
       expect($firstItem.attr('value')).toEqual('1')
     })
 
     it('renders item with text', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $firstItem = $('.govuk-select option:first-child')
       expect($firstItem.text()).toEqual('GOV.UK frontend option 1')
     })
 
     it('renders item with selected', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $selectedItem = $('.govuk-select option:nth-child(2)')
       expect($selectedItem.attr('selected')).toBeTruthy()
     })
 
     it('selects options using selected value', () => {
-      const $ = cheerio.load(render('select', examples['with selected value']))
+      const $ = render('select', examples['with selected value'])
 
       const $selectedItem = $('option[value="2"]')
       expect($selectedItem.attr('selected')).toBeTruthy()
     })
 
     it('allows item.selected to override value', () => {
-      const $ = cheerio.load(render('select', examples['item selected overrides value']))
+      const $ = render('select', examples['item selected overrides value'])
 
       const $selectedItem = $('option[value="green"]')
       expect($selectedItem.attr('selected')).toBeUndefined()
     })
 
     it('renders item with disabled', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $disabledItem = $('.govuk-select option:last-child')
       expect($disabledItem.attr('disabled')).toBeTruthy()
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = cheerio.load(render('select', examples['with optional form-group classes']))
+      const $ = render('select', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
     })
 
     it('renders without falsely items', () => {
-      const $ = cheerio.load(render('select', examples['with falsey values']))
+      const $ = render('select', examples['with falsey values'])
 
       const $items = $('.govuk-select option')
       expect($items.length).toEqual(2)
@@ -107,28 +106,28 @@ describe('Select', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('select', examples['with full width override']))
+      const $ = render('select', examples['with full width override'])
 
       const $component = $('.govuk-select')
       expect($component.hasClass('govuk-!-width-full')).toBeTruthy()
     })
 
     it('renders with aria-describedby', () => {
-      const $ = cheerio.load(render('select', examples['with describedBy']))
+      const $ = render('select', examples['with describedBy'])
 
       const $component = $('.govuk-select')
       expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('select', examples.attributes))
+      const $ = render('select', examples.attributes)
 
       const $component = $('.govuk-select')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with attributes on items', () => {
-      const $ = cheerio.load(render('select', examples['attributes on items']))
+      const $ = render('select', examples['attributes on items'])
 
       const $component = $('.govuk-select')
 
@@ -144,13 +143,13 @@ describe('Select', () => {
 
   describe('when it includes a hint', () => {
     it('renders the hint', () => {
-      const $ = cheerio.load(render('select', examples.hint))
+      const $ = render('select', examples.hint)
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the select as "described by" the hint', () => {
-      const $ = cheerio.load(render('select', examples.hint))
+      const $ = render('select', examples.hint)
 
       const $select = $('.govuk-select')
       const $hint = $('.govuk-hint')
@@ -164,7 +163,7 @@ describe('Select', () => {
     })
 
     it('associates the select as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('select', examples['hint and describedBy']))
+      const $ = render('select', examples['hint and describedBy'])
 
       const $select = $('.govuk-select')
 
@@ -175,13 +174,13 @@ describe('Select', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = cheerio.load(render('select', examples.error))
+      const $ = render('select', examples.error)
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the select as "described by" the error message', () => {
-      const $ = cheerio.load(render('select', examples.error))
+      const $ = render('select', examples.error)
 
       const $input = $('.govuk-select')
       const $errorMessage = $('.govuk-error-message')
@@ -195,7 +194,7 @@ describe('Select', () => {
     })
 
     it('associates the select as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('select', examples['error and describedBy']))
+      const $ = render('select', examples['error and describedBy'])
 
       const $input = $('.govuk-select')
 
@@ -204,14 +203,14 @@ describe('Select', () => {
     })
 
     it('adds the error class to the select', () => {
-      const $ = cheerio.load(render('select', examples.error))
+      const $ = render('select', examples.error)
 
       const $component = $('.govuk-select')
       expect($component.hasClass('govuk-select--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('select', examples.error))
+      const $ = render('select', examples.error)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -220,7 +219,7 @@ describe('Select', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the select as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('select', examples['with hint text and error message']))
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-select')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -235,7 +234,7 @@ describe('Select', () => {
     })
 
     it('associates the select as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('select', examples['with hint text and error message']))
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-select')
 
@@ -246,20 +245,20 @@ describe('Select', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('select', examples['with hint text and error message']))
+      const $ = render('select', examples['with hint text and error message'])
 
       const $component = $('.govuk-form-group > .govuk-select')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the select "id"', () => {
-      const $ = cheerio.load(render('select', examples.default))
+      const $ = render('select', examples.default)
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('select-1')

--- a/src/govuk/components/skip-link/template.test.js
+++ b/src/govuk/components/skip-link/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,21 +11,21 @@ describe('Skip link', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('skip-link', examples.default))
+      const $ = render('skip-link', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders text', () => {
-      const $ = cheerio.load(render('skip-link', examples.default))
+      const $ = render('skip-link', examples.default)
 
       const $component = $('.govuk-skip-link')
       expect($component.html()).toEqual('Skip to main content')
     })
 
     it('renders default href', () => {
-      const $ = cheerio.load(render('skip-link', examples['no href']))
+      const $ = render('skip-link', examples['no href'])
 
       const $component = $('.govuk-skip-link')
       expect($component.attr('href')).toEqual('#content')
@@ -35,42 +34,42 @@ describe('Skip link', () => {
 
   describe('custom options', () => {
     it('renders href', () => {
-      const $ = cheerio.load(render('skip-link', examples['custom href']))
+      const $ = render('skip-link', examples['custom href'])
 
       const $component = $('.govuk-skip-link')
       expect($component.attr('href')).toEqual('#custom')
     })
 
     it('renders text', () => {
-      const $ = cheerio.load(render('skip-link', examples['custom text']))
+      const $ = render('skip-link', examples['custom text'])
 
       const $component = $('.govuk-skip-link')
       expect($component.html()).toEqual('skip')
     })
 
     it('renders escaped html in text', () => {
-      const $ = cheerio.load(render('skip-link', examples['html as text']))
+      const $ = render('skip-link', examples['html as text'])
 
       const $component = $('.govuk-skip-link')
       expect($component.html()).toEqual('&lt;p&gt;skip&lt;/p&gt;')
     })
 
     it('renders html', () => {
-      const $ = cheerio.load(render('skip-link', examples.html))
+      const $ = render('skip-link', examples.html)
 
       const $component = $('.govuk-skip-link')
       expect($component.html()).toEqual('<p>skip</p>')
     })
 
     it('renders classes', () => {
-      const $ = cheerio.load(render('skip-link', examples.classes))
+      const $ = render('skip-link', examples.classes)
 
       const $component = $('.govuk-skip-link')
       expect($component.hasClass('app-skip-link--custom-class')).toBeTruthy()
     })
 
     it('renders attributes', () => {
-      const $ = cheerio.load(render('skip-link', examples.attributes))
+      const $ = render('skip-link', examples.attributes)
 
       const $component = $('.govuk-skip-link')
       expect($component.attr('data-test')).toEqual('attribute')
@@ -78,7 +77,7 @@ describe('Skip link', () => {
     })
 
     it('renders a data-module attribute to initialise JavaScript', () => {
-      const $ = cheerio.load(render('skip-link', examples.default))
+      const $ = render('skip-link', examples.default)
 
       const $component = $('.govuk-skip-link')
 

--- a/src/govuk/components/summary-list/template.test.js
+++ b/src/govuk/components/summary-list/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,7 +11,7 @@ describe('Summary list', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('summary-list', examples.default))
+      const $ = render('summary-list', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
@@ -21,14 +20,14 @@ describe('Summary list', () => {
 
   describe('custom options', () => {
     it('renders classes', async () => {
-      const $ = cheerio.load(render('summary-list', examples['no-border']))
+      const $ = render('summary-list', examples['no-border'])
 
       const $component = $('.govuk-summary-list')
       expect($component.hasClass('govuk-summary-list--no-border')).toBeTruthy()
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('summary-list', examples.attributes))
+      const $ = render('summary-list', examples.attributes)
 
       const $component = $('.govuk-summary-list')
       expect($component.attr('data-attribute-1')).toEqual('value-1')
@@ -38,7 +37,7 @@ describe('Summary list', () => {
 
   describe('rows', () => {
     it('renders list without falsely values', async () => {
-      const $ = cheerio.load(render('summary-list', examples['with falsey values']))
+      const $ = render('summary-list', examples['with falsey values'])
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')
@@ -46,7 +45,7 @@ describe('Summary list', () => {
     })
 
     it('renders classes', async () => {
-      const $ = cheerio.load(render('summary-list', examples['rows with classes']))
+      const $ = render('summary-list', examples['rows with classes'])
 
       const $component = $('.govuk-summary-list')
       const $row = $component.find('.govuk-summary-list__row')
@@ -55,7 +54,7 @@ describe('Summary list', () => {
 
     describe('keys', () => {
       it('renders text', async () => {
-        const $ = cheerio.load(render('summary-list', examples.default))
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
@@ -64,7 +63,7 @@ describe('Summary list', () => {
       })
 
       it('renders html', async () => {
-        const $ = cheerio.load(render('summary-list', examples['key with html']))
+        const $ = render('summary-list', examples['key with html'])
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
@@ -73,7 +72,7 @@ describe('Summary list', () => {
       })
 
       it('renders classes', async () => {
-        const $ = cheerio.load(render('summary-list', examples['key with classes']))
+        const $ = render('summary-list', examples['key with classes'])
 
         const $component = $('.govuk-summary-list')
         const $key = $component.find('dt.govuk-summary-list__key')
@@ -83,7 +82,7 @@ describe('Summary list', () => {
 
     describe('values', () => {
       it('renders text', async () => {
-        const $ = cheerio.load(render('summary-list', examples.default))
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
@@ -92,7 +91,7 @@ describe('Summary list', () => {
       })
 
       it('renders html', async () => {
-        const $ = cheerio.load(render('summary-list', examples['value with html']))
+        const $ = render('summary-list', examples['value with html'])
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
@@ -101,7 +100,7 @@ describe('Summary list', () => {
       })
 
       it('renders classes', async () => {
-        const $ = cheerio.load(render('summary-list', examples['overridden-widths']))
+        const $ = render('summary-list', examples['overridden-widths'])
 
         const $component = $('.govuk-summary-list')
         const $value = $component.find('dd.govuk-summary-list__value')
@@ -111,7 +110,7 @@ describe('Summary list', () => {
 
     describe('actions', () => {
       it('renders href', async () => {
-        const $ = cheerio.load(render('summary-list', examples['actions href']))
+        const $ = render('summary-list', examples['actions href'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -120,7 +119,7 @@ describe('Summary list', () => {
       })
 
       it('renders text', async () => {
-        const $ = cheerio.load(render('summary-list', examples['with actions']))
+        const $ = render('summary-list', examples['with actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -129,7 +128,7 @@ describe('Summary list', () => {
       })
 
       it('renders html', async () => {
-        const $ = cheerio.load(render('summary-list', examples['actions with html']))
+        const $ = render('summary-list', examples['actions with html'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -138,7 +137,7 @@ describe('Summary list', () => {
       })
 
       it('allows the visually hidden prefix to be removed and then manually added with HTML', async () => {
-        const $ = cheerio.load(render('summary-list', examples.translated))
+        const $ = render('summary-list', examples.translated)
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -147,7 +146,7 @@ describe('Summary list', () => {
       })
 
       it('renders custom accessible name', async () => {
-        const $ = cheerio.load(render('summary-list', examples['with actions']))
+        const $ = render('summary-list', examples['with actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -155,7 +154,7 @@ describe('Summary list', () => {
       })
 
       it('renders classes', async () => {
-        const $ = cheerio.load(render('summary-list', examples['actions with classes']))
+        const $ = render('summary-list', examples['actions with classes'])
 
         const $component = $('.govuk-summary-list')
         const $actionList = $component.find('.govuk-summary-list__actions')
@@ -164,7 +163,7 @@ describe('Summary list', () => {
       })
 
       it('renders attributes', async () => {
-        const $ = cheerio.load(render('summary-list', examples['actions with attributes']))
+        const $ = render('summary-list', examples['actions with attributes'])
 
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
@@ -174,7 +173,7 @@ describe('Summary list', () => {
       })
 
       it('renders a single anchor with one action', async () => {
-        const $ = cheerio.load(render('summary-list', examples['single action with anchor']))
+        const $ = render('summary-list', examples['single action with anchor'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions > a')
@@ -183,7 +182,7 @@ describe('Summary list', () => {
       })
 
       it('renders a list with mutliple actions', async () => {
-        const $ = cheerio.load(render('summary-list', examples['with some actions']))
+        const $ = render('summary-list', examples['with some actions'])
 
         const $component = $('.govuk-summary-list')
         const $actionList = $component.find('.govuk-summary-list__actions')
@@ -193,7 +192,7 @@ describe('Summary list', () => {
       })
 
       it('renders classes on actions', async () => {
-        const $ = cheerio.load(render('summary-list', examples['classes on items']))
+        const $ = render('summary-list', examples['classes on items'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions > a')
@@ -202,7 +201,7 @@ describe('Summary list', () => {
       })
 
       it('skips the action column when no array is provided', async () => {
-        const $ = cheerio.load(render('summary-list', examples.default))
+        const $ = render('summary-list', examples.default)
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
@@ -211,7 +210,7 @@ describe('Summary list', () => {
       })
 
       it('skips the action column when no items are in the array provided', async () => {
-        const $ = cheerio.load(render('summary-list', examples['empty items array']))
+        const $ = render('summary-list', examples['empty items array'])
 
         const $component = $('.govuk-summary-list')
         const $action = $component.find('.govuk-summary-list__actions')
@@ -224,7 +223,7 @@ describe('Summary list', () => {
         let $component
 
         beforeAll(() => {
-          $ = cheerio.load(render('summary-list', examples['with some actions']))
+          $ = render('summary-list', examples['with some actions'])
           $component = $('.govuk-summary-list')
         })
 
@@ -251,7 +250,7 @@ describe('Summary list', () => {
         let $component
 
         beforeAll(() => {
-          $ = cheerio.load(render('summary-list', examples.default))
+          $ = render('summary-list', examples.default)
           $component = $('.govuk-summary-list')
         })
 
@@ -271,7 +270,7 @@ describe('Summary list', () => {
 
   describe('summary card', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('summary-list', examples['as a summary card with a text header']))
+      const $ = render('summary-list', examples['as a summary card with a text header'])
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
@@ -284,14 +283,14 @@ describe('Summary list', () => {
     // This is already tested in depth in the 'actions' describe above.
     describe('actions', () => {
       it('renders actions', () => {
-        const $ = cheerio.load(render('summary-list', examples['as a summary card with actions']))
+        const $ = render('summary-list', examples['as a summary card with actions'])
 
         const $actionItems = $('.govuk-summary-card__action')
         expect($actionItems.length).toBe(2)
       })
 
       it('does not render a list if only one action is present', () => {
-        const $ = cheerio.load(render('summary-list', examples['summary card with only 1 action']))
+        const $ = render('summary-list', examples['summary card with only 1 action'])
 
         const $singleAction = $('.govuk-summary-card__actions > a')
         const $actionItems = $('.govuk-summary-card__action')
@@ -302,21 +301,21 @@ describe('Summary list', () => {
 
     describe('title', () => {
       it('renders with a text title', () => {
-        const $ = cheerio.load(render('summary-list', examples['as a summary card with a text header']))
+        const $ = render('summary-list', examples['as a summary card with a text header'])
 
         const $title = $('.govuk-summary-card__title')
         expect($title.text()).toContain('Undergraduate teaching assistant')
       })
 
       it('renders with a html title', () => {
-        const $ = cheerio.load(render('summary-list', examples['as a summary card with a html header']))
+        const $ = render('summary-list', examples['as a summary card with a html header'])
 
         const $title = $('.govuk-summary-card__title')
         expect($title.html()).toContain('<em>Undergraduate teaching assistant</em>')
       })
 
       it('renders with a custom heading level', () => {
-        const $ = cheerio.load(render('summary-list', examples['as a summary card with a custom header level']))
+        const $ = render('summary-list', examples['as a summary card with a custom header level'])
 
         const $title = $('.govuk-summary-card__title')
         expect($title.get(0).tagName).toEqual('h3')
@@ -325,7 +324,7 @@ describe('Summary list', () => {
 
     describe('custom options', () => {
       it('renders custom classes on the summary card', () => {
-        const $ = cheerio.load(render('summary-list', examples['summary card with custom classes']))
+        const $ = render('summary-list', examples['summary card with custom classes'])
 
         const $list = $('.govuk-summary-list')
         const $card = $('.govuk-summary-card')
@@ -334,7 +333,7 @@ describe('Summary list', () => {
       })
 
       it('renders with attributes on the summary card', () => {
-        const $ = cheerio.load(render('summary-list', examples['summary card with custom attributes']))
+        const $ = render('summary-list', examples['summary card with custom attributes'])
 
         const $list = $('.govuk-summary-list')
         const $card = $('.govuk-summary-card')

--- a/src/govuk/components/table/template.test.js
+++ b/src/govuk/components/table/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -11,20 +10,20 @@ describe('Table', () => {
   })
 
   it('passes basic accessibility tests', async () => {
-    const $ = cheerio.load(render('table', examples.default))
+    const $ = render('table', examples.default)
 
     const results = await axe($.html())
     expect(results).toHaveNoViolations()
   })
 
   it('can have additional classes', () => {
-    const $ = cheerio.load(render('table', examples.classes))
+    const $ = render('table', examples.classes)
 
     expect($('.govuk-table').hasClass('custom-class-goes-here')).toBeTruthy()
   })
 
   it('can have additional attributes', () => {
-    const $ = cheerio.load(render('table', examples.attributes))
+    const $ = render('table', examples.attributes)
 
     expect($('.govuk-table').attr('data-foo')).toEqual('bar')
   })
@@ -35,14 +34,14 @@ describe('Table', () => {
 
   describe('captions', () => {
     it('can have custom text', () => {
-      const $ = cheerio.load(render('table', examples['table with head and caption']))
+      const $ = render('table', examples['table with head and caption'])
       const $caption = $('.govuk-table__caption')
 
       expect($caption.text()).toBe('Caption 1: Months and rates')
     })
 
     it('can have additional classes', () => {
-      const $ = cheerio.load(render('table', examples['table with head and caption']))
+      const $ = render('table', examples['table with head and caption'])
       const $caption = $('.govuk-table__caption')
 
       expect($caption.hasClass('govuk-heading-m')).toBeTruthy()
@@ -56,7 +55,7 @@ describe('Table', () => {
   describe('column headers', () => {
     it('can be specified', () => {
       const args = examples['table with head']
-      const $ = cheerio.load(render('table', args))
+      const $ = render('table', args)
 
       const headings = $('.govuk-table').find('thead tr th')
         .map((_, e) => $(e).text())
@@ -70,7 +69,7 @@ describe('Table', () => {
     })
 
     it('have HTML escaped when passed as text', () => {
-      const $ = cheerio.load(render('table', examples['html as text']))
+      const $ = render('table', examples['html as text'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -78,7 +77,7 @@ describe('Table', () => {
     })
 
     it('allow HTML when passed as HTML', () => {
-      const $ = cheerio.load(render('table', examples.html))
+      const $ = render('table', examples.html)
 
       const $th = $('.govuk-table thead tr th')
 
@@ -86,7 +85,7 @@ describe('Table', () => {
     })
 
     it('can have a format specified', () => {
-      const $ = cheerio.load(render('table', examples['table with head']))
+      const $ = render('table', examples['table with head'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -94,7 +93,7 @@ describe('Table', () => {
     })
 
     it('can have additional classes', () => {
-      const $ = cheerio.load(render('table', examples['head with classes']))
+      const $ = render('table', examples['head with classes'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -102,7 +101,7 @@ describe('Table', () => {
     })
 
     it('can have rowspan specified', () => {
-      const $ = cheerio.load(render('table', examples['head with rowspan and colspan']))
+      const $ = render('table', examples['head with rowspan and colspan'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -110,7 +109,7 @@ describe('Table', () => {
     })
 
     it('can have colspan specified', () => {
-      const $ = cheerio.load(render('table', examples['head with rowspan and colspan']))
+      const $ = render('table', examples['head with rowspan and colspan'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -118,7 +117,7 @@ describe('Table', () => {
     })
 
     it('can have additional attributes', () => {
-      const $ = cheerio.load(render('table', examples['head with attributes']))
+      const $ = render('table', examples['head with attributes'])
 
       const $th = $('.govuk-table thead tr th')
 
@@ -133,7 +132,7 @@ describe('Table', () => {
   describe('row headers', () => {
     describe('when firstCellIsHeader is false', () => {
       it('are not included', () => {
-        const $ = cheerio.load(render('table', examples.default))
+        const $ = render('table', examples.default)
 
         const cells = $('.govuk-table').find('tbody tr td')
           .map((_, e) => $(e).text())
@@ -147,7 +146,7 @@ describe('Table', () => {
 
     describe('when firstCellIsHeader is true', () => {
       it('are included', () => {
-        const $ = cheerio.load(render('table', examples['with firstCellIsHeader true']))
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const headings = $('.govuk-table').find('tbody tr th')
           .map((_, e) => $(e).text())
@@ -157,7 +156,7 @@ describe('Table', () => {
       })
 
       it('have HTML escaped when passed as text', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with html as text']))
+        const $ = render('table', examples['firstCellIsHeader with html as text'])
 
         const $th = $('.govuk-table tbody tr th')
 
@@ -165,7 +164,7 @@ describe('Table', () => {
       })
 
       it('allow HTML when passed as HTML', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with html']))
+        const $ = render('table', examples['firstCellIsHeader with html'])
 
         const $th = $('.govuk-table tbody tr th')
 
@@ -173,7 +172,7 @@ describe('Table', () => {
       })
 
       it('are associated with their rows using scope="row"', () => {
-        const $ = cheerio.load(render('table', examples['with firstCellIsHeader true']))
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -181,7 +180,7 @@ describe('Table', () => {
       })
 
       it('have the govuk-table__header class', () => {
-        const $ = cheerio.load(render('table', examples['with firstCellIsHeader true']))
+        const $ = render('table', examples['with firstCellIsHeader true'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -189,7 +188,7 @@ describe('Table', () => {
       })
 
       it('can have additional classes', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with classes']))
+        const $ = render('table', examples['firstCellIsHeader with classes'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -197,7 +196,7 @@ describe('Table', () => {
       })
 
       it('can have rowspan specified', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with rowspan and colspan']))
+        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -205,7 +204,7 @@ describe('Table', () => {
       })
 
       it('can have colspan specified', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with rowspan and colspan']))
+        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -213,7 +212,7 @@ describe('Table', () => {
       })
 
       it('can have additional attributes', () => {
-        const $ = cheerio.load(render('table', examples['firstCellIsHeader with attributes']))
+        const $ = render('table', examples['firstCellIsHeader with attributes'])
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -228,7 +227,7 @@ describe('Table', () => {
 
   describe('cells', () => {
     it('can be specified', () => {
-      const $ = cheerio.load(render('table', examples.default))
+      const $ = render('table', examples.default)
 
       const cells = $('.govuk-table').find('tbody tr')
         .map((_, tr) => {
@@ -244,7 +243,7 @@ describe('Table', () => {
     })
 
     it('can be skipped when falsely', () => {
-      const $ = cheerio.load(render('table', examples['with falsey items']))
+      const $ = render('table', examples['with falsey items'])
 
       const cells = $('.govuk-table').find('tbody tr')
         .map((_, tr) => {
@@ -260,7 +259,7 @@ describe('Table', () => {
     })
 
     it('have HTML escaped when passed as text', () => {
-      const $ = cheerio.load(render('table', examples['html as text']))
+      const $ = render('table', examples['html as text'])
 
       const $td = $('.govuk-table td')
 
@@ -268,7 +267,7 @@ describe('Table', () => {
     })
 
     it('allow HTML when passed as HTML', () => {
-      const $ = cheerio.load(render('table', examples.html))
+      const $ = render('table', examples.html)
 
       const $td = $('.govuk-table td')
 
@@ -276,7 +275,7 @@ describe('Table', () => {
     })
 
     it('can have a format specified', () => {
-      const $ = cheerio.load(render('table', examples.default))
+      const $ = render('table', examples.default)
 
       const $td = $('.govuk-table td')
 
@@ -284,7 +283,7 @@ describe('Table', () => {
     })
 
     it('can have additional classes', () => {
-      const $ = cheerio.load(render('table', examples['rows with classes']))
+      const $ = render('table', examples['rows with classes'])
 
       const $td = $('.govuk-table td')
 
@@ -292,7 +291,7 @@ describe('Table', () => {
     })
 
     it('can have rowspan specified', () => {
-      const $ = cheerio.load(render('table', examples['rows with rowspan and colspan']))
+      const $ = render('table', examples['rows with rowspan and colspan'])
 
       const $td = $('.govuk-table td')
 
@@ -300,7 +299,7 @@ describe('Table', () => {
     })
 
     it('can have colspan specified', () => {
-      const $ = cheerio.load(render('table', examples['rows with rowspan and colspan']))
+      const $ = render('table', examples['rows with rowspan and colspan'])
 
       const $td = $('.govuk-table td')
 
@@ -308,7 +307,7 @@ describe('Table', () => {
     })
 
     it('can have additional attributes', () => {
-      const $ = cheerio.load(render('table', examples['rows with attributes']))
+      const $ = render('table', examples['rows with attributes'])
 
       const $td = $('.govuk-table td')
 

--- a/src/govuk/components/tabs/template.test.js
+++ b/src/govuk/components/tabs/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,21 +11,21 @@ describe('Tabs', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders the first tab selected', () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
 
       const $tab = $('[href="#past-day"]').parent()
       expect($tab.hasClass('govuk-tabs__list-item--selected')).toBeTruthy()
     })
 
     it('hides all but the first panel', () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
 
       expect($('#past-week').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
       expect($('#past-month').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
@@ -36,28 +35,28 @@ describe('Tabs', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('tabs', examples.classes))
+      const $ = render('tabs', examples.classes)
 
       const $component = $('.govuk-tabs')
       expect($component.hasClass('app-tabs--custom-modifier')).toBeTruthy()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('tabs', examples.id))
+      const $ = render('tabs', examples.id)
 
       const $component = $('.govuk-tabs')
       expect($component.attr('id')).toEqual('my-tabs')
     })
 
     it('allows custom title text to be passed', () => {
-      const $ = cheerio.load(render('tabs', examples.title))
+      const $ = render('tabs', examples.title)
 
       const content = $('.govuk-tabs__title').html().trim()
       expect(content).toEqual('Custom title for Contents')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('tabs', examples.attributes))
+      const $ = render('tabs', examples.attributes)
 
       const $component = $('.govuk-tabs')
       expect($component.attr('data-attribute')).toEqual('my data value')
@@ -66,21 +65,21 @@ describe('Tabs', () => {
 
   describe('items', () => {
     it('doesn\'t render a list if items is not defined', () => {
-      const $ = cheerio.load(render('tabs', examples['no item list']))
+      const $ = render('tabs', examples['no item list'])
 
       const $component = $('.govuk-tabs')
       expect($component.find('.govuk-tabs__list').length).toEqual(0)
     })
 
     it('doesn\'t render a list if items is empty', () => {
-      const $ = cheerio.load(render('tabs', examples['empty item list']))
+      const $ = render('tabs', examples['empty item list'])
 
       const $component = $('.govuk-tabs')
       expect($component.find('.govuk-tabs__list').length).toEqual(0)
     })
 
     it('render a matching tab and panel using item id', () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
 
       const $component = $('.govuk-tabs')
 
@@ -91,7 +90,7 @@ describe('Tabs', () => {
     })
 
     it('render without falsey values', () => {
-      const $ = cheerio.load(render('tabs', examples['with falsey values']))
+      const $ = render('tabs', examples['with falsey values'])
 
       const $component = $('.govuk-tabs')
 
@@ -100,7 +99,7 @@ describe('Tabs', () => {
     })
 
     it('render a matching tab and panel using custom idPrefix', () => {
-      const $ = cheerio.load(render('tabs', examples.idPrefix))
+      const $ = render('tabs', examples.idPrefix)
 
       const $component = $('.govuk-tabs')
 
@@ -111,7 +110,7 @@ describe('Tabs', () => {
     })
 
     it('render the label', () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
 
       const $component = $('.govuk-tabs')
 
@@ -120,7 +119,7 @@ describe('Tabs', () => {
     })
 
     it('render with panel content as text, wrapped in styled paragraph', () => {
-      const $ = cheerio.load(render('tabs', examples.default))
+      const $ = render('tabs', examples.default)
       const $component = $('.govuk-tabs')
       const $lastTab = $component.find('.govuk-tabs__panel').last()
 
@@ -129,7 +128,7 @@ describe('Tabs', () => {
     })
 
     it('render escaped html when passed to text content', () => {
-      const $ = cheerio.load(render('tabs', examples['html as text']))
+      const $ = render('tabs', examples['html as text'])
 
       const $component = $('.govuk-tabs')
 
@@ -138,7 +137,7 @@ describe('Tabs', () => {
     })
 
     it('render html when passed to content', () => {
-      const $ = cheerio.load(render('tabs', examples.html))
+      const $ = render('tabs', examples.html)
 
       const $component = $('.govuk-tabs')
 
@@ -147,7 +146,7 @@ describe('Tabs', () => {
     })
 
     it('render a tab anchor with attributes', () => {
-      const $ = cheerio.load(render('tabs', examples['item with attributes']))
+      const $ = render('tabs', examples['item with attributes'])
 
       const $tabItemLink = $('.govuk-tabs__tab')
       expect($tabItemLink.attr('data-attribute')).toEqual('my-attribute')
@@ -155,7 +154,7 @@ describe('Tabs', () => {
     })
 
     it('render a tab panel with attributes', () => {
-      const $ = cheerio.load(render('tabs', examples['panel with attributes']))
+      const $ = render('tabs', examples['panel with attributes'])
 
       const $tabPanelItems = $('.govuk-tabs__panel')
       expect($tabPanelItems.attr('data-attribute')).toEqual('my-attribute')

--- a/src/govuk/components/tag/template.test.js
+++ b/src/govuk/components/tag/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,14 +11,14 @@ describe('Tag', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('tag', examples.default))
+      const $ = render('tag', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders the default example with strong element and text', () => {
-      const $ = cheerio.load(render('tag', examples.default))
+      const $ = render('tag', examples.default)
 
       const $component = $('.govuk-tag')
       expect($component.get(0).tagName).toEqual('strong')
@@ -27,7 +26,7 @@ describe('Tag', () => {
     })
 
     it('renders classes', () => {
-      const $ = cheerio.load(render('tag', examples.inactive))
+      const $ = render('tag', examples.inactive)
 
       const $component = $('.govuk-tag')
       expect($component.hasClass('govuk-tag--grey')).toBeTruthy()
@@ -36,14 +35,14 @@ describe('Tag', () => {
 
   describe('custom options', () => {
     it('renders custom text', () => {
-      const $ = cheerio.load(render('tag', examples.grey))
+      const $ = render('tag', examples.grey)
 
       const $component = $('.govuk-tag')
       expect($component.html()).toContain('Grey')
     })
 
     it('renders attributes', () => {
-      const $ = cheerio.load(render('tag', examples.attributes))
+      const $ = render('tag', examples.attributes)
 
       const $component = $('.govuk-tag')
       expect($component.attr('data-test')).toEqual('attribute')
@@ -53,14 +52,14 @@ describe('Tag', () => {
 
   describe('html', () => {
     it('renders escaped html when passed to text', () => {
-      const $ = cheerio.load(render('tag', examples['html as text']))
+      const $ = render('tag', examples['html as text'])
 
       const $component = $('.govuk-tag')
       expect($component.html()).toContain('&lt;span&gt;alpha&lt;/span&gt;')
     })
 
     it('renders html', () => {
-      const $ = cheerio.load(render('tag', examples.html))
+      const $ = render('tag', examples.html)
 
       const $component = $('.govuk-tag')
       expect($component.html()).toContain('<span>alpha</span>')

--- a/src/govuk/components/textarea/template.test.js
+++ b/src/govuk/components/textarea/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe, htmlWithClassName } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -15,35 +14,35 @@ describe('Textarea', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with id', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('id')).toEqual('more-detail')
     })
 
     it('renders with name', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('name')).toEqual('more-detail')
     })
 
     it('renders with default number of rows', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('rows')).toEqual('5')
     })
 
     it('renders with a form group wrapper', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.length).toBeTruthy()
@@ -52,42 +51,42 @@ describe('Textarea', () => {
 
   describe('custom options', () => {
     it('renders with classes', () => {
-      const $ = cheerio.load(render('textarea', examples.classes))
+      const $ = render('textarea', examples.classes)
 
       const $component = $('.govuk-textarea')
       expect($component.hasClass('app-textarea--custom-modifier')).toBeTruthy()
     })
 
     it('renders with value', () => {
-      const $ = cheerio.load(render('textarea', examples['with default value']))
+      const $ = render('textarea', examples['with default value'])
 
       const $component = $('.govuk-textarea')
       expect($component.text()).toEqual('221B Baker Street\nLondon\nNW1 6XE\n')
     })
 
     it('renders with attributes', () => {
-      const $ = cheerio.load(render('textarea', examples.attributes))
+      const $ = render('textarea', examples.attributes)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('data-attribute')).toEqual('my data value')
     })
 
     it('renders with aria-describedby', () => {
-      const $ = cheerio.load(render('textarea', examples['with describedBy']))
+      const $ = render('textarea', examples['with describedBy'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('renders with rows', () => {
-      const $ = cheerio.load(render('textarea', examples['with custom rows']))
+      const $ = render('textarea', examples['with custom rows'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('rows')).toEqual('8')
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = cheerio.load(render('textarea', examples['with optional form-group classes']))
+      const $ = render('textarea', examples['with optional form-group classes'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -96,21 +95,21 @@ describe('Textarea', () => {
 
   describe('when it has the spellcheck attribute', () => {
     it('renders with spellcheck attribute set to true', () => {
-      const $ = cheerio.load(render('textarea', examples['with spellcheck enabled']))
+      const $ = render('textarea', examples['with spellcheck enabled'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('true')
     })
 
     it('renders with spellcheck attribute set to false', () => {
-      const $ = cheerio.load(render('textarea', examples['with spellcheck disabled']))
+      const $ = render('textarea', examples['with spellcheck disabled'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toEqual('false')
     })
 
     it('renders without spellcheck attribute by default', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-textarea')
       expect($component.attr('spellcheck')).toBeUndefined()
@@ -119,13 +118,13 @@ describe('Textarea', () => {
 
   describe('when it includes a hint', () => {
     it('renders with hint', () => {
-      const $ = cheerio.load(render('textarea', examples['with hint']))
+      const $ = render('textarea', examples['with hint'])
 
       expect(htmlWithClassName($, '.govuk-hint')).toMatchSnapshot()
     })
 
     it('associates the textarea as "described by" the hint', () => {
-      const $ = cheerio.load(render('textarea', examples['with hint']))
+      const $ = render('textarea', examples['with hint'])
 
       const $textarea = $('.govuk-textarea')
       const $hint = $('.govuk-hint')
@@ -139,7 +138,7 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as "described by" the hint and parent fieldset', () => {
-      const $ = cheerio.load(render('textarea', examples['with hint and described by']))
+      const $ = render('textarea', examples['with hint and described by'])
 
       const $textarea = $('.govuk-textarea')
       const $hint = $('.govuk-hint')
@@ -155,13 +154,13 @@ describe('Textarea', () => {
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = cheerio.load(render('textarea', examples['with error message']))
+      const $ = render('textarea', examples['with error message'])
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the textarea as "described by" the error message', () => {
-      const $ = cheerio.load(render('textarea', examples['with error message']))
+      const $ = render('textarea', examples['with error message'])
 
       const $component = $('.govuk-textarea')
       const $errorMessage = $('.govuk-error-message')
@@ -175,7 +174,7 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as "described by" the error message and parent fieldset', () => {
-      const $ = cheerio.load(render('textarea', examples['with error message and described by']))
+      const $ = render('textarea', examples['with error message and described by'])
 
       const $component = $('.govuk-textarea')
       const $errorMessage = $('.govuk-error-message')
@@ -189,14 +188,14 @@ describe('Textarea', () => {
     })
 
     it('adds the error class to the textarea', () => {
-      const $ = cheerio.load(render('textarea', examples['with error message']))
+      const $ = render('textarea', examples['with error message'])
 
       const $component = $('.govuk-textarea')
       expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
 
     it('renders with a form group wrapper that has an error state', () => {
-      const $ = cheerio.load(render('textarea', examples['with error message']))
+      const $ = render('textarea', examples['with error message'])
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -205,7 +204,7 @@ describe('Textarea', () => {
 
   describe('when it includes both a hint and an error message', () => {
     it('associates the textarea as described by both the hint and the error message', () => {
-      const $ = cheerio.load(render('textarea', examples['with hint and error message']))
+      const $ = render('textarea', examples['with hint and error message'])
 
       const $component = $('.govuk-textarea')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -220,7 +219,7 @@ describe('Textarea', () => {
     })
 
     it('associates the textarea as described by the hint, error message and parent fieldset', () => {
-      const $ = cheerio.load(render('textarea', examples['with hint, error message and described by']))
+      const $ = render('textarea', examples['with hint, error message and described by'])
 
       const $component = $('.govuk-textarea')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -237,27 +236,27 @@ describe('Textarea', () => {
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $component = $('.govuk-form-group > .govuk-textarea')
       expect($component.length).toBeTruthy()
     })
 
     it('renders with label', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       expect(htmlWithClassName($, '.govuk-label')).toMatchSnapshot()
     })
 
     it('renders label with "for" attribute reffering the textarea "id"', () => {
-      const $ = cheerio.load(render('textarea', examples.default))
+      const $ = render('textarea', examples.default)
 
       const $label = $('.govuk-label')
       expect($label.attr('for')).toEqual('more-detail')
     })
 
     it('renders label as page heading', () => {
-      const $ = cheerio.load(render('textarea', examples['with label as page heading']))
+      const $ = render('textarea', examples['with label as page heading'])
 
       const $label = $('.govuk-label')
       expect($('.govuk-label-wrapper')).toBeTruthy()
@@ -267,7 +266,7 @@ describe('Textarea', () => {
 
   describe('when it includes an autocomplete attribute', () => {
     it('renders the autocomplete attribute', () => {
-      const $ = cheerio.load(render('textarea', examples['with autocomplete attribute']))
+      const $ = render('textarea', examples['with autocomplete attribute'])
 
       const $component = $('.govuk-textarea')
       expect($component.attr('autocomplete')).toEqual('street-address')

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -1,4 +1,3 @@
-const cheerio = require('cheerio')
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { axe } = require('govuk-frontend-helpers/tests')
 const { getExamples } = require('govuk-frontend-lib/files')
@@ -12,28 +11,28 @@ describe('Warning text', () => {
 
   describe('default example', () => {
     it('passes accessibility tests', async () => {
-      const $ = cheerio.load(render('warning-text', examples.default))
+      const $ = render('warning-text', examples.default)
 
       const results = await axe($.html())
       expect(results).toHaveNoViolations()
     })
 
     it('renders with text', () => {
-      const $ = cheerio.load(render('warning-text', examples.default))
+      const $ = render('warning-text', examples.default)
 
       const $component = $('.govuk-warning-text')
       expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
     })
 
     it('renders with default assistive text', () => {
-      const $ = cheerio.load(render('warning-text', examples.default))
+      const $ = render('warning-text', examples.default)
 
       const $assistiveText = $('.govuk-warning-text__assistive')
       expect($assistiveText.text()).toEqual('Warning')
     })
 
     it('hides the icon from screen readers using the aria-hidden attribute', () => {
-      const $ = cheerio.load(render('warning-text', examples.default))
+      const $ = render('warning-text', examples.default)
 
       const $icon = $('.govuk-warning-text__icon')
       expect($icon.attr('aria-hidden')).toEqual('true')
@@ -42,21 +41,21 @@ describe('Warning text', () => {
 
   describe('custom options', () => {
     it('renders classes', () => {
-      const $ = cheerio.load(render('warning-text', examples.classes))
+      const $ = render('warning-text', examples.classes)
 
       const $component = $('.govuk-warning-text')
       expect($component.hasClass('govuk-warning-text--custom-class')).toBeTruthy()
     })
 
     it('renders custom assistive text', () => {
-      const $ = cheerio.load(render('warning-text', examples['icon fallback text only']))
+      const $ = render('warning-text', examples['icon fallback text only'])
 
       const $assistiveText = $('.govuk-warning-text__assistive')
       expect($assistiveText.html()).toContain('Some custom fallback text')
     })
 
     it('renders attributes', () => {
-      const $ = cheerio.load(render('warning-text', examples.attributes))
+      const $ = render('warning-text', examples.attributes)
 
       const $component = $('.govuk-warning-text')
       expect($component.attr('data-test')).toEqual('attribute')
@@ -66,14 +65,14 @@ describe('Warning text', () => {
 
   describe('html', () => {
     it('renders escaped html when passed to text', () => {
-      const $ = cheerio.load(render('warning-text', examples['html as text']))
+      const $ = render('warning-text', examples['html as text'])
 
       const $component = $('.govuk-warning-text')
       expect($component.html()).toContain('&lt;span&gt;Some custom warning text&lt;/span&gt;')
     })
 
     it('renders html', () => {
-      const $ = cheerio.load(render('warning-text', examples.html))
+      const $ = render('warning-text', examples.html)
 
       const $component = $('.govuk-warning-text')
       expect($component.html()).toContain('<span>Some custom warning text</span>')

--- a/src/govuk/template.test.js
+++ b/src/govuk/template.test.js
@@ -1,7 +1,6 @@
 const crypto = require('crypto')
 const { join } = require('path')
 
-const cheerio = require('cheerio')
 const { paths } = require('govuk-frontend-config')
 const { renderTemplate } = require('govuk-frontend-helpers/nunjucks')
 const nunjucks = require('nunjucks')
@@ -28,17 +27,17 @@ describe('Template', () => {
 
   describe('<html>', () => {
     it('defaults to lang="en"', () => {
-      const $ = cheerio.load(renderTemplate())
+      const $ = renderTemplate()
       expect($('html').attr('lang')).toEqual('en')
     })
 
     it('can have a custom lang set using htmlLang', () => {
-      const $ = cheerio.load(renderTemplate({ htmlLang: 'zu' }))
+      const $ = renderTemplate({ htmlLang: 'zu' })
       expect($('html').attr('lang')).toEqual('zu')
     })
 
     it('can have custom classes added using htmlClasses', () => {
-      const $ = cheerio.load(renderTemplate({ htmlClasses: 'my-custom-class' }))
+      const $ = renderTemplate({ htmlClasses: 'my-custom-class' })
       expect($('html').hasClass('my-custom-class')).toBeTruthy()
     })
   })
@@ -47,7 +46,7 @@ describe('Template', () => {
     it('can have custom social media icons specified using the headIcons block', () => {
       const headIcons = '<link rel="govuk-icon" href="/images/ytf-icon.png">'
 
-      const $ = cheerio.load(renderTemplate({}, { headIcons }))
+      const $ = renderTemplate({}, { headIcons })
 
       // Build a list of the rel values of all links with a rel ending 'icon'
       const icons = $('link[rel$="icon"]').map((_, link) => $(link).attr('rel')).get()
@@ -57,20 +56,20 @@ describe('Template', () => {
     it('can have additional content added to the <head> using the head block', () => {
       const head = '<meta property="foo" content="bar">'
 
-      const $ = cheerio.load(renderTemplate({}, { head }))
+      const $ = renderTemplate({}, { head })
 
       expect($('head meta[property="foo"]').attr('content')).toEqual('bar')
     })
 
     it('uses a default assets path of /assets', () => {
-      const $ = cheerio.load(renderTemplate())
+      const $ = renderTemplate()
       const $icon = $('link[rel="shortcut icon"]')
 
       expect($icon.attr('href')).toEqual('/assets/images/favicon.ico')
     })
 
     it('can have the assets path overridden using assetPath', () => {
-      const $ = cheerio.load(renderTemplate({ assetPath: '/whatever' }))
+      const $ = renderTemplate({ assetPath: '/whatever' })
       const $icon = $('link[rel="shortcut icon"]')
 
       expect($icon.attr('href')).toEqual('/whatever/images/favicon.ico')
@@ -78,21 +77,21 @@ describe('Template', () => {
 
     describe('opengraph image', () => {
       it('is not included if neither assetUrl nor opengraphImageUrl are set ', () => {
-        const $ = cheerio.load(renderTemplate({}))
+        const $ = renderTemplate({})
         const $ogImage = $('meta[property="og:image"]')
 
         expect($ogImage.length).toBe(0)
       })
 
       it('is included using default path and filename if assetUrl is set', () => {
-        const $ = cheerio.load(renderTemplate({ assetUrl: 'https://foo.com/my-assets' }))
+        const $ = renderTemplate({ assetUrl: 'https://foo.com/my-assets' })
         const $ogImage = $('meta[property="og:image"]')
 
         expect($ogImage.attr('content')).toEqual('https://foo.com/my-assets/images/govuk-opengraph-image.png')
       })
 
       it('is included if opengraphImageUrl is set', () => {
-        const $ = cheerio.load(renderTemplate({ opengraphImageUrl: 'https://foo.com/custom/og-image.png' }))
+        const $ = renderTemplate({ opengraphImageUrl: 'https://foo.com/custom/og-image.png' })
         const $ogImage = $('meta[property="og:image"]')
 
         expect($ogImage.attr('content')).toEqual('https://foo.com/custom/og-image.png')
@@ -101,12 +100,12 @@ describe('Template', () => {
 
     describe('<meta name="theme-color">', () => {
       it('has a default content of #0b0c0c', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         expect($('meta[name="theme-color"]').attr('content')).toEqual('#0b0c0c')
       })
 
       it('can be overridden using themeColor', () => {
-        const $ = cheerio.load(renderTemplate({ themeColor: '#ff69b4' }))
+        const $ = renderTemplate({ themeColor: '#ff69b4' })
         expect($('meta[name="theme-color"]').attr('content')).toEqual('#ff69b4')
       })
     })
@@ -114,22 +113,22 @@ describe('Template', () => {
     describe('<title>', () => {
       const expectedTitle = 'GOV.UK - The best place to find government services and information'
       it(`defaults to '${expectedTitle}'`, () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         expect($('title').text()).toEqual(expectedTitle)
       })
 
       it('can be overridden using the pageTitle block', () => {
-        const $ = cheerio.load(renderTemplate({}, { pageTitle: 'Foo' }))
+        const $ = renderTemplate({}, { pageTitle: 'Foo' })
         expect($('title').text()).toEqual('Foo')
       })
 
       it('does not have a lang attribute by default', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         expect($('title').attr('lang')).toBeUndefined()
       })
 
       it('can have a lang attribute specified using pageTitleLang', () => {
-        const $ = cheerio.load(renderTemplate({ pageTitleLang: 'zu' }))
+        const $ = renderTemplate({ pageTitleLang: 'zu' })
         expect($('title').attr('lang')).toEqual('zu')
       })
     })
@@ -137,19 +136,19 @@ describe('Template', () => {
 
   describe('<body>', () => {
     it('can have custom classes added using bodyClasses', () => {
-      const $ = cheerio.load(renderTemplate({ bodyClasses: 'custom-body-class' }))
+      const $ = renderTemplate({ bodyClasses: 'custom-body-class' })
       expect($('body').hasClass('custom-body-class')).toBeTruthy()
     })
 
     it('can have custom attributes added using bodyAttributes', () => {
-      const $ = cheerio.load(renderTemplate({ bodyAttributes: { 'data-foo': 'bar' } }))
+      const $ = renderTemplate({ bodyAttributes: { 'data-foo': 'bar' } })
       expect($('body').attr('data-foo')).toEqual('bar')
     })
 
     it('can have additional content added after the opening tag using bodyStart block', () => {
       const bodyStart = '<div>bodyStart</div>'
 
-      const $ = cheerio.load(renderTemplate({}, { bodyStart }))
+      const $ = renderTemplate({}, { bodyStart })
 
       expect($('body > div:first-of-type').text()).toEqual('bodyStart')
     })
@@ -157,14 +156,14 @@ describe('Template', () => {
     it('can have additional content added before the closing tag using bodyEnd block', () => {
       const bodyEnd = '<div>bodyEnd</div>'
 
-      const $ = cheerio.load(renderTemplate({}, { bodyEnd }))
+      const $ = renderTemplate({}, { bodyEnd })
 
       expect($('body > div:last-of-type').text()).toEqual('bodyEnd')
     })
 
     describe('inline script that adds "js-enabled" class', () => {
       it('should match the hash published in docs', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         const script = $('body > script').first().html()
 
         // Create a base64 encoded hash of the contents of the script tag
@@ -175,13 +174,13 @@ describe('Template', () => {
         expect('sha256-' + hash).toEqual('sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=')
       })
       it('should not have a nonce attribute by default', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         const scriptTag = $('body > script').first()
 
         expect(scriptTag.attr('nonce')).toEqual(undefined)
       })
       it('should have a nonce attribute when nonce is provided', () => {
-        const $ = cheerio.load(renderTemplate({ cspNonce: 'abcdef' }))
+        const $ = renderTemplate({ cspNonce: 'abcdef' })
         const scriptTag = $('body > script').first()
 
         expect(scriptTag.attr('nonce')).toEqual('abcdef')
@@ -192,7 +191,7 @@ describe('Template', () => {
       it('can be overridden using the skipLink block', () => {
         const skipLink = '<div class="my-skip-link">skipLink</div>'
 
-        const $ = cheerio.load(renderTemplate({}, { skipLink }))
+        const $ = renderTemplate({}, { skipLink })
 
         expect($('.my-skip-link').length).toEqual(1)
         expect($('.govuk-skip-link').length).toEqual(0)
@@ -203,7 +202,7 @@ describe('Template', () => {
       it('can be overridden using the header block', () => {
         const header = '<div class="my-header">header</div>'
 
-        const $ = cheerio.load(renderTemplate({}, { header }))
+        const $ = renderTemplate({}, { header })
 
         expect($('.my-header').length).toEqual(1)
         expect($('.govuk-header').length).toEqual(0)
@@ -212,29 +211,29 @@ describe('Template', () => {
 
     describe('<main>', () => {
       it('has role="main", supporting browsers that do not natively support HTML5 elements', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         expect($('main').attr('role')).toEqual('main')
       })
 
       it('can have custom classes added using mainClasses', () => {
-        const $ = cheerio.load(renderTemplate({ mainClasses: 'custom-main-class' }))
+        const $ = renderTemplate({ mainClasses: 'custom-main-class' })
         expect($('main').hasClass('custom-main-class')).toBeTruthy()
       })
 
       it('does not have a lang attribute by default', () => {
-        const $ = cheerio.load(renderTemplate())
+        const $ = renderTemplate()
         expect($('main').attr('lang')).toBeUndefined()
       })
 
       it('can have a lang attribute specified using mainLang', () => {
-        const $ = cheerio.load(renderTemplate({ mainLang: 'zu' }))
+        const $ = renderTemplate({ mainLang: 'zu' })
         expect($('main').attr('lang')).toEqual('zu')
       })
 
       it('can be overridden using the main block', () => {
         const main = '<main class="my-main">header</main>'
 
-        const $ = cheerio.load(renderTemplate({}, { main }))
+        const $ = renderTemplate({}, { main })
 
         expect($('main').length).toEqual(1)
         expect($('main').hasClass('my-main')).toBe(true)
@@ -243,7 +242,7 @@ describe('Template', () => {
       it('can have content injected before it using the beforeContent block', () => {
         const beforeContent = '<div class="before-content">beforeContent</div>'
 
-        const $ = cheerio.load(renderTemplate({}, { beforeContent }))
+        const $ = renderTemplate({}, { beforeContent })
 
         expect($('.before-content').next().is('main')).toBe(true)
       })
@@ -251,7 +250,7 @@ describe('Template', () => {
       it('can have content specified using the content block', () => {
         const content = 'Foo'
 
-        const $ = cheerio.load(renderTemplate({}, { content }))
+        const $ = renderTemplate({}, { content })
 
         expect($('main').text().trim()).toEqual('Foo')
       })
@@ -261,7 +260,7 @@ describe('Template', () => {
       it('can be overridden using the footer block', () => {
         const footer = '<div class="my-footer">footer</div>'
 
-        const $ = cheerio.load(renderTemplate({}, { footer }))
+        const $ = renderTemplate({}, { footer })
 
         expect($('.my-footer').length).toEqual(1)
         expect($('.govuk-footer').length).toEqual(0)


### PR DESCRIPTION
This PR addresses a code review comment in https://github.com/alphagov/govuk-frontend/pull/3412#pullrequestreview-1383787077 from @romaricpascal 

I've also added the `@types/nunjucks` package so we can type-check our Nunjucks code. Before we added **tsconfig.json** files it was downloaded through [automatic type acquisition](https://code.visualstudio.com/docs/nodejs/working-with-javascript#_typings-and-automatic-type-acquisition) by supported editors