### PR TITLE
Include "Review app" in `npm run build:types` check

### DIFF
--- a/app/src/app.mjs
+++ b/app/src/app.mjs
@@ -27,7 +27,7 @@ export default async () => {
 
   // Set up Express.js
   app.set('flags', flags)
-  app.set('query parser', (query) => new URLSearchParams(query))
+  app.set('query parser', 'simple')
 
   // Set up middleware
   app.use('/docs', middleware.docs)
@@ -122,8 +122,7 @@ export default async () => {
 
     let bodyClasses = ''
 
-    // @ts-expect-error `URLSearchParams` as 'query parser'
-    if (req.query.has('iframe')) {
+    if ('iframe' in req.query) {
       bodyClasses = 'app-iframe-in-component-preview'
     }
 

--- a/app/src/common/middleware/legacy.mjs
+++ b/app/src/common/middleware/legacy.mjs
@@ -1,5 +1,9 @@
 /**
  * Legacy query handling
+ *
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @param {import('express').NextFunction} next
  */
 const legacy = (req, res, next) => {
   const { query } = req

--- a/app/src/common/middleware/legacy.mjs
+++ b/app/src/common/middleware/legacy.mjs
@@ -9,8 +9,9 @@ const legacy = (req, res, next) => {
   const { query } = req
 
   // Detect legacy mode
-  res.locals.legacy = ['1', 'true']
-    .includes(query.get('legacy'))
+  res.locals.legacy = typeof query.legacy === 'string'
+    ? ['1', 'true'].includes(query.legacy)
+    : false
 
   // Legacy query for link hrefs
   res.locals.legacyQuery = res.locals.legacy

--- a/app/src/common/middleware/legacy.test.mjs
+++ b/app/src/common/middleware/legacy.test.mjs
@@ -13,7 +13,7 @@ describe('Middleware: Legacy mode', () => {
     agent = supertest.agent(app)
 
     // Add query parser + middleware
-    app.set('query parser', (query) => new URLSearchParams(query))
+    app.set('query parser', 'simple')
     app.use(middleware)
 
     // Add test router

--- a/app/src/common/middleware/request.test.mjs
+++ b/app/src/common/middleware/request.test.mjs
@@ -14,7 +14,7 @@ describe('Middleware: Request handling', () => {
     agent = supertest.agent(app)
 
     // Add query parser + middleware
-    app.set('query parser', (query) => new URLSearchParams(query))
+    app.set('query parser', 'simple')
     app.use(middleware)
 
     // Add test router

--- a/app/src/common/middleware/robots.test.mjs
+++ b/app/src/common/middleware/robots.test.mjs
@@ -12,7 +12,7 @@ describe('Middleware: Search engines (robots.txt)', () => {
     agent = supertest.agent(app)
 
     // Add query parser + middleware
-    app.set('query parser', (query) => new URLSearchParams(query))
+    app.set('query parser', 'simple')
     app.use(middleware)
   })
 

--- a/app/src/routes/banner.mjs
+++ b/app/src/routes/banner.mjs
@@ -1,6 +1,9 @@
 const BANNER_COOKIE_NAME = 'dismissed-app-banner'
 
-export default function (app) {
+/**
+ * @param {import('express').Application} app
+ */
+export default (app) => {
   // Detect if banner should be shown based on cookies set
   app.use(function (request, response, next) {
     const { query, cookies } = request

--- a/app/src/routes/banner.mjs
+++ b/app/src/routes/banner.mjs
@@ -8,7 +8,7 @@ export default (app) => {
   app.use(function (request, response, next) {
     const { query, cookies } = request
 
-    if (query.has('hide-banner')) {
+    if ('hide-banner' in query) {
       app.locals.shouldShowAppBanner = false
       return next()
     }

--- a/app/src/routes/full-page-examples.mjs
+++ b/app/src/routes/full-page-examples.mjs
@@ -2,6 +2,9 @@ import { getFullPageExamples } from 'govuk-frontend-lib/files'
 
 import * as routes from '../views/full-page-examples/index.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   routes.applicantDetails(app)
   routes.cookieBannerEssentialCookies(app)

--- a/app/src/routes/full-page-examples.test.mjs
+++ b/app/src/routes/full-page-examples.test.mjs
@@ -336,21 +336,21 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
-        expect($.html()).toContain('121,842 results')
+        expect($.html()).toContain('482,211 results')
       })
       it('should show sorted results when selected', async () => {
         const response = await fetchPath('search?order=updated-newest')
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
-        expect($.html()).toContain('821,124 results')
+        expect($.html()).toContain('241,128 results')
       })
       it('should show organisation results when selected', async () => {
         const response = await fetchPath('search?order=updated-newest&organisation=hmrc')
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
-        expect($.html()).toContain('212,418 results')
+        expect($.html()).toContain('814,221 results')
       })
     })
 

--- a/app/src/views/full-page-examples/applicant-details/index.mjs
+++ b/app/src/views/full-page-examples/applicant-details/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/applicant-details',
@@ -19,6 +22,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter your date of birth year')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
 

--- a/app/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
+++ b/app/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
@@ -1,3 +1,6 @@
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post('/full-page-examples/cookie-banner-essential-cookies', (request, response) => {
     response.render('./full-page-examples/cookie-banner-essential-cookies/index', {

--- a/app/src/views/full-page-examples/cookie-banner-server-side/index.mjs
+++ b/app/src/views/full-page-examples/cookie-banner-server-side/index.mjs
@@ -1,3 +1,6 @@
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post('/full-page-examples/cookie-banner-server-side', (request, response) => {
     response.render('./full-page-examples/cookie-banner-server-side/index', {

--- a/app/src/views/full-page-examples/feedback/index.mjs
+++ b/app/src/views/full-page-examples/feedback/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/feedback',
@@ -46,6 +49,12 @@ export default (app) => {
         })
 
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/app/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/have-you-changed-your-name',
@@ -10,6 +13,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Select if you have changed your name')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/app/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/how-do-you-want-to-sign-in',
@@ -10,6 +13,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Select how you want to sign in')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/passport-details/index.mjs
+++ b/app/src/views/full-page-examples/passport-details/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/passport-details',
@@ -19,6 +22,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter your expiry year')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
 

--- a/app/src/views/full-page-examples/search/index.mjs
+++ b/app/src/views/full-page-examples/search/index.mjs
@@ -18,11 +18,11 @@ export default (app) => {
     (request, response) => {
       const { query } = request
 
-      query.set('search', query.get('search') ?? 'driving')
-      query.set('order', query.get('order') ?? 'most-viewed')
+      query.search ??= 'driving'
+      query.order ??= 'most-viewed'
 
       // Shuffle the documents based on the query string, to simulate different responses.
-      const seed = query.toString()
+      const seed = JSON.stringify(query)
       const shuffledDocuments = shuffleSeed.shuffle(documents, seed)
 
       const total = '128124'
@@ -32,14 +32,14 @@ export default (app) => {
 
       response.render('./full-page-examples/search/index', {
         documents: shuffledDocuments,
-        order: query.get('order'),
+        order: query.order,
 
         // Make the total more readable
         total: Number(randomizedTotal)
           .toLocaleString('en', { useGrouping: true }),
 
         // In production this should be sanitized
-        values: Object.fromEntries(query)
+        values: query
       })
     }
   )

--- a/app/src/views/full-page-examples/search/index.mjs
+++ b/app/src/views/full-page-examples/search/index.mjs
@@ -4,9 +4,17 @@ import shuffleSeed from 'shuffle-seed'
 
 const { documents } = JSON.parse(await readFile(new URL('data.json', import.meta.url), 'utf8'))
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.get(
     '/full-page-examples/search',
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     */
     (request, response) => {
       const { query } = request
 

--- a/app/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/app/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -18,6 +18,9 @@ function getErrors (errorsInstance) {
   return formattedErrors
 }
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/update-your-account-details',
@@ -30,6 +33,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter your password')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = getErrors(validationResult(request))
 

--- a/app/src/views/full-page-examples/upload-your-photo-success/index.mjs
+++ b/app/src/views/full-page-examples/upload-your-photo-success/index.mjs
@@ -1,6 +1,15 @@
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/upload-your-photo-success',
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       return response.render('./full-page-examples/upload-your-photo-success/index', {
         isSuccess: true

--- a/app/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/app/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/upload-your-photo',
@@ -13,6 +16,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Select I accept the terms and conditions')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/app/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-address',
@@ -19,6 +22,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter your postcode')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/app/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-nationality',
@@ -34,6 +37,12 @@ export default (app) => {
           return true
         })
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/what-is-your-postcode/index.mjs
+++ b/app/src/views/full-page-examples/what-is-your-postcode/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-postcode',
@@ -10,6 +13,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter your home postcode')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
+++ b/app/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
@@ -2,6 +2,9 @@ import { body, validationResult } from 'express-validator'
 
 import { formatValidationErrors } from '../../../utils.mjs'
 
+/**
+ * @param {import('express').Application} app
+ */
 export default (app) => {
   app.post(
     '/full-page-examples/what-was-the-last-country-you-visited',
@@ -10,6 +13,12 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Enter the last country you visited')
     ],
+
+    /**
+     * @param {import('express').Request} request
+     * @param {import('express').Response} response
+     * @returns {void}
+     */
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {

--- a/app/tsconfig.build.json
+++ b/app/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["./src/**/*.mjs"],
+  "exclude": ["**/*.test.*"],
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,6 +74,7 @@
       },
       "optionalDependencies": {
         "@jest/environment": "^29.5.0",
+        "@types/express": "^4.17.17",
         "@types/gulp": "^4.0.10",
         "@types/jest": "^29.5.0",
         "@types/jest-axe": "^3.5.5",
@@ -4246,7 +4247,7 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
       "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -4277,7 +4278,7 @@
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4328,7 +4329,7 @@
       "version": "4.17.17",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.17.tgz",
       "integrity": "sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^4.17.33",
@@ -4340,7 +4341,7 @@
       "version": "4.17.33",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
       "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -4513,7 +4514,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
       "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
@@ -4555,13 +4556,13 @@
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
       "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -4607,7 +4608,7 @@
       "version": "1.15.1",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
       "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   },
   "optionalDependencies": {
     "@jest/environment": "^29.5.0",
+    "@types/express": "^4.17.17",
     "@types/gulp": "^4.0.10",
     "@types/jest": "^29.5.0",
     "@types/jest-axe": "^3.5.5",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,6 +3,9 @@
   "files": [],
   "references": [
     {
+      "path": "./app/tsconfig.build.json"
+    },
+    {
       "path": "./src/tsconfig.build.json"
     }
   ]


### PR DESCRIPTION
Our internal "Review app" imports source code with JSDoc comments but doesn't check for correct usage

Work on https://github.com/alphagov/govuk-frontend/pull/3500 revealed missing Nunjucks params against the community [`@types/nunjucks`](https://www.npmjs.com/package/@types/nunjucks) package

This PR adds enough JSDoc comments to the Review app that we can check our own usage:

```console
npm run build:types
```

We've had some failed deployments recently that these checks would have caught

Although they won't be switched on until we merge:

* https://github.com/alphagov/govuk-frontend/pull/3319