### PR TITLE
Add missing deprecation notices

### DIFF
--- a/src/govuk/components/accordion/accordion.mjs
+++ b/src/govuk/components/accordion/accordion.mjs
@@ -134,6 +134,15 @@ function Accordion ($module, config) {
 
   /** @deprecated Will be made private in v5.0 */
   this.browserSupportsSessionStorage = helper.checkForSessionStorage()
+
+  /** @deprecated Will be made private in v5.0 */
+  this.$showAllButton = null
+
+  /** @deprecated Will be made private in v5.0 */
+  this.$showAllIcon = null
+
+  /** @deprecated Will be made private in v5.0 */
+  this.$showAllText = null
 }
 
 /**

--- a/src/govuk/components/character-count/character-count.mjs
+++ b/src/govuk/components/character-count/character-count.mjs
@@ -62,7 +62,12 @@ function CharacterCount ($module, config) {
   }
 
   var $textarea = $module.querySelector('.govuk-js-character-count')
-  if (!($textarea instanceof HTMLTextAreaElement || $textarea instanceof HTMLInputElement)) {
+  if (
+    !(
+      $textarea instanceof HTMLTextAreaElement ||
+      $textarea instanceof HTMLInputElement
+    )
+  ) {
     return this
   }
 
@@ -105,6 +110,8 @@ function CharacterCount ($module, config) {
     locale: closestAttributeValue($module, 'lang')
   })
 
+  /** @deprecated Will be made private in v5.0 */
+  this.maxLength = Infinity
   // Determine the limit attribute (characters or words)
   if ('maxwords' in this.config && this.config.maxwords) {
     this.maxLength = this.config.maxwords
@@ -131,6 +138,9 @@ function CharacterCount ($module, config) {
 
   /** @deprecated Will be made private in v5.0 */
   this.lastInputValue = ''
+
+  /** @deprecated Will be made private in v5.0 */
+  this.valueChecker = null
 }
 
 /**

--- a/src/govuk/components/details/details.mjs
+++ b/src/govuk/components/details/details.mjs
@@ -24,7 +24,14 @@ function Details ($module) {
     return this
   }
 
+  /** @deprecated Will be made private in v5.0 */
   this.$module = $module
+
+  /** @deprecated Will be made private in v5.0 */
+  this.$summary = null
+
+  /** @deprecated Will be made private in v5.0 */
+  this.$content = null
 }
 
 /**

--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -45,6 +45,9 @@ function Tabs ($module) {
 
   /** @deprecated Will be made private in v5.0 */
   this.boundOnHashChange = this.onHashChange.bind(this)
+
+  /** @deprecated Will be made private in v5.0 */
+  this.changingHash = false
 }
 
 /**


### PR DESCRIPTION
This includes the missing ones spotted in https://github.com/alphagov/govuk-frontend/pull/3512, though the `bound...` properties of the Tabs already had them marked.

It also adds `@deprecated` tags to some of the Character Count properties that were missing them, revealed by a search for `this\.[^.]* = ` in `src/govuk/components`.<F2>