### PR TITLE
Remove incorrect information about visually hidden text on previous/next

### DIFF
--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -36,7 +36,7 @@ params:
       - name: text
         type: string
         required: false
-        description: The link text to the previous page. Defaults to 'Previous page', where 'page' is visually hidden.
+        description: The link text to the previous page. Defaults to 'Previous'.
       - name: labelText
         type: string
         required: false
@@ -57,7 +57,7 @@ params:
       - name: text
         type: string
         required: false
-        description: The link text to the next page. Defaults to 'Next page', where 'page' is visually hidden.
+        description: The link text to the next page. Defaults to 'Next'.
       - name: labelText
         type: string
         required: false

--- a/src/govuk/components/pagination/pagination.yaml
+++ b/src/govuk/components/pagination/pagination.yaml
@@ -225,11 +225,9 @@ examples:
       previous:
         text: 'précédente'
         href: '/previous'
-        visuallyHiddenText: 'Page précédente'
       next:
         text: 'suivante'
         href: '/next'
-        visuallyHiddenText: 'Page suivante'
   - name: with previous only
     data:
       previous:


### PR DESCRIPTION
The [pagination documentation](https://design-system.service.gov.uk/components/pagination/) says that by default, Previous and Next links will have some visually hidden text (eg `Previous<span class="govuk-visually-hidden"> page</span>`).

This doesn't actually seem to be the case - the link text is just 'Previous' or 'Next' (unless `labelText` is also provided, in which case there's a visually hidden colon, but that's it): https://github.com/alphagov/govuk-frontend/blob/6233eaa9cfb6c0dd44ed8341e0ac5e0afe339f84/src/govuk/components/pagination/template.njk#L10-L16

I can't see a visually hidden span or `aria-label` that would match the behaviour described in the documentation, and testing with NVDA on the example at https://design-system.service.gov.uk/components/pagination/default/index.html, those links just read 'Previous' and 'Next'

This PR just updates the documentation to match the current behaviour, but there's probably also a discussion to be had on whether the behaviour of the component should change to match what's described in the documentation. Some of the examples in this file also seem to assume that there are `previous.visuallyHiddenText` and `next.visuallyHiddenText` options: https://github.com/alphagov/govuk-frontend/blob/6233eaa9cfb6c0dd44ed8341e0ac5e0afe339f84/src/govuk/components/pagination/pagination.yaml#L223-L228

Again, those don't seem to actually exist, but maybe they should? (I'm guessing these examples are shown in the review app, which I can't find, because they're not in the Design System documentation)