### PR TITLE
Add note to docs to raise changelog PR before release

### DIFF
--- a/docs/releasing/before-publishing-a-release.md
+++ b/docs/releasing/before-publishing-a-release.md
@@ -37,7 +37,7 @@ A content designer and/or tech writer should do the following:
 - write announcements for slack posts, email and to go on the design system website after we release GOV.UK Frontend (for example, [draft comms for the cookie banner component](https://docs.google.com/document/d/1jVyMB7i94NOeflWaf3kE4Q4APMXGfluK3rOh74IHO08/edit))
 - check who the release’s contributors are and if we have consent to include their name
 
-A technical writer should finalise draft of release notes. Release notes will require a 2i review by another technical writer, make sure the technical writer has time to coordinate this.
+A technical writer should finalise draft of release notes. Release notes will require a 2i review by another technical writer, make sure the technical writer has time to coordinate this. When ready, open a pull request to update the [CHANGELOG.md](https://github.com/alphagov/govuk-frontend/blob/main/CHANGELOG.md) file with the updated release notes.
 
 If the technical writer is unavailable, ask for help in the [gds-technical-writing Slack channel](https://gds.slack.com/archives/CAD0R2NQG) or confer with a content designer.
 


### PR DESCRIPTION
The publishing guide includes a note to update the version written in the CHANGELOG.md file, but there's no guarantee that the rest of the changelog is up-to-date following the draft/2i process.

This PR adds a sentence explicitly mentioning to raise a pull request to update the changelog as part of the comms preparation.

This tripped us up slightly during the 4.6.0 release as we had to stop to extract the updated changelog from Google Docs, convert it from rich text to Markdwon, and resolve any formatting issues that arose before we could continue with the release. 