### PR TITLE
Prevent Chrome headless deprecation warning

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -30,7 +30,18 @@ module.exports = {
        */
       '--no-startup-window'
     ],
-    headless: process.env.HEADLESS !== 'false',
+
+    /**
+     * Allow headless mode switching using `HEADLESS=false`
+     * but default to `1` to skip deprecation warning
+     *
+     * {@link https://developer.chrome.com/articles/new-headless/}
+     */
+    headless: process.env.HEADLESS !== 'false'
+      ? 1
+      : false,
+
+    // See launch arg '--no-startup-window'
     waitForInitialPage: false
   },
 


### PR DESCRIPTION
This PR prevents the recent [Puppeteer `{ headless: true }` deprecation warning](https://github.com/puppeteer/puppeteer/pull/10039):

* https://github.com/puppeteer/puppeteer/pull/10039

We can revisit this in future with “new” headless mode via:

* https://github.com/alphagov/govuk-frontend/issues/3541

Until then it prevents all the console spam we're getting:

<img width="1156" alt="Console spam from Puppeteer" src="https://user-images.githubusercontent.com/415517/234054465-40f919c8-1c9e-485d-bd5e-fd9797f710f1.png">
