### PR TITLE
Clarify docs for radio and checkbox conditionals

### DIFF
--- a/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/src/govuk/components/checkboxes/checkboxes.yaml
@@ -79,13 +79,13 @@ params:
         required: false
         description: Whether the checkbox should be checked when the page loads. Takes precedence over the top-level `values` option.
       - name: conditional
-        type: boolean
+        type: object
         required: false
-        description: If `true`, content provided will be revealed when the item is checked.
-      - name: conditional.html
-        type: string
-        required: false
-        description: Provide content for the conditional reveal.
+        description: Provide additional content to reveal when the checkbox is checked.
+        params:
+          - name: html
+            type: string
+            description: The HTML to reveal when the checkbox is checked
       - name: behaviour
         type: string
         required: false

--- a/src/govuk/components/radios/radios.yaml
+++ b/src/govuk/components/radios/radios.yaml
@@ -71,13 +71,13 @@ params:
         required: false
         description: Whether the radio should be checked when the page loads. Takes precedence over the top-level `value` option.
       - name: conditional
-        type: string
+        type: object
         required: false
-        description: If `true`, content provided will be revealed when the item is checked.
-      - name: conditional.html
-        type: html
-        required: false
-        description: Provide content for the conditional reveal.
+        description: Provide additional content to reveal when the radio is checked.
+        params:
+          - name: html
+            type: string
+            description: The HTML to reveal when the radio is checked
       - name: disabled
         type: boolean
         required: false


### PR DESCRIPTION
The documentation for the conditional Nunjucks macro option for checkboxes and radios is confusing.

The checkboxes documentation lists `conditional` as a boolean, and the radios documentation lists it as a string.

Neither are correct.

The `conditional` option is an object with a single nested option, `html`. The nested `html` option is a string, used to specify the content that is revealed when the checkbox or radio is checked.

Update the component YAML so that the documentation reflects this.

## Checkboxes

### Before

![Screenshot 2023-04-26 at 09 34 30](https://user-images.githubusercontent.com/121939/234522919-b39d7a42-0d9c-4dd6-9b50-73768ee624ca.png)

### After

![Screenshot 2023-04-26 at 09 47 31](https://user-images.githubusercontent.com/121939/234523009-1d57f463-4bad-4a5a-8fbc-31960b9feb63.png)
![Screenshot 2023-04-26 at 09 47 38](https://user-images.githubusercontent.com/121939/234523012-9a110326-c535-47b2-b18f-8db57f2d5450.png)

## Radios

### Before

![Screenshot 2023-04-26 at 09 35 20](https://user-images.githubusercontent.com/121939/234523141-6ad5f9d7-8277-4ecf-a4b0-19b542dd08f9.png)

### After

![Screenshot 2023-04-26 at 09 48 05](https://user-images.githubusercontent.com/121939/234523216-6634da72-d035-416c-804c-dffd5c9a2bc6.png)
![Screenshot 2023-04-26 at 09 48 12](https://user-images.githubusercontent.com/121939/234523222-9f051190-f06e-4fe1-b054-233313b5993d.png)

Closes #1903