### PR TITLE
Update “caniuse” data with `npx update-browserslist-db@latest`

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -30,7 +30,15 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    Do not commit the changes.
 
-7. Run `npm run build-release` to:
+7. Update browser data from ["Can I use"](https://caniuse.com) by running:
+
+   ```
+   npx update-browserslist-db@latest
+   ```
+
+   This step will update the project `package-lock.json` file if updates are found.
+
+8. Run `npm run build-release` to:
 
    - build GOV.UK Frontend into the `/package` and `/dist` directories
    - commit the changes
@@ -38,10 +46,10 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    You will now be prompted to continue or cancel.
 
-8. Create a pull request and copy the changelog text.
+9. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
 
-9. Once a reviewer approves the pull request, merge it to **main**.
+10. Once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6822,9 +6822,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001431",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
-      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true,
       "funding": [
         {
@@ -6834,6 +6834,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },


### PR DESCRIPTION
Just another console warning that popped up today

```console
Browserslist: caniuse-lite is outdated. Please run:
  npx update-browserslist-db@latest
  Why you should do it regularly: https://github.com/browserslist/update-db#readme
```

We apply these data-specific [browserslist](https://browsersl.ist) queries to [Autoprefixer](https://github.com/postcss/autoprefixer#readme) but our data is from November 2022

```
> 0.1%
last 2 Chrome versions
last 2 Firefox versions
last 2 Edge versions
last 2 Samsung versions
```

This PR runs `npx update-browserslist-db@latest` as suggested

Should browser data freshness be an automated test or release checklist item?