### PR TITLE
Add inverse button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### New features
+
+#### Added inverse modifier for buttons on dark backgrounds
+
+You can now style buttons on dark backgrounds to have a white background colour by adding the `govuk-button--inverse` class.
+
+This change was made in [pull request #3556: Add inverse button styles](https://github.com/alphagov/govuk-frontend/pull/3556).
+
 ### Breaking changes
 
 #### Check that disabled buttons work as expected

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -18,21 +18,27 @@ $govuk-button-text-colour: govuk-colour("white") !default;
 
 @include govuk-exports("govuk/component/button") {
   $govuk-button-colour: $govuk-button-background-colour;
+  $govuk-button-text-colour: $govuk-button-text-colour;
   $govuk-button-hover-colour: govuk-shade($govuk-button-colour, 20%);
   $govuk-button-shadow-colour: govuk-shade($govuk-button-colour, 60%);
-  $govuk-button-text-colour: $govuk-button-text-colour;
 
   // Secondary button variables
   $govuk-secondary-button-colour: govuk-colour("light-grey", $legacy: "grey-3");
+  $govuk-secondary-button-text-colour: govuk-colour("black");
   $govuk-secondary-button-hover-colour: govuk-shade($govuk-secondary-button-colour, 10%);
   $govuk-secondary-button-shadow-colour: govuk-shade($govuk-secondary-button-colour, 40%);
-  $govuk-secondary-button-text-colour: govuk-colour("black");
 
   // Warning button variables
   $govuk-warning-button-colour: govuk-colour("red");
+  $govuk-warning-button-text-colour: govuk-colour("white");
   $govuk-warning-button-hover-colour: govuk-shade($govuk-warning-button-colour, 20%);
   $govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 60%);
-  $govuk-warning-button-text-colour: govuk-colour("white");
+
+  // Inverse button variables
+  $govuk-inverse-button-colour: govuk-colour("white");
+  $govuk-inverse-button-text-colour: govuk-colour("blue");
+  $govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
+  $govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
 
   // Because the shadow (s0) is visually 'part of' the button, we need to reduce
   // the height of the button to compensate by adjusting its padding (s1) and
@@ -247,6 +253,38 @@ $govuk-button-text-colour: govuk-colour("white") !default;
 
       &[disabled] {
         background-color: $govuk-warning-button-colour;
+      }
+    }
+  }
+
+  .govuk-button--inverse {
+    background-color: $govuk-inverse-button-colour;
+    box-shadow: 0 $button-shadow-size 0 $govuk-inverse-button-shadow-colour;
+
+    &,
+    &:link,
+    &:visited,
+    &:active,
+    &:hover {
+      color: $govuk-inverse-button-text-colour;
+    }
+
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors so
+    // so that unvisited links styled as buttons do not end up with dark blue
+    // text when focussed.
+    @include _govuk-compatibility(govuk_template) {
+      &:link:focus {
+        color: $govuk-inverse-button-text-colour;
+      }
+    }
+
+    &:hover {
+      background-color: $govuk-inverse-button-hover-colour;
+
+      &[disabled] {
+        background-color: $govuk-inverse-button-colour;
       }
     }
   }

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -148,6 +148,33 @@ examples:
       text: Warning button
       href: '/'
       classes: govuk-button--warning
+  - name: Inverse
+    description: A button that appears on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse
+  - name: Inverse disabled
+    data:
+      name: Inverse
+      text: Inverse button disabled
+      classes: govuk-button--inverse
+      disabled: true
+  - name: Inverse link
+    description: A link button for actions that appear on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse button
+      href: '/'
+      classes: govuk-button--inverse
+  - name: Inverse start button
+    description: A start button that appears on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse start button
+      href: '/'
+      classes: govuk-button--inverse
+      isStartButton: true
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes


### PR DESCRIPTION
Ports the inverse button styles from the [GaaP product page repository](https://github.com/alphagov/product-page-example/blob/master/source/stylesheets/modules/_inverted-button.scss) into Frontend.

I haven't added any additional automated or accessibility tests (not that other stylistic variants have them), but these styles have existed in the wild for a long time already—one would hope that any major issues with the styles had already been identified. 

Closes #2267. 