### PR TITLE
Use JSDoc `@satisfies` for query selector inheritance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,9 @@
       "devDependencies": {
         "@babel/core": "^7.21.4",
         "@babel/preset-env": "^7.21.4",
-        "@typescript-eslint/eslint-plugin": "^5.59.0",
-        "@typescript-eslint/parser": "^5.59.0",
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^5.59.2",
+        "@typescript-eslint/parser": "^5.59.2",
         "autoprefixer": "^9.8.8",
         "cheerio": "^1.0.0-rc.12",
         "cssnano": "^6.0.0",
@@ -27,7 +28,7 @@
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-es-x": "^6.1.0",
         "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-jsdoc": "^43.0.7",
+        "eslint-plugin-jsdoc": "^43.1.1",
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.1.1",
         "govuk-frontend-config": "*",
@@ -77,7 +78,7 @@
         "@types/gulp": "^4.0.10",
         "@types/jest": "^29.5.1",
         "@types/jest-axe": "^3.5.5",
-        "@types/node": "^18.16.0",
+        "@types/node": "^18.16.2",
         "@types/nunjucks": "^3.2.2"
       }
     },
@@ -4299,9 +4300,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==",
+      "version": "18.16.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
+      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
       "devOptional": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -4494,15 +4495,15 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.0.tgz",
-      "integrity": "sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.59.2.tgz",
+      "integrity": "sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
-        "@typescript-eslint/scope-manager": "5.59.0",
-        "@typescript-eslint/type-utils": "5.59.0",
-        "@typescript-eslint/utils": "5.59.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/type-utils": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
@@ -4543,14 +4544,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
-      "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.2.tgz",
+      "integrity": "sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.59.0",
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4570,13 +4571,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
-      "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.2.tgz",
+      "integrity": "sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/visitor-keys": "5.59.0"
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4587,13 +4588,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.0.tgz",
-      "integrity": "sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.59.2.tgz",
+      "integrity": "sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.59.0",
-        "@typescript-eslint/utils": "5.59.0",
+        "@typescript-eslint/typescript-estree": "5.59.2",
+        "@typescript-eslint/utils": "5.59.2",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -4614,9 +4615,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
-      "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.2.tgz",
+      "integrity": "sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4627,13 +4628,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
-      "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.2.tgz",
+      "integrity": "sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/visitor-keys": "5.59.0",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/visitor-keys": "5.59.2",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4669,17 +4670,17 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.0.tgz",
-      "integrity": "sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.59.2.tgz",
+      "integrity": "sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.59.0",
-        "@typescript-eslint/types": "5.59.0",
-        "@typescript-eslint/typescript-estree": "5.59.0",
+        "@typescript-eslint/scope-manager": "5.59.2",
+        "@typescript-eslint/types": "5.59.2",
+        "@typescript-eslint/typescript-estree": "5.59.2",
         "eslint-scope": "^5.1.1",
         "semver": "^7.3.7"
       },
@@ -4732,12 +4733,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
-      "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
+      "version": "5.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.2.tgz",
+      "integrity": "sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.59.0",
+        "@typescript-eslint/types": "5.59.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -9390,9 +9391,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "43.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.0.7.tgz",
-      "integrity": "sha512-32Sx5I9VzO/bqbtslCu3L1GHIPo+QEliwqwjWq+qzbUv76wrkH6ifUEE0EbkuNEn+cHlSIOrg/IJ1PGNN72QZA==",
+      "version": "43.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-43.1.1.tgz",
+      "integrity": "sha512-J2kjjsJ5vBXSyNzqJhceeSGTAgVgZHcPSJKo3vD4tNjUdfky98rR2VfZUDsS1GKL6isyVa8GWvr+Az7Vyg2HXA==",
       "dev": true,
       "dependencies": {
         "@es-joy/jsdoccomment": "~0.37.1",
@@ -9405,7 +9406,7 @@
         "spdx-expression-parse": "^3.0.1"
       },
       "engines": {
-        "node": "^14 || ^16 || ^17 || ^18 || ^19 || ^20"
+        "node": ">=16"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "stylelint": "^14.16.1",
         "stylelint-config-gds": "^0.2.0",
         "stylelint-order": "^6.0.3",
-        "typed-query-selector": "^2.10.1",
         "typedoc": "^0.24.6",
         "typescript": "^5.0.4"
       },
@@ -24895,12 +24894,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/typed-query-selector": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.10.1.tgz",
-      "integrity": "sha512-VyNeetDghQngbLWOVyxUFB95nZF3z3QIrvdsWmuDwwYbePEup9hjZbNT1IK5YP3t8LqicnYNnDpQPW3vq7iCTQ==",
-      "dev": true
     },
     "node_modules/typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -45,8 +45,9 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@babel/preset-env": "^7.21.4",
-    "@typescript-eslint/eslint-plugin": "^5.59.0",
-    "@typescript-eslint/parser": "^5.59.0",
+    "@types/node": "^18.16.3",
+    "@typescript-eslint/eslint-plugin": "^5.59.2",
+    "@typescript-eslint/parser": "^5.59.2",
     "autoprefixer": "^9.8.8",
     "cheerio": "^1.0.0-rc.12",
     "cssnano": "^6.0.0",
@@ -56,7 +57,7 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-es-x": "^6.1.0",
     "eslint-plugin-import": "^2.27.5",
-    "eslint-plugin-jsdoc": "^43.0.7",
+    "eslint-plugin-jsdoc": "^43.1.1",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.1.1",
     "govuk-frontend-config": "*",
@@ -102,7 +103,7 @@
     "@types/gulp": "^4.0.10",
     "@types/jest": "^29.5.1",
     "@types/jest-axe": "^3.5.5",
-    "@types/node": "^18.16.0",
+    "@types/node": "^18.16.2",
     "@types/nunjucks": "^3.2.2"
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "stylelint": "^14.16.1",
     "stylelint-config-gds": "^0.2.0",
     "stylelint-order": "^6.0.3",
-    "typed-query-selector": "^2.10.1",
     "typedoc": "^0.24.6",
     "typescript": "^5.0.4"
   },

--- a/src/govuk/common/govuk-frontend-version.mjs
+++ b/src/govuk/common/govuk-frontend-version.mjs
@@ -3,4 +3,9 @@
  * It doesn't need to be updated manually.
  */
 
+/**
+ * GOV.UK Frontend release version
+ *
+ * {@link https://github.com/alphagov/govuk-frontend/releases}
+ */
 export var version = 'development'

--- a/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/src/govuk/components/checkboxes/checkboxes.mjs
@@ -16,6 +16,7 @@ function Checkboxes ($module) {
     return this
   }
 
+  /** @satisfies {NodeListOf<HTMLInputElement>} */
   var $inputs = $module.querySelectorAll('input[type="checkbox"]')
   if (!$inputs.length) {
     return this
@@ -129,8 +130,7 @@ Checkboxes.prototype.syncConditionalRevealWithInputState = function ($input) {
 Checkboxes.prototype.unCheckAllInputsExcept = function ($input) {
   var $component = this
 
-  /** @type {NodeListOf<HTMLInputElement>} */
-  // @ts-expect-error `NodeListOf<HTMLInputElement>` type expected
+  /** @satisfies {NodeListOf<HTMLInputElement>} */
   var allInputsWithSameName = document.querySelectorAll(
     'input[type="checkbox"][name="' + $input.name + '"]'
   )
@@ -157,8 +157,7 @@ Checkboxes.prototype.unCheckAllInputsExcept = function ($input) {
 Checkboxes.prototype.unCheckExclusiveInputs = function ($input) {
   var $component = this
 
-  /** @type {NodeListOf<HTMLInputElement>} */
-  // @ts-expect-error `NodeListOf<HTMLInputElement>` type expected
+  /** @satisfies {NodeListOf<HTMLInputElement>} */
   var allInputsWithSameNameAndExclusiveBehaviour = document.querySelectorAll(
     'input[data-behaviour="exclusive"][type="checkbox"][name="' + $input.name + '"]'
   )

--- a/src/govuk/components/radios/radios.mjs
+++ b/src/govuk/components/radios/radios.mjs
@@ -16,6 +16,7 @@ function Radios ($module) {
     return this
   }
 
+  /** @satisfies {NodeListOf<HTMLInputElement>} */
   var $inputs = $module.querySelectorAll('input[type="radio"]')
   if (!$inputs.length) {
     return this
@@ -139,6 +140,7 @@ Radios.prototype.handleClick = function (event) {
 
   // We only need to consider radios with conditional reveals, which will have
   // aria-controls attributes.
+  /** @satisfies {NodeListOf<HTMLInputElement>} */
   var $allInputs = document.querySelectorAll('input[type="radio"][aria-controls]')
 
   var $clickedInputForm = $clickedInput.form

--- a/src/govuk/components/tabs/tabs.mjs
+++ b/src/govuk/components/tabs/tabs.mjs
@@ -18,6 +18,7 @@ function Tabs ($module) {
     return this
   }
 
+  /** @satisfies {NodeListOf<HTMLAnchorElement>} */
   var $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
   if (!$tabs.length) {
     return this
@@ -232,7 +233,6 @@ Tabs.prototype.showTab = function ($tab) {
  * @returns {HTMLAnchorElement | null} Tab link
  */
 Tabs.prototype.getTab = function (hash) {
-  // @ts-expect-error `HTMLAnchorElement` type expected
   return this.$module.querySelector('a.govuk-tabs__tab[href="' + hash + '"]')
 }
 
@@ -373,6 +373,7 @@ Tabs.prototype.activateNextTab = function () {
     return
   }
 
+  /** @satisfies {HTMLAnchorElement} */
   var $nextTab = $nextTabListItem.querySelector('a.govuk-tabs__tab')
   if (!$nextTab) {
     return
@@ -400,6 +401,7 @@ Tabs.prototype.activatePreviousTab = function () {
     return
   }
 
+  /** @satisfies {HTMLAnchorElement} */
   var $previousTab = $previousTabListItem.querySelector('a.govuk-tabs__tab')
   if (!$previousTab) {
     return

--- a/src/tsconfig.build.json
+++ b/src/tsconfig.build.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["node", "typed-query-selector"]
+    "types": ["node"]
   }
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -10,12 +10,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": [
-      "jest",
-      "jest-axe",
-      "jest-puppeteer",
-      "node",
-      "typed-query-selector"
-    ]
+    "types": ["jest", "jest-axe", "jest-puppeteer", "node"]
   }
 }

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -2,11 +2,13 @@
  * @type {import('typedoc').TypeDocOptions}
  */
 module.exports = {
+  basePath: './src',
   emit: 'both',
   entryPoints: ['./src/govuk/all.mjs'],
   name: 'govuk-frontend',
   out: './app/dist/docs/jsdoc',
   tsconfig: './src/tsconfig.build.json',
+  sourceLinkTemplate: 'https://github.com/alphagov/govuk-frontend/blob/{gitRevision}/{path}#L{line}',
 
   // Ignore warnings about CharacterCountTranslations using I18n (@private)
   intentionallyNotExported: [


### PR DESCRIPTION
This PR correctly infers "compatible" types in our ESLint + JSDoc compiler checks, removing workarounds

Made possible by ESLint plugin [`eslint-plugin-jsdoc@43.0.9`](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v43.0.9) adding [`@satisfies`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#satisfies-support-in-jsdoc) and [`@overload`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#overload-support-in-jsdoc) support


### Before
Hard coded types and ignored compiler errors

```js
/** @type {NodeListOf<HTMLInputElement>} */
// @ts-expect-error `NodeListOf<HTMLInputElement>` type expected
var allInputsWithSameName = document.querySelectorAll(
  'input[type="checkbox"][name="' + $input.name + '"]'
)
```

### After
Although the CSS selector `input[type="checkbox"]` should infer [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) → [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) → [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement), we can now use [`@satisfies`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#satisfies-support-in-jsdoc) to add those missing prototype inheritance hints 🙌 

```js
/** @satisfies {NodeListOf<HTMLInputElement>} */
var allInputsWithSameName = document.querySelectorAll(
  'input[type="checkbox"][name="' + $input.name + '"]'
)
```

## Hard coded types no more

Before [`@satisfies`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#satisfies-support-in-jsdoc) we used a [`typed-query-selector` workaround](https://github.com/alphagov/govuk-frontend/commit/abdf182d782002e31cf8f36c6a6f949b671fb729) but compound selectors threw errors:

```console
Type 'NodeListOf<Element>' is not assignable to type 'NodeListOf<HTMLInputElement>'.
  Type 'Element' is missing the following properties from type 'HTMLInputElement': accept, align, alt, autocomplete, and 173 more.
```

Our only fix for those more complex cases was to add [`@type` overrides](https://jsdoc.app/tags-type.html)

But because the CSS selector `input[type="checkbox"]` returns either `HTMLInputElement` types (or `null` if not found) we can now use [`@satisfies`](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#satisfies-support-in-jsdoc) until compound selectors are supported:

* https://github.com/microsoft/TypeScript/issues/29037