### PR TITLE
Remove unnecesary class from Warning Text component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ We no longer support link buttons being disabled or using disabled styles.
 
 This change was introduced in [pull request #3557: Remove deprecated `.govuk-button--disabled` class](https://github.com/alphagov/govuk-frontend/pull/3557).
 
+#### Update the HTML for warning text
+
+We've removed the `.govuk-warning-text__assistive` class and its styles from GOV.UK Frontend. This class is unnecessary, as it duplicates the functionality of the `.govuk-visually-hidden` class already present in Frontend.
+
+If you’re not using Nunjucks macros, update your warning text HTML to replace the `govuk-warning-text__assistive` class with the `govuk-visually-hidden` class.
+
+This change was introduced in [pull request #3569: Remove unnecesary class from Warning Text component](https://github.com/alphagov/govuk-frontend/pull/3569).
+
 ## 4.6.0 (Feature release)
 
 ### New features

--- a/src/govuk/components/warning-text/_index.scss
+++ b/src/govuk/components/warning-text/_index.scss
@@ -5,10 +5,6 @@
     padding: govuk-spacing(2) 0;
   }
 
-  .govuk-warning-text__assistive {
-    @include govuk-visually-hidden;
-  }
-
   .govuk-warning-text__icon {
     @include govuk-font($size: false, $weight: bold);
 

--- a/src/govuk/components/warning-text/template.njk
+++ b/src/govuk/components/warning-text/template.njk
@@ -3,7 +3,7 @@
   >
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-warning-text__assistive">{{ params.iconFallbackText | default("Warning") }}</span>
+    <span class="govuk-visually-hidden">{{ params.iconFallbackText | default("Warning") }}</span>
     {{ params.html | safe if params.html else params.text }}
   </strong>
 </div>

--- a/src/govuk/components/warning-text/template.test.js
+++ b/src/govuk/components/warning-text/template.test.js
@@ -19,7 +19,7 @@ describe('Warning text', () => {
     it('renders with default assistive text', () => {
       const $ = render('warning-text', examples.default)
 
-      const $assistiveText = $('.govuk-warning-text__assistive')
+      const $assistiveText = $('.govuk-visually-hidden')
       expect($assistiveText.text()).toEqual('Warning')
     })
 
@@ -42,7 +42,7 @@ describe('Warning text', () => {
     it('renders custom assistive text', () => {
       const $ = render('warning-text', examples['icon fallback text only'])
 
-      const $assistiveText = $('.govuk-warning-text__assistive')
+      const $assistiveText = $('.govuk-visually-hidden')
       expect($assistiveText.html()).toContain('Some custom fallback text')
     })
 


### PR DESCRIPTION
The `govuk-warning-text__assistive` class in the Warning Text component is redundant. It applies exactly the same styles as `govuk-visually-hidden` without any variation in code or purpose, and is not referenced by any JS functionality outside of tests.

This PR replaces the component's bespoke class with the global `govuk-visually-hidden` class.

As this is an alteration to the HTML, it's a breaking change for any users not using Nunjucks macros.

This is how the [equivalent GOV.UK Elements component](https://github.com/alphagov/govuk_elements/blob/master/app/views/snippets/typography_warning_text.html#L3) styled it. The bespoke class was added when the component was [ported into the Design System](https://github.com/alphagov/govuk-frontend/blob/f4b9dabb98684d4e9edd803aea17e0edfb5f12ff/src/components/legal-text/legal-text.html#L4), but it served the same purpose [even then](https://github.com/alphagov/govuk-frontend/blob/1ac78a092b8b499e3159997050cae569c945b1bc/src/components/legal-text/_legal-text.scss#L20-L22).

Closes #3553.