### PR TITLE
Update browser support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ files into your project](https://frontend.design-system.service.gov.uk/install-u
 
 GOV.UK Frontend supports:
 
-- [recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in)
+- [recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in) and Internet Explorer 11
 - [recommended assistive technologies](https://www.gov.uk/service-manual/technology/testing-with-assistive-technologies#which-assistive-technologies-to-test-with)
 - Internet Explorer 8, 9 and 10, although components may not look perfect
 - your users overriding colours in Windows, Firefox and Chrome


### PR DESCRIPTION
Since the Service Manual [removed IE11 from their recommended browsers](https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices#browsers-to-test-in), our README has been a bit out of date, so I've explicitly added it back.

I'm not sure if I should be as explicit with Safari 9, 10, 11, since Safari 12.1+ is recommended by the Service Manual.

