### PR TITLE
Add warning about forking the repository while we work on v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ GOV.UK Frontend ·
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 =====================
 
+> **Warning** We’re currently implementing heavy changes to our code for [our next major version](https://github.com/alphagov/govuk-frontend/milestone/46).
+>
+> We recommend you wait before forking this repository to limit your effort of keeping your fork up to date with our changes.
+>
+> If you were forking to fix a bug in our last releases, please branch off the v4.6.0 tag.
+
 GOV.UK Frontend contains the code you need to start building a user interface
 for government platforms and services.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ GOV.UK Frontend ·
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 =====================
 
-> **Warning** We’re currently implementing heavy changes to our code for [our next major version](https://github.com/alphagov/govuk-frontend/milestone/46).
+> **Warning**
 >
-> We recommend you wait before forking this repository to limit your effort of keeping your fork up to date with our changes.
+> We’re currently implementing extensive changes to our code for [our next major version](https://github.com/alphagov/govuk-frontend/milestone/46).
 >
-> If you were forking to fix a bug in our last releases, please branch off the v4.6.0 tag.
+> While we're making changes, only fork this repository if necessary. This is to limit how often you will need to update your fork to keep up to date.
+>
+> If you're fixing a bug in our previous releases, branch off the [latest 4.x tag](https://github.com/alphagov/govuk-frontend/tags) instead.
 
 GOV.UK Frontend contains the code you need to start building a user interface
 for government platforms and services.


### PR DESCRIPTION
## What

Add a little warning in the README to warn against forking the repository while we work on v5, as well as pointing to which branch to use should someone propose a bug fix for our last release.

## Why

Our code will undergo heavy changes as we develop v5. This will mean a lot of effort to keep a fork up to date with our changes, so we're informing people of that and pointing them to how to fork for a bug fix.