### PR TITLE
Fix URL `file://` path handling on Windows

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -13,12 +13,6 @@ runs:
         key: build-cache-${{ runner.os }}-${{ github.sha }}
         path: packages/*/dist
 
-    - name: Install dependencies
-      uses: ./.github/workflows/actions/install-node
-
-      # Skip install when build is already cached
-      if: steps.build-cache.outputs.cache-hit != 'true'
-
     - name: Build
       id: build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
       - name: Build
         uses: ./.github/workflows/actions/build
 

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -1,4 +1,7 @@
 import { dirname, parse, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+import slash from 'slash'
 
 import { files } from './index.mjs'
 
@@ -36,10 +39,10 @@ export async function write (filePath, result) {
        * Make source file:// paths relative (e.g. for Dart Sass)
        * {@link https://sass-lang.com/documentation/js-api/interfaces/CompileResult#sourceMap}
        */
-      .map((path) => path.startsWith('file://')
-        ? relative(dirname(filePath), new URL(path).pathname)
+      .map((path) => slash(path.startsWith('file://')
+        ? relative(dirname(filePath), fileURLToPath(path))
         : path
-      )
+      ))
 
     writeTasks.push(files.write(`${base}.map`, {
       destPath: dir,

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -1,5 +1,5 @@
-
 import { join } from 'path'
+import { pathToFileURL } from 'url'
 
 import { files } from './index.mjs'
 
@@ -11,7 +11,7 @@ import { files } from './index.mjs'
  * @returns {Promise<void>}
  */
 export async function compile (modulePath, options) {
-  const { default: configFn } = await import(join(options.srcPath, modulePath))
+  const { default: configFn } = await import(pathToFileURL(join(options.srcPath, modulePath)).toString())
 
   // Write to destination
   return files.write(modulePath, {


### PR DESCRIPTION
This PR fixes two Windows regressions added in https://github.com/alphagov/govuk-frontend/pull/3527 and https://github.com/alphagov/govuk-frontend/pull/3372

URL file paths with drive letters `D:/` confuse [`path.relative()`](https://nodejs.org/docs/latest-v18.x/api/path.html#pathrelativefrom-to) and throw errors in [`await import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import):

```console
Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file and data are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'd:'
```

## File URLs with absolute paths

On Windows, Node.js `file://` URL paths look like:

```js
// Example file URL string
const file = 'file:///D:/path/to/asset'
```

### Converting URLs to paths incorrectly

But the property [`new URL(file).pathname`](https://nodejs.org/docs/latest-v18.x/api/url.html#urlpathname) includes a leading forward slash:

```js
// Example file URL pathname ❌
const pathname = '/D:/path/to/asset' 
```

We hadn't realised this breaks [`path.relative()`](https://nodejs.org/docs/latest-v18.x/api/path.html#pathrelativefrom-to) on Windows with paths joined and not resolved:

```js
'..\\..\\..\\..\\D:\\path\\to\\project\\packages\\govuk-frontend\\src\\govuk\\components\\character-count\\_index.scss'
```

### Converting URLs to paths correctly

After investigating this issue (also ["Converting between URLs and file paths"](https://exploringjs.com/nodejs-shell-scripting/ch_nodejs-path.html#converting-between-urls-and-file-paths)) we see that:

1. Compatible cross-platform “path to file URL” changes must use [`pathToFileURL()`](https://nodejs.org/docs/latest-v18.x/api/url.html#urlpathtofileurlpath)
2. Compatible cross-platform “file URL to path” changes must use [`fileURLToPath()`](https://nodejs.org/docs/latest-v18.x/api/url.html#urlfileurltopathurl)

```js
// Example file URL via fileURLToPath() ✅ 
const path = 'D:\\path\\to\\asset'
```