### PR TITLE
Add deprecation warning for `govuk-colour`'s `legacy` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 4.6.1 (Patch release)
+
+### Deprecated features
+
+#### Stop using legacy colour palette
+
+In GOV.UK Frontend v5.0 we will stop supporting compatibility with legacy codebases. As part of this, we're deprecating the legacy colour palette and the `$legacy` parameter of the `govuk-colour` function.
+
+Even if you are not currently using compatibility mode or the legacy colour palette, you will start receiving warnings if the `$legacy` parameter has been used anywhere in your code. These will become errors once v5.0 is released.
+
+This was added in [pull request #3585: Add deprecation warning for `govuk-colour`'s `legacy` parameter](https://github.com/alphagov/govuk-frontend/pull/3585).
+
 ## 4.6.0 (Feature release)
 
 ### New features

--- a/src/govuk/helpers/_colour.scss
+++ b/src/govuk/helpers/_colour.scss
@@ -1,6 +1,7 @@
 @import "../settings/compatibility";
 @import "../settings/colours-palette";
 @import "../settings/colours-organisations";
+@import "../settings/warnings";
 
 ////
 /// @group helpers/colour
@@ -25,10 +26,18 @@
 ///    background-colour: govuk-colour("green", $legacy: #BADA55);
 ///  }
 ///
+/// @deprecated The `$legacy` parameter will be removed in v5.0 with the rest of
+///   the compatibility mode
+///
 /// @throw if `$colour` is not a colour from the colour palette
 /// @access public
 
 @function govuk-colour($colour, $legacy: false) {
+  @if $legacy and not index($govuk-suppressed-warnings, "legacy-palette") {
+    @warn "The $legacy parameter is deprecated. Only the modern colour " +
+      "palette will be supported from v5.0.";
+  }
+
   @if $govuk-use-legacy-palette and $legacy {
     @if type-of($legacy) == "color" {
       @return $legacy;

--- a/src/govuk/helpers/colour.test.js
+++ b/src/govuk/helpers/colour.test.js
@@ -182,6 +182,26 @@ describe('@function govuk-colour', () => {
             'update $govuk-suppressed-warnings with key: "legacy-palette"'
         ]))
     })
+
+    it('outputs a deprecation warning when a $legacy colour is specified', async () => {
+      const sass = `
+        ${sassBootstrap}
+
+        .foo {
+          color: govuk-colour('red', $legacy: 'blue');
+        }
+      `
+
+      await compileSassString(sass, sassConfig)
+
+      // The $govuk-use-legacy-palette warning is always returned first, so look
+      // at index 1 of our array for this warning instead.
+      expect(mockWarnFunction.mock.calls[1])
+        .toEqual(expect.arrayContaining([
+          'The $legacy parameter is deprecated. Only the modern colour ' +
+            'palette will be supported from v5.0.'
+        ]))
+    })
   })
 
   describe('when $govuk-use-legacy-palette is false', () => {


### PR DESCRIPTION
We missed deprecating the `$legacy` parameter of the `govuk-colour` mixin when we deprecated the other legacy colour palette code in [v4.4.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0). As we want to remove this parameter in v5, we should deprecate it beforehand. 

This doesn't use our usual `_warning` mixin due to [mixins not being allowed within functions](https://github.com/alphagov/govuk-frontend/issues/3427). 