### PR TITLE
Fix `govuk-colour` deprecation message mismatch

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_colour.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_colour.scss
@@ -24,9 +24,10 @@
   // Output a warning if $legacy is set to anything. This can't use the
   // `_warning` mixin due to being a function, so we handle it manually.
   @if $legacy and not index($govuk-suppressed-warnings, "legacy-colour-param") {
-    @warn "The `$legacy` parameter is deprecated and is non-operational. It " +
-      "will be removed in the next major version. To silence this warning, " +
-      "update $govuk-suppressed-warnings with key: \"legacy-palette\"";
+    @warn "The `$legacy` parameter of `govuk-colour` is deprecated and is " +
+      "non-operational. It will be removed in the next major version. To " +
+      "silence this warning, update $govuk-suppressed-warnings with key: " +
+      "\"legacy-colour-param\"";
   }
 
   @if type-of($colour) == "color" {

--- a/packages/govuk-frontend/src/govuk/helpers/colour.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.test.js
@@ -99,9 +99,10 @@ describe('@function govuk-colour', () => {
     // argument, which should be the deprecation notice
     expect(mockWarnFunction.mock.calls[0])
       .toEqual(expect.arrayContaining([
-        'The `$legacy` parameter is deprecated and is non-operational. It ' +
-        'will be removed in the next major version. To silence this warning, ' +
-        'update $govuk-suppressed-warnings with key: "legacy-palette"'
+        'The `$legacy` parameter of `govuk-colour` is deprecated and is ' +
+        'non-operational. It will be removed in the next major version. To ' +
+        'silence this warning, update $govuk-suppressed-warnings with key: ' +
+        '"legacy-colour-param"'
       ]))
   })
 })


### PR DESCRIPTION
Fixes a couple of minor issues with the deprecation message from #3576:

- The warning suppression key in the message was wrong.
- The warning didn't name the function with the deprecated parameter. 