### PR TITLE
Remove deprecated static spacing classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ We no longer support link buttons being disabled or using disabled styles.
 
 This change was introduced in [pull request #3557: Remove deprecated `.govuk-button--disabled` class](https://github.com/alphagov/govuk-frontend/pull/3557).
 
+#### Remove deprecated `govuk-!-margin-static` and `govuk-!-padding-static` classes
+
+We've removed the override classes starting with `.govuk-!-margin-static` and `.govuk-!-padding-static` which were deprecated in [GOV.UK Frontend v4.3.1](https://github.com/alphagov/govuk-frontend/releases/tag/v4.3.1).
+
+Use the classes starting with `.govuk-!-static-margin` and `.govuk-!-static-padding` instead.
+
+This change was introduced in [pull request #3593: Remove deprecated static spacing classes](https://github.com/alphagov/govuk-frontend/pull/3593).
+
 #### Update the HTML for warning text
 
 We've removed the `.govuk-warning-text__assistive` class and its styles from GOV.UK Frontend. This class is unnecessary, as it duplicates the functionality of the `.govuk-visually-hidden` class already present in Frontend.

--- a/packages/govuk-frontend/src/govuk/overrides/_spacing.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_spacing.scss
@@ -61,14 +61,6 @@ $_spacing-directions: (
 /// Generate spacing override classes for the given property (e.g. margin)
 /// for each point in the non-responsive spacing scale.
 ///
-/// The classes in the format govuk-#{$property}-static-#{$spacing-point}
-/// and govuk-\!-#{$property}-#{$direction}-static-#{$spacing-point} are deprecated.
-/// For example: govuk-!-margin-static-2 or govuk-!-margin-top-static-2
-///
-/// Use classes in the format .govuk-\!-static-#{$property}-#{$spacing-point}
-/// and .govuk-\!-static-#{$property}-#{$direction}-#{$spacing-point} instead.
-/// For example: govuk-!-static-margin-2 or govuk-!-static-margin-top-2
-///
 /// @param {String} $property - Property to add spacing to (e.g. 'margin')
 ///
 /// @example css
@@ -79,13 +71,11 @@ $_spacing-directions: (
 /// @access private
 @mixin _govuk-generate-static-spacing-overrides($property) {
   @each $spacing-point in map-keys($govuk-spacing-points) {
-    .govuk-\!-#{$property}-static-#{$spacing-point},
     .govuk-\!-static-#{$property}-#{$spacing-point} {
       #{$property}: govuk-spacing($spacing-point) !important;
     }
 
     @each $direction in $_spacing-directions {
-      .govuk-\!-#{$property}-#{$direction}-static-#{$spacing-point},
       .govuk-\!-static-#{$property}-#{$direction}-#{$spacing-point} {
         #{$property}-#{$direction}: govuk-spacing($spacing-point) !important;
       }


### PR DESCRIPTION
Removes the erroneously named `.govuk-!-margin-static` and `.govuk-!-padding-static` classes introduced in v4.3.0 and deprecated in v4.3.1.

Closes #2782. 