### PR TITLE
Remove new link styles feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ In GOV.UK Frontend v3.12.0 we introduced new link styles which:
 
 The new link styles are now enabled by default. If you are setting `$govuk-new-link-styles` to `true` in your Sass you can now remove this.
 
-This change was made in [pull request #3599: Enable new link styles by default](https://github.com/alphagov/govuk-frontend/pull/3599).
+This change was made in [pull request #3599: Enable new link styles by default](https://github.com/alphagov/govuk-frontend/pull/3599) and [pull request #3600: Remove new link styles feature flag](https://github.com/alphagov/govuk-frontend/pull/3600).
 
 ### Breaking changes
 

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -30,14 +30,12 @@
 @mixin govuk-link-decoration {
   text-decoration: underline;
 
-  @if $govuk-new-link-styles {
-    @if $govuk-link-underline-thickness {
-      text-decoration-thickness: $govuk-link-underline-thickness;
-    }
+  @if $govuk-link-underline-thickness {
+    text-decoration-thickness: $govuk-link-underline-thickness;
+  }
 
-    @if $govuk-link-underline-offset {
-      text-underline-offset: $govuk-link-underline-offset;
-    }
+  @if $govuk-link-underline-offset {
+    text-underline-offset: $govuk-link-underline-offset;
   }
 }
 
@@ -50,7 +48,7 @@
 /// @access public
 
 @mixin govuk-link-hover-decoration {
-  @if $govuk-new-link-styles and $govuk-link-hover-underline-thickness {
+  @if $govuk-link-hover-underline-thickness {
     text-decoration-thickness: $govuk-link-hover-underline-thickness;
     // Disable ink skipping on underlines on hover. Browsers haven't
     // standardised on this part of the spec yet, so set both properties

--- a/packages/govuk-frontend/src/govuk/helpers/links.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/links.test.js
@@ -31,38 +31,6 @@ describe('@mixin govuk-link-decoration', () => {
     })
   })
 
-  describe('when $govuk-new-link-styles are disabled', () => {
-    it('does not set text-decoration-thickness', async () => {
-      const sass = `
-        $govuk-new-link-styles: false;
-        @import "base";
-
-        .foo {
-          @include govuk-link-decoration;
-        }
-      `
-
-      await expect(compileSassString(sass)).resolves.toMatchObject({
-        css: expect.not.stringContaining('text-decoration-thickness')
-      })
-    })
-
-    it('does not set text-underline-offset', async () => {
-      const sass = `
-        $govuk-new-link-styles: false;
-        @import "base";
-
-        .foo {
-          @include govuk-link-decoration;
-        }
-      `
-
-      await expect(compileSassString(sass)).resolves.toMatchObject({
-        css: expect.not.stringContaining('text-underline-offset')
-      })
-    })
-  })
-
   describe('when $govuk-link-underline-thickness is falsey', () => {
     it('does not set text-decoration-thickness', async () => {
       const sass = `
@@ -110,25 +78,6 @@ describe('@mixin govuk-link-hover-decoration', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: expect.stringContaining('.foo:hover')
-    })
-  })
-
-  describe('when $govuk-new-link-styles are disabled', () => {
-    it('does not set a hover state', async () => {
-      const sass = `
-        $govuk-new-link-styles: false;
-        @import "base";
-
-        // The mixin shouldn't return anything, so this selector ends up empty and
-        // is omitted from the CSS
-        .foo:hover {
-            @include govuk-link-hover-decoration;
-        }
-      `
-
-      await expect(compileSassString(sass)).resolves.toMatchObject({
-        css: expect.not.stringContaining('.foo:hover')
-      })
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/settings/_links.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_links.scss
@@ -2,19 +2,6 @@
 /// @group settings/links
 ////
 
-/// Enable new link styles
-///
-/// If enabled, the link styles will change. Underlines will:
-///
-/// - be consistently thinner and a bit further away from the link text
-/// - have a clearer hover state, where the underline gets thicker to make the
-///   link stand out to users
-///
-/// @type Boolean
-/// @access public
-
-$govuk-new-link-styles: true !default;
-
 /// Thickness of link underlines
 ///
 /// The default will be either:


### PR DESCRIPTION
This follows on from #3599 and removes the feature flag entirely. I think this makes sense as all of the CSS within the block guarded by the new link styles flag is also guarded by the other settings.

This means we can remove the flag as users can still disable the new link styles by setting:

```scss
$govuk-link-underline-offset: false;
$govuk-link-underline-thickness: false;
$govuk-link-hover-underline-thickness: false;
```

Would appreciate second opinions on whether this makes sense or whether we should do it 'properly' and deprecate it and remove it in v6 instead.