### PR TITLE
Separate JS and CSS diff, and upload diffs as artifacts

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -33,8 +33,9 @@ jobs:
       - name: Generate diff
         id: diff
         run: |
-          git diff -M05 origin/$GITHUB_BASE_REF -- dist \
-            > $GITHUB_WORKSPACE/dist.diff
+          # Using `origin/$GITHUB_BASE_REF` to avoid actually checking out the branch
+          # as all we need is to let Git diff the two references
+          bin/dist-diff.sh origin/$GITHUB_BASE_REF $GITHUB_WORKSPACE
 
       - name: Add comment to PR
         uses: actions/github-script@v6

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -37,6 +37,13 @@ jobs:
           # as all we need is to let Git diff the two references
           bin/dist-diff.sh origin/$GITHUB_BASE_REF $GITHUB_WORKSPACE
 
+      - name: Save distribution diffs
+        uses: actions/upload-artifact@v3
+        with:
+          name: Dist diff
+          path: dist*.diff
+          if-no-files-found: ignore
+
       - name: Add comment to PR
         uses: actions/github-script@v6
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 # Project lockfile only
 package-lock.json
 !/package-lock.json
+
+# Diffs
+*.diff

--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -11,5 +11,19 @@ base="${1:-main}"
 # And the output folder to the current working directory
 output_folder="${2:-`pwd`}"
 
-git diff -M05 $base -- dist \
+# Diff the minified JS file
+git diff \
+  $base:dist/govuk-frontend-$(git show $base:dist/VERSION.txt).min.js \
+  dist/govuk-frontend-$(cat dist/VERSION.txt).min.js \
+  > $output_folder/dist-js.diff
+
+# Diff the minified CSS file
+git diff \
+  $base:dist/govuk-frontend-$(git show $base:dist/VERSION.txt).min.css \
+  dist/govuk-frontend-$(cat dist/VERSION.txt).min.css \
+  > $output_folder/dist-css.diff
+  
+# Diff the rest of the files, excluding the sourcemaps and the minified files
+# See https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
+git diff -M05 $base -- dist ":(exclude)*.map" \
   > $output_folder/dist.diff

--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Computes the diff of `dist` between a provided base reference (branch, tag, commit SHA) and the current HEAD.
+# It outputs the resulting diff in the provided output folder
+# 
+# Usage: `bin/dist-diff.sh <base-reference> <output-folder>`
+
+# Default the base branch to main to allow running locally quickly
+base="${1:-main}"
+# And the output folder to the current working directory
+output_folder="${2:-`pwd`}"
+
+git diff -M05 $base -- dist \
+  > $output_folder/dist.diff


### PR DESCRIPTION
Adds separate diffs for the JS and CSS when diffing `dist`, to prepare from extracting them completely from the main diff in order to limit the chances of the diff being too large to be posted as a comment on a PR (there's a limit of 65536 characters).

The resulting diffs are [uploaded as workflow artifacts](https://github.com/alphagov/govuk-frontend/issues/3229) to provide a fallback access in case the diff are too big for comment on the PR.

The PR extracts the diffing into a shell script, allowing it to be run locally as well.

Once #3571 is merged, we'll be able to post separate comments to the PR for each of the diffs, with links to the workflow artifacts when the diffs are too big.

Closes https://github.com/alphagov/govuk-frontend/issues/3229

> **Note**
>
> The diff comment was generated thanks to manual test changes to the `dist` files in [95c4e3f](https://github.com/alphagov/govuk-frontend/pull/3614/commits/95c4e3fa7f691fcb10a917cbbe8cdaa904a5147f), which has since been removed as we don't want to merge that on main.
