### PR TITLE
Increase Dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   # Update npm packages
   - package-ecosystem: npm
     directory: /
+    open-pull-requests-limit: 10
     reviewers:
       - alphagov/design-system-developers
     schedule:


### PR DESCRIPTION
We've decided to bump Dependabot's max open PR limit back to 10 and see how it goes, since we were falling a bit behind with the default limit of 5.