### PR TITLE
[SPIKE] Modifications to pagination component

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/pagination/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/pagination/index.njk
@@ -1,0 +1,92 @@
+{% from "back-link/macro.njk" import govukBackLink %}
+{% from "pagination/macro.njk" import govukPagination %}
+
+{% extends "layout.njk" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% set veryShortPaginationItems = [
+  { href: '#' },
+  { href: '#' },
+  { href: '#' }
+] %}
+
+{% set shortPaginationItems = [
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' }
+] %}
+
+{% set mediumPaginationItems = [
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' }
+] %}
+
+{% set longPaginationItems = [
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' },
+  { href: '#' }
+] %}
+
+{% block content %}
+
+<h2 class="govuk-heading-l">Very short</h2>
+<p class="govuk-body">Very short paginations (3 or fewer items) are small enough to not need to hide anything on any breakpoint.</p>
+
+{%- for i in range(1, (veryShortPaginationItems | length) + 1) %}
+  {{ govukPagination({
+    items: veryShortPaginationItems,
+    currentPage: i
+  }) }}
+{%- endfor %}
+
+<h2 class="govuk-heading-l">Short</h2>
+<p class="govuk-body">Short paginations (4 items, with default settings) can show all items on wide breakpoints, but hide some for narrow breakpoints.</p>
+
+{%- for i in range(1, (shortPaginationItems | length) + 1) %}
+  {{ govukPagination({
+    items: shortPaginationItems,
+    currentPage: i
+  }) }}
+{%- endfor %}
+
+<h2 class="govuk-heading-l">Medium</h2>
+<p class="govuk-body">Medium length paginations (5 to 7 items, with default settings) have the ability to sometimes be within 'neighbourly' range of both the start and end at the same time, showing all items at once on wide breakpoints, but also have enough items to require removing some in certain contexts and on narrow breakpoints.</p>
+
+{%- for i in range(1, (mediumPaginationItems | length) + 1) %}
+  {{ govukPagination({
+    items: mediumPaginationItems,
+    currentPage: i
+  }) }}
+{%- endfor %}
+
+<h2 class="govuk-heading-l">Long</h2>
+<p class="govuk-body">Long paginations (8 or more items with default settings) have enough items that they can never show all items at once. Some amount of truncation is always required, even on wider breakpoints.</p>
+
+{%- for i in range(1, (longPaginationItems | length) + 1) %}
+  {{ govukPagination({
+    items: longPaginationItems,
+    currentPage: i
+  }) }}
+{%- endfor %}
+
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -37,8 +37,9 @@
   }
 
   .govuk-pagination__item {
-    // Hide items on small screens except the prev/next items,
-    // non-link items and the first and last items
+    // Hide everything initially, we then unhide the stuff we actually want
+    // visible below. It's ridiculous but it works and avoids overly-specific
+    // selectors that mess with the cascade.
     display: none;
 
     // Center align pagination links in their parent list item so that they
@@ -48,6 +49,19 @@
     @include govuk-media-query($from: tablet) {
       display: block;
     }
+  }
+
+  .govuk-pagination__item:first-child,
+  .govuk-pagination__item:last-child,
+  .govuk-pagination__item--current,
+  .govuk-pagination__item--ellipses {
+    display: block;
+  }
+
+  // If there are exactly three items, do not hide the middle item.
+  // Avoids an awkward and pointless '1 | ... | 3' situation.
+  .govuk-pagination__item:nth-child(2):nth-last-child(2) {
+    display: block;
   }
 
   .govuk-pagination__prev,
@@ -70,12 +84,11 @@
     padding-right: 0;
   }
 
-  // Only show first, last and non-link items on mobile
-  .govuk-pagination__item--current,
-  .govuk-pagination__item--ellipses,
-  .govuk-pagination__item:first-child,
-  .govuk-pagination__item:last-child {
-    display: block;
+  // Show 'collapsed only' items only on mobile
+  .govuk-pagination__item--collapsed-only {
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
   }
 
   .govuk-pagination__item--current {

--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -16,14 +16,6 @@ params:
         type: string
         required: true
         description: The link's URL.
-      - name: current
-        type: boolean
-        required: false
-        description: Set to `true` to indicate the current page the user is on.
-      - name: ellipsis
-        type: boolean
-        required: false
-        description: Use this option if you want to specify an ellipsis at a given point between numbers. If you set this option as `true`, any other options for the item are ignored.
       - name: attributes
         type: object
         required: false
@@ -70,6 +62,14 @@ params:
         type: object
         required: false
         description: The HTML attributes (for example, data attributes) you want to add to the anchor.
+  - name: currentPage
+    type: integer
+    required: true
+    description: The index of the current page within the set of `items`. This is a 1-based index, so that it matches the visible number that the component uses by default.
+  - name: neighbouringPages
+    type: integer
+    required: false
+    description: How many pages neighbouring the current page should be shown to the user. For example, when set to 2, links for up to 2 pages before and 2 pages after the current page will be visible, for a total of 5 pages. Defaults to 2.
   - name: landmarkLabel
     type: string
     required: false
@@ -90,14 +90,11 @@ examples:
         href: '/previous'
       next:
         href: '/next'
+      currentPage: 2
       items:
-        - number: 1
-          href: '/page/1'
-        - number: 2
-          href: '/page/2'
-          current: true
-        - number: 3
-          href: '/page/3'
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
   - name: with custom navigation landmark
     data:
       previous:
@@ -105,14 +102,11 @@ examples:
       next:
         href: '/next'
       landmarkLabel: 'search'
+      currentPage: 2
       items:
-        - number: 1
-          href: '/page/1'
-        - number: 2
-          href: '/page/2'
-          current: true
-        - number: 3
-          href: '/page/3'
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
   - name: with custom link and item text
     data:
       previous:
@@ -121,12 +115,12 @@ examples:
       next:
         href: '/next'
         text: 'Next page'
+      currentPage: 2
       items:
         - number: 'one'
           href: '/page/1'
         - number: 'two'
           href: '/page/2'
-          current: true
         - number: 'three'
           href: '/page/3'
   - name: with custom accessible labels on item links
@@ -135,16 +129,13 @@ examples:
         href: '/previous'
       next:
         href: '/next'
+      currentPage: 2
       items:
-        - number: 1
-          href: '/page/1'
+        - href: '/page/1'
           visuallyHiddenText: '1st page'
-        - number: 2
-          href: '/page/2'
-          current: true
+        - href: '/page/2'
           visuallyHiddenText: '2nd page (you are currently on this page)'
-        - number: 3
-          href: '/page/3'
+        - href: '/page/3'
           visuallyHiddenText: '3rd page'
   - name: with many pages
     data:
@@ -152,48 +143,139 @@ examples:
         href: '/previous'
       next:
         href: '/next'
+      currentPage: 10
       items:
-        - number: 1
-          href: '/page/1'
-        - ellipsis: true
-        - number: 8
-          href: '/page/8'
-        - number: 9
-          href: '/page/9'
-        - number: 10
-          href: '/page/10'
-          current: true
-        - number: 11
-          href: '/page/11'
-        - number: 12
-          href: '/page/12'
-        - ellipsis: true
-        - number: 40
-          href: '/page/40'
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
+        - href: '/page/11'
+        - href: '/page/12'
+        - href: '/page/13'
+        - href: '/page/14'
+        - href: '/page/15'
+        - href: '/page/16'
+        - href: '/page/17'
+        - href: '/page/18'
+        - href: '/page/19'
+        - href: '/page/20'
   - name: first page
     data:
       next:
         href: '/next'
+      currentPage: 1
       items:
-        - number: 1
-          href: '/page/1'
-          current: true
-        - number: 2
-          href: '/page/2'
-        - number: 3
-          href: '/page/3'
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
   - name: last page
     data:
       previous:
         href: '/previous'
+      currentPage: 3
       items:
-        - number: 1
-          href: '/page/1'
-        - number: 2
-          href: '/page/2'
-        - number: 3
-          href: '/page/3'
-          current: true
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+  - name: bordering first page
+    data:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      currentPage: 4
+      items:
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
+  - name: bordering last page
+    data:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      currentPage: 7
+      items:
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
+  - name: with fewer neighbours
+    data:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      currentPage: 4
+      neighbouringPages: 1
+      items:
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
+  - name: with more neighbours
+    data:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      currentPage: 7
+      neighbouringPages: 4
+      items:
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
+  - name: with no neighbours
+    data:
+      previous:
+        href: '/previous'
+      next:
+        href: '/next'
+      currentPage: 7
+      neighbouringPages: 0
+      items:
+        - href: '/page/1'
+        - href: '/page/2'
+        - href: '/page/3'
+        - href: '/page/4'
+        - href: '/page/5'
+        - href: '/page/6'
+        - href: '/page/7'
+        - href: '/page/8'
+        - href: '/page/9'
+        - href: '/page/10'
   - name: with prev and next only
     data:
       previous:

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -1,5 +1,21 @@
 {% set blockLevel = not params.items and (params.next or params.previous) %}
 
+{% set currentPage = params.currentPage | int %}
+{% set neighbouringPages = params.neighbouringPages | int if params.neighbouringPages !== undefined else 2 %}
+
+{% set visiblePagesLower = (currentPage - neighbouringPages) | int %}
+{% set visiblePagesUpper = (currentPage + neighbouringPages) | int %}
+
+{% macro _paginationItem(index, item) %}
+  {%- set isCurrent = index == currentPage %}
+  {%- set number = item.number | default(index) %}
+  <li class="govuk-pagination__item {{- ' govuk-pagination__item--current' if isCurrent }}">
+    <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + number) }}" {%- if isCurrent %} aria-current="page"{% endif %} {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
+      {{- number -}}
+    </a>
+  </li>
+{% endmacro %}
+
 <nav class="govuk-pagination {{- ' ' + params.classes if params.classes }} {{- ' govuk-pagination--block' if blockLevel }}" role="navigation" aria-label="{{ params.landmarkLabel | default("results") }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
   {%- if params.previous and params.previous.href -%}
     <div class="govuk-pagination__prev">
@@ -18,21 +34,44 @@
     </div>
   {% endif %}
 
-  {%- if params.items -%}
+  {# Only show numbered pagination if params.items is set #}
+  {%- if params.items %}
     <ul class="govuk-pagination__list">
-      {%- for item in params.items -%}
-        {%- if item.ellipsis -%}
-          <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
-        {%- elseif item.number -%}
-          <li class="govuk-pagination__item {{- ' govuk-pagination__item--current' if item.current }}">
-            <a class="govuk-link govuk-pagination__link" href="{{ item.href }}" aria-label="{{ item.visuallyHiddenText | default("Page " + item.number) }}" {%- if item.current %} aria-current="page" {%- endif -%} {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
-              {{ item.number }}
-            </a>
-          </li>
-        {%- endif -%}
-      {%- endfor -%}
+
+    {# If there are 3 or fewer items in the list, skip the logic and just render them all. #}
+    {%- if params.items | length <= 3 %}
+      {%- for item in params.items %}
+        {{ _paginationItem(loop.index, item) }}
+      {%- endfor %}
+    {%- else %}
+
+      {%- for item in params.items %}
+
+        {# Always show the first and last numbered option #}
+        {%- if loop.first or loop.last %}
+
+          {# If the last item in the loop, and we're likely to need one, prepend an ellipsis #}
+          {%- if loop.last and loop.index > currentPage + 1 %}
+            <li class="govuk-pagination__item govuk-pagination__item--ellipses {{- ' govuk-pagination__item--collapsed-only' if loop.index - 1 <= visiblePagesUpper }}">&ctdot;</li>
+          {%- endif %}
+
+          {{ _paginationItem(loop.index, item) }}
+
+          {# If the first item in the loop, and we're likely to need one, append an ellipsis #}
+          {%- if loop.first and loop.index < currentPage - 1 %}
+            <li class="govuk-pagination__item govuk-pagination__item--ellipses {{- ' govuk-pagination__item--collapsed-only' if loop.index + 1 >= visiblePagesLower }}">&ctdot;</li>
+          {%- endif %}
+
+        {# Is this within neighbourly range of the current page? Show it! #}
+        {%- elif loop.index >= visiblePagesLower and loop.index <= visiblePagesUpper %}
+          {{ _paginationItem(loop.index, item) }}
+        {%- endif %}
+
+      {%- endfor %}
+
+    {%- endif %}
     </ul>
-  {%- endif -%}
+  {%- endif %}
 
   {%- if params.next and params.next.href -%}
     {%- set nextArrow -%}


### PR DESCRIPTION
A little bit of a self-indulgent spike refactoring how the pagination component works, in an effort to resolve #3324 and (potentially) make it a little simpler for teams to use. 

Component page:
https://govuk-frontend-pr-3644.herokuapp.com/components/pagination

Temporary example page showing various pagination lengths in various states: 
https://govuk-frontend-pr-3644.herokuapp.com/examples/pagination

## Background

When investigating #3324 I came up with a couple of potential fixes, but ultimately it seemed (to me, at least) that the root of the problem is that the component lacks context about what information it’s handling. It currently only receives a limited set of explicitly categorised information and is told to format and spit it out again without interrogating it; so when it comes to processing the data more thoroughly (e.g. deciding which things should be hidden on mobile) it can only work off assumptions.

One solution is to allow service teams to provide that context by manually flagging what things are and in what contexts they should be visible, but this creates a burden on the implementor to get all the nuances of it right—if the service has multiple paginations, they'd need to get it right multiple times—and none of it is particularly easy to explain in documentation.

This is my first pass at a [“do the hard work to make it simple”](https://www.gov.uk/guidance/government-design-principles#do-the-hard-work-to-make-it-simple) approach that brings more of the logic into the Nunjucks.

Instead of a backend (or other code) needing to decide ahead of time which pages to render in the pagination, what labels they use, where and when ellipses should appear, etc., this rewrite now only requires implementors to provide a list of (ordered) URLs and what the current page is: the component handles everything else. 

## Changes

### ...to how the component is used

- Users now list all pagination items within the `items` array, rather than just the subset that they wish to show on the page. (This may reduce complexity in backend code, as the same pagination code can be used in multiple pages and contexts?)
- The `item.ellipsis` parameter has been removed. Ellipsis placement and visibility is now determined automatically. 
- The `item.current` parameter has been replaced by a `currentPage` parameter.
- The `item.number` parameter is no longer required. Numbers are automatically generated where not defined. 
- A new `neighbouringPages` parameter has been added, allowing macro users to configure how many pages 'neighbouring' the current page to show. 

### ...to how the component works

- Rather than expecting only the subset of pages the user wants to show, the pagination component now expects _all_ possible pages to be provided. 
- Which pages are to be displayed (`visiblePagesLower` and `visiblePagesUpper`) are determined using a combination of `currentPage` and `neighbouringPages` parameters.
- Every item in the `items` array is now looped through and has various tests ran against it to determine whether it should be output or not.
  - The first and last items are always output.
  - If the first item and `currentPage` are more than 1 index apart, ellipses are appended after the first item.
    - If the _second_ item and `visiblePagesLower` are 1 or more indexes apart, the ellipses will only be shown on mobile. 
  - If the last item and `currentPage` are more than 1 index apart, ellipses are prepended before the last item. 
    - If the _penultimate_ item and `visiblePagesUpper` are 1 or more indexes apart, the ellipses will only be shown on mobile. 
  - If an item is within the range of `visiblePagesLower` and `visiblePagesUpper`, but is not the `currentPage`, it is rendered but will be hidden on mobile.
  - If an item's index matches `currentPage`, it is rendered with a 'current' class. 
  - Items that do not match any of the above conditions are not rendered. 
- As the code to render pagination items is now needed in multiple places, I've refactored it into a private macro within the template.
- If there are three or fewer items in the pagination, a special case is activated where all items are output on all viewports. This prevents the pagination being unnecessarily truncated on narrow viewports (it'll render `1 | 2 | 3` instead of `1 | … | 3`). 

## Thoughts

This is a bit of a compromise between the current method (implementors provide an array of page, with links, optional numbering and other attribute info) and a more fully-automated approach (an implementor doesn't even provide an array and simply say there are 40 pages of results).

Whilst the latter would be even simpler to use, it has the trade-off of removing or restricting a number of features that the current pagination component is capable of, such as being able to customise the labelling of items or use non-incremental URL schemes for paging. 

## Todo

- No tests have been written or updated for the new/altered functionality.
- The full gamut of pagination lengths, `currentPage` selections and `neighbouringPages` combinations hasn't been tested. There may still be edge cases. 
- I've left the previous/next link functionality completely untouched, but we could potentially automate aspects of them given we now consume all possible pages as a set and know our position within the set.
- Currently it's necessary for teams to provide overrides for `item.visuallyHiddenText` and `item.attributes` separately for each item. Defining a way to set these globally for all items would also seem like a nice enhancement. 