### PR TITLE
Ensure shared task `options` are mandatory unless specified

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
       "devDependencies": {
         "@babel/core": "^7.21.8",
         "@babel/preset-env": "^7.21.5",
-        "@types/node": "^20.1.5",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
         "@typescript-eslint/parser": "^5.59.5",
         "concurrently": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@babel/core": "^7.21.8",
     "@babel/preset-env": "^7.21.5",
-    "@types/node": "^20.1.5",
     "@typescript-eslint/eslint-plugin": "^5.59.5",
     "@typescript-eslint/parser": "^5.59.5",
     "concurrently": "^8.0.1",

--- a/packages/govuk-frontend-review/tasks/scripts.mjs
+++ b/packages/govuk-frontend-review/tasks/scripts.mjs
@@ -17,8 +17,9 @@ export const compile = (options) => gulp.series(
       srcPath: join(options.srcPath, 'javascripts'),
       destPath: join(options.destPath, 'javascripts'),
 
-      filePath (file) {
-        return join(file.dir, `${file.name}.min.js`)
+      // Rename with `*.min.js` extension
+      filePath ({ dir, name }) {
+        return join(dir, `${name}.min.js`)
       }
     })
   ),

--- a/packages/govuk-frontend-review/tasks/scripts.mjs
+++ b/packages/govuk-frontend-review/tasks/scripts.mjs
@@ -12,6 +12,8 @@ import gulp from 'gulp'
 export const compile = (options) => gulp.series(
   task.name('compile:js', () =>
     scripts.compile('all.mjs', {
+      ...options,
+
       srcPath: join(options.srcPath, 'javascripts'),
       destPath: join(options.destPath, 'javascripts'),
 

--- a/packages/govuk-frontend-review/tasks/styles.mjs
+++ b/packages/govuk-frontend-review/tasks/styles.mjs
@@ -17,8 +17,9 @@ export const compile = (options) => gulp.series(
       srcPath: join(options.srcPath, 'stylesheets'),
       destPath: join(options.destPath, 'stylesheets'),
 
-      filePath (file) {
-        return join(file.dir, `${file.name}.min.css`)
+      // Rename with `*.min.css` extension
+      filePath ({ dir, name }) {
+        return join(dir, `${name}.min.css`)
       }
     })
   ),

--- a/packages/govuk-frontend-review/tasks/styles.mjs
+++ b/packages/govuk-frontend-review/tasks/styles.mjs
@@ -12,6 +12,8 @@ import gulp from 'gulp'
 export const compile = (options) => gulp.series(
   task.name('compile:scss', () =>
     styles.compile('**/[!_]*.scss', {
+      ...options,
+
       srcPath: join(options.srcPath, 'stylesheets'),
       destPath: join(options.destPath, 'stylesheets'),
 

--- a/packages/govuk-frontend-review/tsconfig.json
+++ b/packages/govuk-frontend-review/tsconfig.json
@@ -8,5 +8,10 @@
     "../../shared/lib",
     "../../shared/tasks"
   ],
-  "exclude": ["./dist/**", "../govuk-frontend/dist/**"]
+  "exclude": ["./dist/**", "../govuk-frontend/dist/**"],
+  "compilerOptions": {
+    "paths": {
+      "govuk-frontend": ["../govuk-frontend/src/govuk/all.mjs"]
+    }
+  }
 }

--- a/packages/govuk-frontend/tasks/build/package.mjs
+++ b/packages/govuk-frontend/tasks/build/package.mjs
@@ -13,9 +13,7 @@ import { fixtures, scripts, styles, templates } from '../index.mjs'
  */
 export default (options) => gulp.series(
   task.name('clean', () =>
-    files.clean('*', {
-      destPath: options.destPath
-    })
+    files.clean('*', options)
   ),
 
   fixtures(options),

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -12,9 +12,7 @@ import gulp from 'gulp'
  */
 export default (options) => gulp.series(
   task.name('clean', () =>
-    files.clean('*', {
-      destPath: options.destPath
-    })
+    files.clean('*', options)
   ),
 
   // Copy GOV.UK Frontend static assets
@@ -28,8 +26,9 @@ export default (options) => gulp.series(
   // Compile GOV.UK Frontend JavaScript
   task.name('compile:js', () =>
     scripts.compile('all.mjs', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk'),
-      destPath: options.destPath,
 
       filePath (file) {
         return join(file.dir, `${file.name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`)
@@ -40,8 +39,9 @@ export default (options) => gulp.series(
   // Compile GOV.UK Frontend Sass
   task.name('compile:scss', () =>
     styles.compile('**/[!_]*.scss', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk'),
-      destPath: options.destPath,
 
       filePath (file) {
         return join(file.dir, `${file.name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`)
@@ -51,8 +51,6 @@ export default (options) => gulp.series(
 
   // Update GOV.UK Frontend version
   task.name("file:version 'VERSION.txt'", () =>
-    files.version('VERSION.txt', {
-      destPath: options.destPath
-    })
+    files.version('VERSION.txt', options)
   )
 )

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -30,8 +30,9 @@ export default (options) => gulp.series(
 
       srcPath: join(options.srcPath, 'govuk'),
 
-      filePath (file) {
-        return join(file.dir, `${file.name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`)
+      // Rename using package name (versioned) and `*.min.js` extension
+      filePath ({ dir, name }) {
+        return join(dir, `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`)
       }
     })
   ),
@@ -43,8 +44,9 @@ export default (options) => gulp.series(
 
       srcPath: join(options.srcPath, 'govuk'),
 
-      filePath (file) {
-        return join(file.dir, `${file.name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`)
+      // Rename using package name (versioned) and `*.min.css` extension
+      filePath ({ dir, name }) {
+        return join(dir, `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`)
       }
     })
   ),

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -31,8 +31,9 @@ export const compile = (options) => gulp.series(
       srcPath: join(options.srcPath, 'govuk'),
       destPath: join(options.destPath, 'govuk'),
 
-      filePath (file) {
-        return join(file.dir, `${file.name}.js`)
+      // Rename with `*.js` extension
+      filePath ({ dir, name }) {
+        return join(dir, `${name}.js`)
       }
     })
   ),

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -14,6 +14,8 @@ export const compile = (options) => gulp.series(
    */
   task.name('compile:mjs', () =>
     scripts.compile('!(*.test).mjs', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk'),
       destPath: join(options.destPath, 'govuk-esm')
     })
@@ -24,6 +26,8 @@ export const compile = (options) => gulp.series(
    */
   task.name('compile:js', () =>
     scripts.compile('**/!(*.test).mjs', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk'),
       destPath: join(options.destPath, 'govuk'),
 

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -39,11 +39,7 @@ export const compile = (options) => gulp.series(
   task.name("compile:js 'govuk-prototype-kit'", () =>
     configs.compile('govuk-prototype-kit.config.mjs', {
       srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: resolve(options.destPath, '../'), // Top level (not dist) for compatibility
-
-      filePath (file) {
-        return join(file.dir, `${file.name}.json`)
-      }
+      destPath: resolve(options.destPath, '../') // Top level (not dist) for compatibility
     })
   )
 )

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -14,6 +14,8 @@ export const compile = (options) => gulp.series(
    */
   task.name('compile:scss', () =>
     styles.compile('**/*.scss', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk'),
       destPath: join(options.destPath, 'govuk')
     })
@@ -24,6 +26,8 @@ export const compile = (options) => gulp.series(
    */
   task.name("compile:scss 'govuk-prototype-kit'", () =>
     styles.compile('init.scss', {
+      ...options,
+
       srcPath: join(options.srcPath, 'govuk-prototype-kit'),
       destPath: join(options.destPath, 'govuk-prototype-kit')
     })

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -15,11 +15,7 @@ export const compile = (options) => gulp.series(
   task.name('compile:scss', () =>
     styles.compile('**/*.scss', {
       srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk'),
-
-      filePath (file) {
-        return join(file.dir, `${file.name}.scss`)
-      }
+      destPath: join(options.destPath, 'govuk')
     })
   ),
 
@@ -29,11 +25,7 @@ export const compile = (options) => gulp.series(
   task.name("compile:scss 'govuk-prototype-kit'", () =>
     styles.compile('init.scss', {
       srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: join(options.destPath, 'govuk-prototype-kit'),
-
-      filePath (file) {
-        return join(file.dir, `${file.name}.scss`)
-      }
+      destPath: join(options.destPath, 'govuk-prototype-kit')
     })
   )
 )

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -26,6 +26,7 @@ export async function write (filePath, result) {
   writeTasks.push(files.write(base, {
     destPath: dir,
 
+    // Add source code
     async fileContents () {
       return code
     }
@@ -47,6 +48,7 @@ export async function write (filePath, result) {
     writeTasks.push(files.write(`${base}.map`, {
       destPath: dir,
 
+      // Add source map as JSON
       async fileContents () {
         return JSON.stringify(map)
       }

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -72,10 +72,10 @@ export async function write (filePath, result) {
  * Asset path options
  *
  * @typedef {object} AssetPathOptions
- * @property {string} [basePath] - Base directory, for example `/path/to/package`
- * @property {string} [srcPath] - Input directory, for example `/path/to/package/src`
- * @property {string} [destPath] - Output directory, for example `/path/to/package/dist`
- * @property {string} [workspace] - Workspace directory (relative), for example `package/dist`
+ * @property {string} basePath - Base directory, for example `/path/to/package`
+ * @property {string} srcPath - Input directory, for example `/path/to/package/src`
+ * @property {string} destPath - Output directory, for example `/path/to/package/dist`
+ * @property {string} workspace - Workspace directory (relative), for example `package/dist`
  */
 
 /**

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -84,7 +84,6 @@ export async function write (filePath, result) {
  * @typedef {object} AssetFileOptions
  * @property {(file: import('path').ParsedPath) => string} [filePath] - File path formatter
  * @property {(contents?: string) => Promise<string>} [fileContents] - File contents formatter
- * @property {string[]} [ignore] - File path patterns to ignore
  */
 
 /**

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -29,7 +29,7 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
         return join(dir, 'fixtures.json')
       },
 
-      // Replace contents with JSON
+      // Add fixtures as JSON (formatted)
       async fileContents () {
         return JSON.stringify(fixture, null, 4)
       }
@@ -61,7 +61,7 @@ export async function generateMacroOptions (pattern, { srcPath, destPath }) {
         return join(dir, 'macro-options.json')
       },
 
-      // Replace contents with JSON
+      // Add macro options as JSON (formatted)
       async fileContents () {
         return JSON.stringify(macroOption, null, 4)
       }

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -11,7 +11,7 @@ import { files } from './index.mjs'
  * Generate fixtures.json from component data
  *
  * @param {AssetEntry[0]} pattern - Path to ${componentName}.yaml
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
 export async function generateFixtures (pattern, { srcPath, destPath }) {
   const componentDataPaths = await getListing(srcPath, pattern)
@@ -22,7 +22,6 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
 
     // Write to destination
     await files.write(componentDataPath, {
-      srcPath,
       destPath,
 
       // Rename to fixtures.json
@@ -44,7 +43,7 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
  * Generate macro-options.json from component data
  *
  * @param {AssetEntry[0]} pattern - Path to ${componentName}.yaml
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
 export async function generateMacroOptions (pattern, { srcPath, destPath }) {
   const componentDataPaths = await getListing(srcPath, pattern)
@@ -55,7 +54,6 @@ export async function generateMacroOptions (pattern, { srcPath, destPath }) {
 
     // Write to destination
     await files.write(componentDataPath, {
-      srcPath,
       destPath,
 
       // Rename to 'macro-options.json'

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -22,7 +22,7 @@ export async function compile (modulePath, options) {
       return join(dir, `${name}.json`)
     },
 
-    // Format config as JSON
+    // Add config as JSON (formatted)
     async fileContents () {
       return JSON.stringify(await configFn(), undefined, 2)
     }

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -7,7 +7,7 @@ import { files } from './index.mjs'
  * Write config to JSON
  *
  * @param {AssetEntry[0]} modulePath - File path to config
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  * @returns {Promise<void>}
  */
 export async function compile (modulePath, options) {

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -17,6 +17,11 @@ export async function compile (modulePath, options) {
   return files.write(modulePath, {
     ...options,
 
+    // Rename with `*.json` extension
+    filePath ({ dir, name }) {
+      return join(dir, `${name}.json`)
+    },
+
     // Format config as JSON
     async fileContents () {
       return JSON.stringify(await configFn(), undefined, 2)

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -45,8 +45,8 @@ export async function version (assetPath, options) {
 export async function write (assetPath, { destPath, filePath, fileContents }) {
   const assetDestPath = join(destPath, filePath ? filePath(parse(assetPath)) : assetPath)
 
-  if (!fileContents) {
-    throw new Error("Option 'fileContents' required")
+  if (!destPath || !fileContents) {
+    throw new Error("Options 'destPath' and 'fileContents' required")
   }
 
   await mkdir(dirname(assetDestPath), { recursive: true })

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -11,7 +11,7 @@ import slash from 'slash'
  * Delete path globs for a given destination
  *
  * @param {string} pattern - Pattern to remove
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "destPath">} options - Asset options
  */
 export async function clean (pattern, { destPath }) {
   await deleteAsync(slash(join(destPath, pattern)), {
@@ -23,7 +23,7 @@ export async function clean (pattern, { destPath }) {
  * Write `packages/govuk-frontend/package.json` version to file
  *
  * @param {AssetEntry[0]} assetPath - File path to asset
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "destPath">} options - Asset options
  */
 export async function version (assetPath, options) {
   await write(assetPath, {
@@ -39,7 +39,7 @@ export async function version (assetPath, options) {
  * Write file task
  *
  * @param {AssetEntry[0]} assetPath - File path to asset
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "destPath" | "filePath" | "fileContents">} options - Asset options
  */
 export async function write (assetPath, { destPath, filePath, fileContents }) {
   const assetDestPath = join(destPath, filePath ? filePath(parse(assetPath)) : assetPath)
@@ -57,7 +57,7 @@ export async function write (assetPath, { destPath, filePath, fileContents }) {
  * Copies files to destination
  *
  * @param {string} pattern - Minimatch pattern
- * @param {AssetEntry[1]} options - Asset options
+ * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
 export async function copy (pattern, { srcPath, destPath }) {
   await cpy([slash(join(srcPath, pattern))], destPath, { cwd: srcPath })

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -29,6 +29,7 @@ export async function version (assetPath, options) {
   await write(assetPath, {
     ...options,
 
+    // Add package version
     async fileContents () {
       return pkg.version
     }

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -13,10 +13,9 @@ import slash from 'slash'
  * @param {string} pattern - Pattern to remove
  * @param {AssetEntry[1]} options - Asset options
  */
-export async function clean (pattern, { destPath, ignore }) {
+export async function clean (pattern, { destPath }) {
   await deleteAsync(slash(join(destPath, pattern)), {
-    cwd: paths.root,
-    ignore
+    cwd: paths.root
   })
 }
 
@@ -60,11 +59,8 @@ export async function write (assetPath, { destPath, filePath, fileContents }) {
  * @param {string} pattern - Minimatch pattern
  * @param {AssetEntry[1]} options - Asset options
  */
-export async function copy (pattern, { srcPath, destPath, ignore = [] }) {
-  const srcPatterns = [slash(join(srcPath, pattern))]
-    .concat(ignore.map((pattern) => `!${pattern}`))
-
-  await cpy(srcPatterns, destPath, { cwd: srcPath })
+export async function copy (pattern, { srcPath, destPath }) {
+  await cpy([slash(join(srcPath, pattern))], destPath, { cwd: srcPath })
 }
 
 /**

--- a/shared/tasks/index.mjs
+++ b/shared/tasks/index.mjs
@@ -14,6 +14,6 @@ export * as task from './task.mjs'
 /**
  * Types for tasks
  *
- * @typedef {Required<import('./assets.mjs').AssetPathOptions>} TaskOptions
+ * @typedef {import('./assets.mjs').AssetPathOptions} TaskOptions
  * @typedef {(options: TaskOptions) => import('gulp').TaskFunction} TaskFunction
  */

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -15,8 +15,7 @@ import { isDev } from './helpers/task-arguments.mjs'
  * Compile JavaScript task
  *
  * @param {string} pattern - Minimatch pattern
- * @param {AssetEntry[1]} [options] - Asset options
- * @returns {Promise<void>}
+ * @param {AssetEntry[1]} options - Asset options
  */
 export async function compile (pattern, options) {
   const modulePaths = await getListing(options.srcPath, pattern)

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -17,7 +17,7 @@ import { assets } from './index.mjs'
  * Compile Sass to CSS task
  *
  * @param {string} pattern - Minimatch pattern
- * @param {AssetEntry[1]} [options] - Asset options
+ * @param {AssetEntry[1]} options - Asset options
  */
 export async function compile (pattern, options) {
   const modulePaths = await getListing(options.srcPath, pattern)


### PR DESCRIPTION
This PR ensures all build task options are mandatory and type checked

I've also included some related changes:

1. Configure the Review app to use `govuk-frontend` JSDoc types again
2. Remove unnecessary options (like renaming `*.scss` to `*.scss`)
3. Adding comments to explain why files are renamed or moved

This work was split out whilst adding **postcss.config.mjs** and **rollup.config.mjs** files to each workspace

### Before
This will crash as no `destPath` has been provided

```js
import { scripts } from 'govuk-frontend-tasks'

// Compile GOV.UK Frontend JavaScript
scripts.compile('!(*.test).mjs', {
  destPath: '/custom/build/path'
})
```

### After
This works by extending the build options using `...options`

```js
import { scripts } from 'govuk-frontend-tasks'

// Default build options
import { options } from './build/options.mjs'

// Compile GOV.UK Frontend JavaScript
scripts.compile('!(*.test).mjs', {
  ...options,
  destPath: '/custom/build/path'
})
```