### PR TITLE
Configure paths to `postcss.config.mjs` files

### DIFF
--- a/packages/govuk-frontend-review/tasks/styles.mjs
+++ b/packages/govuk-frontend-review/tasks/styles.mjs
@@ -16,6 +16,7 @@ export const compile = (options) => gulp.series(
 
       srcPath: join(options.srcPath, 'stylesheets'),
       destPath: join(options.destPath, 'stylesheets'),
+      configPath: join(options.basePath, 'postcss.config.mjs'),
 
       // Rename with `*.min.css` extension
       filePath ({ dir, name }) {

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -44,6 +44,7 @@ export default (options) => gulp.series(
       ...options,
 
       srcPath: join(options.srcPath, 'govuk'),
+      configPath: join(options.basePath, 'postcss.config.mjs'),
 
       // Rename using package name (versioned) and `*.min.css` extension
       filePath ({ dir, name }) {

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -17,7 +17,8 @@ export const compile = (options) => gulp.series(
       ...options,
 
       srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk')
+      destPath: join(options.destPath, 'govuk'),
+      configPath: join(options.basePath, 'postcss.config.mjs')
     })
   ),
 
@@ -29,7 +30,8 @@ export const compile = (options) => gulp.series(
       ...options,
 
       srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: join(options.destPath, 'govuk-prototype-kit')
+      destPath: join(options.destPath, 'govuk-prototype-kit'),
+      configPath: join(options.basePath, 'postcss.config.mjs')
     })
   )
 )

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -77,7 +77,7 @@ export async function write (filePath, result) {
  * @property {string} basePath - Base directory, for example `/path/to/package`
  * @property {string} srcPath - Input directory, for example `/path/to/package/src`
  * @property {string} destPath - Output directory, for example `/path/to/package/dist`
- * @property {string} [configPath] - Config file path (e.g. Rollup configs)
+ * @property {string} [configPath] - Config file path (e.g. PostCSS, Rollup configs)
  * @property {string} workspace - Workspace directory (relative), for example `package/dist`
  */
 

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -37,7 +37,7 @@ export async function compile (pattern, options) {
  *
  * @param {AssetEntry} assetEntry - Asset entry
  */
-export async function compileStylesheet ([modulePath, { basePath, srcPath, destPath, filePath }]) {
+export async function compileStylesheet ([modulePath, { configPath, srcPath, destPath, filePath }]) {
   const moduleSrcPath = join(srcPath, modulePath)
   const moduleDestPath = join(destPath, filePath ? filePath(parse(modulePath)) : modulePath)
 
@@ -105,7 +105,7 @@ export async function compileStylesheet ([modulePath, { basePath, srcPath, destP
   }
 
   // Locate PostCSS config
-  const config = await postcssrc(options, basePath)
+  const config = await postcssrc(options, configPath)
 
   // Transform with PostCSS
   const result = await postcss(config.plugins)


### PR DESCRIPTION
This PR updates our Stylesheets tasks with paths to `postcss.config.mjs`

We've used [`postcss-load-config`](https://github.com/postcss/postcss-load-config) to find configs automatically but it's safer to follow the https://github.com/alphagov/govuk-frontend/pull/3648 approach

We now pass the exact config path to [`postcss-load-config`](https://github.com/postcss/postcss-load-config)