### PR TITLE
Ensure GitHub Actions runs type declaration checks in all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build:app": "npm run build --workspace govuk-frontend-review",
     "build:package": "npm run build:package --workspace govuk-frontend",
     "build:release": "npm run build:release --workspace govuk-frontend",
-    "build:types": "tsc --build tsconfig.build.json",
+    "build:types": "tsc --build tsconfig.json tsconfig.build.json",
     "postbuild:package": "jest --color --selectProjects \"Build tasks\" --testMatch \"**/*package.test*\"",
     "postbuild:release": "jest --color --selectProjects \"Build tasks\" --testMatch \"**/*release.test*\"",
     "heroku-postbuild": "npm run build --workspace govuk-frontend --workspace govuk-frontend-review",

--- a/packages/govuk-frontend/tsconfig.json
+++ b/packages/govuk-frontend/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": [
-    "./src/**/*.js",
-    "./src/**/*.mjs",
+    "**/*.js",
+    "**/*.mjs",
     "../../shared/config",
     "../../shared/helpers",
     "../../shared/lib",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,6 +7,7 @@
     "moduleResolution": "Node",
     "noEmit": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": false,
     "strictBindCallApply": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
This PR closes a gap raised by @domoscargin when discussing https://github.com/alphagov/govuk-frontend/pull/3571

I've enabled [`tsc` skipLibCheck](https://www.typescriptlang.org/tsconfig#skipLibCheck) to prevent 3rd party type issues from showing up in `tsc --build` so we can now check types on tests, tasks and other shared packages in our [**Tests** GitHub Actions workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml)

Previously we've seen the "red squiggles" locally but only checked “build output” in GitHub