### PR TITLE
Update path to govuk-frontend assets when used in the prototype kit

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/init.scss
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/init.scss
@@ -2,7 +2,7 @@ $govuk-prototype-kit-major-version: 0 !default;
 
 $govuk-assets-path: if(
   $govuk-prototype-kit-major-version > 12,
-  $govuk-extensions-url-context + "/govuk-frontend/govuk/assets/",
+  $govuk-extensions-url-context + "/govuk-frontend/dist/govuk/assets/",
   "/govuk/assets/"
 ) !default;
 


### PR DESCRIPTION
We had forgotten to update this when [moving the built files to `dist` in #3498](https://github.com/alphagov/govuk-frontend/pull/3498/commits/3f0db82f9cdeb8c0f1d2296753ebf51ee02b8d08) 😬 This PR sets the appropriate path, both for the latest version of the kit (13) and the earlier ones[^1].


[^1]: Prototype Kit v12 needs a little search and replace to change `govuk-frontend/govuk` into `govuk-frontend/dist/govuk` in the kit's `.scss` files, which is line with what we'd expect from us moving the files.