### PR TITLE
Post separate comments for JS, CSS and other files diffs

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -52,35 +52,11 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { readFile } = require('node:fs/promises')
-            const { comment } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
+            const { commentDistDiffs } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
 
             // PR information
-            const number = '${{ github.event.pull_request.number }}'
+            const issueNumber = '${{ github.event.pull_request.number }}'
             const commit = '${{ github.event.pull_request.head.sha }}'
+            const workspacePath = '${{github.workspace}}'
 
-            const diffs = [{
-              file: 'dist-js.diff',
-              title: 'JavaScript changes to `dist`',
-              marker: 'dist-diff-js'
-              },{
-              file: 'dist-css.diff',
-              title: 'CSS changes to `dist`',
-              marker: 'dist-diff-css'
-            }, {
-              file: 'dist-other.diff',
-              title: 'Other changes to `dist`',
-              marker: 'dist-diff-other'
-            }]
-
-            for(const {file, title, marker} of diffs) {
-              // Read diff from previous step
-              const diffText = await readFile(`${{ github.workspace }}/${file}`, 'utf8')
-
-              // Add or update comment on PR
-              await comment({ github, context }, number, marker, `## ${title}\n` +
-                '```diff\n' +
-                `${diffText}\n` +
-                '```\n\n' +
-                `SHA: ${commit}\n`
-              )
-            }
+            await commentDistDiffs({github, context, workspacePath, issueNumber, commit})

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { commentDiff } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
+            const { commentDiffs } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
 
             // PR information
             const issueNumber = ${{ github.event.pull_request.number }}
@@ -75,6 +75,4 @@ jobs:
               }
             ]
 
-            for (const diff of diffs) {
-              await commentDiff({ github, context, commit }, issueNumber, diff)
-            }
+            await commentDiffs({ github, context, commit }, issueNumber, diffs)

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -54,17 +54,33 @@ jobs:
             const { readFile } = require('node:fs/promises')
             const { comment } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
 
-            // Read diff from previous step
-            const diffText = await readFile('${{ github.workspace }}/dist.diff', 'utf8')
-
             // PR information
             const number = '${{ github.event.pull_request.number }}'
             const commit = '${{ github.event.pull_request.head.sha }}'
 
-            // Add or update comment on PR
-            await comment({ github, context }, number, 'Diff release', '## Changes to dist\n' +
-              '```diff\n' +
-              `${diffText}\n` +
-              '```\n\n' +
-              `SHA: ${commit}\n`
-            )
+            const diffs = [{
+              file: 'dist-js.diff',
+              title: 'JavaScript changes to `dist`',
+              marker: 'dist-diff-js'
+              },{
+              file: 'dist-css.diff',
+              title: 'CSS changes to `dist`',
+              marker: 'dist-diff-css'
+            }, {
+              file: 'dist-other.diff',
+              title: 'Other changes to `dist`',
+              marker: 'dist-diff-other'
+            }]
+
+            for(const {file, title, marker} of diffs) {
+              // Read diff from previous step
+              const diffText = await readFile(`${{ github.workspace }}/${file}`, 'utf8')
+
+              // Add or update comment on PR
+              await comment({ github, context }, number, marker, `## ${title}\n` +
+                '```diff\n' +
+                `${diffText}\n` +
+                '```\n\n' +
+                `SHA: ${commit}\n`
+              )
+            }

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -60,17 +60,17 @@ jobs:
             const diffs = [
               {
                 path: '${{ github.workspace }}/dist-js.diff',
-                title: 'JavaScript changes to `dist`',
+                titleText: 'JavaScript changes to `dist`',
                 markerText: 'dist-diff-js'
               },
               {
                 path: '${{ github.workspace }}/dist-css.diff',
-                title: 'Stylesheets changes to `dist`',
+                titleText: 'Stylesheets changes to `dist`',
                 markerText: 'dist-diff-css'
               },
               {
                 path: '${{ github.workspace }}/dist-other.diff',
-                title: 'Other changes to `dist`',
+                titleText: 'Other changes to `dist`',
                 markerText: 'dist-diff-other'
               }
             ]

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -51,12 +51,30 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const { readFile } = require('node:fs/promises')
-            const { commentDistDiffs } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
+            const { commentDiff } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
 
             // PR information
-            const issueNumber = '${{ github.event.pull_request.number }}'
+            const issueNumber = ${{ github.event.pull_request.number }}
             const commit = '${{ github.event.pull_request.head.sha }}'
-            const workspacePath = '${{github.workspace}}'
 
-            await commentDistDiffs({github, context, workspacePath, issueNumber, commit})
+            const diffs = [
+              {
+                path: '${{ github.workspace }}/dist-js.diff',
+                title: 'JavaScript changes to `dist`',
+                markerText: 'dist-diff-js'
+              },
+              {
+                path: '${{ github.workspace }}/dist-css.diff',
+                title: 'Stylesheets changes to `dist`',
+                markerText: 'dist-diff-css'
+              },
+              {
+                path: '${{ github.workspace }}/dist-other.diff',
+                title: 'Other changes to `dist`',
+                markerText: 'dist-diff-other'
+              }
+            ]
+
+            for (const diff of diffs) {
+              await commentDiff({ github, context, commit }, issueNumber, diff)
+            }

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -19,12 +19,7 @@ const DIST_DIFFS = [
 ]
 
 /**
- * @param {object} githubContext - Github Action context
- * @param {import('@octokit/rest').Octokit} githubContext.github
- * @param {import('@actions/github').context} githubContext.context
- * @param {string} githubContext.workspacePath
- * @param {number} githubContext.issueNumber
- * @param {string} githubContext.commit
+ * @param {GithubActionContext} githubActionContext - Github Action context
  */
 export async function commentDistDiffs (
   { github, context, workspacePath, issueNumber, commit }
@@ -66,10 +61,7 @@ function githubActionArtifactsUrl (runId) {
 }
 
 /**
- * @param {object} githubContext - Github Action context
- * @param {import('@octokit/rest').Octokit} githubContext.github
- * @param {import('@actions/github').context} githubContext.context
- * @param {number} githubContext.issueNumber - GitHub issue or PR number
+ * @param {Pick<GithubActionContext, "github" | "context" | "issueNumber">} githubContext - Github Action context
  * @param {string} markerText - A unique marker used to identify the correct comment
  * @param {string} bodyText - The body of the comment
  */
@@ -113,6 +105,15 @@ export async function comment ({ github, context, issueNumber }, markerText, bod
     ? github.rest.issues.createComment({ ...issueParameters, body })
     : github.rest.issues.updateComment({ ...issueParameters, body, comment_id: commentId }))
 }
+
+/**
+ * @typedef {object} GithubActionContext
+ * @property {import('@octokit/rest').Octokit} github - The pre-authenticated Octokit provided by Github actions
+ * @property {import('@actions/github').context} context - The context of the Github action
+ * @property {string} workspacePath - The path to the root of the
+ * @property {number} issueNumber - This number of the issue the action relates to
+ * @property {string} commit - The SHA of the commit that triggered the action
+ */
 
 /**
  * @typedef {import('@octokit/plugin-rest-endpoint-methods').RestEndpointMethodTypes["issues"]} IssuesEndpoint

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -12,8 +12,9 @@ export async function commentDiff (
   issueNumber,
   { path, title, markerText }
 ) {
-  // Read diff from previous step
-  const diffText = await readFile(path, 'utf8')
+  // Read diff from previous step, defaulting to a little note if the diff is empty
+  // Using `||` and not `??` as `readFile` will return `''` (so not `null` nor `undefined` that `??` handles)
+  const diffText = await readFile(path, 'utf8') || 'No changes found.'
 
   // Add or update comment on PR
   try {

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -108,7 +108,7 @@ function renderCommentFooter ({ context, commit }) {
 function githubActionRunUrl (context) {
   const { runId, repo } = context
 
-  return `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`
+  return `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}/attempts/${process.env.GITHUB_RUN_ATTEMPT}`
 }
 
 /**

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises'
 
 /**
- * Posts the content of multiple diffs in parallel on the given Github issue
+ * Posts the content of multiple diffs in parallel on the given GitHub issue
  *
  * @param {GithubActionContext} githubActionContext
  * @param {number} issueNumber
@@ -29,7 +29,7 @@ export async function commentDiffs (
 }
 
 /**
- * Posts the content of a diff as a comment on a Github issue
+ * Posts the content of a diff as a comment on a GitHub issue
  *
  * @param {GithubActionContext} githubActionContext
  * @param {number} issueNumber
@@ -38,7 +38,7 @@ export async function commentDiffs (
 export async function commentDiff (
   githubActionContext,
   issueNumber,
-  { path, title, markerText }
+  { path, titleText, markerText }
 ) {
   // Read diff from previous step, defaulting to a little note if the diff is empty
   // Using `||` and not `??` as `readFile` will return `''` (so not `null` nor `undefined` that `??` handles)
@@ -51,7 +51,7 @@ export async function commentDiff (
       issueNumber,
       {
         markerText,
-        title,
+        titleText,
         bodyText: '```diff\n' +
           `${diffText}\n` +
           '```'
@@ -63,7 +63,7 @@ export async function commentDiff (
       issueNumber,
       {
         markerText,
-        title,
+        titleText,
         // Unfortunately the best we can do here is a link to the "Artifacts"
         // section as [the upload-artifact action doesn't provide the public
         // URL](https://github.com/actions/upload-artifact/issues/50) :'(
@@ -76,18 +76,18 @@ export async function commentDiff (
 }
 
 /**
- * @param {GithubActionContext} githubContext - Github Action context
+ * @param {GithubActionContext} githubContext - GitHub Action context
  * @param {number} issueNumber - The number of the issue/PR on which to post the comment
  * @param {object} comment
  * @param {string} comment.markerText - A unique marker used to identify the correct comment
- * @param {string} comment.title - The title of the comment
+ * @param {string} comment.titleText - The title of the comment
  * @param {string} comment.bodyText - The body of the comment
  */
-export async function comment ({ github, context, commit }, issueNumber, { title, markerText, bodyText }) {
+export async function comment ({ github, context, commit }, issueNumber, { titleText, markerText, bodyText }) {
   const marker = `<!-- ${markerText} -->`
   const body = [
     marker,
-    `## ${title}`,
+    `## ${titleText}`,
     bodyText,
     '\n---', // <hr> for a little extra separation from content
     renderCommentFooter({ context, commit })
@@ -139,9 +139,9 @@ function renderCommentFooter ({ context, commit }) {
 }
 
 /**
- * Generates a URL to the Github action run
+ * Generates a URL to the GitHub action run
  *
- * @param {import('@actions/github').context} context - The context of the github action
+ * @param {import('@actions/github').context} context - The context of the GitHub action
  * @returns {string} The URL to the "Artifacts" section of the given run
  */
 function githubActionRunUrl (context) {
@@ -152,15 +152,15 @@ function githubActionRunUrl (context) {
 
 /**
  * @typedef {object} GithubActionContext
- * @property {import('@octokit/rest').Octokit} github - The pre-authenticated Octokit provided by Github actions
- * @property {import('@actions/github').context} context - The context of the Github action
+ * @property {import('@octokit/rest').Octokit} github - The pre-authenticated Octokit provided by GitHub actions
+ * @property {import('@actions/github').context} context - The context of the GitHub action
  * @property {string} commit - The SHA of the commit that triggered the action
  */
 
 /**
  * @typedef {object} DiffComment
  * @property {string} path - The path of the file to post as a comment
- * @property {string} title - The title of the comment
+ * @property {string} titleText - The title of the comment
  * @property {string} markerText - The marker to identify the comment
  */
 

--- a/.github/workflows/scripts/comments.mjs
+++ b/.github/workflows/scripts/comments.mjs
@@ -34,13 +34,35 @@ export async function commentDistDiffs (
     const diffText = await readFile(`${workspacePath}/${file}`, 'utf8')
 
     // Add or update comment on PR
-    await comment({ github, context, issueNumber }, marker, `## ${title}\n` +
-      '```diff\n' +
-      `${diffText}\n` +
-      '```\n\n' +
-      `SHA: ${commit}\n`
-    )
+    try {
+      await comment({ github, context, issueNumber }, marker, `## ${title}\n` +
+        '```diff\n' +
+        `${diffText}\n` +
+        '```\n\n' +
+        `SHA: ${commit}\n`
+      )
+    } catch {
+      await comment({ github, context, issueNumber }, marker, `## ${title}\n` +
+        `The diff could not be posted as a comment. You can download it from the [workflow artifacts](${githubActionArtifactsUrl(context.runId)}).` +
+        '\n\n' +
+        `SHA: ${commit}\n`
+      )
+    }
   }
+}
+
+/**
+ * Generates a URL to the "Artifacts" section of a Github action run
+ *
+ * Unfortunately the best we can do here is a link to the "Artifacts" section as
+ * [the upload-artifact action doesn't provide
+ * the public URL](https://github.com/actions/upload-artifact/issues/50) :'(
+ *
+ * @param {number} runId - - The ID of the Github action run
+ * @returns {string} The URL to the "Artifacts" section of the given run
+ */
+function githubActionArtifactsUrl (runId) {
+  return `https://github.com/alphagov/govuk-frontend/actions/runs/${runId}/#artifacts`
 }
 
 /**

--- a/bin/dist-diff.sh
+++ b/bin/dist-diff.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 # Computes the diff of `dist` between a provided base reference (branch, tag, commit SHA) and the current HEAD.
 # It outputs the resulting diff in the provided output folder
@@ -25,5 +25,5 @@ git diff \
   
 # Diff the rest of the files, excluding the sourcemaps and the minified files
 # See https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec
-git diff -M05 $base -- dist ":(exclude)*.map" \
-  > $output_folder/dist.diff
+git diff -M05 $base -- dist ":(exclude)dist/*.min.*" \
+  > $output_folder/dist-other.diff


### PR DESCRIPTION
This PRs updates the Github action running the diff of `dist` to post each diff (JavaScript, CSS, and other files) as a separate comment. This will limit the risk of them being over the 64Kb limit allowed by the Github API for posting comment and close #3546.

In addition to the separate comments, the action will also post a fallback message signposting to the action's artifacts where the diffs are uploaded (added for #3229).

> **Note** The diff display was triggered by 3bd7c5814) which has since then been removed. Similarly, the fallback message was tested by forcing an error and pushing (212da24c5386583f2ae7bc79e30a8c34f9ccef5a being the latest iteration), which has since been overwritten. 