### PR TITLE
Add Rollup stats to review app

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -11,7 +11,9 @@ runs:
       with:
         # Restore build cache (unless commit SHA changes)
         key: build-cache-${{ runner.os }}-${{ github.sha }}
-        path: packages/*/dist
+        path: |
+          packages/*/dist
+          shared/*/dist
 
     - name: Build
       id: build

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -41,6 +41,7 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - copy GOV.UK Prototype Kit config files
 - compile JavaScript to ECMAScript (ES) modules
 - compile JavaScript to Universal Module Definition (UMD)
+- compile Rollup build stats into `./shared/govuk-frontend-stats/dist`
 - runs `npm run postbuild:package` (which will test the output is correct)
 
 **`npm run build:release` will do the following:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -27360,6 +27360,7 @@
         "govuk-frontend": "*",
         "govuk-frontend-config": "*",
         "govuk-frontend-lib": "*",
+        "govuk-frontend-stats": "*",
         "highlight.js": "^11.8.0",
         "iframe-resizer": "^4.3.6",
         "js-beautify": "^1.14.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "license": "MIT",
       "workspaces": [
         ".github/workflows/scripts",
-        "shared/*",
         "packages/govuk-frontend",
         "packages/govuk-frontend-review",
+        "shared/*",
         "docs/examples/*"
       ],
       "devDependencies": {
@@ -13075,6 +13075,10 @@
       "resolved": "packages/govuk-frontend-review",
       "link": true
     },
+    "node_modules/govuk-frontend-stats": {
+      "resolved": "shared/stats",
+      "link": true
+    },
     "node_modules/govuk-frontend-tasks": {
       "resolved": "shared/tasks",
       "link": true
@@ -22300,6 +22304,41 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.9.0.tgz",
+      "integrity": "sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==",
+      "dev": true,
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^2.3.1",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "rollup": "2.x || 3.x"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -27396,6 +27435,24 @@
         "govuk-frontend-config": "*",
         "js-yaml": "^4.1.0",
         "minimatch": "^9.0.0"
+      },
+      "engines": {
+        "node": "^18.12.0",
+        "npm": "^8.1.0 || ^9.1.0"
+      }
+    },
+    "shared/stats": {
+      "name": "govuk-frontend-stats",
+      "license": "MIT",
+      "dependencies": {
+        "govuk-frontend-config": "*",
+        "govuk-frontend-lib": "*"
+      },
+      "devDependencies": {
+        "@rollup/plugin-node-resolve": "^15.0.2",
+        "govuk-frontend": "*",
+        "rollup": "^3.23.0",
+        "rollup-plugin-visualizer": "^5.9.0"
       },
       "engines": {
         "node": "^18.12.0",

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "license": "MIT",
   "workspaces": [
     ".github/workflows/scripts",
-    "shared/*",
     "packages/govuk-frontend",
     "packages/govuk-frontend-review",
+    "shared/*",
     "docs/examples/*"
   ],
   "scripts": {

--- a/packages/govuk-frontend-review/nodemon.json
+++ b/packages/govuk-frontend-review/nodemon.json
@@ -3,7 +3,8 @@
     "./src",
     "../govuk-frontend/src/govuk/**/*.{json,yaml}",
     "../../shared/config",
-    "../../shared/lib"
+    "../../shared/lib",
+    "../../shared/stats"
   ],
   "ignore": ["./src/javascripts/**", "**/*.test.*"],
   "events": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -27,6 +27,7 @@
     "govuk-frontend": "*",
     "govuk-frontend-config": "*",
     "govuk-frontend-lib": "*",
+    "govuk-frontend-stats": "*",
     "highlight.js": "^11.8.0",
     "iframe-resizer": "^4.3.6",
     "js-beautify": "^1.14.7",

--- a/packages/govuk-frontend-review/src/app.test.mjs
+++ b/packages/govuk-frontend-review/src/app.test.mjs
@@ -47,10 +47,7 @@ describe(`http://localhost:${ports.app}`, () => {
       const componentNames = await getComponentNames()
       const componentsList = $('li a[href^="/components/"]').get()
 
-      // Since we have an 'all' component link that renders the default example of all
-      // components, there will always be one more expected link.
-      const expectedComponentLinks = componentNames.length + 1
-      expect(componentsList.length).toEqual(expectedComponentLinks)
+      expect(componentsList.length).toEqual(componentNames.length)
     })
   })
 

--- a/packages/govuk-frontend-review/src/common/middleware/docs.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/docs.mjs
@@ -30,5 +30,6 @@ router.use('/sass', ({ app }, res, next) => {
  */
 router.use('/sass', express.static(join(paths.app, 'dist/docs/sassdoc')))
 router.use('/javascript', express.static(join(paths.app, 'dist/docs/jsdoc')))
+router.use('/stats', express.static(join(paths.stats, 'dist')))
 
 export default router

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/format-number.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/format-number.mjs
@@ -1,0 +1,11 @@
+/**
+ * Format number
+ *
+ * @param {string | number} number - Number to format
+ * @returns {string} Number as formatted string
+ */
+export function formatNumber (number) {
+  return Number(number).toLocaleString('en', {
+    useGrouping: true
+  })
+}

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
@@ -2,4 +2,5 @@
  * Nunjucks filters
  */
 export { componentNameToMacroName } from 'govuk-frontend-lib/names'
+export { formatNumber } from './format-number.mjs'
 export { highlight } from './highlight.mjs'

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -95,7 +95,18 @@
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <h2 class="govuk-heading-l">JavaScript modules</h2>
 
-      {% set rows = [] %}
+      {% set bundleSize = stats["all.mjs"]["total"] %}
+
+      {% set rows = [{
+        key: {
+          classes: "govuk-!-width-three-quarters",
+          text: "Total bundle size"
+        },
+        value: {
+          text: (bundleSize / 1000) | round(2) | formatNumber + " KB"
+        }
+      }] %}
+
       {% for componentName in componentNamesWithJavaScript | sort %}
         {% set componentSize = stats["components/" + componentName + "/" + componentName + ".mjs"]["total"] %}
 

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -36,21 +36,37 @@
         <li><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
       </ul>
-
-      <h2 class="govuk-heading-m">Documentation</h2>
-
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">Sass documentation</h3>
-      <ul class="govuk-list">
-        <li><a href="https://frontend.design-system.service.gov.uk/sass-api-reference/" class="govuk-link">Latest release</a></li>
-        {% if not flags.isDeployedToHeroku %}
-        <li><a href="/docs/sass" class="govuk-link">Local version</a></li>
-        {% endif %}
-      </ul>
-
-      <h3 class="govuk-heading-s govuk-!-margin-bottom-2">JavaScript documentation</h3>
-      <ul class="govuk-list">
-        <li><a href="/docs/javascript" class="govuk-link">Local version</a></li>
-      </ul>
     </div>
+
+  </div>
+
+  <div class="govuk-grid-row">
+
+    <div class="govuk-grid-column-two-thirds">
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+      <h2 class="govuk-heading-l">Documentation</h2>
+
+      <div class="govuk-grid-row">
+
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Sass API reference</h3>
+          <ul class="govuk-list">
+          {% if not flags.isDeployedToHeroku %}
+            <li><a href="/docs/sass" class="govuk-link">Local version</a></li>
+          {% endif %}
+            <li><a href="https://frontend.design-system.service.gov.uk/sass-api-reference/" class="govuk-link">Latest release</a></li>
+          </ul>
+        </div>
+
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">JavaScript API reference</h3>
+          <ul class="govuk-list">
+            <li><a href="/docs/javascript" class="govuk-link">Local version</a></li>
+          </ul>
+        </div>
+
+      </div>
+    </div>
+
   </div>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -14,11 +14,20 @@
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">All components</h3>
       <p class="govuk-body"><a href="/components/all" class="govuk-link govuk-link--muted">View all components</a></p>
 
-      <ul class="govuk-list govuk-!-margin-bottom-8">
-      {% for componentName in componentNames | sort %}
-        <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
-      {% endfor %}
-      </ul>
+      <div class="govuk-grid-row govuk-!-margin-bottom-8">
+
+        {% for componentNamesSlice in componentNames | slice(2) %}
+        <div class="govuk-grid-column-one-half govuk-grid-column-full-from-desktop">
+          <ul class="govuk-list govuk-!-margin-bottom-0">
+          {% for componentName in componentNamesSlice %}
+            <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+        {% endfor %}
+
+      </div>
+
     </div>
 
     <div class="govuk-grid-column-two-thirds-from-desktop">

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -95,12 +95,18 @@
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <h2 class="govuk-heading-l">JavaScript modules</h2>
 
-      {% set bundleSize = stats["all.mjs"]["total"] %}
+      {% set bundleKey = "all" %}
+      {% set bundleSize = stats[bundleKey + ".mjs"]["total"] %}
+
+      {% set bundleHtml %}
+        Total bundle size<br>
+        <a href="/docs/stats/{{ bundleKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ bundleKey }}.mjs</code></a>
+      {% endset %}
 
       {% set rows = [{
         key: {
           classes: "govuk-!-width-three-quarters",
-          text: "Total bundle size"
+          html: bundleHtml
         },
         value: {
           text: (bundleSize / 1000) | round(2) | formatNumber + " KB"
@@ -108,12 +114,18 @@
       }] %}
 
       {% for componentName in componentNamesWithJavaScript | sort %}
-        {% set componentSize = stats["components/" + componentName + "/" + componentName + ".mjs"]["total"] %}
+        {% set componentKey = "components/" + componentName + "/" + componentName %}
+        {% set componentSize = stats[componentKey + ".mjs"]["total"] %}
+
+        {% set componentHtml %}
+          {{ componentName | replace("-", " ") | capitalize }}<br>
+          <a href="/docs/stats/{{ componentKey }}.html" class="govuk-body-s govuk-link govuk-!-font-weight-regular"><code>{{ componentName }}.mjs</code></a>
+        {% endset %}
 
         {% set rows = (rows.push({
           key: {
             classes: "govuk-!-width-three-quarters",
-            text: componentName | replace("-", " ") | capitalize
+            html: componentHtml
           },
           value: {
             text: (componentSize / 1000) | round(2) | formatNumber + " KB"

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -1,5 +1,7 @@
 {% extends "layout.njk" %}
 
+{% from "summary-list/macro.njk" import govukSummaryList %}
+
 {% block content %}
   <h1 class="govuk-heading-xl">
     GOV.UK Frontend
@@ -76,6 +78,32 @@
         </div>
 
       </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+      <h2 class="govuk-heading-l">JavaScript modules</h2>
+
+      {% set rows = [] %}
+      {% for componentName in componentNamesWithJavaScript | sort %}
+        {% set componentSize = stats["components/" + componentName + "/" + componentName + ".mjs"]["total"] %}
+
+        {% set rows = (rows.push({
+          key: {
+            classes: "govuk-!-width-three-quarters",
+            text: componentName | replace("-", " ") | capitalize
+          },
+          value: {
+            text: (componentSize / 1000) | round(2) | formatNumber + " KB"
+          }
+        }), rows) %}
+      {% endfor %}
+
+      {{ govukSummaryList({
+        rows: rows
+      }) }}
     </div>
   </div>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -25,22 +25,22 @@
       <div class="govuk-grid-row">
 
         <div class="govuk-grid-column-one-half">
-          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
-
-          <ul class="govuk-list">
-          {% for exampleName in exampleNames | sort %}
-            <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
-          {% endfor %}
-          </ul>
-        </div>
-
-        <div class="govuk-grid-column-one-half">
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Full page examples</h2>
           <p class="govuk-body"><a href="/full-page-examples" class="govuk-link govuk-link--muted">View all full page examples</a></p>
 
           <ul class="govuk-list">
           {% for example in fullPageExamples %}
             <li><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | replace("-", " ") | capitalize }}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
+
+          <ul class="govuk-list">
+          {% for exampleName in exampleNames | sort %}
+            <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
           {% endfor %}
           </ul>
         </div>

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -9,7 +9,7 @@
 
   <div class="govuk-grid-row">
 
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-one-third-from-desktop">
       <h2 class="govuk-heading-l">Components</h2>
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">All components</h3>
       <p class="govuk-body"><a href="/components/all" class="govuk-link govuk-link--muted">View all components</a></p>
@@ -21,7 +21,7 @@
       </ul>
     </div>
 
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <h2 class="govuk-heading-l">Examples</h2>
 
       <div class="govuk-grid-row">
@@ -54,7 +54,7 @@
 
   <div class="govuk-grid-row">
 
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <h2 class="govuk-heading-l">Documentation</h2>
 
@@ -82,7 +82,7 @@
   </div>
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <h2 class="govuk-heading-l">JavaScript modules</h2>
 

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -14,7 +14,7 @@
       <h3 class="govuk-heading-m govuk-!-margin-bottom-2">All components</h3>
       <p class="govuk-body"><a href="/components/all" class="govuk-link govuk-link--muted">View all components</a></p>
 
-      <ul class="govuk-list">
+      <ul class="govuk-list govuk-!-margin-bottom-8">
       {% for componentName in componentNames | sort %}
         <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
       {% endfor %}
@@ -30,7 +30,7 @@
           <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Full page examples</h2>
           <p class="govuk-body"><a href="/full-page-examples" class="govuk-link govuk-link--muted">View all full page examples</a></p>
 
-          <ul class="govuk-list">
+          <ul class="govuk-list govuk-!-margin-bottom-8">
           {% for example in fullPageExamples %}
             <li><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | replace("-", " ") | capitalize }}</a></li>
           {% endfor %}
@@ -40,7 +40,7 @@
         <div class="govuk-grid-column-one-half">
           <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
 
-          <ul class="govuk-list">
+          <ul class="govuk-list govuk-!-margin-bottom-8">
           {% for exampleName in exampleNames | sort %}
             <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
           {% endfor %}

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -8,18 +8,21 @@
   <div class="govuk-grid-row">
 
     <div class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-m">Components</h2>
+      <h2 class="govuk-heading-l">Components</h2>
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">All components</h3>
+      <p class="govuk-body"><a href="/components/all" class="govuk-link govuk-link--muted">View all components</a></p>
 
       <ul class="govuk-list">
-        <li><a href="/components/all" class="govuk-link">All</a></li>
-        {% for componentName in componentNames | sort %}
-          <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
-        {% endfor %}
+      {% for componentName in componentNames | sort %}
+        <li><a href="/components/{{ componentName }}" class="govuk-link">{{ componentName | replace("-", " ") | capitalize }}</a></li>
+      {% endfor %}
       </ul>
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-m">Examples</h2>
+      <h2 class="govuk-heading-l">Examples</h2>
+
+      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
 
       <ul class="govuk-list">
       {% for exampleName in exampleNames | sort %}
@@ -29,7 +32,8 @@
     </div>
 
     <div class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-m"><a href="/full-page-examples" class="govuk-link">Full page examples</a></h2>
+      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Full page examples</h2>
+      <p class="govuk-body"><a href="/full-page-examples" class="govuk-link govuk-link--muted">View all full page examples</a></p>
 
       <ul class="govuk-list">
       {% for example in fullPageExamples %}

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -19,27 +19,33 @@
       </ul>
     </div>
 
-    <div class="govuk-grid-column-one-third">
+    <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-l">Examples</h2>
 
-      <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
+      <div class="govuk-grid-row">
 
-      <ul class="govuk-list">
-      {% for exampleName in exampleNames | sort %}
-        <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
-      {% endfor %}
-      </ul>
-    </div>
+        <div class="govuk-grid-column-one-half">
+          <h3 class="govuk-heading-m govuk-!-margin-bottom-2">Other examples</h3>
 
-    <div class="govuk-grid-column-one-third">
-      <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Full page examples</h2>
-      <p class="govuk-body"><a href="/full-page-examples" class="govuk-link govuk-link--muted">View all full page examples</a></p>
+          <ul class="govuk-list">
+          {% for exampleName in exampleNames | sort %}
+            <li><a href="/examples/{{ exampleName }}" class="govuk-link">{{ exampleName | replace("-", " ") | capitalize }}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
 
-      <ul class="govuk-list">
-      {% for example in fullPageExamples %}
-        <li><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | replace("-", " ") | capitalize }}</a></li>
-      {% endfor %}
-      </ul>
+        <div class="govuk-grid-column-one-half">
+          <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Full page examples</h2>
+          <p class="govuk-body"><a href="/full-page-examples" class="govuk-link govuk-link--muted">View all full page examples</a></p>
+
+          <ul class="govuk-list">
+          {% for example in fullPageExamples %}
+            <li><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | replace("-", " ") | capitalize }}</a></li>
+          {% endfor %}
+          </ul>
+        </div>
+
+      </div>
     </div>
 
   </div>
@@ -71,6 +77,5 @@
 
       </div>
     </div>
-
   </div>
 {% endblock %}

--- a/packages/govuk-frontend-review/tsconfig.json
+++ b/packages/govuk-frontend-review/tsconfig.json
@@ -6,7 +6,12 @@
     "../govuk-frontend",
     "../../shared/config",
     "../../shared/lib",
+    "../../shared/stats",
     "../../shared/tasks"
   ],
-  "exclude": ["./dist/**", "../govuk-frontend/dist/**"]
+  "exclude": [
+    "./dist/**",
+    "../govuk-frontend/dist/**",
+    "../../shared/stats/dist/**"
+  ]
 }

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -48,6 +48,7 @@
     "build": "npm run build:package",
     "build:package": "gulp build:package --color",
     "build:release": "gulp build:release --color",
+    "build:stats": "npm run stats --workspace govuk-frontend-stats",
     "dev": "gulp dev --color"
   },
   "devDependencies": {

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -176,7 +176,7 @@ describe('packages/govuk-frontend/dist/', () => {
     beforeAll(async () => {
       // Components list (with JavaScript only)
       componentNamesWithJavaScript = await getComponentNames((componentName, componentFiles) =>
-        componentFiles.every(filterPath([`**/${componentName}.mjs`])))
+        componentFiles.some(filterPath([`**/${componentName}.mjs`])))
     })
 
     it('should have component JavaScript file with correct module name', () => {

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -1,6 +1,6 @@
 import { join, resolve } from 'path'
 
-import { configs, scripts, task } from 'govuk-frontend-tasks'
+import { configs, scripts, npm, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 
 /**
@@ -43,5 +43,8 @@ export const compile = (options) => gulp.series(
       srcPath: join(options.srcPath, 'govuk-prototype-kit'),
       destPath: resolve(options.destPath, '../') // Top level (not dist) for compatibility
     })
-  )
+  ),
+
+  // Compile GOV.UK Frontend build stats
+  npm.script('build:stats', [], options)
 )

--- a/shared/config/paths.js
+++ b/shared/config/paths.js
@@ -13,5 +13,8 @@ module.exports = {
   package: join(rootPath, 'packages/govuk-frontend'),
 
   // Express.js review app
-  app: join(rootPath, 'packages/govuk-frontend-review')
+  app: join(rootPath, 'packages/govuk-frontend-review'),
+
+  // Rollup build stats
+  stats: join(rootPath, 'shared/stats')
 }

--- a/shared/stats/package.json
+++ b/shared/stats/package.json
@@ -1,0 +1,24 @@
+{
+  "private": true,
+  "name": "govuk-frontend-stats",
+  "description": "GOV.UK Frontend build stats",
+  "main": "src/index.mjs",
+  "engines": {
+    "node": "^18.12.0",
+    "npm": "^8.1.0 || ^9.1.0"
+  },
+  "license": "MIT",
+  "scripts": {
+    "stats": "rollup --config rollup.config.mjs"
+  },
+  "dependencies": {
+    "govuk-frontend-config": "*",
+    "govuk-frontend-lib": "*"
+  },
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^15.0.2",
+    "govuk-frontend": "*",
+    "rollup": "^3.23.0",
+    "rollup-plugin-visualizer": "^5.9.0"
+  }
+}

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -27,10 +27,19 @@ export default defineConfig(modulePaths
      */
     plugins: [
       resolve(),
+
+      // Stats: File size
       visualizer({
         filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.yaml`),
         projectRoot: packageNameToPath('govuk-frontend', 'dist/govuk-esm/'),
         template: 'list'
+      }),
+
+      // Stats: Module tree map
+      visualizer({
+        filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.html`),
+        projectRoot: packageNameToPath('govuk-frontend', 'dist/govuk-esm/'),
+        template: 'treemap'
       })
     ]
   }))

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -1,0 +1,37 @@
+import { dirname, join, parse } from 'path'
+
+import resolve from '@rollup/plugin-node-resolve'
+import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { defineConfig } from 'rollup'
+import { visualizer } from 'rollup-plugin-visualizer'
+
+import { modulePaths } from './src/index.mjs'
+
+/**
+ * Rollup config with stats output
+ */
+export default defineConfig(modulePaths
+  .map((modulePath) => /** @satisfies {import('rollup').RollupOptions} */({
+    input: join('govuk-frontend/dist/govuk-esm', modulePath),
+
+    /**
+     * Output options
+     */
+    output: {
+      file: join('dist', modulePath),
+      format: 'es'
+    },
+
+    /**
+     * Input plugins
+     */
+    plugins: [
+      resolve(),
+      visualizer({
+        filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.yaml`),
+        projectRoot: packageNameToPath('govuk-frontend', 'dist/govuk-esm/'),
+        template: 'list'
+      })
+    ]
+  }))
+)

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -1,0 +1,46 @@
+import { join, parse } from 'path'
+
+import { paths } from 'govuk-frontend-config'
+import { getComponentNames, filterPath, getYaml } from 'govuk-frontend-lib/files'
+
+/**
+ * Components with JavaScript
+ */
+const componentNamesWithJavaScript = await getComponentNames((componentName, componentFiles) =>
+  componentFiles.some(filterPath([`**/${componentName}.mjs`])))
+
+/**
+ * Rollup input paths
+ */
+export const modulePaths = ['all.mjs']
+  .concat(componentNamesWithJavaScript.map((componentName) =>
+    `components/${componentName}/${componentName}.mjs`))
+
+/**
+ * Rollup module stats
+ *
+ * @param {string} modulePath - Rollup input path
+ * @returns {Promise<{ total: number, modules: ModulesList }>} Rollup module stats
+ */
+export async function getStats (modulePath) {
+  const { base, dir, name } = parse(modulePath)
+
+  // Path to Rollup `npm run build` YAML stats
+  /** @type {Record<string, ModulesList> | undefined} */
+  const stats = await getYaml(join(paths.stats, `dist/${dir}/${name}.yaml`))
+    .catch(() => undefined)
+
+  // Modules bundled
+  const modules = stats?.[base] ?? {}
+
+  // Modules total size
+  const total = Object.values(modules)
+    .map(({ rendered }) => rendered)
+    .reduce((total, rendered) => total + rendered, 0)
+
+  return { total, modules }
+}
+
+/**
+ * @typedef {{ [modulePath: string]: { rendered: number } }} ModulesList
+ */

--- a/shared/stats/tsconfig.json
+++ b/shared/stats/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": [
+    "**/*.mjs",
+    "../config",
+    "../lib",
+    "../tasks",
+    "../../packages/govuk-frontend"
+  ],
+  "exclude": ["./dist/**", "../../packages/govuk-frontend/dist/**"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "./shared/lib"
     },
     {
+      "path": "./shared/stats"
+    },
+    {
       "path": "./shared/tasks"
     }
   ]


### PR DESCRIPTION
This PR adds a new package to generate Rollup build stats for:

* https://github.com/alphagov/govuk-frontend/issues/3281
* https://github.com/alphagov/govuk-frontend/issues/3280

Changes also include:

1. Enables JSDoc type discovery for `govuk-frontend` in any workspace
2. Restarts review app on shared package changes

<img width="700" alt="JavaScript module stats" src="https://github.com/alphagov/govuk-frontend/assets/415517/20405db3-4caf-4ca1-ae68-c7416f50b348">