### PR TITLE
Silence markdown deprecation warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "@types/gulp": "^4.0.10",
         "@types/jest": "^29.5.1",
         "@types/jest-axe": "^3.5.5",
+        "@types/marked": "^5.0.0",
         "@types/node": "^20.2.3",
         "@types/nunjucks": "^3.2.2",
         "puppeteer": "^20.3.0"
@@ -4530,6 +4531,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/marked": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.0.tgz",
+      "integrity": "sha512-YcZe50jhltsCq7rc9MNZC/4QB/OnA2Pd6hrOSTOFajtabN+38slqgDDCeE/0F83SjkKBQcsZUj7VLWR0H5cKRA==",
+      "optional": true
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/gulp": "^4.0.10",
     "@types/jest": "^29.5.1",
     "@types/jest-axe": "^3.5.5",
+    "@types/marked": "^5.0.0",
     "@types/node": "^20.2.3",
     "@types/nunjucks": "^3.2.2",
     "puppeteer": "^20.3.0"

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/markdown.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/markdown.mjs
@@ -7,5 +7,9 @@ import { marked } from 'marked'
  * @returns {string} Rendered Markdown
  */
 export function markdown (content) {
-  return marked.parse(content)
+  // Explicitly set deprecated properties to false to avoid deprecation warnings
+  return marked.parse(content, {
+    mangle: false,
+    headerIds: false
+  })
 }


### PR DESCRIPTION
Since we bumped marked to v5.0.0, we've been getting deprecation warnings:

```
marked(): headerIds and headerPrefix parameters enabled by default, but are deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install  https://www.npmjs.com/package/marked-gfm-heading-id, or disable by setting `{headerIds: false}`.

marked(): mangle parameter is enabled by default, but is deprecated since version 5.0.0, and will be removed in the future. To clear this warning, install https://www.npmjs.com/package/marked-mangle, or disable by setting `{mangle: false}`.
```

We use marked in one place: on our [full page examples index page](https://govuk-frontend-review.herokuapp.com/full-page-examples), to render the "scenarios" under each heading.

We don't mangle anything, and we don't render any headings that might be affected by `headerIds` and `headerPrefix`.

Nevertheless, I've followed `marked`'s advice and installed the `marked-gfm-heading-id` plugin, to maintain expected behaviour if we include headings in the future.

There is no diff in the rendered page.

This introduces the small chore of removing the explicit `mangle: false` once that property defaults to `false`. But since it'll just keep working in that instance anyway, I think not a particularly bad temporary fix.