### PR TITLE
Add Browsersync reload on `*.js` changes in review app

### DIFF
--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -22,7 +22,7 @@ module.exports = {
 
   // Files to watch for auto reload
   files: [
-    join(paths.app, 'dist/javascripts/**/*.mjs'),
+    join(paths.app, 'dist/javascripts/**/*.js'),
     join(paths.app, 'dist/stylesheets/**/*.css'),
     join(paths.app, 'src/views/**/*.njk'),
     packageNameToPath('govuk-frontend', 'dist/govuk/**/*.njk')


### PR DESCRIPTION
Adds a missed extension `*.js` for Browsersync reload from https://github.com/alphagov/govuk-frontend/pull/3690

We'd assumed to watch `*.mjs` but Rollup outputs `*.js` by default