### PR TITLE
Fix a few more `govuk` → `dist/govuk` references

### DIFF
--- a/docs/contributing/managing-change.md
+++ b/docs/contributing/managing-change.md
@@ -24,16 +24,16 @@ You can mention the warnings in the release notes to help users understand if th
 
 For example:
 
-> If you import specific files from the core or overrides layers, you’ll now see a deprecation warning when compiling Sass if you do not import `node_modules/govuk-frontend/govuk/base` first.
+> If you import specific files from the core or overrides layers, you’ll now see a deprecation warning when compiling Sass if you do not import `node_modules/govuk-frontend/dist/govuk/base` first.
 >
-> To fix the warning, import `node_modules/govuk-frontend/govuk/base` first. For example:
+> To fix the warning, import `node_modules/govuk-frontend/dist/govuk/base` first. For example:
 >
 > ```scss
-> @import "node_modules/govuk-frontend/govuk/base";
-> @import "node_modules/govuk-frontend/core/typography";
+> @import "node_modules/govuk-frontend/dist/govuk/base";
+> @import "node_modules/govuk-frontend/dist/core/typography";
 > ```
 >
-> If you do not import `node_modules/govuk-frontend/govuk/base` first, your service will no longer work from GOV.UK Frontend v4.0.0.
+> If you do not import `node_modules/govuk-frontend/dist/govuk/base` first, your service will no longer work from GOV.UK Frontend v5.0.0.
 
 ### Make sure we remember to remove the deprecated feature
 

--- a/packages/govuk-frontend/README.md
+++ b/packages/govuk-frontend/README.md
@@ -37,7 +37,7 @@ imports) if you want to override GOV.UK Frontend with your own styles.
 To import add the below to your Sass file:
 
 ```scss
-@import "node_modules/govuk-frontend/govuk/all";
+@import "node_modules/govuk-frontend/dist/govuk/all";
 ```
 
 [More details on importing styles](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#css)
@@ -48,7 +48,7 @@ Some of the JavaScript included in GOV.UK Frontend improves the usability and
 accessibility of the components. You should make sure that you are importing and
 initialising Javascript in your application to ensure that all users can use it successfully.
 
-You can include Javascript for all components either by copying the `all.js` from `node_modules/govuk-frontend/govuk/` into your application or referencing the file directly:
+You can include Javascript for all components either by copying the `all.js` from `node_modules/govuk-frontend/dist/govuk/` into your application or referencing the file directly:
 
 ```html
 <script src="<path-to-govuk-frontend-all-file>/all.js"></script>


### PR DESCRIPTION
Fixes a few missed `govuk` paths in documentation left over from:

* https://github.com/alphagov/govuk-frontend/pull/3498

These should be moved to ~`govuk`~ `dist/govuk` which we [documented in **CHANGELOG.md**](https://github.com/alphagov/govuk-frontend/pull/3498/commits/cb64d8597792df45e67cde8f71d6f7f22c5d2011)