### PR TITLE
Fix missing "Update your account details" error messages etc

### DIFF
--- a/packages/govuk-frontend-review/src/utils.mjs
+++ b/packages/govuk-frontend-review/src/utils.mjs
@@ -1,17 +1,37 @@
-// To make it easier to use in the view, format express-validator errors.
-export function formatValidationErrors (errorsInstance) {
-  if (errorsInstance.isEmpty()) {
-    return false
-  }
-  const errors = errorsInstance.array()
-  const formattedErrors = {}
-  errors.forEach(error => {
-    formattedErrors[error.path] = {
-      id: error.path,
-      href: '#' + error.path,
-      value: error.value,
-      text: error.msg
-    }
-  })
-  return formattedErrors
+/**
+ * To make it easier to use in the view, format express-validator errors.
+ *
+ * @param {Errors} errors - Validation errors
+ * @returns {Record<string, ErrorFormatted> | undefined} Formatted errors
+ */
+export function formatValidationErrors (errors) {
+  return errors
+    .formatWith((error) => {
+      if (error.type !== 'field') {
+        throw new Error(`Unknown error: ${error.type}`)
+      }
+
+      return {
+        id: error.path,
+        href: `#${error.path}`,
+        value: error.value,
+        text: error.msg
+      }
+    })
+    .mapped()
 }
+
+/**
+ * GOV.UK Frontend error format
+ *
+ * @typedef {object} ErrorFormatted
+ * @property {string} id - Form field 'id' attribute
+ * @property {string} href - Form field 'href' attribute
+ * @property {string} value - Form field value (submitted)
+ * @property {string} text - Form field error message
+ */
+
+/**
+ * @typedef {import('express-validator').ValidationError} Error
+ * @typedef {import('express-validator').Result<Error>} Errors
+ */

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -18,7 +18,6 @@ export default (app) => {
         .not().isEmpty().withMessage('Enter details of your question, problem or feedback')
         .isLength({ max: 300 }).withMessage('Details of your question, problem or feedback must be 300 characters or less'),
       body('do-you-want-a-reply')
-        .exists()
         .not().isEmpty().withMessage('Select yes if you want a reply'),
       body('name')
         .custom((value, { req: request }) => {

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -10,7 +10,6 @@ export default (app) => {
     '/full-page-examples/have-you-changed-your-name',
     [
       body('changed-name')
-        .exists()
         .not().isEmpty().withMessage('Select if you have changed your name')
     ],
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -10,7 +10,6 @@ export default (app) => {
     '/full-page-examples/how-do-you-want-to-sign-in',
     [
       body('sign-in')
-        .exists()
         .not().isEmpty().withMessage('Select how you want to sign in')
     ],
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -43,7 +43,9 @@ export default (app) => {
         // Get the first error message and merge it into a single error message.
         errors[expiryNamePrefix] = {
           id: expiryNamePrefix,
-          href: '#' + firstExpiryErrorId
+          href: '#' + firstExpiryErrorId,
+          value: '',
+          text: ''
         }
 
         // Construct a single error message based on all three error messages.

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -1,22 +1,6 @@
 import { body, validationResult } from 'express-validator'
 
-// To make it easier to use in the view, might be nicer as a Nunjucks function
-function getErrors (errorsInstance) {
-  if (errorsInstance.isEmpty()) {
-    return false
-  }
-  const errors = errorsInstance.array()
-  const formattedErrors = {}
-  errors.forEach(error => {
-    formattedErrors[error.param] = {
-      id: error.param,
-      href: '#' + error.param,
-      value: error.value,
-      text: error.msg
-    }
-  })
-  return formattedErrors
-}
+import { formatValidationErrors } from '../../../utils.mjs'
 
 /**
  * @param {import('express').Application} app
@@ -40,7 +24,7 @@ export default (app) => {
      * @returns {void}
      */
     (request, response) => {
-      const errors = getErrors(validationResult(request))
+      const errors = formatValidationErrors(validationResult(request))
 
       if (!errors) {
         return response.render('./full-page-examples/update-your-account-details/confirm')

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -13,7 +13,6 @@ export default (app) => {
         .exists()
         .not().isEmpty().withMessage('Select a photo'),
       body('terms-and-conditions')
-        .exists()
         .not().isEmpty().withMessage('Select I accept the terms and conditions')
     ],
 


### PR DESCRIPTION
This PR fixes:

1. Fix unchecked radios/checkboxes not passing `exists()`
2. Fix error formatting in “Update your account details” [`error.param` → **`error.path`**](https://express-validator.github.io/docs/migration-v6-to-v7#renamed-properties)

### Missing error messages

**Update your account details**
https://govuk-frontend-review.herokuapp.com/full-page-examples/update-your-account-details

Click "Save account details" and the error messages are missing:

<img width="706" alt="Update your account details screenshot with error summary but no error messages" src="https://github.com/alphagov/govuk-frontend/assets/415517/545a498a-3aa3-40cb-a4fa-dd745556d23f">
