### PR TITLE
Remove checks for newer JavaScript features

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -195,11 +195,8 @@ CharacterCount.prototype.init = function () {
   // When the page is restored after navigating 'back' in some browsers the
   // state of the character count is not restored until *after* the
   // DOMContentLoaded event is fired, so we need to manually update it after the
-  // pageshow event in browsers that support it.
-  window.addEventListener(
-    'onpageshow' in window ? 'pageshow' : 'DOMContentLoaded',
-    this.updateCountMessage.bind(this)
-  )
+  // pageshow event.
+  window.addEventListener('pageshow', this.updateCountMessage.bind(this))
 
   this.updateCountMessage()
 }

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -62,12 +62,8 @@ Checkboxes.prototype.init = function () {
 
   // When the page is restored after navigating 'back' in some browsers the
   // state of form controls is not restored until *after* the DOMContentLoaded
-  // event is fired, so we need to sync after the pageshow event in browsers
-  // that support it.
-  window.addEventListener(
-    'onpageshow' in window ? 'pageshow' : 'DOMContentLoaded',
-    this.syncAllConditionalReveals.bind(this)
-  )
+  // event is fired, so we need to sync after the pageshow event.
+  window.addEventListener('pageshow', this.syncAllConditionalReveals.bind(this))
 
   // Although we've set up handlers to sync state on the pageshow or
   // DOMContentLoaded event, init could be called after those events have fired,

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -45,10 +45,8 @@ function Header ($module) {
  *
  * Check for the presence of the header, menu and menu button – if any are
  * missing then there's nothing to do so return early.
- * Feature sniff for and apply a matchMedia for desktop which will
- * trigger a state sync if the browser viewport moves between states. If
- * matchMedia isn't available, hide the menu button and present the "no js"
- * version of the menu to the user.
+ * Apply a matchMedia for desktop which will trigger a state sync if the browser
+ * viewport moves between states.
  */
 Header.prototype.init = function () {
   // Check that required elements are present
@@ -56,27 +54,23 @@ Header.prototype.init = function () {
     return
   }
 
-  if ('matchMedia' in window) {
-    // Set the matchMedia to the govuk-frontend desktop breakpoint
-    this.mql = window.matchMedia('(min-width: 48.0625em)')
+  // Set the matchMedia to the govuk-frontend desktop breakpoint
+  this.mql = window.matchMedia('(min-width: 48.0625em)')
 
-    if ('addEventListener' in this.mql) {
-      this.mql.addEventListener('change', this.syncState.bind(this))
-    } else {
-      // addListener is a deprecated function, however addEventListener
-      // isn't supported by IE or Safari < 14. We therefore add this in as
-      // a fallback for those browsers
-
-      // @ts-expect-error Property 'addListener' does not exist
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      this.mql.addListener(this.syncState.bind(this))
-    }
-
-    this.syncState()
-    this.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind(this))
+  if ('addEventListener' in this.mql) {
+    this.mql.addEventListener('change', this.syncState.bind(this))
   } else {
-    this.$menuButton.setAttribute('hidden', '')
+    // addListener is a deprecated function, however addEventListener
+    // isn't supported by Safari < 14. We therefore add this in as
+    // a fallback for those browsers
+
+    // @ts-expect-error Property 'addListener' does not exist
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    this.mql.addListener(this.syncState.bind(this))
   }
+
+  this.syncState()
+  this.$menuButton.addEventListener('click', this.handleMenuButtonClick.bind(this))
 }
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -62,12 +62,8 @@ Radios.prototype.init = function () {
 
   // When the page is restored after navigating 'back' in some browsers the
   // state of form controls is not restored until *after* the DOMContentLoaded
-  // event is fired, so we need to sync after the pageshow event in browsers
-  // that support it.
-  window.addEventListener(
-    'onpageshow' in window ? 'pageshow' : 'DOMContentLoaded',
-    this.syncAllConditionalReveals.bind(this)
-  )
+  // event is fired, so we need to sync after the pageshow event.
+  window.addEventListener('pageshow', this.syncAllConditionalReveals.bind(this))
 
   // Although we've set up handlers to sync state on the pageshow or
   // DOMContentLoaded event, init could be called after those events have fired,

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -51,11 +51,7 @@ Tabs.prototype.init = function () {
     return
   }
 
-  if (typeof window.matchMedia === 'function') {
-    this.setupResponsiveChecks()
-  } else {
-    this.setup()
-  }
+  this.setupResponsiveChecks()
 }
 
 /**


### PR DESCRIPTION
## `onpageshow`
[All ES6 module supporting browsers support PageTransitionEvents](https://browsersl.ist/#q=supports+es6-module+and+not+supports+page-transition-events), so we can remove the check for `window.onpageshow`.

Potentially we can go further and revert to checking `document.readyState`, which seems to have been affected by a bug in IE9-10, but this feels cleaner.

## `window.matchMedia`
[All ES6 module supporting browsers support window.matchMedia](https://caniuse.com/matchmedia)

We can probably set up the responsive checks as part of `Tabs.prototype.setup` now, but I didn't do that as I didn't want to mess with the deprecation step of setting those methods to private in v5.0