### PR TITLE
Add shared `getYaml()` lib function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27529,7 +27529,6 @@
         "govuk-frontend-lib": "*",
         "gulp": "^4.0.2",
         "gulp-cli": "^2.3.0",
-        "js-yaml": "^4.1.0",
         "nunjucks": "^3.2.4",
         "plugin-error": "^2.0.1",
         "postcss": "^8.4.23",

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -72,6 +72,16 @@ const mapPathTo = (patterns, callback) => (entryPath) => {
 }
 
 /**
+ * Read config from YAML file
+ *
+ * @param {string} configPath - File path to config
+ * @returns {Promise<any>} Config from YAML file
+ */
+const getYaml = async (configPath) => {
+  return yaml.load(await readFile(configPath, 'utf8'), { json: true })
+}
+
+/**
  * Load single component data
  *
  * @param {string} componentName - Component name
@@ -81,7 +91,7 @@ const getComponentData = async (componentName) => {
   const yamlPath = packageNameToPath('govuk-frontend', `src/govuk/components/${componentName}/${componentName}.yaml`)
 
   /** @type {ComponentData} */
-  const yamlData = yaml.load(await readFile(yamlPath, 'utf8'), { json: true })
+  const yamlData = await getYaml(yamlPath)
 
   return {
     name: componentName,
@@ -156,6 +166,7 @@ module.exports = {
   getExamples,
   getFullPageExamples,
   getListing,
+  getYaml,
   mapPathTo
 }
 

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -1,8 +1,6 @@
-import { readFile } from 'fs/promises'
 import { basename, dirname, join } from 'path'
 
-import { getListing } from 'govuk-frontend-lib/files'
-import yaml from 'js-yaml'
+import { getListing, getYaml } from 'govuk-frontend-lib/files'
 import nunjucks from 'nunjucks'
 
 import { files } from './index.mjs'
@@ -18,7 +16,7 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
 
   // Loop component data paths
   const fixtures = componentDataPaths.map(async (componentDataPath) => {
-    const fixture = await generateFixture(join(srcPath, componentDataPath))
+    const fixture = await generateFixture(componentDataPath, { srcPath })
 
     // Write to destination
     await files.write(componentDataPath, {
@@ -50,7 +48,7 @@ export async function generateMacroOptions (pattern, { srcPath, destPath }) {
 
   // Loop component data paths
   const macroOptions = componentDataPaths.map(async (componentDataPath) => {
-    const macroOption = await generateMacroOption(join(srcPath, componentDataPath))
+    const macroOption = await generateMacroOption(componentDataPath, { srcPath })
 
     // Write to destination
     await files.write(componentDataPath, {
@@ -75,11 +73,12 @@ export async function generateMacroOptions (pattern, { srcPath, destPath }) {
  * Component fixtures YAML to JSON
  *
  * @param {string} componentDataPath - Path to ${componentName}.yaml
+ * @param {Pick<AssetEntry[1], "srcPath">} options - Asset options
  * @returns {Promise<{ component: string; fixtures: { [key: string]: unknown }[] }>} Component fixtures object
  */
-async function generateFixture (componentDataPath) {
+async function generateFixture (componentDataPath, options) {
   /** @type {ComponentData} */
-  const json = await yaml.load(await readFile(componentDataPath, 'utf8'), { json: true })
+  const json = await getYaml(join(options.srcPath, componentDataPath))
 
   if (!json?.examples) {
     throw new Error(`${componentDataPath} is missing "examples"`)
@@ -118,11 +117,12 @@ async function generateFixture (componentDataPath) {
  * Macro options YAML to JSON
  *
  * @param {string} componentDataPath - Path to ${componentName}.yaml
+ * @param {Pick<AssetEntry[1], "srcPath">} options - Asset options
  * @returns {Promise<ComponentOption[] | undefined>} Component macro options
  */
-async function generateMacroOption (componentDataPath) {
+async function generateMacroOption (componentDataPath, options) {
   /** @type {ComponentData} */
-  const json = await yaml.load(await readFile(componentDataPath, 'utf8'), { json: true })
+  const json = await getYaml(join(options.srcPath, componentDataPath))
 
   if (!json?.params) {
     throw new Error(`${componentDataPath} is missing "params"`)

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -20,7 +20,6 @@
     "govuk-frontend-lib": "*",
     "gulp": "^4.0.2",
     "gulp-cli": "^2.3.0",
-    "js-yaml": "^4.1.0",
     "nunjucks": "^3.2.4",
     "plugin-error": "^2.0.1",
     "postcss": "^8.4.23",


### PR DESCRIPTION
This PR adds a new `getYaml()` function to read Rollup performance data, split out from:

* https://github.com/alphagov/govuk-frontend/pull/3681

Now used by `generateFixture()` and `generateMacroOption()` which both read `${componentName}.yaml` files

```js
const json = await getYaml(join(options.srcPath, componentDataPath))
```