### PR TITLE
Add shared `getComponentNames()` and other lib functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27317,6 +27317,7 @@
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
         "express-validator": "^7.0.1",
+        "front-matter": "^4.0.2",
         "govuk-frontend": "*",
         "govuk-frontend-config": "*",
         "govuk-frontend-lib": "*",
@@ -27391,7 +27392,6 @@
       "name": "govuk-frontend-lib",
       "license": "MIT",
       "dependencies": {
-        "front-matter": "^4.0.2",
         "glob": "^10.2.6",
         "govuk-frontend-config": "*",
         "js-yaml": "^4.1.0",

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -24,6 +24,7 @@
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
     "express-validator": "^7.0.1",
+    "front-matter": "^4.0.2",
     "govuk-frontend": "*",
     "govuk-frontend-config": "*",
     "govuk-frontend-lib": "*",

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -2,8 +2,8 @@ import { join } from 'path'
 
 import express from 'express'
 import { paths } from 'govuk-frontend-config'
-import { getDirectories, getComponentsData, getFullPageExamples } from 'govuk-frontend-lib/files'
-import { componentNameToMacroName, packageNameToPath } from 'govuk-frontend-lib/names'
+import { getDirectories, getComponentsData, getComponentNames, getFullPageExamples } from 'govuk-frontend-lib/files'
+import { componentNameToMacroName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
 
 import * as middleware from './common/middleware/index.mjs'
@@ -16,7 +16,7 @@ export default async () => {
   // Cache mapped components and examples
   const [componentsData, componentNames, exampleNames, fullPageExamples] = await Promise.all([
     getComponentsData(),
-    getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components')),
+    getComponentNames(),
     getDirectories(join(paths.app, 'src/views/examples')),
     getFullPageExamples()
   ])

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -2,10 +2,11 @@ import { join } from 'path'
 
 import express from 'express'
 import { paths } from 'govuk-frontend-config'
-import { getDirectories, getComponentsData, getComponentNames, getFullPageExamples } from 'govuk-frontend-lib/files'
+import { getDirectories, getComponentsData, getComponentNames } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
 
+import { getFullPageExamples } from './common/lib/files.mjs'
 import * as middleware from './common/middleware/index.mjs'
 import * as nunjucks from './common/nunjucks/index.mjs'
 import * as routes from './routes/index.mjs'

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -1,12 +1,9 @@
-import { join } from 'path'
-
 import express from 'express'
-import { paths } from 'govuk-frontend-config'
-import { getDirectories, getComponentsData, getComponentNames } from 'govuk-frontend-lib/files'
+import { getComponentsData, getComponentNames } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
 
-import { getFullPageExamples } from './common/lib/files.mjs'
+import { getExampleNames, getFullPageExamples } from './common/lib/files.mjs'
 import * as middleware from './common/middleware/index.mjs'
 import * as nunjucks from './common/nunjucks/index.mjs'
 import * as routes from './routes/index.mjs'
@@ -18,7 +15,7 @@ export default async () => {
   const [componentsData, componentNames, exampleNames, fullPageExamples] = await Promise.all([
     getComponentsData(),
     getComponentNames(),
-    getDirectories(join(paths.app, 'src/views/examples')),
+    getExampleNames(),
     getFullPageExamples()
   ])
 

--- a/packages/govuk-frontend-review/src/app.test.mjs
+++ b/packages/govuk-frontend-review/src/app.test.mjs
@@ -1,8 +1,6 @@
-import { join } from 'path'
-
 import { load } from 'cheerio'
-import { paths, ports } from 'govuk-frontend-config'
-import { getDirectories } from 'govuk-frontend-lib/files'
+import { ports } from 'govuk-frontend-config'
+import { getComponentNames } from 'govuk-frontend-lib/files'
 
 const expectedPages = [
   '/',
@@ -46,7 +44,7 @@ describe(`http://localhost:${ports.app}`, () => {
       const response = await fetchPath('/')
       const $ = load(await response.text())
 
-      const componentNames = await getDirectories(join(paths.package, 'src/govuk/components'))
+      const componentNames = await getComponentNames()
       const componentsList = $('li a[href^="/components/"]').get()
 
       // Since we have an 'all' component link that renders the default example of all

--- a/packages/govuk-frontend-review/src/common/lib/files.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.mjs
@@ -6,6 +6,15 @@ import { paths } from 'govuk-frontend-config'
 import { getDirectories } from 'govuk-frontend-lib/files'
 
 /**
+ * Get example names
+ *
+ * @returns {Promise<string[]>} Component names
+ */
+export function getExampleNames () {
+  return getDirectories(join(paths.app, 'src/views/examples'))
+}
+
+/**
  * Load all full page examples' front matter
  *
  * @returns {Promise<FullPageExample[]>} Full page examples

--- a/packages/govuk-frontend-review/src/common/lib/files.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.mjs
@@ -1,0 +1,43 @@
+import { readFile } from 'fs/promises'
+import { join } from 'path'
+
+import fm from 'front-matter'
+import { paths } from 'govuk-frontend-config'
+import { getDirectories } from 'govuk-frontend-lib/files'
+
+/**
+ * Load all full page examples' front matter
+ *
+ * @returns {Promise<FullPageExample[]>} Full page examples
+ */
+export async function getFullPageExamples () {
+  const directories = await getDirectories(join(paths.app, 'src/views/full-page-examples'))
+
+  // Add metadata (front matter) to each example
+  const examples = await Promise.all(directories.map(async (exampleName) => {
+    const templatePath = join(paths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
+    const { attributes } = fm(await readFile(templatePath, 'utf8'))
+
+    return {
+      name: exampleName,
+      path: exampleName,
+      ...attributes
+    }
+  }))
+
+  const collator = new Intl.Collator('en', {
+    sensitivity: 'base'
+  })
+
+  return examples.sort(({ name: a }, { name: b }) =>
+    collator.compare(a, b))
+}
+
+/**
+ * Full page example from front matter
+ *
+ * @typedef {object} FullPageExample
+ * @property {string} name - Example name
+ * @property {string} [scenario] - Description explaining the example
+ * @property {string} [notes] - Additional notes about the example
+ */

--- a/packages/govuk-frontend-review/src/common/lib/files.test.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.test.mjs
@@ -1,0 +1,40 @@
+import { getFullPageExamples } from './files.mjs'
+
+describe('getFullPageExamples', () => {
+  it('contains name of each example', async () => {
+    const examples = await getFullPageExamples()
+
+    examples.forEach((example) => expect(example).toEqual(
+      expect.objectContaining({
+        name: expect.any(String),
+        path: expect.any(String)
+      })
+    ))
+  })
+
+  it('contains scenario front matter, for some examples', async () => {
+    const examples = await getFullPageExamples()
+
+    // At least 1x example with { name, path, scenario }
+    expect(examples).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: expect.any(String),
+        path: expect.any(String),
+        scenario: expect.any(String)
+      })
+    ]))
+  })
+
+  it('contains notes front matter, for some examples', async () => {
+    const examples = await getFullPageExamples()
+
+    // At least 1x example with { name, path, notes }
+    expect(examples).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: expect.any(String),
+        path: expect.any(String),
+        notes: expect.any(String)
+      })
+    ]))
+  })
+})

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -1,5 +1,4 @@
-import { getFullPageExamples } from 'govuk-frontend-lib/files'
-
+import { getFullPageExamples } from '../common/lib/files.mjs'
 import * as routes from '../views/full-page-examples/index.mjs'
 
 /**

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -1,4 +1,4 @@
-import { filterPath, getDirectories, getListing } from 'govuk-frontend-lib/files'
+import { filterPath, getComponentNames, getListing } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName, packageNameToPath } from 'govuk-frontend-lib/names'
 import slash from 'slash'
 
@@ -9,7 +9,7 @@ import slash from 'slash'
  */
 export default async () => {
   const componentMacros = await getListing(packageNameToPath('govuk-frontend', 'src'), '**/components/**/macro.njk')
-  const componentNames = await getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
+  const componentNames = await getComponentNames()
 
   // Build array of macros
   const nunjucksMacros = componentNames

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -2,7 +2,7 @@ const { join } = require('path')
 
 const { paths } = require('govuk-frontend-config')
 const { nunjucksEnv, renderHTML } = require('govuk-frontend-helpers/nunjucks')
-const { getDirectories, getComponentsData } = require('govuk-frontend-lib/files')
+const { getComponentsData, getComponentNames } = require('govuk-frontend-lib/files')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control
 // over the nunjucks environment.
@@ -21,7 +21,7 @@ describe('Components', () => {
     nunjucksEnvDefault = nunjucksEnv
 
     // Components list
-    componentNames = await getDirectories(join(paths.package, 'src/govuk/components'))
+    componentNames = await getComponentNames()
   })
 
   describe('Nunjucks environment', () => {

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -3,7 +3,7 @@ import { join } from 'path'
 
 import { paths, pkg } from 'govuk-frontend-config'
 import { compileSassFile } from 'govuk-frontend-helpers/tests'
-import { filterPath, getDirectories, getListing, mapPathTo } from 'govuk-frontend-lib/files'
+import { filterPath, getComponentNames, getListing, mapPathTo } from 'govuk-frontend-lib/files'
 import { componentNameToClassName, componentPathToModuleName } from 'govuk-frontend-lib/names'
 
 describe('packages/govuk-frontend/dist/', () => {
@@ -27,7 +27,7 @@ describe('packages/govuk-frontend/dist/', () => {
     componentsFilesDistESM = await getListing(join(paths.package, 'dist/govuk-esm/components'))
 
     // Components list
-    componentNames = await getDirectories(join(paths.package, 'src/govuk/components'))
+    componentNames = await getComponentNames()
   })
 
   it('should contain the expected files', async () => {

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -175,8 +175,8 @@ describe('packages/govuk-frontend/dist/', () => {
 
     beforeAll(async () => {
       // Components list (with JavaScript only)
-      componentNamesWithJavaScript = componentNames
-        .filter((componentName) => componentsFilesSource.includes(join(componentName, `${componentName}.mjs`)))
+      componentNamesWithJavaScript = await getComponentNames((componentName, componentFiles) =>
+        componentFiles.every(filterPath([`**/${componentName}.mjs`])))
     })
 
     it('should have component JavaScript file with correct module name', () => {

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -1,9 +1,7 @@
 const { readFile } = require('fs/promises')
 const { join, parse, relative } = require('path')
 
-const fm = require('front-matter')
 const { glob } = require('glob')
-const { paths } = require('govuk-frontend-config')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
 
@@ -157,36 +155,6 @@ async function getExamples (componentName) {
   return examples
 }
 
-/**
- * Load all full page examples' front matter
- *
- * @returns {Promise<FullPageExample[]>} Full page examples
- */
-const getFullPageExamples = async () => {
-  const directories = await getDirectories(join(paths.app, 'src/views/full-page-examples'))
-
-  // Add metadata (front matter) to each example
-  const examples = await Promise.all(directories.map(async (exampleName) => {
-    const templatePath = join(paths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
-
-    // @ts-expect-error "This expression is not callable" due to incorrect types
-    const { attributes } = fm(await readFile(templatePath, 'utf8'))
-
-    return {
-      name: exampleName,
-      path: exampleName,
-      ...attributes
-    }
-  }))
-
-  const collator = new Intl.Collator('en', {
-    sensitivity: 'base'
-  })
-
-  return examples.sort(({ name: a }, { name: b }) =>
-    collator.compare(a, b))
-}
-
 module.exports = {
   filterPath,
   getComponentData,
@@ -195,7 +163,6 @@ module.exports = {
   getComponentNames,
   getDirectories,
   getExamples,
-  getFullPageExamples,
   getListing,
   getYaml,
   mapPathTo
@@ -230,13 +197,4 @@ module.exports = {
  * @property {string} name - Example name
  * @property {object} data - Example data
  * @property {boolean} [hidden] - Example hidden from review app
- */
-
-/**
- * Full page example from front matter
- *
- * @typedef {object} FullPageExample
- * @property {string} name - Example name
- * @property {string} [scenario] - Description explaining the example
- * @property {string} [notes] - Additional notes about the example
  */

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -110,6 +110,15 @@ const getComponentsData = async () => {
 }
 
 /**
+ * Get component files
+ *
+ * @param {string} [componentName] - Component name
+ * @returns {Promise<string[]>} Component files
+ */
+const getComponentFiles = (componentName = '') =>
+  getListing(packageNameToPath('govuk-frontend', join('src/govuk/components', componentName)))
+
+/**
  * Get component names
  *
  * @returns {Promise<string[]>} Component names
@@ -170,6 +179,7 @@ module.exports = {
   filterPath,
   getComponentData,
   getComponentsData,
+  getComponentFiles,
   getComponentNames,
   getDirectories,
   getExamples,

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -105,9 +105,17 @@ const getComponentData = async (componentName) => {
  * @returns {Promise<(ComponentData & { name: string })[]>} Components' data
  */
 const getComponentsData = async () => {
-  const componentNames = await getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
+  const componentNames = await getComponentNames()
   return Promise.all(componentNames.map(getComponentData))
 }
+
+/**
+ * Get component names
+ *
+ * @returns {Promise<string[]>} Component names
+ */
+const getComponentNames = () =>
+  getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
 
 /**
  * Get examples from a component's metadata file
@@ -162,6 +170,7 @@ module.exports = {
   filterPath,
   getComponentData,
   getComponentsData,
+  getComponentNames,
   getDirectories,
   getExamples,
   getFullPageExamples,

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -119,12 +119,24 @@ const getComponentFiles = (componentName = '') =>
   getListing(packageNameToPath('govuk-frontend', join('src/govuk/components', componentName)))
 
 /**
- * Get component names
+ * Get component names (with optional filter)
  *
+ * @param {(componentName: string, componentFiles: string[]) => boolean} [filter] - Component names array filter
  * @returns {Promise<string[]>} Component names
  */
-const getComponentNames = () =>
-  getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
+const getComponentNames = async (filter) => {
+  const componentNames = await getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
+
+  if (filter) {
+    const componentFiles = await getComponentFiles()
+
+    // Apply component names filter
+    return componentNames.filter((componentName) =>
+      filter(componentName, componentFiles))
+  }
+
+  return componentNames
+}
 
 /**
  * Get examples from a component's metadata file

--- a/shared/lib/files.unit.test.js
+++ b/shared/lib/files.unit.test.js
@@ -1,4 +1,4 @@
-const { getComponentData, getFullPageExamples } = require('./files.js')
+const { getComponentData } = require('./files.js')
 
 describe('getComponentData', () => {
   it('rejects if unable to load component data', async () => {
@@ -43,44 +43,5 @@ describe('getComponentData', () => {
         data: expect.any(Object)
       })
     ))
-  })
-})
-
-describe('getFullPageExamples', () => {
-  it('contains name of each example', async () => {
-    const examples = await getFullPageExamples()
-
-    examples.forEach((example) => expect(example).toEqual(
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String)
-      })
-    ))
-  })
-
-  it('contains scenario front matter, for some examples', async () => {
-    const examples = await getFullPageExamples()
-
-    // At least 1x example with { name, path, scenario }
-    expect(examples).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String),
-        scenario: expect.any(String)
-      })
-    ]))
-  })
-
-  it('contains notes front matter, for some examples', async () => {
-    const examples = await getFullPageExamples()
-
-    // At least 1x example with { name, path, notes }
-    expect(examples).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String),
-        notes: expect.any(String)
-      })
-    ]))
   })
 })

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -13,7 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "front-matter": "^4.0.2",
     "glob": "^10.2.6",
     "govuk-frontend-config": "*",
     "js-yaml": "^4.1.0",

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -1,7 +1,7 @@
 import percySnapshot from '@percy/puppeteer'
 import { download } from 'govuk-frontend-helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from 'govuk-frontend-helpers/puppeteer'
-import { filterPath, getDirectories, getListing } from 'govuk-frontend-lib/files'
+import { filterPath, getComponentNames, getListing } from 'govuk-frontend-lib/files'
 import { packageNameToPath } from 'govuk-frontend-lib/names'
 import puppeteer from 'puppeteer'
 
@@ -25,7 +25,7 @@ export async function launch () {
  */
 export async function screenshots () {
   const browser = await launch()
-  const componentNames = await getDirectories(packageNameToPath('govuk-frontend', 'src/govuk/components'))
+  const componentNames = await getComponentNames()
   const exampleNames = ['text-alignment', 'typography']
 
   // Screenshot stack

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -1,8 +1,7 @@
 import percySnapshot from '@percy/puppeteer'
 import { download } from 'govuk-frontend-helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from 'govuk-frontend-helpers/puppeteer'
-import { filterPath, getComponentNames, getListing } from 'govuk-frontend-lib/files'
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { filterPath, getComponentFiles, getComponentNames } from 'govuk-frontend-lib/files'
 import puppeteer from 'puppeteer'
 
 /**
@@ -64,7 +63,7 @@ export async function screenshots () {
  * @returns {Promise<void>}
  */
 export async function screenshotComponent (page, componentName) {
-  const componentFiles = await getListing(packageNameToPath('govuk-frontend', `src/govuk/components/${componentName}`))
+  const componentFiles = await getComponentFiles(componentName)
 
   // Navigate to component
   await goToComponent(page, componentName)


### PR DESCRIPTION
For the performance stats in https://github.com/alphagov/govuk-frontend/pull/3681 I've split out some library functions for filtering components with JavaScript

### Component names
All components by their directory names

```mjs
await getComponentNames()
```

### Component names
Only JavaScript-enabled components by their directory names

```mjs
await getComponentNames((componentName, componentFiles) =>
  componentFiles.every(filterPath([`**/${componentName}.mjs`])))
```

### Component files
All component files by directory listing (files only)

```mjs
await getComponentFiles()
```

### Review app library functions

I've also split out library functions with [`front-matter`](https://www.npmjs.com/package/front-matter) that weren't shared:

```mjs
await getExampleNames()
await getFullPageExamples()
```