### PR TITLE
Update Browserslist for IE11 `-ms-*` vendor prefixes

### DIFF
--- a/docs/examples/webpack/.browserslistrc
+++ b/docs/examples/webpack/.browserslistrc
@@ -4,5 +4,5 @@ last 2 Firefox versions
 last 2 Edge versions
 last 2 Samsung versions
 Safari >= 9
-ie 9-11
 iOS >= 9
+ie 11

--- a/packages/govuk-frontend-review/.browserslistrc
+++ b/packages/govuk-frontend-review/.browserslistrc
@@ -1,0 +1,8 @@
+> 0.1%
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Edge versions
+last 2 Samsung versions
+Safari >= 9
+ie 9-11
+iOS >= 9

--- a/packages/govuk-frontend-review/.browserslistrc
+++ b/packages/govuk-frontend-review/.browserslistrc
@@ -4,5 +4,5 @@ last 2 Firefox versions
 last 2 Edge versions
 last 2 Samsung versions
 Safari >= 9
-ie 9-11
 iOS >= 9
+ie 11

--- a/packages/govuk-frontend/.browserslistrc
+++ b/packages/govuk-frontend/.browserslistrc
@@ -8,6 +8,7 @@ last 2 Edge versions
 last 2 Samsung versions
 Safari >= 9
 iOS >= 9
+ie 11
 
 [node]
 node 18


### PR DESCRIPTION
This PR restores `ie 11` into **.browserslistrc**

We're currenty seeing Internet Explorer 11 Browserslist stats at:

* [**0.37 %** global audience](https://browsersl.ist/#q=ie+11)
* [**0.08 %** UK audience](https://browsersl.ist/#q=ie+11&region=GB)

We should maintain IE11 `-ms-*` vendor prefixes once we drop below `> 0.1%`