### PR TITLE
Split Rollup plugins into input and output etc

### DIFF
--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -124,7 +124,7 @@ var myExample = new Example()
 
 ## Modules
 
-Use ECMAScript modules (`import`/`export`) over CommonJS and other formats. You can always transpile to your preferred module system.
+Use ECMAScript (ES) modules (`import`/`export`) over CommonJS and other formats. You can always transpile to your preferred module system.
 
 ```js
 import { closestAttributeValue } from '../common/index.mjs'
@@ -136,7 +136,7 @@ export function exampleHelper2 () {}
 
 You must specify the file extension when using the import keyword.
 
-Avoid using namespace imports (`import * as namespace`) in code transpiled to UMD (or AMD, CommonJS) bundled code as this can prevent "tree shaking" optimisations.
+Avoid using namespace imports (`import * as namespace`) in code bundled for CommonJS and other formats as this can prevent "tree shaking" optimisations.
 
 Prefer named exports over default exports to avoid compatibility issues with transpiler "synthetic default" as discussed in: https://github.com/alphagov/govuk-frontend/issues/2829
 

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -39,7 +39,7 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - copy Sass files, applying Autoprefixer via PostCSS
 - copy Nunjucks component template/macro files, including JSON configs
 - copy GOV.UK Prototype Kit config files
-- compile JavaScript to ECMAScript Modules (ESM)
+- compile JavaScript to ECMAScript (ES) modules
 - compile JavaScript to Universal Module Definition (UMD)
 - runs `npm run postbuild:package` (which will test the output is correct)
 

--- a/packages/govuk-frontend-review/nodemon.json
+++ b/packages/govuk-frontend-review/nodemon.json
@@ -1,5 +1,10 @@
 {
-  "watch": ["./src", "../govuk-frontend/src/govuk/**/*.{json,yaml}"],
+  "watch": [
+    "./src",
+    "../govuk-frontend/src/govuk/**/*.{json,yaml}",
+    "../../shared/config",
+    "../../shared/lib"
+  ],
   "ignore": ["./src/javascripts/**", "**/*.test.*"],
   "events": {
     "restart": "browser-sync reload --config browsersync.config.js"

--- a/packages/govuk-frontend-review/rollup.config.mjs
+++ b/packages/govuk-frontend-review/rollup.config.mjs
@@ -14,29 +14,31 @@ export default defineConfig(({ i: input }) => ({
    */
   output: {
     format: 'iife',
-    preserveModules: false
+
+    /**
+     * Output plugins
+     */
+    plugins: [
+      terser({
+        format: { comments: false },
+
+        // Include sources content from source maps to inspect
+        // GOV.UK Frontend and other dependencies' source code
+        sourceMap: {
+          includeSources: true
+        },
+
+        // Compatibility workarounds
+        ecma: 5,
+        safari10: true
+      })
+    ]
   },
 
   /**
    * Input plugins
    */
   plugins: [
-    // Enable import from `node_modules`
-    resolve(),
-
-    // Terser minifier plugin
-    terser({
-      format: { comments: false },
-
-      // Include sources content from source maps to inspect
-      // GOV.UK Frontend and other dependencies' source code
-      sourceMap: {
-        includeSources: true
-      },
-
-      // Compatibility workarounds
-      ecma: 5,
-      safari10: true
-    })
+    resolve()
   ]
 }))

--- a/packages/govuk-frontend-review/tsconfig.json
+++ b/packages/govuk-frontend-review/tsconfig.json
@@ -8,10 +8,5 @@
     "../../shared/lib",
     "../../shared/tasks"
   ],
-  "exclude": ["./dist/**", "../govuk-frontend/dist/**"],
-  "compilerOptions": {
-    "paths": {
-      "govuk-frontend": ["../govuk-frontend/src/govuk/all.mjs"]
-    }
-  }
+  "exclude": ["./dist/**", "../govuk-frontend/dist/**"]
 }

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
         // Allow `this` alias until arrow functions supported
         '@typescript-eslint/no-this-alias': 'off',
 
-        // Rollup transpiles modules to AMD export/define
+        // Rollup transpiles modules into other formats
         'es-x/no-modules': 'off',
 
         // Allow `var` until let/const supported

--- a/packages/govuk-frontend/rollup.esm.config.mjs
+++ b/packages/govuk-frontend/rollup.esm.config.mjs
@@ -5,7 +5,7 @@ import { defineConfig } from 'rollup'
 /**
  * Rollup config for npm publish
  *
- * ECMAScript Modules (ESM) for browser <script type="module">
+ * ECMAScript (ES) modules for browser <script type="module">
  * or using `import` for modern browsers and Node.js scripts
  */
 export default defineConfig(({ i: input }) => ({

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -122,7 +122,7 @@ describe('packages/govuk-frontend/dist/', () => {
     it('should have correct version number', async () => {
       const contents = await readFile(join(paths.package, 'dist/govuk/all.js'), 'utf8')
 
-      // Look for AMD module export 'GOVUKFrontend.version'
+      // Look for CommonJS `version` named export
       expect(contents).toContain(`var version = '${pkg.version}';`)
       expect(contents).toContain('exports.version = version;')
     })
@@ -187,11 +187,11 @@ describe('packages/govuk-frontend/dist/', () => {
         const componentDist = componentsFilesDist.filter(componentFilter)
         const componentDistESM = componentsFilesDistESM.filter(componentFilter)
 
-        // UMD module not found at source
+        // UMD bundle not found at source
         expect(componentSource)
           .toEqual(expect.not.arrayContaining([join(componentName, `${componentName}.js`)]))
 
-        // UMD module generated in dist
+        // UMD bundle generated in dist
         expect(componentDist)
           .toEqual(expect.arrayContaining([join(componentName, `${componentName}.js`)]))
 

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -23,7 +23,7 @@ export const compile = (options) => gulp.series(
   ),
 
   /**
-   * Compile GOV.UK Frontend JavaScript (UMD modules)
+   * Compile GOV.UK Frontend JavaScript (UMD bundles)
    */
   task.name('compile:js', () =>
     scripts.compile('**/!(*.test).mjs', {

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -31,12 +31,7 @@ export const compile = (options) => gulp.series(
 
       srcPath: join(options.srcPath, 'govuk'),
       destPath: join(options.destPath, 'govuk'),
-      configPath: join(options.basePath, 'rollup.umd.config.mjs'),
-
-      // Rename with `*.js` extension
-      filePath ({ dir, name }) {
-        return join(dir, `${name}.js`)
-      }
+      configPath: join(options.basePath, 'rollup.umd.config.mjs')
     })
   ),
 

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -41,9 +41,10 @@ function componentNameToClassName (componentName) {
 }
 
 /**
- * Convert component path to JavaScript UMD module name
+ * Convert component path to JavaScript module name
  *
- * Used by Rollup to set the `window` global and UMD/AMD export name
+ * Used by Rollup to set Universal Module Definition (UMD) export names for
+ * `window` globals maintaining compatibility with CommonJS and AMD `require()`
  *
  * Component paths have kebab-cased file names (button.mjs, date-input.mjs),
  * whilst module names have a `GOVUKFrontend.` prefix and are PascalCased

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -62,14 +62,14 @@ export async function compileJavaScript ([modulePath, { configPath, srcPath, des
         sourcemap: true,
 
         // Write to directory for modules
-        dir: output.preserveModules
+        dir: output.dir ?? (output.preserveModules
           ? destPath
-          : undefined,
+          : undefined),
 
         // Write to file when bundling
-        file: !output.preserveModules
+        file: output.file ?? (!output.preserveModules
           ? moduleDestPath
-          : undefined
+          : undefined)
       }))
     )
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -12,6 +12,9 @@
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "target": "ESNext",
-    "types": ["jest", "jest-axe", "jest-puppeteer", "node"]
+    "types": ["jest", "jest-axe", "jest-puppeteer", "node"],
+    "paths": {
+      "govuk-frontend": ["./packages/govuk-frontend/src/govuk/all.mjs"]
+    }
   }
 }


### PR DESCRIPTION
Following some code reviews on https://github.com/alphagov/govuk-frontend/pull/3681 this PR splits out a few Rollup changes:

1. **Each Rollup config should be standalone**
We no longer extend configs to reduce risk from accidental edits

2. **Ensure Rollup task preserves config `file` or `dir` options**
Removes surprises when editing configs or using [`--file`](https://rollupjs.org/configuration-options/#output-file) and [`--dir`](https://rollupjs.org/configuration-options/#output-dir) CLI flags

3. **Ensure Rollup task matches extension to output format**
Automatically output `*.js` by default or `*.mjs` for ES modules

4. **Split Rollup plugins into input (bundling) and output (generating)**
Matches what we did in [rollup.config.js](https://github.com/alphagov/govuk-design-system/blob/main/rollup.config.js) on the Design System

I've also clarified our docs for ECMAScript (ES) modules versus UMD bundles