### PR TITLE
Remove the first letter modifier from the tag component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,14 @@ The design of the tag component has changed to improve accessibility and readabi
 Text within the tag is no longer bold and uppercase with extra letter spacing, and is
 instead regular 19px text. Due to this, there may be changes to the width of existing tags.
 
+We now longer transform the content of tags to be uppercase automatically and instead recommend the content of tags be lower case with the first word in a tag's content be capitalised. Please check that the contents of tags and tags within phase banners in your service are using the correct capitalisation.
+
 The colours have also changed to make them more distinguishable from buttons.
 
-This change was made in [pull request #3502: Tag design changes](https://github.com/alphagov/govuk-frontend/pull/3502).
+This change was made in:
+
+- [pull request #3502: Tag design changes](https://github.com/alphagov/govuk-frontend/pull/3502).
+- [pull request #3731: Remove the first letter modifier from the tag component](https://github.com/alphagov/govuk-frontend/pull/3731)
 
 #### Added inverse modifier for buttons on dark backgrounds
 

--- a/packages/govuk-frontend/src/govuk/components/tag/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tag/_index.scss
@@ -33,15 +33,6 @@
     }
   }
 
-  // Previously the whole tag was transformed to UPPERCASE. We’ve since decided to switch
-  // to title case to improve readability. The first letter is uppercased to ease the transition,
-  // as the text may be all lowercase within the HTML itself.
-  //
-  // 'capitalize' is used instead of 'uppercase' as a workaround for a spacing bug in Firefox.
-  .govuk-tag::first-letter {
-    text-transform: capitalize;
-  }
-
   .govuk-tag--grey {
     color: govuk-shade(govuk-colour("dark-grey"), 50%);
     background-color: govuk-tint(govuk-colour("dark-grey"), 85%);


### PR DESCRIPTION
## What
Removes the `first-letter` modifier from the tag component, add in the redesign in https://github.com/alphagov/govuk-frontend/pull/3502, and updates the changelog to recommend teams check their content and ensure the first word of their tags are capitalised.

## Why
In the tag redesign we added the `first-letter` selector as a way to get around the risk of teams having tags in older services that secretly have all lowercase content, hidden by the previous tag's `text-transform: uppercase`. We encountered a bug in firefox when testing this however where the width of the tag was incorrectly extended as if the contents of the entire tag had `text-transform: uppercase` applied instead of only the first letter. We changed this to `text-transform: capitalize` to get around this.

Since then, we've encountered further issues in our implementation:

- the firefox bug is still present. If a tag contains several words, the same incorrect width starts to become visible as the size of the "fake" capital letters impact's firefox's width calculation
- there is a kerning issue in firefox and safari when using the `first-letter` selector where the browsers will treat it as a separate inline element, most easily noticeable in the [Turquoise tag example](https://govuk-frontend-review.herokuapp.com/components/tag/turquoise/preview)

After an internal discussion, we think that now the clever workaround is become too risky to use over asking teams update their tag content and risking tag capitalisation being inconsistent across GOV.UK for a period. 