### PR TITLE
Update references from back link to inset text in inset text options list

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/inset-text/inset-text.yaml
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/inset-text.yaml
@@ -2,11 +2,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text to use within the back link component. If `html` is provided, the `text` option will be ignored.
+    description: If `html` is set, this is not required. Text to use within the inset text component. If `html` is provided, the `text` option will be ignored.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML to use within the back link component. If `html` is provided, the `text` option will be ignored.
+    description: If `text` is set, this is not required. HTML to use within the inset text component. If `html` is provided, the `text` option will be ignored.
   - name: caller
     type: nunjucks-block
     required: false


### PR DESCRIPTION
Just fixes a couple of copy/paste errors that have resulted in the inset text guidance on the design system containing references to the back link component by mistake