### PR TITLE
Fix workspace name in `npm version` docs

### DIFF
--- a/docs/releasing/publishing-from-a-support-branch.md
+++ b/docs/releasing/publishing-from-a-support-branch.md
@@ -64,7 +64,7 @@ Read the docs for [what to do before publishing a release](/docs/releasing/befor
 6. Apply the new version number by running:
 
    ```
-   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace package
+   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
    ```
 
    This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -23,7 +23,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 6. Apply the new version number by running:
 
    ```
-   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace package
+   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
    ```
 
    This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.


### PR DESCRIPTION
Fixes a missed workspace rename to ~`package`~ `govuk-frontend`