### PR TITLE
Update review app to “Set up Nunjucks and use the page template”

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -127,7 +127,7 @@ export default async () => {
     const macroParameters = JSON.stringify(exampleConfig.data, null, '\t')
 
     res.locals.componentView = env.renderString(outdent`
-      {% from '${componentName}/macro.njk' import ${macroName} %}
+      {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
       {{ ${macroName}(${macroParameters}) }}
     `, {})
 

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -9,10 +9,8 @@ import * as globals from './globals/index.mjs'
 
 export function renderer (app) {
   const appViews = [
-    join(paths.app, 'src/views/layouts'),
     join(paths.app, 'src/views'),
-    packageNameToPath('govuk-frontend', 'dist/govuk/components'),
-    packageNameToPath('govuk-frontend', 'dist/govuk')
+    packageNameToPath('govuk-frontend', 'dist')
   ]
 
   // Initialise nunjucks environment

--- a/packages/govuk-frontend-review/src/views/all-components.njk
+++ b/packages/govuk-frontend-review/src/views/all-components.njk
@@ -1,6 +1,6 @@
-{% extends "full-width-landmarks.njk" %}
+{% extends "layouts/full-width-landmarks.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "macros/showExamples.njk" import showExamples %}
 
 {% set bodyClasses %}

--- a/packages/govuk-frontend-review/src/views/component-preview.njk
+++ b/packages/govuk-frontend-review/src/views/component-preview.njk
@@ -1,4 +1,4 @@
-{% extends previewLayout + ".njk" %}
+{% extends "layouts/" + previewLayout + ".njk" %}
 
 {% set bodyClasses %}
   {{ bodyClasses }}

--- a/packages/govuk-frontend-review/src/views/component.njk
+++ b/packages/govuk-frontend-review/src/views/component.njk
@@ -1,7 +1,7 @@
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "macros/showExamples.njk" import showExamples %}
 
-{% extends "full-width-landmarks.njk" %}
+{% extends "layouts/full-width-landmarks.njk" %}
 
 {% set bodyClasses %}
   language-markup

--- a/packages/govuk-frontend-review/src/views/examples/button-groups/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/button-groups/index.njk
@@ -1,7 +1,7 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.njk
@@ -1,10 +1,10 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/details-polyfill/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/details-polyfill/index.njk
@@ -1,6 +1,6 @@
-{% from "back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/error-messages/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-messages/index.njk
@@ -1,15 +1,15 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "label/macro.njk" import govukLabel %}
-{% from "input/macro.njk" import govukInput %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "button/macro.njk" import govukButton %}
-{% from "select/macro.njk" import govukSelect %}
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
-{% from 'radios/macro.njk' import govukRadios %}
-{% from 'textarea/macro.njk' import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block styles %}
 <style>

--- a/packages/govuk-frontend-review/src/views/examples/error-summary-with-messages/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary-with-messages/index.njk
@@ -1,10 +1,10 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -1,9 +1,9 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
@@ -1,16 +1,16 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
-{% from "input/macro.njk" import govukInput %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/footer-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/footer-alignment/index.njk
@@ -1,7 +1,7 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "footer/macro.njk" import govukFooter %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-{% extends "full-width-landmarks.njk" %}
+{% extends "layouts/full-width-landmarks.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/form-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-alignment/index.njk
@@ -1,14 +1,14 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "panel/macro.njk" import govukPanel %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "label/macro.njk" import govukLabel %}
-{% from "input/macro.njk" import govukInput %}
-{% from "button/macro.njk" import govukButton %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/label/macro.njk" import govukLabel %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block styles %}
 <style>

--- a/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
@@ -1,10 +1,10 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
-{% from "input/macro.njk" import govukInput %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
 {% set examples = [
   { name: "Initial" },

--- a/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
@@ -1,14 +1,14 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "input/macro.njk" import govukInput %}
-{% from "button/macro.njk" import govukButton %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -46,7 +46,7 @@
 
     {% call govukFieldset() %}
       <span id="textarea"></span>
-      {% from "textarea/macro.njk" import govukTextarea %}
+      {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
       {{ govukTextarea({
         id: "govuk-textarea-a",
         name: "govuk-textarea-a",

--- a/packages/govuk-frontend-review/src/views/examples/grid/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/grid/index.njk
@@ -1,6 +1,6 @@
-{% from "back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/index.njk
@@ -1,12 +1,12 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from 'radios/macro.njk' import govukRadios %}
-{% from 'checkboxes/macro.njk' import govukCheckboxes %}
-{% from 'input/macro.njk' import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/links/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/links/index.njk
@@ -1,6 +1,6 @@
-{% from "back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.njk
@@ -1,8 +1,8 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
@@ -1,6 +1,6 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 
 {% block head %}
   <link rel="stylesheet" href="/stylesheets/app.min.css">

--- a/packages/govuk-frontend-review/src/views/examples/small-form-controls/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/small-form-controls/index.njk
@@ -1,8 +1,8 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
@@ -1,12 +1,12 @@
 {# Example that changes every setting in the template #}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "skip-link/macro.njk" import govukSkipLink %}
-{% from "header/macro.njk" import govukHeader %}
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "footer/macro.njk" import govukFooter %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% set htmlClasses = 'app-html-class' %}
 {% set htmlLang = 'fr' %}

--- a/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% block head %}
   <link rel="stylesheet" href="/stylesheets/app.min.css">

--- a/packages/govuk-frontend-review/src/views/examples/text-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/text-alignment/index.njk
@@ -1,7 +1,7 @@
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "table/macro.njk" import govukTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -1,36 +1,36 @@
 {% set htmlLang = 'cy-GB' %}
 
-{% from "accordion/macro.njk" import govukAccordion %}
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-{% from "character-count/macro.njk" import govukCharacterCount %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "details/macro.njk" import govukDetails %}
-{% from "error-message/macro.njk" import govukErrorMessage %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
-{% from "footer/macro.njk" import govukFooter %}
-{% from "header/macro.njk" import govukHeader %}
-{% from "inset-text/macro.njk" import govukInsetText %}
-{% from "notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "pagination/macro.njk" import govukPagination %}
-{% from "panel/macro.njk" import govukPanel %}
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "skip-link/macro.njk" import govukSkipLink %}
-{% from "summary-list/macro.njk" import govukSummaryList %}
-{% from "table/macro.njk" import govukTable %}
-{% from "tabs/macro.njk" import govukTabs %}
-{% from "tag/macro.njk" import govukTag %}
-{% from "input/macro.njk" import govukInput %}
-{% from "textarea/macro.njk" import govukTextarea %}
-{% from "warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block pageTitle %}Translated examples - GOV.UK Frontend{% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/examples/typography/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/typography/index.njk
@@ -1,7 +1,7 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from 'table/macro.njk' import govukTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/announcements/index.njk
@@ -2,10 +2,10 @@
 scenario: You want to read this article about '2018’s oddest requests from Brits abroad'.
 notes: Based on https://www.gov.uk/government/news/strictly-vampires-and-sausages-2018s-oddest-requests-from-brits-abroad
 ---
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% set pageTitle = "2018’s oddest requests from Brits abroad: ‘Strictly’, vampires and sausages" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
@@ -13,12 +13,12 @@ notes: >-
   This example is based on https://www.gov.uk/bank-holidays.
   The data is not 'live' and so the answer is unlikely to be correct.
 ---
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "tabs/macro.njk" import govukTabs %}
-{% from "panel/macro.njk" import govukPanel %}
-{% from "table/macro.njk" import govukTable %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 
 {% set pageTitle = "UK bank holidays" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
@@ -8,12 +8,12 @@ notes: >-
   Based on https://www.gov.uk/coronavirus
 ---
 
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "header/macro.njk" import govukHeader %}
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "accordion/macro.njk" import govukAccordion %}
-{% from "footer/macro.njk" import govukFooter %}
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
+{% from "govuk/components/footer/macro.njk" import govukFooter %}
 
 {% set pageTitle = "Coronavirus (COVID‑19)" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
@@ -12,11 +12,11 @@ notes: The links to change your answers are not functional.
 ---
 
 {# This example is based of the  "Check your answers before sending your application" example: https://design-system.service.gov.uk/patterns/check-answers/default/index.html #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "summary-list/macro.njk" import govukSummaryList %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Check your answers" %}
 {% set serviceName = "Temporary events notice" %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/confirm-delete/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/confirm-delete/index.njk
@@ -1,7 +1,7 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "warning-text/macro.njk" import govukWarningText %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set homepage_url = "/" %}
 {% set pageTitle = "Are you sure you want to delete Josh Lyman’s account?" %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -15,12 +15,12 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
-{% from "tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set pageTitle = "Apply online for a UK passport" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -13,12 +13,12 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
-{% from "tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set pageTitle = "Apply online for a UK passport" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -17,12 +17,12 @@ notes: >-
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-{% from "cookie-banner/macro.njk" import govukCookieBanner %}
-{% from "tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/cookie-banner/macro.njk" import govukCookieBanner %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set pageTitle = "Apply online for a UK passport" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for your feedback" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
@@ -19,14 +19,14 @@ scenario: >-
 
 notes: Based on https://www.signin.service.gov.uk/feedback
 ---
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "warning-text/macro.njk" import govukWarningText %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "input/macro.njk" import govukInput %}
-{% from "character-count/macro.njk" import govukCharacterCount %}
-{% from "button/macro.njk" import govukButton %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "Send your feedback" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - Verify - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for confirming if you have changed your name" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -11,12 +11,12 @@ scenario: >-
 ---
 
 {# This example is based of the "Radios" example: https://design-system.service.gov.uk/components/radios #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Have you changed your name?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for selecting your identity provider" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -10,13 +10,13 @@ scenario: >-
 notes: Based on https://www.gov.uk/log-in-file-self-assessment-tax-return/sign-in/prove-identity
 ---
 
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "button/macro.njk" import govukButton %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "How do you want to sign in?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -1,5 +1,5 @@
-{% extends "layout.njk" %}
-{% from "back-link/macro.njk" import govukBackLink %}
+{% extends "layouts/layout.njk" %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "We have emailed you a confirmation" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
@@ -11,13 +11,13 @@ scenario: >-
 ---
 
 {# This example is based of the "Passport details" pattern: https://design-system.service.gov.uk/patterns/question-pages/ #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "input/macro.njk" import govukInput %}
-{% from "date-input/macro.njk" import govukDateInput %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Passport details" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
@@ -18,14 +18,14 @@ notes: >-
   This example merges features seen on GOV.UK news and communication finders and search pages.
 ---
 
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "input/macro.njk" import govukInput %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "button/macro.njk" import govukButton %}
-{% from "pagination/macro.njk" import govukPagination %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/pagination/macro.njk" import govukPagination %}
 
 {% set pageTitle = "Search" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
@@ -8,10 +8,10 @@ notes: The links within each section are not functional.
 ---
 
 {# This example is based of the live "Service Manual - Technology" page: https://www.gov.uk/service-manual/technology #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "accordion/macro.njk" import govukAccordion %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/accordion/macro.njk" import govukAccordion %}
 
 {% set pageTitle = "Technology - Service Manual" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
@@ -11,11 +11,11 @@ notes: The buttons and links on this page are not functional.
 ---
 
 {# This example is based of the live "Apply online for a UK passport" start page: https://www.gov.uk/apply-renew-passport #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "breadcrumbs/macro.njk" import govukBreadcrumbs %}
-{% from "button/macro.njk" import govukButton %}
-{% from "tabs/macro.njk" import govukTabs %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 
 {% set pageTitle = "Apply online for a UK passport" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Account details updated" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
@@ -8,12 +8,12 @@ scenario: >-
   1. Intentionally avoid answering the questions before continuing to the next page.
 ---
 
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "input/macro.njk" import govukInput %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Update your account details" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Photo submitted" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -6,15 +6,15 @@ scenario: >-
 ---
 
 {# This example is based of the live "Passport" service: https://www.passport.service.gov.uk/photo/upload #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
-{% from "notification-banner/macro.njk" import govukNotificationBanner %}
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "radios/macro.njk" import govukRadios %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
 
 {% block pageTitle %}Upload your photo - GOV.UK{% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Photo submitted" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -9,15 +9,15 @@ scenario: >-
 ---
 
 {# This example is based of the live "Passport" service: https://www.passport.service.gov.uk/photo/upload #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "phase-banner/macro.njk" import govukPhaseBanner %}
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "radios/macro.njk" import govukRadios %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "button/macro.njk" import govukButton %}
-{% from "file-upload/macro.njk" import govukFileUpload %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {% set pageTitle = "Upload your photo" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for confirming your address" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
@@ -10,13 +10,13 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home address?" example: https://design-system.service.gov.uk/patterns/addresses/multiple/index.html #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "fieldset/macro.njk" import govukFieldset %}
-{% from "input/macro.njk" import govukInput %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "What is your home address?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for confirming your nationality" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
@@ -19,15 +19,15 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your nationality?" example: https://www.registertovote.service.gov.uk/register-to-vote/nationality #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "checkboxes/macro.njk" import govukCheckboxes %}
-{% from "input/macro.njk" import govukInput %}
-{% from "details/macro.njk" import govukDetails %}
-{% from "textarea/macro.njk" import govukTextarea %}
-{% from "button/macro.njk" import govukButton %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
 {% set pageTitle = "What is your nationality?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/confirm.njk
@@ -1,6 +1,6 @@
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for confirming your postcode" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
@@ -9,12 +9,12 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home postcode?" example: https://design-system.service.gov.uk/patterns/question-pages/postcode/index.html #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = "What is your home postcode?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/confirm.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/confirm.njk
@@ -1,7 +1,7 @@
 {# This example is not based on a live example #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "panel/macro.njk" import govukPanel %}
+{% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = "Thank you for confirming the last country you visited" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
@@ -9,13 +9,13 @@ scenario: >-
 ---
 
 {# This example is based of the  "What is your home postcode?" example: https://design-system.service.gov.uk/patterns/question-pages/postcode/index.html #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "button/macro.njk" import govukButton %}
-{% from "select/macro.njk" import govukSelect %}
-{% from "error-summary/macro.njk" import govukErrorSummary %}
-{% from "input/macro.njk" import govukInput %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% set pageTitle = "What was the last country you visited?" %}
 {% block pageTitle %}{{ "Error: " if errors }}{{ pageTitle }} - GOV.UK{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
@@ -14,11 +14,11 @@ notes: The links to change your answers are not functional.
 ---
 
 {# This example is based of the  "Check your answers before sending your application" example: https://design-system.service.gov.uk/patterns/check-answers/default/index.html #}
-{% extends "full-page-example.njk" %}
+{% extends "layouts/full-page-example.njk" %}
 
-{% from "back-link/macro.njk" import govukBackLink %}
-{% from "summary-list/macro.njk" import govukSummaryList %}
-{% from "button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% set pageTitle = "Work history" %}
 {% set serviceName = "Apply for teacher training" %}

--- a/packages/govuk-frontend-review/src/views/index.njk
+++ b/packages/govuk-frontend-review/src/views/index.njk
@@ -1,6 +1,6 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
-{% from "summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
 {% block content %}
   <h1 class="govuk-heading-xl">

--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -1,4 +1,4 @@
-{% extends "template.njk" %}
+{% extends "govuk/template.njk" %}
 
 {% block head %}
   <link rel="stylesheet" href="/stylesheets/app.min.css">

--- a/packages/govuk-frontend-review/src/views/layouts/full-page-example.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/full-page-example.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "layouts/_generic.njk" %}
 
 {% block banner %}
   {% include "../partials/exampleBanner.njk" %}

--- a/packages/govuk-frontend-review/src/views/layouts/full-width-landmarks.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/full-width-landmarks.njk
@@ -1,4 +1,4 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block main %}
   <div class="govuk-width-container">

--- a/packages/govuk-frontend-review/src/views/layouts/full-width.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/full-width.njk
@@ -1,4 +1,4 @@
-{% extends "layout.njk" %}
+{% extends "layouts/layout.njk" %}
 
 {% block main %}
   <div class="govuk-width-container">

--- a/packages/govuk-frontend-review/src/views/layouts/layout.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/layout.njk
@@ -1,4 +1,4 @@
-{% extends "_generic.njk" %}
+{% extends "layouts/_generic.njk" %}
 
 {% set htmlClasses = "app-no-canvas-background" %}
 

--- a/packages/govuk-frontend-review/src/views/macros/showExamples.njk
+++ b/packages/govuk-frontend-review/src/views/macros/showExamples.njk
@@ -1,4 +1,4 @@
-{% from "details/macro.njk" import govukDetails %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% macro showExamples(componentData) %}
 

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -27,7 +27,7 @@ describe('Components', () => {
   describe('Nunjucks environment', () => {
     it('renders template for each component', () => {
       return Promise.all(componentNames.map((componentName) =>
-        expect(nunjucksEnvDefault.render(`${componentName}/template.njk`, {})).resolves
+        expect(nunjucksEnvDefault.render(`govuk/components/${componentName}/template.njk`, {})).resolves
       ))
     })
 

--- a/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
@@ -3,7 +3,7 @@ import { callMacro } from 'govuk-frontend-helpers/nunjucks'
 describe('i18n.njk', () => {
   describe('govukPluralisedI18nAttributes', () => {
     function callMacroUnderTest (...args) {
-      return callMacro('govukPluralisedI18nAttributes', 'macros/i18n.njk', ...args)
+      return callMacro('govukPluralisedI18nAttributes', 'govuk/macros/i18n.njk', ...args)
     }
 
     it('renders a single plural type', () => {

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -4,8 +4,7 @@ const nunjucks = require('nunjucks')
 const { outdent } = require('outdent')
 
 const nunjucksPaths = [
-  packageNameToPath('govuk-frontend', 'src/govuk'),
-  packageNameToPath('govuk-frontend', 'src/govuk/components')
+  packageNameToPath('govuk-frontend', 'src')
 ]
 
 const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
@@ -24,7 +23,7 @@ const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
  */
 function renderHTML (componentName, options, callBlock) {
   const macroName = componentNameToMacroName(componentName)
-  const macroPath = `${componentName}/macro.njk`
+  const macroPath = `govuk/components/${componentName}/macro.njk`
 
   return callMacro(macroName, macroPath, [options], callBlock)
 }
@@ -75,7 +74,7 @@ function callMacro (macroName, macroPath, params = [], callBlock) {
  * @returns {import('cheerio').CheerioAPI} Nunjucks template output
  */
 function renderTemplate (context = {}, blocks = {}) {
-  let viewString = '{% extends "template.njk" %}'
+  let viewString = '{% extends "govuk/template.njk" %}'
 
   for (const [blockName, blockContent] of Object.entries(blocks)) {
     viewString += outdent`

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -85,7 +85,7 @@ async function generateFixture (componentDataPath, options) {
   }
 
   // Nunjucks template
-  const template = join(dirname(componentDataPath), 'template.njk')
+  const template = join(options.srcPath, dirname(componentDataPath), 'template.njk')
   const componentName = basename(dirname(componentDataPath))
 
   // Loop examples


### PR DESCRIPTION
This PR ensures we're following the [**Set up Nunjucks and use the page template**](https://frontend.design-system.service.gov.uk/use-nunjucks/#set-up-nunjucks-and-use-the-page-template) documentation

```njk
{% extends "govuk/template.njk" %}
```

All review app `{% from %}` imports and `{% extends %}` now use the `govuk/` prefix from:

* https://github.com/alphagov/govuk-frontend/issues/1451

## Documentation
We have an issue open to review our documentation in:

* https://github.com/alphagov/govuk-frontend/issues/3639

The changes in this PR confirm that our [documented change to ~`govuk`~ `govuk/dist`](https://github.com/alphagov/govuk-frontend/pull/3498/commits/cb64d8597792df45e67cde8f71d6f7f22c5d2011#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR68) works:

>##### If you’re using Nunjucks
>
>```js
>nunjucks.configure([
>  'node_modules/govuk-frontend/dist'
>])
>```