### PR TITLE
Allow globs in paths for `getListing()` and `getDirectories()`

### DIFF
--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -8,7 +8,10 @@ import slash from 'slash'
  * @returns {Promise<PrototypeKitConfig>} GOV.UK Prototype Kit config
  */
 export default async () => {
-  const componentMacros = await getListing(packageNameToPath('govuk-frontend', 'src'), '**/components/**/macro.njk')
+  const srcPath = packageNameToPath('govuk-frontend', 'src')
+
+  // Locate component macros
+  const componentMacros = await getListing('**/components/**/macro.njk', { cwd: srcPath })
   const componentNames = await getComponentNames()
 
   // Build array of macros

--- a/packages/govuk-frontend/src/govuk/components/components.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.test.js
@@ -8,7 +8,8 @@ describe('Components', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(join(paths.package, 'src/govuk/components'), '**/*.scss', {
+    sassFiles = await getListing('**/src/govuk/components/**/*.scss', {
+      cwd: paths.package,
       ignore: [
         '**/_all.scss',
         '**/_index.scss'
@@ -28,7 +29,7 @@ describe('Components', () => {
 
     it('renders CSS for each component', () => {
       const sassTasks = sassFiles.map((sassFilePath) => {
-        const file = join(paths.package, 'src/govuk/components', sassFilePath)
+        const file = join(paths.package, sassFilePath)
 
         return expect(compileSassFile(file)).resolves.toMatchObject({
           css: expect.any(String),

--- a/packages/govuk-frontend/src/govuk/helpers/helpers.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/helpers.test.js
@@ -9,7 +9,8 @@ describe('The helpers layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(paths.package, 'src/govuk/helpers/**/*.scss', {
+    sassFiles = await getListing('**/src/govuk/helpers/**/*.scss', {
+      cwd: paths.package,
       ignore: ['**/_all.scss']
     })
   })

--- a/packages/govuk-frontend/src/govuk/objects/objects.test.js
+++ b/packages/govuk-frontend/src/govuk/objects/objects.test.js
@@ -9,7 +9,8 @@ describe('The objects layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(paths.package, 'src/govuk/objects/**/*.scss', {
+    sassFiles = await getListing('**/src/govuk/objects/**/*.scss', {
+      cwd: paths.package,
       ignore: ['**/_all.scss']
     })
   })

--- a/packages/govuk-frontend/src/govuk/settings/settings.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/settings.test.js
@@ -9,7 +9,8 @@ describe('The settings layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(paths.package, 'src/govuk/settings/**/*.scss', {
+    sassFiles = await getListing('**/src/govuk/settings/**/*.scss', {
+      cwd: paths.package,
       ignore: ['**/_all.scss']
     })
   })

--- a/packages/govuk-frontend/src/govuk/tools/tools.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/tools.test.js
@@ -9,7 +9,8 @@ describe('The tools layer', () => {
   let sassFiles
 
   beforeAll(async () => {
-    sassFiles = await getListing(paths.package, 'src/govuk/tools/**/*.scss', {
+    sassFiles = await getListing('**/src/govuk/tools/**/*.scss', {
+      cwd: paths.package,
       ignore: ['**/_all.scss']
     })
   })

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -18,13 +18,29 @@ describe('packages/govuk-frontend/dist/', () => {
   let componentNames
 
   beforeAll(async () => {
-    listingPackage = await getListing(paths.package, '*')
-    listingSource = await getListing(join(paths.package, 'src'))
-    listingDist = await getListing(join(paths.package, 'dist'))
+    listingPackage = await getListing('*', {
+      cwd: paths.package
+    })
 
-    componentsFilesSource = await getListing(join(paths.package, 'src/govuk/components'))
-    componentsFilesDist = await getListing(join(paths.package, 'dist/govuk/components'))
-    componentsFilesDistESM = await getListing(join(paths.package, 'dist/govuk-esm/components'))
+    listingSource = await getListing('**/*', {
+      cwd: join(paths.package, 'src')
+    })
+
+    listingDist = await getListing('**/*', {
+      cwd: join(paths.package, 'dist')
+    })
+
+    componentsFilesSource = await getListing('**/*', {
+      cwd: join(paths.package, 'src/govuk/components')
+    })
+
+    componentsFilesDist = await getListing('**/*', {
+      cwd: join(paths.package, 'dist/govuk/components')
+    })
+
+    componentsFilesDistESM = await getListing('**/*', {
+      cwd: join(paths.package, 'dist/govuk-esm/components')
+    })
 
     // Components list
     componentNames = await getComponentNames()

--- a/packages/govuk-frontend/tasks/build/release.test.mjs
+++ b/packages/govuk-frontend/tasks/build/release.test.mjs
@@ -10,8 +10,13 @@ describe('dist/', () => {
   let listingDistAssets
 
   beforeAll(async () => {
-    listingSourceAssets = await getListing(join(paths.package, 'src/govuk/assets'))
-    listingDistAssets = await getListing(join(paths.root, 'dist/assets'))
+    listingSourceAssets = await getListing('**/*', {
+      cwd: join(paths.package, 'src/govuk/assets')
+    })
+
+    listingDistAssets = await getListing('**/*', {
+      cwd: join(paths.root, 'dist/assets')
+    })
   })
 
   describe('assets/', () => {

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -12,7 +12,9 @@ import { files } from './index.mjs'
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
 export async function generateFixtures (pattern, { srcPath, destPath }) {
-  const componentDataPaths = await getListing(srcPath, pattern)
+  const componentDataPaths = await getListing(pattern, {
+    cwd: srcPath
+  })
 
   // Loop component data paths
   const fixtures = componentDataPaths.map(async (componentDataPath) => {
@@ -44,7 +46,9 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
 export async function generateMacroOptions (pattern, { srcPath, destPath }) {
-  const componentDataPaths = await getListing(srcPath, pattern)
+  const componentDataPaths = await getListing(pattern, {
+    cwd: srcPath
+  })
 
   // Loop component data paths
   const macroOptions = componentDataPaths.map(async (componentDataPath) => {

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -12,7 +12,9 @@ import { loadConfigFile } from 'rollup/dist/loadConfigFile.js'
  * @param {AssetEntry[1]} [options] - Asset options for script(s)
  */
 export async function compile (pattern, options) {
-  const modulePaths = await getListing(options.srcPath, pattern)
+  const modulePaths = await getListing(pattern, {
+    cwd: options.srcPath
+  })
 
   // Increase Node.js max listeners warning threshold to silence
   // Rollup calling `process.on('warning')` once per bundle

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -20,7 +20,9 @@ import { assets } from './index.mjs'
  * @param {AssetEntry[1]} options - Asset options
  */
 export async function compile (pattern, options) {
-  const modulePaths = await getListing(options.srcPath, pattern)
+  const modulePaths = await getListing(pattern, {
+    cwd: options.srcPath
+  })
 
   try {
     const compileTasks = modulePaths


### PR DESCRIPTION
This PR is a first step in making our directory listings work with `govuk-frontend@4` again

For example using `**/govuk` instead of hard coding `src/govuk` for gathering legacy stats

```mjs
await getListing('/path/to/govuk-frontend/**/govuk/components/accordion')
```

We can still pass in `option.cwd` where needed:

## Before

```mjs
await getListing(srcPath, pattern, {
  ignore: []
})
```

## After

```mjs
await getListing(pattern, {
  cwd: srcPath,
  ignore: []
})
```