### PR TITLE
Update package helpers to support `govuk-frontend@4`

### DIFF
--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -1,7 +1,7 @@
 const { join } = require('path')
 
 const { paths, ports } = require('govuk-frontend-config')
-const { packageNameToPath } = require('govuk-frontend-lib/names')
+const { packageTypeToPath } = require('govuk-frontend-lib/names')
 
 /**
  * Browsersync config
@@ -25,7 +25,7 @@ module.exports = {
     join(paths.app, 'dist/javascripts/**/*.js'),
     join(paths.app, 'dist/stylesheets/**/*.css'),
     join(paths.app, 'src/views/**/*.njk'),
-    join(packageNameToPath('govuk-frontend'), 'dist/govuk/**/*.njk')
+    packageTypeToPath('govuk-frontend', { modulePath: '**/*.njk' })
   ],
   ignore: ['**/*.test.*'],
 

--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -25,7 +25,7 @@ module.exports = {
     join(paths.app, 'dist/javascripts/**/*.js'),
     join(paths.app, 'dist/stylesheets/**/*.css'),
     join(paths.app, 'src/views/**/*.njk'),
-    packageNameToPath('govuk-frontend', 'dist/govuk/**/*.njk')
+    join(packageNameToPath('govuk-frontend'), 'dist/govuk/**/*.njk')
   ],
   ignore: ['**/*.test.*'],
 

--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -25,7 +25,10 @@ module.exports = {
     join(paths.app, 'dist/javascripts/**/*.js'),
     join(paths.app, 'dist/stylesheets/**/*.css'),
     join(paths.app, 'src/views/**/*.njk'),
-    packageTypeToPath('govuk-frontend', { modulePath: '**/*.njk' })
+    packageTypeToPath('govuk-frontend', {
+      modulePath: '**/*.njk',
+      moduleRoot: paths.app
+    })
   ],
   ignore: ['**/*.test.*'],
 

--- a/packages/govuk-frontend-review/nodemon.json
+++ b/packages/govuk-frontend-review/nodemon.json
@@ -10,7 +10,7 @@
   "events": {
     "restart": "browser-sync reload --config browsersync.config.js"
   },
-  "ext": "mjs,json,yaml",
+  "ext": "js,mjs,json,yaml",
   "quiet": true,
   "signal": "SIGINT"
 }

--- a/packages/govuk-frontend-review/rollup.config.mjs
+++ b/packages/govuk-frontend-review/rollup.config.mjs
@@ -1,5 +1,6 @@
 import resolve from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
+import { paths } from 'govuk-frontend-config'
 import { defineConfig } from 'rollup'
 
 /**
@@ -38,6 +39,6 @@ export default defineConfig(({ i: input }) => ({
    * Input plugins
    */
   plugins: [
-    resolve()
+    resolve({ rootDir: paths.app })
   ]
 }))

--- a/packages/govuk-frontend-review/src/common/middleware/assets.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/assets.mjs
@@ -10,7 +10,7 @@ const router = express.Router()
  * Add middleware to serve static assets
  */
 
-router.use('/assets', express.static(packageNameToPath('govuk-frontend', 'dist/govuk/assets')))
+router.use('/assets', express.static(join(packageNameToPath('govuk-frontend'), 'dist/govuk/assets')))
 router.use('/javascripts', express.static(join(paths.app, 'dist/javascripts')))
 router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 

--- a/packages/govuk-frontend-review/src/common/middleware/assets.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/assets.mjs
@@ -10,7 +10,7 @@ const router = express.Router()
  * Add middleware to serve static assets
  */
 
-router.use('/assets', express.static(packageTypeToPath('govuk-frontend', { modulePath: 'assets' })))
+router.use('/assets', express.static(packageTypeToPath('govuk-frontend', { modulePath: 'assets', moduleRoot: paths.app })))
 router.use('/javascripts', express.static(join(paths.app, 'dist/javascripts')))
 router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 

--- a/packages/govuk-frontend-review/src/common/middleware/assets.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/assets.mjs
@@ -2,7 +2,7 @@ import { join } from 'path'
 
 import express from 'express'
 import { paths } from 'govuk-frontend-config'
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { packageTypeToPath } from 'govuk-frontend-lib/names'
 
 const router = express.Router()
 
@@ -10,7 +10,7 @@ const router = express.Router()
  * Add middleware to serve static assets
  */
 
-router.use('/assets', express.static(join(packageNameToPath('govuk-frontend'), 'dist/govuk/assets')))
+router.use('/assets', express.static(packageTypeToPath('govuk-frontend', { modulePath: 'assets' })))
 router.use('/javascripts', express.static(join(paths.app, 'dist/javascripts')))
 router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 

--- a/packages/govuk-frontend-review/src/common/middleware/vendor.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/vendor.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import express from 'express'
 import { packageNameToPath } from 'govuk-frontend-lib/names'
 
@@ -7,6 +9,6 @@ const router = express.Router()
  * Add middleware to serve dependencies
  * from node_modules
  */
-router.use('/iframe-resizer/', express.static(packageNameToPath('iframe-resizer', 'js')))
+router.use('/iframe-resizer/', express.static(join(packageNameToPath('iframe-resizer'), 'js')))
 
 export default router

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -1,6 +1,4 @@
-import { join } from 'path'
-
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { packageTypeToPath } from 'govuk-frontend-lib/names'
 import beautify from 'js-beautify'
 
 /**
@@ -11,7 +9,9 @@ import beautify from 'js-beautify'
  * @returns {string} Nunjucks code
  */
 export function getHTMLCode (componentName, params) {
-  const templatePath = join(packageNameToPath('govuk-frontend'), `dist/govuk/components/${componentName}/template.njk`)
+  const templatePath = packageTypeToPath('govuk-frontend', {
+    modulePath: `components/${componentName}/template.njk`
+  })
 
   // Render to HTML
   const html = this.env.render(templatePath, { params }).trim()

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -1,3 +1,4 @@
+import { paths } from 'govuk-frontend-config'
 import { packageTypeToPath } from 'govuk-frontend-lib/names'
 import beautify from 'js-beautify'
 
@@ -10,7 +11,8 @@ import beautify from 'js-beautify'
  */
 export function getHTMLCode (componentName, params) {
   const templatePath = packageTypeToPath('govuk-frontend', {
-    modulePath: `components/${componentName}/template.njk`
+    modulePath: `components/${componentName}/template.njk`,
+    moduleRoot: paths.app
   })
 
   // Render to HTML

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import { packageNameToPath } from 'govuk-frontend-lib/names'
 import beautify from 'js-beautify'
 
@@ -9,7 +11,7 @@ import beautify from 'js-beautify'
  * @returns {string} Nunjucks code
  */
 export function getHTMLCode (componentName, params) {
-  const templatePath = packageNameToPath('govuk-frontend', `dist/govuk/components/${componentName}/template.njk`)
+  const templatePath = join(packageNameToPath('govuk-frontend'), `dist/govuk/components/${componentName}/template.njk`)
 
   // Render to HTML
   const html = this.env.render(templatePath, { params }).trim()

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -1,20 +1,27 @@
 import { join } from 'path'
 
 import { paths } from 'govuk-frontend-config'
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { packageResolveToPath } from 'govuk-frontend-lib/names'
 import nunjucks from 'nunjucks'
 
 import * as filters from './filters/index.mjs'
 import * as globals from './globals/index.mjs'
 
+/**
+ * Initialise renderer with Nunjucks environment
+ *
+ * @param {import('express').Application} app - Express.js review app
+ * @returns {import('nunjucks').Environment} Nunjucks Environment
+ */
 export function renderer (app) {
-  const appViews = [
+  const env = nunjucks.configure([
     join(paths.app, 'src/views'),
-    join(packageNameToPath('govuk-frontend'), 'dist')
-  ]
 
-  // Initialise nunjucks environment
-  const env = nunjucks.configure(appViews, {
+    // Remove `govuk/` suffix using `modulePath`
+    packageResolveToPath('govuk-frontend', {
+      modulePath: '../'
+    })
+  ], {
     autoescape: true, // output with dangerous characters are escaped automatically
     express: app, // the Express.js review app that nunjucks should install to
     noCache: true, // never use a cache and recompile templates each time

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -19,7 +19,8 @@ export function renderer (app) {
 
     // Remove `govuk/` suffix using `modulePath`
     packageResolveToPath('govuk-frontend', {
-      modulePath: '../'
+      modulePath: '../',
+      moduleRoot: paths.app
     })
   ], {
     autoescape: true, // output with dangerous characters are escaped automatically

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -10,7 +10,7 @@ import * as globals from './globals/index.mjs'
 export function renderer (app) {
   const appViews = [
     join(paths.app, 'src/views'),
-    packageNameToPath('govuk-frontend', 'dist')
+    join(packageNameToPath('govuk-frontend'), 'dist')
   ]
 
   // Initialise nunjucks environment

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -1,3 +1,5 @@
+const { join } = require('path')
+
 const { packageNameToPath } = require('govuk-frontend-lib/names')
 
 /**
@@ -9,9 +11,9 @@ module.exports = {
   sourceLinkTemplate: 'https://github.com/alphagov/govuk-frontend/blob/{gitRevision}/{path}#L{line}',
 
   // Configure paths
-  basePath: packageNameToPath('govuk-frontend', 'src'),
-  entryPoints: [packageNameToPath('govuk-frontend', 'src/govuk/all.mjs')],
-  tsconfig: packageNameToPath('govuk-frontend', 'tsconfig.build.json'),
+  basePath: join(packageNameToPath('govuk-frontend'), 'src'),
+  entryPoints: [join(packageNameToPath('govuk-frontend'), 'src/govuk/all.mjs')],
+  tsconfig: join(packageNameToPath('govuk-frontend'), 'tsconfig.build.json'),
   out: './dist/docs/jsdoc',
 
   // Ignore warnings about CharacterCountTranslations using I18n (@private)

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -1,6 +1,6 @@
 const { join } = require('path')
 
-const { packageNameToPath } = require('govuk-frontend-lib/names')
+const { packageResolveToPath, packageNameToPath } = require('govuk-frontend-lib/names')
 
 /**
  * @type {import('typedoc').TypeDocOptions}
@@ -12,8 +12,8 @@ module.exports = {
 
   // Configure paths
   basePath: join(packageNameToPath('govuk-frontend'), 'src'),
-  entryPoints: [join(packageNameToPath('govuk-frontend'), 'src/govuk/all.mjs')],
-  tsconfig: join(packageNameToPath('govuk-frontend'), 'tsconfig.build.json'),
+  entryPoints: [packageResolveToPath('govuk-frontend/src/govuk/all.mjs')],
+  tsconfig: packageResolveToPath('govuk-frontend/tsconfig.build.json'),
   out: './dist/docs/jsdoc',
 
   // Ignore warnings about CharacterCountTranslations using I18n (@private)

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -1,3 +1,5 @@
+import { join } from 'path'
+
 import { filterPath, getComponentNames, getListing } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName, packageNameToPath } from 'govuk-frontend-lib/names'
 import slash from 'slash'
@@ -8,7 +10,7 @@ import slash from 'slash'
  * @returns {Promise<PrototypeKitConfig>} GOV.UK Prototype Kit config
  */
 export default async () => {
-  const srcPath = packageNameToPath('govuk-frontend', 'src')
+  const srcPath = join(packageNameToPath('govuk-frontend'), 'src')
 
   // Locate component macros
   const componentMacros = await getListing('**/components/**/macro.njk', { cwd: srcPath })

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -1,10 +1,12 @@
+const { join } = require('path')
+
 const cheerio = require('cheerio')
 const { componentNameToMacroName, packageNameToPath } = require('govuk-frontend-lib/names')
 const nunjucks = require('nunjucks')
 const { outdent } = require('outdent')
 
 const nunjucksPaths = [
-  packageNameToPath('govuk-frontend', 'src')
+  join(packageNameToPath('govuk-frontend'), 'src')
 ]
 
 const nunjucksEnv = nunjucks.configure(nunjucksPaths, {

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -91,7 +91,7 @@ const getYaml = async (configPath) => {
  * @returns {Promise<ComponentData & { name: string }>} Component data
  */
 const getComponentData = async (componentName) => {
-  const yamlPath = packageNameToPath('govuk-frontend', `src/govuk/components/${componentName}/${componentName}.yaml`)
+  const yamlPath = join(packageNameToPath('govuk-frontend'), `src/govuk/components/${componentName}/${componentName}.yaml`)
 
   /** @type {ComponentData} */
   const yamlData = await getYaml(yamlPath)
@@ -119,7 +119,7 @@ const getComponentsData = async () => {
  * @returns {Promise<string[]>} Component files
  */
 const getComponentFiles = (componentName = '') =>
-  getListing(packageNameToPath('govuk-frontend', join('src/govuk/components', componentName, '**/*')))
+  getListing(join(packageNameToPath('govuk-frontend'), `src/govuk/components/${componentName}/**/*`))
 
 /**
  * Get component names (with optional filter)
@@ -128,7 +128,7 @@ const getComponentFiles = (componentName = '') =>
  * @returns {Promise<string[]>} Component names
  */
 const getComponentNames = async (filter) => {
-  const componentNames = await getDirectories(packageNameToPath('govuk-frontend', '**/src/govuk/components/'))
+  const componentNames = await getDirectories(join(packageNameToPath('govuk-frontend'), '**/src/govuk/components/'))
 
   if (filter) {
     const componentFiles = await getComponentFiles()

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -1,4 +1,4 @@
-const { dirname, parse } = require('path')
+const { dirname, join, parse } = require('path')
 
 const { minimatch } = require('minimatch')
 
@@ -62,6 +62,23 @@ function componentPathToModuleName (componentPath) {
 }
 
 /**
+ * Resolve path to package entry from any npm workspace
+ *
+ * Once the package entry is resolved, the option `modulePath` can be used to
+ * append a new path relative to the package entry, for example `i18n.mjs`
+ *
+ * @param {string} packageEntry - Installed npm package entry, for example `govuk-frontend/src/govuk/all.mjs`
+ * @param {Pick<PackageOptions, "modulePath">} [options] - Package resolution options
+ * @returns {string} Path to installed npm package entry
+ */
+function packageResolveToPath (packageEntry, { modulePath } = {}) {
+  const packagePath = require.resolve(packageEntry)
+
+  // Append optional module path
+  return modulePath !== undefined ? join(dirname(packagePath), modulePath) : packagePath
+}
+
+/**
  * Resolve path to package from any npm workspace
  *
  * Used to find npm workspace packages that might be hoisted to
@@ -71,12 +88,21 @@ function componentPathToModuleName (componentPath) {
  * @returns {string} Path to installed npm package
  */
 function packageNameToPath (packageName) {
-  return dirname(require.resolve(`${packageName}/package.json`))
+  return packageResolveToPath(`${packageName}/package.json`, {
+    modulePath: ''
+  })
 }
 
 module.exports = {
   componentNameToClassName,
   componentNameToMacroName,
   componentPathToModuleName,
+  packageResolveToPath,
   packageNameToPath
 }
+
+/**
+ * @typedef {object} PackageOptions
+ * @property {string} [field] - Package field name from package.json, for example `module`
+ * @property {string} [modulePath] - Module path (optional, relative to package entry), for example `i18n.mjs`
+ */

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -1,4 +1,4 @@
-const { dirname, join, parse } = require('path')
+const { dirname, parse } = require('path')
 
 const { minimatch } = require('minimatch')
 
@@ -64,15 +64,14 @@ function componentPathToModuleName (componentPath) {
 /**
  * Resolve path to package from any npm workspace
  *
- * Used by npm workspaces to find packages that might be hoisted to
+ * Used to find npm workspace packages that might be hoisted to
  * the project root node_modules
  *
  * @param {string} packageName - Installed npm package name
- * @param {string} [childPath] - Optional child directory path
  * @returns {string} Path to installed npm package
  */
-function packageNameToPath (packageName, childPath = '') {
-  return join(dirname(require.resolve(`${packageName}/package.json`)), childPath)
+function packageNameToPath (packageName) {
+  return dirname(require.resolve(`${packageName}/package.json`))
 }
 
 module.exports = {

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -6,6 +6,7 @@ import {
   componentNameToClassName,
   componentNameToMacroName,
   componentPathToModuleName,
+  packageResolveToPath,
   packageNameToPath
 } from './names.js'
 
@@ -125,16 +126,48 @@ describe('componentPathToModuleName', () => {
   })
 })
 
-describe('packageNameToPath', () => {
+describe('packageResolveToPath', () => {
   const packages = [
     {
-      name: 'govuk-frontend',
-      path: paths.package
+      packageEntry: 'govuk-frontend/package.json',
+      resolvedPath: join(paths.package, 'package.json')
+    },
+    {
+      packageEntry: 'govuk-frontend/src/govuk/all.mjs',
+      resolvedPath: join(paths.package, 'src/govuk/all.mjs')
+    },
+    {
+      packageEntry: 'govuk-frontend/src/govuk/all.mjs',
+      options: { modulePath: 'i18n.mjs' },
+      resolvedPath: join(paths.package, 'src/govuk/i18n.mjs')
+    },
+    {
+      packageEntry: 'govuk-frontend/src/govuk/all.mjs',
+      options: { modulePath: 'components/accordion/accordion.mjs' },
+      resolvedPath: join(paths.package, 'src/govuk/components/accordion/accordion.mjs')
     }
   ]
 
-  it.each(packages)("locates path for npm package '$name'", ({ name, path }) => {
-    expect(packageNameToPath(name))
-      .toBe(path)
+  it.each(packages)("locates path for npm package entry '$packageEntry'", ({ packageEntry, options, resolvedPath }) => {
+    expect(packageResolveToPath(packageEntry, options))
+      .toBe(resolvedPath)
+  })
+})
+
+describe('packageNameToPath', () => {
+  const packages = [
+    {
+      packageName: 'govuk-frontend',
+      resolvedPath: paths.package
+    },
+    {
+      packageName: 'govuk-frontend-review',
+      resolvedPath: paths.app
+    }
+  ]
+
+  it.each(packages)("locates path for npm package '$packageName'", ({ packageName, resolvedPath }) => {
+    expect(packageNameToPath(packageName))
+      .toBe(resolvedPath)
   })
 })

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -7,6 +7,7 @@ import {
   componentNameToMacroName,
   componentPathToModuleName,
   packageResolveToPath,
+  packageTypeToPath,
   packageNameToPath
 } from './names.js'
 
@@ -150,6 +151,35 @@ describe('packageResolveToPath', () => {
 
   it.each(packages)("locates path for npm package entry '$packageEntry'", ({ packageEntry, options, resolvedPath }) => {
     expect(packageResolveToPath(packageEntry, options))
+      .toBe(resolvedPath)
+  })
+})
+
+describe('packageTypeToPath', () => {
+  const packages = [
+    {
+      packageName: 'govuk-frontend',
+      resolvedPath: join(paths.package, 'dist/govuk/all.js')
+    },
+    {
+      packageName: 'govuk-frontend',
+      options: { modulePath: 'i18n.js' },
+      resolvedPath: join(paths.package, 'dist/govuk/i18n.js')
+    },
+    {
+      packageName: 'govuk-frontend',
+      options: { type: 'module' },
+      resolvedPath: join(paths.package, 'dist/govuk-esm/all.mjs')
+    },
+    {
+      packageName: 'govuk-frontend',
+      options: { modulePath: 'i18n.mjs', type: 'module' },
+      resolvedPath: join(paths.package, 'dist/govuk-esm/i18n.mjs')
+    }
+  ]
+
+  it.each(packages)("locates path for npm package '$packageName' field '$packageField'", ({ packageName, options, resolvedPath }) => {
+    expect(packageTypeToPath(packageName, options))
       .toBe(resolvedPath)
   })
 })

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -201,3 +201,33 @@ describe('packageNameToPath', () => {
       .toBe(resolvedPath)
   })
 })
+
+describe("packageNameToPath (with custom 'node_module' paths)", () => {
+  const packages = [
+    {
+      packageName: 'govuk-frontend',
+      options: { moduleRoot: paths.root },
+      resolvedPath: paths.package
+    },
+    {
+      packageName: 'govuk-frontend-review',
+      options: { moduleRoot: paths.root },
+      resolvedPath: paths.app
+    },
+    {
+      packageName: 'autoprefixer',
+      options: { moduleRoot: paths.package },
+      resolvedPath: join(paths.root, 'node_modules/autoprefixer')
+    },
+    {
+      packageName: 'postcss',
+      options: { moduleRoot: paths.app },
+      resolvedPath: join(paths.root, 'node_modules/postcss')
+    }
+  ]
+
+  it.each(packages)("locates path for npm package '$packageName'", ({ packageName, options = {}, resolvedPath }) => {
+    expect(packageNameToPath(packageName, options))
+      .toBe(resolvedPath)
+  })
+})

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -1,18 +1,22 @@
-import { dirname, join, parse } from 'path'
+import { dirname, join, parse, relative } from 'path'
 
 import resolve from '@rollup/plugin-node-resolve'
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { paths } from 'govuk-frontend-config'
+import { packageTypeToPath } from 'govuk-frontend-lib/names'
 import { defineConfig } from 'rollup'
 import { visualizer } from 'rollup-plugin-visualizer'
 
-import { modulePaths } from './src/index.mjs'
+import { modulePaths, packageOptions } from './src/index.mjs'
+
+// Locate GOV.UK Frontend
+const packagePath = packageTypeToPath('govuk-frontend', packageOptions)
 
 /**
  * Rollup config with stats output
  */
 export default defineConfig(modulePaths
   .map((modulePath) => /** @satisfies {import('rollup').RollupOptions} */({
-    input: join('govuk-frontend/dist/govuk-esm', modulePath),
+    input: relative(paths.stats, packageTypeToPath('govuk-frontend', { ...packageOptions, modulePath })),
 
     /**
      * Output options
@@ -26,19 +30,19 @@ export default defineConfig(modulePaths
      * Input plugins
      */
     plugins: [
-      resolve(),
+      resolve({ rootDir: paths.stats }),
 
       // Stats: File size
       visualizer({
         filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.yaml`),
-        projectRoot: join(packageNameToPath('govuk-frontend'), 'dist/govuk-esm/'),
+        projectRoot: dirname(packagePath),
         template: 'list'
       }),
 
       // Stats: Module tree map
       visualizer({
         filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.html`),
-        projectRoot: join(packageNameToPath('govuk-frontend'), 'dist/govuk-esm/'),
+        projectRoot: dirname(packagePath),
         template: 'treemap'
       })
     ]

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -31,14 +31,14 @@ export default defineConfig(modulePaths
       // Stats: File size
       visualizer({
         filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.yaml`),
-        projectRoot: packageNameToPath('govuk-frontend', 'dist/govuk-esm/'),
+        projectRoot: join(packageNameToPath('govuk-frontend'), 'dist/govuk-esm/'),
         template: 'list'
       }),
 
       // Stats: Module tree map
       visualizer({
         filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.html`),
-        projectRoot: packageNameToPath('govuk-frontend', 'dist/govuk-esm/'),
+        projectRoot: join(packageNameToPath('govuk-frontend'), 'dist/govuk-esm/'),
         template: 'treemap'
       })
     ]

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -16,7 +16,8 @@ const componentNamesWithJavaScript = await getComponentNames((componentName, com
  */
 export const packageOptions = {
   type: 'module',
-  modulePath: 'all.mjs'
+  modulePath: 'all.mjs',
+  moduleRoot: paths.stats
 }
 
 /**

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -10,9 +10,19 @@ const componentNamesWithJavaScript = await getComponentNames((componentName, com
   componentFiles.some(filterPath([`**/${componentName}.mjs`])))
 
 /**
+ * Package options
+ *
+ * @type {import('govuk-frontend-lib/names').PackageOptions}
+ */
+export const packageOptions = {
+  type: 'module',
+  modulePath: 'all.mjs'
+}
+
+/**
  * Rollup input paths
  */
-export const modulePaths = ['all.mjs']
+export const modulePaths = [packageOptions.modulePath]
   .concat(componentNamesWithJavaScript.map((componentName) =>
     `components/${componentName}/${componentName}.mjs`))
 

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -4,7 +4,7 @@ import { join, parse } from 'path'
 import chalk from 'chalk'
 import { paths } from 'govuk-frontend-config'
 import { getListing } from 'govuk-frontend-lib/files'
-import { packageNameToPath } from 'govuk-frontend-lib/names'
+import { packageResolveToPath } from 'govuk-frontend-lib/names'
 import PluginError from 'plugin-error'
 import postcss from 'postcss'
 // eslint-disable-next-line import/default
@@ -39,7 +39,7 @@ export async function compile (pattern, options) {
  *
  * @param {AssetEntry} assetEntry - Asset entry
  */
-export async function compileStylesheet ([modulePath, { configPath, srcPath, destPath, filePath }]) {
+export async function compileStylesheet ([modulePath, { basePath, configPath, srcPath, destPath, filePath }]) {
   const moduleSrcPath = join(srcPath, modulePath)
   const moduleDestPath = join(destPath, filePath ? filePath(parse(modulePath)) : modulePath)
 
@@ -81,7 +81,13 @@ export async function compileStylesheet ([modulePath, { configPath, srcPath, des
 
       // Resolve @imports via
       loadPaths: [
-        join(packageNameToPath('govuk-frontend'), 'dist'),
+        // Remove `govuk/` suffix using `modulePath`
+        packageResolveToPath('govuk-frontend', {
+          modulePath: '../'
+        }),
+
+        // Resolve local packages first
+        join(basePath, 'node_modules'),
         join(paths.root, 'node_modules')
       ],
 

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -83,7 +83,8 @@ export async function compileStylesheet ([modulePath, { basePath, configPath, sr
       loadPaths: [
         // Remove `govuk/` suffix using `modulePath`
         packageResolveToPath('govuk-frontend', {
-          modulePath: '../'
+          modulePath: '../',
+          moduleRoot: basePath
         }),
 
         // Resolve local packages first

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -81,7 +81,7 @@ export async function compileStylesheet ([modulePath, { configPath, srcPath, des
 
       // Resolve @imports via
       loadPaths: [
-        packageNameToPath('govuk-frontend', 'dist'),
+        join(packageNameToPath('govuk-frontend'), 'dist'),
         join(paths.root, 'node_modules')
       ],
 


### PR DESCRIPTION
This PR updates our `require.resolve()` package resolution to work with GOV.UK Frontend v4

As a workaround for https://github.com/alphagov/govuk-frontend/issues/3755 **packageTypeToPath()** can resolve paths via the `main` or `module` fields instead

## Rollup stats for old releases
Package stats can now be built for `govuk-frontend@4` as shown on branch [`package-resolver-v4`](https://github.com/alphagov/govuk-frontend/tree/package-resolver-v4)

```shell
npm version 5.0.0 --no-git-tag-version --workspace govuk-frontend
npm install govuk-frontend@4.6.0 --save --workspace govuk-frontend-stats
```

**Note:** It's necessary to bump our workspace `govuk-frontend` to v5.0.0 to avoid conflict