### PR TITLE
Style details in older browsers

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/details/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_index.scss
@@ -5,24 +5,16 @@
     @include govuk-responsive-margin(6, "bottom");
 
     display: block;
-
-    border-left: $govuk-border-width-wide solid $govuk-border-colour;
   }
 
   .govuk-details__summary {
     // Make the focus outline shrink-wrap the text content of the summary
     display: inline-block;
 
-    margin-top: govuk-spacing(3);
-
     margin-bottom: govuk-spacing(1);
   }
 
   .govuk-details__summary-text {
-    @include govuk-typography-weight-bold;
-    @include govuk-responsive-margin(4, "bottom");
-    padding-left: govuk-spacing(4);
-
     > :first-child {
       margin-top: 0;
     }
@@ -48,6 +40,25 @@
     margin-bottom: 0;
   }
 
+  // Hack to target IE8 - IE11 (and REALLY old Firefox)
+  // These browsers don't support the details element, so fall back to looking
+  // like inset text
+  @media screen\0 {
+    .govuk-details {
+      border-left: $govuk-border-width-wide solid $govuk-border-colour;
+    }
+
+    .govuk-details__summary {
+      margin-top: govuk-spacing(3);
+    }
+
+    .govuk-details__summary-text {
+      @include govuk-typography-weight-bold;
+      @include govuk-responsive-margin(4, "bottom");
+      padding-left: govuk-spacing(4);
+    }
+  }
+
   // We wrap styles for newer browsers in a feature query, which is ignored by
   // older browsers, which always expand the details element.
   //
@@ -57,18 +68,10 @@
   //   - support ES6 modules but not the <details> element (Edge 16 - 18)
   //   - do not support ES6 modules or the <details> element (eg, IE8+)
   @supports not (-ms-ime-align: auto) {
-    // Override default border
-    .govuk-details {
-      border-left: none;
-    }
-
     .govuk-details__summary {
 
       // Absolutely position the marker against this element
       position: relative;
-
-      // Override default top margin
-      margin-top: 0;
 
       // Allow for absolutely positioned marker and align with disclosed text
       padding-left: govuk-spacing(4) + $govuk-border-width;
@@ -88,12 +91,6 @@
     // ...but only underline the text, not the arrow
     .govuk-details__summary-text {
       @include govuk-link-decoration;
-      // Override default font weight
-      @include govuk-typography-weight-regular;
-      // Override default margin
-      margin-bottom: 0;
-      // Override default padding
-      padding-left: 0;
     }
 
     .govuk-details__summary:hover .govuk-details__summary-text {

--- a/packages/govuk-frontend/src/govuk/components/details/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_index.scss
@@ -5,20 +5,38 @@
     @include govuk-responsive-margin(6, "bottom");
 
     display: block;
+
+    border-left: $govuk-border-width-wide solid $govuk-border-colour;
   }
 
   .govuk-details__summary {
     // Make the focus outline shrink-wrap the text content of the summary
     display: inline-block;
 
+    margin-top: govuk-spacing(3);
+
     margin-bottom: govuk-spacing(1);
+  }
+
+  .govuk-details__summary-text {
+    @include govuk-typography-weight-bold;
+    @include govuk-responsive-margin(4, "bottom");
+    padding-left: govuk-spacing(4);
+
+    > :first-child {
+      margin-top: 0;
+    }
+
+    > :only-child,
+    > :last-child {
+      margin-bottom: 0;
+    }
   }
 
   .govuk-details__text {
     padding-top: govuk-spacing(3);
     padding-bottom: govuk-spacing(3);
     padding-left: govuk-spacing(4);
-    border-left: $govuk-border-width solid $govuk-border-colour;
   }
 
   .govuk-details__text p {
@@ -30,16 +48,27 @@
     margin-bottom: 0;
   }
 
-  // Fix for older browsers which:
+  // We wrap styles for newer browsers in a feature query, which is ignored by
+  // older browsers, which always expand the details element.
+  //
+  // Additionally, -ms-ime-align is only supported by Edge 12 - 18
+  //
+  // This ensures we don't use these styles in browsers which:
   //   - support ES6 modules but not the <details> element (Edge 16 - 18)
   //   - do not support ES6 modules or the <details> element (eg, IE8+)
-  // -ms-ime-align is only supported by Edge 12 - 18
-  // Older browsers ignore the entire feature query and use the styles above
   @supports not (-ms-ime-align: auto) {
+    // Override default border
+    .govuk-details {
+      border-left: none;
+    }
+
     .govuk-details__summary {
 
       // Absolutely position the marker against this element
       position: relative;
+
+      // Override default top margin
+      margin-top: 0;
 
       // Allow for absolutely positioned marker and align with disclosed text
       padding-left: govuk-spacing(4) + $govuk-border-width;
@@ -59,6 +88,12 @@
     // ...but only underline the text, not the arrow
     .govuk-details__summary-text {
       @include govuk-link-decoration;
+      // Override default font weight
+      @include govuk-typography-weight-regular;
+      // Override default margin
+      margin-bottom: 0;
+      // Override default padding
+      padding-left: 0;
     }
 
     .govuk-details__summary:hover .govuk-details__summary-text {
@@ -92,6 +127,10 @@
       .govuk-details[open] > & {
         @include govuk-shape-arrow($direction: down, $base: 14px);
       }
+    }
+
+    .govuk-details__text {
+      border-left: $govuk-border-width solid $govuk-border-colour;
     }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/details/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/details/_index.scss
@@ -11,63 +11,7 @@
     // Make the focus outline shrink-wrap the text content of the summary
     display: inline-block;
 
-    // Absolutely position the marker against this element
-    position: relative;
-
     margin-bottom: govuk-spacing(1);
-
-    // Allow for absolutely positioned marker and align with disclosed text
-    padding-left: govuk-spacing(4) + $govuk-border-width;
-
-    // Style the summary to look like a link...
-    color: $govuk-link-colour;
-    cursor: pointer;
-
-    &:hover {
-      color: $govuk-link-hover-colour;
-    }
-
-    &:focus {
-      @include govuk-focused-text;
-    }
-  }
-
-  // ...but only underline the text, not the arrow
-  .govuk-details__summary-text {
-    @include govuk-link-decoration;
-  }
-
-  .govuk-details__summary:hover .govuk-details__summary-text {
-    @include govuk-link-hover-decoration;
-  }
-
-  // Remove the underline when focussed to avoid duplicate borders
-  .govuk-details__summary:focus .govuk-details__summary-text {
-    text-decoration: none;
-  }
-
-  // Remove the default details marker so we can style our own consistently and
-  // ensure it displays in Firefox (see implementation.md for details)
-  .govuk-details__summary::-webkit-details-marker {
-    display: none;
-  }
-
-  // Append our own open / closed marker using a pseudo-element
-  .govuk-details__summary::before {
-    content: "";
-    position: absolute;
-
-    top: -1px;
-    bottom: 0;
-    left: 0;
-
-    margin: auto;
-
-    @include govuk-shape-arrow($direction: right, $base: 14px);
-
-    .govuk-details[open] > & {
-      @include govuk-shape-arrow($direction: down, $base: 14px);
-    }
   }
 
   .govuk-details__text {
@@ -84,5 +28,70 @@
 
   .govuk-details__text > :last-child {
     margin-bottom: 0;
+  }
+
+  // Fix for older browsers which:
+  //   - support ES6 modules but not the <details> element (Edge 16 - 18)
+  //   - do not support ES6 modules or the <details> element (eg, IE8+)
+  // -ms-ime-align is only supported by Edge 12 - 18
+  // Older browsers ignore the entire feature query and use the styles above
+  @supports not (-ms-ime-align: auto) {
+    .govuk-details__summary {
+
+      // Absolutely position the marker against this element
+      position: relative;
+
+      // Allow for absolutely positioned marker and align with disclosed text
+      padding-left: govuk-spacing(4) + $govuk-border-width;
+
+      // Style the summary to look like a link...
+      color: $govuk-link-colour;
+      cursor: pointer;
+
+      &:hover {
+        color: $govuk-link-hover-colour;
+      }
+
+      &:focus {
+        @include govuk-focused-text;
+      }
+    }
+    // ...but only underline the text, not the arrow
+    .govuk-details__summary-text {
+      @include govuk-link-decoration;
+    }
+
+    .govuk-details__summary:hover .govuk-details__summary-text {
+      @include govuk-link-hover-decoration;
+    }
+
+    // Remove the underline when focussed to avoid duplicate borders
+    .govuk-details__summary:focus .govuk-details__summary-text {
+      text-decoration: none;
+    }
+
+    // Remove the default details marker so we can style our own consistently and
+    // ensure it displays in Firefox (see implementation.md for details)
+    .govuk-details__summary::-webkit-details-marker {
+      display: none;
+    }
+
+    // Append our own open / closed marker using a pseudo-element
+    .govuk-details__summary::before {
+      content: "";
+      position: absolute;
+
+      top: -1px;
+      bottom: 0;
+      left: 0;
+
+      margin: auto;
+
+      @include govuk-shape-arrow($direction: right, $base: 14px);
+
+      .govuk-details[open] > & {
+        @include govuk-shape-arrow($direction: down, $base: 14px);
+      }
+    }
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/details/implementation.md
+++ b/packages/govuk-frontend/src/govuk/components/details/implementation.md
@@ -1,5 +1,49 @@
 ## Implementation notes
 
+### Styling in older browsers
+
+#### Browsers with support for `type=module`, `<details>` and feature queries
+
+https://browsersl.ist/#q=supports+details+and+supports+css-featurequeries+and+supports+es6-module&region=GB
+
+Previously, we provided a polyfill for older browsers which do not support the
+`<details>` component. Since most browsers now DO support `<details>`, we've
+removed that polyfill, and we need to make sure browsers which don't support
+`<details>` don't use any styles that make them look interactable.
+
+By wrapping these styles in a feature query, we can capture the vast majority of
+browsers which have full support.
+
+#### Browsers that support `type=module` and feature queries but not `<details>`
+
+https://browsersl.ist/#q=supports+es6-module+and+not+supports+details+and+supports+css-featurequeries&region=GB
+
+This only affects Edge 16 - 18. We filter these out of the support query by
+checking for `-ms-ime-align: auto`, which isn't supported by any other browsers.
+
+#### Browsers that support `<details>` but not `type=module` or feature queries
+
+https://browsersl.ist/#q=supports+details+and+not+supports+css-featurequeries+and+not+supports+es6-module&region=GB
+
+These will default to their native styling of the `<details>` element, with a
+few of our spacing and font styles.
+
+#### Browsers which don't support `<details>`, `type=module` or feature queries
+
+https://browsersl.ist/#q=%3E0.0000001%25+and+not+supports+details+and+not+supports+es6-module+and+not+supports+css-featurequeries&region=GB
+
+This is largely IE 8 - 11.
+
+We can account for IE by styling them like inset text, via a `@media screen\0`
+hack that no other browser supports.
+
+#### Browsers that support feature queries, but not `<details>` or `type=module`
+
+https://browsersl.ist/#q=supports+css-featurequeries+and+not+supports+details+and+not+supports+es6-module&region=GB
+
+This is the only gap, as these browsers will get styled to look interactable,
+even though they aren't. This is largely Opera Mini.
+
 ### Marker styling
 
 Firefox uses display: list-item to show the arrow marker for the summary


### PR DESCRIPTION
Part of #3464 

## What

We're removing the JavaScript polyfill for the `<details>` element.

We need to ensure that the component is not styled to suggest it can be expanded in browsers that do not natively support the `<details>` element.

![Details component in an older browser once the polyfill is removed. The summary text looks like and behaves like a link but does nothing](https://github.com/alphagov/govuk-frontend/assets/22524634/83bd11a2-f23b-47c0-8ab5-c184fcfed9b7)

Browser support for the `<details>` component: https://caniuse.com/?search=details

## Wrap "link-like" styles in a CSS Feature Query
We can wrap most of the Details styles in a feature query which excludes EdgeHTML:

```CSS
/* 
 * -ms-ime-align is only supported on Edge 12 - 18.
 * Additionally, most older browsers that don't support the <details> component don't support feature queries
 * and will ignore everything inside the feature query block
 */
@supports not (-ms-ime-align: auto)
```

This covers the vast majority of browsers (about 97%), which behave as expected.

## Hack for Internet Explorer
IE doesn't support the `<details>` element, so we can style it to look like inset text.
### Internet Explorer 11
![Details component in IE11](https://github.com/alphagov/govuk-frontend/assets/22524634/88920230-8ee5-46e7-83bd-45149d3a2af0)

## Default to browser-native styles
For browsers which support `<details>`, but not CSS feature queries, we simply default to their styles for the `<details>` element, plus some added font and spacing.

### Chrome 27
![Details component in Chrome 27](https://github.com/alphagov/govuk-frontend/assets/22524634/5403526d-c645-4b5c-9e55-b3651e15d484)

### Android 4.1 (emulated)
![Details component in Android Browser 4.1](https://github.com/alphagov/govuk-frontend/assets/22524634/da97e445-b730-4262-a9a3-5c8853486a9c)

## Gaps
Browsers which support feature queries, but not `<details>` or es6 module will still have "linkified" styling, but not be interactable. This largely applies to Opera Mini and early Firefox.
https://browsersl.ist/#q=supports+css-featurequeries+and+not+supports+details+and+not+supports+es6-module&region=GB

This represents around 0.18% of browsers in the UK, and is even more minimal on the latest stats I have for GOV.UK (where the affected Firefox versions account for about 0.001% of traffic).

### Firefox 48
![Details component in Firefox 48](https://github.com/alphagov/govuk-frontend/assets/22524634/ae386059-3bfe-4dd5-9b42-cc7d6952eb57)

