### PR TITLE
Change hierarchy of security section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To be notified when there’s a new release, you can either:
 
 Find out how to [update with npm](https://frontend.design-system.service.gov.uk/updating-with-npm/).
 
-### Security
+## Security
 
 GDS is an advocate of responsible vulnerability disclosure. If you’ve found a vulnerability, we would like to know so we can fix it.
 


### PR DESCRIPTION
The security section is currently an h3 'under' the h2 'Getting updates', but isn't related to getting updates.

Change it to an h2 so that it's a sibling of 'Getting updates' rather than a child, thereby starting a new section.