### PR TITLE
Prefer `MediaQueryList.addEventListener` when available

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -57,13 +57,11 @@ Header.prototype.init = function () {
   // Set the matchMedia to the govuk-frontend desktop breakpoint
   this.mql = window.matchMedia('(min-width: 48.0625em)')
 
+  // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
+  // to be able to fall back to the deprecated MediaQueryList.addListener
   if ('addEventListener' in this.mql) {
     this.mql.addEventListener('change', this.syncState.bind(this))
   } else {
-    // addListener is a deprecated function, however addEventListener
-    // isn't supported by Safari < 14. We therefore add this in as
-    // a fallback for those browsers
-
     // @ts-expect-error Property 'addListener' does not exist
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     this.mql.addListener(this.syncState.bind(this))

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -62,7 +62,17 @@ Tabs.prototype.init = function () {
 Tabs.prototype.setupResponsiveChecks = function () {
   /** @deprecated Will be made private in v5.0 */
   this.mql = window.matchMedia('(min-width: 40.0625em)')
-  this.mql.addListener(this.checkMode.bind(this))
+
+  // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
+  // to be able to fall back to the deprecated MediaQueryList.addListener
+  if ('addEventListener' in this.mql) {
+    this.mql.addEventListener('change', this.checkMode.bind(this))
+  } else {
+    // @ts-expect-error Property 'addListener' does not exist
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    this.mql.addListener(this.checkMode.bind(this))
+  }
+
   this.checkMode()
 }
 


### PR DESCRIPTION
This means we’re only using the deprecated `MediaQueryList.addListener` when `MediaQueryList.addEventListener` doesn’t exist, and aligns the logic between the header and tabs component.