### PR TITLE
Wait for Percy to idle before screenshot task finishes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3973,10 +3973,10 @@
       }
     },
     "node_modules/@percy/sdk-utils": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.24.0.tgz",
-      "integrity": "sha512-kfYxX0rHP5N2Da6HyfjRCVaeNahAO9XV5WD4SKWKKjdKVkV/Z5/XjVgSKlTBLSYxnWDzYJJ4UHZV43Mw+facMA==",
-      "dev": true,
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@percy/sdk-utils/-/sdk-utils-1.25.0.tgz",
+      "integrity": "sha512-jv4/jb3Neh4IgHUOuuB11XbC0Ho7dLH9plRM1JcBwxaoaTeGL9Ftau3OC126320K37yRTO4KZ+sW3jxQk/Ghsw==",
+      "devOptional": true,
       "engines": {
         "node": ">=14"
       }
@@ -27653,6 +27653,14 @@
       "engines": {
         "node": "^18.12.0",
         "npm": "^8.1.0 || ^9.1.0"
+      },
+      "peerDependencies": {
+        "@percy/sdk-utils": ">=1.25"
+      },
+      "peerDependenciesMeta": {
+        "@percy/sdk-utils": {
+          "optional": true
+        }
       }
     }
   }

--- a/packages/govuk-frontend-review/percy.config.js
+++ b/packages/govuk-frontend-review/percy.config.js
@@ -7,7 +7,6 @@ const { executablePath } = require('puppeteer')
  */
 module.exports = {
   discovery: {
-    concurrency: 1,
     launchOptions: {
       executable: executablePath()
     }

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -28,27 +28,14 @@ export async function screenshots () {
   const componentNames = await getComponentNames()
   const exampleNames = ['text-alignment', 'typography']
 
-  // Screenshot stack
-  const input = []
+  // Screenshot components
+  for (const componentName of componentNames) {
+    await screenshotComponent(await browser.newPage(), componentName)
+  }
 
-  // Add components to screenshot
-  input.push(...componentNames.map((screenshotName) =>
-    /** @type {const} */ ([screenshotComponent, screenshotName])))
-
-  // Add examples to screenshot
-  input.push(...exampleNames.map((screenshotName) =>
-    /** @type {const} */ ([screenshotExample, screenshotName])))
-
-  // Batch 4x concurrent screenshots
-  while (input.length) {
-    const batch = input.splice(0, 4)
-
-    // Take screenshots
-    const screenshotTasks = batch.map(async ([screenshotFn, screenshotName]) =>
-      screenshotFn(await browser.newPage(), screenshotName))
-
-    // Wait until batch finishes
-    await Promise.all(screenshotTasks)
+  // Screenshot examples
+  for (const exampleName of exampleNames) {
+    await screenshotExample(await browser.newPage(), exampleName)
   }
 
   // Close browser

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -1,4 +1,5 @@
 import percySnapshot from '@percy/puppeteer'
+import { waitForPercyIdle } from '@percy/sdk-utils'
 import { download } from 'govuk-frontend-helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from 'govuk-frontend-helpers/puppeteer'
 import { filterPath, getComponentFiles, getComponentNames } from 'govuk-frontend-lib/files'
@@ -51,7 +52,10 @@ export async function screenshots () {
   }
 
   // Close browser
-  return browser.close()
+  await browser.close()
+
+  // Wait for Percy to finish
+  return waitForPercyIdle()
 }
 
 /**

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -29,5 +29,13 @@
     "sass-embedded": "^1.62.0",
     "slash": "^5.1.0",
     "yargs-parser": "^21.1.1"
+  },
+  "peerDependencies": {
+    "@percy/sdk-utils": ">=1.25"
+  },
+  "peerDependenciesMeta": {
+    "@percy/sdk-utils": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This PR is a workaround for a potential Percy CLI bug affecting:

```shell
percy exec -- npm run test:screenshots
```

To avoid a potential race condition ([see discussion](https://github.com/percy/cli/discussions/1137#discussioncomment-6110919)) I've included:

1. Wait for Percy using `waitForPercyIdle()` from [@percy/sdk-utils](https://www.npmjs.com/package/@percy/sdk-utils)
2. Run Percy asset discovery concurrently (again)
3. Take Percy snapshots sequentially (again)

```mjs
import { waitForPercyIdle } from '@percy/sdk-utils'

// Take snapshots
// … then wait for Percy

await waitForPercyIdle()
```

### Console output with `percy exec --verbose`

Percy continues to show lots of unfinished activity for resource and snapshot uploads after the [`await percySnapshot()`](https://docs.percy.io/docs/puppeteer#configuration) promises have resolved and `npm run test:screenshots` outputs `Finished 'screenshots'` 

I've attached the [full log output `percy-exec.log`](https://github.com/alphagov/govuk-frontend/files/11679950/percy-exec.log) or see the following excerpt:

```console
[percy:core:page] Page closed (2ms)
[percy:client] Finalizing snapshot 1558916655... (37ms)
[17:17:45] Finished 'screenshots' after 17 s
[percy:client] Creating snapshot: js: error-message... (283ms)
[percy:client] Uploading resources for 28033806... (362ms)
[percy:client] Uploading resource: /percy.1686154655270.log... (1ms)
[percy:client] Finalizing snapshot 1558916705... (412ms)
[percy:client] Creating snapshot: js: error-summary... (242ms)
[percy:client] Uploading resources for 28033806... (318ms)
[percy:client] Uploading resource: /percy.1686154655567.log... (0ms)
[percy:client] Finalizing snapshot 1558916738... (413ms)
[percy:client] Creating snapshot: no-js: details... (315ms)
[percy:client] Uploading resources for 28033806... (412ms)
[percy:client] Uploading resource: /percy.1686154655870.log... (0ms)
```