### PR TITLE
Change autocomplete example to street-address

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -58,7 +58,7 @@ params:
   - name: autocomplete
     type: string
     required: false
-    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for example `postal-code` or `username`. See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
+    description: Attribute to [identify input purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html), for example `street-address`. See [autofill](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill) for full list of attributes that can be used.
   - name: attributes
     type: object
     required: false


### PR DESCRIPTION
The textarea documentation currently uses `postal-code` and `username` as examples for the `autocomplete` option. These are good examples for the text input component, but I wouldn't expect a textarea to be used for those fields. 

I've updated the example for textarea to `street-address`. From reading the [spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute) that's the only autocomplete value I'd really expect to use on a textarea (though technically I think they're all valid) and it's the only value that allows newlines in the canonical format.