### PR TITLE
Simplify logic in `govuk-font` mixin

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -177,15 +177,15 @@
 /// @access public
 
 @mixin govuk-font($size, $weight: regular, $tabular: false, $line-height: false) {
+  @include govuk-typography-common;
+
   @if $tabular {
-    @include govuk-typography-common;
     font-feature-settings: "tnum" 1;
+
     @supports (font-variant-numeric: tabular-nums) {
       font-feature-settings: normal;
       font-variant-numeric: tabular-nums;
     }
-  } @else {
-    @include govuk-typography-common;
   }
 
   @if $weight == regular {


### PR DESCRIPTION
Both flows through this if statement `@include govuk-typography-common` so we can move it out of the if statement and disappear the else clause 🪄