### PR TITLE
Fix hover style on small checkboxes and radio buttons in High Contrast Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,6 +252,7 @@ This change was introduced in [pull request #3773: Omit the value attribute from
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
+- [#3777: Fix hover style on small checkboxes and radio buttons in High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/3777)
 - [#3791: Refactor mobile menu button label/text handling](https://github.com/alphagov/govuk-frontend/pull/3791)
 - [#3862: Fix focus style being overlapped by summary action links](https://github.com/alphagov/govuk-frontend/pull/3862)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -273,6 +273,10 @@
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
     .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+      // Forced colours modes tend to ignore box-shadow.
+      // Apply an outline for those modes to use instead.
+      outline: $govuk-focus-width dashed transparent;
+      outline-offset: 1px;
       box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
     }
 
@@ -282,6 +286,10 @@
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
     .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+      // Set different HCM colour when we have both hover/focus applied at once
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        outline-color: Highlight;
+      }
       box-shadow:
         0 0 0 $govuk-focus-width $govuk-focus-colour, // 1
         0 0 0 $govuk-hover-width $govuk-hover-colour; // 2

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -293,6 +293,10 @@
     // feedback to the user as to which radio they will select when their
     // cursor is outside of the visible area.
     .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+      // Forced colours modes tend to ignore box-shadow.
+      // Apply an outline for those modes to use instead.
+      outline: $govuk-radios-focus-width dashed transparent;
+      outline-offset: 1px;
       box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
     }
 
@@ -302,6 +306,10 @@
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
     .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+      // Set different HCM colour when we have both hover/focus applied at once
+      @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+        outline-color: Highlight;
+      }
       box-shadow:
         0 0 0 $govuk-radios-focus-width $govuk-focus-colour, // 1
         0 0 0 $govuk-hover-width        $govuk-hover-colour; // 2


### PR DESCRIPTION
Hover styles are currently not visible on 'small' checkbox and radio buttons in Windows High Contrast Mode, because the `box-shadow` property is ignored in High Contrast Mode. 

This PR aims to fix that by also applying an `outline` attribute at the same time: transparent normally, but coloured in High Contrast Mode, so that a visual change still takes place on hover.

As `outline` is also used by the focus state, there is some possible overlap here, but given we additionally thicken the input border on focus, a visual distinction between hovered, focused, and simultaneously hovered and focused is retained.

Raised as a low vision usability issue by DAC in their recent audit of Frontend. Resolves #3695.

||Before|After|
|:-|:-|:-|
|Checkbox (hovered)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/3cf70f63-2f87-4f3b-8f8b-36334e89f03b)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/2142b270-1e4b-48de-83d0-cc8913e5f8a8)|
|Checkbox (focused)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/0b0c276f-6e58-4fa7-8e85-b6e5db7c27ad)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/cca1757c-caf7-4947-b91f-1356127f4659)|
|Checkbox (hovered and focused)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/0b0c276f-6e58-4fa7-8e85-b6e5db7c27ad)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/b2a14fb1-a860-4486-a024-9922400e943a)|
|Checkbox (hovered, focused and checked)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/4d6756c1-44b4-497b-83d4-20e1c61c43bc)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/14419853-ad25-4ac9-88c0-01ab516d240d)|
|Radio (hovered)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/0ed390b0-e497-42a8-ade0-773407f1b29f)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/de0b9c08-d3eb-4991-b85d-be9bd8830c34)|
|Radio (focused)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/02d636b5-9234-46b6-9791-e9673d2565c6)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/99d8cf85-f6be-4048-96b5-aff43f6b905d)|
|Radio (hovered and focused)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/02d636b5-9234-46b6-9791-e9673d2565c6)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/7f56bb50-d28e-4503-bdc8-4701e25e43e4)|
|Radio (hovered, focused and checked)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/34c550db-9bba-4f08-939d-7d491da01c0f)|![image](https://github.com/alphagov/govuk-frontend/assets/1253214/5d99b898-ea7a-460f-b2ad-3e362e2a1bce)|
