### PR TITLE
Remove outdated comment in typography helpers

### DIFF
--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -19,10 +19,6 @@
 
   // If the user is using the default GDS Transport font we need to include
   // the font-face declarations.
-  //
-  // We do not need to include the GDS Transport font-face declarations if
-  // alphagov/govuk_template is being used since nta will already be included by
-  // default.
   @if $govuk-include-default-font-face {
     @include _govuk-font-face-gds-transport;
   }


### PR DESCRIPTION
Now that we’ve removed compatibility mode, GOV.UK Frontend no longer supports being used alongside GOV.UK Template.