### PR TITLE
Use Prettier for Nunjucks preview formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,6 @@
         "shared/*",
         "docs/examples/*"
       ],
-      "dependencies": {
-        "puppeteer": "^20.7.2"
-      },
       "devDependencies": {
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
@@ -21340,7 +21337,6 @@
       "version": "2.8.8",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -27613,6 +27609,7 @@
         "marked": "^5.1.0",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
+        "prettier": "^2.8.8",
         "shuffle-seed": "^1.1.6"
       },
       "devDependencies": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -34,6 +34,7 @@
     "marked": "^5.1.0",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
+    "prettier": "^2.8.8",
     "shuffle-seed": "^1.1.6"
   },
   "devDependencies": {

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -1,4 +1,7 @@
+import { inspect } from 'util'
+
 import { outdent } from 'outdent'
+import { format } from 'prettier'
 
 import { componentNameToMacroName } from '../filters/index.mjs'
 
@@ -12,11 +15,25 @@ import { componentNameToMacroName } from '../filters/index.mjs'
 export function getNunjucksCode (componentName, params) {
   const macroName = componentNameToMacroName(componentName)
 
+  // Allow nested HTML strings to wrap at `\n`
+  const paramsFormatted = inspect(params, {
+    compact: false,
+    depth: Infinity,
+    maxArrayLength: Infinity,
+    maxStringLength: Infinity
+  })
+
+  // Format Nunjucks safely with double quotes
+  const macroFormatted = format(`${macroName}(${paramsFormatted})`, {
+    parser: 'espree',
+    semi: false,
+    singleQuote: false,
+    trailingComma: 'none'
+  })
+
   return outdent`
     {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
 
-    {{ ${macroName}(${
-      JSON.stringify(params, undefined, 2)
-    }) }}
+    {{ ${macroFormatted.trim()} }}
   `
 }


### PR DESCRIPTION
This PR switches to Prettier for Nunjucks component previews

We currently use `JSON.stringify()` on our Nunjucks component params which has some issues

## Before

* Param keys are double quoted
* Param values escape quotes and new lines with `\"` and `\n`
* Nested HTML is forced onto a single unformatted line

```njk
{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

{{ govukCheckboxes({
  "name": "nationality",
  "items": [
    {
      "value": "british",
      "text": "British"
    },
    {
      "value": "irish",
      "text": "Irish"
    },
    {
      "value": "other",
      "text": "Citizen of another country",
      "conditional": {
        "html": "<div class=\"govuk-form-group\">\n  <label class=\"govuk-label\" for=\"other-country\">\n    Country\n  </label>\n<input class=\"govuk-input\" id=\"other-country\" name=\"other-country\" type=\"text\" value=\"Ravka\">\n</div>\n"
      }
    }
  ],
  "values": [
    "british",
    "other"
  ]
}) }}
```

## After

* Param keys are not quoted
* Param values optionally use single quotes (when enclosing double quotes)
* Nested HTML uses string joining to preserve formatting

```njk
{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

{{ govukCheckboxes({
  name: "nationality",
  items: [
    {
      value: "british",
      text: "British"
    },
    {
      value: "irish",
      text: "Irish"
    },
    {
      value: "other",
      text: "Citizen of another country",
      conditional: {
        html:
          '<div class="govuk-form-group">\n' +
          '  <label class="govuk-label" for="other-country">\n' +
          "    Country\n" +
          "  </label>\n" +
          '<input class="govuk-input" id="other-country" name="other-country" type="text" value="Ravka">\n' +
          "</div>\n"
      }
    }
  ],
  values: ["british", "other"]
}) }}
```