### PR TITLE
Remove TypeDoc export warning for private `I18n`

### DIFF
--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -18,7 +18,6 @@ module.exports = {
 
   // Ignore warnings about CharacterCountTranslations using I18n (@private)
   intentionallyNotExported: [
-    'I18n',
     'TranslationPluralForms'
   ]
 }


### PR DESCRIPTION
This PR removes [i18n](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/i18n.mjs#L7) from our TypeDoc (JSDoc generator) `intentionallyNotExported` config

In JSDoc we'd marked [i18n](https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/i18n.mjs#L7) as `@private` yet appended it to `@public` properties such as:

```mjs
this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
```

But those properties are also now `@private` so we can remove the config and stop this warning:

```console
[warning] The following symbols were marked as intentionally not exported, but were either not referenced in the documentation, or were exported:
	I18n
```