### PR TITLE
Remove Prettier warning for GOV.UK Prototype Kit config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,3 +16,4 @@ vendor/
 
 # Files to ignore
 package-lock.json
+govuk-prototype-kit.config.json

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,8 @@
+/**
+ * Prettier config
+ *
+ * @type {import('prettier').Config}
+ */
 module.exports = {
   semi: false,
   singleQuote: true,


### PR DESCRIPTION
We recently moved the GOV.UK Prototype Kit config from `govuk-frontend/dist` → `../`

* https://github.com/alphagov/govuk-frontend/pull/3623

But Prettier now tries to lint it when built:

```console
Checking formatting...
[warn] packages/govuk-frontend/govuk-prototype-kit.config.json
[warn] Code style issues found in the above file. Forgot to run Prettier?
```

This PR configures Prettier to ignore `govuk-prototype-kit.config.json`