### PR TITLE
Schedule GitHub Action “Tests” on Ubuntu + Windows

### DIFF
--- a/.github/workflows/tests-scheduled.yml
+++ b/.github/workflows/tests-scheduled.yml
@@ -1,0 +1,28 @@
+name: Tests (Scheduled)
+
+on:
+  workflow_dispatch:
+
+  # Run every weekday at 10:30 AM
+  schedule:
+    - cron: '30 10 * * 1-5'
+
+jobs:
+  test:
+    name: Tests (${{ matrix.runner.name }})
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - name: Ubuntu
+            os: ubuntu-latest
+
+          - name: Windows
+            os: windows-latest
+
+    uses: ./.github/workflows/tests.yml
+    secrets: inherit
+    with:
+      runner: ${{ matrix.runner.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,12 @@ on:
       - 'feature/**'
       - 'support/**'
 
+  workflow_call:
+    inputs:
+      runner:
+        description: Run tests on
+        type: string
+
   workflow_dispatch:
     inputs:
       runner:


### PR DESCRIPTION
This PR schedules our [GitHub Actions **Tests** workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml) to run daily on:

1. Ubuntu
2. Windows

<img width="341" alt="GitHub Actions multi-platform run" src="https://github.com/alphagov/govuk-frontend/assets/415517/b859cc67-de42-4077-b987-74ca15d078cd">

Closes https://github.com/alphagov/govuk-frontend/issues/3638