### PR TITLE
[SPIKE] Dropzone interface for file upload component

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -5,6 +5,7 @@ import { CharacterCount } from './components/character-count/character-count.mjs
 import { Checkboxes } from './components/checkboxes/checkboxes.mjs'
 import { Details } from './components/details/details.mjs'
 import { ErrorSummary } from './components/error-summary/error-summary.mjs'
+import { FileUpload } from './components/file-upload/file-upload.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
 import { Radios } from './components/radios/radios.mjs'
@@ -56,6 +57,11 @@ function initAll (config) {
   if ($errorSummary) {
     new ErrorSummary($errorSummary, config.errorSummary).init()
   }
+
+  const $fileUploads = $scope.querySelectorAll('[data-module="govuk-file-upload"]')
+  $fileUploads.forEach(($fileUpload) => {
+    new FileUpload($fileUpload).init()
+  })
 
   // Find first header module to enhance.
   const $header = $scope.querySelector('[data-module="govuk-header"]')

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -60,7 +60,7 @@
     @include govuk-font($size: 19);
     @include govuk-text-colour;
     padding: $component-padding;
-    border: 2px dashed govuk-colour("mid-grey");
+    border: 2px dashed $govuk-border-colour;
     background-color: govuk-colour("white");
   }
 
@@ -75,5 +75,9 @@
 
   .govuk-file-upload-dropzone--visible .govuk-file-upload-dropzone__hint {
     display: block;
+  }
+
+  .govuk-file-upload-dropzone--hovered .govuk-file-upload-dropzone__hint {
+    border-color: $govuk-success-colour;
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/_index.scss
@@ -47,4 +47,33 @@
       cursor: not-allowed;
     }
   }
+
+  // =========================================================
+  // Drop zone
+  // =========================================================
+
+  .govuk-file-upload-dropzone {
+    position: relative;
+  }
+
+  .govuk-file-upload-dropzone__hint {
+    @include govuk-font($size: 19);
+    @include govuk-text-colour;
+    padding: $component-padding;
+    border: 2px dashed govuk-colour("mid-grey");
+    background-color: govuk-colour("white");
+  }
+
+  .govuk-file-upload-dropzone--visible .govuk-file-upload {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+  }
+
+  .govuk-file-upload-dropzone--visible .govuk-file-upload-dropzone__hint {
+    display: block;
+  }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -1,0 +1,101 @@
+/**
+ * File upload (drag and drop) component
+ *
+ * This is currently only initialised if the dropzone option has been activated.
+ */
+export class FileUpload {
+  /**
+   * @param {Element} $module - HTML element to use for the dropzone
+   */
+  constructor ($module) {
+    if (!$module) {
+      return
+    }
+
+    /** @private */
+    this.$module = $module
+
+    /** @private */
+    this.$input = $module.querySelector('.govuk-file-upload')
+
+    /** @private */
+    this.dropzoneVisibleClass = 'govuk-file-upload-dropzone--visible'
+
+    /** @private */
+    this.dropzoneTimeoutId = null
+  }
+
+  /** Initialise component */
+  init () {
+    this.build()
+  }
+
+  /**
+   * Perform all the steps necessary to get the component activated. At the
+   * moment, this is just binding a bunch of events.
+   *
+   * @private
+   */
+  build () {
+    // Bind event listeners
+    document.addEventListener('dragover', this.handleDragOver.bind(this))
+    document.addEventListener('dragleave', this.handleDragLeave.bind(this))
+    this.$input.addEventListener('drop', this.handleDragLeave.bind(this))
+  }
+
+  /**
+   * Utility function to 'undo' everything this module sets up, just in case
+   * it's needed in future or for testing and the like.
+   *
+   * @private
+   */
+  destroy () {
+    // Remove event listeners
+    document.removeEventListener('dragover', this.handleDragOver.bind(this))
+    document.removeEventListener('dragleave', this.handleDragLeave.bind(this))
+    this.$input.removeEventListener('drop', this.handleDragLeave.bind(this))
+
+    // Ensure the active class is removed in case this is called mid-drag
+    this.$module.classList.remove(this.dropzoneVisibleClass)
+  }
+
+  /**
+   * Show the dropzone if the user drags a file over any part of the webpage.
+   *
+   * @private
+   * @param {DragEvent} event - Dragging event
+   */
+  handleDragOver (event) {
+    // Back out if the things we need to check don't exist
+    if (!event || !event.dataTransfer || !event.dataTransfer.types) {
+      return
+    }
+
+    // Determine whether the thing being dragged is a file, without regard for
+    // what kind of file it is. If it's not a file, just stop, we don't care.
+    if (event.dataTransfer.types.indexOf('Files') === -1) {
+      return
+    }
+
+    // Add the class so that the drop area styles become visible
+    this.$module.classList.add(this.dropzoneVisibleClass)
+  }
+
+  /**
+   * Hide the dropzone if the user stops dragging a file over the webpage, or
+   * has dropped the file. Chrome and Safari fire the dragleave event constantly
+   * so we set a timeout on actually hiding the interface to avoid flickering.
+   *
+   * @private
+   */
+  handleDragLeave () {
+    // Clear the timeout if one is already running
+    clearTimeout(this.dropzoneTimeoutId)
+
+    // Wait 250 ms before actually removing the class. This is annoyingly a
+    // magic number. No real basis other than it works, usually.
+    this.dropzoneTimeoutId = setTimeout(() => {
+      this.$module.classList.remove(this.dropzoneVisibleClass)
+    }, 250)
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.mjs
@@ -8,8 +8,8 @@ export class FileUpload {
    * @param {Element} $module - HTML element to use for the dropzone
    */
   constructor ($module) {
-    if (!$module) {
-      return
+    if (!($module instanceof HTMLElement)) {
+      return this
     }
 
     /** @private */
@@ -20,9 +20,13 @@ export class FileUpload {
 
     /** @private */
     this.dropzoneVisibleClass = 'govuk-file-upload-dropzone--visible'
+    /** @private */
+    this.dropzoneHoveredClass = 'govuk-file-upload-dropzone--hovered'
 
     /** @private */
-    this.dropzoneTimeoutId = null
+    this.viewportTimeoutId = null
+    /** @private */
+    this.inputTimeoutId = null
   }
 
   /** Initialise component */
@@ -35,12 +39,19 @@ export class FileUpload {
    * moment, this is just binding a bunch of events.
    *
    * @private
+   * @returns {this|void} - Will return `this` if not all elements are defined
    */
   build () {
+    if (!(this.$input instanceof HTMLElement)) {
+      return this
+    }
+
     // Bind event listeners
-    document.addEventListener('dragover', this.handleDragOver.bind(this))
-    document.addEventListener('dragleave', this.handleDragLeave.bind(this))
-    this.$input.addEventListener('drop', this.handleDragLeave.bind(this))
+    document.addEventListener('dragover', this.handleViewportDragOver.bind(this))
+    document.addEventListener('dragleave', this.handleViewportDragLeave.bind(this))
+    this.$input.addEventListener('dragover', this.handleInputDragOver.bind(this))
+    this.$input.addEventListener('dragleave', this.handleInputDragLeave.bind(this))
+    this.$input.addEventListener('drop', this.handleDrop.bind(this))
   }
 
   /**
@@ -48,15 +59,45 @@ export class FileUpload {
    * it's needed in future or for testing and the like.
    *
    * @private
+   * @returns {this|void} - Will return `this` if not all elements are defined
    */
   destroy () {
+    if (!(this.$input instanceof HTMLElement)) {
+      return this
+    }
+
     // Remove event listeners
-    document.removeEventListener('dragover', this.handleDragOver.bind(this))
-    document.removeEventListener('dragleave', this.handleDragLeave.bind(this))
-    this.$input.removeEventListener('drop', this.handleDragLeave.bind(this))
+    document.removeEventListener('dragover', this.handleViewportDragOver.bind(this))
+    document.removeEventListener('dragleave', this.handleViewportDragLeave.bind(this))
+    this.$input.removeEventListener('dragover', this.handleInputDragOver.bind(this))
+    this.$input.removeEventListener('dragleave', this.handleInputDragLeave.bind(this))
+    this.$input.removeEventListener('drop', this.handleDrop.bind(this))
 
     // Ensure the active class is removed in case this is called mid-drag
     this.$module.classList.remove(this.dropzoneVisibleClass)
+  }
+
+  /**
+   * Helper function to determine if the thing being dragged is a file or not.
+   *
+   * @private
+   * @param {DragEvent} event - Dragging event
+   * @returns {boolean} - Whether it's a file or not
+   */
+  draggableIsFile (event) {
+    // Back out if the things we need to check don't exist
+    if (!event || !event.dataTransfer || !event.dataTransfer.types) {
+      return false
+    }
+
+    // Determine whether the thing being dragged is a file, without regard for
+    // what kind of file it is. If it's not a file, just stop, we don't care.
+    if (event.dataTransfer.types.indexOf('Files') === -1) {
+      return false
+    }
+
+    // If we got this far it's probably a file
+    return true
   }
 
   /**
@@ -65,37 +106,66 @@ export class FileUpload {
    * @private
    * @param {DragEvent} event - Dragging event
    */
-  handleDragOver (event) {
-    // Back out if the things we need to check don't exist
-    if (!event || !event.dataTransfer || !event.dataTransfer.types) {
-      return
+  handleViewportDragOver (event) {
+    if (this.draggableIsFile(event)) {
+      // Add the class so that the drop area styles become visible
+      this.$module.classList.add(this.dropzoneVisibleClass)
     }
-
-    // Determine whether the thing being dragged is a file, without regard for
-    // what kind of file it is. If it's not a file, just stop, we don't care.
-    if (event.dataTransfer.types.indexOf('Files') === -1) {
-      return
-    }
-
-    // Add the class so that the drop area styles become visible
-    this.$module.classList.add(this.dropzoneVisibleClass)
   }
 
   /**
-   * Hide the dropzone if the user stops dragging a file over the webpage, or
-   * has dropped the file. Chrome and Safari fire the dragleave event constantly
-   * so we set a timeout on actually hiding the interface to avoid flickering.
+   * Hide the dropzone if the user stops dragging a file over the webpage.
+   * Chrome and Safari fire the dragleave event constantly so we set a timeout
+   * on actually hiding the interface to avoid flickering.
    *
    * @private
    */
-  handleDragLeave () {
+  handleViewportDragLeave () {
     // Clear the timeout if one is already running
-    clearTimeout(this.dropzoneTimeoutId)
+    clearTimeout(this.viewportTimeoutId)
 
     // Wait 250 ms before actually removing the class. This is annoyingly a
     // magic number. No real basis other than it works, usually.
-    this.dropzoneTimeoutId = setTimeout(() => {
+    this.viewportTimeoutId = setTimeout(() => {
       this.$module.classList.remove(this.dropzoneVisibleClass)
     }, 250)
+  }
+
+  /**
+   * Draw emphasis to the dropzone if the user has dragged a file over it
+   * specifically, helping a user to recognise that they can safely drop it.
+   *
+   * @private
+   * @param {DragEvent} event - Dragging event
+   */
+  handleInputDragOver (event) {
+    if (this.draggableIsFile(event)) {
+      this.$module.classList.add(this.dropzoneHoveredClass)
+    }
+  }
+
+  /**
+   * Remove emphasis on the dropzone if the user stopped dragging a file over it.
+   *
+   * @private
+   */
+  handleInputDragLeave () {
+    // Clear the timeout if one is already running
+    clearTimeout(this.inputTimeoutId)
+
+    // Wait 250 ms before actually removing the class. This is annoyingly a
+    // magic number. No real basis other than it works, usually.
+    this.inputTimeoutId = setTimeout(() => {
+      this.$module.classList.remove(this.dropzoneHoveredClass)
+    }, 250)
+  }
+
+  /**
+   * Hide the dropzone if the user has dropped a file on it.
+   *
+   * @private
+   */
+  handleDrop () {
+    this.$module.classList.remove(this.dropzoneVisibleClass, this.dropzoneHoveredClass)
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -100,6 +100,21 @@ examples:
         text: Upload a file
       formGroup:
         classes: extra-class
+  - name: with drop zone
+    data:
+      id: file-upload-dropzone
+      name: file-upload-dropzone
+      label:
+        text: Upload a file
+      dropzone: true
+  - name: with custom drop zone text
+    data:
+      id: file-upload-dropzone
+      name: file-upload-dropzone
+      label:
+        text: Llwythwch ffeil i fyny
+      dropzone:
+        text: Gollyngwch ffeil yma i'w ddewis
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.njk
@@ -5,6 +5,27 @@
 {#- a record of other elements that we need to associate with the input using
   aria-describedby – for example hints or error messages -#}
 {% set describedBy = params.describedBy if params.describedBy else "" %}
+
+{% if params.hint %}
+  {% set hintId = params.id + '-hint' %}
+  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
+{% endif %}
+
+{% if params.errorMessage %}
+  {% set errorId = params.id + '-error' %}
+  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
+{% endif %}
+
+{#- define the actual input separately as we place it in different contexts
+  depending on whether dropper functionality is active -#}
+{% set fileInputHtml %}
+  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
+  {%- if params.value %} value="{{ params.value }}"{% endif %}
+  {%- if params.disabled %} disabled{% endif %}
+  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
+  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+{% endset %}
+
 <div class="govuk-form-group {%- if params.errorMessage %} govuk-form-group--error{% endif %} {%- if params.formGroup.classes %} {{ params.formGroup.classes }}{% endif %}">
   {{ govukLabel({
     html: params.label.html,
@@ -15,8 +36,6 @@
     for: params.id
   }) | indent(2) | trim }}
 {% if params.hint %}
-  {% set hintId = params.id + '-hint' %}
-  {% set describedBy = describedBy + ' ' + hintId if describedBy else hintId %}
   {{ govukHint({
     id: hintId,
     classes: params.hint.classes,
@@ -26,8 +45,6 @@
   }) | indent(2) | trim }}
 {% endif %}
 {% if params.errorMessage %}
-  {% set errorId = params.id + '-error' %}
-  {% set describedBy = describedBy + ' ' + errorId if describedBy else errorId %}
   {{ govukErrorMessage({
     id: errorId,
     classes: params.errorMessage.classes,
@@ -37,9 +54,14 @@
     visuallyHiddenText: params.errorMessage.visuallyHiddenText
   }) | indent(2) | trim }}
 {% endif %}
-  <input class="govuk-file-upload {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-file-upload--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="file"
-  {%- if params.value %} value="{{ params.value }}"{% endif %}
-  {%- if params.disabled %} disabled{% endif %}
-  {%- if describedBy %} aria-describedby="{{ describedBy }}"{% endif %}
-  {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+  {%- if params.dropzone %}
+    <div class="govuk-file-upload-dropzone" data-module="govuk-file-upload">
+      {{ fileInputHtml | safe }}
+      <div class="govuk-file-upload-dropzone__hint" hidden>
+        {{- params.dropzone.html | safe if params.dropzone.html else params.dropzone.text | default("Drop a file here to select it") -}}
+      </div>
+    </div>
+  {% else %}
+    {{ fileInputHtml | safe }}
+  {%- endif %}
 </div>


### PR DESCRIPTION
One of the items flagged in the recent audit of Frontend was the lack of a user interface indicating that files could be dragged and dropped into the [File Upload component](https://design-system.service.gov.uk/components/file-upload/).

- #3685

Putting aside that our file upload component is the browser's native control with only light style customisations (and the usability issue is probably the onus of browser vendors, not us), I figured I'd do a technical spike of how we could do something about it in Frontend. 

This is principally a technical prototype. It is intentionally very basic and ugly, and probably not as accessible as it could be, but it does (basically) what it says on the tin.

## Screenshots

### Initial state

Appears as a standard, native file input.

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/02aceb92-0a2c-4449-b4c5-10c0afbec51c)

### With a file dragged over the viewport

A previously hidden div with a dashed grey border and instructions that the user can drop a file here are revealed. The native file input is hidden.

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/a45da14a-a308-480d-b0ee-152bba64f3ac)

### With a file dragged over the dropzone

The div with instructions gains a more prominently coloured border when the user's cursor is within the bounds of it, indicating that it is safe to drop the file.

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/7ca441b8-3501-4a76-8ba9-021ef3fc885f)

### After a file is dropped

The component returns to only showing the native file input, with the value correctly set.

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/3425255a-2e7a-4586-b5f7-78ad06cb1da6)
