### PR TITLE
Migrate to `import { initAll }` from ES module bundle

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,9 @@ module.exports = function (api) {
 
   const presets = [
     ['@babel/preset-env', {
+      exclude: [
+        'transform-dynamic-import'
+      ],
       targets: {
         node: 'current'
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27789,6 +27789,7 @@
       "devDependencies": {
         "@axe-core/puppeteer": "^4.7.3",
         "cheerio": "^1.0.0-rc.12",
+        "govuk-frontend": "*",
         "govuk-frontend-config": "*",
         "govuk-frontend-lib": "*",
         "jest-axe": "^7.0.1",

--- a/packages/govuk-frontend-review/rollup.config.mjs
+++ b/packages/govuk-frontend-review/rollup.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig(({ i: input }) => ({
    * Output options
    */
   output: {
-    format: 'iife',
+    format: 'es',
 
     /**
      * Output plugins

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -112,7 +112,7 @@ export default async () => {
     const componentName = req.params.componentName
     const exampleName = req.params.exampleName || 'default'
 
-    const previewLayout = res.locals.componentData?.previewLayout || 'layout'
+    const previewLayout = res.locals.componentData?.previewLayout
 
     const exampleConfig = res.locals.componentData?.examples.find(
       example => example.name.replace(/ /g, '-') === exampleName

--- a/packages/govuk-frontend-review/src/javascripts/all.mjs
+++ b/packages/govuk-frontend-review/src/javascripts/all.mjs
@@ -1,4 +1,1 @@
-import * as GOVUKFrontend from 'govuk-frontend'
-
-// @ts-expect-error Manually add globals to window for tests
-window.GOVUKFrontend = GOVUKFrontend
+export * from 'govuk-frontend'

--- a/packages/govuk-frontend-review/src/views/component-preview.njk
+++ b/packages/govuk-frontend-review/src/views/component-preview.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/" + previewLayout + ".njk" %}
+{% extends "layouts/" + previewLayout | default('layout') + ".njk" %}
 
 {% set bodyClasses %}
   {{ bodyClasses }}

--- a/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
@@ -45,11 +45,10 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="/javascripts/all.min.js"></script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
   <script type="module">
+    import { initAll } from '/javascripts/all.bundle.min.mjs'
     const $scope = document.getElementById('scoped')
-    window.GOVUKFrontend.initAll({
-      scope: $scope
-    })
+    initAll({ scope: $scope })
   </script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
@@ -121,7 +121,10 @@
 
 {% block bodyEnd %}
   <!-- block:bodyEnd -->
-  <script type="module" src="/javascripts/all.min.js"></script>
-  <script type="module">window.GOVUKFrontend.initAll()</script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
+  <script type="module">
+    import { initAll } from '/javascripts/all.bundle.min.mjs'
+    initAll()
+  </script>
   <!-- endblock:bodyEnd -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
@@ -12,7 +12,10 @@
 
 {% block bodyEnd %}
   <!-- block:bodyEnd -->
-  <script type="module" src="/javascripts/all.min.js"></script>
-  <script type="module">window.GOVUKFrontend.initAll()</script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
+  <script type="module">
+    import { initAll } from '/javascripts/all.bundle.min.mjs'
+    initAll()
+  </script>
   <!-- endblock:bodyEnd -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -937,18 +937,19 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="/javascripts/all.min.js"></script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
   <script type="module">
-    window.GOVUKFrontend.initAll({
+    import { initAll } from '/javascripts/all.bundle.min.mjs'
+    initAll({
       accordion: {
         i18n: {
-          showAllSections: "Dangos adrannau",
-          hideAllSections: "Cuddio adrannau",
+          showAllSections: 'Dangos adrannau',
+          hideAllSections: 'Cuddio adrannau',
         },
-        "i18n.showSection": "Dangos",
-        "i18n.showSectionAriaLabel": "Dangos adran",
-        "i18n.hideSection": "Cuddio",
-        "i18n.hideSectionAriaLabel": "Cuddio adran"
+        'i18n.showSection': 'Dangos',
+        'i18n.showSectionAriaLabel': 'Dangos adran',
+        'i18n.hideSection': 'Cuddio',
+        'i18n.hideSectionAriaLabel': 'Cuddio adran'
       }
     })
   </script>

--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -15,6 +15,9 @@
 {% set mainClasses = 'govuk-main-wrapper--auto-spacing' %}
 
 {% block bodyEnd %}
-  <script type="module" src="/javascripts/all.min.js"></script>
-  <script type="module">window.GOVUKFrontend.initAll()</script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
+  <script type="module">
+    import { initAll } from '/javascripts/all.bundle.min.mjs'
+    initAll()
+  </script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
+++ b/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
@@ -14,5 +14,5 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="/javascripts/all.min.js"></script>
+  <script type="module" src="/javascripts/all.bundle.min.mjs"></script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
+++ b/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
@@ -1,17 +1,18 @@
-<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8"/>
-    <title>Test Boilerplate</title>
-    <link rel="stylesheet" href="/stylesheets/app.min.css">
-  </head>
-  <body class="govuk-template__body">
-    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+{% extends "component-preview.njk" %}
+
+{% set pageTitle = "Test boilerplate" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block content %}
+  <div class="app-whitespace-highlight">
     <h1 class="govuk-heading-l">Test boilerplate</h1>
     <p class="govuk-body">
       Used during testing to inject rendered components and test specific configurations
     </p>
     <div id="slot"></div>
-    <script type="module" src="/javascripts/all.min.js"></script>
-  </body>
-</html>
+  </div>
+{% endblock %}
+
+{% block bodyEnd %}
+  <script type="module" src="/javascripts/all.min.js"></script>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
+++ b/packages/govuk-frontend-review/src/views/tests/boilerplate.njk
@@ -3,6 +3,13 @@
 {% set pageTitle = "Test boilerplate" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
+{% block head %}
+  {{ super() }}
+  <script type="importmap">
+    { "imports": { "govuk-frontend": "/javascripts/all.bundle.min.mjs" } }
+  </script>
+{% endblock %}
+
 {% block content %}
   <div class="app-whitespace-highlight">
     <h1 class="govuk-heading-l">Test boilerplate</h1>

--- a/packages/govuk-frontend-review/tasks/scripts.mjs
+++ b/packages/govuk-frontend-review/tasks/scripts.mjs
@@ -18,9 +18,9 @@ export const compile = (options) => gulp.series(
       destPath: join(options.destPath, 'javascripts'),
       configPath: join(options.basePath, 'rollup.config.mjs'),
 
-      // Rename with `*.min.js` extension
+      // Rename with `*.bundle.min.mjs` extension
       filePath ({ dir, name }) {
-        return join(dir, `${name}.min.js`)
+        return join(dir, `${name}.bundle.min.mjs`)
       }
     })
   ),

--- a/packages/govuk-frontend/postcss.config.mjs
+++ b/packages/govuk-frontend/postcss.config.mjs
@@ -2,7 +2,7 @@ import autoprefixer from 'autoprefixer'
 import cssnano from 'cssnano'
 import cssnanoPresetDefault from 'cssnano-preset-default'
 import { pkg } from 'govuk-frontend-config'
-import { isDev } from 'govuk-frontend-tasks/helpers/task-arguments.mjs'
+import { isDev } from 'govuk-frontend-tasks/helpers/task-arguments.js'
 import postcss from 'postcss'
 import scss from 'postcss-scss'
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -18,14 +18,12 @@ describe('/components/button', () => {
     it('does not prevent further JavaScript from running', async () => {
       await goTo(page, '/tests/boilerplate')
 
-      const result = await page.evaluate((component) => {
-        const namespace = 'GOVUKFrontend' in window
-          ? window.GOVUKFrontend
-          : {}
+      const result = await page.evaluate(async (exportName) => {
+        const namespace = await import('govuk-frontend')
 
         // `undefined` simulates the element being missing,
         // from an unchecked `document.querySelector` for example
-        new namespace[component](undefined).init()
+        new namespace[exportName](undefined).init()
 
         // If our component initialisation breaks, this won't run
         return true

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -648,17 +648,14 @@ describe('Character count', () => {
           // Override maxlength to 10
           maxlength: 10
         },
-        initialiser ({ config, namespace }) {
-          const $component = document.querySelector('[data-module]')
-
+        initialiser ($module) {
           // Set locale to Welsh, which expects translations for 'one', 'two',
           // 'few' 'many' and 'other' forms – with the default English strings
           // provided we only have translations for 'one' and 'other'.
           //
           // We want to make sure we handle this gracefully in case users have
           // an existing character count inside an incorrect locale.
-          $component.setAttribute('lang', 'cy')
-          new namespace.CharacterCount($component, config).init()
+          $module.setAttribute('lang', 'cy')
         }
       })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
@@ -1,4 +1,4 @@
-const { goToComponent, goToExample, renderAndInitialise } = require('govuk-frontend-helpers/puppeteer')
+const { goToComponent, goToExample, renderAndInitialise, goTo } = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('Error Summary', () => {
@@ -82,14 +82,14 @@ describe('Error Summary', () => {
 
     describe('using JavaScript configuration, with no elements on the page', () => {
       it('does not prevent further JavaScript from running', async () => {
-        const result = await page.evaluate((component) => {
-          const namespace = 'GOVUKFrontend' in window
-            ? window.GOVUKFrontend
-            : {}
+        await goTo(page, '/tests/boilerplate')
+
+        const result = await page.evaluate(async (exportName) => {
+          const namespace = await import('govuk-frontend')
 
           // `undefined` simulates the element being missing,
           // from an unchecked `document.querySelector` for example
-          new namespace[component](undefined).init()
+          new namespace[exportName](undefined).init()
 
           // If our component initialisation breaks, this won't run
           return true

--- a/packages/govuk-frontend/src/govuk/components/globals.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/globals.test.mjs
@@ -5,23 +5,19 @@ describe('GOV.UK Frontend', () => {
     let exported
 
     beforeEach(async () => {
-      await goTo(page, '/')
+      await goTo(page, '/tests/boilerplate')
 
-      // Exported via global (e.g GOVUKFrontend.initAll)
-      exported = await page.evaluate(() => 'GOVUKFrontend' in window
-        ? Object.keys(window.GOVUKFrontend)
-        : undefined
+      // Exports available via browser dynamic import
+      exported = await page.evaluate(async () =>
+        Object.keys(await import('govuk-frontend'))
       )
     })
 
     it('exports `initAll` function', async () => {
-      await goTo(page, '/')
+      await goTo(page, '/tests/boilerplate')
 
-      const typeofInitAll = await page.evaluate((utility) => {
-        const namespace = 'GOVUKFrontend' in window
-          ? window.GOVUKFrontend
-          : {}
-
+      const typeofInitAll = await page.evaluate(async (utility) => {
+        const namespace = await import('govuk-frontend')
         return typeof namespace[utility]
       }, 'initAll')
 
@@ -52,10 +48,8 @@ describe('GOV.UK Frontend', () => {
       const components = exported
         .filter(method => !['initAll', 'version'].includes(method))
 
-      const componentsWithoutInitFunctions = await page.evaluate((components) => {
-        const namespace = 'GOVUKFrontend' in window
-          ? window.GOVUKFrontend
-          : {}
+      const componentsWithoutInitFunctions = await page.evaluate(async (components) => {
+        const namespace = await import('govuk-frontend')
 
         return components.filter(component => {
           const prototype = namespace[component].prototype

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@axe-core/puppeteer": "^4.7.3",
     "cheerio": "^1.0.0-rc.12",
+    "govuk-frontend": "*",
     "govuk-frontend-config": "*",
     "govuk-frontend-lib": "*",
     "jest-axe": "^7.0.1",

--- a/shared/helpers/tsconfig.json
+++ b/shared/helpers/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
-  "include": ["**/*.js", "**/*.mjs", "../config", "../lib"]
+  "include": [
+    "**/*.js",
+    "**/*.mjs",
+    "../config",
+    "../lib",
+    "../../packages/govuk-frontend"
+  ],
+  "exclude": ["./dist/**", "../../packages/govuk-frontend/dist/**"]
 }

--- a/shared/tasks/helpers/task-arguments.js
+++ b/shared/tasks/helpers/task-arguments.js
@@ -1,7 +1,7 @@
-import parser from 'yargs-parser'
+const parser = require('yargs-parser')
 
 // Non-flag arguments as tasks
 const { _: tasks } = parser(process.argv)
 
 // Check for development task
-export const isDev = tasks.includes('dev')
+module.exports.isDev = tasks.includes('dev')

--- a/shared/tasks/helpers/task-arguments.unit.test.js
+++ b/shared/tasks/helpers/task-arguments.unit.test.js
@@ -26,35 +26,35 @@ describe('Task arguments', () => {
       it('is flagged false', async () => {
         process.argv = [...argv]
 
-        const { isDev } = await import('./task-arguments.mjs')
+        const { isDev } = require('./task-arguments.js')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:app'", async () => {
         process.argv = [...argv, 'build:app']
 
-        const { isDev } = await import('./task-arguments.mjs')
+        const { isDev } = require('./task-arguments.js')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:package'", async () => {
         process.argv = [...argv, 'build:package']
 
-        const { isDev } = await import('./task-arguments.mjs')
+        const { isDev } = require('./task-arguments.js')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:release'", async () => {
         process.argv = [...argv, 'build:release']
 
-        const { isDev } = await import('./task-arguments.mjs')
+        const { isDev } = require('./task-arguments.js')
         expect(isDev).toBe(false)
       })
 
       it("is flagged true for 'gulp dev'", async () => {
         process.argv = [...argv, 'dev']
 
-        const { isDev } = await import('./task-arguments.mjs')
+        const { isDev } = require('./task-arguments.js')
         expect(isDev).toBe(true)
       })
     })

--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -2,7 +2,7 @@ import runScript from '@npmcli/run-script'
 import { paths } from 'govuk-frontend-config'
 import PluginError from 'plugin-error'
 
-import { isDev } from './helpers/task-arguments.mjs'
+import { isDev } from './helpers/task-arguments.js'
 import { task } from './index.mjs'
 
 /**


### PR DESCRIPTION
This PR follows our switch to ES modules:

* https://github.com/alphagov/govuk-frontend/pull/3769
* https://github.com/alphagov/govuk-frontend/pull/3771

It changes our review app to use ES module `import` not `window.GOVUKFrontend.*` for #3508 

### Before
We include our JavaScript as an IIFE via `<script type="module">`

```html
<script type="module" src="/javascripts/all.min.js"></script>
<script type="module">window.GOVUKFrontend.initAll()</script>
```

### After
We import our JavaScript as an ES module bundle via `<script type="module">`

```html
<script type="module" src="/javascripts/all.bundle.min.mjs"></script>
<script type="module">
  import { initAll } from '/javascripts/all.bundle.min.mjs'
  initAll()
</script>
```

Whilst the first `<script>` is optional we've kept it for the browser preload scanner ([see comment](https://github.com/alphagov/govuk-frontend/pull/3833#discussion_r1234843270))