### PR TITLE
[SPIKE] Babel with ES2018 async `init()` error handling

### DIFF
--- a/docs/examples/webpack/.browserslistrc
+++ b/docs/examples/webpack/.browserslistrc
@@ -1,5 +1,5 @@
 [javascripts]
-> 0.1% in GB and supports es6-module
+> 0.1% in GB and supports es6-module and supports promise-finally
 last 6 Chrome versions
 last 6 Firefox versions
 last 6 Edge versions

--- a/docs/examples/webpack/src/index.html
+++ b/docs/examples/webpack/src/index.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/stylesheets/app.min.css">
   </head>
   <body class="govuk-template__body">
-    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    <script>document.body.className += ' js-enabled' + ('Promise' in window && 'finally' in Promise.prototype && 'noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
     <div class="govuk-width-container">
       <main class="govuk-main-wrapper" id="main-content" role="main">

--- a/docs/examples/webpack/webpack.config.js
+++ b/docs/examples/webpack/webpack.config.js
@@ -128,5 +128,5 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
     errorDetails: true
   },
 
-  target: ['web', 'es2015']
+  target: ['web', 'es2018']
 })

--- a/packages/govuk-frontend-review/.browserslistrc
+++ b/packages/govuk-frontend-review/.browserslistrc
@@ -1,5 +1,5 @@
 [javascripts]
-> 0.1% in GB and supports es6-module
+> 0.1% in GB and supports es6-module and supports promise-finally
 last 6 Chrome versions
 last 6 Firefox versions
 last 6 Edge versions

--- a/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
@@ -49,6 +49,7 @@
   <script type="module">
     import { initAll } from '/javascripts/govuk-frontend-{{ version }}.min.js'
     const $scope = document.getElementById('scoped')
-    initAll({ scope: $scope })
+    initAll({ scope: $scope }).catch((error) =>
+      console.warn('GOV.UK Frontend init failed', error))
   </script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-custom/index.njk
@@ -124,7 +124,8 @@
   <script type="module" src="/javascripts/govuk-frontend-{{ version }}.min.js"></script>
   <script type="module">
     import { initAll } from '/javascripts/govuk-frontend-{{ version }}.min.js'
-    initAll()
+    initAll().catch((error) =>
+      console.warn('GOV.UK Frontend init failed', error))
   </script>
   <!-- endblock:bodyEnd -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/template-default/index.njk
@@ -15,7 +15,8 @@
   <script type="module" src="/javascripts/govuk-frontend-{{ version }}.min.js"></script>
   <script type="module">
     import { initAll } from '/javascripts/govuk-frontend-{{ version }}.min.js'
-    initAll()
+    initAll().catch((error) =>
+      console.warn('GOV.UK Frontend init failed', error))
   </script>
   <!-- endblock:bodyEnd -->
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -951,6 +951,7 @@
         'i18n.hideSection': 'Cuddio',
         'i18n.hideSectionAriaLabel': 'Cuddio adran'
       }
-    })
+    }).catch((error) =>
+      console.warn('GOV.UK Frontend init failed', error))
   </script>
 {% endblock %}

--- a/packages/govuk-frontend-review/src/views/layouts/_generic.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/_generic.njk
@@ -18,6 +18,7 @@
   <script type="module" src="/javascripts/govuk-frontend-{{ version }}.min.js"></script>
   <script type="module">
     import { initAll } from '/javascripts/govuk-frontend-{{ version }}.min.js'
-    initAll()
+    initAll().catch((error) =>
+      console.warn('GOV.UK Frontend init failed', error))
   </script>
 {% endblock %}

--- a/packages/govuk-frontend/.browserslistrc
+++ b/packages/govuk-frontend/.browserslistrc
@@ -2,7 +2,7 @@
 # https://www.gov.uk/service-manual/technology/designing-for-different-browsers-and-devices
 
 [javascripts]
-> 0.1% in GB and supports es6-module
+> 0.1% in GB and supports es6-module and supports promise-finally
 last 6 Chrome versions
 last 6 Firefox versions
 last 6 Edge versions

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -12,8 +12,8 @@ module.exports = {
       excludedFiles: ['**/*.test.mjs'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
-        // Note: Allow ES2015 for import/export syntax
-        ecmaVersion: '2015',
+        // Note: Allow ES2018 for async/await syntax
+        ecmaVersion: '2018',
         project: [resolve(__dirname, 'tsconfig.json')]
       },
       plugins: [
@@ -23,7 +23,7 @@ module.exports = {
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
-        'plugin:es-x/restrict-to-es2015'
+        'plugin:es-x/restrict-to-es2018'
       ],
       env: {
         browser: true

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -17,8 +17,9 @@ import { Tabs } from './components/tabs/tabs.mjs'
  * components provided as part of GOV.UK Frontend.
  *
  * @param {Config} [config] - Config for all components
+ * @returns {Promise<void>}
  */
-function initAll (config) {
+async function initAll (config) {
   config = typeof config !== 'undefined' ? config : {}
 
   // Skip initialisation when GOV.UK Frontend is not supported
@@ -26,62 +27,69 @@ function initAll (config) {
     return
   }
 
+  /**
+   * @type {Promise<Component>[]}
+   */
+  const initList = []
+
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
   const $scope = config.scope instanceof HTMLElement ? config.scope : document
 
   const $accordions = $scope.querySelectorAll('[data-module="govuk-accordion"]')
   $accordions.forEach(($accordion) => {
-    new Accordion($accordion, config.accordion).init()
+    initList.push(new Accordion($accordion, config.accordion).init())
   })
 
   const $buttons = $scope.querySelectorAll('[data-module="govuk-button"]')
   $buttons.forEach(($button) => {
-    new Button($button, config.button).init()
+    initList.push(new Button($button, config.button).init())
   })
 
   const $characterCounts = $scope.querySelectorAll('[data-module="govuk-character-count"]')
   $characterCounts.forEach(($characterCount) => {
-    new CharacterCount($characterCount, config.characterCount).init()
+    initList.push(new CharacterCount($characterCount, config.characterCount).init())
   })
 
   const $checkboxes = $scope.querySelectorAll('[data-module="govuk-checkboxes"]')
   $checkboxes.forEach(($checkbox) => {
-    new Checkboxes($checkbox).init()
+    initList.push(new Checkboxes($checkbox).init())
   })
 
   // Find first error summary module to enhance.
   const $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
   if ($errorSummary) {
-    new ErrorSummary($errorSummary, config.errorSummary).init()
+    initList.push(new ErrorSummary($errorSummary, config.errorSummary).init())
   }
 
   // Find first header module to enhance.
   const $header = $scope.querySelector('[data-module="govuk-header"]')
   if ($header) {
-    new Header($header).init()
+    initList.push(new Header($header).init())
   }
 
   const $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')
   $notificationBanners.forEach(($notificationBanner) => {
-    new NotificationBanner($notificationBanner, config.notificationBanner).init()
+    initList.push(new NotificationBanner($notificationBanner, config.notificationBanner).init())
   })
 
   const $radios = $scope.querySelectorAll('[data-module="govuk-radios"]')
   $radios.forEach(($radio) => {
-    new Radios($radio).init()
+    initList.push(new Radios($radio).init())
   })
 
   // Find first skip link module to enhance.
   const $skipLink = $scope.querySelector('[data-module="govuk-skip-link"]')
   if ($skipLink) {
-    new SkipLink($skipLink).init()
+    initList.push(new SkipLink($skipLink).init())
   }
 
   const $tabs = $scope.querySelectorAll('[data-module="govuk-tabs"]')
   $tabs.forEach(($tabs) => {
-    new Tabs($tabs).init()
+    initList.push(new Tabs($tabs).init())
   })
+
+  await Promise.all(initList)
 }
 
 export {
@@ -100,6 +108,12 @@ export {
   SkipLink,
   Tabs
 }
+
+/**
+ * Component types
+ *
+ * @typedef {Accordion | Button | CharacterCount | Checkboxes | ErrorSummary | Header | NotificationBanner | Radios | SkipLink | Tabs} Component
+ */
 
 /**
  * Config for all components via `initAll()`

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -138,11 +138,13 @@ export class Accordion {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<Accordion>} Accordion component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$sections) {
-      return
+      throw new Error("Component 'Accordion' is missing '$module' or '$sections' fields")
     }
 
     this.initControls()
@@ -151,6 +153,8 @@ export class Accordion {
     // See if "Show all sections" button text should be updated
     const areAllSectionsOpen = this.checkIfAllSectionsOpen()
     this.updateShowAllButton(areAllSectionsOpen)
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -44,15 +44,19 @@ export class Button {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<Button>} Button component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module) {
-      return
+      throw new Error("Component 'Button' is missing '$module' field")
     }
 
     this.$module.addEventListener('keydown', (event) => this.handleKeyDown(event))
     this.$module.addEventListener('click', (event) => this.debounce(event))
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -23,7 +23,8 @@ describe('/components/button', () => {
 
         // `undefined` simulates the element being missing,
         // from an unchecked `document.querySelector` for example
-        new namespace[exportName](undefined).init()
+        new namespace[exportName](undefined).init().catch((error) =>
+          console.warn(`Component '${exportName}' init failed`, error))
 
         // If our component initialisation breaks, this won't run
         return true

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -123,17 +123,19 @@ export class CharacterCount {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<CharacterCount>} Character count component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$textarea) {
-      return
+      throw new Error("Component 'Character count' is missing '$module' or '$textarea' field")
     }
 
     const $textarea = this.$textarea
     const $textareaDescription = document.getElementById(`${$textarea.id}-info`)
     if (!$textareaDescription) {
-      return
+      throw new Error(`Component 'Character count' is missing selector '#${$textarea.id}-info' selector`)
     }
 
     // Inject a description for the textarea if none is present already
@@ -182,6 +184,8 @@ export class CharacterCount {
     // could be called after those events have fired, for example if they are
     // added to the page dynamically, so update now too.
     this.updateCountMessage()
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -39,11 +39,13 @@ export class Checkboxes {
    * We also need to restore the state of any conditional reveals on the page (for
    * example if the user has navigated back), and set up event handlers to keep
    * the reveal in sync with the checkbox state.
+   *
+   * @returns {Promise<Checkboxes>} Checkboxes component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$inputs) {
-      return
+      throw new Error("Component 'Checkboxes' is missing '$module' or '$inputs' fields")
     }
 
     this.$inputs.forEach(($input) => {
@@ -73,6 +75,8 @@ export class Checkboxes {
 
     // Handle events
     this.$module.addEventListener('click', (event) => this.handleClick(event))
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -44,15 +44,19 @@ export class ErrorSummary {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<ErrorSummary>} Error summary component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module) {
-      return
+      throw new Error("Component 'Error summary' is missing '$module' field")
     }
 
     this.setFocus()
     this.$module.addEventListener('click', (event) => this.handleClick(event))
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
@@ -89,7 +89,8 @@ describe('Error Summary', () => {
 
           // `undefined` simulates the element being missing,
           // from an unchecked `document.querySelector` for example
-          new namespace[exportName](undefined).init()
+          new namespace[exportName](undefined).init().catch((error) =>
+            console.warn(`Component '${exportName}' init failed`, error))
 
           // If our component initialisation breaks, this won't run
           return true

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -53,11 +53,13 @@ export class Header {
    * missing then there's nothing to do so return early.
    * Apply a matchMedia for desktop which will trigger a state sync if the browser
    * viewport moves between states.
+   *
+   * @returns {Promise<Header>} Header component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$menuButton || !this.$menu) {
-      return
+      throw new Error("Component 'Header' is missing '$module', '$menuButton' or '$menu' fields")
     }
 
     // Set the matchMedia to the govuk-frontend desktop breakpoint
@@ -75,6 +77,8 @@ export class Header {
 
     this.syncState()
     this.$menuButton.addEventListener('click', () => this.handleMenuButtonClick())
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -34,14 +34,18 @@ export class NotificationBanner {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<NotificationBanner>} Notification banner component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module) {
-      return
+      throw new Error("Component 'Notification banner' is missing '$module' field")
     }
 
     this.setFocus()
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -39,11 +39,13 @@ export class Radios {
    * We also need to restore the state of any conditional reveals on the page (for
    * example if the user has navigated back), and set up event handlers to keep
    * the reveal in sync with the radio state.
+   *
+   * @returns {Promise<Radios>} Radios component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$inputs) {
-      return
+      throw new Error("Component 'Radios' is missing '$module' or '$inputs' fields")
     }
 
     this.$inputs.forEach(($input) => {
@@ -73,6 +75,8 @@ export class Radios {
 
     // Handle events
     this.$module.addEventListener('click', (event) => this.handleClick(event))
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -29,11 +29,13 @@ export class SkipLink {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<SkipLink>} Skip link component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module) {
-      return
+      throw new Error("Component 'Skip link' is missing '$module' field")
     }
 
     // Check for linked element
@@ -44,6 +46,8 @@ export class SkipLink {
 
     this.$linkedElement = $linkedElement
     this.$module.addEventListener('click', () => this.focusLinkedElement())
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -51,14 +51,18 @@ export class Tabs {
 
   /**
    * Initialise component
+   *
+   * @returns {Promise<Tabs>} Tabs component
    */
-  init () {
+  async init () {
     // Check that required elements are present
     if (!this.$module || !this.$tabs) {
-      return
+      throw new Error("Component 'Tabs' is missing '$module' or '$tabs' fields")
     }
 
     this.setupResponsiveChecks()
+
+    return Promise.resolve(this)
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -28,7 +28,7 @@
     {% endif %}
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>
-    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
+    <script{% if cspNonce %} nonce="{{ cspNonce }}"{% endif %}>document.body.className += ' js-enabled' + ('Promise' in window && 'finally' in Promise.prototype && 'noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
     {% block bodyStart %}{% endblock %}
 
     {% block skipLink %}

--- a/packages/govuk-frontend/src/govuk/template.test.js
+++ b/packages/govuk-frontend/src/govuk/template.test.js
@@ -171,7 +171,7 @@ describe('Template', () => {
 
         // A change to the inline script would be a breaking change, and it would also require
         // updating the hash published in https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-isn-t-working-properly
-        expect(`sha256-${hash}`).toEqual('sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=')
+        expect(`sha256-${hash}`).toEqual('sha256-DaPqWKdkcF63017pHOqGly6DsaV45KpnY+rtqK6rPVI=')
       })
       it('should not have a nonce attribute by default', () => {
         const $ = renderTemplate()

--- a/packages/govuk-frontend/tsconfig.build.json
+++ b/packages/govuk-frontend/tsconfig.build.json
@@ -4,7 +4,7 @@
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
-    "target": "ES2015",
+    "target": "ES2018",
     "types": ["node"]
   }
 }

--- a/packages/govuk-frontend/tsconfig.json
+++ b/packages/govuk-frontend/tsconfig.json
@@ -11,7 +11,7 @@
   "exclude": ["./dist/**"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
-    "target": "ES2015",
+    "target": "ES2018",
     "types": ["jest", "jest-axe", "jest-puppeteer", "node"]
   }
 }

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -99,7 +99,8 @@ async function renderAndInitialise (page, componentName, options) {
     }
 
     const namespace = await import('govuk-frontend')
-    new namespace[exportName]($module, options.config).init()
+    new namespace[exportName]($module, options.config).init().catch((error) =>
+      console.warn(`Component '${exportName}' init failed`, error))
   }, componentNameToClassName(componentName), options)
 
   return page


### PR DESCRIPTION
Spike to consider async `init()` and `initAll()` with "catchable" error messages