### PR TITLE
Add colour value for Prime Minister's office

### DIFF
--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -127,6 +127,10 @@ $govuk-colours-organisations: (
     colour: #9c132e,
     colour-websafe: #c2395d
   ),
+  "prime-ministers-office-10-downing-street": (
+    colour: #0b0c0c,
+    colour-websafe: #0b0c0c
+  ),
   "scotland-office": (
     colour: #002663,
     colour-websafe: #405c8a


### PR DESCRIPTION
Currently this is being hard coded on GOV.UK[1] and needs to be consumed from GOV.UK Frontend as we have for all other departments.

1. https://github.com/alphagov/govuk_publishing_components/pull/3143