### PR TITLE
Announce whitespace in screen reader announcements of visually hidden text

### DIFF
--- a/app/src/views/examples/typography/index.njk
+++ b/app/src/views/examples/typography/index.njk
@@ -536,7 +536,74 @@
 
       </section>
 
+      <section class="govuk-!-margin-top-8">
+        <h2 class="govuk-heading-l govuk-!-padding-bottom-2" style="border-bottom: 4px solid;">Visually hidden text</h2>
 
+        <h3 class="govuk-heading-m">Heading with visually hidden text at the beginning</h3>
+
+        <h4 class="govuk-heading-s"><span class="govuk-visually-hidden">Countries starting with </span>A</h4>
+
+        <h3 class="govuk-heading-m">Heading with visually hidden text at the end</h3>
+
+        <h4 class="govuk-heading-s">Search <span class="govuk-visually-hidden">all content</span></h4>
+
+        <h3 class="govuk-heading-m">Heading that is visually hidden</h3>
+
+        <h4 class="govuk-visually-hidden">Navigation menu</h4>
+
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+        <h3 class="govuk-heading-m">Paragraph that contains visually hidden text</h3>
+
+        <p class="govuk-body">This is a paragraph <span class="govuk-visually-hidden">with some visually hidden text</span>.</p>
+
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl">
+
+        <h3 class="govuk-heading-m">Table with visually hidden text</h3>
+
+        {{ govukTable({
+          caption: "2019",
+          captionClasses: "govuk-!-margin-bottom-4",
+          head: [
+            {
+              text: "Date",
+              classes: "govuk-visually-hidden"
+            },
+            {
+              text: "Day",
+              classes: "govuk-visually-hidden"
+            },
+            {
+              text: "Name",
+              classes: "govuk-visually-hidden"
+            }
+          ],
+          rows: [
+            [
+              {
+                text: "19 April"
+              },
+              {
+                text: "Friday"
+              },
+              {
+                text: "Good Friday"
+              }
+            ],
+            [
+              {
+                text: "22 April"
+              },
+              {
+                text: "Monday"
+              },
+              {
+                text: "Easter Monday"
+              }
+            ]
+          ]
+        }) }}
+      </section>
     </div>
   </div>
 {% endblock %}

--- a/src/govuk/helpers/_visually-hidden.scss
+++ b/src/govuk/helpers/_visually-hidden.scss
@@ -16,6 +16,18 @@
 @mixin govuk-visually-hidden($important: true) {
   position: absolute if($important, !important, null);
 
+  // Absolute positioning has the unintended consequence of removing any
+  // whitespace surrounding visually hidden text from the accessibility tree.
+  // Insert a space character before and after visually hidden text to separate
+  // it from any visible text surrounding it.
+  &:before {
+    content: "\00a0";
+  }
+
+  &:after {
+    content: "\00a0";
+  }
+
   width: 1px if($important, !important, null);
   height: 1px if($important, !important, null);
   // If margin is set to a negative value it can cause text to be announced in


### PR DESCRIPTION
This PR fixes a bug in the visually hidden helper class where any whitespace surrounding visually hidden text isn't announced by screen readers. 

## The issue

The issue came up in user research, with a user saying that it was challenging to understand the JAWS announcement of the `<h1>` on the [GOV.UK search results page](https://www.gov.uk/search/all). The issue has also previously [been reported](https://github.com/alphagov/reported-bugs/issues/51) to JAWS. I can replicate it in in JAWS and Chrome/Edge/IE11, as well as NVDA and Chrome/Edge (but not NVDA and Firefox). 

The bug is caused by absolute positioning which removes any whitespace before or after visually hidden text from the accessibility tree. This can lead to unintelligible screen reader announcements, such as the above mentioned GOV.UK search results heading being announced as "Searchall content", instead of "Search all content". The bug also impacts screen reader announcements when the visually hidden text appears _before_ the visible text, for instance on the [Foreign travel advice page](https://www.gov.uk/foreign-travel-advice) where screen readers read the partly visually hidden heading as "Countries starting withA".

The actual issue can be seen by inspecting the accessibility tree value of the above `<h1>` on the search results page. Its value is "Search" (without the correct whitespace) with `position: absolute` included in `.govuk-visually-hidden`, but it is "Search " (with the correct whitespace) without absolute positioning. 

## The fix

To fix this, insert a space character before and after visually hidden text using pseudo elements to separate it from any visible text surrounding it. The fix tests well in all screen readers, regardless of whether the whitespace is before the visually hidden text ("Search all content"), after the visually hidden text ("Countries starting with A") or where the heading text is only made up visually hidden text ("Navigation menu"). The only slight issue I found is that Mac VoiceOver in Safari explicitly announces the inserted space characters when navigating by headings - but this is unlikely to block any users and the user numbers for MacOS VoiceOver are small compared to other assistive technologies. I also tested the fix where the visually hidden text appears as a part of a paragraph or a table cell. Please let me know if there are any other contexts I should test this in.

### Before
<img width="300" alt="Search all content is being read out as searchall content by JAWS" src="https://github.com/alphagov/finder-frontend/assets/5007934/8c550768-c669-4ed4-a606-c6ed1fa3885e">

### After 
<img width="300" alt="Search all content is now correctly read out by JAWS" src="https://github.com/alphagov/finder-frontend/assets/5007934/1445a94a-4c51-4a88-a075-99c40f737808">

### Before
<img width="300" alt="Screenshot 2023-06-15 at 11 22 59" src="https://github.com/alphagov/finder-frontend/assets/5007934/62a146aa-299f-48cd-b730-3cbd3beea26c">

### After  
<img width="300" alt="Screenshot 2023-06-15 at 11 23 21" src="https://github.com/alphagov/finder-frontend/assets/5007934/dc882d7a-e1cf-418b-be1c-0997f703ec27">

## Testing results

### Screen readers
✅ JAWS 2022 / Chrome
✅ JAWS 2023 / Chrome
✅ JAWS 2023 / IE 11
✅ JAWS 2023 / Edge
✅ NVDA / Firefox
✅ NVDA / Chrome
✅ NVDA / Edge
✅ Voiceover / Mac Safari 
❎  Voiceover / iOS Safari 
✅ Talkback / Chrome  Android

iOS VoiceOver announces the visually hidden text separately but this issue is already present on live and has previously been reported [here](https://github.com/alphagov/govuk-frontend/issues/1643#issuecomment-696776658). Interestingly, the below mentioned `aria-label` solution fixes the issue in iOS (at least on headings; other contexts might not work so well) but has other significant problems as documented below.

### Browsers and devices
I was testing that there is no visual difference in the element with the pseudo element space characters.

✅ Edge 
✅ Firefox (Mac and Windows, and when user sets their own custom colours)
✅ Chrome (Mac and Windows)
✅ IE 11
✅ Safari Mac
✅ Safari iOS
✅ Samsung Internet (Android)
✅ Firefox (Android)
✅ Chrome (Android)
 Samsung Internet
✅  Firefox (Android)

#### Other modes tested
✅  Print styles
✅  Hidden and unhidden like `govuk-visually-hidden` when CSS fails to load

## Other fixes that were explored
I also looked into using `opacity: 0` as a possible replacement for `position: absolute`. This tested well in all screen readers and browsers in terms of hiding the element but making it available to screen readers. However, the visually hidden text would remain part of the page flow, potentially causing issues by pushing visible page elements out of flow or down the page. 

Another alternative, also explored [here](https://github.com/alphagov/govuk-frontend/issues/1643#issuecomment-582444654), would be to use a non-breaking space in the markup. This also tested well, but would always need to be inserted in the markup alongside the visually hidden text, making it more of a manual fix which could be accidentally removed by the next person working in the file (the process of inserting and enforcing the character could be be part of a build pipeline but this would introduce an unworkable overhead in many contexts). 

I also explored using `aria-label` (for instance, "Search all content" for the search results heading), but the label does not get announced at all by JAWS and Mac VoiceOver on headings (even though [it seems to be allowable content on headings](https://www.w3.org/TR/wai-aria/#aria-label)); using it for paragraphs or table cells would be at least as unlikely to be announced consistently.

## Notes to reviewers
I ended up including some examples of visually hidden text in the review app. They were helpful when testing but let me know if you'd rather I removed them. The table example specifically is a duplicate of the content on the bank holidays full page example so should probably be removed unless it's useful to have it in same place as the other visually hidden examples.

I'm comparing the PR with the `support/4.6.x` branch, let me know if that's not right.

Fixes https://github.com/alphagov/reported-bugs/issues/51 

