### PR TITLE
Fix Browsersync review app watch extension

### DIFF
--- a/packages/govuk-frontend-review/browsersync.config.js
+++ b/packages/govuk-frontend-review/browsersync.config.js
@@ -22,7 +22,7 @@ module.exports = {
 
   // Files to watch for auto reload
   files: [
-    join(paths.app, 'dist/javascripts/**/*.js'),
+    join(paths.app, 'dist/javascripts/**/*.mjs'),
     join(paths.app, 'dist/stylesheets/**/*.css'),
     join(paths.app, 'src/views/**/*.njk'),
     packageTypeToPath('govuk-frontend', {


### PR DESCRIPTION
Forgot to update Browsersync to watch `*.mjs` in https://github.com/alphagov/govuk-frontend/pull/3833