### PR TITLE
Backport: Add inverse modifiers for Buttons, breadcrumbs and back links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### New features
+
+#### Added inverse modifier for buttons on dark backgrounds
+
+You can now style buttons on dark backgrounds to have a white background colour by adding the `govuk-button--inverse` class.
+
+This change was made in [pull request #3556: Add inverse button styles](https://github.com/alphagov/govuk-frontend/pull/3556).
+
+#### Added inverse modifier for breadcrumbs on dark backgrounds
+
+You can now style breadcrumbs on dark backgrounds to use white text, links and arrows by adding the `govuk-breadcrumbs--inverse` class.
+
+This change was made in [pull request #3774: Add inverse breadcrumb and back link modifiers and styles](https://github.com/alphagov/govuk-frontend/pull/3774).
+
+#### Added inverse modifier for back links on dark backgrounds
+
+You can now style back links on dark backgrounds to have a white link and arrow colour by adding the `govuk-back-link--inverse` class.
+
+This change was made in [pull request #3774: Add inverse breadcrumb and back link modifiers and styles](https://github.com/alphagov/govuk-frontend/pull/3774).
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/package/govuk/components/breadcrumbs/_index.scss
+++ b/package/govuk/components/breadcrumbs/_index.scss
@@ -144,4 +144,16 @@
       }
     }
   }
+
+  .govuk-breadcrumbs--inverse {
+    color: govuk-colour("white");
+
+    .govuk-breadcrumbs__link {
+      @include govuk-link-style-inverse;
+    }
+
+    .govuk-breadcrumbs__list-item::before {
+      border-color: currentcolor;
+    }
+  }
 }

--- a/src/govuk/components/back-link/_index.scss
+++ b/src/govuk/components/back-link/_index.scss
@@ -92,4 +92,12 @@
     bottom: -14px;
     left: 0;
   }
+
+  .govuk-back-link--inverse {
+    @include govuk-link-style-inverse;
+
+    &:before {
+      border-color: currentcolor;
+    }
+  }
 }

--- a/src/govuk/components/back-link/back-link.yaml
+++ b/src/govuk/components/back-link/back-link.yaml
@@ -28,6 +28,10 @@ examples:
     data:
       href: '#'
       text: Back to home
+  - name: with inverted colours
+    data:
+      classes: govuk-back-link--inverse
+      href: '#'
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes

--- a/src/govuk/components/back-link/template.test.js
+++ b/src/govuk/components/back-link/template.test.js
@@ -67,4 +67,11 @@ describe('back-link component', () => {
     expect($component.attr('data-test')).toEqual('attribute')
     expect($component.attr('aria-label')).toEqual('Back to home')
   })
+
+  it('renders with inverted colours if specified', () => {
+    const $ = render('back-link', examples['with inverted colours'])
+
+    const $component = $('.govuk-back-link')
+    expect($component.hasClass('govuk-back-link--inverse')).toBeTruthy()
+  })
 })

--- a/src/govuk/components/breadcrumbs/breadcrumbs.yaml
+++ b/src/govuk/components/breadcrumbs/breadcrumbs.yaml
@@ -82,6 +82,16 @@ examples:
           href: '/education'
         - text: Special educational needs and disability (SEND) and high needs
           href: '/education/special-educational-needs-and-disability-send-and-high-needs'
+  - name: with inverted colours
+    description: Breadcrumbs that appear on dark backgrounds
+    data:
+      classes: govuk-breadcrumbs--inverse
+      items:
+        - text: Home
+          href: '/'
+        - text: Passports, travel and living abroad
+          href: '/browse/abroad'
+        - text: Travel abroad
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: classes

--- a/src/govuk/components/breadcrumbs/template.test.js
+++ b/src/govuk/components/breadcrumbs/template.test.js
@@ -99,5 +99,12 @@ describe('Breadcrumbs', () => {
       const $component = $('.govuk-breadcrumbs')
       expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()
     })
+
+    it('renders with inverted colours if specified', () => {
+      const $ = render('breadcrumbs', examples['with inverted colours'])
+
+      const $component = $('.govuk-breadcrumbs')
+      expect($component.hasClass('govuk-breadcrumbs--inverse')).toBeTruthy()
+    })
   })
 })

--- a/src/govuk/components/button/_index.scss
+++ b/src/govuk/components/button/_index.scss
@@ -18,21 +18,27 @@ $govuk-button-text-colour: govuk-colour("white") !default;
 
 @include govuk-exports("govuk/component/button") {
   $govuk-button-colour: $govuk-button-background-colour;
+  $govuk-button-text-colour: $govuk-button-text-colour;
   $govuk-button-hover-colour: govuk-shade($govuk-button-colour, 20%);
   $govuk-button-shadow-colour: govuk-shade($govuk-button-colour, 60%);
-  $govuk-button-text-colour: $govuk-button-text-colour;
 
   // Secondary button variables
   $govuk-secondary-button-colour: govuk-colour("light-grey", $legacy: "grey-3");
+  $govuk-secondary-button-text-colour: govuk-colour("black");
   $govuk-secondary-button-hover-colour: govuk-shade($govuk-secondary-button-colour, 10%);
   $govuk-secondary-button-shadow-colour: govuk-shade($govuk-secondary-button-colour, 40%);
-  $govuk-secondary-button-text-colour: govuk-colour("black");
 
   // Warning button variables
   $govuk-warning-button-colour: govuk-colour("red");
+  $govuk-warning-button-text-colour: govuk-colour("white");
   $govuk-warning-button-hover-colour: govuk-shade($govuk-warning-button-colour, 20%);
   $govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 60%);
-  $govuk-warning-button-text-colour: govuk-colour("white");
+
+  // Inverse button variables
+  $govuk-inverse-button-colour: govuk-colour("white");
+  $govuk-inverse-button-text-colour: govuk-colour("blue");
+  $govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
+  $govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
 
   // Because the shadow (s0) is visually 'part of' the button, we need to reduce
   // the height of the button to compensate by adjusting its padding (s1) and
@@ -247,6 +253,38 @@ $govuk-button-text-colour: govuk-colour("white") !default;
 
       &[disabled] {
         background-color: $govuk-warning-button-colour;
+      }
+    }
+  }
+
+  .govuk-button--inverse {
+    background-color: $govuk-inverse-button-colour;
+    box-shadow: 0 $button-shadow-size 0 $govuk-inverse-button-shadow-colour;
+
+    &,
+    &:link,
+    &:visited,
+    &:active,
+    &:hover {
+      color: $govuk-inverse-button-text-colour;
+    }
+
+    // alphagov/govuk_template includes a specific a:link:focus selector
+    // designed to make unvisited links a slightly darker blue when focussed, so
+    // we need to override the text colour for that combination of selectors so
+    // so that unvisited links styled as buttons do not end up with dark blue
+    // text when focussed.
+    @include _govuk-compatibility(govuk_template) {
+      &:link:focus {
+        color: $govuk-inverse-button-text-colour;
+      }
+    }
+
+    &:hover {
+      background-color: $govuk-inverse-button-hover-colour;
+
+      &[disabled] {
+        background-color: $govuk-inverse-button-colour;
       }
     }
   }

--- a/src/govuk/components/button/button.yaml
+++ b/src/govuk/components/button/button.yaml
@@ -148,6 +148,33 @@ examples:
       text: Warning button
       href: '/'
       classes: govuk-button--warning
+  - name: Inverse
+    description: A button that appears on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse button
+      classes: govuk-button--inverse
+  - name: Inverse disabled
+    data:
+      name: Inverse
+      text: Inverse button disabled
+      classes: govuk-button--inverse
+      disabled: true
+  - name: Inverse link
+    description: A link button for actions that appear on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse button
+      href: '/'
+      classes: govuk-button--inverse
+  - name: Inverse start button
+    description: A start button that appears on dark backgrounds
+    data:
+      name: Inverse
+      text: Inverse start button
+      href: '/'
+      classes: govuk-button--inverse
+      isStartButton: true
 
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: attributes


### PR DESCRIPTION
This is a backport of the following changes onto `support/4.x` for release in 4.7.0:

- https://github.com/alphagov/govuk-frontend/pull/3556
- https://github.com/alphagov/govuk-frontend/pull/3774

Resolves https://github.com/alphagov/govuk-frontend/issues/3827