### PR TITLE
Babel transform only `*.mjs` files for Jest

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,9 +8,6 @@ module.exports = function (api) {
 
   const presets = [
     ['@babel/preset-env', {
-      exclude: [
-        'transform-dynamic-import'
-      ],
       targets: {
         node: 'current'
       }

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -70,6 +70,8 @@ See [JavaScript Coding Standards](/docs/contributing/coding-standards/js.md#form
 
 We use [Jest](https://jestjs.io/), an automated testing platform with an assertion library, and [Puppeteer](https://pptr.dev/) that is used to control [headless Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome).
 
+Tests should be written using ES modules (`*.mjs`) by default, but use CommonJS modules (`*.js`) for tests using browser [`import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) in Puppeteer. This avoids Babel transforms until [Jest supports `import()` and ES modules](https://jestjs.io/docs/ecmascript-modules) in future.
+
 ### Component tests
 
 We write functional tests for every component to check the output of our Nunjucks code. These are found in `template.test.js` files in each component directory. These Nunjucks tests render the component examples defined in the component yaml files, and assert that the HTML tags, attributes and classes are as expected. For example: checking that when you pass in an `id` to the component using the Nunjucks macro, it outputs the component with an `id` attribute equal to that value.
@@ -86,7 +88,7 @@ You should also test component Javascript logic with unit tests, in a `[componen
 
 ### Global tests
 
-We write functional tests for checking our JavaScript exports and our global sass variables - see [all.test.mjs](/packages/govuk-frontend/src/govuk/all.test.mjs) and [components/globals.test.mjs](/packages/govuk-frontend/src/govuk/components/globals.test.mjs) for examples of global tests we run.
+We write functional tests for checking our JavaScript exports and our global sass variables - see [all.test.mjs](/packages/govuk-frontend/src/govuk/all.test.mjs) and [components/globals.test.js](/packages/govuk-frontend/src/govuk/components/globals.test.js) for examples of global tests we run.
 
 ### Conventions
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -32,10 +32,10 @@ const config = {
    */
   testEnvironment: 'jest-environment-node-single-context',
 
-  // Enable Babel transforms until Jest supports ESM
+  // Enable Babel transforms until Jest supports ESM and `import()`
   // See: https://jestjs.io/docs/ecmascript-modules
   transform: {
-    '^.+\\.m?js$': ['babel-jest', { rootMode: 'upward' }]
+    '^.+\\.mjs$': ['babel-jest', { rootMode: 'upward' }]
   },
 
   // Enable Babel transforms for ESM-only node_modules

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -104,7 +104,7 @@ export default {
         '!**/*.unit.test.{js,mjs}',
 
         // Exclude other tests
-        '!**/components/globals.test.mjs',
+        '!**/components/globals.test.js',
         '!**/components/*/**',
         '!**/tasks/build/**'
       ],
@@ -118,7 +118,7 @@ export default {
       displayName: 'JavaScript component tests',
       testEnvironment: 'govuk-frontend-helpers/jest/environment/puppeteer.mjs',
       testMatch: [
-        '**/components/globals.test.mjs',
+        '**/components/globals.test.js',
         '**/components/*/*.test.{js,mjs}',
 
         // Exclude accessibility/macro/unit tests

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -60,6 +60,7 @@ const config = {
  */
 export default {
   collectCoverageFrom: ['./packages/govuk-frontend/src/**/*.{js,mjs}'],
+  coverageProvider: 'v8',
 
   // Reduce CPU usage during project test runs
   maxWorkers: headless

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,3 +1,6 @@
+import { packageResolveToPath } from 'govuk-frontend-lib/names'
+import { replacePathSepForRegex } from 'jest-regex-util'
+
 import jestPuppeteerConfig from './jest-puppeteer.config.js'
 
 // Detect when browser has been launched headless
@@ -35,7 +38,20 @@ const config = {
   // Enable Babel transforms until Jest supports ESM and `import()`
   // See: https://jestjs.io/docs/ecmascript-modules
   transform: {
-    '^.+\\.mjs$': ['babel-jest', { rootMode: 'upward' }]
+    // Transform all `*.mjs` to compatible CommonJS
+    '^.+\\.mjs$': ['babel-jest', {
+      rootMode: 'upward'
+    }],
+
+    // Transform some `*.js` to compatible CommonJS
+    ...Object.fromEntries([
+      'del',
+      'slash'
+    ].map((packagePath) => [
+      replacePathSepForRegex(`${packageResolveToPath(packagePath)}$`), ['babel-jest', {
+        rootMode: 'upward'
+      }]
+    ]))
   },
 
   // Enable Babel transforms for ESM-only node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "jest": "^29.5.0",
         "jest-environment-node-single-context": "^29.1.0",
         "jest-puppeteer": "^9.0.0",
+        "jest-regex-util": "^29.4.3",
         "jest-serializer-html": "^7.1.0",
         "lint-staged": "^13.2.2",
         "postcss-markdown": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jest": "^29.5.0",
     "jest-environment-node-single-context": "^29.1.0",
     "jest-puppeteer": "^9.0.0",
+    "jest-regex-util": "^29.4.3",
     "jest-serializer-html": "^7.1.0",
     "lint-staged": "^13.2.2",
     "postcss-markdown": "^1.2.0",

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -56,7 +56,7 @@ module.exports = {
       // Matches 'JavaScript component tests' in jest.config.mjs
       // to ignore unknown Jest Puppeteer globals
       files: [
-        '**/components/globals.test.mjs',
+        '**/components/globals.test.js',
         '**/components/*/*.test.{js,mjs}'
       ],
       excludedFiles: [

--- a/packages/govuk-frontend/postcss.config.mjs
+++ b/packages/govuk-frontend/postcss.config.mjs
@@ -2,7 +2,7 @@ import autoprefixer from 'autoprefixer'
 import cssnano from 'cssnano'
 import cssnanoPresetDefault from 'cssnano-preset-default'
 import { pkg } from 'govuk-frontend-config'
-import { isDev } from 'govuk-frontend-tasks/helpers/task-arguments.js'
+import { isDev } from 'govuk-frontend-tasks/helpers/task-arguments.mjs'
 import postcss from 'postcss'
 import scss from 'postcss-scss'
 

--- a/packages/govuk-frontend/src/govuk/components/globals.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.test.js
@@ -1,4 +1,4 @@
-import { goTo, goToExample } from 'govuk-frontend-helpers/puppeteer'
+const { goTo, goToExample } = require('govuk-frontend-helpers/puppeteer')
 
 describe('GOV.UK Frontend', () => {
   describe('javascript', () => {

--- a/shared/tasks/helpers/task-arguments.mjs
+++ b/shared/tasks/helpers/task-arguments.mjs
@@ -1,7 +1,7 @@
-const parser = require('yargs-parser')
+import parser from 'yargs-parser'
 
 // Non-flag arguments as tasks
 const { _: tasks } = parser(process.argv)
 
 // Check for development task
-module.exports.isDev = tasks.includes('dev')
+export const isDev = tasks.includes('dev')

--- a/shared/tasks/helpers/task-arguments.unit.test.mjs
+++ b/shared/tasks/helpers/task-arguments.unit.test.mjs
@@ -26,35 +26,35 @@ describe('Task arguments', () => {
       it('is flagged false', async () => {
         process.argv = [...argv]
 
-        const { isDev } = require('./task-arguments.js')
+        const { isDev } = await import('./task-arguments.mjs')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:app'", async () => {
         process.argv = [...argv, 'build:app']
 
-        const { isDev } = require('./task-arguments.js')
+        const { isDev } = await import('./task-arguments.mjs')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:package'", async () => {
         process.argv = [...argv, 'build:package']
 
-        const { isDev } = require('./task-arguments.js')
+        const { isDev } = await import('./task-arguments.mjs')
         expect(isDev).toBe(false)
       })
 
       it("is flagged false for 'gulp build:release'", async () => {
         process.argv = [...argv, 'build:release']
 
-        const { isDev } = require('./task-arguments.js')
+        const { isDev } = await import('./task-arguments.mjs')
         expect(isDev).toBe(false)
       })
 
       it("is flagged true for 'gulp dev'", async () => {
         process.argv = [...argv, 'dev']
 
-        const { isDev } = require('./task-arguments.js')
+        const { isDev } = await import('./task-arguments.mjs')
         expect(isDev).toBe(true)
       })
     })

--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -2,7 +2,7 @@ import runScript from '@npmcli/run-script'
 import { paths } from 'govuk-frontend-config'
 import PluginError from 'plugin-error'
 
-import { isDev } from './helpers/task-arguments.js'
+import { isDev } from './helpers/task-arguments.mjs'
 import { task } from './index.mjs'
 
 /**


### PR DESCRIPTION
Quick spike to solve to blockers in https://github.com/alphagov/govuk-frontend/pull/3812

1. Puppeteer needs to _keep_ [dynamic `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) to load in a browser
2. Jest needs to _replace_ [dynamic `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) with `require()` for [virtual machine contexts](https://nodejs.org/docs/latest-v18.x/api/vm.html#vm-executing-javascript)

By running Babel only on `*.mjs` ES modules we can use [dynamic `import()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) in `*.js` CommonJS

**Update:** Gave it a couple of runs on Windows to confirm it works:

* https://github.com/alphagov/govuk-frontend/actions/runs/5379997972
* https://github.com/alphagov/govuk-frontend/actions/runs/5380112102