### PR TITLE
Fix focus style being overlapped by summary action links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -253,6 +253,7 @@ This change was introduced in [pull request #3773: Omit the value attribute from
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#3791: Refactor mobile menu button label/text handling](https://github.com/alphagov/govuk-frontend/pull/3791)
+- [#3862: Fix focus style being overlapped by summary action links](https://github.com/alphagov/govuk-frontend/pull/3862)
 
 ## 4.6.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -131,6 +131,15 @@
     }
   }
 
+  // Large groups of action links may wrap onto multiple lines. Because the link
+  // focus styles are applied outside of the link's bounding box, there are
+  // situations where the focus style on a link can be overlapped by subsequent
+  // links. We don't want this, so let's create a new stacking context on focus
+  // so the link always appears to be 'on top'.
+  .govuk-summary-list__actions-list-item .govuk-link:focus {
+    isolation: isolate;
+  }
+
   // No border on entire summary list
   .govuk-summary-list--no-border {
     .govuk-summary-list__row {


### PR DESCRIPTION
Fixes the WCAG 2.2 issue of subsequent action links in the summary list component slightly overlapping the currently focused link.

Resolves #3841. 

## Screenshots

||Before|After|
|:-|:-:|:-:|
|Narrow layout|![A long list of action links. The second, 'use', is focused. A small grey line is partially overlapping it from a link on the line below.](https://github.com/alphagov/govuk-frontend/assets/1253214/e62ca310-a15c-49d8-a2ef-3d55995b7bea)|![A long list of action links. The second, 'use', is focused. The link is unobscured.](https://github.com/alphagov/govuk-frontend/assets/1253214/44bd9890-26fa-4833-9d0b-4d77643ff3ce)|
|Wide layout|![A long list of action links. The eighth, 'upgrade', is focused. A small grey line is partially overlapping it from a link on the line below.](https://github.com/alphagov/govuk-frontend/assets/1253214/c640ebee-9b0a-4c9f-9a37-11200031717b)|![A long list of action links. The eighth, 'upgrade', is focused. The link is unobscured.](https://github.com/alphagov/govuk-frontend/assets/1253214/85a33963-93e7-4dd8-b18b-d5c02872e906)|

## Changes
- Summary list action links now receive the `isolation: isolate` style when focused. This creates a new [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context), making it appear 'above' the surrounding content.

## Thoughts
- There are a few ways that creating a new stacking context could have been done. `position: relative`, `transform: translate(0, 0)`, and others. I've used the `isolation` property as it is intended specifically for this purpose, on the assumption this fix doesn't need to support IE. ([Browser support for `isolation`](https://caniuse.com/mdn-css_properties_isolation))
- This issue doesn't affect the action links on summary cards, as they are already separated using `row-gap`, preventing the overlap from occuring.
  - Presumably we don't want to do the same thing here, as the action link line spacing is consistent with the content next to it and we probably don't want to change that.