### PR TITLE
Fix helpers `getListing()` and `getDirectories()` on Windows etc

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -9,8 +9,10 @@ runs:
       id: build-cache
 
       with:
+        enableCrossOsArchive: true
+
         # Restore build cache (unless commit SHA changes)
-        key: build-cache-${{ runner.os }}-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ github.sha }}
         path: |
           packages/*/dist
           shared/*/dist

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -9,8 +9,10 @@ runs:
       id: npm-install-cache
 
       with:
+        enableCrossOsArchive: true
+
         # Restore `node_modules` cache (unless packages change)
-        key: npm-install-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
+        key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
         path: |
           node_modules
           docs/examples/*/node_modules

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Cache browser download
         uses: actions/cache@v3
         with:
-          key: puppeteer-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: puppeteer-${{ runner.os }}
           path: .cache/puppeteer
 
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -41,7 +41,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     steps:
@@ -59,7 +59,7 @@ jobs:
 
   lint:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
@@ -105,7 +105,7 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
@@ -149,7 +149,7 @@ jobs:
 
   verify:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
     strategy:
@@ -206,7 +206,7 @@ jobs:
 
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
     # Skip when scheduled or run manually

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,7 @@ jobs:
   test:
     name: ${{ matrix.task.description }}
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-    needs: [install]
+    needs: [install, build]
 
     strategy:
       fail-fast: false
@@ -122,48 +122,6 @@ jobs:
             name: test-unit
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript unit tests" --coverage --testLocationInResults
             cache: .cache/jest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Restore dependencies
-        uses: ./.github/workflows/actions/install-node
-
-      - name: Cache task
-        if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
-        with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
-          path: ${{ matrix.task.cache }}
-
-      - name: Run test task
-        run: ${{ matrix.task.run }}
-
-      - name: Save test coverage
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.task.description }} coverage
-          path: coverage
-          if-no-files-found: ignore
-
-  verify:
-    name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-    needs: [install, build]
-
-    strategy:
-      fail-fast: false
-
-      matrix:
-        task:
-          - description: Verify package build
-            name: test-build-package
-            run: npm run build:package
-
-          - description: Verify distribution build
-            name: test-build-release
-            run: npm run build:release
 
           - description: JavaScript behaviour tests
             name: test-behaviour
@@ -200,6 +158,44 @@ jobs:
         with:
           key: ${{ matrix.task.name }}-cache-${{ runner.os }}
           path: ${{ matrix.task.cache }}
+
+      - name: Run test task
+        run: ${{ matrix.task.run }}
+
+      - name: Save test coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.task.description }} coverage
+          path: coverage
+          if-no-files-found: ignore
+
+  verify:
+    name: ${{ matrix.task.description }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    needs: [install, build]
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        task:
+          - description: Verify package build
+            name: test-build-package
+            run: npm run build:package
+
+          - description: Verify distribution build
+            name: test-build-release
+            run: npm run build:release
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
+      - name: Restore build
+        uses: ./.github/workflows/actions/build
 
       - name: Run verify task
         run: ${{ matrix.task.run }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,7 +97,8 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
 
       - name: Run lint task
@@ -156,7 +157,8 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
 
       - name: Run test task

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ on:
           - windows-latest
 
 concurrency:
-  group: tests-${{ github.head_ref || github.run_id }}
+  group: tests-${{ inputs.runner || 'ubuntu-latest' }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -186,6 +186,9 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
+    # Skip when scheduled or run manually
+    if: ${{ !inputs.runner }}
+
     strategy:
       fail-fast: false
 
@@ -267,6 +270,9 @@ jobs:
   regression:
     name: Percy
     needs: [install, build]
+
+    # Skip when scheduled or run manually
+    if: ${{ !inputs.runner }}
 
     # Run existing "Percy screenshots" workflow
     # (after install and build have been cached)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,6 +109,11 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
+    env:
+      # Use 2x CPU cores unless on Windows (runs slower when concurrent)
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      MAX_WORKERS: ${{ inputs.runner == 'windows-latest' && '1' || '2' }}
+
     strategy:
       fail-fast: false
 
@@ -116,32 +121,37 @@ jobs:
         task:
           - description: Nunjucks macro tests
             name: test-macro
-            run: npx jest --color --selectProjects "Nunjucks macro tests"
             cache: .cache/jest
+            projects:
+              - Nunjucks macro tests
 
           - description: JavaScript unit tests
             name: test-unit
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript unit tests" --coverage --testLocationInResults
             cache: .cache/jest
+            projects:
+              - JavaScript unit tests
 
           - description: JavaScript behaviour tests
             name: test-behaviour
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
             cache: .cache/jest
+            projects:
+              - JavaScript behaviour tests
 
           - description: JavaScript component tests
             name: test-component
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
             cache: |
               .cache/jest
               .cache/puppeteer
+            projects:
+              - JavaScript component tests
 
           - description: Accessibility tests
             name: test-accessibility
-            run: npx jest --color --maxWorkers=2 --selectProjects "Accessibility tests"
             cache: |
               .cache/jest
               .cache/puppeteer
+            projects:
+              - Accessibility tests
 
     steps:
       - name: Checkout
@@ -162,7 +172,7 @@ jobs:
           path: ${{ matrix.task.cache }}
 
       - name: Run test task
-        run: ${{ matrix.task.run }}
+        run: npx jest --color ${{ format('--maxWorkers={0} --selectProjects "{1}"', env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
         uses: actions/upload-artifact@v3

--- a/jest-dev-server.config.js
+++ b/jest-dev-server.config.js
@@ -7,6 +7,9 @@ module.exports = {
   command: 'npm start --workspace govuk-frontend-review',
   port: ports.app,
 
+  // Allow 15 seconds to start server
+  launchTimeout: 15000,
+
   // Skip when already running
   usedPortAction: 'ignore'
 }

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -147,6 +147,6 @@ export default {
   // Enable GitHub Actions reporter UI
   reporters: ['default', 'github-actions'],
 
-  // Browser test increased timeout (5s to 15s)
-  testTimeout: 15000
+  // Browser test increased timeout (5s to 30s)
+  testTimeout: 30000
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27838,11 +27838,20 @@
         "glob": "^10.3.0",
         "govuk-frontend-config": "*",
         "js-yaml": "^4.1.0",
-        "minimatch": "^9.0.2"
+        "minimatch": "^9.0.2",
+        "slash": "^3.0.0"
       },
       "engines": {
         "node": "^18.12.0",
         "npm": "^8.1.0 || ^9.1.0"
+      }
+    },
+    "shared/lib/node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "shared/stats": {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accessibility.test.mjs
@@ -31,6 +31,6 @@ describe('/components/accordion', () => {
         await goToComponent(page, 'accordion', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
@@ -19,7 +19,7 @@ describe('/components/accordion', () => {
 
         for (let i = 0; i < numberOfExampleSections; i++) {
           const isContentVisible = await page.waitForSelector(`.govuk-accordion .govuk-accordion__section:nth-of-type(${i + 1}) .govuk-accordion__section-content`,
-            { visible: true, timeout: 1000 }
+            { visible: true, timeout: 5000 }
           )
           expect(isContentVisible).toBeTruthy()
         }

--- a/packages/govuk-frontend/src/govuk/components/back-link/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/back-link/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/back-link', () => {
         await goToComponent(page, 'back-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/breadcrumbs', () => {
         await goToComponent(page, 'breadcrumbs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.test.mjs
@@ -29,6 +29,6 @@ describe('/components/button', () => {
         await goToComponent(page, 'button', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -7,8 +7,8 @@ describe('/components/button', () => {
   const clickTimeoutTime = 1000 // ms
 
   // The longest possible time a button will ignore unintentional clicks for
-  // until it can be clicked again (+ 50ms to stay outside the total wait time)
-  const debouncedWaitTime = clickTimeoutTime + 50
+  // until it can be clicked again (+ 100ms to stay outside the total wait time)
+  const debouncedWaitTime = clickTimeoutTime + 100
 
   beforeAll(async () => {
     examples = await getExamples('button')

--- a/packages/govuk-frontend/src/govuk/components/character-count/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/character-count', () => {
         await goToComponent(page, 'character-count', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -8,8 +8,8 @@ describe('Character count', () => {
   const lastInputOffsetTime = 500 // ms
 
   // The longest possible time from a keyboard user ending input and the screen
-  // reader counter being updated (+ 50ms to stay outside the total wait time)
-  const debouncedWaitTime = focusIntervalTime + lastInputOffsetTime + 50
+  // reader counter being updated (+ 100ms to stay outside the total wait time)
+  const debouncedWaitTime = focusIntervalTime + lastInputOffsetTime + 100
 
   beforeAll(async () => {
     examples = await getExamples('character-count')

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.test.mjs
@@ -30,6 +30,6 @@ describe('/components/checkboxes', () => {
         await goToComponent(page, 'checkboxes', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/cookie-banner', () => {
         await goToComponent(page, 'cookie-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/date-input/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/date-input/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/date-input', () => {
         await goToComponent(page, 'date-input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/details/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/details/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/details', () => {
         await goToComponent(page, 'details', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-message/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-message/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/error-message', () => {
         await goToComponent(page, 'error-message', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/error-summary', () => {
         await goToComponent(page, 'error-summary', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/fieldset', () => {
         await goToComponent(page, 'fieldset', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/file-upload', () => {
         await goToComponent(page, 'file-upload', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/footer/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/footer/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/footer', () => {
         await goToComponent(page, 'footer', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/header/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/header', () => {
         await goToComponent(page, 'header', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/hint/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/hint/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/hint', () => {
         await goToComponent(page, 'hint', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/input/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/input/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/input', () => {
         await goToComponent(page, 'input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/inset-text', () => {
         await goToComponent(page, 'inset-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/label/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/label/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/label', () => {
         await goToComponent(page, 'label', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.test.mjs
@@ -35,6 +35,6 @@ describe('/components/notification-banner', () => {
         await goToComponent(page, 'notification-banner', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/pagination/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/pagination/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/pagination', () => {
         await goToComponent(page, 'pagination', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/panel', () => {
         await goToComponent(page, 'panel', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/phase-banner', () => {
         await goToComponent(page, 'phase-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/accessibility.test.mjs
@@ -30,6 +30,6 @@ describe('/components/radios', () => {
         await goToComponent(page, 'radios', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/select/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/select/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/select', () => {
         await goToComponent(page, 'select', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/skip-link', () => {
         await goToComponent(page, 'skip-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/summary-list', () => {
         await goToComponent(page, 'summary-list', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/table/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/table/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/table', () => {
         await goToComponent(page, 'table', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/tabs', () => {
         await goToComponent(page, 'tabs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
@@ -16,7 +16,7 @@ describe('/components/tabs', () => {
       })
 
       it('falls back to making all tab containers visible', async () => {
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 1000 })
+        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
         expect(isContentVisible).toBeTruthy()
       })
     })
@@ -156,7 +156,7 @@ describe('/components/tabs', () => {
       it('falls back to making the all tab containers visible', async () => {
         await page.emulate(iPhone)
         await goToComponent(page, 'tabs')
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 1000 })
+        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
         expect(isContentVisible).toBeTruthy()
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tag/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tag/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/tag', () => {
         await goToComponent(page, 'tag', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/textarea/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/textarea/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/textarea', () => {
         await goToComponent(page, 'textarea', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/warning-text', () => {
         await goToComponent(page, 'warning-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/packages/govuk-frontend/tasks/build/release.test.mjs
+++ b/packages/govuk-frontend/tasks/build/release.test.mjs
@@ -1,5 +1,4 @@
 import { readFile } from 'fs/promises'
-import { EOL } from 'os'
 import { join } from 'path'
 
 import { paths, pkg } from 'govuk-frontend-config'
@@ -43,7 +42,7 @@ describe('dist/', () => {
     })
 
     it('should contain source mapping URL', () => {
-      expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/${EOL}$`))
+      expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/\n$`))
     })
 
     it('should contain version number custom property', () => {
@@ -84,7 +83,7 @@ describe('dist/', () => {
     })
 
     it('should contain source mapping URL', () => {
-      expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map${EOL}$`))
+      expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map\n$`))
     })
   })
 
@@ -113,7 +112,7 @@ describe('dist/', () => {
     })
 
     it('should contain the correct version', () => {
-      expect(version).toEqual(`${pkg.version}${EOL}`)
+      expect(version).toEqual(`${pkg.version}\n`)
     })
   })
 })

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -5,6 +5,7 @@ const { glob } = require('glob')
 const { paths } = require('govuk-frontend-config')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
+const slash = require('slash')
 
 const { packageNameToPath } = require('./names')
 
@@ -16,7 +17,7 @@ const { packageNameToPath } = require('./names')
  * @returns {Promise<string[]>} File paths
  */
 const getListing = async (directoryPath, options = {}) => {
-  const listing = await glob(directoryPath, {
+  const listing = await glob(slash(directoryPath), {
     absolute: true,
     nodir: true,
     realpath: true,
@@ -36,7 +37,7 @@ const getListing = async (directoryPath, options = {}) => {
  * @returns {Promise<string[]>} Directory names
  */
 const getDirectories = async (directoryPath) => {
-  const listing = await getListing(`${directoryPath}/*/`, { nodir: false })
+  const listing = await getListing(`${slash(directoryPath)}/*/`, { nodir: false })
 
   // Use directory names only
   return listing

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -16,6 +16,7 @@
     "glob": "^10.3.0",
     "govuk-frontend-config": "*",
     "js-yaml": "^4.1.0",
-    "minimatch": "^9.0.2"
+    "minimatch": "^9.0.2",
+    "slash": "^3.0.0"
   }
 }

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -1,5 +1,4 @@
 import { mkdir, writeFile } from 'fs/promises'
-import { EOL } from 'os'
 import { dirname, join, parse } from 'path'
 
 import cpy from 'cpy'
@@ -50,7 +49,7 @@ export async function write (assetPath, { destPath, filePath, fileContents }) {
   }
 
   await mkdir(dirname(assetDestPath), { recursive: true })
-  await writeFile(assetDestPath, `${await fileContents()}${EOL}`)
+  await writeFile(assetDestPath, `${await fileContents()}\n`)
 }
 
 /**


### PR DESCRIPTION
More fixes for places we've assumed Windows line endings and slashes were supported but weren't:

1. Consistently write POSIX line endings now Rollup uses them regardless
2. Convert to POSIX forward slashes in directory listing `glob()` pattern

Plus some timeout and speed fixes for GitHub Actions on Windows

**Update:** Linking to some Windows runs to confirm it works:

* https://github.com/alphagov/govuk-frontend/actions/runs/5379417428
* https://github.com/alphagov/govuk-frontend/actions/runs/5379745838
* https://github.com/alphagov/govuk-frontend/actions/runs/5379877389