### PR TITLE
[SPIKE] Modify accordion header focus so it includes entire clickable area

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
@@ -228,14 +228,12 @@
       }
 
       &:focus {
-        // Remove default focus border around button as
-        // styling is being applied to inner text elements that receive focus
-        outline: 0;
+        @include govuk-focused-text;
 
         .govuk-accordion__section-heading-text-focus,
         .govuk-accordion__section-summary-focus,
         .govuk-accordion__section-toggle-focus {
-          @include govuk-focused-text;
+          color: $govuk-focus-text-colour;
         }
 
         .govuk-accordion-nav__chevron {


### PR DESCRIPTION
Modifies the accordion component's section header focus styles so that they are applied to the entire clickable area of the header, not just the text inside of it. 

For this investigation:
- #3839

---

The modified component: 
https://govuk-frontend-pr-3866.herokuapp.com/components/accordion

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/59e29501-f07c-461e-ae65-c8fef7f32ad1)

---

The unmodified component for comparison:
https://govuk-frontend-review.herokuapp.com/components/accordion

![image](https://github.com/alphagov/govuk-frontend/assets/1253214/9437b0d4-cfd7-4399-88b2-2e154f7af849)
