### PR TITLE
Simplify i18n macro to handle single or plural text

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.njk
@@ -1,13 +1,39 @@
+{% from "../../macros/i18n.njk" import govukI18nAttributes %}
+
 {% set id = params.id %}
 {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
 
 <div class="govuk-accordion {%- if params.classes %} {{ params.classes }}{% endif -%}" data-module="govuk-accordion" id="{{ id }}"
-  {%- if params.hideAllSectionsText %} data-i18n.hide-all-sections="{{ params.hideAllSectionsText | escape }}"{% endif %}
-  {%- if params.hideSectionText %} data-i18n.hide-section="{{ params.hideSectionText | escape }}"{% endif %}
-  {%- if params.hideSectionAriaLabelText %} data-i18n.hide-section-aria-label="{{ params.hideSectionAriaLabelText | escape }}"{% endif %}
-  {%- if params.showAllSectionsText %} data-i18n.show-all-sections="{{ params.showAllSectionsText | escape }}"{% endif %}
-  {%- if params.showSectionText %} data-i18n.show-section="{{ params.showSectionText | escape }}"{% endif %}
-  {%- if params.showSectionAriaLabelText %} data-i18n.show-section-aria-label="{{ params.showSectionAriaLabelText | escape }}"{% endif %}
+  {{- govukI18nAttributes({
+    key: 'hide-all-sections',
+    message: params.hideAllSectionsText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'hide-section',
+    message: params.hideSectionText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'hide-section-aria-label',
+    message: params.hideSectionAriaLabelText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'show-all-sections',
+    message: params.showAllSectionsText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'show-section',
+    message: params.showSectionText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'show-section-aria-label',
+    message: params.showSectionAriaLabelText
+  }) -}}
+
   {%- if params.rememberExpanded !== undefined %} data-remember-expanded="{{ params.rememberExpanded | escape }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   {% for item in params.items %}

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.njk
@@ -1,4 +1,4 @@
-{% from "../../macros/i18n.njk" import govukPluralisedI18nAttributes %}
+{% from "../../macros/i18n.njk" import govukI18nAttributes %}
 
 {% from "../textarea/macro.njk" import govukTextarea %}
 {% from "../hint/macro.njk" import govukHint %}
@@ -6,22 +6,51 @@
 {%- set hasNoLimit = (not params.maxwords and not params.maxlength) %}
 
 <div class="govuk-character-count" data-module="govuk-character-count"
-{%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
-{%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
-{%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
-{#
-  Without maxlength or maxwords, we can't guess if the component will count words or characters.
-  We can't guess a default textarea description to be interpolated in JavaScript
-  once the maximum gets configured there.
-  So we only add the attribute if a textarea description was explicitely provided.
-#}
-{%- if hasNoLimit and params.textareaDescriptionText %}{{govukPluralisedI18nAttributes('textarea-description', {other: params.textareaDescriptionText})}}{% endif %}
-{%- if params.charactersUnderLimitText %}{{govukPluralisedI18nAttributes('characters-under-limit', params.charactersUnderLimitText)}}{% endif %}
-{%- if params.charactersAtLimitText %} data-i18n.characters-at-limit="{{ params.charactersAtLimitText | escape}}"{% endif %}
-{%- if params.charactersOverLimitText %}{{govukPluralisedI18nAttributes('characters-over-limit', params.charactersOverLimitText)}}{% endif %}
-{%- if params.wordsUnderLimitText %}{{govukPluralisedI18nAttributes('words-under-limit', params.wordsUnderLimitText)}}{% endif %}
-{%- if params.wordsAtLimitText %} data-i18n.words-at-limit="{{ params.wordsAtLimitText | escape}}"{% endif %}
-{%- if params.wordsOverLimitText %}{{govukPluralisedI18nAttributes('words-over-limit', params.wordsOverLimitText)}}{% endif %}>
+  {%- if params.maxlength %} data-maxlength="{{ params.maxlength }}"{% endif %}
+  {%- if params.threshold %} data-threshold="{{ params.threshold }}"{% endif %}
+  {%- if params.maxwords %} data-maxwords="{{ params.maxwords }}"{% endif %}
+  {#
+    Without maxlength or maxwords, we can't guess if the component will count words or characters.
+    We can't guess a default textarea description to be interpolated in JavaScript
+    once the maximum gets configured there.
+    So we only add the attribute if a textarea description was explicitely provided.
+  #}
+  {%- if hasNoLimit and params.textareaDescriptionText %}
+    {{- govukI18nAttributes({
+      key: 'textarea-description',
+      messages: { other: params.textareaDescriptionText }
+    }) -}}
+  {% endif -%}
+
+  {{- govukI18nAttributes({
+    key: 'characters-under-limit',
+    messages: params.charactersUnderLimitText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'characters-at-limit',
+    message: params.charactersAtLimitText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'characters-over-limit',
+    messages: params.charactersOverLimitText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'words-under-limit',
+    messages: params.wordsUnderLimitText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'words-at-limit',
+    message: params.wordsAtLimitText
+  }) -}}
+
+  {{- govukI18nAttributes({
+    key: 'words-over-limit',
+    messages: params.wordsOverLimitText
+  }) -}}>
   {{ govukTextarea({
     id: params.id,
     name: params.name,

--- a/packages/govuk-frontend/src/govuk/macros/i18n.njk
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.njk
@@ -1,16 +1,21 @@
 {#
-  Renders the data attributes for the different plural forms of the given
-  translation key.
+  Renders translated text into data attributes by translation key
+
+  - Provide params.message for translation text, singular
+  - Provide params.messages for translation text by corresponding plural rule
 
   {@link https://cldr.unicode.org/index/cldr-spec/plural-rules}
 
   Helps reduce the boilerplate in component templates as they're quite verbose
 
   @private
-  @param {string} translationKey - The kebab-cased name of the translation key
-  @param {object} pluralForms - An object associating translation messages to
-    the plural form they correspond to
+  @param {object} params - i18n macro params
+  @param {string} params.key - Translation key (kebab-case)
+  @param {string} [params.message] - Translation text, singular
+  @param {{ [pluralRule: string]: string }} [params.messages] - Translation text by corresponding plural rule (optional, overrides params.message)
 #}
-{% macro govukPluralisedI18nAttributes(translationKey, pluralForms) %}
-  {% for pluralType, message in pluralForms %} data-i18n.{{translationKey}}.{{pluralType}}="{{message | escape}}"{% endfor %}
+{% macro govukI18nAttributes(params) %}
+  {%- if params.messages -%}
+    {% for pluralRule, message in params.messages %} data-i18n.{{ params.key }}.{{ pluralRule }}="{{ message | escape }}"{% endfor %}
+  {% elseif params.message %} data-i18n.{{ params.key }}="{{ params.message | escape }}"{% endif -%}
 {% endmacro %}

--- a/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
@@ -1,24 +1,36 @@
-import { callMacro } from 'govuk-frontend-helpers/nunjucks'
+import { renderMacro } from 'govuk-frontend-helpers/nunjucks'
 
 describe('i18n.njk', () => {
-  describe('govukPluralisedI18nAttributes', () => {
-    function callMacroUnderTest (...args) {
-      return callMacro('govukPluralisedI18nAttributes', 'govuk/macros/i18n.njk', ...args)
-    }
-
+  describe('govukI18nAttributes', () => {
     it('renders a single plural type', () => {
-      const attributes = callMacroUnderTest(['translation-key', { other: 'You have %{count} characters remaining.' }])
+      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
+        key: 'translation-key',
+        messages: {
+          other: 'You have %{count} characters remaining.'
+        }
+      })
+
       // Note the starting space so we ensure it doesn't stick to possible other previous attributes
       expect(attributes).toEqual(' data-i18n.translation-key.other="You have %{count} characters remaining."')
     })
 
     it('renders multiple plural types', () => {
-      const attributes = callMacroUnderTest(['translation-key', { other: 'You have %{count} characters remaining.', one: 'One character remaining' }])
+      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
+        key: 'translation-key',
+        messages: {
+          other: 'You have %{count} characters remaining.',
+          one: 'One character remaining'
+        }
+      })
+
       expect(attributes).toEqual(' data-i18n.translation-key.other="You have %{count} characters remaining." data-i18n.translation-key.one="One character remaining"')
     })
 
     it('outputs nothing if there are no translations', () => {
-      const attributes = callMacroUnderTest(['translation-key', {}])
+      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
+        key: 'translation-key'
+      })
+
       expect(attributes).toEqual('')
     })
   })

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -27,7 +27,7 @@ function renderHTML (componentName, options, callBlock) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  return callMacro(macroName, macroPath, [options], callBlock)
+  return renderMacro(macroName, macroPath, options, callBlock)
 }
 
 /**
@@ -44,26 +44,24 @@ function render (componentName, options, callBlock) {
 }
 
 /**
- * Returns the string result from calling a macro
+ * Render the string result from calling a macro
  *
  * @param {string} macroName - The name of the macro
- * @param {string} macroPath - The path to the file containing the macro *from the root of the project*
- * @param {{ [key: string]: unknown }[]} params - The parameters that will be passed to the macro. They'll be `JSON.stringify`ed and joined with a `,`
+ * @param {string} macroPath - The path to the file containing the macro
+ * @param {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
  * @param {string} [callBlock] - Content for an optional callBlock, if necessary for the macro to receive one
  * @returns {string} The result of calling the macro
  */
-function callMacro (macroName, macroPath, params = [], callBlock) {
-  const macroParams = params.map(param => JSON.stringify(param, null, 2)).join(',')
+function renderMacro (macroName, macroPath, options = {}, callBlock) {
+  const macroOptions = JSON.stringify(options, undefined, 2)
 
   let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
 
   // If we're nesting child components or text, pass the children to the macro
   // using the 'caller' Nunjucks feature
-  if (callBlock) {
-    macroString += `{%- call ${macroName}(${macroParams}) -%}${callBlock}{%- endcall -%}`
-  } else {
-    macroString += `{{- ${macroName}(${macroParams}) -}}`
-  }
+  macroString += callBlock
+    ? `{%- call ${macroName}(${macroOptions}) -%}${callBlock}{%- endcall -%}`
+    : `{{- ${macroName}(${macroOptions}) -}}`
 
   return nunjucksEnv.renderString(macroString, {})
 }
@@ -91,8 +89,8 @@ function renderTemplate (context = {}, blocks = {}) {
 
 module.exports = {
   nunjucksEnv,
-  callMacro,
   render,
   renderHTML,
+  renderMacro,
   renderTemplate
 }


### PR DESCRIPTION
Split out from the https://github.com/alphagov/govuk-frontend/pull/3812 spike

This PR ensures all component and utility macros can be given a single `params` argument

During component data testing I found it hard to understand how **Character Count** data attributes were rendered, so it also renames `govukPluralisedI18nAttributes()` to `govukI18nAttributes()` to handle single or plural translation text