### PR TITLE
Fix component data typos, missing fields etc

### DIFF
--- a/packages/govuk-frontend/gulpfile.mjs
+++ b/packages/govuk-frontend/gulpfile.mjs
@@ -2,7 +2,7 @@ import gulp from 'gulp'
 
 import * as build from './tasks/build/index.mjs'
 import { options, targets } from './tasks/build/options.mjs'
-import { scripts, styles, templates } from './tasks/index.mjs'
+import { fixtures, scripts, styles, templates } from './tasks/index.mjs'
 
 /**
  * Build target tasks
@@ -14,6 +14,7 @@ gulp.task('dev', build.dev(options))
 /**
  * Utility tasks
  */
+gulp.task('fixtures', fixtures(options))
 gulp.task('scripts', scripts(options))
 gulp.task('styles', styles(options))
 gulp.task('templates', templates(options))

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -86,6 +86,7 @@ params:
           - name: html
             type: string
             description: The HTML to reveal when the checkbox is checked
+            required: true
       - name: behaviour
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -78,6 +78,7 @@ params:
           - name: html
             type: string
             description: The HTML to reveal when the radio is checked
+            required: true
       - name: disabled
         type: boolean
         required: false

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -15,6 +15,7 @@ params:
       - name: key.html
         type: string
         required: true
+        description: If `text` is set, this is not required. HTML to use within each key. If `html` is provided, the `text` option will be ignored.
       - name: key.classes
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -11,7 +11,7 @@ params:
       - name: key.text
         type: string
         required: true
-        description: If `html` is set, this is not required. Text to use within the each key. If `html` is provided, the `text` option will be ignored.
+        description: If `html` is set, this is not required. Text to use within each key. If `html` is provided, the `text` option will be ignored.
       - name: key.html
         type: string
         required: true
@@ -22,11 +22,11 @@ params:
       - name: value.text
         type: string
         required: true
-        description: If `html` is set, this is not required. Text to use within the each value. If `html` is provided, the `text` option will be ignored.
+        description: If `html` is set, this is not required. Text to use within each value. If `html` is provided, the `text` option will be ignored.
       - name: value.html
         type: string
         required: true
-        description: If `text` is set, this is not required. HTML to use within the each value. If `html` is provided, the `text` option will be ignored.
+        description: If `text` is set, this is not required. HTML to use within each value. If `html` is provided, the `text` option will be ignored.
       - name: value.classes
         type: string
         required: false
@@ -51,7 +51,7 @@ params:
           - name: html
             type: string
             required: true
-            description: If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` option will be ignored.
+            description: If `text` is set, this is not required. HTML to use within each action item. If `html` is provided, the `text` option will be ignored.
           - name: visuallyHiddenText
             type: string
             required: false
@@ -77,11 +77,11 @@ params:
           - name: text
             type: string
             required: false
-            description: Text to use within the each title. If `html` is provided, the `text` option will be ignored.
+            description: Text to use within each title. If `html` is provided, the `text` option will be ignored.
           - name: html
             type: string
             required: false
-            description: Text to use within the each title. If `html` is provided, the `text` option will be ignored.
+            description: Text to use within each title. If `html` is provided, the `text` option will be ignored.
           - name: headingLevel
             type: integer
             required: false
@@ -111,7 +111,7 @@ params:
               - name: html
                 type: string
                 required: true
-                description: If `text` is set, this is not required. HTML to use within the each action item. If `html` is provided, the `text` option will be ignored.
+                description: If `text` is set, this is not required. HTML to use within each action item. If `html` is provided, the `text` option will be ignored.
               - name: visuallyHiddenText
                 type: string
                 required: false

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
@@ -40,7 +40,7 @@ params:
           - name: html
             type: string
             required: true
-            description: If `text` is set, this is not required. HTML to use within the each tab panel. If `html` is provided, the `text` option will be ignored.
+            description: If `text` is set, this is not required. HTML to use within each tab panel. If `html` is provided, the `text` option will be ignored.
           - name: attributes
             type: object
             required: false

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -42,7 +42,7 @@ params:
           - name: tag
             type: object
             required: false
-            descrption: Object containing the options for a tag that acts as the status for the task.
+            description: Object containing the options for a tag that acts as the status for the task.
             params:
               - name: text
                 type: string

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -4,7 +4,7 @@ import { npm, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 import slash from 'slash'
 
-import { scripts, styles, templates } from './index.mjs'
+import { fixtures, scripts, styles, templates } from './index.mjs'
 
 /**
  * Watch task
@@ -39,6 +39,15 @@ export const watch = (options) => gulp.parallel(
       npm.script('lint:js:cli', [slash(join(options.workspace, '**/*.{cjs,js,md,mjs}'))]),
       scripts(options)
     ))
+  ),
+
+  /**
+   * Component fixtures watcher
+   */
+  task.name('compile:fixtures watch', () =>
+    gulp.watch([
+      `${slash(options.srcPath)}/govuk/components/*/*.yaml`
+    ], fixtures(options))
   ),
 
   /**

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -175,32 +175,34 @@ module.exports = {
 }
 
 /**
- * Component data from YAML
+ * Component data
  *
  * @typedef {object} ComponentData
- * @property {ComponentOption[]} [params] - Nunjucks macro options
- * @property {ComponentExample[]} [examples] - Example Nunjucks macro options
+ * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
+ * @property {ComponentExample[]} [examples] - Component examples with Nunjucks macro options (or params)
  * @property {string} [previewLayout] - Nunjucks layout for component preview
  * @property {string} [accessibilityCriteria] - Accessibility criteria
  */
 
 /**
- * Component option from YAML
+ * Nunjucks macro option (or param) config
  *
  * @typedef {object} ComponentOption
  * @property {string} name - Option name
- * @property {string} type - Option type
+ * @property {'array' | 'boolean' | 'integer' | 'nunjucks-block' | 'object' | 'string'} type - Option type
  * @property {boolean} required - Option required
  * @property {string} description - Option description
  * @property {boolean} [isComponent] - Option is another component
- * @property {ComponentOption[]} [params] - Nested Nunjucks macro options
+ * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
  */
 
 /**
- * Component example from YAML
+ * Component examples with Nunjucks macro options (or params)
  *
  * @typedef {object} ComponentExample
  * @property {string} name - Example name
- * @property {object} data - Example data
+ * @property {string} [description] - Example description
  * @property {boolean} [hidden] - Example hidden from review app
+ * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
+ * @property {{ [param: string]: unknown }} data - Nunjucks macro options (or params)
  */


### PR DESCRIPTION
This PR fixes various component data typos and missing fields from the https://github.com/alphagov/govuk-frontend/pull/3812 spike

I've added a Gulp watch task to build YAML component data into `fixtures.json` + `macro-options.json` during development. This is useful when running `npm link` with the Design System