### PR TITLE
Update focus style on Error Summary and Notification Banner

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
@@ -9,7 +9,7 @@
     border: $govuk-border-width solid $govuk-error-colour;
 
     &:focus {
-      outline: $govuk-focus-width solid $govuk-focus-colour;
+      @include govuk-focused-box;
     }
   }
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
@@ -8,7 +8,7 @@
     background-color: $govuk-brand-colour;
 
     &:focus {
-      outline: $govuk-focus-width solid $govuk-focus-colour;
+      @include govuk-focused-box;
     }
   }
 


### PR DESCRIPTION
Applies the same `govuk-focused-box` mixin used for images in #3819 to the Error Summary and Notification Banner components, as per @davidc-gds's suggestion.

Merging this would be one way to resolve #1936, as it fixes the problem of the yellow outline not providing sufficient contrast.

## Screenshots

### Error Summary

<img width="605" alt="image" src="https://github.com/alphagov/govuk-frontend/assets/1253214/60a0233d-0da5-405b-a43d-f9add5a76cbc">

### Notification Banner

<img width="605" alt="image" src="https://github.com/alphagov/govuk-frontend/assets/1253214/fe48161b-ba2d-4243-a099-46429f3ac245">

## Thoughts
There was some questions as to whether we should use the exact same focus style as #3819, or develop ones specific to these components that replicate way that text input focus works—with the coloured border becoming thicker and only having the yellow focus colour outline it, as current. 

In my mind, using the same (yellow and black) outline is the 'safer' option. As I found when digging into #3925, the Notification Banner component is currently tied to the `$govuk-brand-colour` setting and there is no requirement or guarantee that the colour used provides sufficient contrast with white. In that case, the black outline would be necessary for WCAG compliance. (However, the more ideal solution would probably be to divorce the colour of the Notification Banner from the brand colour.)