### PR TITLE
Add class `.govuk-frontend-supported` for ES modules support (Checkboxes)

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -6,7 +6,7 @@ export class Checkboxes {
    * @param {Element} $module - HTML element to use for checkboxes
    */
   constructor ($module) {
-    if (!($module instanceof HTMLElement)) {
+    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
       return this
     }
 


### PR DESCRIPTION
Updates the Checkboxes component missed from:

* https://github.com/alphagov/govuk-frontend/pull/3801