### PR TITLE
Update default link for ETP

### DIFF
--- a/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -6,7 +6,7 @@ params:
   - name: redirectUrl
     type: string
     required: false
-    description: URL to redirect the current tab to. Defaults to `https://www.google.com`.
+    description: URL to redirect the current tab to. Defaults to `https://www.bbc.co.uk/weather`.
   - name: id
     type: string
     required: false

--- a/src/govuk/components/exit-this-page/template.njk
+++ b/src/govuk/components/exit-this-page/template.njk
@@ -10,6 +10,6 @@
   {{- govukButton({
     text: params.text | default("Exit this page"),
     classes: "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
-    href: params.redirectUrl | default("https://www.google.com")
+    href: params.redirectUrl | default("https://www.bbc.co.uk/weather")
   }) -}}
 </div>


### PR DESCRIPTION
Missed in initial code review. Our guidance notes that the default link is BBC weather so we should reflect that in the component code.