### PR TITLE
Format JavaScript using Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: 'standard',
+  extends: ['standard', 'prettier'],
   ignorePatterns: [
     '**/dist/**',
     '**/vendor/**',
@@ -19,7 +19,8 @@ module.exports = {
         'plugin:import/recommended',
         'plugin:jsdoc/recommended-typescript-flavor',
         'plugin:n/recommended',
-        'plugin:promise/recommended'
+        'plugin:promise/recommended',
+        'prettier'
       ],
       files: [
         '**/*.{cjs,js,mjs}',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,12 +32,7 @@ module.exports = {
       parserOptions: {
         ecmaVersion: 'latest'
       },
-      plugins: [
-        'import',
-        'jsdoc',
-        'n',
-        'promise'
-      ],
+      plugins: ['import', 'jsdoc', 'n', 'promise'],
       rules: {
         // Check import or require statements are A-Z ordered
         'import/order': [
@@ -56,7 +51,8 @@ module.exports = {
         // Check for valid formatting
         'jsdoc/check-line-alignment': [
           'warn',
-          'never', {
+          'never',
+          {
             wrapIndent: '  '
           }
         ],
@@ -68,7 +64,8 @@ module.exports = {
         // Maintain new line after description
         'jsdoc/tag-lines': [
           'warn',
-          'never', {
+          'never',
+          {
             startLines: 1
           }
         ],

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -32,7 +32,7 @@ const eslint = new ESLint()
  * @param {string} task - The task `lint-staged` wants to execute
  * @returns {Promise<(paths: string[]) => string[]>} Tasks to run with files argument
  */
-function filterTask (task) {
+function filterTask(task) {
   return async (files) => {
     const isIgnored = await Promise.all(
       files.map((file) => eslint.isPathIgnored(file))
@@ -41,10 +41,8 @@ function filterTask (task) {
     // Wrap files in quotes in case they contains a space
     const paths = files
       .filter((_, i) => !isIgnored[i])
-      .map(file => `"${file}"`)
+      .map((file) => `"${file}"`)
 
-    return paths.length
-      ? [`${task} ${paths.join(' ')}`]
-      : []
+    return paths.length ? [`${task} ${paths.join(' ')}`] : []
   }
 }

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -17,7 +17,7 @@ const commands = {
 }
 
 module.exports = {
-  '*.{cjs,js,mjs}': commands.eslint,
+  '*.{cjs,js,mjs}': [commands.eslint, commands.prettier],
   '*.{json,yaml,yml}': commands.prettier,
   '*.md': [commands.eslint, commands.stylelint, commands.prettier],
   '*.scss': [commands.stylelint, commands.prettier]

--- a/babel.config.js
+++ b/babel.config.js
@@ -8,9 +8,12 @@ module.exports = function (api) {
 
   return {
     presets: [
-      ['@babel/preset-env', {
-        browserslistEnv: 'node'
-      }]
+      [
+        '@babel/preset-env',
+        {
+          browserslistEnv: 'node'
+        }
+      ]
     ]
   }
 }

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -20,8 +20,11 @@ export class Example {
   /**
    * @param {Element} $module - HTML element to use for component
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -63,7 +66,7 @@ Use `/** ... */` for multi-line comments. Include a description, and specify typ
  * @param {string} tagName - Tag name (for example 'div')
  * @returns {Element} Ancestor element
  */
-function exampleHelper ($element, tagName) {
+function exampleHelper($element, tagName) {
   // Code goes here
   return $element.querySelector(tagName)
 }
@@ -92,7 +95,7 @@ Add methods to the class.
 ```mjs
 // Good
 class Example {
-  doSomething () {
+  doSomething() {
     // Code goes here
   }
 }
@@ -123,8 +126,8 @@ Use ECMAScript (ES) modules (`import`/`export`) over CommonJS and other formats.
 import { closestAttributeValue } from '../common/index.mjs'
 
 // Code goes here
-export function exampleHelper1 () {}
-export function exampleHelper2 () {}
+export function exampleHelper1() {}
+export function exampleHelper2() {}
 ```
 
 You must specify the file extension when using the import keyword.

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -144,6 +144,8 @@ If you need polyfills for features that are not yet included in this project, pl
 
 GOV.UK Frontend uses [ESLint](https://eslint.org) with [JavaScript Standard Style](https://standardjs.com), an opinionated JavaScript style guide. All JavaScript files follow its conventions, and it runs on GitHub Actions to ensure that new pull requests are in line with them.
 
+For consistent formatting we run [Prettier](https://prettier.io).
+
 The standard docs have a [complete list of rules and some reasoning behind them](https://standardjs.com/rules.html).
 
 Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
@@ -158,4 +160,14 @@ To automatically fix ESLint issues, add the `--fix` flag:
 
 ```shell
 npm run lint:js -- --fix
+```
+
+## Running the formatting task
+
+You can run the formatter with `npm run lint:prettier`, or use formatting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) and [other editors that support Prettier](https://prettier.io/docs/en/editors.html)
+
+To automatically fix Prettier issues in all supported files, add the `--write` flag:
+
+```shell
+npm run lint:prettier -- --write
 ```

--- a/docs/examples/webpack/babel.config.js
+++ b/docs/examples/webpack/babel.config.js
@@ -12,18 +12,21 @@ module.exports = function (api) {
 
   return {
     presets: [
-      ['@babel/preset-env', {
-        browserslistEnv,
+      [
+        '@babel/preset-env',
+        {
+          browserslistEnv,
 
-        // Apply bug fixes to avoid transforms
-        bugfixes: true,
+          // Apply bug fixes to avoid transforms
+          bugfixes: true,
 
-        // Apply smaller "loose" transforms for browsers
-        loose: isBrowser,
+          // Apply smaller "loose" transforms for browsers
+          loose: isBrowser,
 
-        // Skip ES module transforms for browsers
-        modules: isBrowser ? false : 'auto'
-      }]
+          // Skip ES module transforms for browsers
+          modules: isBrowser ? false : 'auto'
+        }
+      ]
     ]
   }
 }

--- a/docs/examples/webpack/webpack.config.js
+++ b/docs/examples/webpack/webpack.config.js
@@ -21,9 +21,7 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
     }
   },
 
-  devtool: WEBPACK_SERVE
-    ? 'inline-source-map'
-    : 'source-map',
+  devtool: WEBPACK_SERVE ? 'inline-source-map' : 'source-map',
 
   entry: {
     app: [
@@ -87,15 +85,17 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
 
   optimization: {
     minimize: mode === 'production',
-    minimizer: [new TerserPlugin({
-      extractComments: true,
-      terserOptions: {
-        format: { comments: false },
+    minimizer: [
+      new TerserPlugin({
+        extractComments: true,
+        terserOptions: {
+          format: { comments: false },
 
-        // Compatibility workarounds
-        safari10: true
-      }
-    })]
+          // Compatibility workarounds
+          safari10: true
+        }
+      })
+    ]
   },
 
   output: {
@@ -111,9 +111,7 @@ module.exports = ({ WEBPACK_SERVE }, { mode }) => ({
       filename: 'stylesheets/[name].min.css'
     }),
     new CopyPlugin({
-      patterns: [
-        join(srcPath, 'index.html')
-      ]
+      patterns: [join(srcPath, 'index.html')]
     })
   ],
 

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -37,9 +37,7 @@ module.exports = {
      *
      * {@link https://developer.chrome.com/articles/new-headless/}
      */
-    headless: process.env.HEADLESS !== 'false'
-      ? 'new'
-      : false,
+    headless: process.env.HEADLESS !== 'false' ? 'new' : false,
 
     // See launch arg '--no-startup-window'
     waitForInitialPage: false

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -39,28 +39,31 @@ const config = {
   // See: https://jestjs.io/docs/ecmascript-modules
   transform: {
     // Transform all `*.mjs` to compatible CommonJS
-    '^.+\\.mjs$': ['babel-jest', {
-      rootMode: 'upward'
-    }],
+    '^.+\\.mjs$': [
+      'babel-jest',
+      {
+        rootMode: 'upward'
+      }
+    ],
 
     // Transform some `*.js` to compatible CommonJS
-    ...Object.fromEntries([
-      'del',
-      'slash'
-    ].map((packagePath) => [
-      replacePathSepForRegex(`${packageResolveToPath(packagePath)}$`), ['babel-jest', {
-        rootMode: 'upward'
-      }]
-    ]))
+    ...Object.fromEntries(
+      ['del', 'slash'].map((packagePath) => [
+        replacePathSepForRegex(`${packageResolveToPath(packagePath)}$`),
+        [
+          'babel-jest',
+          {
+            rootMode: 'upward'
+          }
+        ]
+      ])
+    )
   },
 
   // Enable Babel transforms for ESM-only node_modules
   // See: https://jestjs.io/docs/ecmascript-modules
   transformIgnorePatterns: [
-    `<rootDir>/node_modules/(?!${[
-      'del',
-      'slash'
-    ].join('|')}/)`
+    `<rootDir>/node_modules/(?!${['del', 'slash'].join('|')}/)`
   ]
 }
 
@@ -87,28 +90,20 @@ export default {
     {
       ...config,
       displayName: 'Build tasks',
-      testMatch: [
-        '**/tasks/build/*.test.{js,mjs}'
-      ]
+      testMatch: ['**/tasks/build/*.test.{js,mjs}']
     },
     {
       ...config,
       displayName: 'Nunjucks macro tests',
-      snapshotSerializers: [
-        'jest-serializer-html'
-      ],
+      snapshotSerializers: ['jest-serializer-html'],
       testEnvironment: 'govuk-frontend-helpers/jest/environment/jsdom.mjs',
-      testMatch: [
-        '**/(*.)?template.test.{js,mjs}'
-      ]
+      testMatch: ['**/(*.)?template.test.{js,mjs}']
     },
     {
       ...config,
       displayName: 'JavaScript unit tests',
       testEnvironment: 'govuk-frontend-helpers/jest/environment/jsdom.mjs',
-      testMatch: [
-        '**/*.unit.test.{js,mjs}'
-      ]
+      testMatch: ['**/*.unit.test.{js,mjs}']
     },
     {
       ...config,

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "concurrently": "^8.2.0",
         "editorconfig-checker": "^5.1.1",
         "eslint": "^8.46.0",
+        "eslint-config-prettier": "^9.0.0",
         "eslint-config-standard": "^17.1.0",
         "eslint-plugin-es-x": "^7.2.0",
         "eslint-plugin-import": "^2.28.0",
@@ -10476,6 +10477,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
+      "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-config-standard": {
@@ -26292,9 +26305,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.2.tgz",
-      "integrity": "sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
       "devOptional": true
     },
     "node_modules/tunnel": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lint:editorconfig:cli": "editorconfig-checker",
     "lint:js": "npm run lint:js:cli -- \"**/*.{cjs,js,md,mjs}\"",
     "lint:js:cli": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore --max-warnings 0",
-    "lint:prettier": "npm run lint:prettier:cli -- \"**/*.{json,md,scss,yaml,yml}\"",
+    "lint:prettier": "npm run lint:prettier:cli -- \"**/*.{cjs,js,json,md,mjs,scss,yaml,yml}\"",
     "lint:prettier:cli": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check",
     "lint:scss": "npm run lint:scss:cli -- \"**/*.{md,scss}\"",
     "lint:scss:cli": "stylelint --cache --cache-location .cache/stylelint --cache-strategy content --color --ignore-path .gitignore --max-warnings 0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "concurrently": "^8.2.0",
     "editorconfig-checker": "^5.1.1",
     "eslint": "^8.46.0",
+    "eslint-config-prettier": "^9.0.0",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-es-x": "^7.2.0",
     "eslint-plugin-import": "^2.28.0",

--- a/packages/govuk-frontend-review/.eslintrc.js
+++ b/packages/govuk-frontend-review/.eslintrc.js
@@ -4,9 +4,7 @@ module.exports = {
   overrides: [
     {
       files: ['**/*.mjs'],
-      excludedFiles: [
-        '**/*.test.mjs'
-      ],
+      excludedFiles: ['**/*.test.mjs'],
       parser: '@typescript-eslint/parser',
       parserOptions: {
         project: [join(__dirname, 'tsconfig.json')]

--- a/packages/govuk-frontend-review/postcss.config.mjs
+++ b/packages/govuk-frontend-review/postcss.config.mjs
@@ -16,13 +16,7 @@ export default {
     // For example ':hover' and ':focus' classes to simulate form label states
     pseudoclasses({
       allCombinations: true,
-      restrictTo: [
-        ':link',
-        ':visited',
-        ':hover',
-        ':active',
-        ':focus'
-      ]
+      restrictTo: [':link', ':visited', ':hover', ':active', ':focus']
     }),
 
     // Always minify CSS

--- a/packages/govuk-frontend-review/postcss.config.unit.test.mjs
+++ b/packages/govuk-frontend-review/postcss.config.unit.test.mjs
@@ -1,61 +1,61 @@
 import config from './postcss.config.mjs'
 
 describe('PostCSS config', () => {
-  function getPluginNames (config) {
+  function getPluginNames(config) {
     return config.plugins.flatMap(getPluginName)
   }
 
-  function getPluginName ({ plugins, postcssPlugin }) {
+  function getPluginName({ plugins, postcssPlugin }) {
     return plugins ? getPluginNames({ plugins }) : postcssPlugin
   }
 
   describe('Browserslist', () => {
     it('Uses default environment', () => {
-      expect(config.plugins)
-        .toEqual(expect.arrayContaining([
+      expect(config.plugins).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
             postcssPlugin: 'autoprefixer'
           })
-        ]))
+        ])
+      )
     })
   })
 
   describe('Plugins', () => {
     it('Uses expected plugins', () => {
-      expect(getPluginNames(config))
-        .toEqual([
-          'autoprefixer',
-          'postcss-pseudo-classes',
-          'postcss-discard-comments',
-          'postcss-minify-gradients',
-          'postcss-reduce-initial',
-          'postcss-svgo',
-          'postcss-normalize-display-values',
-          'postcss-reduce-transforms',
-          'postcss-colormin',
-          'postcss-normalize-timing-functions',
-          'postcss-calc',
-          'postcss-convert-values',
-          'postcss-ordered-values',
-          'postcss-minify-selectors',
-          'postcss-minify-params',
-          'postcss-normalize-charset',
-          'postcss-discard-overridden',
-          'postcss-normalize-string',
-          'postcss-normalize-unicode',
-          'postcss-minify-font-values',
-          'postcss-normalize-url',
-          'postcss-normalize-repeat-style',
-          'postcss-normalize-positions',
-          'postcss-normalize-whitespace',
-          'postcss-merge-longhand',
-          'postcss-discard-duplicates',
-          'postcss-merge-rules',
-          'postcss-discard-empty',
-          'postcss-unique-selectors',
-          'css-declaration-sorter',
-          'cssnano-util-raw-cache'
-        ])
+      expect(getPluginNames(config)).toEqual([
+        'autoprefixer',
+        'postcss-pseudo-classes',
+        'postcss-discard-comments',
+        'postcss-minify-gradients',
+        'postcss-reduce-initial',
+        'postcss-svgo',
+        'postcss-normalize-display-values',
+        'postcss-reduce-transforms',
+        'postcss-colormin',
+        'postcss-normalize-timing-functions',
+        'postcss-calc',
+        'postcss-convert-values',
+        'postcss-ordered-values',
+        'postcss-minify-selectors',
+        'postcss-minify-params',
+        'postcss-normalize-charset',
+        'postcss-discard-overridden',
+        'postcss-normalize-string',
+        'postcss-normalize-unicode',
+        'postcss-minify-font-values',
+        'postcss-normalize-url',
+        'postcss-normalize-repeat-style',
+        'postcss-normalize-positions',
+        'postcss-normalize-whitespace',
+        'postcss-merge-longhand',
+        'postcss-discard-duplicates',
+        'postcss-merge-rules',
+        'postcss-discard-empty',
+        'postcss-unique-selectors',
+        'css-declaration-sorter',
+        'cssnano-util-raw-cache'
+      ])
     })
   })
 })

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -151,9 +151,9 @@ export default async () => {
 
       res.locals.componentView = env.renderString(
         outdent`
-      {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
-      {{ ${macroName}(${macroParameters}) }}
-    `,
+          {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
+          {{ ${macroName}(${macroParameters}) }}
+        `,
         {}
       )
 

--- a/packages/govuk-frontend-review/src/app.test.mjs
+++ b/packages/govuk-frontend-review/src/app.test.mjs
@@ -18,7 +18,7 @@ const expectedPages = [
 ]
 
 describe(`http://localhost:${ports.app}`, () => {
-  describe.each(expectedPages)('%s', path => {
+  describe.each(expectedPages)('%s', (path) => {
     it('should resolve with a http status code of 200', async () => {
       const { status } = await fetchPath(path, { method: 'HEAD' })
       expect(status).toEqual(200)
@@ -58,17 +58,14 @@ describe(`http://localhost:${ports.app}`, () => {
   describe('/examples/template-custom', () => {
     const templatePath = '/examples/template-custom'
 
-    it.each([
-      'headIcons',
-      'bodyStart',
-      'main',
-      'content',
-      'bodyEnd'
-    ])('should have a %s block set', async (block) => {
-      const response = await fetchPath(templatePath)
-      const $ = load(await response.text())
-      expect($.html()).toContain(`<!-- block:${block} -->`)
-    })
+    it.each(['headIcons', 'bodyStart', 'main', 'content', 'bodyEnd'])(
+      'should have a %s block set',
+      async (block) => {
+        const response = await fetchPath(templatePath)
+        const $ = load(await response.text())
+        expect($.html()).toContain(`<!-- block:${block} -->`)
+      }
+    )
 
     it('should have additional `htmlClasses`', async () => {
       const response = await fetchPath(templatePath)
@@ -110,7 +107,9 @@ describe(`http://localhost:${ports.app}`, () => {
       const $ = load(await response.text())
 
       const $title = $('title')
-      expect($title.html()).toBe("GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l'information")
+      expect($title.html()).toBe(
+        "GOV.UK - Le meilleur endroit pour trouver des services gouvernementaux et de l'information"
+      )
     })
 
     it('should have an application stylesheet', async () => {
@@ -146,7 +145,9 @@ describe(`http://localhost:${ports.app}`, () => {
       const $phaseBanner = $('.govuk-phase-banner')
       const $text = $phaseBanner.find('.govuk-phase-banner__text')
 
-      expect($text.html()).toContain("C'est un nouveau service - vos <a class=\"govuk-link\" href=\"#\">commentaires</a> nous aideront à l'améliorer.")
+      expect($text.html()).toContain(
+        'C\'est un nouveau service - vos <a class="govuk-link" href="#">commentaires</a> nous aideront à l\'améliorer.'
+      )
     })
 
     it('should have a custom Footer component', async () => {
@@ -184,7 +185,9 @@ describe(`http://localhost:${ports.app}`, () => {
       const $ = load(await response.text())
 
       const $main = $('main')
-      expect($main.attr('class')).toBe('govuk-main-wrapper govuk-main-wrapper--auto-spacing app-main-class')
+      expect($main.attr('class')).toBe(
+        'govuk-main-wrapper govuk-main-wrapper--auto-spacing app-main-class'
+      )
     })
   })
 })

--- a/packages/govuk-frontend-review/src/common/lib/files.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.mjs
@@ -10,7 +10,7 @@ import { getDirectories } from 'govuk-frontend-lib/files'
  *
  * @returns {Promise<string[]>} Component names
  */
-export function getExampleNames () {
+export function getExampleNames() {
   return getDirectories(join(paths.app, 'src/views/examples'))
 }
 
@@ -19,27 +19,35 @@ export function getExampleNames () {
  *
  * @returns {Promise<FullPageExample[]>} Full page examples
  */
-export async function getFullPageExamples () {
-  const directories = await getDirectories(join(paths.app, 'src/views/full-page-examples'))
+export async function getFullPageExamples() {
+  const directories = await getDirectories(
+    join(paths.app, 'src/views/full-page-examples')
+  )
 
   // Add metadata (front matter) to each example
-  const examples = await Promise.all(directories.map(async (exampleName) => {
-    const templatePath = join(paths.app, 'src/views/full-page-examples', exampleName, 'index.njk')
-    const { attributes } = fm(await readFile(templatePath, 'utf8'))
+  const examples = await Promise.all(
+    directories.map(async (exampleName) => {
+      const templatePath = join(
+        paths.app,
+        'src/views/full-page-examples',
+        exampleName,
+        'index.njk'
+      )
+      const { attributes } = fm(await readFile(templatePath, 'utf8'))
 
-    return {
-      name: exampleName,
-      path: exampleName,
-      ...attributes
-    }
-  }))
+      return {
+        name: exampleName,
+        path: exampleName,
+        ...attributes
+      }
+    })
+  )
 
   const collator = new Intl.Collator('en', {
     sensitivity: 'base'
   })
 
-  return examples.sort(({ name: a }, { name: b }) =>
-    collator.compare(a, b))
+  return examples.sort(({ name: a }, { name: b }) => collator.compare(a, b))
 }
 
 /**

--- a/packages/govuk-frontend-review/src/common/lib/files.test.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.test.mjs
@@ -4,37 +4,43 @@ describe('getFullPageExamples', () => {
   it('contains name of each example', async () => {
     const examples = await getFullPageExamples()
 
-    examples.forEach((example) => expect(example).toEqual(
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String)
-      })
-    ))
+    examples.forEach((example) =>
+      expect(example).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          path: expect.any(String)
+        })
+      )
+    )
   })
 
   it('contains scenario front matter, for some examples', async () => {
     const examples = await getFullPageExamples()
 
     // At least 1x example with { name, path, scenario }
-    expect(examples).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String),
-        scenario: expect.any(String)
-      })
-    ]))
+    expect(examples).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+          path: expect.any(String),
+          scenario: expect.any(String)
+        })
+      ])
+    )
   })
 
   it('contains notes front matter, for some examples', async () => {
     const examples = await getFullPageExamples()
 
     // At least 1x example with { name, path, notes }
-    expect(examples).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        name: expect.any(String),
-        path: expect.any(String),
-        notes: expect.any(String)
-      })
-    ]))
+    expect(examples).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+          path: expect.any(String),
+          notes: expect.any(String)
+        })
+      ])
+    )
   })
 })

--- a/packages/govuk-frontend-review/src/common/middleware/assets.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/assets.mjs
@@ -6,28 +6,19 @@ import { packageTypeToPath } from 'govuk-frontend-lib/names'
 
 const router = express.Router()
 
+// Resolve GOV.UK Frontend from review app `node_modules`
+// to allow previous versions to be installed locally
+const frontendPath = packageTypeToPath('govuk-frontend', {
+  modulePath: '/',
+  moduleRoot: paths.app
+})
+
 /**
  * Add middleware to serve static assets
  */
 
-router.use(
-  '/assets',
-  express.static(
-    packageTypeToPath('govuk-frontend', {
-      modulePath: 'assets',
-      moduleRoot: paths.app
-    })
-  )
-)
-router.use(
-  '/javascripts',
-  express.static(
-    packageTypeToPath('govuk-frontend', {
-      modulePath: '/',
-      moduleRoot: paths.app
-    })
-  )
-)
+router.use('/assets', express.static(join(frontendPath, 'assets')))
+router.use('/javascripts', express.static(frontendPath))
 router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 
 export default router

--- a/packages/govuk-frontend-review/src/common/middleware/assets.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/assets.mjs
@@ -10,8 +10,24 @@ const router = express.Router()
  * Add middleware to serve static assets
  */
 
-router.use('/assets', express.static(packageTypeToPath('govuk-frontend', { modulePath: 'assets', moduleRoot: paths.app })))
-router.use('/javascripts', express.static(packageTypeToPath('govuk-frontend', { modulePath: '/', moduleRoot: paths.app })))
+router.use(
+  '/assets',
+  express.static(
+    packageTypeToPath('govuk-frontend', {
+      modulePath: 'assets',
+      moduleRoot: paths.app
+    })
+  )
+)
+router.use(
+  '/javascripts',
+  express.static(
+    packageTypeToPath('govuk-frontend', {
+      modulePath: '/',
+      moduleRoot: paths.app
+    })
+  )
+)
 router.use('/stylesheets', express.static(join(paths.app, 'dist/stylesheets')))
 
 export default router

--- a/packages/govuk-frontend-review/src/common/middleware/docs.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/docs.mjs
@@ -19,7 +19,9 @@ router.use('/sass', ({ app }, res, next) => {
   const { isDeployedToHeroku } = app.get('flags')
 
   if (isDeployedToHeroku) {
-    return res.redirect('https://frontend.design-system.service.gov.uk/sass-api-reference/')
+    return res.redirect(
+      'https://frontend.design-system.service.gov.uk/sass-api-reference/'
+    )
   }
 
   next()

--- a/packages/govuk-frontend-review/src/common/middleware/request.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/request.mjs
@@ -7,9 +7,11 @@ const router = express.Router()
  * Parses form POST requests into `req.body`
  * that can be used for validation
  */
-router.use(express.urlencoded({
-  extended: true
-}))
+router.use(
+  express.urlencoded({
+    extended: true
+  })
+)
 
 /**
  * Parses cookie headers into `req.cookie`

--- a/packages/govuk-frontend-review/src/common/middleware/request.test.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/request.test.mjs
@@ -46,13 +46,10 @@ describe('Middleware: Request handling', () => {
 
       // Send form payload as string
       // application/x-www-form-urlencoded
-      await agent
-        .post('/')
-        .send(payload.toString())
+      await agent.post('/').send(payload.toString())
 
       // Form payload object
-      expect(req.body)
-        .toEqual(Object.fromEntries(payload))
+      expect(req.body).toEqual(Object.fromEntries(payload))
     })
   })
 
@@ -71,13 +68,10 @@ describe('Middleware: Request handling', () => {
       // Send cookies as string
       await agent
         .get('/')
-        .set('Cookie', [...cookies]
-          .map((cookie) => cookie.join('='))
-          .join(';'))
+        .set('Cookie', [...cookies].map((cookie) => cookie.join('=')).join(';'))
 
       // Cookies object
-      expect(req.cookies)
-        .toEqual(Object.fromEntries(cookies))
+      expect(req.cookies).toEqual(Object.fromEntries(cookies))
     })
   })
 })

--- a/packages/govuk-frontend-review/src/common/middleware/vendor.mjs
+++ b/packages/govuk-frontend-review/src/common/middleware/vendor.mjs
@@ -9,6 +9,9 @@ const router = express.Router()
  * Add middleware to serve dependencies
  * from node_modules
  */
-router.use('/iframe-resizer/', express.static(join(packageNameToPath('iframe-resizer'), 'js')))
+router.use(
+  '/iframe-resizer/',
+  express.static(join(packageNameToPath('iframe-resizer'), 'js'))
+)
 
 export default router

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/format-number.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/format-number.mjs
@@ -4,7 +4,7 @@
  * @param {string | number} number - Number to format
  * @returns {string} Number as formatted string
  */
-export function formatNumber (number) {
+export function formatNumber(number) {
   return Number(number).toLocaleString('en', {
     useGrouping: true
   })

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/highlight.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/highlight.mjs
@@ -7,6 +7,7 @@ import hljs from 'highlight.js'
  * @param {string} [language] - Code programming language
  * @returns {string} Code with syntax highlighting
  */
-export function highlight (code, language) {
-  return hljs.highlight(code.trim(), { language: language || 'plaintext' }).value
+export function highlight(code, language) {
+  return hljs.highlight(code.trim(), { language: language || 'plaintext' })
+    .value
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/slugify.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/slugify.mjs
@@ -6,6 +6,6 @@ import slug from 'slug'
  * @param {string} string - String to format
  * @returns {string} URL friendly "slug"
  */
-export function slugify (string) {
+export function slugify(string) {
   return slug(string, { lower: true })
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/unslugify.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/unslugify.mjs
@@ -6,6 +6,6 @@ import filters from 'nunjucks/src/filters.js'
  * @param {string} string - String to format
  * @returns {string} Human readable text
  */
-export function unslugify (string) {
+export function unslugify(string) {
   return filters.capitalize(string.replace(/-/g, ' '))
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -9,7 +9,7 @@ import beautify from 'js-beautify'
  * @param {unknown} params - Component macro params
  * @returns {string} Nunjucks code
  */
-export function getHTMLCode (componentName, params) {
+export function getHTMLCode(componentName, params) {
   const templatePath = packageTypeToPath('govuk-frontend', {
     modulePath: `components/${componentName}/template.njk`,
     moduleRoot: paths.app

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -12,7 +12,7 @@ import { componentNameToMacroName } from '../filters/index.mjs'
  * @param {unknown} params - Component macro params
  * @returns {string} Nunjucks code
  */
-export function getNunjucksCode (componentName, params) {
+export function getNunjucksCode(componentName, params) {
   const macroName = componentNameToMacroName(componentName)
 
   // Allow nested HTML strings to wrap at `\n`

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/markdown.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/markdown.mjs
@@ -6,6 +6,6 @@ import { marked } from 'marked'
  * @param {string} content - Markdown source
  * @returns {string} Rendered Markdown
  */
-export function markdown (content) {
+export function markdown(content) {
   return marked.parse(content)
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -13,23 +13,26 @@ import * as globals from './globals/index.mjs'
  * @param {import('express').Application} app - Express.js review app
  * @returns {import('nunjucks').Environment} Nunjucks Environment
  */
-export function renderer (app) {
-  const env = nunjucks.configure([
-    join(paths.app, 'src/views'),
+export function renderer(app) {
+  const env = nunjucks.configure(
+    [
+      join(paths.app, 'src/views'),
 
-    // Remove `govuk/` suffix using `modulePath`
-    packageResolveToPath('govuk-frontend', {
-      modulePath: '../',
-      moduleRoot: paths.app
-    })
-  ], {
-    autoescape: true, // output with dangerous characters are escaped automatically
-    express: app, // the Express.js review app that nunjucks should install to
-    noCache: true, // never use a cache and recompile templates each time
-    trimBlocks: true, // automatically remove trailing newlines from a block/tag
-    lstripBlocks: true, // automatically remove leading whitespace from a block/tag
-    watch: true // reload templates when they are changed. needs chokidar dependency to be installed
-  })
+      // Remove `govuk/` suffix using `modulePath`
+      packageResolveToPath('govuk-frontend', {
+        modulePath: '../',
+        moduleRoot: paths.app
+      })
+    ],
+    {
+      autoescape: true, // output with dangerous characters are escaped automatically
+      express: app, // the Express.js review app that nunjucks should install to
+      noCache: true, // never use a cache and recompile templates each time
+      trimBlocks: true, // automatically remove trailing newlines from a block/tag
+      lstripBlocks: true, // automatically remove leading whitespace from a block/tag
+      watch: true // reload templates when they are changed. needs chokidar dependency to be installed
+    }
+  )
 
   // Set view engine
   app.set('view engine', 'njk')

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -34,12 +34,15 @@ export default (app) => {
 
   // Display full page examples index by default if not handled already
   app.get('/full-page-examples/:exampleName', function (req, res, next) {
-    res.render(`full-page-examples/${req.params.exampleName}/index`, function (error, html) {
-      if (error) {
-        next(error)
-      } else {
-        res.send(html)
+    res.render(
+      `full-page-examples/${req.params.exampleName}/index`,
+      function (error, html) {
+        if (error) {
+          next(error)
+        } else {
+          res.send(html)
+        }
       }
-    })
+    )
   })
 }

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.test.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.test.mjs
@@ -56,6 +56,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath('/full-page-examples/feedback', {
           method: 'POST'
         })
+
         const body = await response.text()
         const $ = load(body)
 
@@ -77,6 +78,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/have-you-changed-your-name'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -93,6 +95,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/have-you-changed-your-name',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -128,6 +131,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/passport-details',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -149,6 +153,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/update-your-account-details'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -165,6 +170,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/update-your-account-details',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -186,6 +192,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/upload-your-photo'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -202,6 +209,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/upload-your-photo',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -223,6 +231,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/how-do-you-want-to-sign-in'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -239,6 +248,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/how-do-you-want-to-sign-in',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -260,6 +270,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/what-is-your-nationality'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -276,6 +287,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/what-is-your-nationality',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -297,6 +309,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/what-is-your-address'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -313,6 +326,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/what-is-your-address',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -334,6 +348,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/what-is-your-postcode'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -350,6 +365,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/what-is-your-postcode',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -378,6 +394,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/search?order=updated-newest'
         )
+
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
@@ -387,6 +404,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/search?order=updated-newest&organisation=hmrc'
         )
+
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
@@ -399,6 +417,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         const response = await fetchPath(
           '/full-page-examples/what-was-the-last-country-you-visited'
         )
+
         const body = await response.text()
         const $ = load(body)
 
@@ -415,6 +434,7 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
           '/full-page-examples/what-was-the-last-country-you-visited',
           { method: 'POST' }
         )
+
         const body = await response.text()
         const $ = load(body)
 

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.test.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.test.mjs
@@ -20,7 +20,7 @@ const expectedPages = [
 ]
 
 describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
-  describe.each(expectedPages)('%s', path => {
+  describe.each(expectedPages)('%s', (path) => {
     it('should resolve with a http status code of 200', async () => {
       const { status } = await fetchPath(path, { method: 'HEAD' })
       expect(status).toEqual(200)
@@ -53,7 +53,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/feedback', { method: 'POST' })
+        const response = await fetchPath('/full-page-examples/feedback', {
+          method: 'POST'
+        })
         const body = await response.text()
         const $ = load(body)
 
@@ -72,7 +74,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('have-you-changed-your-name', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/have-you-changed-your-name')
+        const response = await fetchPath(
+          '/full-page-examples/have-you-changed-your-name'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -85,7 +89,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/have-you-changed-your-name', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/have-you-changed-your-name',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -117,7 +124,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/passport-details', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/passport-details',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -136,7 +146,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('update-your-account-details', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/update-your-account-details')
+        const response = await fetchPath(
+          '/full-page-examples/update-your-account-details'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -149,7 +161,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/update-your-account-details', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/update-your-account-details',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -168,7 +183,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('upload-your-photo', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/upload-your-photo')
+        const response = await fetchPath(
+          '/full-page-examples/upload-your-photo'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -181,7 +198,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/upload-your-photo', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/upload-your-photo',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -200,7 +220,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('how-do-you-want-to-sign-in', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/how-do-you-want-to-sign-in')
+        const response = await fetchPath(
+          '/full-page-examples/how-do-you-want-to-sign-in'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -213,7 +235,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/how-do-you-want-to-sign-in', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/how-do-you-want-to-sign-in',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -232,7 +257,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('what-is-your-nationality', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-nationality')
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-nationality'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -245,7 +272,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-nationality', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-nationality',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -264,7 +294,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('what-is-your-address', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-address')
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-address'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -277,7 +309,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-address', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-address',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -296,7 +331,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('what-is-your-postcode', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-postcode')
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-postcode'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -309,7 +346,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-is-your-postcode', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/what-is-your-postcode',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -335,14 +375,18 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($.html()).toContain('482,211 results')
       })
       it('should show sorted results when selected', async () => {
-        const response = await fetchPath('/full-page-examples/search?order=updated-newest')
+        const response = await fetchPath(
+          '/full-page-examples/search?order=updated-newest'
+        )
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
         expect($.html()).toContain('241,128 results')
       })
       it('should show organisation results when selected', async () => {
-        const response = await fetchPath('/full-page-examples/search?order=updated-newest&organisation=hmrc')
+        const response = await fetchPath(
+          '/full-page-examples/search?order=updated-newest&organisation=hmrc'
+        )
         const body = await response.text()
         const $ = load(body)
         // Check the results are correct
@@ -352,7 +396,9 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
 
     describe('what-was-the-last-country-you-visited', () => {
       it('should not show errors if submit with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-was-the-last-country-you-visited')
+        const response = await fetchPath(
+          '/full-page-examples/what-was-the-last-country-you-visited'
+        )
         const body = await response.text()
         const $ = load(body)
 
@@ -365,7 +411,10 @@ describe(`http://localhost:${ports.app}/full-page-examples/`, () => {
         expect($errorSummary.length).toBeFalsy()
       })
       it('should show errors if form is submitted with no input', async () => {
-        const response = await fetchPath('/full-page-examples/what-was-the-last-country-you-visited', { method: 'POST' })
+        const response = await fetchPath(
+          '/full-page-examples/what-was-the-last-country-you-visited',
+          { method: 'POST' }
+        )
         const body = await response.text()
         const $ = load(body)
 

--- a/packages/govuk-frontend-review/src/utils.mjs
+++ b/packages/govuk-frontend-review/src/utils.mjs
@@ -4,7 +4,7 @@
  * @param {Errors} errors - Validation errors
  * @returns {Record<string, ErrorFormatted> | undefined} Formatted errors
  */
-export function formatValidationErrors (errors) {
+export function formatValidationErrors(errors) {
   return errors
     .formatWith((error) => {
       if (error.type !== 'field') {

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.mjs
@@ -2,9 +2,15 @@
  * @param {import('express').Application} app
  */
 export default (app) => {
-  app.post('/full-page-examples/cookie-banner-essential-cookies', (request, response) => {
-    response.render('./full-page-examples/cookie-banner-essential-cookies/index', {
-      cookies: request.body.cookies
-    })
-  })
+  app.post(
+    '/full-page-examples/cookie-banner-essential-cookies',
+    (request, response) => {
+      response.render(
+        './full-page-examples/cookie-banner-essential-cookies/index',
+        {
+          cookies: request.body.cookies
+        }
+      )
+    }
+  )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.mjs
@@ -2,10 +2,13 @@
  * @param {import('express').Application} app
  */
 export default (app) => {
-  app.post('/full-page-examples/cookie-banner-server-side', (request, response) => {
-    response.render('./full-page-examples/cookie-banner-server-side/index', {
-      cookies: request.body.cookies,
-      currentUrl: request.url
-    })
-  })
+  app.post(
+    '/full-page-examples/cookie-banner-server-side',
+    (request, response) => {
+      response.render('./full-page-examples/cookie-banner-server-side/index', {
+        cookies: request.body.cookies,
+        currentUrl: request.url
+      })
+    }
+  )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -18,6 +18,7 @@ export default (app) => {
         .withMessage(
           'What were you trying to do must be 100 characters or less'
         ),
+
       body('detail')
         .exists()
         .not()
@@ -27,10 +28,12 @@ export default (app) => {
         .withMessage(
           'Details of your question, problem or feedback must be 300 characters or less'
         ),
+
       body('do-you-want-a-reply')
         .not()
         .isEmpty()
         .withMessage('Select yes if you want a reply'),
+
       body('name').custom((value, { req: request }) => {
         // See https://github.com/express-validator/express-validator/pull/658
         const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
@@ -42,6 +45,7 @@ export default (app) => {
         }
         return true
       }),
+
       body('email').custom((value, { req: request }) => {
         // See https://github.com/express-validator/express-validator/pull/658
         const wantsReply = request.body['do-you-want-a-reply'] === 'yes'

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.mjs
@@ -11,42 +11,53 @@ export default (app) => {
     [
       body('what-were-you-trying-to-do')
         .exists()
-        .not().isEmpty().withMessage('Enter what you were trying to do')
-        .isLength({ max: 100 }).withMessage('What were you trying to do must be 100 characters or less'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter what you were trying to do')
+        .isLength({ max: 100 })
+        .withMessage(
+          'What were you trying to do must be 100 characters or less'
+        ),
       body('detail')
         .exists()
-        .not().isEmpty().withMessage('Enter details of your question, problem or feedback')
-        .isLength({ max: 300 }).withMessage('Details of your question, problem or feedback must be 300 characters or less'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter details of your question, problem or feedback')
+        .isLength({ max: 300 })
+        .withMessage(
+          'Details of your question, problem or feedback must be 300 characters or less'
+        ),
       body('do-you-want-a-reply')
-        .not().isEmpty().withMessage('Select yes if you want a reply'),
-      body('name')
-        .custom((value, { req: request }) => {
-          // See https://github.com/express-validator/express-validator/pull/658
-          const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
-          if (!wantsReply) {
-            return true
-          }
-          if (!value) {
-            throw new Error('Enter your name')
-          }
+        .not()
+        .isEmpty()
+        .withMessage('Select yes if you want a reply'),
+      body('name').custom((value, { req: request }) => {
+        // See https://github.com/express-validator/express-validator/pull/658
+        const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
+        if (!wantsReply) {
           return true
-        }),
-      body('email')
-        .custom((value, { req: request }) => {
-          // See https://github.com/express-validator/express-validator/pull/658
-          const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
-          if (!wantsReply) {
-            return true
-          }
-          if (!value) {
-            throw new Error('Enter your email address')
-          }
-          if (!value.includes('@')) {
-            throw new Error('Enter an email address in the correct format, like name@example.com')
-          }
+        }
+        if (!value) {
+          throw new Error('Enter your name')
+        }
+        return true
+      }),
+      body('email').custom((value, { req: request }) => {
+        // See https://github.com/express-validator/express-validator/pull/658
+        const wantsReply = request.body['do-you-want-a-reply'] === 'yes'
+        if (!wantsReply) {
           return true
-        })
-
+        }
+        if (!value) {
+          throw new Error('Enter your email address')
+        }
+        if (!value.includes('@')) {
+          throw new Error(
+            'Enter an email address in the correct format, like name@example.com'
+          )
+        }
+        return true
+      })
     ],
 
     /**

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.mjs
@@ -10,7 +10,9 @@ export default (app) => {
     '/full-page-examples/have-you-changed-your-name',
     [
       body('changed-name')
-        .not().isEmpty().withMessage('Select if you have changed your name')
+        .not()
+        .isEmpty()
+        .withMessage('Select if you have changed your name')
     ],
 
     /**
@@ -21,11 +23,14 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/have-you-changed-your-name/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/have-you-changed-your-name/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
       response.render('./full-page-examples/have-you-changed-your-name/confirm')
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.mjs
@@ -10,7 +10,9 @@ export default (app) => {
     '/full-page-examples/how-do-you-want-to-sign-in',
     [
       body('sign-in')
-        .not().isEmpty().withMessage('Select how you want to sign in')
+        .not()
+        .isEmpty()
+        .withMessage('Select how you want to sign in')
     ],
 
     /**
@@ -21,11 +23,14 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/how-do-you-want-to-sign-in/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/how-do-you-want-to-sign-in/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
       response.render('./full-page-examples/how-do-you-want-to-sign-in/confirm')
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -14,16 +14,19 @@ export default (app) => {
         .not()
         .isEmpty()
         .withMessage('Enter your passport number'),
+
       body('expiry-day')
         .exists()
         .not()
         .isEmpty()
         .withMessage('Enter your expiry day'),
+
       body('expiry-month')
         .exists()
         .not()
         .isEmpty()
         .withMessage('Enter your expiry month'),
+
       body('expiry-year')
         .exists()
         .not()

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.mjs
@@ -11,16 +11,24 @@ export default (app) => {
     [
       body('passport-number')
         .exists()
-        .not().isEmpty().withMessage('Enter your passport number'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your passport number'),
       body('expiry-day')
         .exists()
-        .not().isEmpty().withMessage('Enter your expiry day'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your expiry day'),
       body('expiry-month')
         .exists()
-        .not().isEmpty().withMessage('Enter your expiry month'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your expiry month'),
       body('expiry-year')
         .exists()
-        .not().isEmpty().withMessage('Enter your expiry year')
+        .not()
+        .isEmpty()
+        .withMessage('Enter your expiry year')
     ],
 
     /**
@@ -37,7 +45,9 @@ export default (app) => {
 
       // If any of the date inputs error apply a general error.
       const expiryNamePrefix = 'expiry'
-      const expiryErrors = Object.values(errors).filter(error => error.id.includes(`${expiryNamePrefix}-`))
+      const expiryErrors = Object.values(errors).filter((error) =>
+        error.id.includes(`${expiryNamePrefix}-`)
+      )
       if (expiryErrors.length) {
         const firstExpiryErrorId = expiryErrors[0].id
         // Get the first error message and merge it into a single error message.
@@ -53,14 +63,18 @@ export default (app) => {
         if (expiryErrors.length === 3) {
           errors[expiryNamePrefix].text += 'date'
         } else {
-          errors[expiryNamePrefix].text += expiryErrors.map(error => error.text.replace('Enter your expiry ', '')).join(' and ')
+          errors[expiryNamePrefix].text += expiryErrors
+            .map((error) => error.text.replace('Enter your expiry ', ''))
+            .join(' and ')
         }
       }
 
       let errorSummary = Object.values(errors)
       if (expiryErrors) {
         // Remove all other errors from the summary so we only have one message that links to the expiry input.
-        errorSummary = errorSummary.filter(error => !error.id.includes(`${expiryNamePrefix}-`))
+        errorSummary = errorSummary.filter(
+          (error) => !error.id.includes(`${expiryNamePrefix}-`)
+        )
       }
 
       response.render('./full-page-examples/passport-details/index', {

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.mjs
@@ -2,7 +2,9 @@ import { readFile } from 'fs/promises'
 
 import shuffleSeed from 'shuffle-seed'
 
-const { documents } = JSON.parse(await readFile(new URL('data.json', import.meta.url), 'utf8'))
+const { documents } = JSON.parse(
+  await readFile(new URL('data.json', import.meta.url), 'utf8')
+)
 
 /**
  * @param {import('express').Application} app
@@ -28,15 +30,18 @@ export default (app) => {
       const total = '128124'
 
       // Shuffle the total based on the query string
-      const randomizedTotal = shuffleSeed.shuffle(total.split(''), seed).join('')
+      const randomizedTotal = shuffleSeed
+        .shuffle(total.split(''), seed)
+        .join('')
 
       response.render('./full-page-examples/search/index', {
         documents: shuffledDocuments,
         order: query.order,
 
         // Make the total more readable
-        total: Number(randomizedTotal)
-          .toLocaleString('en', { useGrouping: true }),
+        total: Number(randomizedTotal).toLocaleString('en', {
+          useGrouping: true
+        }),
 
         // In production this should be sanitized
         values: query

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -18,6 +18,7 @@ export default (app) => {
         .not()
         .isEmpty()
         .withMessage('Enter your email address'),
+
       body('password')
         .exists()
         .not()

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.mjs
@@ -11,11 +11,18 @@ export default (app) => {
     [
       body('email')
         .exists()
-        .isEmail().withMessage('Enter an email address in the correct format, like name@example.com')
-        .not().isEmpty().withMessage('Enter your email address'),
+        .isEmail()
+        .withMessage(
+          'Enter an email address in the correct format, like name@example.com'
+        )
+        .not()
+        .isEmpty()
+        .withMessage('Enter your email address'),
       body('password')
         .exists()
-        .not().isEmpty().withMessage('Enter your password')
+        .not()
+        .isEmpty()
+        .withMessage('Enter your password')
     ],
 
     /**
@@ -27,14 +34,19 @@ export default (app) => {
       const errors = formatValidationErrors(validationResult(request))
 
       if (!errors) {
-        return response.render('./full-page-examples/update-your-account-details/confirm')
+        return response.render(
+          './full-page-examples/update-your-account-details/confirm'
+        )
       }
 
-      response.render('./full-page-examples/update-your-account-details/index', {
-        errors,
-        errorSummary: Object.values(errors),
-        values: request.body // In production this should sanitized.
-      })
+      response.render(
+        './full-page-examples/update-your-account-details/index',
+        {
+          errors,
+          errorSummary: Object.values(errors),
+          values: request.body // In production this should sanitized.
+        }
+      )
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.mjs
@@ -11,9 +11,12 @@ export default (app) => {
      * @returns {void}
      */
     (request, response) => {
-      return response.render('./full-page-examples/upload-your-photo-success/index', {
-        isSuccess: true
-      })
+      return response.render(
+        './full-page-examples/upload-your-photo-success/index',
+        {
+          isSuccess: true
+        }
+      )
     }
   )
 }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -10,6 +10,7 @@ export default (app) => {
     '/full-page-examples/upload-your-photo',
     [
       body('photo').exists().not().isEmpty().withMessage('Select a photo'),
+
       body('terms-and-conditions')
         .not()
         .isEmpty()

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.mjs
@@ -9,11 +9,11 @@ export default (app) => {
   app.post(
     '/full-page-examples/upload-your-photo',
     [
-      body('photo')
-        .exists()
-        .not().isEmpty().withMessage('Select a photo'),
+      body('photo').exists().not().isEmpty().withMessage('Select a photo'),
       body('terms-and-conditions')
-        .not().isEmpty().withMessage('Select I accept the terms and conditions')
+        .not()
+        .isEmpty()
+        .withMessage('Select I accept the terms and conditions')
     ],
 
     /**

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -14,16 +14,19 @@ export default (app) => {
         .not()
         .isEmpty()
         .withMessage('Enter your building and street'),
+
       body('address-town')
         .exists()
         .not()
         .isEmpty()
         .withMessage('Enter your town and city'),
+
       body('address-county')
         .exists()
         .not()
         .isEmpty()
         .withMessage('Enter your county'),
+
       body('address-postcode')
         .exists()
         .not()

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.mjs
@@ -11,16 +11,24 @@ export default (app) => {
     [
       body('address-line-1')
         .exists()
-        .not().isEmpty().withMessage('Enter your building and street'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your building and street'),
       body('address-town')
         .exists()
-        .not().isEmpty().withMessage('Enter your town and city'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your town and city'),
       body('address-county')
         .exists()
-        .not().isEmpty().withMessage('Enter your county'),
+        .not()
+        .isEmpty()
+        .withMessage('Enter your county'),
       body('address-postcode')
         .exists()
-        .not().isEmpty().withMessage('Enter your postcode')
+        .not()
+        .isEmpty()
+        .withMessage('Enter your postcode')
     ],
 
     /**
@@ -31,11 +39,14 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/what-is-your-address/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/what-is-your-address/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
       response.render('./full-page-examples/what-is-your-address/confirm')
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -23,6 +23,7 @@ export default (app) => {
         }
         return true
       }),
+
       body('country-name').custom((value, { req: request }) => {
         // See https://github.com/express-validator/express-validator/pull/658
         const confirmedNationality = request.body['confirm-nationality'] || []

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.mjs
@@ -9,33 +9,32 @@ export default (app) => {
   app.post(
     '/full-page-examples/what-is-your-nationality',
     [
-      body('confirm-nationality')
-        .custom((value, { req: request }) => {
-          // See https://github.com/express-validator/express-validator/pull/658
-          const cannotProvideNationality = !!request.body['details-cannot-provide-nationality']
-          // If the user cannot provide their nationality and has given us separate details
-          // then do not show an error for the nationality fields.
-          if (cannotProvideNationality) {
-            return true
-          }
-          if (!value) {
-            throw new Error('Select your nationality or nationalities')
-          }
+      body('confirm-nationality').custom((value, { req: request }) => {
+        // See https://github.com/express-validator/express-validator/pull/658
+        const cannotProvideNationality =
+          !!request.body['details-cannot-provide-nationality']
+        // If the user cannot provide their nationality and has given us separate details
+        // then do not show an error for the nationality fields.
+        if (cannotProvideNationality) {
           return true
-        }),
-      body('country-name')
-        .custom((value, { req: request }) => {
-          // See https://github.com/express-validator/express-validator/pull/658
-          const confirmedNationality = request.body['confirm-nationality'] || []
-          // If the other country option is selected and there's no value.
-          if (
-            confirmedNationality.includes('other-country-nationality') &&
-              !value
-          ) {
-            throw new Error('Enter your country')
-          }
-          return true
-        })
+        }
+        if (!value) {
+          throw new Error('Select your nationality or nationalities')
+        }
+        return true
+      }),
+      body('country-name').custom((value, { req: request }) => {
+        // See https://github.com/express-validator/express-validator/pull/658
+        const confirmedNationality = request.body['confirm-nationality'] || []
+        // If the other country option is selected and there's no value.
+        if (
+          confirmedNationality.includes('other-country-nationality') &&
+          !value
+        ) {
+          throw new Error('Enter your country')
+        }
+        return true
+      })
     ],
 
     /**
@@ -46,11 +45,14 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/what-is-your-nationality/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/what-is-your-nationality/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
       response.render('./full-page-examples/what-is-your-nationality/confirm')
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.mjs
@@ -11,7 +11,9 @@ export default (app) => {
     [
       body('address-postcode')
         .exists()
-        .not().isEmpty().withMessage('Enter your home postcode')
+        .not()
+        .isEmpty()
+        .withMessage('Enter your home postcode')
     ],
 
     /**
@@ -22,11 +24,14 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/what-is-your-postcode/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/what-is-your-postcode/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
       response.render('./full-page-examples/what-is-your-postcode/confirm')
     }

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.mjs
@@ -11,7 +11,9 @@ export default (app) => {
     [
       body('last-visited-country')
         .exists()
-        .not().isEmpty().withMessage('Enter the last country you visited')
+        .not()
+        .isEmpty()
+        .withMessage('Enter the last country you visited')
     ],
 
     /**
@@ -22,13 +24,18 @@ export default (app) => {
     (request, response) => {
       const errors = formatValidationErrors(validationResult(request))
       if (errors) {
-        return response.render('./full-page-examples/what-was-the-last-country-you-visited/index', {
-          errors,
-          errorSummary: Object.values(errors),
-          values: request.body // In production this should sanitized.
-        })
+        return response.render(
+          './full-page-examples/what-was-the-last-country-you-visited/index',
+          {
+            errors,
+            errorSummary: Object.values(errors),
+            values: request.body // In production this should sanitized.
+          }
+        )
       }
-      response.render('./full-page-examples/what-was-the-last-country-you-visited/confirm')
+      response.render(
+        './full-page-examples/what-was-the-last-country-you-visited/confirm'
+      )
     }
   )
 }

--- a/packages/govuk-frontend-review/tasks/build/dev.mjs
+++ b/packages/govuk-frontend-review/tasks/build/dev.mjs
@@ -9,8 +9,9 @@ import { watch } from '../index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export default (options) => gulp.parallel(
-  npm.script('serve', [], options), // Express.js server using Nodemon
-  npm.script('proxy', [], options), // Auto reloading proxy using Browsersync
-  watch(options)
-)
+export default (options) =>
+  gulp.parallel(
+    npm.script('serve', [], options), // Express.js server using Nodemon
+    npm.script('proxy', [], options), // Auto reloading proxy using Browsersync
+    watch(options)
+  )

--- a/packages/govuk-frontend-review/tasks/build/dist.mjs
+++ b/packages/govuk-frontend-review/tasks/build/dist.mjs
@@ -9,13 +9,9 @@ import { scripts, styles } from '../index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export default (options) => gulp.series(
-  task.name('clean', () =>
-    files.clean('*', options)
-  ),
+export default (options) =>
+  gulp.series(
+    task.name('clean', () => files.clean('*', options)),
 
-  gulp.parallel(
-    scripts(options),
-    styles(options)
+    gulp.parallel(scripts(options), styles(options))
   )
-)

--- a/packages/govuk-frontend-review/tasks/scripts.mjs
+++ b/packages/govuk-frontend-review/tasks/scripts.mjs
@@ -7,6 +7,5 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const compile = (options) => gulp.series(
-  npm.script('build:jsdoc', [], options)
-)
+export const compile = (options) =>
+  gulp.series(npm.script('build:jsdoc', [], options))

--- a/packages/govuk-frontend-review/tasks/styles.mjs
+++ b/packages/govuk-frontend-review/tasks/styles.mjs
@@ -9,22 +9,23 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const compile = (options) => gulp.series(
-  task.name('compile:scss', () =>
-    styles.compile('**/[!_]*.scss', {
-      ...options,
+export const compile = (options) =>
+  gulp.series(
+    task.name('compile:scss', () =>
+      styles.compile('**/[!_]*.scss', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'stylesheets'),
-      destPath: join(options.destPath, 'stylesheets'),
-      configPath: join(options.basePath, 'postcss.config.mjs'),
+        srcPath: join(options.srcPath, 'stylesheets'),
+        destPath: join(options.destPath, 'stylesheets'),
+        configPath: join(options.basePath, 'postcss.config.mjs'),
 
-      // Rename with `*.min.css` extension
-      filePath ({ dir, name }) {
-        return join(dir, `${name}.min.css`)
-      }
-    })
-  ),
+        // Rename with `*.min.css` extension
+        filePath({ dir, name }) {
+          return join(dir, `${name}.min.css`)
+        }
+      })
+    ),
 
-  // Build SassDoc for /docs/sass
-  npm.script('build:sassdoc', [], options)
-)
+    // Build SassDoc for /docs/sass
+    npm.script('build:sassdoc', [], options)
+  )

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -15,34 +15,44 @@ import { scripts, styles } from './index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const watch = (options) => gulp.parallel(
-  /**
-   * Stylesheets lint watcher
-   */
-  task.name('lint:scss watch', () =>
-    gulp.watch([
-      `${slash(paths.app)}/src/**/*.scss`
-    ], npm.script('lint:scss:cli', [slash(join(options.workspace, '**/*.scss'))]))
-  ),
+export const watch = (options) =>
+  gulp.parallel(
+    /**
+     * Stylesheets lint watcher
+     */
+    task.name('lint:scss watch', () =>
+      gulp.watch(
+        [`${slash(paths.app)}/src/**/*.scss`],
+        npm.script('lint:scss:cli', [
+          slash(join(options.workspace, '**/*.scss'))
+        ])
+      )
+    ),
 
-  /**
-   * Stylesheets build watcher
-   */
-  task.name('compile:scss watch', () =>
-    gulp.watch([
-      `${slash(paths.app)}/sassdoc.config.yaml`,
-      `${slash(paths.app)}/src/**/*.scss`,
-      `${slash(paths.package)}/dist/govuk/**/*.scss`
-    ], styles(options))
-  ),
+    /**
+     * Stylesheets build watcher
+     */
+    task.name('compile:scss watch', () =>
+      gulp.watch(
+        [
+          `${slash(paths.app)}/sassdoc.config.yaml`,
+          `${slash(paths.app)}/src/**/*.scss`,
+          `${slash(paths.package)}/dist/govuk/**/*.scss`
+        ],
+        styles(options)
+      )
+    ),
 
-  /**
-   * JavaScripts build watcher
-   */
-  task.name('compile:js watch', () =>
-    gulp.watch([
-      `${slash(paths.app)}/typedoc.config.js`,
-      `${slash(paths.package)}/dist/govuk/**/*.mjs`
-    ], scripts(options))
+    /**
+     * JavaScripts build watcher
+     */
+    task.name('compile:js watch', () =>
+      gulp.watch(
+        [
+          `${slash(paths.app)}/typedoc.config.js`,
+          `${slash(paths.package)}/dist/govuk/**/*.mjs`
+        ],
+        scripts(options)
+      )
+    )
   )
-)

--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -1,6 +1,9 @@
 const { join } = require('path')
 
-const { packageResolveToPath, packageNameToPath } = require('govuk-frontend-lib/names')
+const {
+  packageResolveToPath,
+  packageNameToPath
+} = require('govuk-frontend-lib/names')
 
 /**
  * @type {import('typedoc').TypeDocOptions}
@@ -8,7 +11,8 @@ const { packageResolveToPath, packageNameToPath } = require('govuk-frontend-lib/
 module.exports = {
   emit: 'both',
   name: 'govuk-frontend',
-  sourceLinkTemplate: 'https://github.com/alphagov/govuk-frontend/blob/{gitRevision}/{path}#L{line}',
+  sourceLinkTemplate:
+    'https://github.com/alphagov/govuk-frontend/blob/{gitRevision}/{path}#L{line}',
 
   // Configure paths
   basePath: join(packageNameToPath('govuk-frontend'), 'src'),
@@ -17,8 +21,5 @@ module.exports = {
   out: './dist/docs/jsdoc',
 
   // Ignore warnings about class fields using I18n (@private)
-  intentionallyNotExported: [
-    'I18n',
-    'TranslationPluralForms'
-  ]
+  intentionallyNotExported: ['I18n', 'TranslationPluralForms']
 }

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -16,10 +16,7 @@ module.exports = {
         ecmaVersion: '2015',
         project: [resolve(__dirname, 'tsconfig.json')]
       },
-      plugins: [
-        '@typescript-eslint',
-        'es-x'
-      ],
+      plugins: ['@typescript-eslint', 'es-x'],
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
@@ -44,7 +41,8 @@ module.exports = {
 
         // JSDoc blocks are mandatory
         'jsdoc/require-jsdoc': [
-          'error', {
+          'error',
+          {
             enableFixer: false,
             require: {
               ClassDeclaration: true,

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -23,7 +23,8 @@ module.exports = {
       extends: [
         'plugin:@typescript-eslint/recommended',
         'plugin:@typescript-eslint/recommended-requiring-type-checking',
-        'plugin:es-x/restrict-to-es2015'
+        'plugin:es-x/restrict-to-es2015',
+        'prettier'
       ],
       env: {
         browser: true

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -12,18 +12,21 @@ module.exports = function (api) {
 
   return {
     presets: [
-      ['@babel/preset-env', {
-        browserslistEnv,
+      [
+        '@babel/preset-env',
+        {
+          browserslistEnv,
 
-        // Apply bug fixes to avoid transforms
-        bugfixes: true,
+          // Apply bug fixes to avoid transforms
+          bugfixes: true,
 
-        // Apply smaller "loose" transforms for browsers
-        loose: isBrowser,
+          // Apply smaller "loose" transforms for browsers
+          loose: isBrowser,
 
-        // Skip ES module transforms for browsers
-        modules: isBrowser ? false : 'auto'
-      }]
+          // Skip ES module transforms for browsers
+          modules: isBrowser ? false : 'auto'
+        }
+      ]
     ]
   }
 }

--- a/packages/govuk-frontend/postcss.config.mjs
+++ b/packages/govuk-frontend/postcss.config.mjs
@@ -31,13 +31,17 @@ export default ({ to = '' } = {}) => ({
     },
 
     // Always minify CSS
-    to.endsWith('.css') && cssnano({
-      preset: [cssnanoPresetDefault, {
-        // Sorted CSS is smaller when gzipped, but we sort using Stylelint
-        // https://cssnano.co/docs/optimisations/cssdeclarationsorter/
-        cssDeclarationSorter: false
-      }]
-    })
+    to.endsWith('.css') &&
+      cssnano({
+        preset: [
+          cssnanoPresetDefault,
+          {
+            // Sorted CSS is smaller when gzipped, but we sort using Stylelint
+            // https://cssnano.co/docs/optimisations/cssdeclarationsorter/
+            cssDeclarationSorter: false
+          }
+        ]
+      })
   ],
 
   // Sass syntax support

--- a/packages/govuk-frontend/postcss.config.unit.test.mjs
+++ b/packages/govuk-frontend/postcss.config.unit.test.mjs
@@ -1,11 +1,11 @@
 import configFn from './postcss.config.mjs'
 
 describe('PostCSS config', () => {
-  function getPluginNames (config) {
+  function getPluginNames(config) {
     return config.plugins.flatMap(getPluginName)
   }
 
-  function getPluginName ({ plugins, postcssPlugin }) {
+  function getPluginName({ plugins, postcssPlugin }) {
     return plugins ? getPluginNames({ plugins }) : postcssPlugin
   }
 
@@ -13,12 +13,13 @@ describe('PostCSS config', () => {
     it('Uses default environment', () => {
       const config = configFn()
 
-      expect(config.plugins)
-        .toEqual(expect.arrayContaining([
+      expect(config.plugins).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
             postcssPlugin: 'autoprefixer'
           })
-        ]))
+        ])
+      )
     })
 
     it.each([
@@ -29,12 +30,13 @@ describe('PostCSS config', () => {
     ])('Uses default environment for $from', ({ from, to }) => {
       const config = configFn({ from, to })
 
-      expect(config.plugins)
-        .toEqual(expect.arrayContaining([
+      expect(config.plugins).toEqual(
+        expect.arrayContaining([
           expect.objectContaining({
             postcssPlugin: 'autoprefixer'
           })
-        ]))
+        ])
+      )
     })
   })
 
@@ -48,39 +50,38 @@ describe('PostCSS config', () => {
       ])('Adds plugins for $from', ({ from, to }) => {
         const config = configFn({ from, to })
 
-        expect(getPluginNames(config))
-          .toEqual([
-            'autoprefixer',
-            'govuk-frontend-version',
-            'postcss-discard-comments',
-            'postcss-minify-gradients',
-            'postcss-reduce-initial',
-            'postcss-svgo',
-            'postcss-normalize-display-values',
-            'postcss-reduce-transforms',
-            'postcss-colormin',
-            'postcss-normalize-timing-functions',
-            'postcss-calc',
-            'postcss-convert-values',
-            'postcss-ordered-values',
-            'postcss-minify-selectors',
-            'postcss-minify-params',
-            'postcss-normalize-charset',
-            'postcss-discard-overridden',
-            'postcss-normalize-string',
-            'postcss-normalize-unicode',
-            'postcss-minify-font-values',
-            'postcss-normalize-url',
-            'postcss-normalize-repeat-style',
-            'postcss-normalize-positions',
-            'postcss-normalize-whitespace',
-            'postcss-merge-longhand',
-            'postcss-discard-duplicates',
-            'postcss-merge-rules',
-            'postcss-discard-empty',
-            'postcss-unique-selectors',
-            'cssnano-util-raw-cache'
-          ])
+        expect(getPluginNames(config)).toEqual([
+          'autoprefixer',
+          'govuk-frontend-version',
+          'postcss-discard-comments',
+          'postcss-minify-gradients',
+          'postcss-reduce-initial',
+          'postcss-svgo',
+          'postcss-normalize-display-values',
+          'postcss-reduce-transforms',
+          'postcss-colormin',
+          'postcss-normalize-timing-functions',
+          'postcss-calc',
+          'postcss-convert-values',
+          'postcss-ordered-values',
+          'postcss-minify-selectors',
+          'postcss-minify-params',
+          'postcss-normalize-charset',
+          'postcss-discard-overridden',
+          'postcss-normalize-string',
+          'postcss-normalize-unicode',
+          'postcss-minify-font-values',
+          'postcss-normalize-url',
+          'postcss-normalize-repeat-style',
+          'postcss-normalize-positions',
+          'postcss-normalize-whitespace',
+          'postcss-merge-longhand',
+          'postcss-discard-duplicates',
+          'postcss-merge-rules',
+          'postcss-discard-empty',
+          'postcss-unique-selectors',
+          'cssnano-util-raw-cache'
+        ])
       })
     })
 
@@ -93,11 +94,10 @@ describe('PostCSS config', () => {
       ])('Adds plugins for $from', ({ from, to }) => {
         const config = configFn({ from, to })
 
-        expect(getPluginNames(config))
-          .toEqual([
-            'autoprefixer',
-            'govuk-frontend-version'
-          ])
+        expect(getPluginNames(config)).toEqual([
+          'autoprefixer',
+          'govuk-frontend-version'
+        ])
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -1,7 +1,14 @@
 import { join } from 'path'
 
-import { filterPath, getComponentNames, getListing } from 'govuk-frontend-lib/files'
-import { componentNameToMacroName, packageNameToPath } from 'govuk-frontend-lib/names'
+import {
+  filterPath,
+  getComponentNames,
+  getListing
+} from 'govuk-frontend-lib/files'
+import {
+  componentNameToMacroName,
+  packageNameToPath
+} from 'govuk-frontend-lib/names'
 import slash from 'slash'
 
 /**
@@ -13,33 +20,27 @@ export default async () => {
   const srcPath = join(packageNameToPath('govuk-frontend'), 'src')
 
   // Locate component macros
-  const componentMacros = await getListing('**/components/**/macro.njk', { cwd: srcPath })
+  const componentMacros = await getListing('**/components/**/macro.njk', {
+    cwd: srcPath
+  })
   const componentNames = await getComponentNames()
 
   // Build array of macros
-  const nunjucksMacros = componentNames
-    .map((componentName) => {
-      const [macroPath = ''] = componentMacros
-        .filter(filterPath([`**/${componentName}/macro.njk`]))
+  const nunjucksMacros = componentNames.map((componentName) => {
+    const [macroPath = ''] = componentMacros.filter(
+      filterPath([`**/${componentName}/macro.njk`])
+    )
 
-      return {
-        importFrom: slash(macroPath),
-        macroName: componentNameToMacroName(componentName)
-      }
-    })
+    return {
+      importFrom: slash(macroPath),
+      macroName: componentNameToMacroName(componentName)
+    }
+  })
 
   return {
-    assets: [
-      '/dist/govuk/assets',
-      '/dist/govuk/all.bundle.js.map'
-    ],
-    sass: [
-      '/dist/govuk-prototype-kit/init.scss'
-    ],
-    scripts: [
-      '/dist/govuk/all.bundle.js',
-      '/dist/govuk-prototype-kit/init.js'
-    ],
+    assets: ['/dist/govuk/assets', '/dist/govuk/all.bundle.js.map'],
+    sass: ['/dist/govuk-prototype-kit/init.scss'],
+    scripts: ['/dist/govuk/all.bundle.js', '/dist/govuk-prototype-kit/init.js'],
     nunjucksMacros,
     nunjucksPaths: ['/dist']
   }

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -14,9 +14,7 @@ describe('GOV.UK Prototype Kit config', () => {
       '/dist/govuk/all.bundle.js.map'
     ])
 
-    expect(config.sass).toEqual([
-      '/dist/govuk-prototype-kit/init.scss'
-    ])
+    expect(config.sass).toEqual(['/dist/govuk-prototype-kit/init.scss'])
 
     expect(config.scripts).toEqual([
       '/dist/govuk/all.bundle.js',

--- a/packages/govuk-frontend/src/govuk-prototype-kit/init.js
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/init.js
@@ -1,7 +1,9 @@
 // @ts-nocheck
-if (window.GOVUKPrototypeKit &&
+if (
+  window.GOVUKPrototypeKit &&
   window.GOVUKPrototypeKit.documentReady &&
-  window.GOVUKPrototypeKit.majorVersion >= 13) {
+  window.GOVUKPrototypeKit.majorVersion >= 13
+) {
   window.GOVUKPrototypeKit.documentReady(function () {
     window.GOVUKFrontend.initAll()
   })

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -21,7 +21,7 @@ import { Tabs } from './components/tabs/tabs.mjs'
  *
  * @param {Config} [config] - Config for all components
  */
-function initAll (config) {
+function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
 
   // Skip initialisation when GOV.UK Frontend is not supported
@@ -43,23 +43,31 @@ function initAll (config) {
     new Button($button, config.button)
   })
 
-  const $characterCounts = $scope.querySelectorAll('[data-module="govuk-character-count"]')
+  const $characterCounts = $scope.querySelectorAll(
+    '[data-module="govuk-character-count"]'
+  )
   $characterCounts.forEach(($characterCount) => {
     new CharacterCount($characterCount, config.characterCount)
   })
 
-  const $checkboxes = $scope.querySelectorAll('[data-module="govuk-checkboxes"]')
+  const $checkboxes = $scope.querySelectorAll(
+    '[data-module="govuk-checkboxes"]'
+  )
   $checkboxes.forEach(($checkbox) => {
     new Checkboxes($checkbox)
   })
 
   // Find first error summary module to enhance.
-  const $errorSummary = $scope.querySelector('[data-module="govuk-error-summary"]')
+  const $errorSummary = $scope.querySelector(
+    '[data-module="govuk-error-summary"]'
+  )
   if ($errorSummary) {
     new ErrorSummary($errorSummary, config.errorSummary)
   }
 
-  const $exitThisPageButtons = $scope.querySelectorAll('[data-module="govuk-exit-this-page"]')
+  const $exitThisPageButtons = $scope.querySelectorAll(
+    '[data-module="govuk-exit-this-page"]'
+  )
   $exitThisPageButtons.forEach(($button) => {
     new ExitThisPage($button, config.exitThisPage)
   })
@@ -70,7 +78,9 @@ function initAll (config) {
     new Header($header)
   }
 
-  const $notificationBanners = $scope.querySelectorAll('[data-module="govuk-notification-banner"]')
+  const $notificationBanners = $scope.querySelectorAll(
+    '[data-module="govuk-notification-banner"]'
+  )
   $notificationBanners.forEach(($notificationBanner) => {
     new NotificationBanner($notificationBanner, config.notificationBanner)
   })

--- a/packages/govuk-frontend/src/govuk/all.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.test.mjs
@@ -78,22 +78,23 @@ describe('GOV.UK Frontend', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a group', async () => {
-      return sassdoc.parse([
-        `${slash(paths.package)}/src/govuk/**/*.scss`,
-        `!${slash(paths.package)}/src/govuk/vendor/*.scss`
-      ])
-        .then(docs => docs.forEach(doc => {
-          return expect(doc).toMatchObject({
-            // Include doc.context.name in the expected result when this fails,
-            // giving you the context to be able to fix it
-            context: {
-              name: doc.context.name
-            },
-            group: [
-              expect.not.stringMatching('undefined')
-            ]
+      return sassdoc
+        .parse([
+          `${slash(paths.package)}/src/govuk/**/*.scss`,
+          `!${slash(paths.package)}/src/govuk/vendor/*.scss`
+        ])
+        .then((docs) =>
+          docs.forEach((doc) => {
+            return expect(doc).toMatchObject({
+              // Include doc.context.name in the expected result when this fails,
+              // giving you the context to be able to fix it
+              context: {
+                name: doc.context.name
+              },
+              group: [expect.not.stringMatching('undefined')]
+            })
           })
-        }))
+        )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/common/closest-attribute-value.mjs
+++ b/packages/govuk-frontend/src/govuk/common/closest-attribute-value.mjs
@@ -6,7 +6,7 @@
  * @param {string} attributeName - The name of the attribute
  * @returns {string | null} Attribute value
  */
-export function closestAttributeValue ($element, attributeName) {
+export function closestAttributeValue($element, attributeName) {
   const $closestElementWithAttribute = $element.closest(`[${attributeName}]`)
   return $closestElementWithAttribute
     ? $closestElementWithAttribute.getAttribute(attributeName)

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -18,7 +18,7 @@
  * @private
  * @returns {{ [key: string]: unknown }} A flattened object of key-value pairs.
  */
-export function mergeConfigs (/* configObject1, configObject2, ...configObjects */) {
+export function mergeConfigs(/* configObject1, configObject2, ...configObjects */) {
   /**
    * Function to take nested objects and flatten them to a dot-separated keyed
    * object. Doing this means we don't need to do any deep/recursive merging of
@@ -97,14 +97,16 @@ export function mergeConfigs (/* configObject1, configObject2, ...configObjects 
  * @throws {Error} Config object required
  * @throws {Error} Namespace string required
  */
-export function extractConfigByNamespace (configObject, namespace) {
+export function extractConfigByNamespace(configObject, namespace) {
   // Check we have what we need
   if (!configObject || typeof configObject !== 'object') {
     throw new Error('Provide a `configObject` of type "object".')
   }
 
   if (!namespace || typeof namespace !== 'string') {
-    throw new Error('Provide a `namespace` of type "string" to filter the `configObject` by.')
+    throw new Error(
+      'Provide a `namespace` of type "string" to filter the `configObject` by.'
+    )
   }
 
   /** @type {{ [key: string]: unknown }} */
@@ -114,7 +116,10 @@ export function extractConfigByNamespace (configObject, namespace) {
     // Split the key into parts, using . as our namespace separator
     const keyParts = key.split('.')
     // Check if the first namespace matches the configured namespace
-    if (Object.prototype.hasOwnProperty.call(configObject, key) && keyParts[0] === namespace) {
+    if (
+      Object.prototype.hasOwnProperty.call(configObject, key) &&
+      keyParts[0] === namespace
+    ) {
       // Remove the first item (the namespace) from the parts array,
       // but only if there is more than one part (we don't want blank keys!)
       if (keyParts.length > 1) {

--- a/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
+++ b/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
@@ -13,7 +13,7 @@
  * @param {string} value - The value to normalise
  * @returns {string | boolean | number | undefined} Normalised data
  */
-export function normaliseString (value) {
+export function normaliseString(value) {
   if (typeof value !== 'string') {
     return value
   }
@@ -46,7 +46,7 @@ export function normaliseString (value) {
  * @param {DOMStringMap} dataset - HTML element dataset
  * @returns {{ [key: string]: unknown }} Normalised dataset
  */
-export function normaliseDataset (dataset) {
+export function normaliseDataset(dataset) {
   /** @type {{ [key: string]: unknown }} */
   const out = {}
 

--- a/packages/govuk-frontend/src/govuk/common/normalise-dataset.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/normalise-dataset.unit.test.mjs
@@ -95,13 +95,15 @@ describe('normaliseString', () => {
 
 describe('normaliseDataset', () => {
   it('normalises the entire dataset', () => {
-    expect(normaliseDataset({
-      aNumber: '1000',
-      aDecimalNumber: '100.50',
-      aBoolean: 'true',
-      aString: 'Hello!',
-      anOptionalString: ''
-    })).toEqual({
+    expect(
+      normaliseDataset({
+        aNumber: '1000',
+        aDecimalNumber: '100.50',
+        aBoolean: 'true',
+        aString: 'Hello!',
+        anOptionalString: ''
+      })
+    ).toEqual({
       aNumber: 1000,
       aDecimalNumber: 100.5,
       aBoolean: true,

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -112,8 +112,11 @@ export class Accordion {
    * @param {Element} $module - HTML element to use for accordion
    * @param {AccordionConfig} [config] - Accordion config
    */
-  constructor ($module, config) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module, config) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -148,7 +151,7 @@ export class Accordion {
    *
    * @private
    */
-  initControls () {
+  initControls() {
     // Create "Show all" button and set attributes
     this.$showAllButton = document.createElement('button')
     this.$showAllButton.setAttribute('type', 'button')
@@ -172,11 +175,15 @@ export class Accordion {
     this.$showAllButton.appendChild(this.$showAllText)
 
     // Handle click events on the show/hide all button
-    this.$showAllButton.addEventListener('click', () => this.onShowOrHideAllToggle())
+    this.$showAllButton.addEventListener('click', () =>
+      this.onShowOrHideAllToggle()
+    )
 
     // Handle 'beforematch' events, if the user agent supports them
     if ('onbeforematch' in document) {
-      document.addEventListener('beforematch', (event) => this.onBeforeMatch(event))
+      document.addEventListener('beforematch', (event) =>
+        this.onBeforeMatch(event)
+      )
     }
   }
 
@@ -185,7 +192,7 @@ export class Accordion {
    *
    * @private
    */
-  initSectionHeaders () {
+  initSectionHeaders() {
     // Loop through sections
     this.$sections.forEach(($section, i) => {
       const $header = $section.querySelector(`.${this.sectionHeaderClass}`)
@@ -213,7 +220,7 @@ export class Accordion {
    * @param {Element} $header - Section header
    * @param {number} index - Section index
    */
-  constructHeaderMarkup ($header, index) {
+  constructHeaderMarkup($header, index) {
     const $span = $header.querySelector(`.${this.sectionButtonClass}`)
     const $heading = $header.querySelector(`.${this.sectionHeadingClass}`)
     const $summary = $header.querySelector(`.${this.sectionSummaryClass}`)
@@ -225,7 +232,10 @@ export class Accordion {
     // Create a button element that will replace the '.govuk-accordion__section-button' span
     const $button = document.createElement('button')
     $button.setAttribute('type', 'button')
-    $button.setAttribute('aria-controls', `${this.$module.id}-content-${index + 1}`)
+    $button.setAttribute(
+      'aria-controls',
+      `${this.$module.id}-content-${index + 1}`
+    )
 
     // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
     for (let i = 0; i < $span.attributes.length; i++) {
@@ -319,7 +329,7 @@ export class Accordion {
    * @private
    * @param {Event} event - Generic event
    */
-  onBeforeMatch (event) {
+  onBeforeMatch(event) {
     const $fragment = event.target
 
     // Handle elements with `.closest()` support only
@@ -340,7 +350,7 @@ export class Accordion {
    * @private
    * @param {Element} $section - Section element
    */
-  onSectionToggle ($section) {
+  onSectionToggle($section) {
     const expanded = this.isExpanded($section)
     this.setExpanded(!expanded, $section)
 
@@ -353,7 +363,7 @@ export class Accordion {
    *
    * @private
    */
-  onShowOrHideAllToggle () {
+  onShowOrHideAllToggle() {
     const nowExpanded = !this.checkIfAllSectionsOpen()
 
     // Loop through sections
@@ -373,16 +383,20 @@ export class Accordion {
    * @param {boolean} expanded - Section expanded
    * @param {Element} $section - Section element
    */
-  setExpanded (expanded, $section) {
+  setExpanded(expanded, $section) {
     const $showHideIcon = $section.querySelector(`.${this.upChevronIconClass}`)
-    const $showHideText = $section.querySelector(`.${this.sectionShowHideTextClass}`)
+    const $showHideText = $section.querySelector(
+      `.${this.sectionShowHideTextClass}`
+    )
     const $button = $section.querySelector(`.${this.sectionButtonClass}`)
     const $content = $section.querySelector(`.${this.sectionContentClass}`)
 
-    if (!$showHideIcon ||
+    if (
+      !$showHideIcon ||
       !($showHideText instanceof HTMLElement) ||
       !$button ||
-      !$content) {
+      !$content
+    ) {
       return
     }
 
@@ -396,7 +410,9 @@ export class Accordion {
     // Update aria-label combining
     const ariaLabelParts = []
 
-    const $headingText = $section.querySelector(`.${this.sectionHeadingTextClass}`)
+    const $headingText = $section.querySelector(
+      `.${this.sectionHeadingTextClass}`
+    )
     if ($headingText instanceof HTMLElement) {
       ariaLabelParts.push($headingText.innerText.trim())
     }
@@ -441,7 +457,7 @@ export class Accordion {
    * @param {Element} $section - Section element
    * @returns {boolean} True if expanded
    */
-  isExpanded ($section) {
+  isExpanded($section) {
     return $section.classList.contains(this.sectionExpandedClass)
   }
 
@@ -451,11 +467,13 @@ export class Accordion {
    * @private
    * @returns {boolean} True if all sections are open
    */
-  checkIfAllSectionsOpen () {
+  checkIfAllSectionsOpen() {
     // Get a count of all the Accordion sections
     const sectionsCount = this.$sections.length
     // Get a count of all Accordion sections that are expanded
-    const expandedSectionCount = this.$module.querySelectorAll(`.${this.sectionExpandedClass}`).length
+    const expandedSectionCount = this.$module.querySelectorAll(
+      `.${this.sectionExpandedClass}`
+    ).length
     const areAllSectionsOpen = sectionsCount === expandedSectionCount
 
     return areAllSectionsOpen
@@ -467,7 +485,7 @@ export class Accordion {
    * @private
    * @param {boolean} expanded - Section expanded
    */
-  updateShowAllButton (expanded) {
+  updateShowAllButton(expanded) {
     const newButtonText = expanded
       ? this.i18n.t('hideAllSections')
       : this.i18n.t('showAllSections')
@@ -489,7 +507,7 @@ export class Accordion {
    * @private
    * @param {Element} $section - Section element
    */
-  storeState ($section) {
+  storeState($section) {
     if (this.browserSupportsSessionStorage && this.config.rememberExpanded) {
       // We need a unique way of identifying each content in the Accordion. Since
       // an `#id` should be unique and an `id` is required for `aria-` attributes
@@ -514,13 +532,15 @@ export class Accordion {
    * @private
    * @param {Element} $section - Section element
    */
-  setInitialState ($section) {
+  setInitialState($section) {
     if (this.browserSupportsSessionStorage && this.config.rememberExpanded) {
       const $button = $section.querySelector(`.${this.sectionButtonClass}`)
 
       if ($button) {
         const contentId = $button.getAttribute('aria-controls')
-        const contentState = contentId ? window.sessionStorage.getItem(contentId) : null
+        const contentState = contentId
+          ? window.sessionStorage.getItem(contentId)
+          : null
 
         if (contentState !== null) {
           this.setExpanded(contentState === 'true', $section)
@@ -539,9 +559,12 @@ export class Accordion {
    * @private
    * @returns {Element} DOM element
    */
-  getButtonPunctuationEl () {
+  getButtonPunctuationEl() {
     const $punctuationEl = document.createElement('span')
-    $punctuationEl.classList.add('govuk-visually-hidden', this.sectionHeadingDividerClass)
+    $punctuationEl.classList.add(
+      'govuk-visually-hidden',
+      this.sectionHeadingDividerClass
+    )
     $punctuationEl.innerHTML = ', '
     return $punctuationEl
   }
@@ -578,7 +601,8 @@ const helper = {
     let result
     try {
       window.sessionStorage.setItem(testString, testString)
-      result = window.sessionStorage.getItem(testString) === testString.toString()
+      result =
+        window.sessionStorage.getItem(testString) === testString.toString()
       window.sessionStorage.removeItem(testString)
       return result
     } catch (exception) {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
@@ -1,4 +1,9 @@
-const { goToComponent, goToExample, renderAndInitialise, getAccessibleName } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  goToExample,
+  renderAndInitialise,
+  getAccessibleName
+} = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('/components/accordion', () => {
@@ -18,7 +23,10 @@ describe('/components/accordion', () => {
         const numberOfExampleSections = 2
 
         for (let i = 0; i < numberOfExampleSections; i++) {
-          const isContentVisible = await page.waitForSelector(`.govuk-accordion .govuk-accordion__section:nth-of-type(${i + 1}) .govuk-accordion__section-content`,
+          const isContentVisible = await page.waitForSelector(
+            `.govuk-accordion .govuk-accordion__section:nth-of-type(${
+              i + 1
+            }) .govuk-accordion__section-content`,
             { visible: true, timeout: 5000 }
           )
           expect(isContentVisible).toBeTruthy()
@@ -28,7 +36,12 @@ describe('/components/accordion', () => {
       it('does not display "↓/↑" in the section headings', async () => {
         await goToComponent(page, 'accordion')
 
-        const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron').length)
+        const numberOfIcons = await page.evaluate(
+          () =>
+            document.body.querySelectorAll(
+              '.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron'
+            ).length
+        )
         expect(numberOfIcons).toEqual(0)
       })
     })
@@ -46,7 +59,13 @@ describe('/components/accordion', () => {
 
         for (let i = 0; i < numberOfExampleSections; i++) {
           const sectionHeaderButtonExpanded = await page.evaluate(function (i) {
-            return document.body.querySelector(`.govuk-accordion .govuk-accordion__section:nth-of-type(${2 + i}) .govuk-accordion__section-button`).getAttribute('aria-expanded')
+            return document.body
+              .querySelector(
+                `.govuk-accordion .govuk-accordion__section:nth-of-type(${
+                  2 + i
+                }) .govuk-accordion__section-button`
+              )
+              .getAttribute('aria-expanded')
           }, i)
 
           expect(sectionHeaderButtonExpanded).toEqual('false')
@@ -56,10 +75,18 @@ describe('/components/accordion', () => {
       it('should change the Show all sections button to Hide all sections when both sections are opened', async () => {
         await goToComponent(page, 'accordion')
 
-        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
-        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+        await page.click(
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+        )
+        await page.click(
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header'
+        )
 
-        const openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all').textContent)
+        const openOrCloseAllButtonText = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-accordion__show-all')
+              .textContent
+        )
         await page.click('.govuk-accordion__show-all')
 
         expect(openOrCloseAllButtonText).toEqual('Hide all sections')
@@ -70,11 +97,23 @@ describe('/components/accordion', () => {
 
         await page.click('.govuk-accordion__show-all')
 
-        const firstSectionHeaderButtonExpanded = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section').item(0).querySelector('.govuk-accordion__section-button').getAttribute('aria-expanded'))
+        const firstSectionHeaderButtonExpanded = await page.evaluate(() =>
+          document.body
+            .querySelectorAll('.govuk-accordion__section')
+            .item(0)
+            .querySelector('.govuk-accordion__section-button')
+            .getAttribute('aria-expanded')
+        )
 
         expect(firstSectionHeaderButtonExpanded).toBeTruthy()
 
-        const secondSectionHeaderButtonExpanded = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section').item(1).querySelector('.govuk-accordion__section-button').getAttribute('aria-expanded'))
+        const secondSectionHeaderButtonExpanded = await page.evaluate(() =>
+          document.body
+            .querySelectorAll('.govuk-accordion__section')
+            .item(1)
+            .querySelector('.govuk-accordion__section-button')
+            .getAttribute('aria-expanded')
+        )
 
         expect(secondSectionHeaderButtonExpanded).toBeTruthy()
       })
@@ -88,40 +127,59 @@ describe('/components/accordion', () => {
 
         for (let i = 0; i < numberOfExampleSections; i++) {
           const sectionHeaderButtonExpanded = await page.evaluate(function (i) {
-            return document.body.querySelector(`.govuk-accordion .govuk-accordion__section:nth-of-type(${2 + i}) .govuk-accordion__section-button`).getAttribute('aria-expanded')
+            return document.body
+              .querySelector(
+                `.govuk-accordion .govuk-accordion__section:nth-of-type(${
+                  2 + i
+                }) .govuk-accordion__section-button`
+              )
+              .getAttribute('aria-expanded')
           }, i)
 
           expect(sectionHeaderButtonExpanded).toEqual('true')
         }
 
-        const openOrCloseAllButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all').textContent)
+        const openOrCloseAllButtonText = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-accordion__show-all')
+              .textContent
+        )
 
         expect(openOrCloseAllButtonText).toEqual('Hide all sections')
       })
 
       it('should maintain the expanded state after a page refresh', async () => {
-        const sectionHeaderButton = '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
+        const sectionHeaderButton =
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
 
         await goToComponent(page, 'accordion')
         await page.click(sectionHeaderButton)
 
         const expandedState = await page.evaluate((sectionHeaderButton) => {
-          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
+          return document.body
+            .querySelector(sectionHeaderButton)
+            .getAttribute('aria-expanded')
         }, sectionHeaderButton)
 
         await page.reload({
           waitUntil: 'load'
         })
 
-        const expandedStateAfterRefresh = await page.evaluate((sectionHeaderButton) => {
-          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
-        }, sectionHeaderButton)
+        const expandedStateAfterRefresh = await page.evaluate(
+          (sectionHeaderButton) => {
+            return document.body
+              .querySelector(sectionHeaderButton)
+              .getAttribute('aria-expanded')
+          },
+          sectionHeaderButton
+        )
 
         expect(expandedState).toEqual(expandedStateAfterRefresh)
       })
 
       it('should not maintain the expanded state after a page refresh, if configured', async () => {
-        const sectionHeaderButton = '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
+        const sectionHeaderButton =
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
 
         await goToComponent(page, 'accordion', {
           exampleName: 'with-remember-expanded-off'
@@ -129,16 +187,23 @@ describe('/components/accordion', () => {
         await page.click(sectionHeaderButton)
 
         const expandedState = await page.evaluate((sectionHeaderButton) => {
-          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
+          return document.body
+            .querySelector(sectionHeaderButton)
+            .getAttribute('aria-expanded')
         }, sectionHeaderButton)
 
         await page.reload({
           waitUntil: 'load'
         })
 
-        const expandedStateAfterRefresh = await page.evaluate((sectionHeaderButton) => {
-          return document.body.querySelector(sectionHeaderButton).getAttribute('aria-expanded')
-        }, sectionHeaderButton)
+        const expandedStateAfterRefresh = await page.evaluate(
+          (sectionHeaderButton) => {
+            return document.body
+              .querySelector(sectionHeaderButton)
+              .getAttribute('aria-expanded')
+          },
+          sectionHeaderButton
+        )
 
         expect(expandedState).not.toEqual(expandedStateAfterRefresh)
       })
@@ -146,7 +211,12 @@ describe('/components/accordion', () => {
       it('should transform the button span to <button>', async () => {
         await goToComponent(page, 'accordion')
 
-        const buttonTag = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button').tagName)
+        const buttonTag = await page.evaluate(
+          () =>
+            document.body.querySelector(
+              '.govuk-accordion .govuk-accordion__section-button'
+            ).tagName
+        )
 
         expect(buttonTag).toEqual('BUTTON')
       })
@@ -154,7 +224,11 @@ describe('/components/accordion', () => {
       it('should contain a heading text container', async () => {
         await goToComponent(page, 'accordion')
 
-        const headingTextContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-heading-text'))
+        const headingTextContainer = await page.evaluate(() =>
+          document.body.querySelector(
+            '.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-heading-text'
+          )
+        )
 
         expect(headingTextContainer).toBeTruthy()
       })
@@ -163,7 +237,11 @@ describe('/components/accordion', () => {
         it('should contain a heading text focus container', async () => {
           await goToComponent(page, 'accordion')
 
-          const headingTextFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-heading-text > .govuk-accordion__section-heading-text-focus'))
+          const headingTextFocusContainer = await page.evaluate(() =>
+            document.body.querySelector(
+              '.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-heading-text > .govuk-accordion__section-heading-text-focus'
+            )
+          )
 
           expect(headingTextFocusContainer).toBeTruthy()
         })
@@ -172,14 +250,22 @@ describe('/components/accordion', () => {
             exampleName: 'with-additional-descriptions'
           })
 
-          const summaryFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-summary > .govuk-accordion__section-summary-focus'))
+          const summaryFocusContainer = await page.evaluate(() =>
+            document.body.querySelector(
+              '.govuk-accordion .govuk-accordion__section-button > .govuk-accordion__section-summary > .govuk-accordion__section-summary-focus'
+            )
+          )
 
           expect(summaryFocusContainer).toBeTruthy()
         })
         it('should contain a show/hide focus container', async () => {
           await goToComponent(page, 'accordion')
 
-          const headingTextFocusContainer = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-toggle > .govuk-accordion__section-toggle-focus'))
+          const headingTextFocusContainer = await page.evaluate(() =>
+            document.body.querySelector(
+              '.govuk-accordion .govuk-accordion__section-button .govuk-accordion__section-toggle > .govuk-accordion__section-toggle-focus'
+            )
+          )
 
           expect(headingTextFocusContainer).toBeTruthy()
         })
@@ -190,7 +276,12 @@ describe('/components/accordion', () => {
           await goToComponent(page, 'accordion')
 
           const numberOfExampleSections = 2
-          const numberOfIcons = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron').length)
+          const numberOfIcons = await page.evaluate(
+            () =>
+              document.body.querySelectorAll(
+                '.govuk-accordion .govuk-accordion__section .govuk-accordion-nav__chevron'
+              ).length
+          )
 
           expect(numberOfIcons).toEqual(numberOfExampleSections)
         })
@@ -200,11 +291,23 @@ describe('/components/accordion', () => {
         it('should contain hidden comma " ," after the heading text for when CSS does not load', async () => {
           await goToComponent(page, 'accordion')
 
-          const commaAfterHeadingTextClassName = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').nextElementSibling.className)
+          const commaAfterHeadingTextClassName = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-heading-text'
+              ).nextElementSibling.className
+          )
 
-          const commaAfterHeadingTextContent = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').nextElementSibling.innerHTML)
+          const commaAfterHeadingTextContent = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-heading-text'
+              ).nextElementSibling.innerHTML
+          )
 
-          expect(commaAfterHeadingTextClassName).toEqual('govuk-visually-hidden govuk-accordion__section-heading-divider')
+          expect(commaAfterHeadingTextClassName).toEqual(
+            'govuk-visually-hidden govuk-accordion__section-heading-divider'
+          )
 
           expect(commaAfterHeadingTextContent).toEqual(', ')
         })
@@ -214,11 +317,21 @@ describe('/components/accordion', () => {
             exampleName: 'with-additional-descriptions'
           })
 
-          const commaAfterHeadingTextClassName = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-summary').nextElementSibling.className)
+          const commaAfterHeadingTextClassName = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__section-summary')
+                .nextElementSibling.className
+          )
 
-          const commaAfterHeadingTextContent = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-summary').nextElementSibling.innerHTML)
+          const commaAfterHeadingTextContent = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__section-summary')
+                .nextElementSibling.innerHTML
+          )
 
-          expect(commaAfterHeadingTextClassName).toEqual('govuk-visually-hidden govuk-accordion__section-heading-divider')
+          expect(commaAfterHeadingTextClassName).toEqual(
+            'govuk-visually-hidden govuk-accordion__section-heading-divider'
+          )
 
           expect(commaAfterHeadingTextContent).toEqual(', ')
         })
@@ -232,7 +345,12 @@ describe('/components/accordion', () => {
             })
 
             const summaryClass = 'govuk-accordion__section-summary govuk-body'
-            const firstSummaryElement = await page.evaluate(() => document.body.querySelectorAll('.govuk-accordion__section-button > span')[2].className)
+            const firstSummaryElement = await page.evaluate(
+              () =>
+                document.body.querySelectorAll(
+                  '.govuk-accordion__section-button > span'
+                )[2].className
+            )
             expect(firstSummaryElement).toMatch(summaryClass)
           })
         })
@@ -243,7 +361,12 @@ describe('/components/accordion', () => {
               exampleName: 'with-additional-descriptions'
             })
 
-            const firstSummaryElement = await page.evaluate(() => document.body.querySelector('.govuk-accordion .govuk-accordion__section .govuk-accordion__section-summary').outerHTML)
+            const firstSummaryElement = await page.evaluate(
+              () =>
+                document.body.querySelector(
+                  '.govuk-accordion .govuk-accordion__section .govuk-accordion__section-summary'
+                ).outerHTML
+            )
 
             expect(firstSummaryElement).toMatch(/<span[^>]*>/)
           })
@@ -252,10 +375,18 @@ describe('/components/accordion', () => {
 
       it('should change the Show text to Hide when sections are opened', async () => {
         await goToComponent(page, 'accordion')
-        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
-        await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+        await page.click(
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+        )
+        await page.click(
+          '.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header'
+        )
 
-        const ShowOrHideButtonText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').textContent)
+        const ShowOrHideButtonText = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-accordion__section-toggle-text')
+              .textContent
+        )
 
         expect(ShowOrHideButtonText).toEqual('Hide')
       })
@@ -263,7 +394,11 @@ describe('/components/accordion', () => {
       it('should have a data-nosnippet attribute on the "Show / hide" container to hide it from search result snippets', async () => {
         await goToComponent(page, 'accordion')
 
-        const dataNoSnippetAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle').getAttribute('data-nosnippet'))
+        const dataNoSnippetAttribute = await page.evaluate(() =>
+          document.body
+            .querySelector('.govuk-accordion__section-toggle')
+            .getAttribute('data-nosnippet')
+        )
 
         expect(dataNoSnippetAttribute).toEqual('')
       })
@@ -308,9 +443,17 @@ describe('/components/accordion', () => {
         it('should have an aria-labelledby that matches the heading text ID', async () => {
           await goToComponent(page, 'accordion')
 
-          const ariaLabelledByValue = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-content').getAttribute('aria-labelledby'))
+          const ariaLabelledByValue = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion__section-content')
+              .getAttribute('aria-labelledby')
+          )
 
-          const headingTextId = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-heading-text').getAttribute('id'))
+          const headingTextId = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion__section-heading-text')
+              .getAttribute('id')
+          )
 
           expect(ariaLabelledByValue).toEqual(headingTextId)
         })
@@ -322,8 +465,16 @@ describe('/components/accordion', () => {
             exampleName: 'with-translations'
           })
 
-          const showAllSectionsDataAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion').getAttribute('data-i18n.show-all-sections'))
-          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+          const showAllSectionsDataAttribute = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion')
+              .getAttribute('data-i18n.show-all-sections')
+          )
+          const allSectionsToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__show-all-text')
+                .innerHTML
+          )
 
           expect(allSectionsToggleText).toEqual(showAllSectionsDataAttribute)
         })
@@ -331,7 +482,11 @@ describe('/components/accordion', () => {
         it('should localise "Show all sections" based on JavaScript configuration', async () => {
           await goToExample(page, 'translated')
 
-          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+          const allSectionsToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__show-all-text')
+                .innerHTML
+          )
 
           expect(allSectionsToggleText).toBe('Dangos adrannau')
         })
@@ -340,11 +495,23 @@ describe('/components/accordion', () => {
           await goToComponent(page, 'accordion', {
             exampleName: 'with-translations'
           })
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header')
+          await page.click(
+            '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+          )
+          await page.click(
+            '.govuk-accordion .govuk-accordion__section:nth-of-type(3) .govuk-accordion__section-header'
+          )
 
-          const hideAllSectionsDataAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion').getAttribute('data-i18n.hide-all-sections'))
-          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+          const hideAllSectionsDataAttribute = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion')
+              .getAttribute('data-i18n.hide-all-sections')
+          )
+          const allSectionsToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__show-all-text')
+                .innerHTML
+          )
 
           expect(allSectionsToggleText).toEqual(hideAllSectionsDataAttribute)
         })
@@ -353,7 +520,11 @@ describe('/components/accordion', () => {
           await goToExample(page, 'translated')
           await page.click('.govuk-accordion .govuk-accordion__show-all')
 
-          const allSectionsToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__show-all-text').innerHTML)
+          const allSectionsToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector('.govuk-accordion__show-all-text')
+                .innerHTML
+          )
 
           expect(allSectionsToggleText).toBe('Cuddio adrannau')
         })
@@ -363,8 +534,17 @@ describe('/components/accordion', () => {
             exampleName: 'with-translations'
           })
 
-          const showSectionDataAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion').getAttribute('data-i18n.show-section'))
-          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+          const showSectionDataAttribute = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion')
+              .getAttribute('data-i18n.show-section')
+          )
+          const firstSectionToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-toggle-text'
+              ).innerHTML
+          )
 
           expect(firstSectionToggleText).toEqual(showSectionDataAttribute)
         })
@@ -372,7 +552,12 @@ describe('/components/accordion', () => {
         it('should localise "Show section" based on JavaScript configuration', async () => {
           await goToExample(page, 'translated')
 
-          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+          const firstSectionToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-toggle-text'
+              ).innerHTML
+          )
 
           expect(firstSectionToggleText).toBe('Dangos')
         })
@@ -387,11 +572,10 @@ describe('/components/accordion', () => {
               .querySelector('.govuk-accordion')
               .getAttribute('data-i18n.show-section-aria-label')
           )
-          const firstSectionToggleAriaLabel = await page.evaluate(
-            () =>
-              document.body.querySelector(
-                '.govuk-accordion__section-button'
-              ).getAttribute('aria-label')
+          const firstSectionToggleAriaLabel = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion__section-button')
+              .getAttribute('aria-label')
           )
 
           expect(
@@ -408,26 +592,46 @@ describe('/components/accordion', () => {
               .getAttribute('aria-label')
           )
 
-          expect(firstSectionToggleAriaLabel.endsWith('Dangos adran')).toBeTruthy()
+          expect(
+            firstSectionToggleAriaLabel.endsWith('Dangos adran')
+          ).toBeTruthy()
         })
 
         it('should localise "Hide section" based on data attribute', async () => {
           await goToComponent(page, 'accordion', {
             exampleName: 'with-translations'
           })
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+          await page.click(
+            '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+          )
 
-          const hideSectionDataAttribute = await page.evaluate(() => document.body.querySelector('.govuk-accordion').getAttribute('data-i18n.hide-section'))
-          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+          const hideSectionDataAttribute = await page.evaluate(() =>
+            document.body
+              .querySelector('.govuk-accordion')
+              .getAttribute('data-i18n.hide-section')
+          )
+          const firstSectionToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-toggle-text'
+              ).innerHTML
+          )
 
           expect(firstSectionToggleText).toEqual(hideSectionDataAttribute)
         })
 
         it('should localise "Hide section" based on JavaScript configuration', async () => {
           await goToExample(page, 'translated')
-          await page.click('.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header')
+          await page.click(
+            '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+          )
 
-          const firstSectionToggleText = await page.evaluate(() => document.body.querySelector('.govuk-accordion__section-toggle-text').innerHTML)
+          const firstSectionToggleText = await page.evaluate(
+            () =>
+              document.body.querySelector(
+                '.govuk-accordion__section-toggle-text'
+              ).innerHTML
+          )
 
           expect(firstSectionToggleText).toBe('Cuddio')
         })

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
@@ -21,7 +21,9 @@ describe('Accordion', () => {
       const $componentContent = $('.govuk-accordion__section-content').first()
 
       expect($componentContent.find('p').hasClass('govuk-body')).toBeTruthy()
-      expect($componentContent.text().trim()).toEqual('We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.')
+      expect($componentContent.text().trim()).toEqual(
+        'We need to know your nationality so we can work out which elections you’re entitled to vote in. If you cannot provide your nationality, you’ll have to send copies of identity documents through the post.'
+      )
     })
 
     it('renders with content as html', () => {
@@ -65,14 +67,18 @@ describe('Accordion', () => {
       const $ = render('accordion', examples['heading html'])
       const $componentHeadingButton = $('.govuk-accordion__section-button')
 
-      expect($componentHeadingButton.html().trim()).toEqual('<span class="myClass">Section A</span>')
+      expect($componentHeadingButton.html().trim()).toEqual(
+        '<span class="myClass">Section A</span>'
+      )
     })
 
     it('renders with section expanded class', () => {
       const $ = render('accordion', examples['with one section open'])
       const $componentSection = $('.govuk-accordion__section').first()
 
-      expect($componentSection.hasClass('govuk-accordion__section--expanded')).toBeTruthy()
+      expect(
+        $componentSection.hasClass('govuk-accordion__section--expanded')
+      ).toBeTruthy()
     })
 
     it('renders with summary', () => {
@@ -94,12 +100,20 @@ describe('Accordion', () => {
       const $ = render('accordion', examples['with translations'])
       const $component = $('.govuk-accordion')
 
-      expect($component.attr('data-i18n.hide-all-sections')).toEqual('Collapse all sections')
-      expect($component.attr('data-i18n.show-all-sections')).toEqual('Expand all sections')
+      expect($component.attr('data-i18n.hide-all-sections')).toEqual(
+        'Collapse all sections'
+      )
+      expect($component.attr('data-i18n.show-all-sections')).toEqual(
+        'Expand all sections'
+      )
       expect($component.attr('data-i18n.hide-section')).toEqual('Collapse')
-      expect($component.attr('data-i18n.hide-section-aria-label')).toEqual('Collapse this section')
+      expect($component.attr('data-i18n.hide-section-aria-label')).toEqual(
+        'Collapse this section'
+      )
       expect($component.attr('data-i18n.show-section')).toEqual('Expand')
-      expect($component.attr('data-i18n.show-section-aria-label')).toEqual('Expand this section')
+      expect($component.attr('data-i18n.show-section-aria-label')).toEqual(
+        'Expand this section'
+      )
     })
 
     it('renders with remember expanded data attribute', () => {

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
@@ -35,7 +35,10 @@ describe('Breadcrumbs', () => {
 
   describe('custom options', () => {
     it('renders item with text', () => {
-      const $ = render('breadcrumbs', examples['with last breadcrumb as current page'])
+      const $ = render(
+        'breadcrumbs',
+        examples['with last breadcrumb as current page']
+      )
 
       const $item = $('.govuk-breadcrumbs__list-item').last()
       expect($item.text()).toEqual('Travel abroad')
@@ -74,7 +77,9 @@ describe('Breadcrumbs', () => {
       const $ = render('breadcrumbs', examples.classes)
 
       const $component = $('.govuk-breadcrumbs')
-      expect($component.hasClass('app-breadcrumbs--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-breadcrumbs--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with attributes', () => {
@@ -89,7 +94,9 @@ describe('Breadcrumbs', () => {
       const $ = render('breadcrumbs', examples['with collapse on mobile'])
 
       const $component = $('.govuk-breadcrumbs')
-      expect($component.hasClass('govuk-breadcrumbs--collapse-on-mobile')).toBeTruthy()
+      expect(
+        $component.hasClass('govuk-breadcrumbs--collapse-on-mobile')
+      ).toBeTruthy()
     })
 
     it('renders with inverted colours if specified', () => {

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -28,8 +28,11 @@ export class Button {
    * @param {Element} $module - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */
-  constructor ($module, config) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module, config) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -41,7 +44,9 @@ export class Button {
       normaliseDataset($module.dataset)
     )
 
-    this.$module.addEventListener('keydown', (event) => this.handleKeyDown(event))
+    this.$module.addEventListener('keydown', (event) =>
+      this.handleKeyDown(event)
+    )
     this.$module.addEventListener('click', (event) => this.debounce(event))
   }
 
@@ -56,7 +61,7 @@ export class Button {
    * @private
    * @param {KeyboardEvent} event - Keydown event
    */
-  handleKeyDown (event) {
+  handleKeyDown(event) {
     const $target = event.target
 
     // Handle space bar only
@@ -65,7 +70,10 @@ export class Button {
     }
 
     // Handle elements with [role="button"] only
-    if ($target instanceof HTMLElement && $target.getAttribute('role') === 'button') {
+    if (
+      $target instanceof HTMLElement &&
+      $target.getAttribute('role') === 'button'
+    ) {
       event.preventDefault() // prevent the page from scrolling
       $target.click()
     }
@@ -82,7 +90,7 @@ export class Button {
    * @param {MouseEvent} event - Mouse click event
    * @returns {undefined | false} Returns undefined, or false when debounced
    */
-  debounce (event) {
+  debounce(event) {
     // Check the button that was clicked has preventDoubleClick enabled
     if (!this.config.preventDoubleClick) {
       return

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -1,4 +1,8 @@
-const { goTo, goToComponent, renderAndInitialise } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goTo,
+  goToComponent,
+  renderAndInitialise
+} = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('/components/button', () => {
@@ -42,7 +46,9 @@ describe('/components/button', () => {
     })
 
     it('triggers the click event when the space key is pressed', async () => {
-      const pathname = await page.evaluate(() => document.body.getElementsByTagName('a')[0].getAttribute('href'))
+      const pathname = await page.evaluate(() =>
+        document.body.getElementsByTagName('a')[0].getAttribute('href')
+      )
 
       await page.focus('a[role="button"]')
 
@@ -66,25 +72,33 @@ describe('/components/button', () => {
      * @param {import('puppeteer').ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
      * @returns {Promise<import('puppeteer').ElementHandle<HTMLButtonElement>>} Puppeteer button element
      */
-    async function setButtonTracking ($button) {
+    async function setButtonTracking($button) {
       const counts = {
         click: 0,
         debounce: 0
       }
 
       // Track number of button clicks
-      await $button.evaluate((el, counts) => el.addEventListener('click', (event) => {
-        counts.click++
-        el.dataset.clickCount = `${counts.click}`
+      await $button.evaluate(
+        (el, counts) =>
+          el.addEventListener(
+            'click',
+            (event) => {
+              counts.click++
+              el.dataset.clickCount = `${counts.click}`
 
-        // Track number of button clicks that debounced
-        event.preventDefault = () => {
-          counts.debounce++
-          el.dataset.debounceCount = `${counts.debounce}`
-        }
+              // Track number of button clicks that debounced
+              event.preventDefault = () => {
+                counts.debounce++
+                el.dataset.debounceCount = `${counts.debounce}`
+              }
 
-        // Add listener during capture phase to spy on event
-      }, { capture: true }), counts)
+              // Add listener during capture phase to spy on event
+            },
+            { capture: true }
+          ),
+        counts
+      )
 
       return $button
     }
@@ -95,7 +109,7 @@ describe('/components/button', () => {
      * @param {import('puppeteer').ElementHandle<HTMLButtonElement>} $button - Puppeteer button element
      * @returns {Promise<{ click: number; debounce: number; }>} Number of times the button was clicked
      */
-    function getButtonTracking ($button) {
+    function getButtonTracking($button) {
       return $button.evaluate((el) => ({
         click: parseInt(el.dataset.clickCount ?? '0'),
         debounce: parseInt(el.dataset.debounceCount ?? '0')
@@ -157,8 +171,12 @@ describe('/components/button', () => {
         $button.evaluate((el) => el.parentNode.appendChild(el.cloneNode(true)))
 
         // Locate original and cloned button
-        const $button1 = await setButtonTracking(await page.$('button:nth-child(1)'))
-        const $button2 = await setButtonTracking(await page.$('button:nth-child(2)'))
+        const $button1 = await setButtonTracking(
+          await page.$('button:nth-child(1)')
+        )
+        const $button2 = await setButtonTracking(
+          await page.$('button:nth-child(2)')
+        )
 
         await $button1.click({ count: 2 })
         await $button2.click()
@@ -213,8 +231,12 @@ describe('/components/button', () => {
         $button.evaluate((el) => el.parentNode.appendChild(el.cloneNode(true)))
 
         // Locate original and cloned button
-        const $button1 = await setButtonTracking(await page.$('button:nth-child(1)'))
-        const $button2 = await setButtonTracking(await page.$('button:nth-child(2)'))
+        const $button1 = await setButtonTracking(
+          await page.$('button:nth-child(1)')
+        )
+        const $button2 = await setButtonTracking(
+          await page.$('button:nth-child(2)')
+        )
 
         await $button1.click({ count: 2 })
         await $button2.click()
@@ -294,8 +316,12 @@ describe('/components/button', () => {
         $button.evaluate((el) => el.parentNode.appendChild(el.cloneNode(true)))
 
         // Locate original and cloned button
-        const $button1 = await setButtonTracking(await page.$('button:nth-child(1)'))
-        const $button2 = await setButtonTracking(await page.$('button:nth-child(2)'))
+        const $button1 = await setButtonTracking(
+          await page.$('button:nth-child(1)')
+        )
+        const $button2 = await setButtonTracking(
+          await page.$('button:nth-child(2)')
+        )
 
         await $button1.click({ count: 2 })
         await $button2.click()

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -92,9 +92,9 @@ describe('/components/button', () => {
                 counts.debounce++
                 el.dataset.debounceCount = `${counts.debounce}`
               }
-
-              // Add listener during capture phase to spy on event
             },
+
+            // Add listener during capture phase to spy on event
             { capture: true }
           ),
         counts

--- a/packages/govuk-frontend/src/govuk/components/button/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/template.test.js
@@ -190,7 +190,7 @@ describe('Button', () => {
       expect($component.get(0).tagName).toEqual('a')
     })
 
-    it('renders a button if you don\'t pass anything', () => {
+    it("renders a button if you don't pass anything", () => {
       const $ = render('button', examples['no type'])
 
       const $component = $('.govuk-button')

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -63,8 +63,11 @@ export class CharacterCount {
    * @param {Element} $module - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
    */
-  constructor ($module, config) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module, config) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -120,7 +123,9 @@ export class CharacterCount {
     this.$module = $module
     this.$textarea = $textarea
 
-    const $textareaDescription = document.getElementById(`${this.$textarea.id}-info`)
+    const $textareaDescription = document.getElementById(
+      `${this.$textarea.id}-info`
+    )
     if (!$textareaDescription) {
       return
     }
@@ -129,7 +134,9 @@ export class CharacterCount {
     // for when the component was rendered with no maxlength, maxwords
     // nor custom textareaDescriptionText
     if ($textareaDescription.innerText.match(/^\s*$/)) {
-      $textareaDescription.innerText = this.i18n.t('textareaDescription', { count: this.maxLength })
+      $textareaDescription.innerText = this.i18n.t('textareaDescription', {
+        count: this.maxLength
+      })
     }
 
     // Move the textarea description to be immediately after the textarea
@@ -139,10 +146,14 @@ export class CharacterCount {
     // Create the *screen reader* specific live-updating counter
     // This doesn't need any styling classes, as it is never visible
     const $screenReaderCountMessage = document.createElement('div')
-    $screenReaderCountMessage.className = 'govuk-character-count__sr-status govuk-visually-hidden'
+    $screenReaderCountMessage.className =
+      'govuk-character-count__sr-status govuk-visually-hidden'
     $screenReaderCountMessage.setAttribute('aria-live', 'polite')
     this.$screenReaderCountMessage = $screenReaderCountMessage
-    $textareaDescription.insertAdjacentElement('afterend', $screenReaderCountMessage)
+    $textareaDescription.insertAdjacentElement(
+      'afterend',
+      $screenReaderCountMessage
+    )
 
     // Create our live-updating counter element, copying the classes from the
     // textarea description for backwards compatibility as these may have been
@@ -181,7 +192,7 @@ export class CharacterCount {
    *
    * @private
    */
-  bindChangeEvents () {
+  bindChangeEvents() {
     this.$textarea.addEventListener('keyup', () => this.handleKeyUp())
 
     // Bind focus/blur events to start/stop polling
@@ -197,7 +208,7 @@ export class CharacterCount {
    *
    * @private
    */
-  handleKeyUp () {
+  handleKeyUp() {
     this.updateVisibleCountMessage()
     this.lastInputTimestamp = Date.now()
   }
@@ -217,9 +228,12 @@ export class CharacterCount {
    *
    * @private
    */
-  handleFocus () {
+  handleFocus() {
     this.valueChecker = window.setInterval(() => {
-      if (!this.lastInputTimestamp || (Date.now() - 500) >= this.lastInputTimestamp) {
+      if (
+        !this.lastInputTimestamp ||
+        Date.now() - 500 >= this.lastInputTimestamp
+      ) {
         this.updateIfValueChanged()
       }
     }, 1000)
@@ -232,7 +246,7 @@ export class CharacterCount {
    *
    * @private
    */
-  handleBlur () {
+  handleBlur() {
     // Cancel value checking on blur
     clearInterval(this.valueChecker)
   }
@@ -242,7 +256,7 @@ export class CharacterCount {
    *
    * @private
    */
-  updateIfValueChanged () {
+  updateIfValueChanged() {
     if (this.$textarea.value !== this.lastInputValue) {
       this.lastInputValue = this.$textarea.value
       this.updateCountMessage()
@@ -257,7 +271,7 @@ export class CharacterCount {
    *
    * @private
    */
-  updateCountMessage () {
+  updateCountMessage() {
     this.updateVisibleCountMessage()
     this.updateScreenReaderCountMessage()
   }
@@ -267,15 +281,19 @@ export class CharacterCount {
    *
    * @private
    */
-  updateVisibleCountMessage () {
+  updateVisibleCountMessage() {
     const remainingNumber = this.maxLength - this.count(this.$textarea.value)
 
     // If input is over the threshold, remove the disabled class which renders the
     // counter invisible.
     if (this.isOverThreshold()) {
-      this.$visibleCountMessage.classList.remove('govuk-character-count__message--disabled')
+      this.$visibleCountMessage.classList.remove(
+        'govuk-character-count__message--disabled'
+      )
     } else {
-      this.$visibleCountMessage.classList.add('govuk-character-count__message--disabled')
+      this.$visibleCountMessage.classList.add(
+        'govuk-character-count__message--disabled'
+      )
     }
 
     // Update styles
@@ -298,7 +316,7 @@ export class CharacterCount {
    *
    * @private
    */
-  updateScreenReaderCountMessage () {
+  updateScreenReaderCountMessage() {
     // If over the threshold, remove the aria-hidden attribute, allowing screen
     // readers to announce the content of the element.
     if (this.isOverThreshold()) {
@@ -319,7 +337,7 @@ export class CharacterCount {
    * @param {string} text - The text to count the characters of
    * @returns {number} the number of characters (or words) in the text
    */
-  count (text) {
+  count(text) {
     if ('maxwords' in this.config && this.config.maxwords) {
       const tokens = text.match(/\S+/g) || [] // Matches consecutive non-whitespace chars
       return tokens.length
@@ -334,10 +352,11 @@ export class CharacterCount {
    * @private
    * @returns {string} Status message
    */
-  getCountMessage () {
+  getCountMessage() {
     const remainingNumber = this.maxLength - this.count(this.$textarea.value)
 
-    const countType = 'maxwords' in this.config && this.config.maxwords ? 'words' : 'characters'
+    const countType =
+      'maxwords' in this.config && this.config.maxwords ? 'words' : 'characters'
     return this.formatCountMessage(remainingNumber, countType)
   }
 
@@ -350,14 +369,17 @@ export class CharacterCount {
    * @param {string} countType - "words" or "characters"
    * @returns {string} Status message
    */
-  formatCountMessage (remainingNumber, countType) {
+  formatCountMessage(remainingNumber, countType) {
     if (remainingNumber === 0) {
       return this.i18n.t(`${countType}AtLimit`)
     }
 
-    const translationKeySuffix = remainingNumber < 0 ? 'OverLimit' : 'UnderLimit'
+    const translationKeySuffix =
+      remainingNumber < 0 ? 'OverLimit' : 'UnderLimit'
 
-    return this.i18n.t(`${countType}${translationKeySuffix}`, { count: Math.abs(remainingNumber) })
+    return this.i18n.t(`${countType}${translationKeySuffix}`, {
+      count: Math.abs(remainingNumber)
+    })
   }
 
   /**
@@ -371,7 +393,7 @@ export class CharacterCount {
    * @returns {boolean} true if the current count is over the config.threshold
    *   (or no threshold is set)
    */
-  isOverThreshold () {
+  isOverThreshold() {
     // No threshold means we're always above threshold so save some computation
     if (!this.config.threshold) {
       return true
@@ -381,9 +403,9 @@ export class CharacterCount {
     const currentLength = this.count(this.$textarea.value)
     const maxLength = this.maxLength
 
-    const thresholdValue = maxLength * this.config.threshold / 100
+    const thresholdValue = (maxLength * this.config.threshold) / 100
 
-    return (thresholdValue <= currentLength)
+    return thresholdValue <= currentLength
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -1,4 +1,7 @@
-const { goToComponent, renderAndInitialise } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  renderAndInitialise
+} = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('Character count', () => {
@@ -26,7 +29,10 @@ describe('Character count', () => {
 
     it('shows the textarea description', async () => {
       await goToComponent(page, 'character-count')
-      const message = await page.$eval('.govuk-character-count__message', el => el.innerHTML.trim())
+      const message = await page.$eval(
+        '.govuk-character-count__message',
+        (el) => el.innerHTML.trim()
+      )
 
       expect(message).toEqual('You can enter up to 10 characters')
     })
@@ -39,17 +45,22 @@ describe('Character count', () => {
       })
 
       it('injects the visual counter', async () => {
-        const message = await page.$('.govuk-character-count__status') !== null
+        const message =
+          (await page.$('.govuk-character-count__status')) !== null
         expect(message).toBeTruthy()
       })
 
       it('injects the screen reader counter', async () => {
-        const srMessage = await page.$('.govuk-character-count__sr-status') !== null
+        const srMessage =
+          (await page.$('.govuk-character-count__sr-status')) !== null
         expect(srMessage).toBeTruthy()
       })
 
       it('hides the textarea description', async () => {
-        const messageClasses = await page.$eval('.govuk-character-count__message', el => el.className)
+        const messageClasses = await page.$eval(
+          '.govuk-character-count__message',
+          (el) => el.className
+        )
         expect(messageClasses).toContain('govuk-visually-hidden')
       })
     })
@@ -58,10 +69,16 @@ describe('Character count', () => {
       it('shows the dynamic message', async () => {
         await goToComponent(page, 'character-count')
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 10 characters remaining')
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 10 characters remaining')
       })
 
@@ -70,10 +87,16 @@ describe('Character count', () => {
           exampleName: 'with-default-value'
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 67 characters remaining')
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 67 characters remaining')
       })
 
@@ -84,13 +107,19 @@ describe('Character count', () => {
           delay: 50
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 9 characters remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 9 characters remaining')
       })
 
@@ -101,13 +130,19 @@ describe('Character count', () => {
           delay: 50
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 1 character remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 1 character remaining')
       })
 
@@ -121,13 +156,19 @@ describe('Character count', () => {
         })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 1 character too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 1 character too many')
         })
 
@@ -136,23 +177,35 @@ describe('Character count', () => {
             delay: 50
           })
 
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 2 characters too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 2 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          const textareaClasses = await page.$eval(
+            '.govuk-js-character-count',
+            (el) => el.className
+          )
           expect(textareaClasses).toContain('govuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          const messageClasses = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.className
+          )
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
@@ -165,20 +218,32 @@ describe('Character count', () => {
         })
 
         it('shows the number of characters over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 23 characters too many')
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 23 characters too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          const textareaClasses = await page.$eval(
+            '.govuk-js-character-count',
+            (el) => el.className
+          )
           expect(textareaClasses).toContain('govuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          const messageClasses = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.className
+          )
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
@@ -191,14 +256,20 @@ describe('Character count', () => {
         })
 
         it('does not show the limit until the threshold is reached', async () => {
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          const visibility = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => window.getComputedStyle(el).visibility
+          )
           expect(visibility).toEqual('hidden')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           // Ensure threshold is hidden for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.getAttribute('aria-hidden')
+          )
           expect(ariaHidden).toEqual('true')
         })
 
@@ -207,14 +278,20 @@ describe('Character count', () => {
             delay: 50
           })
 
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          const visibility = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => window.getComputedStyle(el).visibility
+          )
           expect(visibility).toEqual('visible')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
           // Ensure threshold is visible for users of assistive technologies
-          const ariaHidden = await page.$eval('.govuk-character-count__sr-status', el => el.getAttribute('aria-hidden'))
+          const ariaHidden = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.getAttribute('aria-hidden')
+          )
           expect(ariaHidden).toBeFalsy()
         })
       })
@@ -228,10 +305,16 @@ describe('Character count', () => {
         })
 
         it('still works correctly', async () => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 10 characters remaining')
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 10 characters remaining')
         })
       })
@@ -244,10 +327,16 @@ describe('Character count', () => {
         })
 
         it('still works correctly', async () => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 10 characters remaining')
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 10 characters remaining')
         })
       })
@@ -260,7 +349,9 @@ describe('Character count', () => {
         })
 
         it('should not have a maxlength attribute once the JS has run', async () => {
-          const textareaMaxLength = await page.$eval('.govuk-textarea', el => el.getAttribute('maxlength'))
+          const textareaMaxLength = await page.$eval('.govuk-textarea', (el) =>
+            el.getAttribute('maxlength')
+          )
           expect(textareaMaxLength).toBeNull()
         })
       })
@@ -272,10 +363,16 @@ describe('Character count', () => {
           exampleName: 'with-word-count'
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 10 words remaining')
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 10 words remaining')
       })
 
@@ -288,13 +385,19 @@ describe('Character count', () => {
           delay: 50
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 8 words remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 8 words remaining')
       })
 
@@ -307,13 +410,19 @@ describe('Character count', () => {
           delay: 50
         })
 
-        const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+        const message = await page.$eval(
+          '.govuk-character-count__status',
+          (el) => el.innerHTML.trim()
+        )
         expect(message).toEqual('You have 1 word remaining')
 
         // Wait for debounced update to happen
         await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-        const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+        const srMessage = await page.$eval(
+          '.govuk-character-count__sr-status',
+          (el) => el.innerHTML.trim()
+        )
         expect(srMessage).toEqual('You have 1 word remaining')
       })
 
@@ -329,13 +438,19 @@ describe('Character count', () => {
         })
 
         it('shows the number of words over the limit', async () => {
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 1 word too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 1 word too many')
         })
 
@@ -344,23 +459,35 @@ describe('Character count', () => {
             delay: 50
           })
 
-          const message = await page.$eval('.govuk-character-count__status', el => el.innerHTML.trim())
+          const message = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.innerHTML.trim()
+          )
           expect(message).toEqual('You have 2 words too many')
 
           // Wait for debounced update to happen
           await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
 
-          const srMessage = await page.$eval('.govuk-character-count__sr-status', el => el.innerHTML.trim())
+          const srMessage = await page.$eval(
+            '.govuk-character-count__sr-status',
+            (el) => el.innerHTML.trim()
+          )
           expect(srMessage).toEqual('You have 2 words too many')
         })
 
         it('adds error styles to the textarea', async () => {
-          const textareaClasses = await page.$eval('.govuk-js-character-count', el => el.className)
+          const textareaClasses = await page.$eval(
+            '.govuk-js-character-count',
+            (el) => el.className
+          )
           expect(textareaClasses).toContain('govuk-textarea--error')
         })
 
         it('adds error styles to the count message', async () => {
-          const messageClasses = await page.$eval('.govuk-character-count__status', el => el.className)
+          const messageClasses = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => el.className
+          )
           expect(messageClasses).toContain('govuk-error-message')
         })
       })
@@ -419,7 +546,10 @@ describe('Character count', () => {
             delay: 50
           })
 
-          const visibility = await page.$eval('.govuk-character-count__status', el => window.getComputedStyle(el).visibility)
+          const visibility = await page.$eval(
+            '.govuk-character-count__status',
+            (el) => window.getComputedStyle(el).visibility
+          )
           expect(visibility).toEqual('visible')
         })
 
@@ -595,8 +725,7 @@ describe('Character count', () => {
           // (and interpolated to replace `%{count}` with the maximum)
 
           await renderAndInitialise(page, 'character-count', {
-            params:
-              examples['when neither maxlength nor maxwords are set'],
+            params: examples['when neither maxlength nor maxwords are set'],
             config: {
               maxlength: 10
             }
@@ -648,7 +777,7 @@ describe('Character count', () => {
           // Override maxlength to 10
           maxlength: 10
         },
-        initialiser ($module) {
+        initialiser($module) {
           // Set locale to Welsh, which expects translations for 'one', 'two',
           // 'few' 'many' and 'other' forms – with the default English strings
           // provided we only have translations for 'one' and 'other'.

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.unit.test.mjs
@@ -26,11 +26,31 @@ describe('CharacterCount', () => {
       })
 
       const cases = [
-        { number: 1, type: 'characters', expected: 'You have 1 character remaining' },
-        { number: 10, type: 'characters', expected: 'You have 10 characters remaining' },
-        { number: -1, type: 'characters', expected: 'You have 1 character too many' },
-        { number: -10, type: 'characters', expected: 'You have 10 characters too many' },
-        { number: 0, type: 'characters', expected: 'You have 0 characters remaining' },
+        {
+          number: 1,
+          type: 'characters',
+          expected: 'You have 1 character remaining'
+        },
+        {
+          number: 10,
+          type: 'characters',
+          expected: 'You have 10 characters remaining'
+        },
+        {
+          number: -1,
+          type: 'characters',
+          expected: 'You have 1 character too many'
+        },
+        {
+          number: -10,
+          type: 'characters',
+          expected: 'You have 10 characters too many'
+        },
+        {
+          number: 0,
+          type: 'characters',
+          expected: 'You have 0 characters remaining'
+        },
         { number: 1, type: 'words', expected: 'You have 1 word remaining' },
         { number: 10, type: 'words', expected: 'You have 10 words remaining' },
         { number: -1, type: 'words', expected: 'You have 1 word too many' },
@@ -39,14 +59,18 @@ describe('CharacterCount', () => {
       ]
       it.each(cases)(
         'picks the relevant translation for $number $type',
-        function test ({ number, type, expected }) {
+        function test({ number, type, expected }) {
           expect(component.formatCountMessage(number, type)).toEqual(expected)
         }
       )
 
       it('formats the number inserted in the message', () => {
-        expect(component.formatCountMessage(10000, 'words')).toEqual('You have 10,000 words remaining')
-        expect(component.formatCountMessage(-10000, 'words')).toEqual('You have 10,000 words too many')
+        expect(component.formatCountMessage(10000, 'words')).toEqual(
+          'You have 10,000 words remaining'
+        )
+        expect(component.formatCountMessage(-10000, 'words')).toEqual(
+          'You have 10,000 words too many'
+        )
       })
     })
 
@@ -55,15 +79,21 @@ describe('CharacterCount', () => {
         it('overrides the default translation keys', () => {
           const $div = $container.cloneNode(true)
           const component = new CharacterCount($div, {
-            i18n: { charactersUnderLimit: { one: 'Custom text. Count: %{count}' } }
+            i18n: {
+              charactersUnderLimit: { one: 'Custom text. Count: %{count}' }
+            }
           })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(1, 'characters')).toEqual('Custom text. Count: 1')
+          expect(component.formatCountMessage(1, 'characters')).toEqual(
+            'Custom text. Count: 1'
+          )
 
           // Other keys remain untouched
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10, 'characters')).toEqual('You have 10 characters remaining')
+          expect(component.formatCountMessage(10, 'characters')).toEqual(
+            'You have 10 characters remaining'
+          )
         })
 
         it('uses specific keys for when limit is reached', () => {
@@ -76,10 +106,14 @@ describe('CharacterCount', () => {
           })
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(0, 'characters')).toEqual('Custom text.')
+          expect(component.formatCountMessage(0, 'characters')).toEqual(
+            'Custom text.'
+          )
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(0, 'words')).toEqual('Different custom text.')
+          expect(component.formatCountMessage(0, 'words')).toEqual(
+            'Different custom text.'
+          )
         })
       })
 
@@ -91,7 +125,9 @@ describe('CharacterCount', () => {
           const component = new CharacterCount($div)
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10000, 'words')).toEqual('You have 10.000 words remaining')
+          expect(component.formatCountMessage(10000, 'words')).toEqual(
+            'You have 10.000 words remaining'
+          )
         })
 
         it('overrides the locale when set on an ancestor', () => {
@@ -104,29 +140,41 @@ describe('CharacterCount', () => {
           const component = new CharacterCount($div)
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10000, 'words')).toEqual('You have 10.000 words remaining')
+          expect(component.formatCountMessage(10000, 'words')).toEqual(
+            'You have 10.000 words remaining'
+          )
         })
       })
 
       describe('Data attribute configuration', () => {
         it('overrides the default translation keys', () => {
           const $div = $container.cloneNode(true)
-          $div.setAttribute('data-i18n.characters-under-limit.one', 'Custom text. Count: %{count}')
+          $div.setAttribute(
+            'data-i18n.characters-under-limit.one',
+            'Custom text. Count: %{count}'
+          )
 
           const component = new CharacterCount($div)
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(1, 'characters')).toEqual('Custom text. Count: 1')
+          expect(component.formatCountMessage(1, 'characters')).toEqual(
+            'Custom text. Count: 1'
+          )
 
           // Other keys remain untouched
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(10, 'characters')).toEqual('You have 10 characters remaining')
+          expect(component.formatCountMessage(10, 'characters')).toEqual(
+            'You have 10 characters remaining'
+          )
         })
 
         describe('precedence over JavaScript configuration', () => {
           it('overrides translation keys', () => {
             const $div = $container.cloneNode(true)
-            $div.setAttribute('data-i18n.characters-under-limit.one', 'Custom text. Count: %{count}')
+            $div.setAttribute(
+              'data-i18n.characters-under-limit.one',
+              'Custom text. Count: %{count}'
+            )
 
             const component = new CharacterCount($div, {
               i18n: {
@@ -137,14 +185,20 @@ describe('CharacterCount', () => {
             })
 
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(1, 'characters')).toEqual('Custom text. Count: 1')
+            expect(component.formatCountMessage(1, 'characters')).toEqual(
+              'Custom text. Count: 1'
+            )
 
             // Other keys remain untouched
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(-10, 'characters')).toEqual('You have 10 characters too many')
+            expect(component.formatCountMessage(-10, 'characters')).toEqual(
+              'You have 10 characters too many'
+            )
 
             // @ts-expect-error Property 'formatCountMessage' is private
-            expect(component.formatCountMessage(0, 'characters')).toEqual('You have 0 characters remaining')
+            expect(component.formatCountMessage(0, 'characters')).toEqual(
+              'You have 0 characters remaining'
+            )
           })
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -39,7 +39,9 @@ describe('Character count', () => {
       const $ = render('character-count', examples.classes)
 
       const $component = $('.govuk-js-character-count')
-      expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-character-count--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with rows', () => {
@@ -67,7 +69,9 @@ describe('Character count', () => {
       const $ = render('character-count', examples['formGroup with classes'])
 
       const $component = $('.govuk-form-group')
-      expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-character-count--custom-modifier')
+      ).toBeTruthy()
     })
   })
 
@@ -76,7 +80,9 @@ describe('Character count', () => {
       const $ = render('character-count', examples.default)
 
       const $countMessage = $('.govuk-character-count__message')
-      expect($countMessage.text()).toContain('You can enter up to 10 characters')
+      expect($countMessage.text()).toContain(
+        'You can enter up to 10 characters'
+      )
     })
 
     it('renders with the amount of words expected', () => {
@@ -96,12 +102,14 @@ describe('Character count', () => {
         WORD_BOUNDARY + $countMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($textarea.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('renders with custom classes', () => {
-      const $ = render('character-count', examples['custom classes on countMessage'])
+      const $ = render(
+        'character-count',
+        examples['custom classes on countMessage']
+      )
 
       const $countMessage = $('.govuk-character-count__message')
       expect($countMessage.hasClass('app-custom-count-message')).toBeTruthy()
@@ -148,20 +156,25 @@ describe('Character count', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($textarea.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(hintId)
     })
   })
 
   describe('when it includes an error message', () => {
     it('renders with error message', () => {
-      const $ = render('character-count', examples['with default value exceeding limit'])
+      const $ = render(
+        'character-count',
+        examples['with default value exceeding limit']
+      )
 
       expect(htmlWithClassName($, '.govuk-error-message')).toMatchSnapshot()
     })
 
     it('associates the character-count as "described by" the error message', () => {
-      const $ = render('character-count', examples['with default value exceeding limit'])
+      const $ = render(
+        'character-count',
+        examples['with default value exceeding limit']
+      )
 
       const $component = $('.govuk-js-character-count')
       const $errorMessage = $('.govuk-error-message')
@@ -170,28 +183,38 @@ describe('Character count', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('adds the error class to the character-count', () => {
-      const $ = render('character-count', examples['with default value exceeding limit'])
+      const $ = render(
+        'character-count',
+        examples['with default value exceeding limit']
+      )
 
       const $component = $('.govuk-js-character-count')
       expect($component.hasClass('govuk-textarea--error')).toBeTruthy()
     })
 
     it('renders with classes', () => {
-      const $ = render('character-count', examples['custom classes with error message'])
+      const $ = render(
+        'character-count',
+        examples['custom classes with error message']
+      )
 
       const $component = $('.govuk-js-character-count')
-      expect($component.hasClass('app-character-count--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-character-count--custom-modifier')
+      ).toBeTruthy()
     })
   })
 
   describe('with dependant components', () => {
     it('have correct nesting order', () => {
-      const $ = render('character-count', examples['with default value exceeding limit'])
+      const $ = render(
+        'character-count',
+        examples['with default value exceeding limit']
+      )
 
       const $component = $('.govuk-form-group > .govuk-js-character-count')
       expect($component.length).toBeTruthy()
@@ -222,7 +245,10 @@ describe('Character count', () => {
 
   describe('with custom textarea description', () => {
     it('allows customisation of the textarea description', () => {
-      const $ = render('character-count', examples['with custom textarea description'])
+      const $ = render(
+        'character-count',
+        examples['with custom textarea description']
+      )
 
       const message = $('.govuk-character-count__message').text().trim()
       expect(message).toEqual('Gallwch ddefnyddio hyd at 10 nod')
@@ -258,11 +284,16 @@ describe('Character count', () => {
       // it needs to pass down any textarea description to the JavaScript
       // so it can inject the limit it may have received at instantiation
       it('renders the textarea description as a data attribute', () => {
-        const $ = render('character-count', examples['when neither maxlength nor maxwords are set'])
+        const $ = render(
+          'character-count',
+          examples['when neither maxlength nor maxwords are set']
+        )
 
         // Fallback hint is passed as data attribute
         const $component = $('[data-module]')
-        expect($component.attr('data-i18n.textarea-description.other')).toEqual('No more than %{count} characters')
+        expect($component.attr('data-i18n.textarea-description.other')).toEqual(
+          'No more than %{count} characters'
+        )
 
         // No content is set as the accessible description cannot be interpolated on the backend
         // It'll be up to the JavaScript to fill it in
@@ -275,11 +306,15 @@ describe('Character count', () => {
       it('does not render a textarea description data attribute', () => {
         const $ = render(
           'character-count',
-          examples['when neither maxlength/maxwords nor textarea description are set']
+          examples[
+            'when neither maxlength/maxwords nor textarea description are set'
+          ]
         )
 
         const $component = $('[data-module]')
-        expect($component.attr('data-i18n.textarea-description.other')).toBeFalsy()
+        expect(
+          $component.attr('data-i18n.textarea-description.other')
+        ).toBeFalsy()
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -96,13 +96,13 @@ describe('Character count', () => {
       const $ = render('character-count', examples.default)
 
       const $textarea = $('.govuk-js-character-count')
-      const $countMessage = $('.govuk-character-count__message')
+      const countMessageId = $('.govuk-character-count__message').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $countMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${countMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($textarea.attr('aria-describedby')).toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('renders with custom classes', () => {
@@ -150,13 +150,13 @@ describe('Character count', () => {
       const $ = render('character-count', examples['with hint'])
 
       const $textarea = $('.govuk-js-character-count')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($textarea.attr('aria-describedby')).toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -177,13 +177,13 @@ describe('Character count', () => {
       )
 
       const $component = $('.govuk-js-character-count')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('adds the error class to the character-count', () => {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -22,8 +22,11 @@ export class Checkboxes {
    *
    * @param {Element} $module - HTML element to use for checkboxes
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -70,8 +73,10 @@ export class Checkboxes {
    *
    * @private
    */
-  syncAllConditionalReveals () {
-    this.$inputs.forEach(($input) => this.syncConditionalRevealWithInputState($input))
+  syncAllConditionalReveals() {
+    this.$inputs.forEach(($input) =>
+      this.syncConditionalRevealWithInputState($input)
+    )
   }
 
   /**
@@ -83,18 +88,24 @@ export class Checkboxes {
    * @private
    * @param {HTMLInputElement} $input - Checkbox input
    */
-  syncConditionalRevealWithInputState ($input) {
+  syncConditionalRevealWithInputState($input) {
     const targetId = $input.getAttribute('aria-controls')
     if (!targetId) {
       return
     }
 
     const $target = document.getElementById(targetId)
-    if ($target && $target.classList.contains('govuk-checkboxes__conditional')) {
+    if (
+      $target &&
+      $target.classList.contains('govuk-checkboxes__conditional')
+    ) {
       const inputIsChecked = $input.checked
 
       $input.setAttribute('aria-expanded', inputIsChecked.toString())
-      $target.classList.toggle('govuk-checkboxes__conditional--hidden', !inputIsChecked)
+      $target.classList.toggle(
+        'govuk-checkboxes__conditional--hidden',
+        !inputIsChecked
+      )
     }
   }
 
@@ -107,14 +118,14 @@ export class Checkboxes {
    * @private
    * @param {HTMLInputElement} $input - Checkbox input
    */
-  unCheckAllInputsExcept ($input) {
+  unCheckAllInputsExcept($input) {
     /** @satisfies {NodeListOf<HTMLInputElement>} */
     const allInputsWithSameName = document.querySelectorAll(
       `input[type="checkbox"][name="${$input.name}"]`
     )
 
     allInputsWithSameName.forEach(($inputWithSameName) => {
-      const hasSameFormOwner = ($input.form === $inputWithSameName.form)
+      const hasSameFormOwner = $input.form === $inputWithSameName.form
       if (hasSameFormOwner && $inputWithSameName !== $input) {
         $inputWithSameName.checked = false
         this.syncConditionalRevealWithInputState($inputWithSameName)
@@ -132,14 +143,15 @@ export class Checkboxes {
    * @private
    * @param {HTMLInputElement} $input - Checkbox input
    */
-  unCheckExclusiveInputs ($input) {
+  unCheckExclusiveInputs($input) {
     /** @satisfies {NodeListOf<HTMLInputElement>} */
-    const allInputsWithSameNameAndExclusiveBehaviour = document.querySelectorAll(
-      `input[data-behaviour="exclusive"][type="checkbox"][name="${$input.name}"]`
-    )
+    const allInputsWithSameNameAndExclusiveBehaviour =
+      document.querySelectorAll(
+        `input[data-behaviour="exclusive"][type="checkbox"][name="${$input.name}"]`
+      )
 
     allInputsWithSameNameAndExclusiveBehaviour.forEach(($exclusiveInput) => {
-      const hasSameFormOwner = ($input.form === $exclusiveInput.form)
+      const hasSameFormOwner = $input.form === $exclusiveInput.form
       if (hasSameFormOwner) {
         $exclusiveInput.checked = false
         this.syncConditionalRevealWithInputState($exclusiveInput)
@@ -156,11 +168,14 @@ export class Checkboxes {
    * @private
    * @param {MouseEvent} event - Click event
    */
-  handleClick (event) {
+  handleClick(event) {
     const $clickedInput = event.target
 
     // Ignore clicks on things that aren't checkbox inputs
-    if (!($clickedInput instanceof HTMLInputElement) || $clickedInput.type !== 'checkbox') {
+    if (
+      !($clickedInput instanceof HTMLInputElement) ||
+      $clickedInput.type !== 'checkbox'
+    ) {
       return
     }
 
@@ -176,7 +191,8 @@ export class Checkboxes {
     }
 
     // Handle 'exclusive' checkbox behaviour (ie "None of these")
-    const hasBehaviourExclusive = ($clickedInput.getAttribute('data-behaviour') === 'exclusive')
+    const hasBehaviourExclusive =
+      $clickedInput.getAttribute('data-behaviour') === 'exclusive'
     if (hasBehaviourExclusive) {
       this.unCheckAllInputsExcept($clickedInput)
     } else {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
@@ -1,4 +1,10 @@
-const { goToComponent, goToExample, getAttribute, getProperty, isVisible } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  goToExample,
+  getAttribute,
+  getProperty,
+  isVisible
+} = require('govuk-frontend-helpers/puppeteer')
 
 describe('Checkboxes with conditional reveals', () => {
   describe('when JavaScript is unavailable or fails', () => {
@@ -29,17 +35,23 @@ describe('Checkboxes with conditional reveals', () => {
       })
 
       it('has no ARIA attributes applied', async () => {
-        const $inputsWithAriaExpanded = await $component.$$('.govuk-checkboxes__input[aria-expanded]')
-        const $inputsWithAriaControls = await $component.$$('.govuk-checkboxes__input[aria-controls]')
+        const $inputsWithAriaExpanded = await $component.$$(
+          '.govuk-checkboxes__input[aria-expanded]'
+        )
+        const $inputsWithAriaControls = await $component.$$(
+          '.govuk-checkboxes__input[aria-controls]'
+        )
 
         expect($inputsWithAriaExpanded.length).toBe(0)
         expect($inputsWithAriaControls.length).toBe(0)
       })
 
       it('falls back to making all conditional content visible', async () => {
-        return Promise.all($conditionals.map(async ($conditional) => {
-          return expect(await isVisible($conditional)).toBe(true)
-        }))
+        return Promise.all(
+          $conditionals.map(async ($conditional) => {
+            return expect(await isVisible($conditional)).toBe(true)
+          })
+        )
       })
     })
   })
@@ -60,7 +72,9 @@ describe('Checkboxes with conditional reveals', () => {
 
       it('has conditional content revealed that is associated with a checked input', async () => {
         const $input = $inputs[0] // First input, checked
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         expect(await getProperty($input, 'checked')).toBe(true)
         expect(await isVisible($conditional)).toBe(true)
@@ -68,7 +82,9 @@ describe('Checkboxes with conditional reveals', () => {
 
       it('has no conditional content revealed that is associated with an unchecked input', async () => {
         const $input = $inputs[$inputs.length - 1] // Last input, unchecked
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         expect(await getProperty($input, 'checked')).toBe(false)
         expect(await isVisible($conditional)).toBe(false)
@@ -110,7 +126,9 @@ describe('Checkboxes with conditional reveals', () => {
 
       it('toggles the conditional content when clicking an input', async () => {
         const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         // Initially collapsed
         expect(await getProperty($input, 'checked')).toBe(false)
@@ -131,7 +149,9 @@ describe('Checkboxes with conditional reveals', () => {
 
       it('toggles the conditional content when using an input with a keyboard', async () => {
         const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         // Initially collapsed
         expect(await getProperty($input, 'checked')).toBe(false)
@@ -221,7 +241,9 @@ describe('Checkboxes with a "None" checkbox and conditional reveals', () => {
 
     it('unchecks other checkboxes and hides conditional reveals when the "None" checkbox is checked', async () => {
       const $input = $inputs[3]
-      const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+      const $conditional = await $component.$(
+        `[id="${await getAttribute($input, 'aria-controls')}"]`
+      )
 
       // Check the "Another access need" checkbox
       await $inputs[3].click()
@@ -250,9 +272,15 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
     beforeEach(async () => {
       await goToExample(page, 'conditional-reveals')
 
-      $inputsPrimary = await page.$$('.govuk-checkboxes__input[id^="colour-primary"]')
-      $inputsSecondary = await page.$$('.govuk-checkboxes__input[id^="colour-secondary"]')
-      $inputsOther = await page.$$('.govuk-checkboxes__input[id^="colour-other"]')
+      $inputsPrimary = await page.$$(
+        '.govuk-checkboxes__input[id^="colour-primary"]'
+      )
+      $inputsSecondary = await page.$$(
+        '.govuk-checkboxes__input[id^="colour-secondary"]'
+      )
+      $inputsOther = await page.$$(
+        '.govuk-checkboxes__input[id^="colour-other"]'
+      )
     })
 
     it('none checkbox unchecks other checkboxes in other groups', async () => {
@@ -269,7 +297,9 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
     })
 
     it('hides conditional reveals in other groups', async () => {
-      const $conditionalPrimary = await page.$(`[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`)
+      const $conditionalPrimary = await page.$(
+        `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
+      )
 
       // Check the second checkbox in the first group, which reveals additional content
       await $inputsPrimary[1].click()

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -17,14 +17,22 @@ describe('Checkboxes', () => {
 
     const $component = $('.govuk-checkboxes')
 
-    const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-    const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+    const $firstInput = $component.find(
+      '.govuk-checkboxes__item:first-child input'
+    )
+    const $firstLabel = $component.find(
+      '.govuk-checkboxes__item:first-child label'
+    )
     expect($firstInput.attr('name')).toEqual('nationality')
     expect($firstInput.val()).toEqual('british')
     expect($firstLabel.text()).toContain('British')
 
-    const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-    const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
+    const $lastInput = $component.find(
+      '.govuk-checkboxes__item:last-child input'
+    )
+    const $lastLabel = $component.find(
+      '.govuk-checkboxes__item:last-child label'
+    )
     expect($lastInput.attr('name')).toEqual('nationality')
     expect($lastInput.val()).toEqual('other')
     expect($lastLabel.text()).toContain('Citizen of another country')
@@ -94,7 +102,10 @@ describe('Checkboxes', () => {
   })
 
   it('render a custom class on the form group', () => {
-    const $ = render('checkboxes', examples['with optional form-group classes showing group error'])
+    const $ = render(
+      'checkboxes',
+      examples['with optional form-group classes showing group error']
+    )
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -106,13 +117,21 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
       expect($firstInput.attr('id')).toEqual('nationality')
       expect($firstLabel.attr('for')).toEqual('nationality')
 
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-      const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      const $lastLabel = $component.find(
+        '.govuk-checkboxes__item:last-child label'
+      )
       expect($lastInput.attr('id')).toEqual('nationality-3')
       expect($lastLabel.attr('for')).toEqual('nationality-3')
     })
@@ -122,13 +141,21 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
       expect($firstInput.attr('id')).toEqual('nationality')
       expect($firstLabel.attr('for')).toEqual('nationality')
 
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
-      const $lastLabel = $component.find('.govuk-checkboxes__item:last-child label')
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
+      const $lastLabel = $component.find(
+        '.govuk-checkboxes__item:last-child label'
+      )
       expect($lastInput.attr('id')).toEqual('nationality-2')
       expect($lastLabel.attr('for')).toEqual('nationality-2')
     })
@@ -138,11 +165,17 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
       expect($lastInput.attr('id')).toBe('with-id-and-name-3')
 
-      const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
-      const $firstLabel = $component.find('.govuk-checkboxes__item:first-child label')
+      const $firstInput = $component.find(
+        '.govuk-checkboxes__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-checkboxes__item:first-child label'
+      )
       expect($firstInput.attr('id')).toBe('item_british')
       expect($firstLabel.attr('for')).toEqual('item_british')
     })
@@ -152,7 +185,9 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
       expect($lastInput.attr('name')).toBe('custom-name-scottish')
     })
 
@@ -161,7 +196,9 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $disabledInput = $component.find('.govuk-checkboxes__item:last-child input')
+      const $disabledInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
       expect($disabledInput.attr('disabled')).toEqual('disabled')
     })
 
@@ -169,8 +206,12 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with checked item'])
 
       const $component = $('.govuk-checkboxes')
-      const $secondInput = $component.find('.govuk-checkboxes__item:nth-child(2) input')
-      const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+      const $secondInput = $component.find(
+        '.govuk-checkboxes__item:nth-child(2) input'
+      )
+      const $lastInput = $component.find(
+        '.govuk-checkboxes__item:last-child input'
+      )
       expect($secondInput.attr('checked')).toEqual('checked')
       expect($lastInput.attr('checked')).toEqual('checked')
     })
@@ -199,11 +240,15 @@ describe('Checkboxes', () => {
 
         const $component = $('.govuk-checkboxes')
 
-        const $firstInput = $component.find('.govuk-checkboxes__item:first-child input')
+        const $firstInput = $component.find(
+          '.govuk-checkboxes__item:first-child input'
+        )
         expect($firstInput.attr('data-attribute')).toEqual('ABC')
         expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
 
-        const $lastInput = $component.find('.govuk-checkboxes__item:last-child input')
+        const $lastInput = $component.find(
+          '.govuk-checkboxes__item:last-child input'
+        )
         expect($lastInput.attr('data-attribute')).toEqual('GHI')
         expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
       })
@@ -215,19 +260,25 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with hints on items'])
 
       const $firstHint = $('.govuk-checkboxes__hint').first()
-      expect($firstHint.text().trim()).toContain('You\'ll have a user ID if you\'ve registered for Self Assessment or filed a tax return online before.')
+      expect($firstHint.text().trim()).toContain(
+        "You'll have a user ID if you've registered for Self Assessment or filed a tax return online before."
+      )
     })
 
     it('it renders the correct id attribute for the hint', () => {
       const $ = render('checkboxes', examples['with hints on items'])
 
-      expect($('.govuk-checkboxes__hint').attr('id')).toBe('government-gateway-item-hint')
+      expect($('.govuk-checkboxes__hint').attr('id')).toBe(
+        'government-gateway-item-hint'
+      )
     })
 
     it('the input describedBy attribute matches the item hint id', () => {
       const $ = render('checkboxes', examples['with hints on items'])
 
-      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe('government-gateway-item-hint')
+      expect($('.govuk-checkboxes__input').attr('aria-describedby')).toBe(
+        'government-gateway-item-hint'
+      )
     })
   })
 
@@ -237,18 +288,26 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
       expect($firstConditional.text().trim()).toContain('Email address')
-      expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeTruthy()
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeTruthy()
     })
     it('visible by default when checked', () => {
       const $ = render('checkboxes', examples['with conditional item checked'])
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
       expect($firstConditional.text().trim()).toContain('Email address')
-      expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeFalsy()
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeFalsy()
     })
 
     it('visible when checked with pre-checked values', () => {
@@ -256,9 +315,13 @@ describe('Checkboxes', () => {
 
       const $component = $('.govuk-checkboxes')
 
-      const $firstConditional = $component.find('.govuk-checkboxes__conditional').first()
+      const $firstConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .first()
       expect($firstConditional.text().trim()).toContain('Country')
-      expect($firstConditional.hasClass('govuk-checkboxes__conditional--hidden')).toBeFalsy()
+      expect(
+        $firstConditional.hasClass('govuk-checkboxes__conditional--hidden')
+      ).toBeFalsy()
     })
 
     it('with association to the input they are controlled by', () => {
@@ -267,9 +330,13 @@ describe('Checkboxes', () => {
       const $component = $('.govuk-checkboxes')
 
       const $lastInput = $component.find('.govuk-checkboxes__input').last()
-      const $lastConditional = $component.find('.govuk-checkboxes__conditional').last()
+      const $lastConditional = $component
+        .find('.govuk-checkboxes__conditional')
+        .last()
 
-      expect($lastInput.attr('data-aria-controls')).toBe('conditional-how-contacted-3')
+      expect($lastInput.attr('data-aria-controls')).toBe(
+        'conditional-how-contacted-3'
+      )
       expect($lastConditional.attr('id')).toBe('conditional-how-contacted-3')
     })
 
@@ -277,7 +344,9 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['empty conditional'])
 
       const $component = $('.govuk-checkboxes')
-      expect($component.find('.govuk-checkboxes__conditional').length).toEqual(0)
+      expect($component.find('.govuk-checkboxes__conditional').length).toEqual(
+        0
+      )
     })
 
     it('does not associate checkboxes with empty conditionals', () => {
@@ -312,7 +381,10 @@ describe('Checkboxes', () => {
     })
 
     it('associates the fieldset as "described by" the error message', () => {
-      const $ = render('checkboxes', examples['with fieldset and error message'])
+      const $ = render(
+        'checkboxes',
+        examples['with fieldset and error message']
+      )
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
@@ -321,31 +393,37 @@ describe('Checkboxes', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = render('checkboxes', examples['with error message and fieldset describedBy'])
+      const $ = render(
+        'checkboxes',
+        examples['with error message and fieldset describedBy']
+      )
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('does not associate each input as "described by" the error message', () => {
-      const $ = render('checkboxes', examples['with error message and hints on items'])
+      const $ = render(
+        'checkboxes',
+        examples['with error message and hints on items']
+      )
 
       const $inputs = $('input')
 
       $inputs.each((index, input) => {
-        let expectedDescribedById = `waste-${(index + 1)}-item-hint`
+        let expectedDescribedById = `waste-${index + 1}-item-hint`
         if (index === 0) {
           expectedDescribedById = 'waste-item-hint'
         }
@@ -387,7 +465,9 @@ describe('Checkboxes', () => {
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(hintId)
@@ -406,12 +486,14 @@ describe('Checkboxes', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = render('checkboxes', examples['with error, hint and fieldset describedBy'])
+      const $ = render(
+        'checkboxes',
+        examples['with error, hint and fieldset describedBy']
+      )
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -421,8 +503,7 @@ describe('Checkboxes', () => {
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
     })
   })
 
@@ -430,7 +511,9 @@ describe('Checkboxes', () => {
     it('have correct nesting order', () => {
       const $ = render('checkboxes', examples['fieldset params'])
 
-      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-checkboxes')
+      const $component = $(
+        '.govuk-form-group > .govuk-fieldset > .govuk-checkboxes'
+      )
       expect($component.length).toBeTruthy()
     })
 
@@ -455,33 +538,53 @@ describe('Checkboxes', () => {
 
   describe('single checkbox without a fieldset', () => {
     it('adds aria-describedby to input if there is an error', () => {
-      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input"])
+      const $ = render(
+        'checkboxes',
+        examples["with single option set 'aria-describedby' on input"]
+      )
       const $input = $('input')
       expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
     })
 
     it('adds aria-describedby to input if there is an error and parent fieldset', () => {
-      const $ = render('checkboxes', examples["with single option set 'aria-describedby' on input, and describedBy"])
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option set 'aria-describedby' on input, and describedBy"
+        ]
+      )
       const $input = $('input')
 
-      expect($input.attr('aria-describedby'))
-        .toMatch('some-id t-and-c-error')
+      expect($input.attr('aria-describedby')).toMatch('some-id t-and-c-error')
     })
   })
 
   describe('single checkbox (with hint) without a fieldset', () => {
     it('adds aria-describedby to input if there is an error and a hint', () => {
-      const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input"])
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option (and hint) set 'aria-describedby' on input"
+        ]
+      )
       const $input = $('input')
-      expect($input.attr('aria-describedby')).toMatch('t-and-c-with-hint-error t-and-c-with-hint-item-hint')
+      expect($input.attr('aria-describedby')).toMatch(
+        't-and-c-with-hint-error t-and-c-with-hint-item-hint'
+      )
     })
 
     it('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
-      const $ = render('checkboxes', examples["with single option (and hint) set 'aria-describedby' on input, and describedBy"])
+      const $ = render(
+        'checkboxes',
+        examples[
+          "with single option (and hint) set 'aria-describedby' on input, and describedBy"
+        ]
+      )
       const $input = $('input')
 
-      expect($input.attr('aria-describedby'))
-        .toMatch('some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint')
+      expect($input.attr('aria-describedby')).toMatch(
+        'some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint'
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -367,17 +367,15 @@ describe('Checkboxes', () => {
     it('uses the idPrefix for the error message id if provided', () => {
       const $ = render('checkboxes', examples['with error and idPrefix'])
 
-      const $errorMessage = $('.govuk-error-message')
-
-      expect($errorMessage.attr('id')).toEqual('id-prefix-error')
+      const errorMessageId = $('.govuk-error-message').attr('id')
+      expect(errorMessageId).toEqual('id-prefix-error')
     })
 
     it('falls back to using the name for the error message id', () => {
       const $ = render('checkboxes', examples['with error message'])
 
-      const $errorMessage = $('.govuk-error-message')
-
-      expect($errorMessage.attr('id')).toEqual('waste-error')
+      const errorMessageId = $('.govuk-error-message').attr('id')
+      expect(errorMessageId).toEqual('waste-error')
     })
 
     it('associates the fieldset as "described by" the error message', () => {
@@ -387,13 +385,13 @@ describe('Checkboxes', () => {
       )
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
@@ -403,15 +401,13 @@ describe('Checkboxes', () => {
       )
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('does not associate each input as "described by" the error message', () => {
@@ -450,27 +446,25 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with id and name'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
-
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
       const $ = render('checkboxes', examples['with fieldset describedBy'])
-      const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
 
-      const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const $fieldset = $('.govuk-fieldset')
+      const hintId = $('.govuk-hint').attr('id')
+
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -479,14 +473,15 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples['with error message and hint'])
 
       const $fieldset = $('.govuk-fieldset')
+
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
@@ -496,14 +491,14 @@ describe('Checkboxes', () => {
       )
 
       const $fieldset = $('.govuk-fieldset')
-      const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const combinedIds = new RegExp(
+      const describedByCombined = new RegExp(
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
     })
   })
 
@@ -538,21 +533,19 @@ describe('Checkboxes', () => {
 
   describe('single checkbox without a fieldset', () => {
     it('adds aria-describedby to input if there is an error', () => {
-      const $ = render(
-        'checkboxes',
-        examples["with single option set 'aria-describedby' on input"]
-      )
+      const exampleName = "with single option set 'aria-describedby' on input"
+
+      const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
+
       expect($input.attr('aria-describedby')).toMatch('t-and-c-error')
     })
 
     it('adds aria-describedby to input if there is an error and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option set 'aria-describedby' on input, and describedBy"
-        ]
-      )
+      const exampleName =
+        "with single option set 'aria-describedby' on input, and describedBy"
+
+      const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch('some-id t-and-c-error')
@@ -561,25 +554,22 @@ describe('Checkboxes', () => {
 
   describe('single checkbox (with hint) without a fieldset', () => {
     it('adds aria-describedby to input if there is an error and a hint', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option (and hint) set 'aria-describedby' on input"
-        ]
-      )
+      const exampleName =
+        "with single option (and hint) set 'aria-describedby' on input"
+
+      const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
+
       expect($input.attr('aria-describedby')).toMatch(
         't-and-c-with-hint-error t-and-c-with-hint-item-hint'
       )
     })
 
     it('adds aria-describedby to input if there is an error, hint and parent fieldset', () => {
-      const $ = render(
-        'checkboxes',
-        examples[
-          "with single option (and hint) set 'aria-describedby' on input, and describedBy"
-        ]
-      )
+      const exampleName =
+        "with single option (and hint) set 'aria-describedby' on input, and describedBy"
+
+      const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch(

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -2,7 +2,10 @@ const { join } = require('path')
 
 const { paths } = require('govuk-frontend-config')
 const { nunjucksEnv, renderHTML } = require('govuk-frontend-helpers/nunjucks')
-const { getComponentsData, getComponentNames } = require('govuk-frontend-lib/files')
+const {
+  getComponentsData,
+  getComponentNames
+} = require('govuk-frontend-lib/files')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control
 // over the nunjucks environment.
@@ -26,15 +29,31 @@ describe('Components', () => {
 
   describe('Nunjucks environment', () => {
     it('renders template for each component', () => {
-      return Promise.all(componentNames.map((componentName) =>
-        expect(nunjucksEnvDefault.render(`govuk/components/${componentName}/template.njk`, {})).resolves
-      ))
+      return Promise.all(
+        componentNames.map(
+          (componentName) =>
+            expect(
+              nunjucksEnvDefault.render(
+                `govuk/components/${componentName}/template.njk`,
+                {}
+              )
+            ).resolves
+        )
+      )
     })
 
     it('renders template for each component (different base path)', () => {
-      return Promise.all(componentNames.map((componentName) =>
-        expect(nunjucksEnvCustom.render(`components/${componentName}/template.njk`, {})).resolves
-      ))
+      return Promise.all(
+        componentNames.map(
+          (componentName) =>
+            expect(
+              nunjucksEnvCustom.render(
+                `components/${componentName}/template.njk`,
+                {}
+              )
+            ).resolves
+        )
+      )
     })
   })
 
@@ -48,7 +67,10 @@ describe('Components', () => {
         rules: {
           // Allow for multiple buttons in the same form to have the same name
           // (as in the cookie banner examples)
-          'form-dup-name': ['error', { shared: ['radio', 'checkbox', 'submit'] }],
+          'form-dup-name': [
+            'error',
+            { shared: ['radio', 'checkbox', 'submit'] }
+          ],
 
           // Allow pattern attribute on input type="number"
           'input-attributes': 'off',
@@ -91,8 +113,8 @@ describe('Components', () => {
         elements: [
           'html5',
           {
-          // Allow textarea autocomplete attribute to be street-address
-          // (html-validate only allows on/off in default rules)
+            // Allow textarea autocomplete attribute to be street-address
+            // (html-validate only allows on/off in default rules)
             textarea: {
               attributes: {
                 autocomplete: { enum: ['on', 'off', 'street-address'] }
@@ -114,13 +136,22 @@ describe('Components', () => {
 
       // Validate component examples
       for (const { name: componentName, examples } of componentsData) {
-        const exampleTasks = examples.map(async ({ name: exampleName, data }) => {
-          const html = renderHTML(componentName, data)
+        const exampleTasks = examples.map(
+          async ({ name: exampleName, data }) => {
+            const html = renderHTML(componentName, data)
 
-          // Validate HTML
-          return expect({ componentName, exampleName, report: await validator.validateString(html) })
-            .toEqual({ componentName, exampleName, report: expect.objectContaining({ valid: true }) })
-        })
+            // Validate HTML
+            return expect({
+              componentName,
+              exampleName,
+              report: await validator.validateString(html)
+            }).toEqual({
+              componentName,
+              exampleName,
+              report: expect.objectContaining({ valid: true })
+            })
+          }
+        )
 
         // Validate all component examples in parallel
         await Promise.all(exampleTasks)

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -30,29 +30,19 @@ describe('Components', () => {
   describe('Nunjucks environment', () => {
     it('renders template for each component', () => {
       return Promise.all(
-        componentNames.map(
-          (componentName) =>
-            expect(
-              nunjucksEnvDefault.render(
-                `govuk/components/${componentName}/template.njk`,
-                {}
-              )
-            ).resolves
-        )
+        componentNames.map((componentName) => {
+          const viewPath = `govuk/components/${componentName}/template.njk`
+          return expect(nunjucksEnvDefault.render(viewPath, {})).resolves
+        })
       )
     })
 
     it('renders template for each component (different base path)', () => {
       return Promise.all(
-        componentNames.map(
-          (componentName) =>
-            expect(
-              nunjucksEnvCustom.render(
-                `components/${componentName}/template.njk`,
-                {}
-              )
-            ).resolves
-        )
+        componentNames.map((componentName) => {
+          const viewPath = `components/${componentName}/template.njk`
+          return expect(nunjucksEnvCustom.render(viewPath, {})).resolves
+        })
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/components.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.test.js
@@ -10,10 +10,7 @@ describe('Components', () => {
   beforeAll(async () => {
     sassFiles = await getListing('**/src/govuk/components/**/*.scss', {
       cwd: paths.package,
-      ignore: [
-        '**/_all.scss',
-        '**/_index.scss'
-      ]
+      ignore: ['**/_all.scss', '**/_index.scss']
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
@@ -20,28 +20,36 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['heading html as text'])
 
       const $heading = $('.govuk-cookie-banner__heading')
-      expect($heading.html().trim()).toEqual('Cookies on &lt;span&gt;my service&lt;/span&gt;')
+      expect($heading.html().trim()).toEqual(
+        'Cookies on &lt;span&gt;my service&lt;/span&gt;'
+      )
     })
 
     it('renders heading html', () => {
       const $ = render('cookie-banner', examples['heading html'])
 
       const $heading = $('.govuk-cookie-banner__heading')
-      expect($heading.html().trim()).toEqual('Cookies on <span>my service</span>')
+      expect($heading.html().trim()).toEqual(
+        'Cookies on <span>my service</span>'
+      )
     })
 
     it('renders main content text', () => {
       const $ = render('cookie-banner', examples.default)
 
       const $content = $('.govuk-cookie-banner__content')
-      expect($content.text()).toEqual('We use analytics cookies to help understand how users use our service.')
+      expect($content.text()).toEqual(
+        'We use analytics cookies to help understand how users use our service.'
+      )
     })
 
     it('renders main content html', () => {
       const $ = render('cookie-banner', examples.html)
 
       const $content = $('.govuk-cookie-banner__content')
-      expect($content.html().trim()).toEqual('<p class="govuk-body">We use cookies in <span>our service</span>.</p>')
+      expect($content.html().trim()).toEqual(
+        '<p class="govuk-body">We use cookies in <span>our service</span>.</p>'
+      )
     })
 
     it('renders classes', () => {
@@ -94,7 +102,10 @@ describe('Cookie Banner', () => {
     })
 
     it('sets role attribute when role provided', () => {
-      const $ = render('cookie-banner', examples['accepted confirmation banner'])
+      const $ = render(
+        'cookie-banner',
+        examples['accepted confirmation banner']
+      )
 
       const $component = $('.govuk-cookie-banner')
       const $banner = $component.find('.govuk-cookie-banner__message')
@@ -132,7 +143,10 @@ describe('Cookie Banner', () => {
     })
 
     it('ignores other button options if href provided', () => {
-      const $ = render('cookie-banner', examples['link with false button options'])
+      const $ = render(
+        'cookie-banner',
+        examples['link with false button options']
+      )
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
       expect($actions.get(0).tagName).toEqual('a')
@@ -185,7 +199,9 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['button classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-button')
-      expect($actions.attr('class')).toEqual('govuk-button my-button-class app-button-class')
+      expect($actions.attr('class')).toEqual(
+        'govuk-button my-button-class app-button-class'
+      )
     })
 
     it('renders button with custom attributes', () => {
@@ -207,7 +223,9 @@ describe('Cookie Banner', () => {
       const $ = render('cookie-banner', examples['link classes'])
 
       const $actions = $('.govuk-cookie-banner .govuk-link')
-      expect($actions.attr('class')).toEqual('govuk-link my-link-class app-link-class')
+      expect($actions.attr('class')).toEqual(
+        'govuk-link my-link-class app-link-class'
+      )
     })
 
     it('renders link with custom attributes', () => {

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -190,28 +190,26 @@ describe('Date input', () => {
       const $ = render('date-input', examples['complete question'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
       const $ = render('date-input', examples['with hint and describedBy'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -233,13 +231,13 @@ describe('Date input', () => {
       const $ = render('date-input', examples['with errors only'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
@@ -276,11 +274,11 @@ describe('Date input', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -82,7 +82,9 @@ describe('Date input', () => {
       const $ = render('date-input', examples.default)
 
       const $items = $('.govuk-date-input__item')
-      const $firstItemInput = $('.govuk-date-input:first-child .govuk-date-input__input')
+      const $firstItemInput = $(
+        '.govuk-date-input:first-child .govuk-date-input__input'
+      )
 
       expect($items.length).toEqual(3)
       expect($firstItemInput.attr('name')).toEqual('day')
@@ -122,7 +124,9 @@ describe('Date input', () => {
       const $ = render('date-input', examples.classes)
 
       const $component = $('.govuk-date-input')
-      expect($component.hasClass('app-date-input--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-date-input--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with attributes', () => {
@@ -166,7 +170,10 @@ describe('Date input', () => {
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('date-input', examples['with optional form-group classes'])
+      const $ = render(
+        'date-input',
+        examples['with optional form-group classes']
+      )
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -189,8 +196,7 @@ describe('Date input', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
@@ -200,11 +206,12 @@ describe('Date input', () => {
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($fieldset.attr('aria-describedby')).toMatch(hintId)
     })
   })
 
@@ -232,8 +239,7 @@ describe('Date input', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
@@ -241,8 +247,9 @@ describe('Date input', () => {
 
       const $fieldset = $('.govuk-fieldset')
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch('some-id dob-errors-error')
+      expect($fieldset.attr('aria-describedby')).toMatch(
+        'some-id dob-errors-error'
+      )
     })
 
     it('renders with a form group wrapper that has an error state', () => {
@@ -273,8 +280,7 @@ describe('Date input', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
@@ -282,8 +288,9 @@ describe('Date input', () => {
 
       const $fieldset = $('.govuk-fieldset')
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch('dob-errors-hint dob-errors-error')
+      expect($fieldset.attr('aria-describedby')).toMatch(
+        'dob-errors-hint dob-errors-error'
+      )
     })
   })
 
@@ -291,7 +298,9 @@ describe('Date input', () => {
     it('have correct nesting order', () => {
       const $ = render('date-input', examples['complete question'])
 
-      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-date-input')
+      const $component = $(
+        '.govuk-form-group > .govuk-fieldset > .govuk-date-input'
+      )
       expect($component.length).toBeTruthy()
     })
 

--- a/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
@@ -48,7 +48,9 @@ describe('Error message', () => {
     const $ = render('error-message', examples.default)
 
     const $component = $('.govuk-error-message')
-    expect($component.text().trim()).toEqual('Error: Error message about full name goes here')
+    expect($component.text().trim()).toEqual(
+      'Error: Error message about full name goes here'
+    )
   })
 
   it('allows the visually hidden prefix to be customised', () => {
@@ -69,6 +71,8 @@ describe('Error message', () => {
     const $ = render('error-message', examples.translated)
 
     const $component = $('.govuk-error-message')
-    expect($component.html().trim()).toContain('<span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma')
+    expect($component.html().trim()).toContain(
+      '<span class="govuk-visually-hidden">Gwall:</span> Neges gwall am yr enw llawn yn mynd yma'
+    )
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -21,7 +21,7 @@ export class ErrorSummary {
    * @param {Element} $module - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
-  constructor ($module, config) {
+  constructor($module, config) {
     // Some consuming code may not be passing a module,
     // for example if they initialise the component
     // on their own by directly passing the result
@@ -29,7 +29,10 @@ export class ErrorSummary {
     // To avoid breaking further JavaScript initialisation
     // we need to safeguard against this so things keep
     // working the same now we read the elements data attributes
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -50,7 +53,7 @@ export class ErrorSummary {
    *
    * @private
    */
-  setFocus () {
+  setFocus() {
     if (this.config.disableAutoFocus) {
       return
     }
@@ -72,7 +75,7 @@ export class ErrorSummary {
    * @private
    * @param {MouseEvent} event - Click event
    */
-  handleClick (event) {
+  handleClick(event) {
     const $target = event.target
     if (this.focusTarget($target)) {
       event.preventDefault()
@@ -98,7 +101,7 @@ export class ErrorSummary {
    * @param {EventTarget} $target - Event target
    * @returns {boolean} True if the target was able to be focussed
    */
-  focusTarget ($target) {
+  focusTarget($target) {
     // If the element that was clicked was not a link, return early
     if (!($target instanceof HTMLAnchorElement)) {
       return false
@@ -138,7 +141,7 @@ export class ErrorSummary {
    * @param {string} url - URL
    * @returns {string | undefined} Fragment from URL, without the hash
    */
-  getFragmentFromUrl (url) {
+  getFragmentFromUrl(url) {
     if (url.indexOf('#') === -1) {
       return undefined
     }
@@ -162,7 +165,7 @@ export class ErrorSummary {
    * @returns {Element | null} Associated legend or label, or null if no associated
    *   legend or label can be found
    */
-  getAssociatedLegendOrLabel ($input) {
+  getAssociatedLegendOrLabel($input) {
     const $fieldset = $input.closest('fieldset')
 
     if ($fieldset) {
@@ -173,7 +176,10 @@ export class ErrorSummary {
 
         // If the input type is radio or checkbox, always use the legend if there
         // is one.
-        if ($input instanceof HTMLInputElement && ($input.type === 'checkbox' || $input.type === 'radio')) {
+        if (
+          $input instanceof HTMLInputElement &&
+          ($input.type === 'checkbox' || $input.type === 'radio')
+        ) {
           return $candidateLegend
         }
 
@@ -198,8 +204,10 @@ export class ErrorSummary {
       }
     }
 
-    return document.querySelector(`label[for='${$input.getAttribute('id')}']`) ||
+    return (
+      document.querySelector(`label[for='${$input.getAttribute('id')}']`) ||
       $input.closest('label')
+    )
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
@@ -1,4 +1,9 @@
-const { goToComponent, goToExample, renderAndInitialise, goTo } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  goToExample,
+  renderAndInitialise,
+  goTo
+} = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('Error Summary', () => {
@@ -10,21 +15,30 @@ describe('Error Summary', () => {
 
   it('adds the tabindex attribute on page load', async () => {
     await goToComponent(page, 'error-summary')
-    const tabindex = await page.$eval('.govuk-error-summary', el => el.getAttribute('tabindex'))
+    const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+      el.getAttribute('tabindex')
+    )
     expect(tabindex).toEqual('-1')
   })
 
   it('is automatically focused when the page loads', async () => {
     await goToComponent(page, 'error-summary')
-    const moduleName = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+    const moduleName = await page.evaluate(() =>
+      document.activeElement.getAttribute('data-module')
+    )
     expect(moduleName).toBe('govuk-error-summary')
   })
 
   it('removes the tabindex attribute on blur', async () => {
     await goToComponent(page, 'error-summary')
-    await page.$eval('.govuk-error-summary', el => el instanceof window.HTMLElement && el.blur())
+    await page.$eval(
+      '.govuk-error-summary',
+      (el) => el instanceof window.HTMLElement && el.blur()
+    )
 
-    const tabindex = await page.$eval('.govuk-error-summary', el => el.getAttribute('tabindex'))
+    const tabindex = await page.$eval('.govuk-error-summary', (el) =>
+      el.getAttribute('tabindex')
+    )
     expect(tabindex).toBeNull()
   })
 
@@ -45,8 +59,8 @@ describe('Error Summary', () => {
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(
-          () => document.activeElement.getAttribute('data-module')
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')
@@ -72,8 +86,8 @@ describe('Error Summary', () => {
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(
-          () => document.activeElement.getAttribute('data-module')
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')
@@ -115,8 +129,8 @@ describe('Error Summary', () => {
       })
 
       it('is automatically focused when the page loads', async () => {
-        const moduleName = await page.evaluate(
-          () => document.activeElement.getAttribute('data-module')
+        const moduleName = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
         )
         expect(moduleName).toBe('govuk-error-summary')
       })
@@ -141,8 +155,8 @@ describe('Error Summary', () => {
       })
 
       it('does not focus on page load', async () => {
-        const activeElement = await page.evaluate(
-          () => document.activeElement.getAttribute('data-module')
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
         )
 
         expect(activeElement).not.toBe('govuk-error-summary')
@@ -156,43 +170,64 @@ describe('Error Summary', () => {
     ['a textarea', 'textarea', 'label[for="textarea"]'],
     ['a select', 'select', 'label[for="select"]'],
     ['a date input', 'dateinput-day', '.test-date-input-legend'],
-    ['a specific field in a date input', 'dateinput2-year', '.test-date-input2-legend'],
+    [
+      'a specific field in a date input',
+      'dateinput2-year',
+      '.test-date-input2-legend'
+    ],
     ['a file upload', 'file', 'label[for="file"]'],
     ['a group of radio buttons', 'radios', '#test-radios legend'],
     ['a group of checkboxes', 'checkboxes', '#test-checkboxes legend'],
     ['a single checkbox', 'single-checkbox', 'label[for="single-checkbox"]'],
-    ['a conditionally revealed input', 'yes-input', '#test-conditional-reveal legend'],
-    ['a group of radio buttons after a particularly long heading', 'radios-big-heading', '.test-radios-big-heading-legend'],
+    [
+      'a conditionally revealed input',
+      'yes-input',
+      '#test-conditional-reveal legend'
+    ],
+    [
+      'a group of radio buttons after a particularly long heading',
+      'radios-big-heading',
+      '.test-radios-big-heading-legend'
+    ],
     // Rather than scrolling to the fieldset, we expect to scroll to the label
     // because of the distance between the input and the fieldset
-    ['an input within a large fieldset', 'address-postcode', 'label[for="address-postcode"]']
+    [
+      'an input within a large fieldset',
+      'address-postcode',
+      'label[for="address-postcode"]'
+    ]
   ]
 
-  describe.each(inputTypes)('when linking to %s', (_, inputId, legendOrLabelSelector) => {
-    beforeAll(async () => {
-      await goToExample(page, 'error-summary')
-      await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
-    })
+  describe.each(inputTypes)(
+    'when linking to %s',
+    (_, inputId, legendOrLabelSelector) => {
+      beforeAll(async () => {
+        await goToExample(page, 'error-summary')
+        await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
+      })
 
-    it('focuses the target input', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.id)
-      expect(activeElement).toBe(inputId)
-    })
+      it('focuses the target input', async () => {
+        const activeElement = await page.evaluate(
+          () => document.activeElement.id
+        )
+        expect(activeElement).toBe(inputId)
+      })
 
-    it('scrolls the label or legend to the top of the screen', async () => {
-      const legendOrLabelOffsetFromTop = await page.$eval(
-        legendOrLabelSelector,
-        $ => $.getBoundingClientRect().top
-      )
+      it('scrolls the label or legend to the top of the screen', async () => {
+        const legendOrLabelOffsetFromTop = await page.$eval(
+          legendOrLabelSelector,
+          ($) => $.getBoundingClientRect().top
+        )
 
-      // Allow for high DPI displays (device pixel ratio)
-      expect(legendOrLabelOffsetFromTop).toBeGreaterThanOrEqual(0)
-      expect(legendOrLabelOffsetFromTop).toBeLessThan(1)
-    })
+        // Allow for high DPI displays (device pixel ratio)
+        expect(legendOrLabelOffsetFromTop).toBeGreaterThanOrEqual(0)
+        expect(legendOrLabelOffsetFromTop).toBeLessThan(1)
+      })
 
-    it('does not include a hash in the URL', async () => {
-      const hash = await page.evaluate(() => window.location.hash)
-      expect(hash).toBe('')
-    })
-  })
+      it('does not include a hash in the URL', async () => {
+        const hash = await page.evaluate(() => window.location.hash)
+        expect(hash).toBe('')
+      })
+    }
+  )
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
@@ -11,7 +11,9 @@ describe('Error-summary', () => {
   describe('default example', () => {
     it('has a child container with the role=alert attribute', () => {
       const $ = render('error-summary', examples.default)
-      const childRoleAttr = $('.govuk-error-summary div:first-child').attr('role')
+      const childRoleAttr = $('.govuk-error-summary div:first-child').attr(
+        'role'
+      )
 
       expect(childRoleAttr).toEqual('alert')
     })
@@ -33,14 +35,18 @@ describe('Error-summary', () => {
     it('error list item is an anchor tag if href attribute is specified', () => {
       const $ = render('error-summary', examples.default)
 
-      const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child')
+      const errorItem = $(
+        '.govuk-error-summary .govuk-error-summary__list li:first-child'
+      )
       expect(errorItem.children().get(0).tagName).toEqual('a')
     })
 
     it('render anchor tag href attribute is correctly', () => {
       const $ = render('error-summary', examples.default)
 
-      const errorItem = $('.govuk-error-summary .govuk-error-summary__list li:first-child a')
+      const errorItem = $(
+        '.govuk-error-summary .govuk-error-summary__list li:first-child a'
+      )
       expect(errorItem.attr('href')).toEqual('#example-error-1')
     })
   })
@@ -82,9 +88,15 @@ describe('Error-summary', () => {
     })
 
     it('renders nested components in description using `call`', () => {
-      const $ = render('error-summary', {}, '<div class="app-nested-component"></div>')
+      const $ = render(
+        'error-summary',
+        {},
+        '<div class="app-nested-component"></div>'
+      )
 
-      expect($('.govuk-error-summary .app-nested-component').length).toBeTruthy()
+      expect(
+        $('.govuk-error-summary .app-nested-component').length
+      ).toBeTruthy()
     })
 
     it('allows additional classes to be added to the error-summary component', () => {
@@ -112,7 +124,11 @@ describe('Error-summary', () => {
 
     it('renders error item text', () => {
       const $ = render('error-summary', examples['without links'])
-      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li:first-child').text().trim()
+      const errorItemText = $(
+        '.govuk-error-summary .govuk-error-summary__list li:first-child'
+      )
+        .text()
+        .trim()
 
       expect(errorItemText).toEqual('Invalid username or password')
     })
@@ -120,33 +136,63 @@ describe('Error-summary', () => {
     it('allows error item HTML to be passed un-escaped', () => {
       const $ = render('error-summary', examples['error list with html'])
 
-      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
+      const errorItemText = $(
+        '.govuk-error-summary .govuk-error-summary__list li'
+      )
+        .html()
+        .trim()
 
-      expect(errorItemText).toEqual('The date your passport was issued <b>must</b> be in the past')
+      expect(errorItemText).toEqual(
+        'The date your passport was issued <b>must</b> be in the past'
+      )
     })
 
     it('allows error item text to be passed whilst escaping HTML entities', () => {
-      const $ = render('error-summary', examples['error list with html as text'])
+      const $ = render(
+        'error-summary',
+        examples['error list with html as text']
+      )
 
-      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li').html().trim()
+      const errorItemText = $(
+        '.govuk-error-summary .govuk-error-summary__list li'
+      )
+        .html()
+        .trim()
 
-      expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
+      expect(errorItemText).toEqual(
+        'Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error'
+      )
     })
 
     it('allows error item HTML inside "a" tag to be passed un-escaped', () => {
       const $ = render('error-summary', examples['error list with html link'])
 
-      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
+      const errorItemText = $(
+        '.govuk-error-summary .govuk-error-summary__list li a'
+      )
+        .html()
+        .trim()
 
-      expect(errorItemText).toEqual('Descriptive link to the <b>question</b> with an error')
+      expect(errorItemText).toEqual(
+        'Descriptive link to the <b>question</b> with an error'
+      )
     })
 
     it('allows error item text inside "a" tag to be passed whilst escaping HTML entities', () => {
-      const $ = render('error-summary', examples['error list with html as text link'])
+      const $ = render(
+        'error-summary',
+        examples['error list with html as text link']
+      )
 
-      const errorItemText = $('.govuk-error-summary .govuk-error-summary__list li a').html().trim()
+      const errorItemText = $(
+        '.govuk-error-summary .govuk-error-summary__list li a'
+      )
+        .html()
+        .trim()
 
-      expect(errorItemText).toEqual('Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error')
+      expect(errorItemText).toEqual(
+        'Descriptive link to the &lt;b&gt;question&lt;/b&gt; with an error'
+      )
     })
 
     it('allows to disable autofocus', () => {
@@ -157,7 +203,10 @@ describe('Error-summary', () => {
     })
 
     it('allows to explicitely enable autofocus', () => {
-      const $ = render('error-summary', examples['autofocus explicitly enabled'])
+      const $ = render(
+        'error-summary',
+        examples['autofocus explicitly enabled']
+      )
 
       const $component = $('.govuk-error-summary')
       expect($component.attr('data-disable-auto-focus')).toBe('false')

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -74,8 +74,11 @@ export class ExitThisPage {
    * @param {Element} $module - HTML element that wraps the Exit This Page button
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
-  constructor ($module, config) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module, config) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -94,7 +97,9 @@ export class ExitThisPage {
     this.$module = $module
     this.$button = $button
 
-    const $skiplinkButton = document.querySelector('.govuk-js-exit-this-page-skiplink')
+    const $skiplinkButton = document.querySelector(
+      '.govuk-js-exit-this-page-skiplink'
+    )
     if ($skiplinkButton instanceof HTMLAnchorElement) {
       this.$skiplinkButton = $skiplinkButton
     }
@@ -120,7 +125,7 @@ export class ExitThisPage {
    *
    * @private
    */
-  initUpdateSpan () {
+  initUpdateSpan() {
     this.$updateSpan = document.createElement('span')
     this.$updateSpan.setAttribute('role', 'status')
     this.$updateSpan.className = 'govuk-visually-hidden'
@@ -133,13 +138,16 @@ export class ExitThisPage {
    *
    * @private
    */
-  initButtonClickHandler () {
+  initButtonClickHandler() {
     // Main EtP button
     this.$button.addEventListener('click', this.handleClick.bind(this))
 
     // EtP secondary link
     if (this.$skiplinkButton) {
-      this.$skiplinkButton.addEventListener('click', this.handleClick.bind(this))
+      this.$skiplinkButton.addEventListener(
+        'click',
+        this.handleClick.bind(this)
+      )
     }
   }
 
@@ -148,7 +156,7 @@ export class ExitThisPage {
    *
    * @private
    */
-  buildIndicator () {
+  buildIndicator() {
     // Build container
     // Putting `aria-hidden` on it as it won't contain any readable information
     this.$indicatorContainer = document.createElement('div')
@@ -172,12 +180,16 @@ export class ExitThisPage {
    *
    * @private
    */
-  updateIndicator () {
+  updateIndicator() {
     // Show or hide the indicator container depending on keypressCounter value
     if (this.keypressCounter > 0) {
-      this.$indicatorContainer.classList.add('govuk-exit-this-page__indicator--visible')
+      this.$indicatorContainer.classList.add(
+        'govuk-exit-this-page__indicator--visible'
+      )
     } else {
-      this.$indicatorContainer.classList.remove('govuk-exit-this-page__indicator--visible')
+      this.$indicatorContainer.classList.remove(
+        'govuk-exit-this-page__indicator--visible'
+      )
     }
 
     // Turn on only the indicators we want on
@@ -200,7 +212,7 @@ export class ExitThisPage {
    *
    * @private
    */
-  exitPage () {
+  exitPage() {
     this.$updateSpan.innerText = ''
 
     // Blank the page
@@ -232,7 +244,7 @@ export class ExitThisPage {
    * @private
    * @param {MouseEvent} event - mouse click event
    */
-  handleClick (event) {
+  handleClick(event) {
     event.preventDefault()
     this.exitPage()
   }
@@ -244,7 +256,7 @@ export class ExitThisPage {
    * @private
    * @param {KeyboardEvent} event - keyup event
    */
-  handleKeypress (event) {
+  handleKeypress(event) {
     // Detect if the 'Shift' key has been pressed. We want to only do things if it
     // was pressed by itself and not in a combination with another key—so we keep
     // track of whether the preceding keyup had shiftKey: true on it, and if it
@@ -306,7 +318,7 @@ export class ExitThisPage {
    *
    * @private
    */
-  setKeypressTimer () {
+  setKeypressTimer() {
     // Clear any existing timeout. This is so only one timer is running even if
     // there are multiple keypresses in quick succession.
     window.clearTimeout(this.keypressTimeoutId)
@@ -323,7 +335,7 @@ export class ExitThisPage {
    *
    * @private
    */
-  resetKeypressTimer () {
+  resetKeypressTimer() {
     window.clearTimeout(this.keypressTimeoutId)
     this.keypressTimeoutId = null
 
@@ -351,7 +363,7 @@ export class ExitThisPage {
    *
    * @deprecated Will be made private in v5.0
    */
-  resetPage () {
+  resetPage() {
     // If an overlay is set, remove it and reset the value
     document.body.classList.remove('govuk-exit-this-page-hide-content')
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -1,4 +1,7 @@
-const { goToComponent, goToExample } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  goToExample
+} = require('govuk-frontend-helpers/puppeteer')
 
 const buttonClass = '.govuk-js-exit-this-page-button'
 const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
@@ -17,12 +20,11 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the button', async () => {
       await goToComponent(page, 'exit-this-page')
 
-      const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+      const pathname = await page.$eval(buttonClass, (el) =>
+        el.getAttribute('href')
+      )
 
-      await Promise.all([
-        page.waitForNavigation(),
-        page.click(buttonClass)
-      ])
+      await Promise.all([page.waitForNavigation(), page.click(buttonClass)])
 
       const url = new URL(await page.url())
       expect(url.pathname).toBe(pathname)
@@ -31,7 +33,9 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the skiplink', async () => {
       await goToExample(page, 'exit-this-page-with-skiplink')
 
-      const href = await page.$eval(skiplinkClass, el => el.getAttribute('href'))
+      const href = await page.$eval(skiplinkClass, (el) =>
+        el.getAttribute('href')
+      )
 
       await Promise.all([
         page.waitForNavigation(),
@@ -48,12 +52,11 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the button', async () => {
       await goToComponent(page, 'exit-this-page')
 
-      const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+      const pathname = await page.$eval(buttonClass, (el) =>
+        el.getAttribute('href')
+      )
 
-      await Promise.all([
-        page.waitForNavigation(),
-        page.click(buttonClass)
-      ])
+      await Promise.all([page.waitForNavigation(), page.click(buttonClass)])
 
       const url = new URL(await page.url())
       expect(url.pathname).toBe(pathname)
@@ -62,7 +65,9 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the skiplink', async () => {
       await goToExample(page, 'exit-this-page-with-skiplink')
 
-      const href = await page.$eval(skiplinkClass, el => el.getAttribute('href'))
+      const href = await page.$eval(skiplinkClass, (el) =>
+        el.getAttribute('href')
+      )
 
       await Promise.all([
         page.waitForNavigation(),
@@ -79,10 +84,13 @@ describe('/components/exit-this-page', () => {
 
       // Stop the button from navigating away from the current page as a workaround
       // to puppeteer struggling to return to previous pages after navigation reliably
-      await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
       await page.click(buttonClass)
 
-      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      const ghostOverlay = await page.evaluate(
+        (overlayClass) => document.body.querySelector(overlayClass),
+        overlayClass
+      )
       expect(ghostOverlay).not.toBeNull()
     })
 
@@ -94,11 +102,14 @@ describe('/components/exit-this-page', () => {
       //
       // We apply this to the button and not the skiplink because we pull the href
       // from the button rather than the skiplink
-      await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
       await page.focus(skiplinkClass)
       await page.click(skiplinkClass)
 
-      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      const ghostOverlay = await page.evaluate(
+        (overlayClass) => document.body.querySelector(overlayClass),
+        overlayClass
+      )
       expect(ghostOverlay).not.toBeNull()
     })
 
@@ -106,7 +117,9 @@ describe('/components/exit-this-page', () => {
       it('activates the button functionality when the Shift key is pressed 3 times', async () => {
         await goToComponent(page, 'exit-this-page')
 
-        const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+        const pathname = await page.$eval(buttonClass, (el) =>
+          el.getAttribute('href')
+        )
 
         await Promise.all([
           page.keyboard.press('Shift'),
@@ -124,7 +137,9 @@ describe('/components/exit-this-page', () => {
 
         await page.keyboard.press('Shift')
 
-        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        const message = await page.$eval(buttonClass, (el) =>
+          el.nextElementSibling.innerHTML.trim()
+        )
         expect(message).toBe('Shift, press 2 more times to exit.')
       })
 
@@ -134,7 +149,9 @@ describe('/components/exit-this-page', () => {
         await page.keyboard.press('Shift')
         await page.keyboard.press('Shift')
 
-        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        const message = await page.$eval(buttonClass, (el) =>
+          el.nextElementSibling.innerHTML.trim()
+        )
         expect(message).toBe('Shift, press 1 more time to exit.')
       })
 
@@ -142,13 +159,15 @@ describe('/components/exit-this-page', () => {
         await goToComponent(page, 'exit-this-page')
 
         // Make the button not navigate away from the current page
-        await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+        await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
 
         await page.keyboard.press('Shift')
         await page.keyboard.press('Shift')
         await page.keyboard.press('Shift')
 
-        const message = await page.$eval(overlayClass, el => el.innerHTML.trim())
+        const message = await page.$eval(overlayClass, (el) =>
+          el.innerHTML.trim()
+        )
         expect(message).toBe('Loading.')
       })
 
@@ -160,7 +179,9 @@ describe('/components/exit-this-page', () => {
         // Wait for 6 seconds (one full second over the 5 second limit)
         await new Promise((resolve) => setTimeout(resolve, 6000))
 
-        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        const message = await page.$eval(buttonClass, (el) =>
+          el.nextElementSibling.innerHTML.trim()
+        )
         expect(message).toBe('Exit this page expired.')
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
@@ -14,7 +14,9 @@ describe('Exit this page', () => {
       const $button = $('.govuk-exit-this-page').find('.govuk-button')
 
       expect($button.hasClass('govuk-button--warning')).toBeTruthy()
-      expect($button.html()).toContain('<span class="govuk-visually-hidden">Emergency</span> Exit this page')
+      expect($button.html()).toContain(
+        '<span class="govuk-visually-hidden">Emergency</span> Exit this page'
+      )
       expect($button.attr('href')).toBe('/full-page-examples/announcements')
     })
   })
@@ -70,8 +72,12 @@ describe('Exit this page', () => {
 
       expect($component.attr('data-i18n.activated')).toBe('Tudalen ymadael')
       expect($component.attr('data-i18n.timed-out')).toBe("Wedi'i amseru")
-      expect($component.attr('data-i18n.press-two-more-times')).toBe("Pwyswch 'Shift' 2 gwaith arall")
-      expect($component.attr('data-i18n.press-one-more-time')).toBe("Pwyswch 'Shift' 1 mwy o amser")
+      expect($component.attr('data-i18n.press-two-more-times')).toBe(
+        "Pwyswch 'Shift' 2 gwaith arall"
+      )
+      expect($component.attr('data-i18n.press-one-more-time')).toBe(
+        "Pwyswch 'Shift' 1 mwy o amser"
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
@@ -67,7 +67,9 @@ describe('fieldset', () => {
   it('renders html when passed as fieldset content', () => {
     const $ = render('fieldset', examples['html fieldset content'])
 
-    expect($('.govuk-fieldset .my-content').text().trim()).toEqual('This is some content to put inside the fieldset')
+    expect($('.govuk-fieldset .my-content').text().trim()).toEqual(
+      'This is some content to put inside the fieldset'
+    )
   })
 
   it('renders nested components using `call`', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -88,28 +88,26 @@ describe('File upload', () => {
       const $ = render('file-upload', examples['with hint text'])
 
       const $component = $('.govuk-file-upload')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(hintId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
       const $ = render('file-upload', examples['with hint and describedBy'])
 
       const $component = $('.govuk-file-upload')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(hintId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -124,28 +122,26 @@ describe('File upload', () => {
       const $ = render('file-upload', examples.error)
 
       const $component = $('.govuk-file-upload')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
       const $ = render('file-upload', examples['with error and describedBy'])
 
       const $component = $('.govuk-file-upload')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('includes the error class on the component', () => {
@@ -171,11 +167,11 @@ describe('File upload', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
@@ -190,17 +186,11 @@ describe('File upload', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY +
-          describedById +
-          WHITESPACE +
-          hintId +
-          WHITESPACE +
-          errorMessageId +
-          WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${describedById}${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -40,7 +40,9 @@ describe('File upload', () => {
       const $ = render('file-upload', examples.classes)
 
       const $component = $('.govuk-file-upload')
-      expect($component.hasClass('app-file-upload--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-file-upload--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with value', () => {
@@ -65,7 +67,10 @@ describe('File upload', () => {
     })
 
     it('renders with a form group wrapper that has extra classes', () => {
-      const $ = render('file-upload', examples['with optional form-group classes'])
+      const $ = render(
+        'file-upload',
+        examples['with optional form-group classes']
+      )
 
       const $formGroup = $('.govuk-form-group')
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
@@ -89,8 +94,7 @@ describe('File upload', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($component.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
@@ -100,11 +104,12 @@ describe('File upload', () => {
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($component.attr('aria-describedby')).toMatch(hintId)
     })
   })
 
@@ -125,8 +130,7 @@ describe('File upload', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
@@ -136,11 +140,12 @@ describe('File upload', () => {
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('includes the error class on the component', () => {
@@ -170,25 +175,32 @@ describe('File upload', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
       const describedById = 'some-id'
 
-      const $ = render('file-upload', examples['with error, describedBy and hint'])
+      const $ = render(
+        'file-upload',
+        examples['with error, describedBy and hint']
+      )
 
       const $component = $('.govuk-file-upload')
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
       const combinedIds = new RegExp(
-        WORD_BOUNDARY + describedById + WHITESPACE + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+        WORD_BOUNDARY +
+          describedById +
+          WHITESPACE +
+          hintId +
+          WHITESPACE +
+          errorMessageId +
+          WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -56,7 +56,7 @@ describe('footer', () => {
       expect($heading.text()).toEqual('Support links')
     })
 
-    it('doesn\'t render footer link list when no items are provided', () => {
+    it("doesn't render footer link list when no items are provided", () => {
       const $ = render('footer', examples['with empty meta items'])
 
       expect($('.govuk-footer__inline-list').length).toEqual(0)
@@ -84,7 +84,9 @@ describe('footer', () => {
       const $ = render('footer', examples['meta html as text'])
 
       const $custom = $('.govuk-footer__meta-custom')
-      expect($custom.text()).toContain('GOV.UK Prototype Kit <strong>v7.0.1</strong>')
+      expect($custom.text()).toContain(
+        'GOV.UK Prototype Kit <strong>v7.0.1</strong>'
+      )
     })
 
     it('renders custom meta html', () => {
@@ -148,14 +150,20 @@ describe('footer', () => {
     })
 
     it('renders one-column section full width by default', () => {
-      const $ = render('footer', examples['with default width navigation (one column)'])
+      const $ = render(
+        'footer',
+        examples['with default width navigation (one column)']
+      )
 
       const $section = $('.govuk-footer__section')
       expect($section.hasClass('govuk-grid-column-full')).toBeTruthy()
     })
 
     it('renders two-column section full width by default', () => {
-      const $ = render('footer', examples['with default width navigation (two columns)'])
+      const $ = render(
+        'footer',
+        examples['with default width navigation (two columns)']
+      )
 
       const $section = $('.govuk-footer__section')
       expect($section.hasClass('govuk-grid-column-full')).toBeTruthy()
@@ -194,24 +202,36 @@ describe('footer', () => {
     })
 
     it('can be customised with `text` parameter', () => {
-      const $ = render('footer', examples['with custom text content licence and copyright notice'])
+      const $ = render(
+        'footer',
+        examples['with custom text content licence and copyright notice']
+      )
 
       const $licenceMessage = $('.govuk-footer__licence-description')
-      expect($licenceMessage.text()).toContain('Drwydded y Llywodraeth Agored v3.0')
+      expect($licenceMessage.text()).toContain(
+        'Drwydded y Llywodraeth Agored v3.0'
+      )
     })
 
     it('can be customised with `html` parameter', () => {
-      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
+      const $ = render(
+        'footer',
+        examples['with custom HTML content licence and copyright notice']
+      )
 
       const $licenceMessage = $('.govuk-footer__licence-description')
-      expect($licenceMessage.html()).toContain('<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>')
+      expect($licenceMessage.html()).toContain(
+        '<a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license">Drwydded y Llywodraeth Agored v3.0</a>'
+      )
     })
 
     it('escapes HTML in the `text` parameter', () => {
       const $ = render('footer', examples['with HTML passed as text content'])
 
       const $licenceMessage = $('.govuk-footer__licence-description')
-      expect($licenceMessage.html()).toContain('&lt;a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license"&gt;Drwydded y Llywodraeth Agored v3.0&lt;/a&gt;')
+      expect($licenceMessage.html()).toContain(
+        '&lt;a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence-cymraeg/version/3/" rel="license"&gt;Drwydded y Llywodraeth Agored v3.0&lt;/a&gt;'
+      )
     })
   })
 
@@ -224,24 +244,34 @@ describe('footer', () => {
     })
 
     it('can be customised with `text` parameter', () => {
-      const $ = render('footer', examples['with custom text content licence and copyright notice'])
+      const $ = render(
+        'footer',
+        examples['with custom text content licence and copyright notice']
+      )
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
       expect($copyrightMessage.text()).toContain('© Hawlfraint y Goron')
     })
 
     it('can be customised with `html` parameter', () => {
-      const $ = render('footer', examples['with custom HTML content licence and copyright notice'])
+      const $ = render(
+        'footer',
+        examples['with custom HTML content licence and copyright notice']
+      )
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
-      expect($copyrightMessage.html()).toContain('<span>Hawlfraint y Goron</span>')
+      expect($copyrightMessage.html()).toContain(
+        '<span>Hawlfraint y Goron</span>'
+      )
     })
 
     it('escapes HTML in the `text` parameter', () => {
       const $ = render('footer', examples['with HTML passed as text content'])
 
       const $copyrightMessage = $('.govuk-footer__copyright-logo')
-      expect($copyrightMessage.html()).toContain('&lt;span&gt;Hawlfraint y Goron&lt;/span&gt;')
+      expect($copyrightMessage.html()).toContain(
+        '&lt;span&gt;Hawlfraint y Goron&lt;/span&gt;'
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/globals.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.test.js
@@ -26,7 +26,7 @@ describe('GOV.UK Frontend', () => {
 
     it('exports Components', async () => {
       const components = exported
-        .filter(method => !['initAll', 'version'].includes(method))
+        .filter((method) => !['initAll', 'version'].includes(method))
         .sort()
 
       // Ensure GOV.UK Frontend exports the expected components

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -36,16 +36,21 @@ export class Header {
    *
    * @param {Element} $module - HTML element to use for header
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
     this.$module = $module
     this.$menuButton = $module.querySelector('.govuk-js-header-toggle')
-    this.$menu = this.$menuButton && $module.querySelector(
-      `#${this.$menuButton.getAttribute('aria-controls')}`
-    )
+    this.$menu =
+      this.$menuButton &&
+      $module.querySelector(
+        `#${this.$menuButton.getAttribute('aria-controls')}`
+      )
 
     if (
       !(
@@ -70,7 +75,9 @@ export class Header {
     }
 
     this.syncState()
-    this.$menuButton.addEventListener('click', () => this.handleMenuButtonClick())
+    this.$menuButton.addEventListener('click', () =>
+      this.handleMenuButtonClick()
+    )
   }
 
   /**
@@ -83,7 +90,7 @@ export class Header {
    *
    * @private
    */
-  syncState () {
+  syncState() {
     if (this.mql.matches) {
       this.$menu.removeAttribute('hidden')
       this.$menuButton.setAttribute('hidden', '')
@@ -107,7 +114,7 @@ export class Header {
    *
    * @private
    */
-  handleMenuButtonClick () {
+  handleMenuButtonClick() {
     this.menuIsOpen = !this.menuIsOpen
     this.syncState()
   }

--- a/packages/govuk-frontend/src/govuk/components/header/header.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.test.js
@@ -22,16 +22,17 @@ describe('Header navigation', () => {
     })
 
     it('shows the navigation', async () => {
-      const navDisplay = await page.$eval('.govuk-header__navigation-list',
-        el => window.getComputedStyle(el).getPropertyValue('display')
+      const navDisplay = await page.$eval(
+        '.govuk-header__navigation-list',
+        (el) => window.getComputedStyle(el).getPropertyValue('display')
       )
 
       expect(navDisplay).toBe('block')
     })
 
     it('does not show the mobile menu button', async () => {
-      const buttonDisplay = await page.$eval('.govuk-js-header-toggle',
-        el => window.getComputedStyle(el).getPropertyValue('display')
+      const buttonDisplay = await page.$eval('.govuk-js-header-toggle', (el) =>
+        window.getComputedStyle(el).getPropertyValue('display')
       )
 
       expect(buttonDisplay).toBe('none')
@@ -54,12 +55,13 @@ describe('Header navigation', () => {
       })
 
       it('reveals the menu button', async () => {
-        const hidden = await page.$eval('.govuk-js-header-toggle',
-          el => el.hasAttribute('hidden')
+        const hidden = await page.$eval('.govuk-js-header-toggle', (el) =>
+          el.hasAttribute('hidden')
         )
 
-        const buttonDisplay = await page.$eval('.govuk-js-header-toggle',
-          el => window.getComputedStyle(el).getPropertyValue('display')
+        const buttonDisplay = await page.$eval(
+          '.govuk-js-header-toggle',
+          (el) => window.getComputedStyle(el).getPropertyValue('display')
         )
 
         expect(hidden).toBe(false)
@@ -67,12 +69,14 @@ describe('Header navigation', () => {
       })
 
       it('hides the menu via the hidden attribute', async () => {
-        const hidden = await page.$eval('.govuk-header__navigation-list',
-          el => el.hasAttribute('hidden')
+        const hidden = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => el.hasAttribute('hidden')
         )
 
-        const navDisplay = await page.$eval('.govuk-header__navigation-list',
-          el => window.getComputedStyle(el).getPropertyValue('display')
+        const navDisplay = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => window.getComputedStyle(el).getPropertyValue('display')
         )
 
         expect(hidden).toBe(true)
@@ -80,8 +84,9 @@ describe('Header navigation', () => {
       })
 
       it('exposes the collapsed state of the menu button using aria-expanded', async () => {
-        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
-          el => el.getAttribute('aria-expanded')
+        const ariaExpanded = await page.$eval(
+          '.govuk-header__menu-button',
+          (el) => el.getAttribute('aria-expanded')
         )
 
         expect(ariaExpanded).toBe('false')
@@ -99,12 +104,14 @@ describe('Header navigation', () => {
       })
 
       it('shows the menu', async () => {
-        const hidden = await page.$eval('.govuk-header__navigation-list',
-          el => el.hasAttribute('hidden')
+        const hidden = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => el.hasAttribute('hidden')
         )
 
-        const navDisplay = await page.$eval('.govuk-header__navigation-list',
-          el => window.getComputedStyle(el).getPropertyValue('display')
+        const navDisplay = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => window.getComputedStyle(el).getPropertyValue('display')
         )
 
         expect(hidden).toBe(false)
@@ -112,8 +119,9 @@ describe('Header navigation', () => {
       })
 
       it('exposes the expanded state of the menu button using aria-expanded', async () => {
-        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
-          el => el.getAttribute('aria-expanded')
+        const ariaExpanded = await page.$eval(
+          '.govuk-header__menu-button',
+          (el) => el.getAttribute('aria-expanded')
         )
 
         expect(ariaExpanded).toBe('true')
@@ -132,12 +140,14 @@ describe('Header navigation', () => {
       })
 
       it('adds the hidden attribute back to the menu, hiding it', async () => {
-        const hidden = await page.$eval('.govuk-header__navigation-list',
-          el => el.hasAttribute('hidden')
+        const hidden = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => el.hasAttribute('hidden')
         )
 
-        const navDisplay = await page.$eval('.govuk-header__navigation-list',
-          el => window.getComputedStyle(el).getPropertyValue('display')
+        const navDisplay = await page.$eval(
+          '.govuk-header__navigation-list',
+          (el) => window.getComputedStyle(el).getPropertyValue('display')
         )
 
         expect(hidden).toBe(true)
@@ -145,8 +155,9 @@ describe('Header navigation', () => {
       })
 
       it('exposes the collapsed state of the menu button using aria-expanded', async () => {
-        const ariaExpanded = await page.$eval('.govuk-header__menu-button',
-          el => el.getAttribute('aria-expanded')
+        const ariaExpanded = await page.$eval(
+          '.govuk-header__menu-button',
+          (el) => el.getAttribute('aria-expanded')
         )
 
         expect(ariaExpanded).toBe('false')

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -39,7 +39,9 @@ describe('header', () => {
       const $component = $('.govuk-header')
       const $container = $component.find('.govuk-header__container')
 
-      expect($container.hasClass('govuk-header__container--full-width')).toBeTruthy()
+      expect(
+        $container.hasClass('govuk-header__container--full-width')
+      ).toBeTruthy()
     })
 
     it('renders custom navigation classes', () => {
@@ -89,7 +91,10 @@ describe('header', () => {
     })
 
     it('does not use a link when no service url is provided', () => {
-      const $ = render('header', examples['with service name but no service url'])
+      const $ = render(
+        'header',
+        examples['with service name but no service url']
+      )
 
       const $component = $('.govuk-header')
       const $serviceName = $component.find('.govuk-header__service-name')
@@ -139,7 +144,10 @@ describe('header', () => {
     })
 
     it('renders navigation label and menu button text when these are both set', () => {
-      const $ = render('header', examples['with custom navigation label and custom menu button text'])
+      const $ = render(
+        'header',
+        examples['with custom navigation label and custom menu button text']
+      )
 
       const $component = $('.govuk-header')
       const $nav = $component.find('nav')
@@ -153,14 +161,18 @@ describe('header', () => {
       const $ = render('header', examples['with navigation'])
 
       const $activeItem = $('li.govuk-header__navigation-item:first-child')
-      expect($activeItem.hasClass('govuk-header__navigation-item--active')).toBeTruthy()
+      expect(
+        $activeItem.hasClass('govuk-header__navigation-item--active')
+      ).toBeTruthy()
     })
 
     it('allows navigation item text to be passed whilst escaping HTML entities', () => {
       const $ = render('header', examples['navigation item with html as text'])
 
       const $navigationLink = $('.govuk-header__navigation-item a')
-      expect($navigationLink.html()).toContain('&lt;em&gt;Navigation item 1&lt;/em&gt;')
+      expect($navigationLink.html()).toContain(
+        '&lt;em&gt;Navigation item 1&lt;/em&gt;'
+      )
     })
 
     it('allows navigation item HTML to be passed un-escaped', () => {
@@ -171,14 +183,20 @@ describe('header', () => {
     })
 
     it('renders navigation item with text without a link', () => {
-      const $ = render('header', examples['navigation item with text without link'])
+      const $ = render(
+        'header',
+        examples['navigation item with text without link']
+      )
 
       const $navigationItem = $('.govuk-header__navigation-item')
       expect($navigationItem.html().trim()).toEqual('Navigation item 1')
     })
 
     it('renders navigation item with html without a link', () => {
-      const $ = render('header', examples['navigation item with html without link'])
+      const $ = render(
+        'header',
+        examples['navigation item with html without link']
+      )
 
       const $navigationItem = $('.govuk-header__navigation-item')
       expect($navigationItem.html()).toContain('<em>Navigation item 1</em>')

--- a/packages/govuk-frontend/src/govuk/components/hint/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.test.js
@@ -13,7 +13,9 @@ describe('Hint', () => {
       const $ = render('hint', examples.default)
 
       const content = $('.govuk-hint').text()
-      expect(content).toEqual('\n  It\'s on your National Insurance card, benefit letter, payslip or P60.\nFor example, \'QQ 12 34 56 C\'.\n\n')
+      expect(content).toEqual(
+        "\n  It's on your National Insurance card, benefit letter, payslip or P60.\nFor example, 'QQ 12 34 56 C'.\n\n"
+      )
     })
 
     it('renders with classes', () => {
@@ -34,14 +36,18 @@ describe('Hint', () => {
       const $ = render('hint', examples['html as text'])
 
       const content = $('.govuk-hint').html().trim()
-      expect(content).toEqual('Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body')
+      expect(content).toEqual(
+        'Unexpected &lt;strong&gt;bold text&lt;/strong&gt; in body'
+      )
     })
 
     it('allows HTML to be passed un-escaped', () => {
       const $ = render('hint', examples['with html'])
 
       const content = $('.govuk-hint').html().trim()
-      expect(content).toEqual('It\'s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.\nFor example, \'QQ 12 34 56 C\'.')
+      expect(content).toEqual(
+        'It\'s on your National Insurance card, benefit letter, payslip or <a class="govuk-link" href="#">P60</a>.\nFor example, \'QQ 12 34 56 C\'.'
+      )
     })
 
     it('renders with attributes', () => {

--- a/packages/govuk-frontend/src/govuk/components/input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.test.js
@@ -111,28 +111,26 @@ describe('Input', () => {
       const $ = render('input', examples['with hint text'])
 
       const $input = $('.govuk-input')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby')).toMatch(hintId)
+      expect($input.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
       const $ = render('input', examples['hint with describedBy'])
 
       const $input = $('.govuk-input')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby')).toMatch(hintId)
+      expect($input.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -147,28 +145,26 @@ describe('Input', () => {
       const $ = render('input', examples['with error message'])
 
       const $input = $('.govuk-input')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
       const $ = render('input', examples['error with describedBy'])
 
       const $input = $('.govuk-input')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('includes the error class on the input', () => {
@@ -217,11 +213,11 @@ describe('Input', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
@@ -231,11 +227,11 @@ describe('Input', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
+      const describedByCombined = new RegExp(
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.test.js
@@ -92,7 +92,7 @@ describe('Input', () => {
       expect($formGroup.hasClass('extra-class')).toBeTruthy()
     })
 
-    it('doesn\'t render the input wrapper', () => {
+    it("doesn't render the input wrapper", () => {
       const $ = render('input', examples.default)
 
       const $wrapper = $('.govuk-form-group > .govuk-input__wrapper')
@@ -117,8 +117,7 @@ describe('Input', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($input.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($input.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('associates the input as "described by" the hint and parent fieldset', () => {
@@ -128,11 +127,12 @@ describe('Input', () => {
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($input.attr('aria-describedby')).toMatch(hintId)
     })
   })
 
@@ -153,8 +153,7 @@ describe('Input', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the input as "described by" the error message and parent fieldset', () => {
@@ -164,11 +163,12 @@ describe('Input', () => {
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('includes the error class on the input', () => {
@@ -221,8 +221,7 @@ describe('Input', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
@@ -236,8 +235,7 @@ describe('Input', () => {
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
   })
 
@@ -292,14 +290,18 @@ describe('Input', () => {
     it('renders the prefix inside the wrapper', () => {
       const $ = render('input', examples['with prefix'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
       expect($prefix.length).toBeTruthy()
     })
 
     it('renders the text in the prefix', () => {
       const $ = render('input', examples['with prefix'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
 
       expect($prefix.html()).toEqual('£')
     })
@@ -307,7 +309,9 @@ describe('Input', () => {
     it('allows prefix text to be passed whilst escaping HTML entities', () => {
       const $ = render('input', examples['with prefix with html as text'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
 
       expect($prefix.html()).toEqual('&lt;span&gt;£&lt;/span&gt;')
     })
@@ -315,7 +319,9 @@ describe('Input', () => {
     it('allows prefix HTML to be passed un-escaped', () => {
       const $ = render('input', examples['with prefix with html'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
 
       expect($prefix.html()).toEqual('<span>£</span>')
     })
@@ -323,21 +329,29 @@ describe('Input', () => {
     it('hides the prefix from screen readers using the aria-hidden attribute', () => {
       const $ = render('input', examples['with prefix'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
       expect($prefix.attr('aria-hidden')).toEqual('true')
     })
 
     it('renders with classes', () => {
       const $ = render('input', examples['with prefix with classes'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
-      expect($prefix.hasClass('app-input__prefix--custom-modifier')).toBeTruthy()
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
+      expect(
+        $prefix.hasClass('app-input__prefix--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with attributes', () => {
       const $ = render('input', examples['with prefix with attributes'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
       expect($prefix.attr('data-attribute')).toEqual('value')
     })
   })
@@ -353,14 +367,18 @@ describe('Input', () => {
     it('renders the suffix inside the wrapper', () => {
       const $ = render('input', examples['with suffix'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
       expect($suffix.length).toBeTruthy()
     })
 
     it('renders the text in the prefix', () => {
       const $ = render('input', examples['with prefix'])
 
-      const $prefix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix')
+      const $prefix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix'
+      )
 
       expect($prefix.html()).toEqual('£')
     })
@@ -368,7 +386,9 @@ describe('Input', () => {
     it('allows suffix text to be passed whilst escaping HTML entities', () => {
       const $ = render('input', examples['with suffix with html as text'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
 
       expect($suffix.html()).toEqual('&lt;span&gt;kg&lt;/span&gt;')
     })
@@ -376,7 +396,9 @@ describe('Input', () => {
     it('allows suffix HTML to be passed un-escaped', () => {
       const $ = render('input', examples['with suffix with html'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
 
       expect($suffix.html()).toEqual('<span>kg</span>')
     })
@@ -384,21 +406,29 @@ describe('Input', () => {
     it('hides the suffix from screen readers using the aria-hidden attribute', () => {
       const $ = render('input', examples['with suffix'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
       expect($suffix.attr('aria-hidden')).toEqual('true')
     })
 
     it('renders with classes', () => {
       const $ = render('input', examples['with suffix with classes'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
-      expect($suffix.hasClass('app-input__suffix--custom-modifier')).toBeTruthy()
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
+      expect(
+        $suffix.hasClass('app-input__suffix--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with attributes', () => {
       const $ = render('input', examples['with suffix with attributes'])
 
-      const $suffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix')
+      const $suffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__suffix'
+      )
       expect($suffix.attr('data-attribute')).toEqual('value')
     })
   })
@@ -407,7 +437,9 @@ describe('Input', () => {
     it('renders the prefix before the suffix', () => {
       const $ = render('input', examples['with prefix and suffix'])
 
-      const $prefixBeforeSuffix = $('.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix ~ .govuk-input__suffix')
+      const $prefixBeforeSuffix = $(
+        '.govuk-form-group > .govuk-input__wrapper > .govuk-input__prefix ~ .govuk-input__suffix'
+      )
       expect($prefixBeforeSuffix.length).toBeTruthy()
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
@@ -13,7 +13,9 @@ describe('Inset text', () => {
       const $ = render('inset-text', examples.classes)
 
       const $component = $('.govuk-inset-text')
-      expect($component.hasClass('app-inset-text--custom-modifier')).toBeTruthy()
+      expect(
+        $component.hasClass('app-inset-text--custom-modifier')
+      ).toBeTruthy()
     })
 
     it('renders with id', () => {
@@ -24,7 +26,11 @@ describe('Inset text', () => {
     })
 
     it('renders nested components using `call`', () => {
-      const $ = render('inset-text', {}, '<div class="app-nested-component"></div>')
+      const $ = render(
+        'inset-text',
+        {},
+        '<div class="app-nested-component"></div>'
+      )
 
       expect($('.govuk-inset-text .app-nested-component').length).toBeTruthy()
     })
@@ -33,16 +39,26 @@ describe('Inset text', () => {
       const $ = render('inset-text', examples['html as text'])
 
       const content = $('.govuk-inset-text').html().trim()
-      expect(content).toEqual('It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.')
+      expect(content).toEqual(
+        'It can take &lt;b&gt;up to 8 weeks&lt;/b&gt; to register a lasting power of attorney if there are no mistakes in the application.'
+      )
     })
 
     it('allows HTML to be passed un-escaped', () => {
       const $ = render('inset-text', examples['with html'])
 
-      const mainContent = $('.govuk-inset-text .govuk-body:first-child').text().trim()
-      const warningContent = $('.govuk-inset-text .govuk-warning-text__text').text().trim()
-      expect(mainContent).toEqual('It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.')
-      expect(warningContent).toEqual('Warning\n    You can be fined up to £5,000 if you don’t register.')
+      const mainContent = $('.govuk-inset-text .govuk-body:first-child')
+        .text()
+        .trim()
+      const warningContent = $('.govuk-inset-text .govuk-warning-text__text')
+        .text()
+        .trim()
+      expect(mainContent).toEqual(
+        'It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.'
+      )
+      expect(warningContent).toEqual(
+        'Warning\n    You can be fined up to £5,000 if you don’t register.'
+      )
     })
 
     it('renders with attributes', () => {

--- a/packages/govuk-frontend/src/govuk/components/label/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/label/template.test.js
@@ -42,7 +42,9 @@ describe('Label', () => {
       const $ = render('label', examples['html as text'])
 
       const labelText = $('.govuk-label').html().trim()
-      expect(labelText).toEqual('National Insurance number, &lt;em&gt;NINO&lt;/em&gt;')
+      expect(labelText).toEqual(
+        'National Insurance number, &lt;em&gt;NINO&lt;/em&gt;'
+      )
     })
 
     it('allows label HTML to be passed un-escaped', () => {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -18,8 +18,11 @@ export class NotificationBanner {
    * @param {Element} $module - HTML element to use for notification banner
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
-  constructor ($module, config) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module, config) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -46,7 +49,7 @@ export class NotificationBanner {
    *
    * @private
    */
-  setFocus () {
+  setFocus() {
     if (this.config.disableAutoFocus) {
       return
     }

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
@@ -1,4 +1,7 @@
-const { renderAndInitialise, goToComponent } = require('govuk-frontend-helpers/puppeteer')
+const {
+  renderAndInitialise,
+  goToComponent
+} = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
 describe('Notification banner, when type is set to "success"', () => {
@@ -13,7 +16,9 @@ describe('Notification banner, when type is set to "success"', () => {
       exampleName: 'with-type-as-success'
     })
 
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+    const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+      el.getAttribute('tabindex')
+    )
 
     expect(tabindex).toEqual('-1')
   })
@@ -23,7 +28,9 @@ describe('Notification banner, when type is set to "success"', () => {
       exampleName: 'with-type-as-success'
     })
 
-    const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+    const activeElement = await page.evaluate(() =>
+      document.activeElement.getAttribute('data-module')
+    )
 
     expect(activeElement).toBe('govuk-notification-banner')
   })
@@ -33,9 +40,14 @@ describe('Notification banner, when type is set to "success"', () => {
       exampleName: 'with-type-as-success'
     })
 
-    await page.$eval('.govuk-notification-banner', el => el instanceof window.HTMLElement && el.blur())
+    await page.$eval(
+      '.govuk-notification-banner',
+      (el) => el instanceof window.HTMLElement && el.blur()
+    )
 
-    const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+    const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+      el.getAttribute('tabindex')
+    )
     expect(tabindex).toBeNull()
   })
 
@@ -47,13 +59,17 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+      const activeElement = await page.evaluate(() =>
+        document.activeElement.getAttribute('data-module')
+      )
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -70,13 +86,17 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+      const activeElement = await page.evaluate(() =>
+        document.activeElement.getAttribute('data-module')
+      )
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -93,13 +113,17 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+      const activeElement = await page.evaluate(() =>
+        document.activeElement.getAttribute('data-module')
+      )
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -116,13 +140,17 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toEqual('-1')
     })
 
     it('is automatically focused when the page loads', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+      const activeElement = await page.evaluate(() =>
+        document.activeElement.getAttribute('data-module')
+      )
 
       expect(activeElement).toBe('govuk-notification-banner')
     })
@@ -131,18 +159,23 @@ describe('Notification banner, when type is set to "success"', () => {
   describe('and role is overridden to "region"', () => {
     beforeAll(async () => {
       await goToComponent(page, 'notification-banner', {
-        exampleName: 'role=alert-overridden-to-role=region,-with-type-as-success'
+        exampleName:
+          'role=alert-overridden-to-role=region,-with-type-as-success'
       })
     })
 
     it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBeNull()
     })
 
     it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.getAttribute('data-module'))
+      const activeElement = await page.evaluate(() =>
+        document.activeElement.getAttribute('data-module')
+      )
 
       expect(activeElement).not.toBe('govuk-notification-banner')
     })
@@ -156,9 +189,14 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('does not remove the tabindex attribute on blur', async () => {
-      await page.$eval('.govuk-notification-banner', el => el instanceof window.HTMLElement && el.blur())
+      await page.$eval(
+        '.govuk-notification-banner',
+        (el) => el instanceof window.HTMLElement && el.blur()
+      )
 
-      const tabindex = await page.$eval('.govuk-notification-banner', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+        el.getAttribute('tabindex')
+      )
       expect(tabindex).toEqual('2')
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
@@ -28,7 +28,9 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples.default)
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('data-module')).toEqual('govuk-notification-banner')
+      expect($component.attr('data-module')).toEqual(
+        'govuk-notification-banner'
+      )
     })
 
     it('renders header container', () => {
@@ -56,7 +58,9 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples.default)
       const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
+      expect($content.html().trim()).toEqual(
+        'This publication was withdrawn on 7 March 2014.'
+      )
     })
   })
 
@@ -72,11 +76,16 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['custom text'])
       const $content = $('.govuk-notification-banner__heading')
 
-      expect($content.html().trim()).toEqual('This publication was withdrawn on 7 March 2014.')
+      expect($content.html().trim()).toEqual(
+        'This publication was withdrawn on 7 March 2014.'
+      )
     })
 
     it('renders custom heading level', () => {
-      const $ = render('notification-banner', examples['custom title heading level'])
+      const $ = render(
+        'notification-banner',
+        examples['custom title heading level']
+      )
       const $title = $('.govuk-notification-banner__title')
 
       expect($title.get(0).tagName).toEqual('h3')
@@ -90,7 +99,10 @@ describe('Notification-banner', () => {
     })
 
     it('renders aria-labelledby attribute matching the title id when role overridden to region', () => {
-      const $ = render('notification-banner', examples['role=alert overridden to role=region, with type as success'])
+      const $ = render(
+        'notification-banner',
+        examples['role=alert overridden to role=region, with type as success']
+      )
       const ariaAttr = $('.govuk-notification-banner').attr('aria-labelledby')
       const titleId = $('.govuk-notification-banner__title').attr('id')
 
@@ -112,14 +124,20 @@ describe('Notification-banner', () => {
     })
 
     it('adds data-disable-auto-focus="true" if disableAutoFocus is true', () => {
-      const $ = render('notification-banner', examples['auto-focus disabled, with type as success'])
+      const $ = render(
+        'notification-banner',
+        examples['auto-focus disabled, with type as success']
+      )
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('data-disable-auto-focus')).toBe('true')
     })
 
     it('adds data-disable-auto-focus="false" if disableAutoFocus is false', () => {
-      const $ = render('notification-banner', examples['auto-focus explicitly enabled, with type as success'])
+      const $ = render(
+        'notification-banner',
+        examples['auto-focus explicitly enabled, with type as success']
+      )
 
       const $component = $('.govuk-notification-banner')
       expect($component.attr('data-disable-auto-focus')).toBe('false')
@@ -145,13 +163,21 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['title html as text'])
       const $title = $('.govuk-notification-banner__title')
 
-      expect($title.html().trim()).toEqual('&lt;span&gt;Important information&lt;/span&gt;')
+      expect($title.html().trim()).toEqual(
+        '&lt;span&gt;Important information&lt;/span&gt;'
+      )
     })
 
     it('renders nested components using `call`', () => {
-      const $ = render('notification-banner', {}, '<div class="app-nested-component"></div>')
+      const $ = render(
+        'notification-banner',
+        {},
+        '<div class="app-nested-component"></div>'
+      )
 
-      expect($('.govuk-notification-banner .app-nested-component').length).toBeTruthy()
+      expect(
+        $('.govuk-notification-banner .app-nested-component').length
+      ).toBeTruthy()
     })
 
     it('renders title as html', () => {
@@ -165,14 +191,18 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['html as text'])
       const $content = $('.govuk-notification-banner__content')
 
-      expect($content.html().trim()).toEqual('<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>')
+      expect($content.html().trim()).toEqual(
+        '<p class="govuk-notification-banner__heading">&lt;span&gt;This publication was withdrawn on 7 March 2014.&lt;/span&gt;</p>'
+      )
     })
 
     it('renders content as html', () => {
       const $ = render('notification-banner', examples['with text as html'])
       const $contentHtml = $('.govuk-notification-banner__content')
 
-      expect($contentHtml.html().trim()).toEqual('<h3 class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014</h3><p class="govuk-body">Archived and replaced by the <a href="#" class="govuk-notification-banner__link">new planning guidance</a> launched 6 March 2014 on an external website</p>')
+      expect($contentHtml.html().trim()).toEqual(
+        '<h3 class="govuk-notification-banner__heading">This publication was withdrawn on 7 March 2014</h3><p class="govuk-body">Archived and replaced by the <a href="#" class="govuk-notification-banner__link">new planning guidance</a> launched 6 March 2014 on an external website</p>'
+      )
     })
   })
 
@@ -181,7 +211,9 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['with type as success'])
 
       const $component = $('.govuk-notification-banner')
-      expect($component.hasClass('govuk-notification-banner--success')).toBeTruthy()
+      expect(
+        $component.hasClass('govuk-notification-banner--success')
+      ).toBeTruthy()
     })
 
     it('has role=alert attribute', () => {
@@ -195,7 +227,9 @@ describe('Notification-banner', () => {
       const $ = render('notification-banner', examples['with type as success'])
       const $component = $('.govuk-notification-banner')
 
-      expect($component.attr('aria-labelledby')).toEqual('govuk-notification-banner-title')
+      expect($component.attr('aria-labelledby')).toEqual(
+        'govuk-notification-banner-title'
+      )
     })
 
     it('renders a title id for aria-labelledby', () => {
@@ -213,7 +247,10 @@ describe('Notification-banner', () => {
     })
 
     it('renders custom title id and aria-labelledby', () => {
-      const $ = render('notification-banner', examples['custom title id with type as success'])
+      const $ = render(
+        'notification-banner',
+        examples['custom title id with type as success']
+      )
       const $component = $('.govuk-notification-banner')
       const $title = $('.govuk-notification-banner__title')
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -13,9 +13,15 @@ describe('Pagination', () => {
       const $ = render('pagination', examples.default)
       const $previous = $('.govuk-pagination__prev .govuk-pagination__link')
       const $next = $('.govuk-pagination__next .govuk-pagination__link')
-      const $firstNumber = $('.govuk-pagination__item:first-child .govuk-pagination__link')
-      const $secondNumber = $('.govuk-pagination__item:nth-child(2) .govuk-pagination__link')
-      const $thirdNumber = $('.govuk-pagination__item:last-child .govuk-pagination__link')
+      const $firstNumber = $(
+        '.govuk-pagination__item:first-child .govuk-pagination__link'
+      )
+      const $secondNumber = $(
+        '.govuk-pagination__item:nth-child(2) .govuk-pagination__link'
+      )
+      const $thirdNumber = $(
+        '.govuk-pagination__item:last-child .govuk-pagination__link'
+      )
 
       expect($previous.attr('href')).toEqual('/previous')
       expect($next.attr('href')).toEqual('/next')
@@ -48,7 +54,9 @@ describe('Pagination', () => {
 
     it('marks up pagination items as ellipses when specified', () => {
       const $ = render('pagination', examples['with many pages'])
-      const $firstEllipsis = $('.govuk-pagination__item:nth-child(2).govuk-pagination__item--ellipses')
+      const $firstEllipsis = $(
+        '.govuk-pagination__item:nth-child(2).govuk-pagination__item--ellipses'
+      )
 
       expect($firstEllipsis).toBeTruthy()
       // Test for the unicode character of &ctdot;
@@ -58,7 +66,10 @@ describe('Pagination', () => {
 
   describe('with custom text, labels and landmarks', () => {
     it('renders a custom navigation landmark', () => {
-      const $ = render('pagination', examples['with custom navigation landmark'])
+      const $ = render(
+        'pagination',
+        examples['with custom navigation landmark']
+      )
       const $nav = $('.govuk-pagination')
 
       expect($nav.attr('aria-label')).toEqual('search')
@@ -80,13 +91,24 @@ describe('Pagination', () => {
     })
 
     it('renders custom accessible labels for pagination items', () => {
-      const $ = render('pagination', examples['with custom accessible labels on item links'])
-      const $firstNumber = $('.govuk-pagination__item:first-child .govuk-pagination__link')
-      const $secondNumber = $('.govuk-pagination__item:nth-child(2) .govuk-pagination__link')
-      const $thirdNumber = $('.govuk-pagination__item:last-child .govuk-pagination__link')
+      const $ = render(
+        'pagination',
+        examples['with custom accessible labels on item links']
+      )
+      const $firstNumber = $(
+        '.govuk-pagination__item:first-child .govuk-pagination__link'
+      )
+      const $secondNumber = $(
+        '.govuk-pagination__item:nth-child(2) .govuk-pagination__link'
+      )
+      const $thirdNumber = $(
+        '.govuk-pagination__item:last-child .govuk-pagination__link'
+      )
 
       expect($firstNumber.attr('aria-label')).toEqual('1st page')
-      expect($secondNumber.attr('aria-label')).toEqual('2nd page (you are currently on this page)')
+      expect($secondNumber.attr('aria-label')).toEqual(
+        '2nd page (you are currently on this page)'
+      )
       expect($thirdNumber.attr('aria-label')).toEqual('3rd page')
     })
   })
@@ -133,9 +155,16 @@ describe('Pagination', () => {
     })
 
     it('applies labels when provided', () => {
-      const $ = render('pagination', examples['with prev and next only and labels'])
-      const $prevLabel = $('.govuk-pagination__prev .govuk-pagination__link-label')
-      const $nextLabel = $('.govuk-pagination__next .govuk-pagination__link-label')
+      const $ = render(
+        'pagination',
+        examples['with prev and next only and labels']
+      )
+      const $prevLabel = $(
+        '.govuk-pagination__prev .govuk-pagination__link-label'
+      )
+      const $nextLabel = $(
+        '.govuk-pagination__next .govuk-pagination__link-label'
+      )
 
       expect($prevLabel.text()).toEqual('Paying VAT and duty')
       expect($nextLabel.text()).toEqual('Registering an imported vehicle')
@@ -146,8 +175,12 @@ describe('Pagination', () => {
     // of the label so that there's a clear underline hover state on the link
     it('adds the decoration class to the link title if no label is present', () => {
       const $ = render('pagination', examples['with prev and next only'])
-      const $decoratedPreviousLinkTitle = $('.govuk-pagination__prev .govuk-pagination__link-title--decorated')
-      const $decoratedNextLinkTitle = $('.govuk-pagination__next .govuk-pagination__link-title--decorated')
+      const $decoratedPreviousLinkTitle = $(
+        '.govuk-pagination__prev .govuk-pagination__link-title--decorated'
+      )
+      const $decoratedNextLinkTitle = $(
+        '.govuk-pagination__next .govuk-pagination__link-title--decorated'
+      )
 
       expect($decoratedPreviousLinkTitle).toBeTruthy()
       expect($decoratedNextLinkTitle).toBeTruthy()

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -43,7 +43,9 @@ describe('Panel', () => {
       const $ = render('panel', examples['title html as text'])
 
       const panelTitle = $('.govuk-panel__title').html().trim()
-      expect(panelTitle).toEqual('Application &lt;strong&gt;not&lt;/strong&gt; complete')
+      expect(panelTitle).toEqual(
+        'Application &lt;strong&gt;not&lt;/strong&gt; complete'
+      )
     })
 
     it('renders title as specified heading level', () => {
@@ -70,14 +72,18 @@ describe('Panel', () => {
       const $ = render('panel', examples['body html as text'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
-      expect(panelBodyText).toEqual('Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;')
+      expect(panelBodyText).toEqual(
+        'Your reference number&lt;br&gt;&lt;strong&gt;HDJ2123F&lt;/strong&gt;'
+      )
     })
 
     it('allows body HTML to be passed un-escaped', () => {
       const $ = render('panel', examples['body html'])
 
       const panelBodyText = $('.govuk-panel__body').html().trim()
-      expect(panelBodyText).toEqual('Your reference number<br><strong>HDJ2123F</strong>')
+      expect(panelBodyText).toEqual(
+        'Your reference number<br><strong>HDJ2123F</strong>'
+      )
     })
 
     it('allows additional classes to be added to the component', () => {

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
@@ -21,21 +21,27 @@ describe('Phase banner', () => {
       const $ = render('phase-banner', examples.text)
       const phaseBannerText = $('.govuk-phase-banner__text').text().trim()
 
-      expect(phaseBannerText).toEqual('This is a new service – your feedback will help us to improve it')
+      expect(phaseBannerText).toEqual(
+        'This is a new service – your feedback will help us to improve it'
+      )
     })
 
     it('allows body text to be passed whilst escaping HTML entities', () => {
       const $ = render('phase-banner', examples['html as text'])
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
-      expect(phaseBannerText).toEqual('This is a new service - your &lt;a href="#" class="govuk-link"&gt;feedback&lt;/a&gt; will help us to improve it.')
+      expect(phaseBannerText).toEqual(
+        'This is a new service - your &lt;a href="#" class="govuk-link"&gt;feedback&lt;/a&gt; will help us to improve it.'
+      )
     })
 
     it('allows body HTML to be passed un-escaped', () => {
       const $ = render('phase-banner', examples.default)
 
       const phaseBannerText = $('.govuk-phase-banner__text').html().trim()
-      expect(phaseBannerText).toEqual('This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.')
+      expect(phaseBannerText).toEqual(
+        'This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.'
+      )
     })
 
     it('allows additional attributes to be added to the component', () => {
@@ -51,19 +57,25 @@ describe('Phase banner', () => {
     it('renders the tag component text', () => {
       const $ = render('phase-banner', examples.default)
 
-      expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
+      expect(
+        htmlWithClassName($, '.govuk-phase-banner__content__tag')
+      ).toMatchSnapshot()
     })
 
     it('renders the tag component html', () => {
       const $ = render('phase-banner', examples['tag html'])
 
-      expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
+      expect(
+        htmlWithClassName($, '.govuk-phase-banner__content__tag')
+      ).toMatchSnapshot()
     })
 
     it('renders the tag component classes', () => {
       const $ = render('phase-banner', examples['tag classes'])
 
-      expect(htmlWithClassName($, '.govuk-phase-banner__content__tag')).toMatchSnapshot()
+      expect(
+        htmlWithClassName($, '.govuk-phase-banner__content__tag')
+      ).toMatchSnapshot()
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -22,8 +22,11 @@ export class Radios {
    *
    * @param {Element} $module - HTML element to use for radios
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -70,8 +73,10 @@ export class Radios {
    *
    * @private
    */
-  syncAllConditionalReveals () {
-    this.$inputs.forEach(($input) => this.syncConditionalRevealWithInputState($input))
+  syncAllConditionalReveals() {
+    this.$inputs.forEach(($input) =>
+      this.syncConditionalRevealWithInputState($input)
+    )
   }
 
   /**
@@ -83,7 +88,7 @@ export class Radios {
    * @private
    * @param {HTMLInputElement} $input - Radio input
    */
-  syncConditionalRevealWithInputState ($input) {
+  syncConditionalRevealWithInputState($input) {
     const targetId = $input.getAttribute('aria-controls')
     if (!targetId) {
       return
@@ -94,7 +99,10 @@ export class Radios {
       const inputIsChecked = $input.checked
 
       $input.setAttribute('aria-expanded', inputIsChecked.toString())
-      $target.classList.toggle('govuk-radios__conditional--hidden', !inputIsChecked)
+      $target.classList.toggle(
+        'govuk-radios__conditional--hidden',
+        !inputIsChecked
+      )
     }
   }
 
@@ -109,18 +117,23 @@ export class Radios {
    * @private
    * @param {MouseEvent} event - Click event
    */
-  handleClick (event) {
+  handleClick(event) {
     const $clickedInput = event.target
 
     // Ignore clicks on things that aren't radio buttons
-    if (!($clickedInput instanceof HTMLInputElement) || $clickedInput.type !== 'radio') {
+    if (
+      !($clickedInput instanceof HTMLInputElement) ||
+      $clickedInput.type !== 'radio'
+    ) {
       return
     }
 
     // We only need to consider radios with conditional reveals, which will have
     // aria-controls attributes.
     /** @satisfies {NodeListOf<HTMLInputElement>} */
-    const $allInputs = document.querySelectorAll('input[type="radio"][aria-controls]')
+    const $allInputs = document.querySelectorAll(
+      'input[type="radio"][aria-controls]'
+    )
 
     const $clickedInputForm = $clickedInput.form
     const $clickedInputName = $clickedInput.name

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
@@ -1,4 +1,10 @@
-const { goToComponent, goToExample, getProperty, getAttribute, isVisible } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  goToExample,
+  getProperty,
+  getAttribute,
+  isVisible
+} = require('govuk-frontend-helpers/puppeteer')
 
 describe('Radios with conditional reveals', () => {
   describe('when JavaScript is unavailable or fails', () => {
@@ -29,17 +35,23 @@ describe('Radios with conditional reveals', () => {
       })
 
       it('has no ARIA attributes applied', async () => {
-        const $inputsWithAriaExpanded = await $component.$$('.govuk-radios__input[aria-expanded]')
-        const $inputsWithAriaControls = await $component.$$('.govuk-radios__input[aria-controls]')
+        const $inputsWithAriaExpanded = await $component.$$(
+          '.govuk-radios__input[aria-expanded]'
+        )
+        const $inputsWithAriaControls = await $component.$$(
+          '.govuk-radios__input[aria-controls]'
+        )
 
         expect($inputsWithAriaExpanded.length).toBe(0)
         expect($inputsWithAriaControls.length).toBe(0)
       })
 
       it('falls back to making all conditional content visible', async () => {
-        return Promise.all($conditionals.map(async ($conditional) => {
-          return expect(await isVisible($conditional)).toBe(true)
-        }))
+        return Promise.all(
+          $conditionals.map(async ($conditional) => {
+            return expect(await isVisible($conditional)).toBe(true)
+          })
+        )
       })
     })
   })
@@ -60,7 +72,9 @@ describe('Radios with conditional reveals', () => {
 
       it('has conditional content revealed that is associated with a checked input', async () => {
         const $input = $inputs[0] // First input, checked
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         expect(await getProperty($input, 'checked')).toBe(true)
         expect(await isVisible($conditional)).toBe(true)
@@ -68,7 +82,9 @@ describe('Radios with conditional reveals', () => {
 
       it('has no conditional content revealed that is associated with an unchecked input', async () => {
         const $input = $inputs[$inputs.length - 1] // Last input, unchecked
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         expect(await getProperty($input, 'checked')).toBe(false)
         expect(await isVisible($conditional)).toBe(false)
@@ -110,7 +126,9 @@ describe('Radios with conditional reveals', () => {
 
       it('toggles the conditional content when clicking an input', async () => {
         const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         // Initially collapsed
         expect(await getProperty($input, 'checked')).toBe(false)
@@ -131,7 +149,9 @@ describe('Radios with conditional reveals', () => {
 
       it('toggles the conditional content when using an input with a keyboard', async () => {
         const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(`[id="${await getAttribute($input, 'aria-controls')}"]`)
+        const $conditional = await $component.$(
+          `[id="${await getAttribute($input, 'aria-controls')}"]`
+        )
 
         // Initially collapsed
         expect(await getProperty($input, 'checked')).toBe(false)
@@ -174,12 +194,18 @@ describe('Radios with multiple groups', () => {
 
       $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
       $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
-      $inputsNotInForm = await page.$$('.govuk-radios__input[id^="question-not-in-form"]')
+      $inputsNotInForm = await page.$$(
+        '.govuk-radios__input[id^="question-not-in-form"]'
+      )
     })
 
     it('toggles conditional reveals in other groups', async () => {
-      const $conditionalWarm = await page.$(`[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`)
-      const $conditionalCool = await page.$(`[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`)
+      const $conditionalWarm = await page.$(
+        `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
+      )
+      const $conditionalCool = await page.$(
+        `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
+      )
 
       // Select red in warm colours
       await $inputsWarm[0].click()
@@ -195,7 +221,9 @@ describe('Radios with multiple groups', () => {
     })
 
     it('toggles conditional reveals when not in a form', async () => {
-      const $conditionalWarm = await page.$(`[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`)
+      const $conditionalWarm = await page.$(
+        `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
+      )
 
       // Select first input in radios not in a form
       await $inputsNotInForm[0].click()
@@ -218,7 +246,9 @@ describe('Radios with multiple groups and conditional reveals', () => {
     })
 
     it('hides conditional reveals in other groups', async () => {
-      const $conditionalPrimary = await page.$(`[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`)
+      const $conditionalPrimary = await page.$(
+        `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
+      )
 
       // Choose the second radio in the first group, which reveals additional content
       await $inputsPrimary[1].click()

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -339,13 +339,13 @@ describe('Radios', () => {
       const $ = render('radios', examples['with fieldset and error message'])
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
@@ -355,15 +355,13 @@ describe('Radios', () => {
       )
 
       const $fieldset = $('.govuk-fieldset')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('renders with a form group wrapper that has an error state', () => {
@@ -382,11 +380,11 @@ describe('Radios', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
@@ -399,11 +397,11 @@ describe('Radios', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
+      const describedByCombined = new RegExp(
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -65,7 +65,10 @@ describe('Radios', () => {
   })
 
   it('render a custom class on the form group', () => {
-    const $ = render('radios', examples['with optional form-group classes showing group error'])
+    const $ = render(
+      'radios',
+      examples['with optional form-group classes showing group error']
+    )
 
     const $formGroup = $('.govuk-form-group')
     expect($formGroup.hasClass('govuk-form-group--error')).toBeTruthy()
@@ -77,8 +80,12 @@ describe('Radios', () => {
 
       const $component = $('.govuk-radios')
 
-      const $firstInput = $component.find('.govuk-radios__item:first-child input')
-      const $firstLabel = $component.find('.govuk-radios__item:first-child label')
+      const $firstInput = $component.find(
+        '.govuk-radios__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-radios__item:first-child label'
+      )
       expect($firstInput.attr('id')).toEqual('example-default')
       expect($firstLabel.attr('for')).toEqual('example-default')
 
@@ -93,8 +100,12 @@ describe('Radios', () => {
 
       const $component = $('.govuk-radios')
 
-      const $firstInput = $component.find('.govuk-radios__item:first-child input')
-      const $firstLabel = $component.find('.govuk-radios__item:first-child label')
+      const $firstInput = $component.find(
+        '.govuk-radios__item:first-child input'
+      )
+      const $firstLabel = $component.find(
+        '.govuk-radios__item:first-child label'
+      )
       expect($firstInput.attr('id')).toEqual('example-id-prefix')
       expect($firstLabel.attr('for')).toEqual('example-id-prefix')
 
@@ -142,11 +153,15 @@ describe('Radios', () => {
 
         const $component = $('.govuk-radios')
 
-        const $firstInput = $component.find('.govuk-radios__item:first-child input')
+        const $firstInput = $component.find(
+          '.govuk-radios__item:first-child input'
+        )
         expect($firstInput.attr('data-attribute')).toEqual('ABC')
         expect($firstInput.attr('data-second-attribute')).toEqual('DEF')
 
-        const $lastInput = $component.find('.govuk-radios__item:last-child input')
+        const $lastInput = $component.find(
+          '.govuk-radios__item:last-child input'
+        )
         expect($lastInput.attr('data-attribute')).toEqual('GHI')
         expect($lastInput.attr('data-second-attribute')).toEqual('JKL')
       })
@@ -156,8 +171,9 @@ describe('Radios', () => {
       it('it renders the hint text', () => {
         const $ = render('radios', examples['with hints on items'])
 
-        expect($('.govuk-radios__hint').text())
-          .toContain('You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.')
+        expect($('.govuk-radios__hint').text()).toContain(
+          'You’ll have a user ID if you’ve registered for Self Assessment or filed a tax return online before.'
+        )
       })
 
       it('it renders the correct id attribute for the hint', () => {
@@ -169,7 +185,9 @@ describe('Radios', () => {
       it('the input describedBy attribute matches the item hint id', () => {
         const $ = render('radios', examples['with hints on items'])
 
-        expect($('.govuk-radios__input').attr('aria-describedby')).toBe('gateway-item-hint')
+        expect($('.govuk-radios__input').attr('aria-describedby')).toBe(
+          'gateway-item-hint'
+        )
       })
     })
 
@@ -179,17 +197,26 @@ describe('Radios', () => {
 
         const $component = $('.govuk-radios')
 
-        const $hiddenConditional = $component.find('.govuk-radios__conditional').first()
+        const $hiddenConditional = $component
+          .find('.govuk-radios__conditional')
+          .first()
         expect($hiddenConditional.text()).toContain('Email address')
-        expect($hiddenConditional.hasClass('govuk-radios__conditional--hidden')).toBeTruthy()
+        expect(
+          $hiddenConditional.hasClass('govuk-radios__conditional--hidden')
+        ).toBeTruthy()
       })
 
       it('visible when checked because of checkedValue', () => {
-        const $ = render('radios', examples['with conditional items and pre-checked value'])
+        const $ = render(
+          'radios',
+          examples['with conditional items and pre-checked value']
+        )
 
         const $conditional = $('.govuk-radios__conditional').last()
         expect($conditional.text()).toContain('Mobile phone number')
-        expect($conditional.hasClass('govuk-radios__conditional--hidden')).toBeFalsy()
+        expect(
+          $conditional.hasClass('govuk-radios__conditional--hidden')
+        ).toBeFalsy()
       })
 
       it('visible by default when checked', () => {
@@ -197,9 +224,13 @@ describe('Radios', () => {
 
         const $component = $('.govuk-radios')
 
-        const $visibleConditional = $component.find('.govuk-radios__conditional').first()
+        const $visibleConditional = $component
+          .find('.govuk-radios__conditional')
+          .first()
         expect($visibleConditional.text()).toContain('Email')
-        expect($visibleConditional.hasClass('govuk-radios__conditional--hidden')).toBeFalsy()
+        expect(
+          $visibleConditional.hasClass('govuk-radios__conditional--hidden')
+        ).toBeFalsy()
       })
 
       it('with association to the input they are controlled by', () => {
@@ -208,9 +239,13 @@ describe('Radios', () => {
         const $component = $('.govuk-radios')
 
         const $firstInput = $component.find('.govuk-radios__input').first()
-        const $firstConditional = $component.find('.govuk-radios__conditional').first()
+        const $firstConditional = $component
+          .find('.govuk-radios__conditional')
+          .first()
 
-        expect($firstInput.attr('data-aria-controls')).toBe('conditional-how-contacted')
+        expect($firstInput.attr('data-aria-controls')).toBe(
+          'conditional-how-contacted'
+        )
         expect($firstConditional.attr('id')).toBe('conditional-how-contacted')
       })
 
@@ -265,7 +300,9 @@ describe('Radios', () => {
 
       const $fieldset = $('.govuk-fieldset')
 
-      expect($fieldset.attr('aria-describedby')).toMatch('example-multiple-hints-hint')
+      expect($fieldset.attr('aria-describedby')).toMatch(
+        'example-multiple-hints-hint'
+      )
     })
 
     it('associates the fieldset as "described by" the hint and parent fieldset', () => {
@@ -308,22 +345,25 @@ describe('Radios', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the fieldset as "described by" the error message and parent fieldset', () => {
-      const $ = render('radios', examples['with fieldset, error message and describedBy'])
+      const $ = render(
+        'radios',
+        examples['with fieldset, error message and describedBy']
+      )
 
       const $fieldset = $('.govuk-fieldset')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($fieldset.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('renders with a form group wrapper that has an error state', () => {
@@ -346,12 +386,14 @@ describe('Radios', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the fieldset as described by the hint, error message and parent fieldset', () => {
-      const $ = render('radios', examples['with hint, error message and describedBy'])
+      const $ = render(
+        'radios',
+        examples['with hint, error message and describedBy']
+      )
 
       const $fieldset = $('.govuk-fieldset')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -361,8 +403,7 @@ describe('Radios', () => {
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($fieldset.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($fieldset.attr('aria-describedby')).toMatch(combinedIds)
     })
   })
 
@@ -370,7 +411,9 @@ describe('Radios', () => {
     it('have correct nesting order', () => {
       const $ = render('radios', examples.inline)
 
-      const $component = $('.govuk-form-group > .govuk-fieldset > .govuk-radios')
+      const $component = $(
+        '.govuk-form-group > .govuk-fieldset > .govuk-radios'
+      )
       expect($component.length).toBeTruthy()
     })
 

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -188,8 +188,7 @@ describe('Select', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($select.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($select.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('associates the select as "described by" the hint and parent fieldset', () => {
@@ -197,8 +196,7 @@ describe('Select', () => {
 
       const $select = $('.govuk-select')
 
-      expect($select.attr('aria-describedby'))
-        .toMatch('some-id')
+      expect($select.attr('aria-describedby')).toMatch('some-id')
     })
   })
 
@@ -219,8 +217,7 @@ describe('Select', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($input.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the select as "described by" the error message and parent fieldset', () => {
@@ -228,8 +225,7 @@ describe('Select', () => {
 
       const $input = $('.govuk-select')
 
-      expect($input.attr('aria-describedby'))
-        .toMatch('some-id')
+      expect($input.attr('aria-describedby')).toMatch('some-id')
     })
 
     it('adds the error class to the select', () => {
@@ -259,8 +255,7 @@ describe('Select', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the select as described by the hint, error message and parent fieldset', () => {
@@ -268,8 +263,9 @@ describe('Select', () => {
 
       const $component = $('.govuk-select')
 
-      expect($component.attr('aria-describedby'))
-        .toMatch('select-2-hint select-2-error')
+      expect($component.attr('aria-describedby')).toMatch(
+        'select-2-hint select-2-error'
+      )
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -182,13 +182,13 @@ describe('Select', () => {
       const $ = render('select', examples.hint)
 
       const $select = $('.govuk-select')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($select.attr('aria-describedby')).toMatch(hintId)
+      expect($select.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the select as "described by" the hint and parent fieldset', () => {
@@ -211,13 +211,13 @@ describe('Select', () => {
       const $ = render('select', examples.error)
 
       const $input = $('.govuk-select')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($input.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($input.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the select as "described by" the error message and parent fieldset', () => {
@@ -251,11 +251,11 @@ describe('Select', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the select as described by the hint, error message and parent fieldset', () => {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -18,8 +18,11 @@ export class SkipLink {
    *
    * @param {Element} $module - HTML element to use for skip link
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLAnchorElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLAnchorElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -41,7 +44,7 @@ export class SkipLink {
    * @private
    * @returns {HTMLElement | null} $linkedElement - DOM element linked to from the skip link
    */
-  getLinkedElement () {
+  getLinkedElement() {
     const linkedElementId = this.getFragmentFromUrl()
     if (!linkedElementId) {
       return null
@@ -57,7 +60,7 @@ export class SkipLink {
    *
    * @private
    */
-  focusLinkedElement () {
+  focusLinkedElement() {
     if (!this.$linkedElement.getAttribute('tabindex')) {
       // Set the element tabindex to -1 so it can be focused with JavaScript.
       this.$linkedElement.setAttribute('tabindex', '-1')
@@ -65,7 +68,9 @@ export class SkipLink {
 
       // Add listener for blur on the focused element (unless the listener has previously been added)
       if (!this.linkedElementListener) {
-        this.$linkedElement.addEventListener('blur', () => this.removeFocusProperties())
+        this.$linkedElement.addEventListener('blur', () =>
+          this.removeFocusProperties()
+        )
         this.linkedElementListener = true
       }
     }
@@ -81,7 +86,7 @@ export class SkipLink {
    *
    * @private
    */
-  removeFocusProperties () {
+  removeFocusProperties() {
     this.$linkedElement.removeAttribute('tabindex')
     this.$linkedElement.classList.remove('govuk-skip-link-focused-element')
   }
@@ -95,7 +100,7 @@ export class SkipLink {
    * @private
    * @returns {string | undefined} Fragment from URL, without the hash symbol
    */
-  getFragmentFromUrl () {
+  getFragmentFromUrl() {
     // Bail if the anchor link doesn't have a hash
     if (!this.$module.hash) {
       return

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -15,29 +15,43 @@ describe('/examples/template-default', () => {
     })
 
     it('adds the tabindex attribute to the linked element', async () => {
-      const tabindex = await page.$eval('.govuk-main-wrapper', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-main-wrapper', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBe('-1')
     })
 
     it('adds the class for removing the native focus style to the linked element', async () => {
-      const cssClass = await page.$eval('.govuk-main-wrapper', el => el.classList.contains('govuk-skip-link-focused-element'))
+      const cssClass = await page.$eval('.govuk-main-wrapper', (el) =>
+        el.classList.contains('govuk-skip-link-focused-element')
+      )
 
       expect(cssClass).toBeTruthy()
     })
 
     it('removes the tabindex attribute from the linked element on blur', async () => {
-      await page.$eval('.govuk-main-wrapper', el => el instanceof window.HTMLElement && el.blur())
+      await page.$eval(
+        '.govuk-main-wrapper',
+        (el) => el instanceof window.HTMLElement && el.blur()
+      )
 
-      const tabindex = await page.$eval('.govuk-main-wrapper', el => el.getAttribute('tabindex'))
+      const tabindex = await page.$eval('.govuk-main-wrapper', (el) =>
+        el.getAttribute('tabindex')
+      )
 
       expect(tabindex).toBeNull()
     })
 
     it('removes the class for removing the native focus style from the linked element on blur', async () => {
-      await page.$eval('.govuk-main-wrapper', el => el instanceof window.HTMLElement && el.blur())
+      await page.$eval(
+        '.govuk-main-wrapper',
+        (el) => el instanceof window.HTMLElement && el.blur()
+      )
 
-      const cssClass = await page.$eval('.govuk-main-wrapper', el => el.getAttribute('class'))
+      const cssClass = await page.$eval('.govuk-main-wrapper', (el) =>
+        el.getAttribute('class')
+      )
 
       expect(cssClass).not.toContain('govuk-skip-link-focused-element')
     })

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
@@ -123,7 +123,9 @@ describe('Summary list', () => {
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
-        expect($actionLink.html()).toContain('Edit<span class="visually-hidden"> name</span>')
+        expect($actionLink.html()).toContain(
+          'Edit<span class="visually-hidden"> name</span>'
+        )
       })
 
       it('allows the visually hidden prefix to be removed and then manually added with HTML', async () => {
@@ -132,7 +134,9 @@ describe('Summary list', () => {
         const $component = $('.govuk-summary-list')
         const $actionLink = $component.find('.govuk-summary-list__actions > a')
 
-        expect($actionLink.html()).toContain('Golygu<span class="govuk-visually-hidden"> dyddiad geni</span>')
+        expect($actionLink.html()).toContain(
+          'Golygu<span class="govuk-visually-hidden"> dyddiad geni</span>'
+        )
       })
 
       it('renders custom accessible name', async () => {
@@ -176,7 +180,9 @@ describe('Summary list', () => {
 
         const $component = $('.govuk-summary-list')
         const $actionList = $component.find('.govuk-summary-list__actions')
-        const $secondAction = $actionList.find('.govuk-summary-list__actions-list-item:last-child')
+        const $secondAction = $actionList.find(
+          '.govuk-summary-list__actions-list-item:last-child'
+        )
 
         expect($secondAction.text().trim()).toBe('Delete name')
       })
@@ -219,14 +225,22 @@ describe('Summary list', () => {
 
         it('does not add no-actions modifier class to rows with actions', () => {
           // The first row has actions
-          const $firstRow = $component.find('.govuk-summary-list__row:first-child')
-          expect($firstRow.hasClass('govuk-summary-list__row--no-actions')).toBeFalsy()
+          const $firstRow = $component.find(
+            '.govuk-summary-list__row:first-child'
+          )
+          expect(
+            $firstRow.hasClass('govuk-summary-list__row--no-actions')
+          ).toBeFalsy()
         })
 
         it('adds no-actions modifier class to rows without actions', () => {
           // The second row does not have actions
-          const $secondRow = $component.find('.govuk-summary-list__row:nth-child(2)')
-          expect($secondRow.hasClass('govuk-summary-list__row--no-actions')).toBeTruthy()
+          const $secondRow = $component.find(
+            '.govuk-summary-list__row:nth-child(2)'
+          )
+          expect(
+            $secondRow.hasClass('govuk-summary-list__row--no-actions')
+          ).toBeTruthy()
         })
       })
 
@@ -242,7 +256,9 @@ describe('Summary list', () => {
         it('does not add no-actions modifier class to any of the rows', () => {
           // The first row has actions
           const $rows = $component.find('.govuk-summary-list__row')
-          expect($rows.hasClass('govuk-summary-list__row--no-actions')).toBeFalsy()
+          expect(
+            $rows.hasClass('govuk-summary-list__row--no-actions')
+          ).toBeFalsy()
         })
       })
     })
@@ -256,39 +272,58 @@ describe('Summary list', () => {
     // This is already tested in depth in the 'actions' describe above.
     describe('actions', () => {
       it('renders actions', () => {
-        const $ = render('summary-list', examples['as a summary card with actions'])
+        const $ = render(
+          'summary-list',
+          examples['as a summary card with actions']
+        )
 
         const $actionItems = $('.govuk-summary-card__action')
         expect($actionItems.length).toBe(2)
       })
 
       it('does not render a list if only one action is present', () => {
-        const $ = render('summary-list', examples['summary card with only 1 action'])
+        const $ = render(
+          'summary-list',
+          examples['summary card with only 1 action']
+        )
 
         const $singleAction = $('.govuk-summary-card__actions > a')
         const $actionItems = $('.govuk-summary-card__action')
         expect($actionItems.length).toBe(0)
-        expect($singleAction.text().trim()).toBe('My lonely action (Undergraduate teaching assistant)')
+        expect($singleAction.text().trim()).toBe(
+          'My lonely action (Undergraduate teaching assistant)'
+        )
       })
     })
 
     describe('title', () => {
       it('renders with a text title', () => {
-        const $ = render('summary-list', examples['as a summary card with a text header'])
+        const $ = render(
+          'summary-list',
+          examples['as a summary card with a text header']
+        )
 
         const $title = $('.govuk-summary-card__title')
         expect($title.text()).toContain('Undergraduate teaching assistant')
       })
 
       it('renders with a html title', () => {
-        const $ = render('summary-list', examples['as a summary card with a html header'])
+        const $ = render(
+          'summary-list',
+          examples['as a summary card with a html header']
+        )
 
         const $title = $('.govuk-summary-card__title')
-        expect($title.html()).toContain('<em>Undergraduate teaching assistant</em>')
+        expect($title.html()).toContain(
+          '<em>Undergraduate teaching assistant</em>'
+        )
       })
 
       it('renders with a custom heading level', () => {
-        const $ = render('summary-list', examples['as a summary card with a custom header level'])
+        const $ = render(
+          'summary-list',
+          examples['as a summary card with a custom header level']
+        )
 
         const $title = $('.govuk-summary-card__title')
         expect($title.get(0).tagName).toEqual('h3')
@@ -297,7 +332,10 @@ describe('Summary list', () => {
 
     describe('custom options', () => {
       it('renders custom classes on the summary card', () => {
-        const $ = render('summary-list', examples['summary card with custom classes'])
+        const $ = render(
+          'summary-list',
+          examples['summary card with custom classes']
+        )
 
         const $list = $('.govuk-summary-list')
         const $card = $('.govuk-summary-card')
@@ -306,7 +344,10 @@ describe('Summary list', () => {
       })
 
       it('renders with attributes on the summary card', () => {
-        const $ = render('summary-list', examples['summary card with custom attributes'])
+        const $ = render(
+          'summary-list',
+          examples['summary card with custom attributes']
+        )
 
         const $list = $('.govuk-summary-list')
         const $card = $('.govuk-summary-card')

--- a/packages/govuk-frontend/src/govuk/components/table/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/table/template.test.js
@@ -49,7 +49,8 @@ describe('Table', () => {
       const args = examples['table with head']
       const $ = render('table', args)
 
-      const headings = $('.govuk-table').find('thead tr th')
+      const headings = $('.govuk-table')
+        .find('thead tr th')
         .map((_, e) => $(e).text())
         .get()
 
@@ -65,7 +66,9 @@ describe('Table', () => {
 
       const $th = $('.govuk-table thead tr th')
 
-      expect($th.html()).toEqual('Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;')
+      expect($th.html()).toEqual(
+        'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
+      )
     })
 
     it('allow HTML when passed as HTML', () => {
@@ -126,13 +129,22 @@ describe('Table', () => {
       it('are not included', () => {
         const $ = render('table', examples.default)
 
-        const cells = $('.govuk-table').find('tbody tr td')
+        const cells = $('.govuk-table')
+          .find('tbody tr td')
           .map((_, e) => $(e).text())
           .get()
 
-        expect(cells).toEqual(
-          ['January', '£85', '£95', 'February', '£75', '£55', 'March', '£165', '£125']
-        )
+        expect(cells).toEqual([
+          'January',
+          '£85',
+          '£95',
+          'February',
+          '£75',
+          '£55',
+          'March',
+          '£165',
+          '£125'
+        ])
       })
     })
 
@@ -140,7 +152,8 @@ describe('Table', () => {
       it('are included', () => {
         const $ = render('table', examples['with firstCellIsHeader true'])
 
-        const headings = $('.govuk-table').find('tbody tr th')
+        const headings = $('.govuk-table')
+          .find('tbody tr th')
           .map((_, e) => $(e).text())
           .get()
 
@@ -148,11 +161,16 @@ describe('Table', () => {
       })
 
       it('have HTML escaped when passed as text', () => {
-        const $ = render('table', examples['firstCellIsHeader with html as text'])
+        const $ = render(
+          'table',
+          examples['firstCellIsHeader with html as text']
+        )
 
         const $th = $('.govuk-table tbody tr th')
 
-        expect($th.html()).toEqual('Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;')
+        expect($th.html()).toEqual(
+          'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
+        )
       })
 
       it('allow HTML when passed as HTML', () => {
@@ -188,7 +206,10 @@ describe('Table', () => {
       })
 
       it('can have rowspan specified', () => {
-        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
+        const $ = render(
+          'table',
+          examples['firstCellIsHeader with rowspan and colspan']
+        )
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -196,7 +217,10 @@ describe('Table', () => {
       })
 
       it('can have colspan specified', () => {
-        const $ = render('table', examples['firstCellIsHeader with rowspan and colspan'])
+        const $ = render(
+          'table',
+          examples['firstCellIsHeader with rowspan and colspan']
+        )
 
         const $th = $('.govuk-table').find('tbody tr th')
 
@@ -221,9 +245,15 @@ describe('Table', () => {
     it('can be specified', () => {
       const $ = render('table', examples.default)
 
-      const cells = $('.govuk-table').find('tbody tr')
+      const cells = $('.govuk-table')
+        .find('tbody tr')
         .map((_, tr) => {
-          return [$(tr).find('td').map((_, td) => $(td).text()).get()]
+          return [
+            $(tr)
+              .find('td')
+              .map((_, td) => $(td).text())
+              .get()
+          ]
         })
         .get()
 
@@ -237,9 +267,15 @@ describe('Table', () => {
     it('can be skipped when falsely', () => {
       const $ = render('table', examples['with falsey items'])
 
-      const cells = $('.govuk-table').find('tbody tr')
+      const cells = $('.govuk-table')
+        .find('tbody tr')
         .map((_, tr) => {
-          return [$(tr).find('td').map((_, td) => $(td).text()).get()]
+          return [
+            $(tr)
+              .find('td')
+              .map((_, td) => $(td).text())
+              .get()
+          ]
         })
         .get()
 
@@ -255,7 +291,9 @@ describe('Table', () => {
 
       const $td = $('.govuk-table td')
 
-      expect($td.html()).toEqual('Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;')
+      expect($td.html()).toEqual(
+        'Foo &lt;script&gt;hacking.do(1337)&lt;/script&gt;'
+      )
     })
 
     it('allow HTML when passed as HTML', () => {

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -35,8 +35,11 @@ export class Tabs {
   /**
    * @param {Element} $module - HTML element to use for tabs
    */
-  constructor ($module) {
-    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+  constructor($module) {
+    if (
+      !($module instanceof HTMLElement) ||
+      !document.body.classList.contains('govuk-frontend-supported')
+    ) {
       return this
     }
 
@@ -62,7 +65,7 @@ export class Tabs {
    *
    * @private
    */
-  setupResponsiveChecks () {
+  setupResponsiveChecks() {
     this.mql = window.matchMedia('(min-width: 40.0625em)')
 
     // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
@@ -83,7 +86,7 @@ export class Tabs {
    *
    * @private
    */
-  checkMode () {
+  checkMode() {
     if (this.mql.matches) {
       this.setup()
     } else {
@@ -96,9 +99,11 @@ export class Tabs {
    *
    * @private
    */
-  setup () {
+  setup() {
     const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll('.govuk-tabs__list-item')
+    const $tabListItems = this.$module.querySelectorAll(
+      '.govuk-tabs__list-item'
+    )
 
     if (!this.$tabs || !$tabList || !$tabListItems) {
       return
@@ -139,9 +144,11 @@ export class Tabs {
    *
    * @private
    */
-  teardown () {
+  teardown() {
     const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll('a.govuk-tabs__list-item')
+    const $tabListItems = this.$module.querySelectorAll(
+      'a.govuk-tabs__list-item'
+    )
 
     if (!this.$tabs || !$tabList || !$tabListItems) {
       return
@@ -172,7 +179,7 @@ export class Tabs {
    * @private
    * @returns {void | undefined} Returns void, or undefined when prevented
    */
-  onHashChange () {
+  onHashChange() {
     const hash = window.location.hash
     const $tabWithHash = this.getTab(hash)
     if (!$tabWithHash) {
@@ -202,7 +209,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  hideTab ($tab) {
+  hideTab($tab) {
     this.unhighlightTab($tab)
     this.hidePanel($tab)
   }
@@ -213,7 +220,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  showTab ($tab) {
+  showTab($tab) {
     this.highlightTab($tab)
     this.showPanel($tab)
   }
@@ -225,7 +232,7 @@ export class Tabs {
    * @param {string} hash - Hash fragment including #
    * @returns {HTMLAnchorElement | null} Tab link
    */
-  getTab (hash) {
+  getTab(hash) {
     return this.$module.querySelector(`a.govuk-tabs__tab[href="${hash}"]`)
   }
 
@@ -235,7 +242,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  setAttributes ($tab) {
+  setAttributes($tab) {
     // set tab attributes
     const panelId = this.getHref($tab).slice(1)
     $tab.setAttribute('id', `tab_${panelId}`)
@@ -261,7 +268,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  unsetAttributes ($tab) {
+  unsetAttributes($tab) {
     // unset tab attributes
     $tab.removeAttribute('id')
     $tab.removeAttribute('role')
@@ -287,7 +294,7 @@ export class Tabs {
    * @param {MouseEvent} event - Mouse click event
    * @returns {void} Returns void
    */
-  onTabClick (event) {
+  onTabClick(event) {
     const $currentTab = this.getCurrentTab()
     const $nextTab = event.currentTarget
 
@@ -311,7 +318,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  createHistoryEntry ($tab) {
+  createHistoryEntry($tab) {
     const $panel = this.getPanel($tab)
     if (!$panel) {
       return
@@ -335,7 +342,7 @@ export class Tabs {
    * @private
    * @param {KeyboardEvent} event - Keydown event
    */
-  onTabKeydown (event) {
+  onTabKeydown(event) {
     switch (event.keyCode) {
       case this.keys.left:
       case this.keys.up:
@@ -355,7 +362,7 @@ export class Tabs {
    *
    * @private
    */
-  activateNextTab () {
+  activateNextTab() {
     const $currentTab = this.getCurrentTab()
     if (!$currentTab || !$currentTab.parentElement) {
       return
@@ -383,13 +390,14 @@ export class Tabs {
    *
    * @private
    */
-  activatePreviousTab () {
+  activatePreviousTab() {
     const $currentTab = this.getCurrentTab()
     if (!$currentTab || !$currentTab.parentElement) {
       return
     }
 
-    const $previousTabListItem = $currentTab.parentElement.previousElementSibling
+    const $previousTabListItem =
+      $currentTab.parentElement.previousElementSibling
     if (!$previousTabListItem) {
       return
     }
@@ -413,7 +421,7 @@ export class Tabs {
    * @param {HTMLAnchorElement} $tab - Tab link
    * @returns {Element | null} Tab panel
    */
-  getPanel ($tab) {
+  getPanel($tab) {
     return this.$module.querySelector(this.getHref($tab))
   }
 
@@ -423,7 +431,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  showPanel ($tab) {
+  showPanel($tab) {
     const $panel = this.getPanel($tab)
     if (!$panel) {
       return
@@ -438,7 +446,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  hidePanel ($tab) {
+  hidePanel($tab) {
     const $panel = this.getPanel($tab)
     if (!$panel) {
       return
@@ -453,7 +461,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  unhighlightTab ($tab) {
+  unhighlightTab($tab) {
     if (!$tab.parentElement) {
       return
     }
@@ -469,7 +477,7 @@ export class Tabs {
    * @private
    * @param {HTMLAnchorElement} $tab - Tab link
    */
-  highlightTab ($tab) {
+  highlightTab($tab) {
     if (!$tab.parentElement) {
       return
     }
@@ -485,8 +493,10 @@ export class Tabs {
    * @private
    * @returns {HTMLAnchorElement | null} Tab link
    */
-  getCurrentTab () {
-    return this.$module.querySelector('.govuk-tabs__list-item--selected a.govuk-tabs__tab')
+  getCurrentTab() {
+    return this.$module.querySelector(
+      '.govuk-tabs__list-item--selected a.govuk-tabs__tab'
+    )
   }
 
   /**
@@ -500,7 +510,7 @@ export class Tabs {
    * @param {HTMLAnchorElement} $tab - Tab link
    * @returns {string} Hash fragment including #
    */
-  getHref ($tab) {
+  getHref($tab) {
     const href = $tab.getAttribute('href')
     const hash = href.slice(href.indexOf('#'), href.length)
     return hash

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
@@ -16,7 +16,10 @@ describe('/components/tabs', () => {
       })
 
       it('falls back to making all tab containers visible', async () => {
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
+        const isContentVisible = await page.waitForSelector(
+          '.govuk-tabs__panel',
+          { visible: true, timeout: 5000 }
+        )
         expect(isContentVisible).toBeTruthy()
       })
     })
@@ -27,20 +30,40 @@ describe('/components/tabs', () => {
       })
 
       it('should indicate the open state of the first tab', async () => {
-        const firstTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:first-child .govuk-tabs__tab').getAttribute('aria-selected'))
+        const firstTabAriaSelected = await page.evaluate(() =>
+          document.body
+            .querySelector(
+              '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
+            )
+            .getAttribute('aria-selected')
+        )
         expect(firstTabAriaSelected).toEqual('true')
 
-        const firstTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:first-child').className)
+        const firstTabClasses = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-tabs__list-item:first-child')
+              .className
+        )
         expect(firstTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
       it('should display the first tab panel', async () => {
-        const tabPanelIsHidden = await page.evaluate(() => document.body.querySelector('.govuk-tabs > .govuk-tabs__panel').classList.contains('govuk-tabs__panel--hidden'))
+        const tabPanelIsHidden = await page.evaluate(() =>
+          document.body
+            .querySelector('.govuk-tabs > .govuk-tabs__panel')
+            .classList.contains('govuk-tabs__panel--hidden')
+        )
         expect(tabPanelIsHidden).toBeFalsy()
       })
 
       it('should hide all the tab panels except for the first one', async () => {
-        const tabPanelIsHidden = await page.evaluate(() => document.body.querySelector('.govuk-tabs > .govuk-tabs__panel ~ .govuk-tabs__panel').classList.contains('govuk-tabs__panel--hidden'))
+        const tabPanelIsHidden = await page.evaluate(() =>
+          document.body
+            .querySelector(
+              '.govuk-tabs > .govuk-tabs__panel ~ .govuk-tabs__panel'
+            )
+            .classList.contains('govuk-tabs__panel--hidden')
+        )
         expect(tabPanelIsHidden).toBeTruthy()
       })
     })
@@ -54,10 +77,20 @@ describe('/components/tabs', () => {
         // Click the second tab
         await page.click('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab')
 
-        const secondTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-selected'))
+        const secondTabAriaSelected = await page.evaluate(() =>
+          document.body
+            .querySelector(
+              '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+            )
+            .getAttribute('aria-selected')
+        )
         expect(secondTabAriaSelected).toEqual('true')
 
-        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2)').className)
+        const secondTabClasses = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-tabs__list-item:nth-child(2)')
+              .className
+        )
         expect(secondTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
@@ -66,8 +99,14 @@ describe('/components/tabs', () => {
         await page.click('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab')
 
         const secondTabPanelIsHidden = await page.evaluate(() => {
-          const secondTabAriaControls = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-controls')
-          return document.body.querySelector(`[id="${secondTabAriaControls}"]`).classList.contains('govuk-tabs__panel--hidden')
+          const secondTabAriaControls = document.body
+            .querySelector(
+              '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+            )
+            .getAttribute('aria-controls')
+          return document.body
+            .querySelector(`[id="${secondTabAriaControls}"]`)
+            .classList.contains('govuk-tabs__panel--hidden')
         })
         expect(secondTabPanelIsHidden).toBeFalsy()
       })
@@ -80,16 +119,26 @@ describe('/components/tabs', () => {
         it('should display the tab panel associated with the selected tab', async () => {
           await page.evaluate(() => {
             // Replace contents of second tab with a DOM element
-            const secondTab = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab')
+            const secondTab = document.body.querySelector(
+              '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+            )
             secondTab.innerHTML = '<span>Tab 2</span>'
           })
 
           // Click the DOM element inside the second tab
-          await page.click('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab span')
+          await page.click(
+            '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab span'
+          )
 
           const secondTabPanelIsHidden = await page.evaluate(() => {
-            const secondTabAriaControls = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-controls')
-            return document.body.querySelector(`[id="${secondTabAriaControls}"]`).classList.contains('govuk-tabs__panel--hidden')
+            const secondTabAriaControls = document.body
+              .querySelector(
+                '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+              )
+              .getAttribute('aria-controls')
+            return document.body
+              .querySelector(`[id="${secondTabAriaControls}"]`)
+              .classList.contains('govuk-tabs__panel--hidden')
           })
           expect(secondTabPanelIsHidden).toBeFalsy()
         })
@@ -106,10 +155,20 @@ describe('/components/tabs', () => {
         await page.focus('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
         await page.keyboard.press('ArrowRight')
 
-        const secondTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-selected'))
+        const secondTabAriaSelected = await page.evaluate(() =>
+          document.body
+            .querySelector(
+              '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+            )
+            .getAttribute('aria-selected')
+        )
         expect(secondTabAriaSelected).toEqual('true')
 
-        const secondTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__list-item:nth-child(2)').className)
+        const secondTabClasses = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-tabs__list-item:nth-child(2)')
+              .className
+        )
         expect(secondTabClasses).toContain('govuk-tabs__list-item--selected')
       })
 
@@ -119,8 +178,14 @@ describe('/components/tabs', () => {
         await page.keyboard.down('ArrowRight')
 
         const secondTabPanelIsHidden = await page.evaluate(() => {
-          const secondTabAriaControls = document.body.querySelector('.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab').getAttribute('aria-controls')
-          return document.body.querySelector(`[id="${secondTabAriaControls}"]`).classList.contains('govuk-tabs__panel--hidden')
+          const secondTabAriaControls = document.body
+            .querySelector(
+              '.govuk-tabs__list-item:nth-child(2) .govuk-tabs__tab'
+            )
+            .getAttribute('aria-controls')
+          return document.body
+            .querySelector(`[id="${secondTabAriaControls}"]`)
+            .classList.contains('govuk-tabs__panel--hidden')
         })
         expect(secondTabPanelIsHidden).toBeFalsy()
       })
@@ -130,13 +195,25 @@ describe('/components/tabs', () => {
       it('should indicate the open state of the associated tab', async () => {
         await goTo(page, '/components/tabs/preview/#past-week')
 
-        const currentTabAriaSelected = await page.evaluate(() => document.body.querySelector('.govuk-tabs__tab[href="#past-week"]').getAttribute('aria-selected'))
+        const currentTabAriaSelected = await page.evaluate(() =>
+          document.body
+            .querySelector('.govuk-tabs__tab[href="#past-week"]')
+            .getAttribute('aria-selected')
+        )
         expect(currentTabAriaSelected).toEqual('true')
 
-        const currentTabClasses = await page.evaluate(() => document.body.querySelector('.govuk-tabs__tab[href="#past-week"]').parentElement.className)
+        const currentTabClasses = await page.evaluate(
+          () =>
+            document.body.querySelector('.govuk-tabs__tab[href="#past-week"]')
+              .parentElement.className
+        )
         expect(currentTabClasses).toContain('govuk-tabs__list-item--selected')
 
-        const currentTabPanelIsHidden = await page.evaluate(() => document.getElementById('past-week').classList.contains('govuk-tabs__panel--hidden'))
+        const currentTabPanelIsHidden = await page.evaluate(() =>
+          document
+            .getElementById('past-week')
+            .classList.contains('govuk-tabs__panel--hidden')
+        )
         expect(currentTabPanelIsHidden).toBeFalsy()
       })
 
@@ -147,7 +224,9 @@ describe('/components/tabs', () => {
 
         await page.click('[href="#anchor"]')
 
-        const activeElementId = await page.evaluate(() => document.activeElement.id)
+        const activeElementId = await page.evaluate(
+          () => document.activeElement.id
+        )
         expect(activeElementId).toEqual('anchor')
       })
     })
@@ -156,7 +235,10 @@ describe('/components/tabs', () => {
       it('falls back to making the all tab containers visible', async () => {
         await page.emulate(iPhone)
         await goToComponent(page, 'tabs')
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
+        const isContentVisible = await page.waitForSelector(
+          '.govuk-tabs__panel',
+          { visible: true, timeout: 5000 }
+        )
         expect(isContentVisible).toBeTruthy()
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
@@ -20,7 +20,9 @@ describe('Tabs', () => {
       const $ = render('tabs', examples.default)
 
       expect($('#past-week').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
-      expect($('#past-month').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
+      expect(
+        $('#past-month').hasClass('govuk-tabs__panel--hidden')
+      ).toBeTruthy()
       expect($('#past-year').hasClass('govuk-tabs__panel--hidden')).toBeTruthy()
     })
   })
@@ -56,14 +58,14 @@ describe('Tabs', () => {
   })
 
   describe('items', () => {
-    it('doesn\'t render a list if items is not defined', () => {
+    it("doesn't render a list if items is not defined", () => {
       const $ = render('tabs', examples['no item list'])
 
       const $component = $('.govuk-tabs')
       expect($component.find('.govuk-tabs__list').length).toEqual(0)
     })
 
-    it('doesn\'t render a list if items is empty', () => {
+    it("doesn't render a list if items is empty", () => {
       const $ = render('tabs', examples['empty item list'])
 
       const $component = $('.govuk-tabs')
@@ -75,7 +77,9 @@ describe('Tabs', () => {
 
       const $component = $('.govuk-tabs')
 
-      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      const $firstTab = $component.find(
+        '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
+      )
       const $firstPanel = $component.find('.govuk-tabs__panel')
       expect($firstTab.attr('href')).toEqual('#past-day')
       expect($firstPanel.attr('id')).toEqual('past-day')
@@ -95,7 +99,9 @@ describe('Tabs', () => {
 
       const $component = $('.govuk-tabs')
 
-      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      const $firstTab = $component.find(
+        '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
+      )
       const $firstPanel = $component.find('.govuk-tabs__panel')
       expect($firstTab.attr('href')).toEqual('#custom-1')
       expect($firstPanel.attr('id')).toEqual('custom-1')
@@ -106,7 +112,9 @@ describe('Tabs', () => {
 
       const $component = $('.govuk-tabs')
 
-      const $firstTab = $component.find('.govuk-tabs__list-item:first-child .govuk-tabs__tab')
+      const $firstTab = $component.find(
+        '.govuk-tabs__list-item:first-child .govuk-tabs__tab'
+      )
       expect($firstTab.text().trim()).toEqual('Past day')
     })
 
@@ -116,7 +124,9 @@ describe('Tabs', () => {
       const $lastTab = $component.find('.govuk-tabs__panel').last()
 
       expect($lastTab.find('p').hasClass('govuk-body')).toBeTruthy()
-      expect($lastTab.text().trim()).toEqual('There is no data for this year yet, check back later')
+      expect($lastTab.text().trim()).toEqual(
+        'There is no data for this year yet, check back later'
+      )
     })
 
     it('render escaped html when passed to text content', () => {
@@ -125,7 +135,9 @@ describe('Tabs', () => {
       const $component = $('.govuk-tabs')
 
       const $firstPanel = $component.find('.govuk-tabs__panel .govuk-body')
-      expect($firstPanel.html().trim()).toEqual('&lt;p&gt;Panel 1 content&lt;/p&gt;')
+      expect($firstPanel.html().trim()).toEqual(
+        '&lt;p&gt;Panel 1 content&lt;/p&gt;'
+      )
     })
 
     it('render html when passed to content', () => {

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -58,12 +58,16 @@ describe('Task List', () => {
 
     it('adds a with-link modifier class to the task', async () => {
       const $itemLink = $component.find('.govuk-task-list__item')
-      expect($itemLink.hasClass('govuk-task-list__item--with-link')).toBeTruthy()
+      expect(
+        $itemLink.hasClass('govuk-task-list__item--with-link')
+      ).toBeTruthy()
     })
 
     it('associates the task name link with the status using aria', async () => {
       const $itemLink = $component.find('.govuk-task-list__link')
-      const $statusWithId = $component.find(`#${$itemLink.attr('aria-describedby')}`)
+      const $statusWithId = $component.find(
+        `#${$itemLink.attr('aria-describedby')}`
+      )
 
       expect($statusWithId.text()).toContain('Completed')
     })
@@ -73,7 +77,9 @@ describe('Task List', () => {
 
       const $itemWithLink = $('.govuk-task-list__item:first-child')
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
-      expect($itemWithLinkTitle.hasClass('custom-class-on-linked-title')).toBeTruthy()
+      expect(
+        $itemWithLinkTitle.hasClass('custom-class-on-linked-title')
+      ).toBeTruthy()
     })
 
     it('escapes the title when passed as text', () => {
@@ -95,7 +101,10 @@ describe('Task List', () => {
 
   describe('when a task does not have an href set', () => {
     it('does not link the task title', () => {
-      const $ = render('task-list', examples['example with hint text and additional states'])
+      const $ = render(
+        'task-list',
+        examples['example with hint text and additional states']
+      )
 
       const $itemWithNoLink = $('.govuk-task-list__item:last-child')
       const $itemWithNoLinkTitle = $itemWithNoLink.find('div')
@@ -106,24 +115,36 @@ describe('Task List', () => {
       const $ = render('task-list', examples['custom classes'])
 
       const $itemWithNoLink = $('.govuk-task-list__item:last-child')
-      const $itemWithNoLinkTitle = $itemWithNoLink.find('.govuk-task-list__name-and-hint div')
-      expect($itemWithNoLinkTitle.hasClass('custom-class-on-unlinked-title')).toBeTruthy()
+      const $itemWithNoLinkTitle = $itemWithNoLink.find(
+        '.govuk-task-list__name-and-hint div'
+      )
+      expect(
+        $itemWithNoLinkTitle.hasClass('custom-class-on-unlinked-title')
+      ).toBeTruthy()
     })
 
     it('escapes the title when passed as text', () => {
       const $ = render('task-list', examples['html passed as text'])
 
       const $itemWithoutLink = $('.govuk-task-list__item:last-child')
-      const $itemWithoutLinkTitle = $itemWithoutLink.find('.govuk-task-list__name-and-hint')
-      expect($itemWithoutLinkTitle.text()).toContain('<strong>Unlinked Title</strong>')
+      const $itemWithoutLinkTitle = $itemWithoutLink.find(
+        '.govuk-task-list__name-and-hint'
+      )
+      expect($itemWithoutLinkTitle.text()).toContain(
+        '<strong>Unlinked Title</strong>'
+      )
     })
 
     it('allows HTML in the title when passed as html', () => {
       const $ = render('task-list', examples.html)
 
       const $itemWithoutLink = $('.govuk-task-list__item:last-child')
-      const $itemWithoutLinkTitle = $itemWithoutLink.find('.govuk-task-list__name-and-hint')
-      expect($itemWithoutLinkTitle.html()).toContain('<strong>Unlinked Title</strong>')
+      const $itemWithoutLinkTitle = $itemWithoutLink.find(
+        '.govuk-task-list__name-and-hint'
+      )
+      expect($itemWithoutLinkTitle.html()).toContain(
+        '<strong>Unlinked Title</strong>'
+      )
     })
   })
 
@@ -177,7 +198,10 @@ describe('Task List', () => {
     let $component
 
     beforeAll(function () {
-      const $ = render('task-list', examples['example with hint text and additional states'])
+      const $ = render(
+        'task-list',
+        examples['example with hint text and additional states']
+      )
       $component = $('.govuk-task-list')
     })
 

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -120,28 +120,26 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with hint'])
 
       const $textarea = $('.govuk-textarea')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($textarea.attr('aria-describedby')).toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the textarea as "described by" the hint and parent fieldset', () => {
       const $ = render('textarea', examples['with hint and described by'])
 
       const $textarea = $('.govuk-textarea')
-      const $hint = $('.govuk-hint')
+      const hintId = $('.govuk-hint').attr('id')
 
-      const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
-      expect($textarea.attr('aria-describedby')).toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(describedBy)
     })
   })
 
@@ -156,13 +154,13 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with error message'])
 
       const $component = $('.govuk-textarea')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('associates the textarea as "described by" the error message and parent fieldset', () => {
@@ -172,15 +170,13 @@ describe('Textarea', () => {
       )
 
       const $component = $('.govuk-textarea')
-      const $errorMessage = $('.govuk-error-message')
+      const errorMessageId = $('.govuk-error-message').attr('id')
 
-      const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
-          'id'
-        )}${WORD_BOUNDARY}`
+      const describedBy = new RegExp(
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(describedBy)
     })
 
     it('adds the error class to the textarea', () => {
@@ -206,11 +202,11 @@ describe('Textarea', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
-        WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
+      const describedByCombined = new RegExp(
+        `${WORD_BOUNDARY}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
 
     it('associates the textarea as described by the hint, error message and parent fieldset', () => {
@@ -223,11 +219,11 @@ describe('Textarea', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
       const hintId = $('.govuk-hint').attr('id')
 
-      const combinedIds = new RegExp(
+      const describedByCombined = new RegExp(
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby')).toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(describedByCombined)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -126,8 +126,7 @@ describe('Textarea', () => {
         WORD_BOUNDARY + $hint.attr('id') + WORD_BOUNDARY
       )
 
-      expect($textarea.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(hintId)
     })
 
     it('associates the textarea as "described by" the hint and parent fieldset', () => {
@@ -137,11 +136,12 @@ describe('Textarea', () => {
       const $hint = $('.govuk-hint')
 
       const hintId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$hint.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($textarea.attr('aria-describedby'))
-        .toMatch(hintId)
+      expect($textarea.attr('aria-describedby')).toMatch(hintId)
     })
   })
 
@@ -162,22 +162,25 @@ describe('Textarea', () => {
         WORD_BOUNDARY + $errorMessage.attr('id') + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('associates the textarea as "described by" the error message and parent fieldset', () => {
-      const $ = render('textarea', examples['with error message and described by'])
+      const $ = render(
+        'textarea',
+        examples['with error message and described by']
+      )
 
       const $component = $('.govuk-textarea')
       const $errorMessage = $('.govuk-error-message')
 
       const errorMessageId = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr('id')}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}some-id${WHITESPACE}${$errorMessage.attr(
+          'id'
+        )}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(errorMessageId)
+      expect($component.attr('aria-describedby')).toMatch(errorMessageId)
     })
 
     it('adds the error class to the textarea', () => {
@@ -207,12 +210,14 @@ describe('Textarea', () => {
         WORD_BOUNDARY + hintId + WHITESPACE + errorMessageId + WORD_BOUNDARY
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
 
     it('associates the textarea as described by the hint, error message and parent fieldset', () => {
-      const $ = render('textarea', examples['with hint, error message and described by'])
+      const $ = render(
+        'textarea',
+        examples['with hint, error message and described by']
+      )
 
       const $component = $('.govuk-textarea')
       const errorMessageId = $('.govuk-error-message').attr('id')
@@ -222,8 +227,7 @@ describe('Textarea', () => {
         `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
-      expect($component.attr('aria-describedby'))
-        .toMatch(combinedIds)
+      expect($component.attr('aria-describedby')).toMatch(combinedIds)
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
@@ -13,7 +13,9 @@ describe('Warning text', () => {
       const $ = render('warning-text', examples.default)
 
       const $component = $('.govuk-warning-text')
-      expect($component.text()).toContain('You can be fined up to £5,000 if you don’t register.')
+      expect($component.text()).toContain(
+        'You can be fined up to £5,000 if you don’t register.'
+      )
     })
 
     it('renders with default assistive text', () => {
@@ -36,7 +38,9 @@ describe('Warning text', () => {
       const $ = render('warning-text', examples.classes)
 
       const $component = $('.govuk-warning-text')
-      expect($component.hasClass('govuk-warning-text--custom-class')).toBeTruthy()
+      expect(
+        $component.hasClass('govuk-warning-text--custom-class')
+      ).toBeTruthy()
     })
 
     it('renders custom assistive text', () => {
@@ -60,14 +64,18 @@ describe('Warning text', () => {
       const $ = render('warning-text', examples['html as text'])
 
       const $component = $('.govuk-warning-text')
-      expect($component.html()).toContain('&lt;span&gt;Some custom warning text&lt;/span&gt;')
+      expect($component.html()).toContain(
+        '&lt;span&gt;Some custom warning text&lt;/span&gt;'
+      )
     })
 
     it('renders html', () => {
       const $ = render('warning-text', examples.html)
 
       const $component = $('.govuk-warning-text')
-      expect($component.html()).toContain('<span>Some custom warning text</span>')
+      expect($component.html()).toContain(
+        '<span>Some custom warning text</span>'
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/colour.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.test.js
@@ -38,10 +38,10 @@ describe('@function govuk-colour', () => {
 
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: #ff0000;
-          }
-        `
+        .foo {
+          color: #ff0000;
+        }
+      `
     })
   })
 
@@ -56,10 +56,10 @@ describe('@function govuk-colour', () => {
 
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: #ff0000;
-          }
-        `
+        .foo {
+          color: #ff0000;
+        }
+      `
     })
   })
 
@@ -127,10 +127,10 @@ describe('@function govuk-organisation-colour', () => {
 
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: #9A00A8;
-          }
-        `
+        .foo {
+          color: #9A00A8;
+        }
+      `
     })
   })
 
@@ -145,10 +145,10 @@ describe('@function govuk-organisation-colour', () => {
 
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: #A81223;
-          }
-        `
+        .foo {
+          color: #A81223;
+        }
+      `
     })
   })
 
@@ -163,10 +163,10 @@ describe('@function govuk-organisation-colour', () => {
 
     await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            border-color: #EC22FF;
-          }
-        `
+        .foo {
+          border-color: #EC22FF;
+        }
+      `
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/helpers/colour.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/colour.test.js
@@ -4,8 +4,7 @@ const { sassNull } = require('sass-embedded')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
-const mockWarnFunction = jest.fn()
-  .mockReturnValue(sassNull)
+const mockWarnFunction = jest.fn().mockReturnValue(sassNull)
 
 const sassConfig = {
   logger: {
@@ -37,15 +36,13 @@ describe('@function govuk-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: #ff0000;
           }
         `
-      })
+    })
   })
 
   it('works with unquoted strings', async () => {
@@ -57,15 +54,13 @@ describe('@function govuk-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: #ff0000;
           }
         `
-      })
+    })
   })
 
   it('throws an error if a non-existent colour is requested', async () => {
@@ -77,11 +72,9 @@ describe('@function govuk-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .rejects
-      .toThrow(
-        'Unknown colour `hooloovoo`'
-      )
+    await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+      'Unknown colour `hooloovoo`'
+    )
   })
 
   it('throws a deprecation warning if the $legacy parameter is used', async () => {
@@ -97,13 +90,14 @@ describe('@function govuk-colour', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the deprecation notice
-    expect(mockWarnFunction.mock.calls[0])
-      .toEqual(expect.arrayContaining([
+    expect(mockWarnFunction.mock.calls[0]).toEqual(
+      expect.arrayContaining([
         'The `$legacy` parameter of `govuk-colour` is deprecated and is ' +
-        'non-operational. It will be removed in the next major version. To ' +
-        'silence this warning, update $govuk-suppressed-warnings with key: ' +
-        '"legacy-colour-param"'
-      ]))
+          'non-operational. It will be removed in the next major version. To ' +
+          'silence this warning, update $govuk-suppressed-warnings with key: ' +
+          '"legacy-colour-param"'
+      ])
+    )
   })
 })
 
@@ -131,15 +125,13 @@ describe('@function govuk-organisation-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: #9A00A8;
           }
         `
-      })
+    })
   })
 
   it('falls back to the default colour if a websafe colour is not explicitly defined', async () => {
@@ -151,15 +143,13 @@ describe('@function govuk-organisation-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: #A81223;
           }
         `
-      })
+    })
   })
 
   it('can be overridden to return the non-websafe colour', async () => {
@@ -171,15 +161,13 @@ describe('@function govuk-organisation-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass, sassConfig)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             border-color: #EC22FF;
           }
         `
-      })
+    })
   })
 
   it('throws an error if a non-existent organisation is requested', async () => {
@@ -191,10 +179,8 @@ describe('@function govuk-organisation-colour', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .rejects
-      .toThrow(
-        'Unknown organisation `muggle-born-registration-commission`'
-      )
+    await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+      'Unknown organisation `muggle-born-registration-commission`'
+    )
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/grid.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/grid.test.js
@@ -23,15 +23,13 @@ describe('grid system', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               content: 25%;
             }
           `
-        })
+      })
     })
 
     it('throws an error that the specified key does not exist in the map of widths', async () => {
@@ -41,9 +39,9 @@ describe('grid system', () => {
         $value: govuk-grid-width(seven-fifths);
         `
 
-      await expect(compileSassString(sass))
-        .rejects
-        .toThrow('Unknown grid width `seven-fifths`')
+      await expect(compileSassString(sass)).rejects.toThrow(
+        'Unknown grid width `seven-fifths`'
+      )
     })
   })
 
@@ -57,10 +55,8 @@ describe('grid system', () => {
         }
         `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .govuk-grid-column-full {
               box-sizing: border-box;
               width: 100%;
@@ -73,7 +69,7 @@ describe('grid system', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('allows different widths to be specified using $width', async () => {
@@ -85,10 +81,8 @@ describe('grid system', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .govuk-grid-column-two-thirds {
               box-sizing: border-box;
               width: 100%;
@@ -101,7 +95,7 @@ describe('grid system', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('allows predefined breakpoints to be specified using $at', async () => {
@@ -112,10 +106,8 @@ describe('grid system', () => {
           @include govuk-grid-column(one-quarter, $at: desktop);
         }
       `
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .govuk-grid-column-one-quarter-at-desktop {
               box-sizing: border-box;
               padding: 0 15px;
@@ -127,7 +119,7 @@ describe('grid system', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('allows custom breakpoints to be specified using $at', async () => {
@@ -139,10 +131,8 @@ describe('grid system', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .govuk-grid-column-one-quarter-at-500px {
               box-sizing: border-box;
               width: 100%;
@@ -155,7 +145,7 @@ describe('grid system', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('allows columns to float right using $float: right', async () => {
@@ -167,10 +157,8 @@ describe('grid system', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .govuk-grid-column-one-half-right {
               box-sizing: border-box;
               width: 100%;
@@ -183,7 +171,7 @@ describe('grid system', () => {
               }
             }
           `
-        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/grid.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/grid.test.js
@@ -25,10 +25,10 @@ describe('grid system', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
-            .foo {
-              content: 25%;
-            }
-          `
+          .foo {
+            content: 25%;
+          }
+        `
       })
     })
 
@@ -57,18 +57,18 @@ describe('grid system', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .govuk-grid-column-full {
+            box-sizing: border-box;
+            width: 100%;
+            padding: 0 15px;
+          }
+          @media (min-width: 40.0625em) {
             .govuk-grid-column-full {
-              box-sizing: border-box;
               width: 100%;
-              padding: 0 15px;
+              float: left;
             }
-            @media (min-width: 40.0625em) {
-              .govuk-grid-column-full {
-                width: 100%;
-                float: left;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -83,18 +83,18 @@ describe('grid system', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .govuk-grid-column-two-thirds {
+            box-sizing: border-box;
+            width: 100%;
+            padding: 0 15px;
+          }
+          @media (min-width: 40.0625em) {
             .govuk-grid-column-two-thirds {
-              box-sizing: border-box;
-              width: 100%;
-              padding: 0 15px;
+              width: 66.6666666667%;
+              float: left;
             }
-            @media (min-width: 40.0625em) {
-              .govuk-grid-column-two-thirds {
-                width: 66.6666666667%;
-                float: left;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -108,17 +108,17 @@ describe('grid system', () => {
       `
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .govuk-grid-column-one-quarter-at-desktop {
+            box-sizing: border-box;
+            padding: 0 15px;
+          }
+          @media (min-width: 48.0625em) {
             .govuk-grid-column-one-quarter-at-desktop {
-              box-sizing: border-box;
-              padding: 0 15px;
+              width: 25%;
+              float: left;
             }
-            @media (min-width: 48.0625em) {
-              .govuk-grid-column-one-quarter-at-desktop {
-                width: 25%;
-                float: left;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -133,18 +133,18 @@ describe('grid system', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .govuk-grid-column-one-quarter-at-500px {
+            box-sizing: border-box;
+            width: 100%;
+            padding: 0 15px;
+          }
+          @media (min-width: 31.25em) {
             .govuk-grid-column-one-quarter-at-500px {
-              box-sizing: border-box;
-              width: 100%;
-              padding: 0 15px;
+              width: 25%;
+              float: left;
             }
-            @media (min-width: 31.25em) {
-              .govuk-grid-column-one-quarter-at-500px {
-                width: 25%;
-                float: left;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -159,18 +159,18 @@ describe('grid system', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .govuk-grid-column-one-half-right {
+            box-sizing: border-box;
+            width: 100%;
+            padding: 0 15px;
+          }
+          @media (min-width: 40.0625em) {
             .govuk-grid-column-one-half-right {
-              box-sizing: border-box;
-              width: 100%;
-              padding: 0 15px;
+              width: 50%;
+              float: right;
             }
-            @media (min-width: 40.0625em) {
-              .govuk-grid-column-one-half-right {
-                width: 50%;
-                float: right;
-              }
-            }
-          `
+          }
+        `
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/helpers/helpers.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/helpers.test.js
@@ -35,7 +35,9 @@ describe('The helpers layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "helpers" group', async () => {
-      const docs = await sassdoc.parse(join(paths.package, 'src/govuk/helpers/**/*.scss'))
+      const docs = await sassdoc.parse(
+        join(paths.package, 'src/govuk/helpers/**/*.scss')
+      )
 
       for (const doc of docs) {
         expect(doc).toMatchObject({
@@ -44,9 +46,7 @@ describe('The helpers layer', () => {
           context: {
             name: doc.context.name
           },
-          group: [
-            expect.stringMatching(/^helpers/)
-          ]
+          group: [expect.stringMatching(/^helpers/)]
         })
       }
     })

--- a/packages/govuk-frontend/src/govuk/helpers/media-queries.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/media-queries.test.js
@@ -24,12 +24,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (min-width: 20em) {
-            .foo {
-              color: red;
-            }
+        @media (min-width: 20em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -47,12 +47,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (min-width: 20em) {
-            .foo {
-              color: red;
-            }
+        @media (min-width: 20em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -68,12 +68,12 @@ describe('@mixin govuk-media-query', () => {
     `
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (max-width: 20em) {
-            .foo {
-              color: red;
-            }
+        @media (max-width: 20em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -91,12 +91,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (max-width: 61.24em) {
-            .foo {
-              color: red;
-            }
+        @media (max-width: 61.24em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -113,12 +113,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (min-width: 20em) and (max-width: 40em) {
-            .foo {
-              color: red;
-            }
+        @media (min-width: 20em) and (max-width: 40em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -136,12 +136,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (min-width: 20em) and (max-width: 46.24em) {
-            .foo {
-              color: red;
-            }
+        @media (min-width: 20em) and (max-width: 46.24em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -158,12 +158,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media (max-width: 40em) and (orientation: landscape) {
-            .foo {
-              color: red;
-            }
+        @media (max-width: 40em) and (orientation: landscape) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 
@@ -180,12 +180,12 @@ describe('@mixin govuk-media-query', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @media aural and (max-width: 40em) {
-            .foo {
-              color: red;
-            }
+        @media aural and (max-width: 40em) {
+          .foo {
+            color: red;
           }
-        `
+        }
+      `
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/media-queries.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/media-queries.test.js
@@ -22,17 +22,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (min-width: 20em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target min-width using a predefined breakpoint', async () => {
@@ -47,17 +45,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (min-width: 20em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target max-width using a numeric value', async () => {
@@ -70,17 +66,15 @@ describe('@mixin govuk-media-query', () => {
         }
       }
     `
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (max-width: 20em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target max-width using a predefined breakpoint', async () => {
@@ -95,17 +89,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (max-width: 61.24em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target combined min-width and max-width using numeric values', async () => {
@@ -119,17 +111,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (min-width: 20em) and (max-width: 40em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target combined min-width and max-width using predefined breakpoints', async () => {
@@ -144,17 +134,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (min-width: 20em) and (max-width: 46.24em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target using custom directives', async () => {
@@ -168,17 +156,15 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media (max-width: 40em) and (orientation: landscape) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 
   it('allows you to target particular media types', async () => {
@@ -192,16 +178,14 @@ describe('@mixin govuk-media-query', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @media aural and (max-width: 40em) {
             .foo {
               color: red;
             }
           }
         `
-      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/spacing.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/spacing.test.js
@@ -38,15 +38,13 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             top: 15px;
           }
         `
-      })
+    })
   })
 
   it('returns CSS for a property based on a negative spacing point', async () => {
@@ -58,15 +56,13 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             top: -15px;
           }
         `
-      })
+    })
   })
 
   it('throws an error when passed anything other than a number', async () => {
@@ -78,11 +74,9 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .rejects
-      .toThrow(
-        'Expected a number (integer), but got a string.'
-      )
+    await expect(compileSassString(sass)).rejects.toThrow(
+      'Expected a number (integer), but got a string.'
+    )
   })
 
   it('throws an error when passed a non-existent point', async () => {
@@ -94,11 +88,9 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .rejects
-      .toThrow(
-        'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
-      )
+    await expect(compileSassString(sass)).rejects.toThrow(
+      'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
+    )
   })
 
   it('throws an error when passed a non-existent negative point', async () => {
@@ -110,11 +102,9 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .rejects
-      .toThrow(
-        'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
-      )
+    await expect(compileSassString(sass)).rejects.toThrow(
+      'Unknown spacing variable `999`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.'
+    )
   })
 
   it('handles negative zero', async () => {
@@ -126,15 +116,13 @@ describe('@function govuk-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             top: 0;
           }
         `
-      })
+    })
   })
 })
 
@@ -148,10 +136,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             margin: 15px;
           }
@@ -161,7 +147,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('outputs CSS for a property and direction based on the spacing map', async () => {
@@ -173,10 +159,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             padding-top: 15px;
           }
@@ -186,7 +170,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('throws an exception when passed a non-existent point', async () => {
@@ -198,11 +182,9 @@ describe('@mixin _govuk-responsive-spacing', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .rejects
-      .toThrow(
-        'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
-      )
+    await expect(compileSassString(sass)).rejects.toThrow(
+      'Unknown spacing point `14px`. Make sure you are using a point from the responsive spacing scale in `_settings/spacing.scss`.'
+    )
   })
 
   describe('when $important is set to true', () => {
@@ -219,10 +201,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               margin: 15px !important;
             }
@@ -232,7 +212,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('marks the rule as important for the property and direction', async () => {
@@ -249,10 +229,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               margin-top: 15px !important;
             }
@@ -262,7 +240,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
               }
             }
           `
-        })
+      })
     })
   })
 
@@ -280,10 +258,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               margin: 17px;
             }
@@ -293,7 +269,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('adjusts the value for the property and direction', async () => {
@@ -310,10 +286,8 @@ describe('@mixin _govuk-responsive-spacing', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               margin-top: 17px;
             }
@@ -323,7 +297,7 @@ describe('@mixin _govuk-responsive-spacing', () => {
               }
             }
           `
-        })
+      })
     })
   })
 })
@@ -338,10 +312,8 @@ describe('@mixin govuk-responsive-margin', () => {
         }
       `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             margin: 15px;
           }
@@ -351,7 +323,7 @@ describe('@mixin govuk-responsive-margin', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('outputs extreme responsive margins', async () => {
@@ -368,10 +340,8 @@ describe('@mixin govuk-responsive-margin', () => {
         }
       `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             margin-top: 17px !important;
           }
@@ -381,7 +351,7 @@ describe('@mixin govuk-responsive-margin', () => {
             }
           }
         `
-      })
+    })
   })
 })
 
@@ -395,10 +365,8 @@ describe('@mixin govuk-responsive-padding', () => {
         }
       `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             padding: 15px;
           }
@@ -408,7 +376,7 @@ describe('@mixin govuk-responsive-padding', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('outputs extreme responsive padding', async () => {
@@ -425,10 +393,8 @@ describe('@mixin govuk-responsive-padding', () => {
         }
       `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             padding-top: 17px !important;
           }
@@ -438,6 +404,6 @@ describe('@mixin govuk-responsive-padding', () => {
             }
           }
         `
-      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/spacing.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/spacing.test.js
@@ -40,10 +40,10 @@ describe('@function govuk-spacing', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            top: 15px;
-          }
-        `
+        .foo {
+          top: 15px;
+        }
+      `
     })
   })
 
@@ -58,10 +58,10 @@ describe('@function govuk-spacing', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            top: -15px;
-          }
-        `
+        .foo {
+          top: -15px;
+        }
+      `
     })
   })
 
@@ -118,10 +118,10 @@ describe('@function govuk-spacing', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            top: 0;
-          }
-        `
+        .foo {
+          top: 0;
+        }
+      `
     })
   })
 })
@@ -138,15 +138,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          margin: 15px;
+        }
+        @media (min-width: 30em) {
           .foo {
-            margin: 15px;
+            margin: 25px;
           }
-          @media (min-width: 30em) {
-            .foo {
-              margin: 25px;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -161,15 +161,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          padding-top: 15px;
+        }
+        @media (min-width: 30em) {
           .foo {
-            padding-top: 15px;
+            padding-top: 25px;
           }
-          @media (min-width: 30em) {
-            .foo {
-              padding-top: 25px;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -203,15 +203,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            margin: 15px !important;
+          }
+          @media (min-width: 30em) {
             .foo {
-              margin: 15px !important;
+              margin: 25px !important;
             }
-            @media (min-width: 30em) {
-              .foo {
-                margin: 25px !important;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -231,15 +231,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            margin-top: 15px !important;
+          }
+          @media (min-width: 30em) {
             .foo {
-              margin-top: 15px !important;
+              margin-top: 25px !important;
             }
-            @media (min-width: 30em) {
-              .foo {
-                margin-top: 25px !important;
-              }
-            }
-          `
+          }
+        `
       })
     })
   })
@@ -260,15 +260,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            margin: 17px;
+          }
+          @media (min-width: 30em) {
             .foo {
-              margin: 17px;
+              margin: 27px;
             }
-            @media (min-width: 30em) {
-              .foo {
-                margin: 27px;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -288,15 +288,15 @@ describe('@mixin _govuk-responsive-spacing', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            margin-top: 17px;
+          }
+          @media (min-width: 30em) {
             .foo {
-              margin-top: 17px;
+              margin-top: 27px;
             }
-            @media (min-width: 30em) {
-              .foo {
-                margin-top: 27px;
-              }
-            }
-          `
+          }
+        `
       })
     })
   })
@@ -314,15 +314,15 @@ describe('@mixin govuk-responsive-margin', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          margin: 15px;
+        }
+        @media (min-width: 30em) {
           .foo {
-            margin: 15px;
+            margin: 25px;
           }
-          @media (min-width: 30em) {
-            .foo {
-              margin: 25px;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -342,15 +342,15 @@ describe('@mixin govuk-responsive-margin', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          margin-top: 17px !important;
+        }
+        @media (min-width: 30em) {
           .foo {
-            margin-top: 17px !important;
+            margin-top: 27px !important;
           }
-          @media (min-width: 30em) {
-            .foo {
-              margin-top: 27px !important;
-            }
-          }
-        `
+        }
+      `
     })
   })
 })
@@ -367,15 +367,15 @@ describe('@mixin govuk-responsive-padding', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          padding: 15px;
+        }
+        @media (min-width: 30em) {
           .foo {
-            padding: 15px;
+            padding: 25px;
           }
-          @media (min-width: 30em) {
-            .foo {
-              padding: 25px;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -395,15 +395,15 @@ describe('@mixin govuk-responsive-padding', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          padding-top: 17px !important;
+        }
+        @media (min-width: 30em) {
           .foo {
-            padding-top: 17px !important;
+            padding-top: 27px !important;
           }
-          @media (min-width: 30em) {
-            .foo {
-              padding-top: 27px !important;
-            }
-          }
-        `
+        }
+      `
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/helpers/typography.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.test.js
@@ -132,10 +132,10 @@ describe('@function _govuk-line-height', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            line-height: 3.141;
-          }
-        `
+        .foo {
+          line-height: 3.141;
+        }
+      `
     })
   })
 
@@ -150,10 +150,10 @@ describe('@function _govuk-line-height', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            line-height: 2em;
-          }
-        `
+        .foo {
+          line-height: 2em;
+        }
+      `
     })
   })
 
@@ -168,10 +168,10 @@ describe('@function _govuk-line-height', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            line-height: 1.5;
-          }
-        `
+        .foo {
+          line-height: 1.5;
+        }
+      `
     })
   })
 })
@@ -188,17 +188,17 @@ describe('@mixin govuk-typography-responsive', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          font-size: 0.75rem;
+          line-height: 1.25;
+        }
+        @media (min-width: 30em) {
           .foo {
-            font-size: 0.75rem;
-            line-height: 1.25;
+            font-size: 0.875rem;
+            line-height: 1.4285714286;
           }
-          @media (min-width: 30em) {
-            .foo {
-              font-size: 0.875rem;
-              line-height: 1.4285714286;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -213,17 +213,17 @@ describe('@mixin govuk-typography-responsive', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
+        .foo {
+          font-size: 0.75rem;
+          line-height: 1.25;
+        }
+        @media print {
           .foo {
-            font-size: 0.75rem;
-            line-height: 1.25;
+            font-size: 14pt;
+            line-height: 1.5;
           }
-          @media print {
-            .foo {
-              font-size: 14pt;
-              line-height: 1.5;
-            }
-          }
-        `
+        }
+      `
     })
   })
 
@@ -253,17 +253,17 @@ describe('@mixin govuk-typography-responsive', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            font-size: 0.75rem !important;
+            line-height: 1.25 !important;
+          }
+          @media (min-width: 30em) {
             .foo {
-              font-size: 0.75rem !important;
-              line-height: 1.25 !important;
+              font-size: 0.875rem !important;
+              line-height: 1.4285714286 !important;
             }
-            @media (min-width: 30em) {
-              .foo {
-                font-size: 0.875rem !important;
-                line-height: 1.4285714286 !important;
-              }
-            }
-          `
+          }
+        `
       })
     })
 
@@ -278,17 +278,17 @@ describe('@mixin govuk-typography-responsive', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            font-size: 0.75rem !important;
+            line-height: 1.25 !important;
+          }
+          @media print {
             .foo {
-              font-size: 0.75rem !important;
-              line-height: 1.25 !important;
+              font-size: 14pt !important;
+              line-height: 1.5 !important;
             }
-            @media print {
-              .foo {
-                font-size: 14pt !important;
-                line-height: 1.5 !important;
-              }
-            }
-          `
+          }
+        `
       })
     })
   })
@@ -305,17 +305,17 @@ describe('@mixin govuk-typography-responsive', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            font-size: 0.75rem;
+            line-height: 1.75;
+          }
+          @media (min-width: 30em) {
             .foo {
-              font-size: 0.75rem;
-              line-height: 1.75;
+              font-size: 0.875rem;
+              line-height: 1.5;
             }
-            @media (min-width: 30em) {
-              .foo {
-                font-size: 0.875rem;
-                line-height: 1.5;
-              }
-            }
-          `
+          }
+        `
       })
     })
   })
@@ -334,26 +334,26 @@ describe('@mixin govuk-typography-responsive', () => {
 
       await expect(compileSassString(sass)).resolves.toMatchObject({
         css: outdent`
+          .foo {
+            font-family: "GDS Transport", arial, sans-serif;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+            font-weight: 400;
+            font-size: 0.75rem;
+            line-height: 1.25;
+          }
+          @media print {
             .foo {
-              font-family: "GDS Transport", arial, sans-serif;
-              -webkit-font-smoothing: antialiased;
-              -moz-osx-font-smoothing: grayscale;
-              font-weight: 400;
-              font-size: 0.75rem;
-              line-height: 1.25;
+              font-family: sans-serif;
             }
-            @media print {
-              .foo {
-                font-family: sans-serif;
-              }
+          }
+          @media (min-width: 30em) {
+            .foo {
+              font-size: 0.875rem;
+              line-height: 1.4285714286;
             }
-            @media (min-width: 30em) {
-              .foo {
-                font-size: 0.875rem;
-                line-height: 1.4285714286;
-              }
-            }
-          `
+          }
+        `
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/helpers/typography.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.test.js
@@ -4,8 +4,7 @@ const { sassNull } = require('sass-embedded')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
-const mockWarnFunction = jest.fn()
-  .mockReturnValue(sassNull)
+const mockWarnFunction = jest.fn().mockReturnValue(sassNull)
 
 const sassConfig = {
   logger: {
@@ -131,15 +130,13 @@ describe('@function _govuk-line-height', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             line-height: 3.141;
           }
         `
-      })
+    })
   })
 
   it('preserves line-height if using different units', async () => {
@@ -151,15 +148,13 @@ describe('@function _govuk-line-height', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             line-height: 2em;
           }
         `
-      })
+    })
   })
 
   it('converts line-height to a relative number', async () => {
@@ -171,15 +166,13 @@ describe('@function _govuk-line-height', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             line-height: 1.5;
           }
         `
-      })
+    })
   })
 })
 
@@ -193,10 +186,8 @@ describe('@mixin govuk-typography-responsive', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             font-size: 0.75rem;
             line-height: 1.25;
@@ -208,7 +199,7 @@ describe('@mixin govuk-typography-responsive', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('outputs CSS with suitable media queries for print', async () => {
@@ -220,10 +211,8 @@ describe('@mixin govuk-typography-responsive', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             font-size: 0.75rem;
             line-height: 1.25;
@@ -235,7 +224,7 @@ describe('@mixin govuk-typography-responsive', () => {
             }
           }
         `
-      })
+    })
   })
 
   it('throws an exception when passed a size that is not in the scale', async () => {
@@ -247,11 +236,9 @@ describe('@mixin govuk-typography-responsive', () => {
       }
     `
 
-    await expect(compileSassString(sass, sassConfig))
-      .rejects
-      .toThrow(
-        'Unknown font size `3.1415926536` - expected a point from the typography scale.'
-      )
+    await expect(compileSassString(sass, sassConfig)).rejects.toThrow(
+      'Unknown font size `3.1415926536` - expected a point from the typography scale.'
+    )
   })
 
   describe('when $important is set to true', () => {
@@ -264,10 +251,8 @@ describe('@mixin govuk-typography-responsive', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               font-size: 0.75rem !important;
               line-height: 1.25 !important;
@@ -279,7 +264,7 @@ describe('@mixin govuk-typography-responsive', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('marks font-size and line-height as important for print media', async () => {
@@ -291,10 +276,8 @@ describe('@mixin govuk-typography-responsive', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               font-size: 0.75rem !important;
               line-height: 1.25 !important;
@@ -306,7 +289,7 @@ describe('@mixin govuk-typography-responsive', () => {
               }
             }
           `
-        })
+      })
     })
   })
 
@@ -320,10 +303,8 @@ describe('@mixin govuk-typography-responsive', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               font-size: 0.75rem;
               line-height: 1.75;
@@ -335,7 +316,7 @@ describe('@mixin govuk-typography-responsive', () => {
               }
             }
           `
-        })
+      })
     })
   })
 
@@ -351,10 +332,8 @@ describe('@mixin govuk-typography-responsive', () => {
         }
       `
 
-      await expect(compileSassString(sass))
-        .resolves
-        .toMatchObject({
-          css: outdent`
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: outdent`
             .foo {
               font-family: "GDS Transport", arial, sans-serif;
               -webkit-font-smoothing: antialiased;
@@ -375,7 +354,7 @@ describe('@mixin govuk-typography-responsive', () => {
               }
             }
           `
-        })
+      })
     })
 
     it('enables tabular numbers opentype feature flags if $tabular: true', async () => {

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -13,12 +13,13 @@ export class I18n {
    * @param {object} [config] - Configuration options for the function.
    * @param {string} [config.locale] - An overriding locale for the PluralRules functionality.
    */
-  constructor (translations, config) {
+  constructor(translations, config) {
     // Make list of translations available throughout function
     this.translations = translations || {}
 
     // The locale to use for PluralRules and NumberFormat
-    this.locale = (config && config.locale) || document.documentElement.lang || 'en'
+    this.locale =
+      (config && config.locale) || document.documentElement.lang || 'en'
   }
 
   /**
@@ -31,7 +32,7 @@ export class I18n {
    * @throws {Error} Lookup key required
    * @throws {Error} Options required for `${}` placeholders
    */
-  t (lookupKey, options) {
+  t(lookupKey, options) {
     if (!lookupKey) {
       // Print a console error if no lookup key has been provided
       throw new Error('i18n: lookup key missing')
@@ -42,7 +43,10 @@ export class I18n {
     // falsy, as this could legitimately be 0.
     if (options && typeof options.count === 'number') {
       // Get the plural suffix
-      lookupKey = `${lookupKey}.${this.getPluralSuffix(lookupKey, options.count)}`
+      lookupKey = `${lookupKey}.${this.getPluralSuffix(
+        lookupKey,
+        options.count
+      )}`
     }
 
     // Fetch the translation string for that lookup key
@@ -52,7 +56,9 @@ export class I18n {
       // Check for ${} placeholders in the translation string
       if (translationString.match(/%{(.\S+)}/)) {
         if (!options) {
-          throw new Error('i18n: cannot replace placeholders in string if no option data provided')
+          throw new Error(
+            'i18n: cannot replace placeholders in string if no option data provided'
+          )
         }
 
         return this.replacePlaceholders(translationString, options)
@@ -74,7 +80,7 @@ export class I18n {
    * @param {{ [key: string]: unknown }} options - Any options passed with the translation string, e.g: for string interpolation.
    * @returns {string} The translation string to output, with $\{\} placeholders replaced
    */
-  replacePlaceholders (translationString, options) {
+  replacePlaceholders(translationString, options) {
     /** @type {Intl.NumberFormat | undefined} */
     let formatter
 
@@ -98,23 +104,29 @@ export class I18n {
 
           // If a user has passed `false` as the value for the placeholder
           // treat it as though the value should not be displayed
-          if (placeholderValue === false || (
-            typeof placeholderValue !== 'number' &&
-            typeof placeholderValue !== 'string')
+          if (
+            placeholderValue === false ||
+            (typeof placeholderValue !== 'number' &&
+              typeof placeholderValue !== 'string')
           ) {
             return ''
           }
 
           // If the placeholder's value is a number, localise the number formatting
           if (typeof placeholderValue === 'number') {
-            return formatter ? formatter.format(placeholderValue) : `${placeholderValue}`
+            return formatter
+              ? formatter.format(placeholderValue)
+              : `${placeholderValue}`
           }
 
           return placeholderValue
         } else {
-          throw new Error(`i18n: no data found to replace ${placeholderWithBraces} placeholder in string`)
+          throw new Error(
+            `i18n: no data found to replace ${placeholderWithBraces} placeholder in string`
+          )
         }
-      })
+      }
+    )
   }
 
   /**
@@ -127,8 +139,12 @@ export class I18n {
    *
    * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
    */
-  hasIntlPluralRulesSupport () {
-    return Boolean(window.Intl && ('PluralRules' in window.Intl && Intl.PluralRules.supportedLocalesOf(this.locale).length))
+  hasIntlPluralRulesSupport() {
+    return Boolean(
+      window.Intl &&
+        'PluralRules' in window.Intl &&
+        Intl.PluralRules.supportedLocalesOf(this.locale).length
+    )
   }
 
   /**
@@ -141,8 +157,12 @@ export class I18n {
    *
    * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
    */
-  hasIntlNumberFormatSupport () {
-    return Boolean(window.Intl && ('NumberFormat' in window.Intl && Intl.NumberFormat.supportedLocalesOf(this.locale).length))
+  hasIntlNumberFormatSupport() {
+    return Boolean(
+      window.Intl &&
+        'NumberFormat' in window.Intl &&
+        Intl.NumberFormat.supportedLocalesOf(this.locale).length
+    )
   }
 
   /**
@@ -160,13 +180,15 @@ export class I18n {
    * @returns {PluralRule} The suffix associated with the correct pluralisation for this locale.
    * @throws {Error} Plural form `.other` required when preferred plural form is missing
    */
-  getPluralSuffix (lookupKey, count) {
+  getPluralSuffix(lookupKey, count) {
     // Validate that the number is actually a number.
     //
     // Number(count) will turn anything that can't be converted to a Number type
     // into 'NaN'. isFinite filters out NaN, as it isn't a finite number.
     count = Number(count)
-    if (!isFinite(count)) { return 'other' }
+    if (!isFinite(count)) {
+      return 'other'
+    }
 
     let preferredForm
 
@@ -186,7 +208,9 @@ export class I18n {
       // to the console
     } else if (`${lookupKey}.other` in this.translations) {
       if (console && 'warn' in console) {
-        console.warn(`i18n: Missing plural form ".${preferredForm}" for "${this.locale}" locale. Falling back to ".other".`)
+        console.warn(
+          `i18n: Missing plural form ".${preferredForm}" for "${this.locale}" locale. Falling back to ".other".`
+        )
       }
 
       return 'other'
@@ -207,7 +231,7 @@ export class I18n {
    * @param {number} count - Number used to determine which pluralisation to use.
    * @returns {PluralRule} The pluralisation form for count in this locale.
    */
-  selectPluralFormUsingFallbackRules (count) {
+  selectPluralFormUsingFallbackRules(count) {
     // Currently our custom code can only handle positive integers, so let's
     // make sure our number is one of those.
     count = Math.abs(Math.floor(count))
@@ -232,14 +256,16 @@ export class I18n {
    * @returns {string | undefined} The name of the pluralisation rule to use (a key for one
    *   of the functions in this.pluralRules)
    */
-  getPluralRulesForLocale () {
+  getPluralRulesForLocale() {
     const locale = this.locale
     const localeShort = locale.split('-')[0]
 
     // Look through the plural rules map to find which `pluralRule` is
     // appropriate for our current `locale`.
     for (const pluralRule in I18n.pluralRulesMap) {
-      if (Object.prototype.hasOwnProperty.call(I18n.pluralRulesMap, pluralRule)) {
+      if (
+        Object.prototype.hasOwnProperty.call(I18n.pluralRulesMap, pluralRule)
+      ) {
         const languages = I18n.pluralRulesMap[pluralRule]
         for (let i = 0; i < languages.length; i++) {
           if (languages[i] === locale || languages[i] === localeShort) {
@@ -287,8 +313,30 @@ export class I18n {
     chinese: ['my', 'zh', 'id', 'ja', 'jv', 'ko', 'ms', 'th', 'vi'],
     french: ['hy', 'bn', 'fr', 'gu', 'hi', 'fa', 'pa', 'zu'],
     german: [
-      'af', 'sq', 'az', 'eu', 'bg', 'ca', 'da', 'nl', 'en', 'et', 'fi', 'ka',
-      'de', 'el', 'hu', 'lb', 'no', 'so', 'sw', 'sv', 'ta', 'te', 'tr', 'ur'
+      'af',
+      'sq',
+      'az',
+      'eu',
+      'bg',
+      'ca',
+      'da',
+      'nl',
+      'en',
+      'et',
+      'fi',
+      'ka',
+      'de',
+      'el',
+      'hu',
+      'lb',
+      'no',
+      'so',
+      'sw',
+      'sv',
+      'ta',
+      'te',
+      'tr',
+      'ur'
     ],
     irish: ['ga'],
     russian: ['ru', 'uk'],
@@ -312,57 +360,105 @@ export class I18n {
    */
   static pluralRules = {
     /* eslint-disable jsdoc/require-jsdoc */
-    arabic (n) {
-      if (n === 0) { return 'zero' }
-      if (n === 1) { return 'one' }
-      if (n === 2) { return 'two' }
-      if (n % 100 >= 3 && n % 100 <= 10) { return 'few' }
-      if (n % 100 >= 11 && n % 100 <= 99) { return 'many' }
+    arabic(n) {
+      if (n === 0) {
+        return 'zero'
+      }
+      if (n === 1) {
+        return 'one'
+      }
+      if (n === 2) {
+        return 'two'
+      }
+      if (n % 100 >= 3 && n % 100 <= 10) {
+        return 'few'
+      }
+      if (n % 100 >= 11 && n % 100 <= 99) {
+        return 'many'
+      }
       return 'other'
     },
-    chinese () {
+    chinese() {
       return 'other'
     },
-    french (n) {
+    french(n) {
       return n === 0 || n === 1 ? 'one' : 'other'
     },
-    german (n) {
+    german(n) {
       return n === 1 ? 'one' : 'other'
     },
-    irish (n) {
-      if (n === 1) { return 'one' }
-      if (n === 2) { return 'two' }
-      if (n >= 3 && n <= 6) { return 'few' }
-      if (n >= 7 && n <= 10) { return 'many' }
+    irish(n) {
+      if (n === 1) {
+        return 'one'
+      }
+      if (n === 2) {
+        return 'two'
+      }
+      if (n >= 3 && n <= 6) {
+        return 'few'
+      }
+      if (n >= 7 && n <= 10) {
+        return 'many'
+      }
       return 'other'
     },
-    russian (n) {
+    russian(n) {
       const lastTwo = n % 100
       const last = lastTwo % 10
-      if (last === 1 && lastTwo !== 11) { return 'one' }
-      if (last >= 2 && last <= 4 && !(lastTwo >= 12 && lastTwo <= 14)) { return 'few' }
-      if (last === 0 || (last >= 5 && last <= 9) || (lastTwo >= 11 && lastTwo <= 14)) { return 'many' }
+      if (last === 1 && lastTwo !== 11) {
+        return 'one'
+      }
+      if (last >= 2 && last <= 4 && !(lastTwo >= 12 && lastTwo <= 14)) {
+        return 'few'
+      }
+      if (
+        last === 0 ||
+        (last >= 5 && last <= 9) ||
+        (lastTwo >= 11 && lastTwo <= 14)
+      ) {
+        return 'many'
+      }
       // Note: The 'other' suffix is only used by decimal numbers in Russian.
       // We don't anticipate it being used, but it's here for consistency.
       return 'other'
     },
-    scottish (n) {
-      if (n === 1 || n === 11) { return 'one' }
-      if (n === 2 || n === 12) { return 'two' }
-      if ((n >= 3 && n <= 10) || (n >= 13 && n <= 19)) { return 'few' }
+    scottish(n) {
+      if (n === 1 || n === 11) {
+        return 'one'
+      }
+      if (n === 2 || n === 12) {
+        return 'two'
+      }
+      if ((n >= 3 && n <= 10) || (n >= 13 && n <= 19)) {
+        return 'few'
+      }
       return 'other'
     },
-    spanish (n) {
-      if (n === 1) { return 'one' }
-      if (n % 1000000 === 0 && n !== 0) { return 'many' }
+    spanish(n) {
+      if (n === 1) {
+        return 'one'
+      }
+      if (n % 1000000 === 0 && n !== 0) {
+        return 'many'
+      }
       return 'other'
     },
-    welsh (n) {
-      if (n === 0) { return 'zero' }
-      if (n === 1) { return 'one' }
-      if (n === 2) { return 'two' }
-      if (n === 3) { return 'few' }
-      if (n === 6) { return 'many' }
+    welsh(n) {
+      if (n === 0) {
+        return 'zero'
+      }
+      if (n === 1) {
+        return 'one'
+      }
+      if (n === 2) {
+        return 'two'
+      }
+      if (n === 3) {
+        return 'few'
+      }
+      if (n === 6) {
+        return 'many'
+      }
       return 'other'
     }
     /* eslint-enable jsdoc/require-jsdoc */

--- a/packages/govuk-frontend/src/govuk/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.unit.test.mjs
@@ -21,7 +21,9 @@ describe('I18n', () => {
     it('returns the HTML for a given lookup key', () => {
       const i18n = new I18n(translations)
       const returnString = i18n.t('htmlString')
-      expect(returnString).toBe('Hello<span class="govuk-visually-hidden"> world</span>')
+      expect(returnString).toBe(
+        'Hello<span class="govuk-visually-hidden"> world</span>'
+      )
     })
 
     it('returns the lookup key if no translation is defined', () => {
@@ -45,24 +47,38 @@ describe('I18n', () => {
 
       it('throws an error if the options data is not present', () => {
         const i18n = new I18n(translations)
-        expect(() => { i18n.t('nameString') }).toThrowError('i18n: cannot replace placeholders in string if no option data provided')
+        expect(() => {
+          i18n.t('nameString')
+        }).toThrowError(
+          'i18n: cannot replace placeholders in string if no option data provided'
+        )
       })
 
       it('throws an error if the options object is empty', () => {
         const i18n = new I18n(translations)
-        expect(() => { i18n.t('nameString', {}) }).toThrowError('i18n: no data found to replace %{name} placeholder in string')
+        expect(() => {
+          i18n.t('nameString', {})
+        }).toThrowError(
+          'i18n: no data found to replace %{name} placeholder in string'
+        )
       })
 
       it('throws an error if the options object does not have a matching key', () => {
         const i18n = new I18n(translations)
-        expect(() => { i18n.t('nameString', { unrelatedThing: 'hello' }) }).toThrowError('i18n: no data found to replace %{name} placeholder in string')
+        expect(() => {
+          i18n.t('nameString', { unrelatedThing: 'hello' })
+        }).toThrowError(
+          'i18n: no data found to replace %{name} placeholder in string'
+        )
       })
 
       it('only matches %{} as a placeholder', () => {
         const i18n = new I18n({
           price: '%{name}, this } item %{ costs $5.00'
         })
-        expect(i18n.t('price', { name: 'John' })).toBe('John, this } item %{ costs $5.00')
+        expect(i18n.t('price', { name: 'John' })).toBe(
+          'John, this } item %{ costs $5.00'
+        )
       })
 
       it('can lookup a placeholder value with non-alphanumeric key', () => {
@@ -83,7 +99,11 @@ describe('I18n', () => {
         const i18n = new I18n({
           age: 'My age is %{valueOf}'
         })
-        expect(() => { i18n.t('age', {}) }).toThrowError('i18n: no data found to replace %{valueOf} placeholder in string')
+        expect(() => {
+          i18n.t('age', {})
+        }).toThrowError(
+          'i18n: no data found to replace %{valueOf} placeholder in string'
+        )
       })
 
       it('replaces the placeholder with the provided data', () => {
@@ -109,33 +129,53 @@ describe('I18n', () => {
 
       it('selects the correct data to replace in the string', () => {
         const i18n = new I18n(translations)
-        expect(i18n.t('nameString', { number: 50, name: 'Claire', otherName: 'Zoe' })).toBe('My name is Claire')
+        expect(
+          i18n.t('nameString', { number: 50, name: 'Claire', otherName: 'Zoe' })
+        ).toBe('My name is Claire')
       })
 
       it('replaces multiple placeholders, if present', () => {
         const i18n = new I18n({
           nameString: 'Their name is %{name}. %{name} is %{age} years old'
         })
-        expect(i18n.t('nameString', { number: 50, name: 'Andrew', otherName: 'Vic', age: 22 })).toBe('Their name is Andrew. Andrew is 22 years old')
+        expect(
+          i18n.t('nameString', {
+            number: 50,
+            name: 'Andrew',
+            otherName: 'Vic',
+            age: 22
+          })
+        ).toBe('Their name is Andrew. Andrew is 22 years old')
       })
 
       it('replaces very long placeholders', () => {
         const i18n = new I18n({
-          nameString: 'Hi %{aVeryLongPlaceholderName}. %{aVeryLongPlaceholderName}, it sure is nice to meet you.'
+          nameString:
+            'Hi %{aVeryLongPlaceholderName}. %{aVeryLongPlaceholderName}, it sure is nice to meet you.'
         })
-        expect(i18n.t('nameString', { aVeryLongPlaceholderName: 'Bob' })).toBe('Hi Bob. Bob, it sure is nice to meet you.')
+        expect(i18n.t('nameString', { aVeryLongPlaceholderName: 'Bob' })).toBe(
+          'Hi Bob. Bob, it sure is nice to meet you.'
+        )
       })
 
       it('nested placeholder only resolves with a matching key', () => {
         const i18n = new I18n({
           nameString: 'Their name is %{name%{age}}'
         })
-        expect(i18n.t('nameString', { name: 'Andrew', age: 55, 'name%{age}': 'Testing' })).toBe('Their name is Testing')
+        expect(
+          i18n.t('nameString', {
+            name: 'Andrew',
+            age: 55,
+            'name%{age}': 'Testing'
+          })
+        ).toBe('Their name is Testing')
       })
 
       it('handles placeholder-style text within options values', () => {
         const i18n = new I18n(translations)
-        expect(i18n.t('nameString', { name: '%{name}' })).toBe('My name is %{name}')
+        expect(i18n.t('nameString', { name: '%{name}' })).toBe(
+          'My name is %{name}'
+        )
       })
 
       it('formats numbers that are passed as placeholders', () => {
@@ -145,8 +185,12 @@ describe('I18n', () => {
         const i18nEn = new I18n(translations, { locale: 'en' })
         const i18nDe = new I18n(translations, { locale: 'de' })
 
-        expect(i18nEn.t('ageString', { age: 2000 })).toBe('I am 2,000 years old')
-        expect(i18nDe.t('ageString', { age: 2000 })).toBe('I am 2.000 years old')
+        expect(i18nEn.t('ageString', { age: 2000 })).toBe(
+          'I am 2,000 years old'
+        )
+        expect(i18nDe.t('ageString', { age: 2000 })).toBe(
+          'I am 2.000 years old'
+        )
       })
 
       it('does not format number-like strings that are passed as placeholders', () => {
@@ -154,18 +198,23 @@ describe('I18n', () => {
           yearString: 'Happy new year %{year}'
         })
 
-        expect(i18n.t('yearString', { year: '2023' })).toBe('Happy new year 2023')
+        expect(i18n.t('yearString', { year: '2023' })).toBe(
+          'Happy new year 2023'
+        )
       })
     })
 
     describe('pluralisation', () => {
       it('interpolates the count variable into the correct plural form', () => {
-        const i18n = new I18n({
-          'test.one': '%{count} test',
-          'test.other': '%{count} tests'
-        }, {
-          locale: 'en'
-        })
+        const i18n = new I18n(
+          {
+            'test.one': '%{count} test',
+            'test.other': '%{count} tests'
+          },
+          {
+            locale: 'en'
+          }
+        )
 
         expect(i18n.t('test', { count: 1 })).toBe('1 test')
         expect(i18n.t('test', { count: 5 })).toBe('5 tests')
@@ -178,8 +227,11 @@ describe('I18n', () => {
 
     beforeEach(() => {
       // Silence warnings in test output, and allow us to 'expect' them
-      consoleWarn = jest.spyOn(global.console, 'warn')
-        .mockImplementation(() => { /* noop */ })
+      consoleWarn = jest
+        .spyOn(global.console, 'warn')
+        .mockImplementation(() => {
+          /* noop */
+        })
     })
 
     afterEach(() => {
@@ -187,44 +239,58 @@ describe('I18n', () => {
     })
 
     it('uses `Intl.PluralRules` when available', () => {
-      const IntlPluralRulesSelect = jest.spyOn(global.Intl.PluralRules.prototype, 'select')
+      const IntlPluralRulesSelect = jest
+        .spyOn(global.Intl.PluralRules.prototype, 'select')
         .mockImplementation(() => 'one')
 
-      const i18n = new I18n({
-        'test.one': 'test',
-        'test.other': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.one': 'test',
+          'test.other': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
 
       expect(i18n.getPluralSuffix('test', 1)).toBe('one')
       expect(IntlPluralRulesSelect).toBeCalledWith(1)
     })
 
     it('falls back to internal fallback rules', () => {
-      const i18n = new I18n({
-        'test.one': 'test',
-        'test.other': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.one': 'test',
+          'test.other': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
 
-      jest.spyOn(i18n, 'hasIntlPluralRulesSupport')
+      jest
+        .spyOn(i18n, 'hasIntlPluralRulesSupport')
         .mockImplementation(() => false)
 
-      const selectPluralFormUsingFallbackRules = jest.spyOn(i18n, 'selectPluralFormUsingFallbackRules')
+      const selectPluralFormUsingFallbackRules = jest.spyOn(
+        i18n,
+        'selectPluralFormUsingFallbackRules'
+      )
 
       i18n.getPluralSuffix('test', 1)
       expect(selectPluralFormUsingFallbackRules).toBeCalledWith(1)
     })
 
     it('returns the preferred plural form for the locale if a translation exists', () => {
-      const i18n = new I18n({
-        'test.one': 'test',
-        'test.other': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.one': 'test',
+          'test.other': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
       expect(i18n.getPluralSuffix('test', 1)).toBe('one')
     })
 
@@ -233,22 +299,31 @@ describe('I18n', () => {
       { form: 'two', count: 2 },
       { form: 'few', count: 3 },
       { form: 'many', count: 6 }
-    ])('`$form` falls back to `other` if preferred form `$form` is missing', ({ count }) => {
-      const i18n = new I18n({
-        'test.other': 'test'
-      }, {
-        locale: 'cy'
-      })
+    ])(
+      '`$form` falls back to `other` if preferred form `$form` is missing',
+      ({ count }) => {
+        const i18n = new I18n(
+          {
+            'test.other': 'test'
+          },
+          {
+            locale: 'cy'
+          }
+        )
 
-      expect(i18n.getPluralSuffix('test', count)).toBe('other')
-    })
+        expect(i18n.getPluralSuffix('test', count)).toBe('other')
+      }
+    )
 
     it('logs a console warning when falling back to `other`', () => {
-      const i18n = new I18n({
-        'test.other': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.other': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
 
       i18n.getPluralSuffix('test', 1)
 
@@ -258,31 +333,42 @@ describe('I18n', () => {
     })
 
     it('throws an error if trying to use `other` but `other` is not provided', () => {
-      const i18n = new I18n({}, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {},
+        {
+          locale: 'en'
+        }
+      )
 
-      expect(() => { i18n.getPluralSuffix('test', 2) })
-        .toThrowError('i18n: Plural form ".other" is required for "en" locale')
+      expect(() => {
+        i18n.getPluralSuffix('test', 2)
+      }).toThrowError('i18n: Plural form ".other" is required for "en" locale')
     })
 
     it('throws an error if a plural form is not provided and neither is `other`', () => {
-      const i18n = new I18n({
-        'test.one': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.one': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
 
-      expect(() => { i18n.getPluralSuffix('test', 2) })
-        .toThrowError('i18n: Plural form ".other" is required for "en" locale')
+      expect(() => {
+        i18n.getPluralSuffix('test', 2)
+      }).toThrowError('i18n: Plural form ".other" is required for "en" locale')
     })
 
     it('returns `other` for non-numbers', () => {
-      const i18n = new I18n({
-        'test.other': 'test'
-      }, {
-        locale: 'en'
-      })
+      const i18n = new I18n(
+        {
+          'test.other': 'test'
+        },
+        {
+          locale: 'en'
+        }
+      )
 
       // @ts-expect-error Parameter 'count' not a number
       expect(i18n.getPluralSuffix('test', 'nonsense')).toBe('other')
@@ -325,16 +411,21 @@ describe('I18n', () => {
       ['cy', [3, 6]]
     ]
 
-    it.each(locales)('matches `Intl.PluralRules.select()` for %s locale', (locale, localeNumbers) => {
-      const i18n = new I18n({}, { locale })
-      const intl = new Intl.PluralRules(locale)
+    it.each(locales)(
+      'matches `Intl.PluralRules.select()` for %s locale',
+      (locale, localeNumbers) => {
+        const i18n = new I18n({}, { locale })
+        const intl = new Intl.PluralRules(locale)
 
-      const numbersToTest = [0, 1, 2, 5, 25, 100, ...localeNumbers]
+        const numbersToTest = [0, 1, 2, 5, 25, 100, ...localeNumbers]
 
-      numbersToTest.forEach(num => {
-        expect(i18n.selectPluralFormUsingFallbackRules(num)).toBe(intl.select(num))
-      })
-    })
+        numbersToTest.forEach((num) => {
+          expect(i18n.selectPluralFormUsingFallbackRules(num)).toBe(
+            intl.select(num)
+          )
+        })
+      }
+    )
 
     it('returns "other" for unsupported locales', () => {
       const locale = 'la'
@@ -342,7 +433,7 @@ describe('I18n', () => {
 
       const numbersToTest = [0, 1, 2, 5, 25, 100]
 
-      numbersToTest.forEach(num => {
+      numbersToTest.forEach((num) => {
         expect(i18n.selectPluralFormUsingFallbackRules(num)).toBe('other')
       })
     })

--- a/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
@@ -3,33 +3,49 @@ import { renderMacro } from 'govuk-frontend-helpers/nunjucks'
 describe('i18n.njk', () => {
   describe('govukI18nAttributes', () => {
     it('renders a single plural type', () => {
-      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
-        key: 'translation-key',
-        messages: {
-          other: 'You have %{count} characters remaining.'
+      const attributes = renderMacro(
+        'govukI18nAttributes',
+        'govuk/macros/i18n.njk',
+        {
+          key: 'translation-key',
+          messages: {
+            other: 'You have %{count} characters remaining.'
+          }
         }
-      })
+      )
 
       // Note the starting space so we ensure it doesn't stick to possible other previous attributes
-      expect(attributes).toEqual(' data-i18n.translation-key.other="You have %{count} characters remaining."')
+      expect(attributes).toEqual(
+        ' data-i18n.translation-key.other="You have %{count} characters remaining."'
+      )
     })
 
     it('renders multiple plural types', () => {
-      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
-        key: 'translation-key',
-        messages: {
-          other: 'You have %{count} characters remaining.',
-          one: 'One character remaining'
+      const attributes = renderMacro(
+        'govukI18nAttributes',
+        'govuk/macros/i18n.njk',
+        {
+          key: 'translation-key',
+          messages: {
+            other: 'You have %{count} characters remaining.',
+            one: 'One character remaining'
+          }
         }
-      })
+      )
 
-      expect(attributes).toEqual(' data-i18n.translation-key.other="You have %{count} characters remaining." data-i18n.translation-key.one="One character remaining"')
+      expect(attributes).toEqual(
+        ' data-i18n.translation-key.other="You have %{count} characters remaining." data-i18n.translation-key.one="One character remaining"'
+      )
     })
 
     it('outputs nothing if there are no translations', () => {
-      const attributes = renderMacro('govukI18nAttributes', 'govuk/macros/i18n.njk', {
-        key: 'translation-key'
-      })
+      const attributes = renderMacro(
+        'govukI18nAttributes',
+        'govuk/macros/i18n.njk',
+        {
+          key: 'translation-key'
+        }
+      )
 
       expect(attributes).toEqual('')
     })

--- a/packages/govuk-frontend/src/govuk/objects/objects.test.js
+++ b/packages/govuk-frontend/src/govuk/objects/objects.test.js
@@ -30,7 +30,9 @@ describe('The objects layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "objects" group', async () => {
-      const docs = await sassdoc.parse(join(paths.package, 'src/govuk/objects/**/*.scss'))
+      const docs = await sassdoc.parse(
+        join(paths.package, 'src/govuk/objects/**/*.scss')
+      )
 
       for (const doc of docs) {
         expect(doc).toMatchObject({
@@ -39,9 +41,7 @@ describe('The objects layer', () => {
           context: {
             name: doc.context.name
           },
-          group: [
-            expect.stringMatching(/^objects/)
-          ]
+          group: [expect.stringMatching(/^objects/)]
         })
       }
     })

--- a/packages/govuk-frontend/src/govuk/settings/settings.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/settings.test.js
@@ -35,7 +35,9 @@ describe('The settings layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "settings" group', async () => {
-      const docs = await sassdoc.parse(join(paths.package, 'src/govuk/settings/**/*.scss'))
+      const docs = await sassdoc.parse(
+        join(paths.package, 'src/govuk/settings/**/*.scss')
+      )
 
       for (const doc of docs) {
         expect(doc).toMatchObject({
@@ -44,9 +46,7 @@ describe('The settings layer', () => {
           context: {
             name: doc.context.name
           },
-          group: [
-            expect.stringMatching(/^settings/)
-          ]
+          group: [expect.stringMatching(/^settings/)]
         })
       }
     })

--- a/packages/govuk-frontend/src/govuk/settings/warnings.test.js
+++ b/packages/govuk-frontend/src/govuk/settings/warnings.test.js
@@ -3,8 +3,7 @@ const { sassNull } = require('sass-embedded')
 
 // Create a mock warn function that we can use to override the native @warn
 // function, that we can make assertions about post-render.
-const mockWarnFunction = jest.fn()
-  .mockReturnValue(sassNull)
+const mockWarnFunction = jest.fn().mockReturnValue(sassNull)
 
 const sassConfig = {
   logger: {
@@ -25,11 +24,12 @@ describe('Warnings mixin', () => {
 
     // Expect our mocked @warn function to have been called once with a single
     // argument, which should be the test message
-    expect(mockWarnFunction.mock.calls[0])
-      .toEqual(expect.arrayContaining([
+    expect(mockWarnFunction.mock.calls[0]).toEqual(
+      expect.arrayContaining([
         'This is a warning. To silence this warning, update ' +
-        '$govuk-suppressed-warnings with key: "test"'
-      ]))
+          '$govuk-suppressed-warnings with key: "test"'
+      ])
+    )
   })
 
   it('Only fires one @warn per warning key', async () => {

--- a/packages/govuk-frontend/src/govuk/template.test.js
+++ b/packages/govuk-frontend/src/govuk/template.test.js
@@ -49,7 +49,9 @@ describe('Template', () => {
       const $ = renderTemplate({}, { headIcons })
 
       // Build a list of the rel values of all links with a rel ending 'icon'
-      const icons = $('link[rel$="icon"]').map((_, link) => $(link).attr('rel')).get()
+      const icons = $('link[rel$="icon"]')
+        .map((_, link) => $(link).attr('rel'))
+        .get()
       expect(icons).toEqual(['govuk-icon'])
     })
 
@@ -87,14 +89,20 @@ describe('Template', () => {
         const $ = renderTemplate({ assetUrl: 'https://foo.com/my-assets' })
         const $ogImage = $('meta[property="og:image"]')
 
-        expect($ogImage.attr('content')).toEqual('https://foo.com/my-assets/images/govuk-opengraph-image.png')
+        expect($ogImage.attr('content')).toEqual(
+          'https://foo.com/my-assets/images/govuk-opengraph-image.png'
+        )
       })
 
       it('is included if opengraphImageUrl is set', () => {
-        const $ = renderTemplate({ opengraphImageUrl: 'https://foo.com/custom/og-image.png' })
+        const $ = renderTemplate({
+          opengraphImageUrl: 'https://foo.com/custom/og-image.png'
+        })
         const $ogImage = $('meta[property="og:image"]')
 
-        expect($ogImage.attr('content')).toEqual('https://foo.com/custom/og-image.png')
+        expect($ogImage.attr('content')).toEqual(
+          'https://foo.com/custom/og-image.png'
+        )
       })
     })
 
@@ -111,7 +119,8 @@ describe('Template', () => {
     })
 
     describe('<title>', () => {
-      const expectedTitle = 'GOV.UK - The best place to find government services and information'
+      const expectedTitle =
+        'GOV.UK - The best place to find government services and information'
       it(`defaults to '${expectedTitle}'`, () => {
         const $ = renderTemplate()
         expect($('title').text()).toEqual(expectedTitle)
@@ -171,7 +180,9 @@ describe('Template', () => {
 
         // A change to the inline script would be a breaking change, and it would also require
         // updating the hash published in https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#if-your-javascript-isn-t-working-properly
-        expect(`sha256-${hash}`).toEqual('sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=')
+        expect(`sha256-${hash}`).toEqual(
+          'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='
+        )
       })
       it('should not have a nonce attribute by default', () => {
         const $ = renderTemplate()

--- a/packages/govuk-frontend/src/govuk/tools/exports.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/exports.test.js
@@ -21,10 +21,10 @@ describe('@mixin govuk-exports', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: red;
-          }
-        `
+        .foo {
+          color: red;
+        }
+      `
     })
   })
 
@@ -47,14 +47,14 @@ describe('@mixin govuk-exports', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            color: red;
-          }
+        .foo {
+          color: red;
+        }
 
-          .bar {
-            color: blue;
-          }
-        `
+        .bar {
+          color: blue;
+        }
+      `
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/exports.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/exports.test.js
@@ -19,15 +19,13 @@ describe('@mixin govuk-exports', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: red;
           }
         `
-      })
+    })
   })
 
   it('will export differently named sections', async () => {
@@ -47,10 +45,8 @@ describe('@mixin govuk-exports', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             color: red;
           }
@@ -59,6 +55,6 @@ describe('@mixin govuk-exports', () => {
             color: blue;
           }
         `
-      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/font-url.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/font-url.test.js
@@ -14,16 +14,14 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @font-face {
             font-family: "whatever";
             src: url("/path/to/fonts/whatever.woff2");
           }
         `
-      })
+    })
   })
 
   it('can be overridden to use a defined Sass function', async () => {
@@ -39,16 +37,14 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @font-face {
             font-family: "whatever";
             src: "WHATEVER.WOFF2";
           }
         `
-      })
+    })
   })
 
   it('can be overridden to use a custom function', async () => {
@@ -68,15 +64,13 @@ describe('@function font-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           @font-face {
             font-family: "whatever";
             src: url("/custom/whatever.woff2");
           }
         `
-      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/font-url.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/font-url.test.js
@@ -16,11 +16,11 @@ describe('@function font-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @font-face {
-            font-family: "whatever";
-            src: url("/path/to/fonts/whatever.woff2");
-          }
-        `
+        @font-face {
+          font-family: "whatever";
+          src: url("/path/to/fonts/whatever.woff2");
+        }
+      `
     })
   })
 
@@ -39,11 +39,11 @@ describe('@function font-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @font-face {
-            font-family: "whatever";
-            src: "WHATEVER.WOFF2";
-          }
-        `
+        @font-face {
+          font-family: "whatever";
+          src: "WHATEVER.WOFF2";
+        }
+      `
     })
   })
 
@@ -66,11 +66,11 @@ describe('@function font-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          @font-face {
-            font-family: "whatever";
-            src: url("/custom/whatever.woff2");
-          }
-        `
+        @font-face {
+          font-family: "whatever";
+          src: url("/custom/whatever.woff2");
+        }
+      `
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/image-url.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/image-url.test.js
@@ -15,10 +15,10 @@ describe('@function image-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            background-image: url("/path/to/images/baz.png");
-          }
-        `
+        .foo {
+          background-image: url("/path/to/images/baz.png");
+        }
+      `
     })
   })
 
@@ -35,10 +35,10 @@ describe('@function image-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            background-image: "BAZ.PNG";
-          }
-        `
+        .foo {
+          background-image: "BAZ.PNG";
+        }
+      `
     })
   })
 
@@ -60,10 +60,10 @@ describe('@function image-url', () => {
 
     await expect(compileSassString(sass)).resolves.toMatchObject({
       css: outdent`
-          .foo {
-            background-image: url("/custom/baz.png");
-          }
-        `
+        .foo {
+          background-image: url("/custom/baz.png");
+        }
+      `
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/image-url.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/image-url.test.js
@@ -13,15 +13,13 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             background-image: url("/path/to/images/baz.png");
           }
         `
-      })
+    })
   })
 
   it('can be overridden to use a defined Sass function', async () => {
@@ -35,15 +33,13 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             background-image: "BAZ.PNG";
           }
         `
-      })
+    })
   })
 
   it('can be overridden to use a custom function', async () => {
@@ -62,14 +58,12 @@ describe('@function image-url', () => {
       }
     `
 
-    await expect(compileSassString(sass))
-      .resolves
-      .toMatchObject({
-        css: outdent`
+    await expect(compileSassString(sass)).resolves.toMatchObject({
+      css: outdent`
           .foo {
             background-image: url("/custom/baz.png");
           }
         `
-      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/tools/tools.test.js
+++ b/packages/govuk-frontend/src/govuk/tools/tools.test.js
@@ -35,7 +35,9 @@ describe('The tools layer', () => {
 
   describe('Sass documentation', () => {
     it('associates everything with a "tools" group', async () => {
-      const docs = await sassdoc.parse(join(paths.package, 'src/govuk/tools/**/*.scss'))
+      const docs = await sassdoc.parse(
+        join(paths.package, 'src/govuk/tools/**/*.scss')
+      )
 
       for (const doc of docs) {
         expect(doc).toMatchObject({
@@ -44,9 +46,7 @@ describe('The tools layer', () => {
           context: {
             name: doc.context.name
           },
-          group: [
-            expect.stringMatching(/^tools/)
-          ]
+          group: [expect.stringMatching(/^tools/)]
         })
       }
     })

--- a/packages/govuk-frontend/tasks/assets.mjs
+++ b/packages/govuk-frontend/tasks/assets.mjs
@@ -8,11 +8,12 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const assets = (options) => gulp.series(
-  task.name('copy:assets', () =>
-    files.copy('**/*', {
-      srcPath: join(options.srcPath, 'govuk/assets'),
-      destPath: join(options.destPath, 'govuk/assets')
-    })
+export const assets = (options) =>
+  gulp.series(
+    task.name('copy:assets', () =>
+      files.copy('**/*', {
+        srcPath: join(options.srcPath, 'govuk/assets'),
+        destPath: join(options.destPath, 'govuk/assets')
+      })
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/build/dev.mjs
+++ b/packages/govuk-frontend/tasks/build/dev.mjs
@@ -8,6 +8,4 @@ import { watch } from '../index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export default (options) => gulp.series(
-  watch(options)
-)
+export default (options) => gulp.series(watch(options))

--- a/packages/govuk-frontend/tasks/build/package.mjs
+++ b/packages/govuk-frontend/tasks/build/package.mjs
@@ -11,22 +11,21 @@ import { assets, fixtures, scripts, styles, templates } from '../index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export default (options) => gulp.series(
-  task.name('clean', () =>
-    files.clean('*', options)
-  ),
+export default (options) =>
+  gulp.series(
+    task.name('clean', () => files.clean('*', options)),
 
-  assets(options),
-  fixtures(options),
-  scripts(options),
-  styles(options),
-  templates(options),
+    assets(options),
+    fixtures(options),
+    scripts(options),
+    styles(options),
+    templates(options),
 
-  // Copy GOV.UK Prototype Kit JavaScript
-  task.name("copy:files 'govuk-prototype-kit'", () =>
-    files.copy('**/*.js', {
-      srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: join(options.destPath, 'govuk-prototype-kit')
-    })
+    // Copy GOV.UK Prototype Kit JavaScript
+    task.name("copy:files 'govuk-prototype-kit'", () =>
+      files.copy('**/*.js', {
+        srcPath: join(options.srcPath, 'govuk-prototype-kit'),
+        destPath: join(options.destPath, 'govuk-prototype-kit')
+      })
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -3,7 +3,12 @@ import { join } from 'path'
 
 import { paths, pkg } from 'govuk-frontend-config'
 import { compileSassFile } from 'govuk-frontend-helpers/tests'
-import { filterPath, getComponentNames, getListing, mapPathTo } from 'govuk-frontend-lib/files'
+import {
+  filterPath,
+  getComponentNames,
+  getListing,
+  mapPathTo
+} from 'govuk-frontend-lib/files'
 import { componentNameToClassName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
 
@@ -43,8 +48,10 @@ describe('packages/govuk-frontend/dist/', () => {
     componentNames = await getComponentNames()
 
     // Components list (with JavaScript only)
-    componentNamesWithJavaScript = await getComponentNames((componentName, componentFiles) =>
-      componentFiles.some(filterPath([`**/${componentName}.mjs`])))
+    componentNamesWithJavaScript = await getComponentNames(
+      (componentName, componentFiles) =>
+        componentFiles.some(filterPath([`**/${componentName}.mjs`]))
+    )
   })
 
   it('should contain the expected files', async () => {
@@ -65,46 +72,59 @@ describe('packages/govuk-frontend/dist/', () => {
       .flatMap(mapPathTo(['**/govuk-prototype-kit.config.mjs'], () => []))
 
       // All source `**/*.mjs` files compiled to ES modules
-      .flatMap(mapPathTo(['**/*.mjs'], ({ dir: requirePath, name }) => [
-        join(requirePath, `${name}.mjs`),
-        join(requirePath, `${name}.mjs.map`) // with source map
-      ]))
+      .flatMap(
+        mapPathTo(['**/*.mjs'], ({ dir: requirePath, name }) => [
+          join(requirePath, `${name}.mjs`),
+          join(requirePath, `${name}.mjs.map`) // with source map
+        ])
+      )
 
       // Only package entries and components are compiled to ES module + UMD bundles
-      .flatMap(mapPathTo(['**/govuk/{all,components/**/*}.mjs'], ({ dir: requirePath, name }) => [
-        join(requirePath, `${name}.mjs`),
+      .flatMap(
+        mapPathTo(
+          ['**/govuk/{all,components/**/*}.mjs'],
+          ({ dir: requirePath, name }) => [
+            join(requirePath, `${name}.mjs`),
 
-        // UMD bundles for compatibility (e.g. Rails Asset Pipeline)
-        join(requirePath, `${name}.bundle.js`),
-        join(requirePath, `${name}.bundle.js.map`), // with source map
+            // UMD bundles for compatibility (e.g. Rails Asset Pipeline)
+            join(requirePath, `${name}.bundle.js`),
+            join(requirePath, `${name}.bundle.js.map`), // with source map
 
-        // ES module bundles for browsers
-        join(requirePath, `${name}.bundle.mjs`),
-        join(requirePath, `${name}.bundle.mjs.map`) // with source map
-      ]))
+            // ES module bundles for browsers
+            join(requirePath, `${name}.bundle.mjs`),
+            join(requirePath, `${name}.bundle.mjs.map`) // with source map
+          ]
+        )
+      )
 
       // Only main package entry is compiled to minified ES module bundle
-      .flatMap(mapPathTo(['**/govuk/all.mjs'], ({ dir: requirePath }) => [
-        join(requirePath, 'all.mjs'),
+      .flatMap(
+        mapPathTo(['**/govuk/all.mjs'], ({ dir: requirePath }) => [
+          join(requirePath, 'all.mjs'),
 
-        // ES module bundles for browsers, minified
-        join(requirePath, 'govuk-frontend.min.js'), // avoid .mjs extension MIME issues
-        join(requirePath, 'govuk-frontend.min.js.map') // with source map
-      ]))
+          // ES module bundles for browsers, minified
+          join(requirePath, 'govuk-frontend.min.js'), // avoid .mjs extension MIME issues
+          join(requirePath, 'govuk-frontend.min.js.map') // with source map
+        ])
+      )
 
       // Add Autoprefixer prefixes to all source '*.scss' files
-      .flatMap(mapPathTo(['**/*.scss'], ({ dir: requirePath, name }) => [
-        join(requirePath, `${name}.scss`),
-        join(requirePath, `${name}.scss.map`) // with source map
-      ]))
+      .flatMap(
+        mapPathTo(['**/*.scss'], ({ dir: requirePath, name }) => [
+          join(requirePath, `${name}.scss`),
+          join(requirePath, `${name}.scss.map`) // with source map
+        ])
+      )
 
       // Replaces source component '*.yaml' with:
       // - `fixtures.json` fixtures for tests
       // - `macro-options.json` component options
-      .flatMap(mapPathTo(['**/*.yaml'], ({ dir: requirePath }) => [
-        join(requirePath, 'fixtures.json'),
-        join(requirePath, 'macro-options.json')
-      ]))
+      .flatMap(
+        mapPathTo(['**/*.yaml'], ({ dir: requirePath }) => [
+          join(requirePath, 'fixtures.json'),
+          join(requirePath, 'macro-options.json')
+        ])
+      )
       .sort()
 
     // Compare array of actual output files
@@ -138,7 +158,10 @@ describe('packages/govuk-frontend/dist/', () => {
   describe('ECMAScript (ES) modules', () => {
     describe('all.mjs', () => {
       it('should export each module', async () => {
-        const contents = await readFile(join(paths.package, 'dist/govuk/all.mjs'), 'utf8')
+        const contents = await readFile(
+          join(paths.package, 'dist/govuk/all.mjs'),
+          'utf8'
+        )
 
         // Look for ES import for each component
         expect(contents).toContain(outdent`
@@ -156,13 +179,18 @@ describe('packages/govuk-frontend/dist/', () => {
         `)
 
         // Look for ES modules named exports
-        expect(contents).toContain('export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };')
+        expect(contents).toContain(
+          'export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };'
+        )
       })
     })
 
     describe('common/govuk-frontend-version.mjs', () => {
       it('should have correct version number', async () => {
-        const contents = await readFile(join(paths.package, 'dist/govuk/common/govuk-frontend-version.mjs'), 'utf8')
+        const contents = await readFile(
+          join(paths.package, 'dist/govuk/common/govuk-frontend-version.mjs'),
+          'utf8'
+        )
 
         // Look for ES modules `version` named export
         expect(contents).toContain(`const version = '${pkg.version}';`)
@@ -174,17 +202,24 @@ describe('packages/govuk-frontend/dist/', () => {
   describe('Universal Module Definition (UMD)', () => {
     describe('all.bundle.js', () => {
       it('should export each module', async () => {
-        const contents = await readFile(join(paths.package, 'dist/govuk/all.bundle.js'), 'utf8')
+        const contents = await readFile(
+          join(paths.package, 'dist/govuk/all.bundle.js'),
+          'utf8'
+        )
 
         // Look for AMD module definition for 'GOVUKFrontend'
-        expect(contents).toContain("typeof define === 'function' && define.amd ? define('GOVUKFrontend', ['exports'], factory)")
+        expect(contents).toContain(
+          "typeof define === 'function' && define.amd ? define('GOVUKFrontend', ['exports'], factory)"
+        )
 
         // Look for bundled components with CommonJS named exports
         for (const componentName of componentNamesWithJavaScript) {
           const componentClassName = componentNameToClassName(componentName)
 
           expect(contents).toContain(`class ${componentClassName} {`)
-          expect(contents).toContain(`exports.${componentClassName} = ${componentClassName};`)
+          expect(contents).toContain(
+            `exports.${componentClassName} = ${componentClassName};`
+          )
         }
 
         // Look for CommonJS named exports for utilities
@@ -203,29 +238,43 @@ describe('packages/govuk-frontend/dist/', () => {
         const componentDist = componentsFilesDist.filter(componentFilter)
 
         // File not found at source
-        expect(componentSource)
-          .toEqual(expect.not.arrayContaining([join(componentName, 'macro-options.json')]))
+        expect(componentSource).toEqual(
+          expect.not.arrayContaining([
+            join(componentName, 'macro-options.json')
+          ])
+        )
 
         // File generated in dist
-        expect(componentDist)
-          .toEqual(expect.arrayContaining([join(componentName, 'macro-options.json')]))
+        expect(componentDist).toEqual(
+          expect.arrayContaining([join(componentName, 'macro-options.json')])
+        )
 
-        const [optionsPath] = componentDist
-          .filter(filterPath(['**/macro-options.json']))
+        const [optionsPath] = componentDist.filter(
+          filterPath(['**/macro-options.json'])
+        )
 
         // Component options
-        const options = JSON.parse(await readFile(join(paths.package, 'dist/govuk/components', optionsPath), 'utf8'))
+        const options = JSON.parse(
+          await readFile(
+            join(paths.package, 'dist/govuk/components', optionsPath),
+            'utf8'
+          )
+        )
         expect(options).toBeInstanceOf(Array)
 
         // Component options requirements
-        const optionTasks = options.map(async (option) => expect(option).toEqual(
-          expect.objectContaining({
-            name: expect.stringMatching(/^[A-Z]+$/i),
-            type: expect.stringMatching(/array|boolean|integer|string|object|nunjucks-block/),
-            required: expect.any(Boolean),
-            description: expect.any(String)
-          })
-        ))
+        const optionTasks = options.map(async (option) =>
+          expect(option).toEqual(
+            expect.objectContaining({
+              name: expect.stringMatching(/^[A-Z]+$/i),
+              type: expect.stringMatching(
+                /array|boolean|integer|string|object|nunjucks-block/
+              ),
+              required: expect.any(Boolean),
+              description: expect.any(String)
+            })
+          )
+        )
 
         // Check all component options
         return Promise.all(optionTasks)
@@ -238,39 +287,53 @@ describe('packages/govuk-frontend/dist/', () => {
 
   describe('Components with JavaScript', () => {
     it('should have component JavaScript file with correct module name', () => {
-      const componentTasks = componentNamesWithJavaScript.map(async (componentName) => {
-        const componentFilter = filterPath([`**/${componentName}/**`])
+      const componentTasks = componentNamesWithJavaScript.map(
+        async (componentName) => {
+          const componentFilter = filterPath([`**/${componentName}/**`])
 
-        const componentClassName = componentNameToClassName(componentName)
+          const componentClassName = componentNameToClassName(componentName)
 
-        const componentSource = componentsFilesSource.filter(componentFilter)
-        const componentDist = componentsFilesDist.filter(componentFilter)
+          const componentSource = componentsFilesSource.filter(componentFilter)
+          const componentDist = componentsFilesDist.filter(componentFilter)
 
-        // UMD bundle not found at source
-        expect(componentSource)
-          .toEqual(expect.not.arrayContaining([
-            join(componentName, `${componentName}.bundle.js`)
-          ]))
+          // UMD bundle not found at source
+          expect(componentSource).toEqual(
+            expect.not.arrayContaining([
+              join(componentName, `${componentName}.bundle.js`)
+            ])
+          )
 
-        // ES modules and UMD bundle generated in dist
-        expect(componentDist)
-          .toEqual(expect.arrayContaining([
-            join(componentName, `${componentName}.mjs`),
-            join(componentName, `${componentName}.bundle.js`)
-          ]))
+          // ES modules and UMD bundle generated in dist
+          expect(componentDist).toEqual(
+            expect.arrayContaining([
+              join(componentName, `${componentName}.mjs`),
+              join(componentName, `${componentName}.bundle.js`)
+            ])
+          )
 
-        const [modulePathESM] = componentDist
-          .filter(filterPath([`**/${componentName}.mjs`]))
+          const [modulePathESM] = componentDist.filter(
+            filterPath([`**/${componentName}.mjs`])
+          )
 
-        const [modulePathUMD] = componentDist
-          .filter(filterPath([`**/${componentName}.bundle.js`]))
+          const [modulePathUMD] = componentDist.filter(
+            filterPath([`**/${componentName}.bundle.js`])
+          )
 
-        const moduleTextESM = await readFile(join(paths.package, 'dist/govuk/components', modulePathESM), 'utf8')
-        const moduleTextUMD = await readFile(join(paths.package, 'dist/govuk/components', modulePathUMD), 'utf8')
+          const moduleTextESM = await readFile(
+            join(paths.package, 'dist/govuk/components', modulePathESM),
+            'utf8'
+          )
+          const moduleTextUMD = await readFile(
+            join(paths.package, 'dist/govuk/components', modulePathUMD),
+            'utf8'
+          )
 
-        expect(moduleTextESM).toContain(`export { ${componentClassName} }`)
-        expect(moduleTextUMD).toContain(`exports.${componentClassName} = ${componentClassName};`)
-      })
+          expect(moduleTextESM).toContain(`export { ${componentClassName} }`)
+          expect(moduleTextUMD).toContain(
+            `exports.${componentClassName} = ${componentClassName};`
+          )
+        }
+      )
 
       // Check all component files
       return Promise.all(componentTasks)
@@ -286,30 +349,40 @@ describe('packages/govuk-frontend/dist/', () => {
         const componentDist = componentsFilesDist.filter(componentFilter)
 
         // File not found at source
-        expect(componentSource)
-          .toEqual(expect.not.arrayContaining([join(componentName, 'fixtures.json')]))
+        expect(componentSource).toEqual(
+          expect.not.arrayContaining([join(componentName, 'fixtures.json')])
+        )
 
         // File generated in dist
-        expect(componentDist)
-          .toEqual(expect.arrayContaining([join(componentName, 'fixtures.json')]))
+        expect(componentDist).toEqual(
+          expect.arrayContaining([join(componentName, 'fixtures.json')])
+        )
 
-        const [fixturesPath] = componentDist
-          .filter(filterPath([`**/${componentName}/fixtures.json`]))
+        const [fixturesPath] = componentDist.filter(
+          filterPath([`**/${componentName}/fixtures.json`])
+        )
 
         // Component fixtures
-        const { component, fixtures } = JSON.parse(await readFile(join(paths.package, 'dist/govuk/components', fixturesPath), 'utf8'))
+        const { component, fixtures } = JSON.parse(
+          await readFile(
+            join(paths.package, 'dist/govuk/components', fixturesPath),
+            'utf8'
+          )
+        )
         expect(component).toEqual(componentName)
         expect(fixtures).toBeInstanceOf(Array)
 
         // Component fixtures requirements
-        const optionTasks = fixtures.map(async (fixture) => expect(fixture).toEqual(
-          expect.objectContaining({
-            name: expect.any(String),
-            options: expect.any(Object),
-            html: expect.any(String),
-            hidden: expect.any(Boolean)
-          })
-        ))
+        const optionTasks = fixtures.map(async (fixture) =>
+          expect(fixture).toEqual(
+            expect.objectContaining({
+              name: expect.any(String),
+              options: expect.any(Object),
+              html: expect.any(String),
+              hidden: expect.any(Boolean)
+            })
+          )
+        )
 
         // Check all component fixtures
         return Promise.all(optionTasks)

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -10,52 +10,57 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export default (options) => gulp.series(
-  task.name('clean', () =>
-    files.clean('*', options)
-  ),
+export default (options) =>
+  gulp.series(
+    task.name('clean', () => files.clean('*', options)),
 
-  // Copy GOV.UK Frontend static assets
-  task.name('copy:assets', () =>
-    files.copy('*/**', {
-      srcPath: join(options.srcPath, 'govuk/assets'),
-      destPath: join(options.destPath, 'assets')
-    })
-  ),
+    // Copy GOV.UK Frontend static assets
+    task.name('copy:assets', () =>
+      files.copy('*/**', {
+        srcPath: join(options.srcPath, 'govuk/assets'),
+        destPath: join(options.destPath, 'assets')
+      })
+    ),
 
-  // Compile GOV.UK Frontend JavaScript
-  task.name("compile:js 'release'", () =>
-    scripts.compile('all.mjs', {
-      ...options,
+    // Compile GOV.UK Frontend JavaScript
+    task.name("compile:js 'release'", () =>
+      scripts.compile('all.mjs', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk'),
-      configPath: join(options.basePath, 'rollup.release.config.mjs'),
+        srcPath: join(options.srcPath, 'govuk'),
+        configPath: join(options.basePath, 'rollup.release.config.mjs'),
 
-      // Rename using package name (versioned) and `*.min.js` extension due to
-      // web server ES module `*.mjs` Content-Type header support
-      filePath ({ dir, name }) {
-        return join(dir, `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`)
-      }
-    })
-  ),
+        // Rename using package name (versioned) and `*.min.js` extension due to
+        // web server ES module `*.mjs` Content-Type header support
+        filePath({ dir, name }) {
+          return join(
+            dir,
+            `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.js`
+          )
+        }
+      })
+    ),
 
-  // Compile GOV.UK Frontend Sass
-  task.name('compile:scss', () =>
-    styles.compile('**/[!_]*.scss', {
-      ...options,
+    // Compile GOV.UK Frontend Sass
+    task.name('compile:scss', () =>
+      styles.compile('**/[!_]*.scss', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk'),
-      configPath: join(options.basePath, 'postcss.config.mjs'),
+        srcPath: join(options.srcPath, 'govuk'),
+        configPath: join(options.basePath, 'postcss.config.mjs'),
 
-      // Rename using package name (versioned) and `*.min.css` extension
-      filePath ({ dir, name }) {
-        return join(dir, `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`)
-      }
-    })
-  ),
+        // Rename using package name (versioned) and `*.min.css` extension
+        filePath({ dir, name }) {
+          return join(
+            dir,
+            `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`
+          )
+        }
+      })
+    ),
 
-  // Update GOV.UK Frontend version
-  task.name("file:version 'VERSION.txt'", () =>
-    files.version('VERSION.txt', options)
+    // Update GOV.UK Frontend version
+    task.name("file:version 'VERSION.txt'", () =>
+      files.version('VERSION.txt', options)
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/build/release.test.mjs
+++ b/packages/govuk-frontend/tasks/build/release.test.mjs
@@ -38,11 +38,15 @@ describe('dist/', () => {
     })
 
     it('should contain the copyright notice', () => {
-      expect(stylesheet).toContain('/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */')
+      expect(stylesheet).toContain(
+        '/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */'
+      )
     })
 
     it('should contain source mapping URL', () => {
-      expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/\n$`))
+      expect(stylesheet).toMatch(
+        new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/\n$`)
+      )
     })
 
     it('should contain version number custom property', () => {
@@ -56,12 +60,18 @@ describe('dist/', () => {
 
     beforeAll(async () => {
       filename = `govuk-frontend-${pkg.version}.min.css.map`
-      sourcemap = JSON.parse(await readFile(join(paths.root, `dist/${filename}`), 'utf8'))
+      sourcemap = JSON.parse(
+        await readFile(join(paths.root, `dist/${filename}`), 'utf8')
+      )
     })
 
     it('should contain relative paths to sources', () => {
-      expect(sourcemap.sources).toContain('../packages/govuk-frontend/src/govuk/all.scss')
-      expect(sourcemap.sources).toContain('../packages/govuk-frontend/src/govuk/core/_govuk-frontend-version.scss')
+      expect(sourcemap.sources).toContain(
+        '../packages/govuk-frontend/src/govuk/all.scss'
+      )
+      expect(sourcemap.sources).toContain(
+        '../packages/govuk-frontend/src/govuk/core/_govuk-frontend-version.scss'
+      )
     })
   })
 
@@ -83,7 +93,9 @@ describe('dist/', () => {
     })
 
     it('should contain source mapping URL', () => {
-      expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map\n$`))
+      expect(javascript).toMatch(
+        new RegExp(`//# sourceMappingURL=${filename}.map\n$`)
+      )
     })
   })
 
@@ -93,12 +105,18 @@ describe('dist/', () => {
 
     beforeAll(async () => {
       filename = `govuk-frontend-${pkg.version}.min.js.map`
-      sourcemap = JSON.parse(await readFile(join(paths.root, `dist/${filename}`), 'utf8'))
+      sourcemap = JSON.parse(
+        await readFile(join(paths.root, `dist/${filename}`), 'utf8')
+      )
     })
 
     it('should contain relative paths to sources', () => {
-      expect(sourcemap.sources).toContain('../packages/govuk-frontend/src/govuk/all.mjs')
-      expect(sourcemap.sources).toContain('../packages/govuk-frontend/src/govuk/common/govuk-frontend-version.mjs')
+      expect(sourcemap.sources).toContain(
+        '../packages/govuk-frontend/src/govuk/all.mjs'
+      )
+      expect(sourcemap.sources).toContain(
+        '../packages/govuk-frontend/src/govuk/common/govuk-frontend-version.mjs'
+      )
     })
   })
 

--- a/packages/govuk-frontend/tasks/fixtures.mjs
+++ b/packages/govuk-frontend/tasks/fixtures.mjs
@@ -8,24 +8,25 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const compile = (options) => gulp.series(
-  /**
-   * Generate GOV.UK Frontend fixtures.json from ${componentName}.yaml
-   */
-  task.name('compile:fixtures', () =>
-    components.generateFixtures('**/*.yaml', {
-      srcPath: join(options.srcPath, 'govuk/components'),
-      destPath: join(options.destPath, 'govuk/components')
-    })
-  ),
+export const compile = (options) =>
+  gulp.series(
+    /**
+     * Generate GOV.UK Frontend fixtures.json from ${componentName}.yaml
+     */
+    task.name('compile:fixtures', () =>
+      components.generateFixtures('**/*.yaml', {
+        srcPath: join(options.srcPath, 'govuk/components'),
+        destPath: join(options.destPath, 'govuk/components')
+      })
+    ),
 
-  /**
-   * Generate GOV.UK Frontend macro-options.json from ${componentName}.yaml
-   */
-  task.name('compile:macro-options', () =>
-    components.generateMacroOptions('**/*.yaml', {
-      srcPath: join(options.srcPath, 'govuk/components'),
-      destPath: join(options.destPath, 'govuk/components')
-    })
+    /**
+     * Generate GOV.UK Frontend macro-options.json from ${componentName}.yaml
+     */
+    task.name('compile:macro-options', () =>
+      components.generateMacroOptions('**/*.yaml', {
+        srcPath: join(options.srcPath, 'govuk/components'),
+        destPath: join(options.destPath, 'govuk/components')
+      })
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -9,49 +9,50 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const compile = (options) => gulp.series(
-  /**
-   * Compile GOV.UK Frontend JavaScript for all entry points
-   */
-  task.name("compile:js 'modules'", () =>
-    scripts.compile('**/{all,components/*/!(*.test)}.mjs', {
-      ...options,
+export const compile = (options) =>
+  gulp.series(
+    /**
+     * Compile GOV.UK Frontend JavaScript for all entry points
+     */
+    task.name("compile:js 'modules'", () =>
+      scripts.compile('**/{all,components/*/!(*.test)}.mjs', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk'),
-      configPath: join(options.basePath, 'rollup.publish.config.mjs')
-    })
-  ),
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'rollup.publish.config.mjs')
+      })
+    ),
 
-  /**
-   * Compile GOV.UK Frontend JavaScript (minified) for main entry point only
-   */
-  task.name("compile:js 'minified'", () =>
-    scripts.compile('**/all.mjs', {
-      ...options,
+    /**
+     * Compile GOV.UK Frontend JavaScript (minified) for main entry point only
+     */
+    task.name("compile:js 'minified'", () =>
+      scripts.compile('**/all.mjs', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk'),
-      configPath: join(options.basePath, 'rollup.release.config.mjs'),
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'rollup.release.config.mjs'),
 
-      // Rename using package name and `*.min.js` extension due to
-      // web server ES module `*.mjs` Content-Type header support
-      filePath ({ dir, name }) {
-        return join(dir, `${name.replace(/^all/, pkg.name)}.min.js`)
-      }
-    })
-  ),
+        // Rename using package name and `*.min.js` extension due to
+        // web server ES module `*.mjs` Content-Type header support
+        filePath({ dir, name }) {
+          return join(dir, `${name.replace(/^all/, pkg.name)}.min.js`)
+        }
+      })
+    ),
 
-  /**
-   * Compile GOV.UK Prototype Kit config
-   */
-  task.name("compile:js 'govuk-prototype-kit'", () =>
-    configs.compile('govuk-prototype-kit.config.mjs', {
-      srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: resolve(options.destPath, '../') // Top level (not dist) for compatibility
-    })
-  ),
+    /**
+     * Compile GOV.UK Prototype Kit config
+     */
+    task.name("compile:js 'govuk-prototype-kit'", () =>
+      configs.compile('govuk-prototype-kit.config.mjs', {
+        srcPath: join(options.srcPath, 'govuk-prototype-kit'),
+        destPath: resolve(options.destPath, '../') // Top level (not dist) for compatibility
+      })
+    ),
 
-  // Compile GOV.UK Frontend build stats
-  npm.script('build:stats', [], options)
-)
+    // Compile GOV.UK Frontend build stats
+    npm.script('build:stats', [], options)
+  )

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -8,30 +8,31 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const compile = (options) => gulp.series(
-  /**
-   * Apply CSS prefixes to GOV.UK Frontend Sass
-   */
-  task.name('compile:scss', () =>
-    styles.compile('**/*.scss', {
-      ...options,
+export const compile = (options) =>
+  gulp.series(
+    /**
+     * Apply CSS prefixes to GOV.UK Frontend Sass
+     */
+    task.name('compile:scss', () =>
+      styles.compile('**/*.scss', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk'),
-      configPath: join(options.basePath, 'postcss.config.mjs')
-    })
-  ),
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'postcss.config.mjs')
+      })
+    ),
 
-  /**
-   * Apply CSS prefixes to GOV.UK Prototype Kit Sass
-   */
-  task.name("compile:scss 'govuk-prototype-kit'", () =>
-    styles.compile('init.scss', {
-      ...options,
+    /**
+     * Apply CSS prefixes to GOV.UK Prototype Kit Sass
+     */
+    task.name("compile:scss 'govuk-prototype-kit'", () =>
+      styles.compile('init.scss', {
+        ...options,
 
-      srcPath: join(options.srcPath, 'govuk-prototype-kit'),
-      destPath: join(options.destPath, 'govuk-prototype-kit'),
-      configPath: join(options.basePath, 'postcss.config.mjs')
-    })
+        srcPath: join(options.srcPath, 'govuk-prototype-kit'),
+        destPath: join(options.destPath, 'govuk-prototype-kit'),
+        configPath: join(options.basePath, 'postcss.config.mjs')
+      })
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/templates.mjs
+++ b/packages/govuk-frontend/tasks/templates.mjs
@@ -8,11 +8,12 @@ import gulp from 'gulp'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const templates = (options) => gulp.series(
-  task.name('copy:templates', () =>
-    files.copy('**/*.{md,njk}', {
-      srcPath: join(options.srcPath, 'govuk'),
-      destPath: join(options.destPath, 'govuk')
-    })
+export const templates = (options) =>
+  gulp.series(
+    task.name('copy:templates', () =>
+      files.copy('**/*.{md,njk}', {
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk')
+      })
+    )
   )
-)

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -15,54 +15,63 @@ import { assets, fixtures, scripts, styles, templates } from './index.mjs'
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */
-export const watch = (options) => gulp.parallel(
-  /**
-   * Stylesheets build + lint watcher
-   */
-  task.name('lint:scss watch', () =>
-    gulp.watch([
-      `${slash(options.srcPath)}/govuk/**/*.scss`,
-      `!${slash(options.srcPath)}/govuk/vendor/*`
-    ], gulp.parallel(
-      npm.script('lint:scss:cli', [slash(join(options.workspace, '**/*.scss'))]),
-      styles(options)
-    ))
-  ),
+export const watch = (options) =>
+  gulp.parallel(
+    /**
+     * Stylesheets build + lint watcher
+     */
+    task.name('lint:scss watch', () =>
+      gulp.watch(
+        [
+          `${slash(options.srcPath)}/govuk/**/*.scss`,
+          `!${slash(options.srcPath)}/govuk/vendor/*`
+        ],
+        gulp.parallel(
+          npm.script('lint:scss:cli', [
+            slash(join(options.workspace, '**/*.scss'))
+          ]),
+          styles(options)
+        )
+      )
+    ),
 
-  /**
-   * JavaScripts build + lint watcher
-   */
-  task.name('lint:js watch', () =>
-    gulp.watch([
-      `${slash(options.srcPath)}/govuk/**/*.mjs`
-    ], gulp.parallel(
-      npm.script('lint:js:cli', [slash(join(options.workspace, '**/*.{cjs,js,md,mjs}'))]),
-      scripts(options)
-    ))
-  ),
+    /**
+     * JavaScripts build + lint watcher
+     */
+    task.name('lint:js watch', () =>
+      gulp.watch(
+        [`${slash(options.srcPath)}/govuk/**/*.mjs`],
+        gulp.parallel(
+          npm.script('lint:js:cli', [
+            slash(join(options.workspace, '**/*.{cjs,js,md,mjs}'))
+          ]),
+          scripts(options)
+        )
+      )
+    ),
 
-  /**
-   * Component fixtures watcher
-   */
-  task.name('compile:fixtures watch', () =>
-    gulp.watch([
-      `${slash(options.srcPath)}/govuk/components/*/*.yaml`
-    ], fixtures(options))
-  ),
+    /**
+     * Component fixtures watcher
+     */
+    task.name('compile:fixtures watch', () =>
+      gulp.watch(
+        [`${slash(options.srcPath)}/govuk/components/*/*.yaml`],
+        fixtures(options)
+      )
+    ),
 
-  /**
-   * Component template watcher
-   */
-  task.name('copy:templates watch', () =>
-    gulp.watch([
-      `${slash(options.srcPath)}/govuk/**/*.{md,njk}`
-    ], templates(options))
-  ),
+    /**
+     * Component template watcher
+     */
+    task.name('copy:templates watch', () =>
+      gulp.watch(
+        [`${slash(options.srcPath)}/govuk/**/*.{md,njk}`],
+        templates(options)
+      )
+    ),
 
-  // Copy GOV.UK Frontend static assets
-  task.name('copy:assets watch', () =>
-    gulp.watch([
-      `${slash(options.srcPath)}/govuk/assets/**`
-    ], assets(options))
+    // Copy GOV.UK Frontend static assets
+    task.name('copy:assets watch', () =>
+      gulp.watch([`${slash(options.srcPath)}/govuk/assets/**`], assets(options))
+    )
   )
-)

--- a/shared/helpers/jest/browser/close.mjs
+++ b/shared/helpers/jest/browser/close.mjs
@@ -6,7 +6,7 @@ import teardown from 'jest-environment-puppeteer/teardown'
  * @param {import('jest').Config} jestConfig - Jest config
  * @returns {Promise<void>}
  */
-export default function browserClose (jestConfig) {
+export default function browserClose(jestConfig) {
   // Close browser, stop server (also in watch mode)
   return teardown({ ...jestConfig, watch: false })
 }

--- a/shared/helpers/jest/browser/download.mjs
+++ b/shared/helpers/jest/browser/download.mjs
@@ -7,7 +7,7 @@ import { PUPPETEER_REVISIONS } from 'puppeteer-core/lib/cjs/puppeteer/revisions.
 /**
  * Puppeteer browser downloader
  */
-export async function download () {
+export async function download() {
   const browser = Browser.CHROME
 
   // Download management

--- a/shared/helpers/jest/browser/download.test.mjs
+++ b/shared/helpers/jest/browser/download.test.mjs
@@ -18,14 +18,18 @@ describe('Browser tasks: Puppeteer browser downloader', () => {
     browsers = []
 
     // Mock Puppeteer browser cache API
-    jest.mocked(Cache.prototype.getInstalledBrowsers).mockImplementation(() => browsers)
+    jest
+      .mocked(Cache.prototype.getInstalledBrowsers)
+      .mockImplementation(() => browsers)
     jest.mocked(Cache.prototype.clear).mockReturnValue()
   })
 
   it('downloads by default', async () => {
     await download()
 
-    expect(install).toHaveBeenCalledWith(expect.objectContaining({ buildId: 'new-version' }))
+    expect(install).toHaveBeenCalledWith(
+      expect.objectContaining({ buildId: 'new-version' })
+    )
     expect(install).toHaveBeenCalledTimes(1)
 
     // Outdated versions always removed
@@ -44,7 +48,9 @@ describe('Browser tasks: Puppeteer browser downloader', () => {
 
     await download()
 
-    expect(install).toHaveBeenCalledWith(expect.objectContaining({ buildId: 'new-version' }))
+    expect(install).toHaveBeenCalledWith(
+      expect.objectContaining({ buildId: 'new-version' })
+    )
     expect(install).toHaveBeenCalledTimes(1)
 
     // Outdated versions always removed
@@ -69,7 +75,9 @@ describe('Browser tasks: Puppeteer browser downloader', () => {
 
     await download()
 
-    expect(install).toHaveBeenCalledWith(expect.objectContaining({ buildId: 'new-version' }))
+    expect(install).toHaveBeenCalledWith(
+      expect.objectContaining({ buildId: 'new-version' })
+    )
     expect(install).toHaveBeenCalledTimes(1)
 
     // Outdated versions always removed

--- a/shared/helpers/jest/browser/open.mjs
+++ b/shared/helpers/jest/browser/open.mjs
@@ -8,7 +8,7 @@ import { download } from './download.mjs'
  * @param {import('jest').Config} jestConfig - Jest config
  * @returns {Promise<void>}
  */
-export default async function browserOpen (jestConfig) {
+export default async function browserOpen(jestConfig) {
   await download() // Download browser
   return setup(jestConfig) // Open browser, start server
 }

--- a/shared/helpers/jest/environment/jsdom.mjs
+++ b/shared/helpers/jest/environment/jsdom.mjs
@@ -5,14 +5,16 @@ import { TestEnvironment } from 'jest-environment-jsdom'
  * Adds jsdom window/document globals, shared test globals
  */
 class BrowserVirtualEnvironment extends TestEnvironment {
-  async setup () {
+  async setup() {
     await super.setup()
 
     // Access virtual console
     const { virtualConsole } = this.dom
 
     // Ensure test fails for browser exceptions
-    virtualConsole.on('jsdomError', (error) => process.emit('uncaughtException', error))
+    virtualConsole.on('jsdomError', (error) =>
+      process.emit('uncaughtException', error)
+    )
   }
 }
 

--- a/shared/helpers/jest/environment/puppeteer.mjs
+++ b/shared/helpers/jest/environment/puppeteer.mjs
@@ -5,7 +5,7 @@ import { TestEnvironment } from 'jest-environment-puppeteer'
  * Adds Puppeteer page/browser globals, shared test globals
  */
 class BrowserAutomationEnvironment extends TestEnvironment {
-  async setup () {
+  async setup() {
     await super.setup()
 
     // Listen for browser exceptions

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -1,13 +1,14 @@
 const { join } = require('path')
 
 const cheerio = require('cheerio')
-const { componentNameToMacroName, packageNameToPath } = require('govuk-frontend-lib/names')
+const {
+  componentNameToMacroName,
+  packageNameToPath
+} = require('govuk-frontend-lib/names')
 const nunjucks = require('nunjucks')
 const { outdent } = require('outdent')
 
-const nunjucksPaths = [
-  join(packageNameToPath('govuk-frontend'), 'src')
-]
+const nunjucksPaths = [join(packageNameToPath('govuk-frontend'), 'src')]
 
 const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
   trimBlocks: true,
@@ -23,7 +24,7 @@ const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
  *   Nunjucks call tag, with the callBlock passed as the contents of the block
  * @returns {string} HTML rendered by the macro
  */
-function renderHTML (componentName, options, callBlock) {
+function renderHTML(componentName, options, callBlock) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
@@ -39,7 +40,7 @@ function renderHTML (componentName, options, callBlock) {
  *   Nunjucks call tag, with the callBlock passed as the contents of the block
  * @returns {import('cheerio').CheerioAPI} HTML rendered by the macro
  */
-function render (componentName, options, callBlock) {
+function render(componentName, options, callBlock) {
   return cheerio.load(renderHTML(componentName, options, callBlock))
 }
 
@@ -52,7 +53,7 @@ function render (componentName, options, callBlock) {
  * @param {string} [callBlock] - Content for an optional callBlock, if necessary for the macro to receive one
  * @returns {string} The result of calling the macro
  */
-function renderMacro (macroName, macroPath, options = {}, callBlock) {
+function renderMacro(macroName, macroPath, options = {}, callBlock) {
   const macroOptions = JSON.stringify(options, undefined, 2)
 
   let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
@@ -73,7 +74,7 @@ function renderMacro (macroName, macroPath, options = {}, callBlock) {
  * @param {{ [blockName: string]: string }} [blocks] - Nunjucks blocks
  * @returns {import('cheerio').CheerioAPI} Nunjucks template output
  */
-function renderTemplate (context = {}, blocks = {}) {
+function renderTemplate(context = {}, blocks = {}) {
   let viewString = '{% extends "govuk/template.njk" %}'
 
   for (const [blockName, blockContent] of Object.entries(blocks)) {

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -12,7 +12,7 @@ const { renderHTML } = require('./nunjucks')
  * @param {import('axe-core').RuleObject} [overrides] - Axe rule overrides
  * @returns {Promise<import('axe-core').AxeResults>} Axe Puppeteer instance
  */
-async function axe (page, overrides = {}) {
+async function axe(page, overrides = {}) {
   const reporter = new AxePuppeteer(page)
     .setLegacyMode(true) // Share single page via iframe
     .include('body')
@@ -48,9 +48,7 @@ async function axe (page, overrides = {}) {
   }
 
   // Create report
-  const report = await reporter
-    .options({ rules })
-    .analyze()
+  const report = await reporter.options({ rules }).analyze()
 
   // Add preview URL to report violations
   report.violations.forEach((violation) => {
@@ -81,28 +79,36 @@ async function axe (page, overrides = {}) {
  *   browser to execute arbitrary initialisation
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-async function renderAndInitialise (page, componentName, options) {
+async function renderAndInitialise(page, componentName, options) {
   await goTo(page, '/tests/boilerplate')
 
   const html = renderHTML(componentName, options.params)
 
   // Inject rendered HTML into the page
-  await page.$eval('#slot', (slot, htmlForSlot) => {
-    slot.innerHTML = htmlForSlot
-  }, html)
+  await page.$eval(
+    '#slot',
+    (slot, htmlForSlot) => {
+      slot.innerHTML = htmlForSlot
+    },
+    html
+  )
 
   // Run a script to init the JavaScript component
-  await page.evaluate(async (exportName, options) => {
-    const $module = document.querySelector('[data-module]')
+  await page.evaluate(
+    async (exportName, options) => {
+      const $module = document.querySelector('[data-module]')
 
-    if (options.initialiser) {
-      options.initialiser($module)
-    }
+      if (options.initialiser) {
+        options.initialiser($module)
+      }
 
-    const namespace = await import('govuk-frontend')
-    /* eslint-disable-next-line no-new */
-    new namespace[exportName]($module, options.config)
-  }, componentNameToClassName(componentName), options)
+      const namespace = await import('govuk-frontend')
+      /* eslint-disable-next-line no-new */
+      new namespace[exportName]($module, options.config)
+    },
+    componentNameToClassName(componentName),
+    options
+  )
 
   return page
 }
@@ -114,7 +120,7 @@ async function renderAndInitialise (page, componentName, options) {
  * @param {URL['pathname']} path - URL path
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-async function goTo (page, path) {
+async function goTo(page, path) {
   const { href, pathname } = new URL(path, `http://localhost:${ports.app}`)
 
   const response = await page.goto(href)
@@ -137,7 +143,7 @@ async function goTo (page, path) {
  * @param {string} exampleName - Example name
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-function goToExample (page, exampleName) {
+function goToExample(page, exampleName) {
   return goTo(page, `/examples/${exampleName}`)
 }
 
@@ -150,7 +156,7 @@ function goToExample (page, exampleName) {
  * @param {string} options.exampleName - Example name
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-function goToComponent (page, componentName, options) {
+function goToComponent(page, componentName, options) {
   const exampleName = slug(options?.exampleName ?? '', { lower: true })
 
   // Add example name to URL or use default
@@ -168,7 +174,7 @@ function goToComponent (page, componentName, options) {
  * @param {string} propertyName - Property name to return value for
  * @returns {Promise<unknown>} Property value
  */
-async function getProperty ($element, propertyName) {
+async function getProperty($element, propertyName) {
   const handle = await $element.getProperty(propertyName)
   return handle.jsonValue()
 }
@@ -180,7 +186,7 @@ async function getProperty ($element, propertyName) {
  * @param {string} attributeName - Attribute name to return value for
  * @returns {Promise<string | null>} Attribute value
  */
-function getAttribute ($element, attributeName) {
+function getAttribute($element, attributeName) {
   return $element.evaluate((el, name) => el.getAttribute(name), attributeName)
 }
 
@@ -192,7 +198,7 @@ function getAttribute ($element, attributeName) {
  * @returns {Promise<string>} The element's accessible name
  * @throws {TypeError} If the element has no corresponding node in the accessibility tree
  */
-async function getAccessibleName (page, $element) {
+async function getAccessibleName(page, $element) {
   // Purposefully doesn't use `?.` to return undefined if there's no node in the
   // accessibility tree. This lets us distinguish different kinds of failures:
   // - assertion on the name failing: we need to figure out
@@ -208,8 +214,8 @@ async function getAccessibleName (page, $element) {
  * @param {import('puppeteer').ElementHandle} $element - Puppeteer element handle
  * @returns {Promise<boolean>} Element visibility
  */
-async function isVisible ($element) {
-  return !!await $element.boundingBox()
+async function isVisible($element) {
+  return !!(await $element.boundingBox())
 }
 
 module.exports = {

--- a/shared/helpers/tests.js
+++ b/shared/helpers/tests.js
@@ -15,7 +15,7 @@ const sassPaths = [
  * @param {import('sass-embedded').Options} [options] - Options to pass to Sass
  * @returns {Promise<import('sass-embedded').CompileResult>} Sass compile result
  */
-async function compileSassFile (path, options = {}) {
+async function compileSassFile(path, options = {}) {
   return compileAsync(path, {
     loadPaths: sassPaths,
     logger: Logger.silent,
@@ -31,7 +31,7 @@ async function compileSassFile (path, options = {}) {
  * @param {import('sass-embedded').Options} [options] - Options to pass to Sass
  * @returns {Promise<import('sass-embedded').CompileResult>} Sass compile result
  */
-async function compileSassString (source, options = {}) {
+async function compileSassString(source, options = {}) {
   return compileStringAsync(source, {
     loadPaths: sassPaths,
     logger: Logger.silent,
@@ -65,7 +65,7 @@ const fetchPath = (path, options = {}) => {
  * @param {string} className - the top level class 'Block' in B.E.M terminology
  * @returns {string} returns HTML
  */
-function htmlWithClassName ($, className) {
+function htmlWithClassName($, className) {
   const $component = $(className)
   const classSelector = className.replace('.', '')
   // Remove all other elements that do not match this component

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -26,7 +26,9 @@ const getListing = async (directoryPath, options = {}) => {
 
   // Use relative paths
   return listing
-    .map((entryPath) => relative(options.cwd?.toString() ?? paths.root, entryPath))
+    .map((entryPath) =>
+      relative(options.cwd?.toString() ?? paths.root, entryPath)
+    )
     .sort()
 }
 
@@ -37,12 +39,12 @@ const getListing = async (directoryPath, options = {}) => {
  * @returns {Promise<string[]>} Directory names
  */
 const getDirectories = async (directoryPath) => {
-  const listing = await getListing(`${slash(directoryPath)}/*/`, { nodir: false })
+  const listing = await getListing(`${slash(directoryPath)}/*/`, {
+    nodir: false
+  })
 
   // Use directory names only
-  return listing
-    .map((directoryPath) => basename(directoryPath))
-    .sort()
+  return listing.map((directoryPath) => basename(directoryPath)).sort()
 }
 
 /**
@@ -53,9 +55,7 @@ const getDirectories = async (directoryPath) => {
  * @returns {(entryPath: string) => boolean} Returns true for files matching every pattern
  */
 const filterPath = (patterns) => (entryPath) => {
-  return patterns.every(
-    (pattern) => minimatch(entryPath, pattern)
-  )
+  return patterns.every((pattern) => minimatch(entryPath, pattern))
 }
 
 /**
@@ -70,9 +70,7 @@ const mapPathTo = (patterns, callback) => (entryPath) => {
   const isMatch = filterPath(patterns)
 
   // Run callback on files matching every pattern (or original path)
-  return isMatch(entryPath)
-    ? callback(parse(entryPath))
-    : entryPath
+  return isMatch(entryPath) ? callback(parse(entryPath)) : entryPath
 }
 
 /**
@@ -92,7 +90,10 @@ const getYaml = async (configPath) => {
  * @returns {Promise<ComponentData & { name: string }>} Component data
  */
 const getComponentData = async (componentName) => {
-  const yamlPath = join(packageNameToPath('govuk-frontend'), `src/govuk/components/${componentName}/${componentName}.yaml`)
+  const yamlPath = join(
+    packageNameToPath('govuk-frontend'),
+    `src/govuk/components/${componentName}/${componentName}.yaml`
+  )
 
   /** @type {ComponentData} */
   const yamlData = await getYaml(yamlPath)
@@ -120,7 +121,12 @@ const getComponentsData = async () => {
  * @returns {Promise<string[]>} Component files
  */
 const getComponentFiles = (componentName = '') =>
-  getListing(join(packageNameToPath('govuk-frontend'), `src/govuk/components/${componentName}/**/*`))
+  getListing(
+    join(
+      packageNameToPath('govuk-frontend'),
+      `src/govuk/components/${componentName}/**/*`
+    )
+  )
 
 /**
  * Get component names (with optional filter)
@@ -129,14 +135,17 @@ const getComponentFiles = (componentName = '') =>
  * @returns {Promise<string[]>} Component names
  */
 const getComponentNames = async (filter) => {
-  const componentNames = await getDirectories(join(packageNameToPath('govuk-frontend'), '**/src/govuk/components/'))
+  const componentNames = await getDirectories(
+    join(packageNameToPath('govuk-frontend'), '**/src/govuk/components/')
+  )
 
   if (filter) {
     const componentFiles = await getComponentFiles()
 
     // Apply component names filter
     return componentNames.filter((componentName) =>
-      filter(componentName, componentFiles))
+      filter(componentName, componentFiles)
+    )
   }
 
   return componentNames
@@ -148,7 +157,7 @@ const getComponentNames = async (filter) => {
  * @param {string} componentName - Component name
  * @returns {Promise<{ [name: string]: ComponentExample['data'] }>} returns object that includes all examples at once
  */
-async function getExamples (componentName) {
+async function getExamples(componentName) {
   const componentData = await getComponentData(componentName)
 
   /** @type {{ [name: string]: ComponentExample['data'] }} */

--- a/shared/lib/files.unit.test.js
+++ b/shared/lib/files.unit.test.js
@@ -2,46 +2,51 @@ const { getComponentData } = require('./files.js')
 
 describe('getComponentData', () => {
   it('rejects if unable to load component data', async () => {
-    await expect(getComponentData('not-a-real-component'))
-      .rejects
-      .toThrow(/ENOENT: no such file or directory/)
+    await expect(getComponentData('not-a-real-component')).rejects.toThrow(
+      /ENOENT: no such file or directory/
+    )
   })
 
   it('outputs objects with an array of params and examples', async () => {
     const componentName = 'accordion'
     const componentData = await getComponentData(componentName)
 
-    expect(componentData)
-      .toEqual(expect.objectContaining({
+    expect(componentData).toEqual(
+      expect.objectContaining({
         name: componentName,
         params: expect.arrayContaining([expect.any(Object)]),
         examples: expect.arrayContaining([expect.any(Object)])
-      }))
+      })
+    )
   })
 
   it('outputs a param for each object with the expected attributes', async () => {
     const componentName = 'accordion'
     const { params } = await getComponentData(componentName)
 
-    params.forEach((param) => expect(param).toEqual(
-      expect.objectContaining({
-        name: expect.any(String),
-        type: expect.any(String),
-        required: expect.any(Boolean),
-        description: expect.any(String)
-      })
-    ))
+    params.forEach((param) =>
+      expect(param).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          type: expect.any(String),
+          required: expect.any(Boolean),
+          description: expect.any(String)
+        })
+      )
+    )
   })
 
   it('contains example objects with the expected attributes', async () => {
     const componentName = 'accordion'
     const { examples } = await getComponentData(componentName)
 
-    examples.forEach((example) => expect(example).toEqual(
-      expect.objectContaining({
-        name: expect.any(String),
-        data: expect.any(Object)
-      })
-    ))
+    examples.forEach((example) =>
+      expect(example).toEqual(
+        expect.objectContaining({
+          name: expect.any(String),
+          data: expect.any(Object)
+        })
+      )
+    )
   })
 })

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -9,13 +9,15 @@ const { minimatch } = require('minimatch')
  * @param {string} value - Input kebab-cased string
  * @returns {string} Output PascalCased string
  */
-function kebabCaseToPascalCase (value) {
-  return value
-    .toLowerCase()
-    .split('-')
-    // capitalize each 'word'
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('')
+function kebabCaseToPascalCase(value) {
+  return (
+    value
+      .toLowerCase()
+      .split('-')
+      // capitalize each 'word'
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('')
+  )
 }
 
 /**
@@ -27,7 +29,7 @@ function kebabCaseToPascalCase (value) {
  * @param {string} componentName - A kebab-cased component name
  * @returns {string} The name of its corresponding Nunjucks macro
  */
-function componentNameToMacroName (componentName) {
+function componentNameToMacroName(componentName) {
   return `govuk${kebabCaseToPascalCase(componentName)}`
 }
 
@@ -37,7 +39,7 @@ function componentNameToMacroName (componentName) {
  * @param {string} componentName - A kebab-cased component name
  * @returns {string} The name of its corresponding JavaScript class
  */
-function componentNameToClassName (componentName) {
+function componentNameToClassName(componentName) {
   return kebabCaseToPascalCase(componentName)
 }
 
@@ -54,7 +56,7 @@ function componentNameToClassName (componentName) {
  * @param {string} componentPath - Path to component with kebab-cased file name
  * @returns {string} The name of its corresponding module
  */
-function componentPathToModuleName (componentPath) {
+function componentPathToModuleName(componentPath) {
   const { name } = parse(componentPath)
 
   return minimatch(componentPath, '**/components/**', { matchBase: true })
@@ -72,13 +74,15 @@ function componentPathToModuleName (componentPath) {
  * @param {Pick<PackageOptions, "modulePath" | "moduleRoot">} [options] - Package resolution options
  * @returns {string} Path to installed npm package entry
  */
-function packageResolveToPath (packageEntry, { modulePath, moduleRoot } = {}) {
+function packageResolveToPath(packageEntry, { modulePath, moduleRoot } = {}) {
   const packagePath = require.resolve(packageEntry, {
     paths: [moduleRoot ?? paths.root]
   })
 
   // Append optional module path
-  return modulePath !== undefined ? join(dirname(packagePath), modulePath) : packagePath
+  return modulePath !== undefined
+    ? join(dirname(packagePath), modulePath)
+    : packagePath
 }
 
 /**
@@ -104,13 +108,19 @@ function packageResolveToPath (packageEntry, { modulePath, moduleRoot } = {}) {
  * @param {PackageOptions} [options] - Package resolution options
  * @returns {string} Path to installed npm package field
  */
-function packageTypeToPath (packageName, { modulePath, moduleRoot, type = 'commonjs' } = {}) {
+function packageTypeToPath(
+  packageName,
+  { modulePath, moduleRoot, type = 'commonjs' } = {}
+) {
   const packageEntry = `${packageName}/package.json`
   const packageField = type === 'module' ? 'module' : 'main'
 
   // Package field as child path
-  const entryPath = require(packageResolveToPath(packageEntry, { moduleRoot }))[packageField]
-  const childPath = modulePath !== undefined ? join(dirname(entryPath), modulePath) : entryPath
+  const entryPath = require(packageResolveToPath(packageEntry, { moduleRoot }))[
+    packageField
+  ]
+  const childPath =
+    modulePath !== undefined ? join(dirname(entryPath), modulePath) : entryPath
 
   // Append optional module path
   return packageResolveToPath(packageEntry, {
@@ -129,7 +139,7 @@ function packageTypeToPath (packageName, { modulePath, moduleRoot, type = 'commo
  * @param {Pick<PackageOptions, "moduleRoot">} [options] - Package resolution options
  * @returns {string} Path to installed npm package
  */
-function packageNameToPath (packageName, options) {
+function packageNameToPath(packageName, options) {
   return packageResolveToPath(`${packageName}/package.json`, {
     modulePath: '',
     ...options

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -31,10 +31,12 @@ describe('componentNameToClassName', () => {
     }
   ]
 
-  it.each(components)("transforms component '$name' to class '$className'", ({ name, className }) => {
-    expect(componentNameToClassName(name))
-      .toBe(className)
-  })
+  it.each(components)(
+    "transforms component '$name' to class '$className'",
+    ({ name, className }) => {
+      expect(componentNameToClassName(name)).toBe(className)
+    }
+  )
 })
 
 describe('componentNameToMacroName', () => {
@@ -57,10 +59,12 @@ describe('componentNameToMacroName', () => {
     }
   ]
 
-  it.each(components)("transforms component '$name' to macro '$macroName'", ({ name, macroName }) => {
-    expect(componentNameToMacroName(name))
-      .toBe(macroName)
-  })
+  it.each(components)(
+    "transforms component '$name' to macro '$macroName'",
+    ({ name, macroName }) => {
+      expect(componentNameToMacroName(name)).toBe(macroName)
+    }
+  )
 })
 
 describe('componentPathToModuleName', () => {
@@ -83,48 +87,52 @@ describe('componentPathToModuleName', () => {
     }
   ]
 
-  const others = [
-    'common/index.mjs',
-    'common/normalise-dataset.mjs'
-  ]
+  const others = ['common/index.mjs', 'common/normalise-dataset.mjs']
 
-  it.each(components)("transforms '$path' to '$moduleName'", ({ path, moduleName }) => {
-    const srcPath = join(paths.package, 'src/govuk')
+  it.each(components)(
+    "transforms '$path' to '$moduleName'",
+    ({ path, moduleName }) => {
+      const srcPath = join(paths.package, 'src/govuk')
 
-    // Path variations
-    const pathAbsolute = join(srcPath, path)
-    const pathRelativeToRoot = relative(paths.root, pathAbsolute)
-    const pathRelativeToSource = relative(srcPath, pathAbsolute)
+      // Path variations
+      const pathAbsolute = join(srcPath, path)
+      const pathRelativeToRoot = relative(paths.root, pathAbsolute)
+      const pathRelativeToSource = relative(srcPath, pathAbsolute)
 
-    // Absolute path
-    // For example `/path/to/project/packages/govuk-frontend/src/govuk/components/button/button.mjs`
-    expect(componentPathToModuleName(pathAbsolute))
-      .toBe(moduleName)
+      // Absolute path
+      // For example `/path/to/project/packages/govuk-frontend/src/govuk/components/button/button.mjs`
+      expect(componentPathToModuleName(pathAbsolute)).toBe(moduleName)
 
-    // Relative path (to project)
-    // For example `packages/govuk-frontend/src/govuk/components/button/button.mjs`
-    expect(componentPathToModuleName(pathRelativeToRoot))
-      .toBe(moduleName)
+      // Relative path (to project)
+      // For example `packages/govuk-frontend/src/govuk/components/button/button.mjs`
+      expect(componentPathToModuleName(pathRelativeToRoot)).toBe(moduleName)
 
-    // Relative path (to source)
-    // For example `components/button/button.mjs`
-    expect(componentPathToModuleName(pathRelativeToSource))
-      .toBe(moduleName)
-  })
+      // Relative path (to source)
+      // For example `components/button/button.mjs`
+      expect(componentPathToModuleName(pathRelativeToSource)).toBe(moduleName)
+    }
+  )
 
-  it.each(others)("transforms unknown components to 'GOVUKFrontend'", (path) => {
-    const srcPath = join(paths.package, 'src/govuk')
+  it.each(others)(
+    "transforms unknown components to 'GOVUKFrontend'",
+    (path) => {
+      const srcPath = join(paths.package, 'src/govuk')
 
-    // Path variations
-    const pathAbsolute = join(srcPath, path)
-    const pathRelativeToRoot = relative(paths.root, pathAbsolute)
-    const pathRelativeToSource = relative(srcPath, pathAbsolute)
+      // Path variations
+      const pathAbsolute = join(srcPath, path)
+      const pathRelativeToRoot = relative(paths.root, pathAbsolute)
+      const pathRelativeToSource = relative(srcPath, pathAbsolute)
 
-    // Unknown components always named 'GOVUKFrontend'
-    expect(componentPathToModuleName(pathAbsolute)).toBe('GOVUKFrontend')
-    expect(componentPathToModuleName(pathRelativeToRoot)).toBe('GOVUKFrontend')
-    expect(componentPathToModuleName(pathRelativeToSource)).toBe('GOVUKFrontend')
-  })
+      // Unknown components always named 'GOVUKFrontend'
+      expect(componentPathToModuleName(pathAbsolute)).toBe('GOVUKFrontend')
+      expect(componentPathToModuleName(pathRelativeToRoot)).toBe(
+        'GOVUKFrontend'
+      )
+      expect(componentPathToModuleName(pathRelativeToSource)).toBe(
+        'GOVUKFrontend'
+      )
+    }
+  )
 })
 
 describe('packageResolveToPath', () => {
@@ -145,14 +153,19 @@ describe('packageResolveToPath', () => {
     {
       packageEntry: 'govuk-frontend/src/govuk/all.mjs',
       options: { modulePath: 'components/accordion/accordion.mjs' },
-      resolvedPath: join(paths.package, 'src/govuk/components/accordion/accordion.mjs')
+      resolvedPath: join(
+        paths.package,
+        'src/govuk/components/accordion/accordion.mjs'
+      )
     }
   ]
 
-  it.each(packages)("locates path for npm package entry '$packageEntry'", ({ packageEntry, options, resolvedPath }) => {
-    expect(packageResolveToPath(packageEntry, options))
-      .toBe(resolvedPath)
-  })
+  it.each(packages)(
+    "locates path for npm package entry '$packageEntry'",
+    ({ packageEntry, options, resolvedPath }) => {
+      expect(packageResolveToPath(packageEntry, options)).toBe(resolvedPath)
+    }
+  )
 })
 
 describe('packageTypeToPath', () => {
@@ -174,19 +187,30 @@ describe('packageTypeToPath', () => {
     {
       packageName: 'govuk-frontend',
       options: { modulePath: 'components/accordion/accordion.bundle.js' },
-      resolvedPath: join(paths.package, 'dist/govuk/components/accordion/accordion.bundle.js')
+      resolvedPath: join(
+        paths.package,
+        'dist/govuk/components/accordion/accordion.bundle.js'
+      )
     },
     {
       packageName: 'govuk-frontend',
-      options: { modulePath: 'components/accordion/accordion.bundle.mjs', type: 'module' },
-      resolvedPath: join(paths.package, 'dist/govuk/components/accordion/accordion.bundle.mjs')
+      options: {
+        modulePath: 'components/accordion/accordion.bundle.mjs',
+        type: 'module'
+      },
+      resolvedPath: join(
+        paths.package,
+        'dist/govuk/components/accordion/accordion.bundle.mjs'
+      )
     }
   ]
 
-  it.each(packages)("locates path for npm package '$packageName' field '$packageField'", ({ packageName, options, resolvedPath }) => {
-    expect(packageTypeToPath(packageName, options))
-      .toBe(resolvedPath)
-  })
+  it.each(packages)(
+    "locates path for npm package '$packageName' field '$packageField'",
+    ({ packageName, options, resolvedPath }) => {
+      expect(packageTypeToPath(packageName, options)).toBe(resolvedPath)
+    }
+  )
 })
 
 describe('packageNameToPath', () => {
@@ -201,10 +225,12 @@ describe('packageNameToPath', () => {
     }
   ]
 
-  it.each(packages)("locates path for npm package '$packageName'", ({ packageName, resolvedPath }) => {
-    expect(packageNameToPath(packageName))
-      .toBe(resolvedPath)
-  })
+  it.each(packages)(
+    "locates path for npm package '$packageName'",
+    ({ packageName, resolvedPath }) => {
+      expect(packageNameToPath(packageName)).toBe(resolvedPath)
+    }
+  )
 })
 
 describe("packageNameToPath (with custom 'node_module' paths)", () => {
@@ -231,8 +257,10 @@ describe("packageNameToPath (with custom 'node_module' paths)", () => {
     }
   ]
 
-  it.each(packages)("locates path for npm package '$packageName'", ({ packageName, options = {}, resolvedPath }) => {
-    expect(packageNameToPath(packageName, options))
-      .toBe(resolvedPath)
-  })
+  it.each(packages)(
+    "locates path for npm package '$packageName'",
+    ({ packageName, options = {}, resolvedPath }) => {
+      expect(packageNameToPath(packageName, options)).toBe(resolvedPath)
+    }
+  )
 })

--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -14,37 +14,51 @@ const packagePath = packageTypeToPath('govuk-frontend', packageOptions)
 /**
  * Rollup config with stats output
  */
-export default defineConfig(modulePaths
-  .map((modulePath) => /** @satisfies {import('rollup').RollupOptions} */({
-    input: relative(paths.stats, packageTypeToPath('govuk-frontend', { ...packageOptions, modulePath })),
+export default defineConfig(
+  modulePaths.map(
+    (modulePath) =>
+      /** @satisfies {import('rollup').RollupOptions} */ ({
+        input: relative(
+          paths.stats,
+          packageTypeToPath('govuk-frontend', { ...packageOptions, modulePath })
+        ),
 
-    /**
-     * Output options
-     */
-    output: {
-      file: join('dist', modulePath),
-      format: 'es'
-    },
+        /**
+         * Output options
+         */
+        output: {
+          file: join('dist', modulePath),
+          format: 'es'
+        },
 
-    /**
-     * Input plugins
-     */
-    plugins: [
-      resolve({ rootDir: paths.stats }),
+        /**
+         * Input plugins
+         */
+        plugins: [
+          resolve({ rootDir: paths.stats }),
 
-      // Stats: File size
-      visualizer({
-        filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.yaml`),
-        projectRoot: dirname(packagePath),
-        template: 'list'
-      }),
+          // Stats: File size
+          visualizer({
+            filename: join(
+              'dist',
+              dirname(modulePath),
+              `${parse(modulePath).name}.yaml`
+            ),
+            projectRoot: dirname(packagePath),
+            template: 'list'
+          }),
 
-      // Stats: Module tree map
-      visualizer({
-        filename: join('dist', dirname(modulePath), `${parse(modulePath).name}.html`),
-        projectRoot: dirname(packagePath),
-        template: 'treemap'
+          // Stats: Module tree map
+          visualizer({
+            filename: join(
+              'dist',
+              dirname(modulePath),
+              `${parse(modulePath).name}.html`
+            ),
+            projectRoot: dirname(packagePath),
+            template: 'treemap'
+          })
+        ]
       })
-    ]
-  }))
+  )
 )

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -1,13 +1,19 @@
 import { join, parse } from 'path'
 
 import { paths } from 'govuk-frontend-config'
-import { getComponentNames, filterPath, getYaml } from 'govuk-frontend-lib/files'
+import {
+  getComponentNames,
+  filterPath,
+  getYaml
+} from 'govuk-frontend-lib/files'
 
 /**
  * Components with JavaScript
  */
-const componentNamesWithJavaScript = await getComponentNames((componentName, componentFiles) =>
-  componentFiles.some(filterPath([`**/${componentName}.mjs`])))
+const componentNamesWithJavaScript = await getComponentNames(
+  (componentName, componentFiles) =>
+    componentFiles.some(filterPath([`**/${componentName}.mjs`]))
+)
 
 /**
  * Package options
@@ -23,9 +29,11 @@ export const packageOptions = {
 /**
  * Rollup input paths
  */
-export const modulePaths = [packageOptions.modulePath]
-  .concat(componentNamesWithJavaScript.map((componentName) =>
-    `components/${componentName}/${componentName}.mjs`))
+export const modulePaths = [packageOptions.modulePath].concat(
+  componentNamesWithJavaScript.map(
+    (componentName) => `components/${componentName}/${componentName}.mjs`
+  )
+)
 
 /**
  * Rollup module stats
@@ -33,13 +41,14 @@ export const modulePaths = [packageOptions.modulePath]
  * @param {string} modulePath - Rollup input path
  * @returns {Promise<{ total: number, modules: ModulesList }>} Rollup module stats
  */
-export async function getStats (modulePath) {
+export async function getStats(modulePath) {
   const { base, dir, name } = parse(modulePath)
 
   // Path to Rollup `npm run build` YAML stats
   /** @type {Record<string, ModulesList> | undefined} */
-  const stats = await getYaml(join(paths.stats, `dist/${dir}/${name}.yaml`))
-    .catch(() => undefined)
+  const stats = await getYaml(
+    join(paths.stats, `dist/${dir}/${name}.yaml`)
+  ).catch(() => undefined)
 
   // Modules bundled
   const modules = stats?.[base] ?? {}

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -12,7 +12,7 @@ import { files } from './index.mjs'
  * @param {AssetOutput} result - Generated or minified bundle
  * @returns {Promise<void>}
  */
-export async function write (filePath, result) {
+export async function write(filePath, result) {
   const { base, dir } = parse(filePath)
 
   const writeTasks = []
@@ -23,14 +23,16 @@ export async function write (filePath, result) {
   const code = 'css' in result ? result.css : result.code
 
   // 1. Write code (example.js)
-  writeTasks.push(files.write(base, {
-    destPath: dir,
+  writeTasks.push(
+    files.write(base, {
+      destPath: dir,
 
-    // Add source code
-    async fileContents () {
-      return code
-    }
-  }))
+      // Add source code
+      async fileContents() {
+        return code
+      }
+    })
+  )
 
   // 2. Write source map (example.js.map)
   if (map && 'sources' in map) {
@@ -40,19 +42,24 @@ export async function write (filePath, result) {
        * Make source file:// paths relative (e.g. for Dart Sass)
        * {@link https://sass-lang.com/documentation/js-api/interfaces/CompileResult#sourceMap}
        */
-      .map((path) => slash(path.startsWith('file://')
-        ? relative(dirname(filePath), fileURLToPath(path))
-        : path
-      ))
+      .map((path) =>
+        slash(
+          path.startsWith('file://')
+            ? relative(dirname(filePath), fileURLToPath(path))
+            : path
+        )
+      )
 
-    writeTasks.push(files.write(`${base}.map`, {
-      destPath: dir,
+    writeTasks.push(
+      files.write(`${base}.map`, {
+        destPath: dir,
 
-      // Add source map as JSON
-      async fileContents () {
-        return JSON.stringify(map)
-      }
-    }))
+        // Add source map as JSON
+        async fileContents() {
+          return JSON.stringify(map)
+        }
+      })
+    )
   }
 
   await Promise.all(writeTasks)

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -2,7 +2,12 @@ import percySnapshot from '@percy/puppeteer'
 import { waitForPercyIdle } from '@percy/sdk-utils'
 import { download } from 'govuk-frontend-helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from 'govuk-frontend-helpers/puppeteer'
-import { filterPath, getComponentFiles, getComponentNames, getExamples } from 'govuk-frontend-lib/files'
+import {
+  filterPath,
+  getComponentFiles,
+  getComponentNames,
+  getExamples
+} from 'govuk-frontend-lib/files'
 import puppeteer from 'puppeteer'
 
 /**
@@ -10,7 +15,7 @@ import puppeteer from 'puppeteer'
  *
  * @returns {Promise<import('puppeteer').Browser>} Puppeteer browser object
  */
-export async function launch () {
+export async function launch() {
   await download()
 
   // Open browser
@@ -23,7 +28,7 @@ export async function launch () {
  *
  * @returns {Promise<void>}
  */
-export async function screenshots () {
+export async function screenshots() {
   const browser = await launch()
   const componentNames = await getComponentNames()
 
@@ -54,10 +59,7 @@ export async function screenshots () {
   }
 
   // Screenshot specific example pages
-  for (const exampleName of [
-    'text-alignment',
-    'typography'
-  ]) {
+  for (const exampleName of ['text-alignment', 'typography']) {
     await screenshotExample(await browser.newPage(), exampleName)
   }
 
@@ -78,7 +80,7 @@ export async function screenshots () {
  * @param {string} options.exampleName - Example name
  * @returns {Promise<void>}
  */
-export async function screenshotComponent (page, componentName, options) {
+export async function screenshotComponent(page, componentName, options) {
   const componentFiles = await getComponentFiles(componentName)
 
   // Navigate to component
@@ -113,7 +115,7 @@ export async function screenshotComponent (page, componentName, options) {
  * @param {string} exampleName - Component name
  * @returns {Promise<void>}
  */
-export async function screenshotExample (page, exampleName) {
+export async function screenshotExample(page, exampleName) {
   await goToExample(page, exampleName)
 
   // Dismiss app banner

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -11,7 +11,7 @@ import { files } from './index.mjs'
  * @param {AssetEntry[0]} pattern - Path to ${componentName}.yaml
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
-export async function generateFixtures (pattern, { srcPath, destPath }) {
+export async function generateFixtures(pattern, { srcPath, destPath }) {
   const componentDataPaths = await getListing(pattern, {
     cwd: srcPath
   })
@@ -25,12 +25,12 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
       destPath,
 
       // Rename to fixtures.json
-      filePath ({ dir }) {
+      filePath({ dir }) {
         return join(dir, 'fixtures.json')
       },
 
       // Add fixtures as JSON (formatted)
-      async fileContents () {
+      async fileContents() {
         return JSON.stringify(fixture, null, 4)
       }
     })
@@ -45,26 +45,28 @@ export async function generateFixtures (pattern, { srcPath, destPath }) {
  * @param {AssetEntry[0]} pattern - Path to ${componentName}.yaml
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
-export async function generateMacroOptions (pattern, { srcPath, destPath }) {
+export async function generateMacroOptions(pattern, { srcPath, destPath }) {
   const componentDataPaths = await getListing(pattern, {
     cwd: srcPath
   })
 
   // Loop component data paths
   const macroOptions = componentDataPaths.map(async (componentDataPath) => {
-    const macroOption = await generateMacroOption(componentDataPath, { srcPath })
+    const macroOption = await generateMacroOption(componentDataPath, {
+      srcPath
+    })
 
     // Write to destination
     await files.write(componentDataPath, {
       destPath,
 
       // Rename to 'macro-options.json'
-      filePath ({ dir }) {
+      filePath({ dir }) {
         return join(dir, 'macro-options.json')
       },
 
       // Add macro options as JSON (formatted)
-      async fileContents () {
+      async fileContents() {
         return JSON.stringify(macroOption, null, 4)
       }
     })
@@ -80,7 +82,7 @@ export async function generateMacroOptions (pattern, { srcPath, destPath }) {
  * @param {Pick<AssetEntry[1], "srcPath">} options - Asset options
  * @returns {Promise<{ component: string; fixtures: { [key: string]: unknown }[] }>} Component fixtures object
  */
-async function generateFixture (componentDataPath, options) {
+async function generateFixture(componentDataPath, options) {
   /** @type {ComponentData} */
   const json = await getYaml(join(options.srcPath, componentDataPath))
 
@@ -89,7 +91,11 @@ async function generateFixture (componentDataPath, options) {
   }
 
   // Nunjucks template
-  const template = join(options.srcPath, dirname(componentDataPath), 'template.njk')
+  const template = join(
+    options.srcPath,
+    dirname(componentDataPath),
+    'template.njk'
+  )
   const componentName = basename(dirname(componentDataPath))
 
   // Loop examples
@@ -124,7 +130,7 @@ async function generateFixture (componentDataPath, options) {
  * @param {Pick<AssetEntry[1], "srcPath">} options - Asset options
  * @returns {Promise<ComponentOption[] | undefined>} Component macro options
  */
-async function generateMacroOption (componentDataPath, options) {
+async function generateMacroOption(componentDataPath, options) {
   /** @type {ComponentData} */
   const json = await getYaml(join(options.srcPath, componentDataPath))
 

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -10,20 +10,22 @@ import { files } from './index.mjs'
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  * @returns {Promise<void>}
  */
-export async function compile (modulePath, options) {
-  const { default: configFn } = await import(pathToFileURL(join(options.srcPath, modulePath)).toString())
+export async function compile(modulePath, options) {
+  const { default: configFn } = await import(
+    pathToFileURL(join(options.srcPath, modulePath)).toString()
+  )
 
   // Write to destination
   return files.write(modulePath, {
     ...options,
 
     // Rename with `*.json` extension
-    filePath ({ dir, name }) {
+    filePath({ dir, name }) {
       return join(dir, `${name}.json`)
     },
 
     // Add config as JSON (formatted)
-    async fileContents () {
+    async fileContents() {
       return JSON.stringify(await configFn(), undefined, 2)
     }
   })

--- a/shared/tasks/files.mjs
+++ b/shared/tasks/files.mjs
@@ -12,7 +12,7 @@ import slash from 'slash'
  * @param {string} pattern - Pattern to remove
  * @param {Pick<AssetEntry[1], "destPath">} options - Asset options
  */
-export async function clean (pattern, { destPath }) {
+export async function clean(pattern, { destPath }) {
   await deleteAsync(slash(join(destPath, pattern)), {
     cwd: paths.root
   })
@@ -24,12 +24,12 @@ export async function clean (pattern, { destPath }) {
  * @param {AssetEntry[0]} assetPath - File path to asset
  * @param {Pick<AssetEntry[1], "destPath">} options - Asset options
  */
-export async function version (assetPath, options) {
+export async function version(assetPath, options) {
   await write(assetPath, {
     ...options,
 
     // Add package version
-    async fileContents () {
+    async fileContents() {
       return pkg.version
     }
   })
@@ -41,8 +41,11 @@ export async function version (assetPath, options) {
  * @param {AssetEntry[0]} assetPath - File path to asset
  * @param {Pick<AssetEntry[1], "destPath" | "filePath" | "fileContents">} options - Asset options
  */
-export async function write (assetPath, { destPath, filePath, fileContents }) {
-  const assetDestPath = join(destPath, filePath ? filePath(parse(assetPath)) : assetPath)
+export async function write(assetPath, { destPath, filePath, fileContents }) {
+  const assetDestPath = join(
+    destPath,
+    filePath ? filePath(parse(assetPath)) : assetPath
+  )
 
   if (!destPath || !fileContents) {
     throw new Error("Options 'destPath' and 'fileContents' required")
@@ -59,7 +62,7 @@ export async function write (assetPath, { destPath, filePath, fileContents }) {
  * @param {string} pattern - Minimatch pattern
  * @param {Pick<AssetEntry[1], "srcPath" | "destPath">} options - Asset options
  */
-export async function copy (pattern, { srcPath, destPath }) {
+export async function copy(pattern, { srcPath, destPath }) {
   await cpy([slash(join(srcPath, pattern))], destPath, { cwd: srcPath })
 }
 

--- a/shared/tasks/helpers/task-arguments.unit.test.mjs
+++ b/shared/tasks/helpers/task-arguments.unit.test.mjs
@@ -6,16 +6,17 @@ describe('Task arguments', () => {
 
     args = {
       posix: ['/usr/bin/node', '/path/to/project/node_modules/.bin/gulp'],
-      windows: ['node.exe', 'C:\\path\\to\\project\\node_modules\\.bin\\gulp.cmd']
+      windows: [
+        'node.exe',
+        'C:\\path\\to\\project\\node_modules\\.bin\\gulp.cmd'
+      ]
     }
   })
 
-  describe.each(
-    [
-      { key: 'posix', description: 'Linux, macOS etc' },
-      { key: 'windows', description: 'Windows only' }
-    ]
-  )('Platform: $description', ({ key }) => {
+  describe.each([
+    { key: 'posix', description: 'Linux, macOS etc' },
+    { key: 'windows', description: 'Windows only' }
+  ])('Platform: $description', ({ key }) => {
     describe('Flag: isDev', () => {
       let argv
 

--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -13,7 +13,7 @@ import { task } from './index.mjs'
  * @param {import('./index.mjs').TaskOptions} [options] - Task options
  * @returns {Promise<void>} Script run
  */
-export async function run (name, args = [], options) {
+export async function run(name, args = [], options) {
   const pkgPath = options?.basePath ?? paths.root
 
   try {
@@ -50,7 +50,7 @@ export async function run (name, args = [], options) {
  * @param {import('./index.mjs').TaskOptions} [options] - Task options
  * @returns {() => Promise<void>} Script run
  */
-export function script (name, args = [], options) {
+export function script(name, args = [], options) {
   let displayName = `npm run ${name}`
 
   if (args.length) {

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -19,14 +19,15 @@ import { assets } from './index.mjs'
  * @param {string} pattern - Minimatch pattern
  * @param {AssetEntry[1]} options - Asset options
  */
-export async function compile (pattern, options) {
+export async function compile(pattern, options) {
   const modulePaths = await getListing(pattern, {
     cwd: options.srcPath
   })
 
   try {
-    const compileTasks = modulePaths
-      .map((modulePath) => compileStylesheet([modulePath, options]))
+    const compileTasks = modulePaths.map((modulePath) =>
+      compileStylesheet([modulePath, options])
+    )
 
     await Promise.all(compileTasks)
   } catch (cause) {
@@ -39,9 +40,15 @@ export async function compile (pattern, options) {
  *
  * @param {AssetEntry} assetEntry - Asset entry
  */
-export async function compileStylesheet ([modulePath, { basePath, configPath, srcPath, destPath, filePath }]) {
+export async function compileStylesheet([
+  modulePath,
+  { basePath, configPath, srcPath, destPath, filePath }
+]) {
   const moduleSrcPath = join(srcPath, modulePath)
-  const moduleDestPath = join(destPath, filePath ? filePath(parse(modulePath)) : modulePath)
+  const moduleDestPath = join(
+    destPath,
+    filePath ? filePath(parse(modulePath)) : modulePath
+  )
 
   let css
   let map
@@ -69,7 +76,7 @@ export async function compileStylesheet ([modulePath, { basePath, configPath, sr
 
   // Compile Sass to CSS
   if (moduleDestPath.endsWith('.css')) {
-    ({ css, sourceMap: map } = await compileAsync(moduleSrcPath, {
+    ;({ css, sourceMap: map } = await compileAsync(moduleSrcPath, {
       alertColor: true,
 
       // Turn off dependency warnings
@@ -117,8 +124,10 @@ export async function compileStylesheet ([modulePath, { basePath, configPath, sr
   const config = await postcssrc(options, configPath)
 
   // Transform with PostCSS
-  const result = await postcss(config.plugins)
-    .process(css, { ...options, ...config.options })
+  const result = await postcss(config.plugins).process(css, {
+    ...options,
+    ...config.options
+  })
 
   // Write to files
   await assets.write(moduleDestPath, result)
@@ -131,7 +140,7 @@ export async function compileStylesheet ([modulePath, { basePath, configPath, sr
  * @returns {import('sass-embedded').Logger} Sass logger
  */
 export const logger = (config) => ({
-  warn (message, options) {
+  warn(message, options) {
     let log = `${message}\n`
 
     // Silence Sass suppressed warnings
@@ -148,25 +157,32 @@ export const logger = (config) => ({
       const column = ' '.repeat(`${number}`.length)
 
       // Source code warning arrows
-      const arrows = '^'.repeat(text.length)
+      const arrows = '^'
+        .repeat(text.length)
         .padStart(context.indexOf(text) + text.length)
 
       // Source code snippet showing warning in red
       log += '\n\n'
       log += `${chalk.blue(`${column} ╷`)}\n`
-      log += `${chalk.blue(`${number} │`)} ${context.replace(text, chalk.red(text))}`
+      log += `${chalk.blue(`${number} │`)} ${context.replace(
+        text,
+        chalk.red(text)
+      )}`
       log += `${chalk.blue(`${column} │`)} ${chalk.red(arrows)}\n`
       log += `${chalk.blue(`${column} ╵`)}\n`
     }
 
     // Check for stack trace
-    options.stack?.trim().split('\n').forEach((line) => {
-      log += `    ${line}\n`
-    })
+    options.stack
+      ?.trim()
+      .split('\n')
+      .forEach((line) => {
+        log += `    ${line}\n`
+      })
 
-    const title = chalk.bold.yellow(options.deprecation
-      ? 'Deprecation Warning'
-      : 'Warning')
+    const title = chalk.bold.yellow(
+      options.deprecation ? 'Deprecation Warning' : 'Warning'
+    )
 
     console.warn(`${title}: ${log}`)
   }

--- a/shared/tasks/task.mjs
+++ b/shared/tasks/task.mjs
@@ -8,7 +8,7 @@
  * @param {TaskFunction} taskFn - Task function to wrap
  * @returns {TaskFunction} Script run
  */
-export function name (displayName, taskFn) {
+export function name(displayName, taskFn) {
   taskFn.displayName = displayName
   return taskFn
 }


### PR DESCRIPTION
This PR configures Prettier to format `*.{cjs,js,mjs}` files

I've also added [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier#readme) to turn off ESLint rules handled by Prettier, since:

* [StandardJS](https://standardjs.com) removes semicolons almost everywhere, [Prettier](https://prettier.io) inserts them
* [StandardJS](https://standardjs.com) adds spaces before function parentheses, [Prettier](https://prettier.io) removes them

We also have a PR to switch stylesheet formatting to Prettier:

* https://github.com/alphagov/govuk-frontend/pull/3799