### PR TITLE
Allow Crown copyright notice to be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,12 @@ These additional styles are not included if you use `govuk-font-tabular-numbers`
 
 This change was introduced in [pull request #4307: Refactor tabular number activation into their own mixin](https://github.com/alphagov/govuk-frontend/pull/4307)
 
+#### Allow Crown copyright notice to be removed
+
+For non-GOV.UK branded websites, you can now remove the copyright notice and coat of arms from the [footer component](https://design-system.service.gov.uk/components/footer/) by setting the `copyright` Nunjucks option to `false`.
+
+This was added in [pull request #3876: Allow Crown copyright notice to be removed](https://github.com/alphagov/govuk-frontend/pull/3876). Thanks to [@paulrobertlloyd](https://github.com/paulrobertlloyd) for contributing this improvement.
+
 ### Recommended changes
 
 #### Replace instances of `govuk-typography-responsive` with `govuk-font-size`

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -83,7 +83,7 @@ params:
   - name: copyright
     type: object | boolean
     required: false
-    description: Crown copyright notice that links to a page on [The National Archives](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/). Setting this to `false` removes this notice and the royal coat of arms.
+    description: The copyright information in the footer component that links to [The National Archives ‘Crown copyright’ page](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/). Defaults to the `text` option value. If you set this option to `false`, the whole copyright notice is removed, including the Royal coat of arms.
     params:
       - name: text
         type: string

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -81,9 +81,9 @@ params:
         required: false
         description: If `text` is set, this is not required. If `html` is provided, the `text` option will be ignored. If neither are provided, the text for the Open Government Licence is used. The content licence is inside a `<span>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it.
   - name: copyright
-    type: object
+    type: object | boolean
     required: false
-    description: The copyright information in the footer component, this defaults to `"© Crown copyright"`.
+    description: Crown copyright notice that links to a page on [The National Archives](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/). Setting this to `false` removes this notice and the royal coat of arms.
     params:
       - name: text
         type: string
@@ -157,6 +157,11 @@ examples:
         text: 'Mae’r holl gynnwys ar gael dan Drwydded y Llywodraeth Agored v3.0, ac eithrio lle nodir yn wahanol'
       copyright:
         text: '© Hawlfraint y Goron'
+
+  - name: with copyright notice removed
+    description: Crown copyright notice removed
+    options:
+      copyright: false
 
   - name: with meta
     description: Secondary navigation with meta information relating to the site

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -76,18 +76,16 @@
           {% endif %}
         </span>
       </div>
+      {%- if params.copyright != false -%}
       <div class="govuk-footer__meta-item">
         <a
           class="govuk-footer__link govuk-footer__copyright-logo"
           href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
         >
-          {%- if params.copyright.html or params.copyright.text -%}
-            {{ params.copyright.html | safe if params.copyright.html else params.copyright.text }}
-          {%- else -%}
-            © Crown copyright
-          {%- endif -%}
+          {{ (params.copyright.html | safe if params.copyright.html else params.copyright.text) | default("© Crown copyright", true) }}
         </a>
       </div>
+      {%- endif -%}
     </div>
   </div>
 </footer>

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -243,6 +243,13 @@ describe('footer', () => {
       expect($copyrightMessage.text()).toContain('© Crown copyright')
     })
 
+    it('can be removed', () => {
+      const $ = render('footer', examples['with copyright notice removed'])
+
+      const $copyrightMessage = $('.govuk-footer__copyright-logo')
+      expect($copyrightMessage.length).toBeFalsy()
+    })
+
     it('can be customised with `text` parameter', () => {
       const $ = render(
         'footer',


### PR DESCRIPTION
Split off from #3873 and closes https://github.com/alphagov/govuk-frontend/issues/1290

This PR may be a bit contentious, and relates to using `govuk-frontend` outside the realms of central government (i.e. usage by local authorities or at-length/corporate entities) and in community projects (i.e. X-GOVUK) where Crown copyright isn’t applicable.

There are few limitations with the footer regarding this currently. While you can change the copyright text, the following features remain hard coded:

* The copyright notice links to [this page on The National Archives](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/)
* The copyright notice is always shown with the royal coat of arms above it

I considered providing a set of options to allow each of these aspects to be undone, perhaps by introducing a separate `crownCopyright` option that is overruled if a `copyright` option is provided… but this started to feel a bit too heavy handed and added needless complexity.

So instead I’m suggesting allowing for the Crown copyright statement to be removable. If a user wants to added their own copyright, they could include this using the `contentLicence` option. (A separate PR is needed to opt-out of showing the OGL logo.)

This is how the footer looks without the Crown copyright notice:

![Screenshot of footer without royal coat of arms and Crown copyright notice.](https://github.com/alphagov/govuk-frontend/assets/813383/38fc2018-51ce-4f22-a5a7-5c2aca167df7)

Related issue: #1290