### PR TITLE
Deprecate `govuk-device-pixel-ratio` mixin and make private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Deprecated `govuk-device-pixel-ratio` mixin
+
+The next main release of GOV.UK Frontend will remove support for Internet Explorer 8 (IE8). In preparation for this, we've added `govuk-device-pixel-ratio` to the list of deprecated mixins.
+
+This mixin is used to serve different background images based on a device's screen resolution. The same result can be achieved using a single image and the `background-size` property.
+
 ### New features
 
 #### Task list component added

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -76,7 +76,7 @@
     min-width: $govuk-footer-crest-image-width;
     padding-top: ($govuk-footer-crest-image-height + govuk-spacing(2));
     background-image: govuk-image-url("govuk-crest.png");
-    @include govuk-device-pixel-ratio {
+    @include _govuk-device-pixel-ratio {
       background-image: govuk-image-url("govuk-crest-2x.png");
     }
     background-repeat: no-repeat;

--- a/packages/govuk-frontend/src/govuk/helpers/_device-pixels.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_device-pixels.scss
@@ -2,6 +2,21 @@
 /// @group helpers
 ////
 
+/// A private version of the govuk-device-pixel-ratio mixin to avoid deprecation
+/// warnings where we use it internally
+///
+/// @access private
+
+@mixin _govuk-device-pixel-ratio($ratio: 2) {
+  // stylelint-disable indentation
+  @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
+    only screen and (-o-min-device-pixel-ratio: #{($ratio * 10)} / 10),
+    only screen and (min-resolution: #{($ratio * 96)}dpi),
+    only screen and (min-resolution: #{$ratio}dppx) {
+      @content;
+    }
+}
+
 /// Media query for retina images (device-pixel-ratio)
 ///
 /// @param {Number} $ratio [2] - Device pixel ratio
@@ -26,13 +41,15 @@
 ///   }
 ///
 /// @access public
+/// @deprecated Will be removed in v5.1
 
 @mixin govuk-device-pixel-ratio($ratio: 2) {
-  // stylelint-disable indentation
-  @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
-    only screen and (-o-min-device-pixel-ratio: #{($ratio * 10)} / 10),
-    only screen and (min-resolution: #{($ratio * 96)}dpi),
-    only screen and (min-resolution: #{$ratio}dppx) {
-      @content;
-    }
+  @include _warning(
+    ie8,
+    "The govuk-device-pixel-ratio mixin is deprecated and will be removed in v5.1."
+  );
+
+  @include _govuk-device-pixel-ratio($ratio) {
+    @content;
+  }
 }


### PR DESCRIPTION
There’s a single place where the `govuk-device-pixel-ratio` mixin is required, and that can be removed in #3873.

Given the breaking 5.0 release, and impending v4.7 release, this PR deprecates this mixin prior to its removal in 5.0.

In the meantime, it also makes this mixin private… not sure if this is the right approach, so happy to be corrected on how best to manage this change.