### PR TITLE
Add `html` parameter to Exit this Page button

### DIFF
--- a/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -2,7 +2,11 @@ params:
   - name: text
     type: string
     required: false
-    description: Text for the link. Defaults to `Exit this page`.
+    description: Text for the link. If `html` is provided, the `text` option will be ignored. Defaults to 'Exit this page'.
+  - name: html
+    type: string
+    required: false
+    description: HTML for the link. If `html` is provided, the `text` option will be ignored.
   - name: redirectUrl
     type: string
     required: false
@@ -62,3 +66,7 @@ examples:
       classes: 'test-class'
       attributes:
         test-attribute: true
+  - name: testing-html
+    hidden: true
+    data:
+      html: 'Exit <em>this</em> test'

--- a/src/govuk/components/exit-this-page/template.njk
+++ b/src/govuk/components/exit-this-page/template.njk
@@ -8,6 +8,7 @@
   {%- if params.pressOneMoreTimeText %} data-i18n.press-one-more-time="{{ params.pressOneMoreTimeText | escape }}"{% endif %}
 >
   {{- govukButton({
+    html: params.html,
     text: params.text | default("Exit this page"),
     classes: "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
     href: params.redirectUrl | default("https://www.bbc.co.uk/weather")

--- a/src/govuk/components/exit-this-page/template.test.js
+++ b/src/govuk/components/exit-this-page/template.test.js
@@ -40,6 +40,13 @@ describe('Exit this page', () => {
       expect($button.text()).toContain('Exit this test')
     })
 
+    it('renders with custom HTML', () => {
+      const $ = render('exit-this-page', examples['testing-html'])
+      const $button = $('.govuk-exit-this-page').find('.govuk-button')
+
+      expect($button.html()).toContain('Exit <em>this</em> test')
+    })
+
     it('renders with a custom URL', () => {
       const $ = render('exit-this-page', examples.testing)
       const $button = $('.govuk-exit-this-page').find('.govuk-button')


### PR DESCRIPTION
In relation to #3688.

## Changes
- Adds a `html` parameter to the EtP component, to complement the existing `text` parameter. This is to allow service teams to provide their own copy containing visually-hidden text.
- Updates tests and parameter documentation to align with these changes.