### PR TITLE
Change span to <p> in error message options

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/error-message/error-message.yaml
+++ b/packages/govuk-frontend/src/govuk/components/error-message/error-message.yaml
@@ -10,15 +10,15 @@ params:
   - name: id
     type: string
     required: false
-    description: ID attribute to add to the error message span tag.
+    description: ID attribute to add to the error message `<p>` tag.
   - name: classes
     type: string
     required: false
-    description: Classes to add to the error message span tag.
+    description: Classes to add to the error message `<p>` tag.
   - name: attributes
     type: object
     required: false
-    description: HTML attributes (for example data attributes) to add to the error message span tag.
+    description: HTML attributes (for example data attributes) to add to the error message `<p>` tag.
   - name: visuallyHiddenText
     type: string
     required: false


### PR DESCRIPTION
In 4.0.0, [error messages were changed](https://github.com/alphagov/govuk-frontend/pull/2452) from `<span>`s to `<p>`s, but the macro documentation still references spans. This fixes those references