### PR TITLE
Group Dependabot package updates into shared PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,13 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
     schedule:
-      # Defaults to weekly on Monday
       interval: weekly
       time: '10:30'
-      # Setting a timezone so we let dependabot worry about BST
       timezone: 'Europe/London'
+
     versioning-strategy: increase
 
     allow:
@@ -23,9 +24,9 @@ updates:
     directory: /
     reviewers:
       - alphagov/design-system-developers
+
+    # Schedule run every Monday, local time
     schedule:
-      # Defaults to weekly on Monday
       interval: weekly
       time: '10:30'
-      # Setting a timezone so we let dependabot worry about BST
       timezone: 'Europe/London'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,55 @@ updates:
   - package-ecosystem: npm
     directory: /
     open-pull-requests-limit: 10
+
+    # Group packages into shared PR
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+
+      lint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'editorconfig-checker'
+          - 'eslint'
+          - 'eslint-*'
+          - 'standard'
+          - 'prettier'
+          - 'stylelint'
+          - 'stylelint-*'
+          - 'typescript'
+
+      percy:
+        patterns:
+          - '@percy/*'
+
+      postcss:
+        patterns:
+          - 'autoprefixer'
+          - 'cssnano'
+          - 'cssnano-*'
+          - 'postcss'
+          - 'postcss-*'
+
+      rollup:
+        patterns:
+          - '@rollup/*'
+          - 'rollup'
+          - 'rollup-*'
+
+      test:
+        patterns:
+          - '@axe-core/*'
+          - '@jest/*'
+          - '@puppeteer/*'
+          - '@types/jest'
+          - '@types/jest-*'
+          - 'jest'
+          - 'jest-*'
+          - 'puppeteer'
+          - 'puppeteer-*'
+
     reviewers:
       - alphagov/design-system-developers
 


### PR DESCRIPTION
Sets up Dependabot groups for packages that can be grouped together

Some groups like `@babel/*` and `@percy/*` will avoid compatibility issues
Others are to reduce the noise of all the separate PRs on Mondays