### PR TITLE
Update default `aria-label` in Pagination component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,16 @@ If you need to maintain the existing behaviour, you can set the value to an empt
 
 This change was introduced in [pull request #3773: Omit the value attribute from select options with no value](https://github.com/alphagov/govuk-frontend/pull/3773).
 
+### Suggested changes
+
+#### Update the Pagination component's default `aria-label`
+
+The default value of the Pagination component's `aria-label` has been updated to be more descriptive of the contents of the region. If you are using the component's default label, you may wish to update it to the new value.
+
+You don't need to change anything if you're using the `govukPagination` Nunjucks macro.
+
+This change was introduced in [pull request #3899: Update default `aria-label` in Pagination component](https://github.com/alphagov/govuk-frontend/pull/3899).
+
 ### Fixes
 
 We’ve made fixes to GOV.UK Frontend in the following pull requests:

--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -73,7 +73,7 @@ params:
   - name: landmarkLabel
     type: string
     required: false
-    description: The label for the navigation landmark that wraps the pagination. Defaults to 'results'.
+    description: The label for the navigation landmark that wraps the pagination. Defaults to 'Pagination'.
   - name: classes
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -1,6 +1,6 @@
 {% set blockLevel = not params.items and (params.next or params.previous) %}
 
-<nav class="govuk-pagination {{- ' ' + params.classes if params.classes }} {{- ' govuk-pagination--block' if blockLevel }}" role="navigation" aria-label="{{ params.landmarkLabel | default("results") }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
+<nav class="govuk-pagination {{- ' ' + params.classes if params.classes }} {{- ' govuk-pagination--block' if blockLevel }}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination") }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
   {%- if params.previous and params.previous.href -%}
     <div class="govuk-pagination__prev">
       <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev" {%- for attribute, value in params.previous.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>


### PR DESCRIPTION
In the recent audit of GOV.UK Frontend, it was flagged that the default `aria-label` of 'results' did not describe the purpose of the region adequately. The component is not a list of results, but a list of pages. The audit suggested we change the label to 'Results pagination'.

Taking into mind that the pagination component is designed for use in contexts that are not related to showing results—such as the previous/next variation, which is intended for navigating between content pages—I have further simplified this to 'Pagination'.

Although this may now be too generic, something 'generic' strikes me as being a more appropriate default than something specific enough to be incorrect or misleading. I still worry that it might be too much of a technical term to be well understood. Happy to hear other views on this.

Resolves #3684.