### PR TITLE
Add visually-hidden text to clarify pagination links

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
+++ b/packages/govuk-frontend/src/govuk/components/pagination/pagination.yaml
@@ -36,7 +36,11 @@ params:
       - name: text
         type: string
         required: false
-        description: The link text to the previous page. Defaults to 'Previous'.
+        description: The text content of the link to the previous page. Defaults to 'Previous page', with 'page' being visually hidden. If `html` is provided, the `text` option will be ignored.
+      - name: html
+        type: string
+        required: false
+        description: The HTML content of the link to the previous page. Defaults to 'Previous page', with 'page' being visually hidden. If `html` is provided, the `text` option will be ignored.
       - name: labelText
         type: string
         required: false
@@ -57,7 +61,11 @@ params:
       - name: text
         type: string
         required: false
-        description: The link text to the next page. Defaults to 'Next'.
+        description: The text content of the link to the next page. Defaults to 'Next page', with 'page' being visually hidden. If `html` is provided, the `text` option will be ignored.
+      - name: html
+        type: string
+        required: false
+        description: The HTML content of the link to the next page. Defaults to 'Next page', with 'page' being visually hidden. If `html` is provided, the `text` option will be ignored.
       - name: labelText
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -8,7 +8,11 @@
           <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
         </svg>
         <span class="govuk-pagination__link-title {{- ' govuk-pagination__link-title--decorated' if blockLevel and not params.previous.labelText }}">
-          {{- params.previous.text | default("Previous") -}}
+          {%- if params.previous.html or params.previous.text -%}
+            {{ params.previous.html | safe if params.previous.html else params.previous.text }}
+          {%- else -%}
+            Previous<span class="govuk-visually-hidden"> page</span>
+          {%- endif -%}
         </span>
         {%- if params.previous.labelText and blockLevel -%}
           <span class="govuk-visually-hidden">:</span>
@@ -47,7 +51,11 @@
           {{- nextArrow | safe -}}
         {%- endif %}
         <span class="govuk-pagination__link-title {{- ' govuk-pagination__link-title--decorated' if blockLevel and not params.next.labelText }}">
-          {{- params.next.text | default("Next") -}}
+          {%- if params.next.html or params.next.text -%}
+            {{ params.next.html | safe if params.next.html else params.next.text }}
+          {%- else -%}
+            Next<span class="govuk-visually-hidden"> page</span>
+          {%- endif -%}
         </span>
         {%- if params.next.labelText and blockLevel -%}
           <span class="govuk-visually-hidden">:</span>


### PR DESCRIPTION
Adds visually-hidden text to previous and next links to try and clarify their purpose out of context. Resolves #3679.

## Changes
- Updates the default previous and next link text to include the word 'page' in a visually-hidden span next to them.
- Adds support for `previous.html` and `next.html` so that teams can localise these buttons with visually-hidden text, if needed. 