### PR TITLE
Remove side effects from package.json

### DIFF
--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -23,9 +23,6 @@
     "./govuk-prototype-kit.config.json": "./govuk-prototype-kit.config.json",
     "./package.json": "./package.json"
   },
-  "sideEffects": [
-    "**/vendor/**"
-  ],
   "engines": {
     "node": ">= 4.2.0"
   },


### PR DESCRIPTION
Since we’ve now removed the last of the polyfills in the vendor directory, I believe we can remove this from our `package.json`.