### PR TITLE
Watch for changes to assets

### DIFF
--- a/packages/govuk-frontend/tasks/assets.mjs
+++ b/packages/govuk-frontend/tasks/assets.mjs
@@ -1,0 +1,18 @@
+import { join } from 'path'
+
+import { files, task } from 'govuk-frontend-tasks'
+import gulp from 'gulp'
+
+/**
+ * Copy GOV.UK Frontend assets (for watch)
+ *
+ * @type {import('govuk-frontend-tasks').TaskFunction}
+ */
+export const assets = (options) => gulp.series(
+  task.name('copy:assets', () =>
+    files.copy('**/*', {
+      srcPath: join(options.srcPath, 'govuk/assets'),
+      destPath: join(options.destPath, 'govuk/assets')
+    })
+  )
+)

--- a/packages/govuk-frontend/tasks/build/package.mjs
+++ b/packages/govuk-frontend/tasks/build/package.mjs
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { files, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 
-import { fixtures, scripts, styles, templates } from '../index.mjs'
+import { assets, fixtures, scripts, styles, templates } from '../index.mjs'
 
 /**
  * Build package task
@@ -16,18 +16,11 @@ export default (options) => gulp.series(
     files.clean('*', options)
   ),
 
+  assets(options),
   fixtures(options),
   scripts(options),
   styles(options),
   templates(options),
-
-  // Copy GOV.UK Frontend static assets
-  task.name('copy:assets', () =>
-    files.copy('**/*', {
-      srcPath: join(options.srcPath, 'govuk/assets'),
-      destPath: join(options.destPath, 'govuk/assets')
-    })
-  ),
 
   // Copy GOV.UK Prototype Kit JavaScript
   task.name("copy:files 'govuk-prototype-kit'", () =>

--- a/packages/govuk-frontend/tasks/index.mjs
+++ b/packages/govuk-frontend/tasks/index.mjs
@@ -1,6 +1,7 @@
 /**
  * Build tasks
  */
+export { assets } from './assets.mjs'
 export { compile as fixtures } from './fixtures.mjs'
 export { compile as scripts } from './scripts.mjs'
 export { compile as styles } from './styles.mjs'

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -4,7 +4,7 @@ import { npm, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 import slash from 'slash'
 
-import { fixtures, scripts, styles, templates } from './index.mjs'
+import { assets, fixtures, scripts, styles, templates } from './index.mjs'
 
 /**
  * Watch task
@@ -57,5 +57,12 @@ export const watch = (options) => gulp.parallel(
     gulp.watch([
       `${slash(options.srcPath)}/govuk/**/*.{md,njk}`
     ], templates(options))
+  ),
+
+  // Copy GOV.UK Frontend static assets
+  task.name('copy:assets watch', () =>
+    gulp.watch([
+      `${slash(options.srcPath)}/govuk/assets/**`
+    ], assets(options))
   )
 )


### PR DESCRIPTION
I was taking a look at #3873 and noticed that changes to assets were not reflected in the review app unless I manually ran `npm run build:package`.

Watch the `govuk/assets` folder and re-run the assets task when there are changes.

This means that changes to the assets folder are applied to the dist folder (and therefore are reflected in the review app) without having to manually run the `build:package` task.