### PR TITLE
[main] Pin GitHub `actions/setup-node` to v3.6.0

### DIFF
--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v3.6.0
       id: setup-node
 
       with:

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0 # Need to also checkout the base branch to compare
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           cache: npm
           node-version-file: .nvmrc

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           cache: npm
           node-version: 8 # Node.js 8 supported by Dart Sass v1.0.0
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Dart Sass v1
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           cache: npm
           node-version: 4 # Node.js 4 supported by Node Sass v3.4.0
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Node Sass v8.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -251,7 +251,7 @@ jobs:
         uses: ./.github/workflows/actions/build
 
       - name: Change Node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v3.6.0
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
Cherry-picking @colinrotherham's fix from #3909 to make the same changes on the `main` branch.

---
Workaround for an npm cache path issue throwing the error:

```
Post job cleanup.
Error: Cache folder paths are not retrieved for npm with cache-dependency-path =
```