### PR TITLE
re-add inverse breadcrumbs sass

### DIFF
--- a/src/govuk/components/breadcrumbs/_index.scss
+++ b/src/govuk/components/breadcrumbs/_index.scss
@@ -139,4 +139,16 @@
       }
     }
   }
+
+  .govuk-breadcrumbs--inverse {
+    color: govuk-colour("white");
+
+    .govuk-breadcrumbs__link {
+      @include govuk-link-style-inverse;
+    }
+
+    .govuk-breadcrumbs__list-item:before {
+      border-color: currentcolor;
+    }
+  }
 }


### PR DESCRIPTION
Somehow during the backporting of inverse modifiers for buttons, breadcrumbs and back links in https://github.com/alphagov/govuk-frontend/issues/3827, the actual sass code for the inverse breadcrumbs was missed.