### PR TITLE
Clarify docs for all nested options

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -61,14 +61,19 @@ params:
             type: string
             required: true
             description: If `text` is set, this is not required. The heading HTML content of each section. The header is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
-      - name: summary.text
-        type: string
+      - name: summary
+        type: object
         required: false
-        description: The summary line text content of each section. If `html` is provided, the `text` option will be ignored.
-      - name: summary.html
-        type: string
-        required: false
-        description: The summary line HTML content of each section. The summary line is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
+        description: The summary line of each section.
+        params:
+          - name: text
+            type: string
+            required: false
+            description: The summary line text content of each section. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: false
+            description: The summary line HTML content of each section. The summary line is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
       - name: content.text
         type: string
         required: true

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -48,14 +48,19 @@ params:
     required: true
     description: An array of sections within the accordion.
     params:
-      - name: heading.text
-        type: string
+      - name: heading
+        type: object
         required: true
-        description: If `html` is set, this is not required. The heading text of each section. If `html` is provided, the `text` option will be ignored.
-      - name: heading.html
-        type: string
-        required: true
-        description: If `text` is set, this is not required. The heading HTML content of each section. The header is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
+        description: The heading of each section.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: If `html` is set, this is not required. The heading text of each section. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: If `text` is set, this is not required. The heading HTML content of each section. The header is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
       - name: summary.text
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -74,14 +74,19 @@ params:
             type: string
             required: false
             description: The summary line HTML content of each section. The summary line is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
-      - name: content.text
-        type: string
+      - name: content
+        type: object
         required: true
-        description: If `html` is set, this is not required. The text content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
-      - name: content.html
-        type: string
-        required: true
-        description: If `text` is set, this is not required. The HTML content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
+        description: The content of each section.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: If `html` is set, this is not required. The text content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: If `text` is set, this is not required. The HTML content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
       - name: expanded
         type: boolean
         required: false

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.yaml
@@ -51,27 +51,27 @@ params:
       - name: heading.text
         type: string
         required: true
-        description: The title of each section. If `heading.html` is supplied, this is ignored.
+        description: If `html` is set, this is not required. The heading text of each section. If `html` is provided, the `text` option will be ignored.
       - name: heading.html
         type: string
         required: true
-        description: The HTML content of the header for each section. Used as the title for each section. The header is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it.
+        description: If `text` is set, this is not required. The heading HTML content of each section. The header is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
       - name: summary.text
         type: string
         required: false
-        description: Text content for summary line. If `summary.html` is supplied, this is ignored.
+        description: The summary line text content of each section. If `html` is provided, the `text` option will be ignored.
       - name: summary.html
         type: string
         required: false
-        description: The HTML content for the summary line. The summary line is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it.
+        description: The summary line HTML content of each section. The summary line is inside the HTML `<button>` element, so you can only add [phrasing content](https://html.spec.whatwg.org/#phrasing-content) to it. If `html` is provided, the `text` option will be ignored.
       - name: content.text
         type: string
         required: true
-        description: The text content of each section, which is hidden when the section is closed. If `content.html` is supplied, this is ignored.
+        description: If `html` is set, this is not required. The text content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
       - name: content.html
         type: string
         required: true
-        description: The HTML content of each section, which is hidden when the section is closed.
+        description: If `text` is set, this is not required. The HTML content of each section, which is hidden when the section is closed. If `html` is provided, the `text` option will be ignored.
       - name: expanded
         type: boolean
         required: false

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -25,18 +25,23 @@ params:
             type: string
             required: false
             description: Classes to add to the key wrapper.
-      - name: value.text
-        type: string
+      - name: value
+        type: object
         required: true
-        description: If `html` is set, this is not required. Text to use within each value. If `html` is provided, the `text` option will be ignored.
-      - name: value.html
-        type: string
-        required: true
-        description: If `text` is set, this is not required. HTML to use within each value. If `html` is provided, the `text` option will be ignored.
-      - name: value.classes
-        type: string
-        required: false
-        description: Classes to add to the value wrapper.
+        description: The value of each row.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: If `html` is set, this is not required. Text to use within each value. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: If `text` is set, this is not required. HTML to use within each value. If `html` is provided, the `text` option will be ignored.
+          - name: classes
+            type: string
+            required: false
+            description: Classes to add to the value wrapper.
       - name: actions.classes
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -8,18 +8,23 @@ params:
         type: string
         required: false
         description: Classes to add to the row `div`.
-      - name: key.text
-        type: string
+      - name: key
+        type: object
         required: true
-        description: If `html` is set, this is not required. Text to use within each key. If `html` is provided, the `text` option will be ignored.
-      - name: key.html
-        type: string
-        required: true
-        description: If `text` is set, this is not required. HTML to use within each key. If `html` is provided, the `text` option will be ignored.
-      - name: key.classes
-        type: string
-        required: false
-        description: Classes to add to the key wrapper.
+        description: The key of each row.
+        params:
+          - name: text
+            type: string
+            required: true
+            description: If `html` is set, this is not required. Text to use within each key. If `html` is provided, the `text` option will be ignored.
+          - name: html
+            type: string
+            required: true
+            description: If `text` is set, this is not required. HTML to use within each key. If `html` is provided, the `text` option will be ignored.
+          - name: classes
+            type: string
+            required: false
+            description: Classes to add to the key wrapper.
       - name: value.text
         type: string
         required: true

--- a/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/summary-list.yaml
@@ -42,39 +42,44 @@ params:
             type: string
             required: false
             description: Classes to add to the value wrapper.
-      - name: actions.classes
-        type: string
+      - name: actions
+        type: object
         required: false
-        description: Classes to add to the actions wrapper.
-      - name: actions.items
-        type: array
-        required: false
-        description: Array of action item objects.
+        description: The actions of each row.
         params:
-          - name: href
-            type: string
-            required: true
-            description: The value of the link's `href` attribute for an action item.
-          - name: text
-            type: string
-            required: true
-            description: If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` option will be ignored.
-          - name: html
-            type: string
-            required: true
-            description: If `text` is set, this is not required. HTML to use within each action item. If `html` is provided, the `text` option will be ignored.
-          - name: visuallyHiddenText
-            type: string
-            required: false
-            description: Actions rely on context from the surrounding content so may require additional accessible text. Text supplied to this option is appended to the end. Use `html` for more complicated scenarios.
           - name: classes
             type: string
             required: false
-            description: Classes to add to the action item.
-          - name: attributes
-            type: object
+            description: Classes to add to the actions wrapper.
+          - name: items
+            type: array
             required: false
-            description: HTML attributes (for example data attributes) to add to the action item.
+            description: Array of action item objects.
+            params:
+              - name: href
+                type: string
+                required: true
+                description: The value of the link's `href` attribute for an action item.
+              - name: text
+                type: string
+                required: true
+                description: If `html` is set, this is not required. Text to use within each action item. If `html` is provided, the `text` option will be ignored.
+              - name: html
+                type: string
+                required: true
+                description: If `text` is set, this is not required. HTML to use within each action item. If `html` is provided, the `text` option will be ignored.
+              - name: visuallyHiddenText
+                type: string
+                required: false
+                description: Actions rely on context from the surrounding content so may require additional accessible text. Text supplied to this option is appended to the end. Use `html` for more complicated scenarios.
+              - name: classes
+                type: string
+                required: false
+                description: Classes to add to the action item.
+              - name: attributes
+                type: object
+                required: false
+                description: HTML attributes (for example data attributes) to add to the action item.
   - name: card
     type: object
     required: false


### PR DESCRIPTION
I noticed last week that we sometimes "dot-prefix" nested option names with the associated parent or component

The Prototype Kit team are looking into generating documentation from component `macro-options.json` so this change copies what we did for [**Radios** and **Checkboxes** `conditional`](https://github.com/alphagov/govuk-frontend/commit/b815522894e1f841f019ef61d91e6e690eb768af) to structure all nested options correctly

### Accordion

1. ~`heading.text`~, ~`heading.html`~ → `heading`
1. ~`summary.text`~, ~`summary.html`~ → `summary`
1. ~`content.text`~, ~`content.html`~ → `content`

### Summary list

1. ~`key.text`~, ~`key.html`~ → `key`
1. ~`value.text`~, ~`value.html`~ → `value`
1. ~`actions.text`~, ~`actions.html`~ → `actions`

Like other nested options, these now show as separate tables (with links) on the Design System website:

<img width="780" alt="Accordion items showing nested options" src="https://github.com/alphagov/govuk-frontend/assets/415517/e343effe-a615-486f-b855-c04c31bd228c">