### PR TITLE
[SPIKE] Add bundled-only `"browser"` package exports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,7 +232,7 @@ jobs:
         run: ${{ matrix.task.run }}
 
   package:
-    name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
+    name: Export ${{ join(matrix.conditions, ' ') || 'require' }}, Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     needs: [install, build]
 
@@ -245,17 +245,17 @@ jobs:
           - 18 # Node.js 17+ cannot use package exports with trailing slashes
 
         conditions:
-          - require
-          - import
+          - [require]
+          - [import]
 
         include:
-          - conditions: require
+          - conditions: []
             node-version: 12.18 # Node.js 12.18 uses package exports with trailing slashes
 
     env:
       # Node.js conditions override from "require" to "import" etc
       # https://nodejs.org/api/cli.html#-c-condition---conditionscondition
-      FLAGS: ${{ matrix.conditions != 'require' && format(' --conditions {0}', matrix.conditions) || '' }}
+      FLAGS: ${{ matrix.conditions[0] != null && format(' --conditions {0}', join(matrix.conditions, ' --conditions ')) || '' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -247,6 +247,8 @@ jobs:
         conditions:
           - [require]
           - [import]
+          - [browser, require]
+          - [browser, import]
 
         include:
           - conditions: []

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,17 +241,16 @@ jobs:
 
       matrix:
         node-version:
-          - 12.18 # Node.js 12.18 uses package exports with trailing slashes
-          - 12 # But Node.js 12.20+ uses package exports with subpath patterns
-          - 18
+          - 12 # Node.js 12.20+ uses package exports with subpath patterns
+          - 18 # Node.js 17+ cannot use package exports with trailing slashes
 
         conditions:
           - require
           - import
 
-        exclude:
-          - conditions: import
-            node-version: 12.18
+        include:
+          - conditions: require
+            node-version: 12.18 # Node.js 12.18 uses package exports with trailing slashes
 
     env:
       # Node.js conditions override from "require" to "import" etc

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -13,6 +13,12 @@
   ],
   "exports": {
     ".": {
+      "browser": {
+        "sass": "./dist/govuk/all.scss",
+        "import": "./dist/govuk/all.bundle.mjs",
+        "require": "./dist/govuk/all.bundle.js",
+        "default": "./dist/govuk/all.bundle.js"
+      },
       "sass": "./dist/govuk/all.scss",
       "import": "./dist/govuk/all.mjs",
       "require": "./dist/govuk/all.bundle.js",


### PR DESCRIPTION
This spike adds "pre-bundled" **package.json** `"browser"` exports whilst defaulting to separate modules

Whilst not included in this PR, we could resolve UMD for browser-based bundlers alongside CommonJS

(For example, Browserify and webpack v4)

```json
".": {
  "browser": {
    "sass": "./dist/govuk/all.scss",
    "import": "./dist/govuk/all.bundle.mjs",
    "require": "./dist/govuk/all.bundle.js",
    "default": "./dist/govuk/all.bundle.js"
  },
  "sass": "./dist/govuk/all.scss",
  "import": "./dist/govuk/all.mjs",
  "require": "./dist/govuk/all.cjs",
  "default": "./dist/govuk/all.bundle.js"
}
```

Split out from:

* https://github.com/alphagov/govuk-frontend/pull/3726#discussion_r1252818553

Includes a commit from https://github.com/alphagov/govuk-frontend/pull/3906 to improve our export test output