### PR TITLE
Improvements to inverse components

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/_index.scss
@@ -119,7 +119,7 @@
   }
 
   .govuk-breadcrumbs--inverse {
-    color: govuk-colour("white");
+    color: $govuk-inverse-text-colour;
 
     .govuk-breadcrumbs__link {
       @include govuk-link-style-inverse;

--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -16,6 +16,20 @@ $govuk-button-background-colour: govuk-colour("green") !default;
 
 $govuk-button-text-colour: govuk-colour("white") !default;
 
+/// Inverted button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-background-colour: $govuk-inverse-text-colour !default;
+
+/// Inverted button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-text-colour: $govuk-brand-colour !default;
+
 @include govuk-exports("govuk/component/button") {
   $govuk-button-colour: $govuk-button-background-colour;
   $govuk-button-text-colour: $govuk-button-text-colour;
@@ -35,8 +49,8 @@ $govuk-button-text-colour: govuk-colour("white") !default;
   $govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 60%);
 
   // Inverse button variables
-  $govuk-inverse-button-colour: govuk-colour("white");
-  $govuk-inverse-button-text-colour: govuk-colour("blue");
+  $govuk-inverse-button-colour: $govuk-inverse-button-background-colour;
+  $govuk-inverse-button-text-colour: $govuk-inverse-button-text-colour;
   $govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
   $govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -172,7 +172,7 @@
     margin: 0;
     padding: 0;
     border: 0;
-    color: govuk-colour("white");
+    color: $govuk-header-text;
     background: none;
     cursor: pointer;
 

--- a/packages/govuk-frontend/src/govuk/helpers/_links.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_links.scss
@@ -259,14 +259,14 @@
 @mixin govuk-link-style-inverse {
   &:link,
   &:visited {
-    color: govuk-colour("white");
+    color: $govuk-inverse-text-colour;
   }
 
   // Force a colour change on hover to work around a bug in Safari
   // https://bugs.webkit.org/show_bug.cgi?id=224483
   &:hover,
   &:active {
-    color: rgba(govuk-colour("white"), .99);
+    color: rgba($govuk-inverse-text-colour, .99);
   }
 
   &:focus {

--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -57,6 +57,15 @@ $govuk-print-text-colour: #000000 !default;
 
 $govuk-secondary-text-colour: govuk-colour("dark-grey") !default;
 
+/// Inverse text colour
+///
+/// Used for text and links that appear on dark coloured backgrounds.
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-text-colour: govuk-colour("white") !default;
+
 /// Focus colour
 ///
 /// Used for outline (and background, where appropriate) when interactive


### PR DESCRIPTION
Makes some improvements to how we handle colours for 'inverse' components, which are intended to be used on dark background colours. 

Includes the changes discussed in #3918. 

## Changes
- Adds a global variable to define the inverse text colour: `$govuk-inverse-text-colour`.
- Changes the `govuk-link-style-inverse` mixin to use the new variable.
  - This bubbles the change to the Back Link and Breadcrumbs components, which use the mixin.
- Changes the Breadcrumbs component to use the new variable (for arrows and plain text breadcrumb items).
- Changes the default colours used by the inverse Button:
  - The text colour has been changed from `govuk-colour("blue")` to `$govuk-brand-colour`. 
  - The background colour has been changed from `govuk-colour("white")` to `$govuk-inverse-text-colour`.
- Refactors the Button component so that the inverse button colours can be changed manually if desired, e.g. if the inverse text colour and brand colour do not have sufficient contrast with one another.
  - These are exposed as `$govuk-inverse-button-text-colour` and `$govuk-inverse-button-background-colour`.

### Not changed
- There are several other components where we use white text on a coloured background, but I have not changed them to use the new variable. This is because the background colours are hardcoded in many of these instances, so a user could not easily change them to complement a modified `$govuk-inverse-text-colour`. This includes:
  - Header — hardcoded `white` on `black`
  - Panel (confirmation) — hardcoded `white` on `green`
  - Notification Banner (success) — hardcoded `white` on `green`
  - Warning Text — icon is hardcoded `white` on `black`

## Thoughts
- Interestingly, the default Notification Banner is hardcoded to use `white` on `$govuk-brand-colour`, despite there being no guarantee that the brand colour provides sufficient contrast. This seems like it could be an oversight. Does it need looking into?