### PR TITLE
Update README and CHANGELOG for ES module bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ const Button = require('govuk-frontend/dist/govuk/components/button/button')
 For example using `import`:
 
 ```mjs
-import Button from 'govuk-frontend/dist/govuk-esm/components/button/button.mjs'
+import Button from 'govuk-frontend/dist/govuk/components/button/button.mjs'
 ```
 
 ##### If you’re using Sass

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,25 @@ For example using `import`:
 import Button from 'govuk-frontend/dist/govuk/components/button/button.mjs'
 ```
 
+##### If you’re including JavaScript directly
+
+Replace GOV.UK Frontend `all.js` with `govuk-frontend.min.js` and use `<script type="module">` for ES modules:
+
+```html
+<script type="module" src="{path-to-javascript}/govuk-frontend.min.js"></script>
+```
+
+Next replace `<script>window.GOVUKFrontend.initAll()</script>` to import and initialise GOV.UK Frontend using ES modules:
+
+```html
+<script type="module">
+  import { initAll } from '{path-to-javascript}/govuk-frontend.min.js'
+  initAll()
+</script>
+```
+
+If you import JavaScript using a different method, you might need to make some changes. Refer to the [detailed guidance on importing JavaScript](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript).
+
 ##### If you’re using Sass
 
 Replace `govuk-frontend/govuk` with `govuk-frontend/dist/govuk` in any [Sass](https://sass-lang.com/) `@import` paths.

--- a/packages/govuk-frontend/README.md
+++ b/packages/govuk-frontend/README.md
@@ -46,18 +46,21 @@ To import add the below to your Sass file:
 
 Some of the JavaScript included in GOV.UK Frontend improves the usability and
 accessibility of the components. You should make sure that you are importing and
-initialising JavaScript in your application to ensure that all users can use it successfully.
+initialising JavaScript in your application. This will ensure all users can use it successfully.
 
-You can include JavaScript for all components either by copying the `all.bundle.js` from `node_modules/govuk-frontend/dist/govuk/` into your application or referencing the file directly:
+You can include JavaScript for all components by copying both `govuk-frontend.min.js` and `govuk-frontend.min.js.map` from `node_modules/govuk-frontend/dist/govuk/` into your application and referencing the JavaScript directly:
 
 ```html
-<script type="module" src="<path-to-govuk-frontend-all-file>/all.bundle.js"></script>
+<script type="module" src="{path-to-javascript}/govuk-frontend.min.js"></script>
 ```
 
-Next you need to initialise the script by adding:
+Next you need to import and initialise GOV.UK Frontend by adding:
 
 ```html
-<script type="module">window.GOVUKFrontend.initAll()</script>
+<script type="module">
+  import { initAll } from '{path-to-javascript}/govuk-frontend.min.js'
+  initAll()
+</script>
 ```
 
 [More details on importing JavaScript and advanced options](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript)

--- a/packages/govuk-frontend/README.md
+++ b/packages/govuk-frontend/README.md
@@ -46,9 +46,9 @@ To import add the below to your Sass file:
 
 Some of the JavaScript included in GOV.UK Frontend improves the usability and
 accessibility of the components. You should make sure that you are importing and
-initialising Javascript in your application to ensure that all users can use it successfully.
+initialising JavaScript in your application to ensure that all users can use it successfully.
 
-You can include Javascript for all components either by copying the `all.bundle.js` from `node_modules/govuk-frontend/dist/govuk/` into your application or referencing the file directly:
+You can include JavaScript for all components either by copying the `all.bundle.js` from `node_modules/govuk-frontend/dist/govuk/` into your application or referencing the file directly:
 
 ```html
 <script type="module" src="<path-to-govuk-frontend-all-file>/all.bundle.js"></script>
@@ -60,7 +60,7 @@ Next you need to initialise the script by adding:
 <script type="module">window.GOVUKFrontend.initAll()</script>
 ```
 
-[More details on importing Javascript and advanced options](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript)
+[More details on importing JavaScript and advanced options](https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript)
 
 ## Importing assets
 


### PR DESCRIPTION
This PR changes our documentation to use the ES module `govuk-frontend.min.js` bundle:

1. Update the README "Importing JavaScript" documentation
2. Update CHANGELOG with breaking change to swap `all.js` with ES modules

The previous default `all.js` became `all.bundle.js` in https://github.com/alphagov/govuk-frontend/commit/f8335d91610bbcb52d47b0613bd80bcb22ef99c4 as part of:

* https://github.com/alphagov/govuk-frontend/issues/3482

