### PR TITLE
Additional tests for task list Nunjucks macro, allow attributes on tags and tidy up

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/task-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/task-list/_index.scss
@@ -1,3 +1,5 @@
+@import "../tag/index";
+
 @include govuk-exports("govuk/component/task-list") {
   $govuk-task-list-hover-colour: govuk-colour("light-grey");
 

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -41,21 +41,9 @@ params:
         params:
           - name: tag
             type: object
+            isComponent: true
             required: false
-            description: Object containing the options for a tag that acts as the status for the task.
-            params:
-              - name: text
-                type: string
-                required: true
-                description: Text to use within the tag. If `html` is provided, the `text` argument will be ignored.
-              - name: html
-                type: string
-                required: true
-                description: HTML to use within the tag. If `html` is provided, the `text` argument will be ignored.
-              - name: classes
-                type: string
-                required: false
-                description: Classes to add to the tag.
+            description: Options for the tag component.
           - name: text
             required: false
             type: string

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -186,8 +186,7 @@ examples:
             tag:
               text: Error
               classes: govuk-tag--red
-        - classes: app-task-list__item--no-link
-          title:
+        - title:
             text: Payment
           hint:
             text: It will cost between £15 and £75

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -92,7 +92,6 @@ params:
 examples:
   - name: default
     data:
-      idPrefix: 'task-list-example'
       items:
         - title:
             text: Company Directors
@@ -118,7 +117,6 @@ examples:
 
   - name: example with 3 states
     data:
-      idPrefix: 'task-list-example'
       items:
         - title:
             text: Company Directors
@@ -149,7 +147,6 @@ examples:
 
   - name: example with hint text and additional states
     data:
-      idPrefix: 'task-list-example'
       items:
         - title:
             text: Company Directors
@@ -196,7 +193,6 @@ examples:
 
   - name: example with all possible colours
     data:
-      idPrefix: 'task-list-example'
       items:
         - title:
             text: Task A
@@ -312,6 +308,20 @@ examples:
       items:
         - title:
             text: A Link
+          href: '#'
+          status:
+            tag:
+              text: Status
+
+  - name: custom id prefix
+    hidden: true
+    data:
+      idPrefix: my-custom-id
+      items:
+        - title:
+            text: A Link
+          hint:
+            text: Hint text
           href: '#'
           status:
             tag:

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -326,3 +326,39 @@ examples:
           status:
             tag:
               text: Status
+
+  - name: html passed as text
+    hidden: true
+    data:
+      idPrefix: my-custom-id
+      items:
+        - title:
+            text: <strong>Linked Title</strong>
+          hint:
+            text: <strong>Hint</strong>
+          href: '#'
+          status:
+            text: <strong>Status</strong>
+        - title:
+            text: <strong>Unlinked Title</strong>
+          status:
+            tag:
+              text: <strong>Tag</strong>
+
+  - name: html
+    hidden: true
+    data:
+      idPrefix: my-custom-id
+      items:
+        - title:
+            html: <strong>Linked Title</strong>
+          hint:
+            html: <strong>Hint</strong>
+          href: '#'
+          status:
+            html: <strong>Status</strong>
+        - title:
+            html: <strong>Unlinked Title</strong>
+          status:
+            tag:
+              html: <strong>Tag</strong>

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -300,6 +300,8 @@ examples:
           status:
             tag:
               text: Status
+              attributes:
+                data-tag-attribute: tag-value
 
   - name: custom id prefix
     hidden: true

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -99,7 +99,6 @@ examples:
           href: '#'
           status:
             text: Completed
-            classes: govuk-tag--black
 
         - title:
             text: Registered company details

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -279,3 +279,27 @@ examples:
             tag:
               text: Yellow
               classes: govuk-tag--yellow
+
+  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: custom classes
+    hidden: true
+    data:
+      classes: custom-class-on-component
+      items:
+        - title:
+            text: A Link
+            classes: custom-class-on-linked-title
+          href: '#'
+          classes: custom-class-on-task
+          status:
+            classes: custom-class-on-status
+            tag:
+              text: Status
+              classes: custom-class-on-tag
+
+        - title:
+            text: Not a link
+            classes: custom-class-on-unlinked-title
+          status:
+            tag:
+              text: Status

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -303,3 +303,16 @@ examples:
           status:
             tag:
               text: Status
+
+  - name: custom attributes
+    hidden: true
+    data:
+      attributes:
+        data-custom-attribute: custom-value
+      items:
+        - title:
+            text: A Link
+          href: '#'
+          status:
+            tag:
+              text: Status

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -20,11 +20,7 @@
       </div>
       <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
         {% if item.status.tag %}
-          {{ govukTag({
-            text: item.status.tag.text,
-            html: item.status.tag.html,
-            classes: item.status.tag.classes
-          }) | indent(4) | trim }}
+          {{ govukTag(item.status.tag) | indent(4) | trim }}
         {% else %}
           {{ item.status.html | safe if item.status.html else item.status.text }}
         {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.njk
@@ -1,18 +1,16 @@
 {% from "../tag/macro.njk" import govukTag -%}
 
 {% set idPrefix = params.idPrefix if params.idPrefix else "task-list" %}
-<ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+<ul class="govuk-task-list {%- if params.classes %} {{ params.classes }}{% endif %}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %}>
   {% for item in params.items %}
-    {% if item.hint %}
-      {%- set hintId = idPrefix + "-" + loop.index + "-hint" -%}
-    {% endif %}
+    {%- set hintId = idPrefix + "-" + loop.index + "-hint" -%}
     {%- set statusId = idPrefix + "-" + loop.index + "-status" -%}
     <li class="govuk-task-list__item {%- if item.href %} govuk-task-list__item--with-link{% endif %}{%- if item.classes %} {{ item.classes }}{% endif %}">
       <div class="govuk-task-list__task-name-and-hint">
         {% if item.href %}
           <a class="govuk-link govuk-task-list__link {%- if item.title.classes %} {{ item.title.classes }}{% endif %}" href="{{ item.href }}" aria-describedby="{{ hintId + " " if item.hint }}{{ statusId }}">{{ item.title.html | safe if item.title.html else item.title.text }}</a>
         {% else %}
-          <div{% if item.title.classes %} class="{{ item.title.classes }}" {%- endif %}>{{ item.title.html | safe if item.title.html else item.title.text }}</div>
+          <div {%- if item.title.classes %} class="{{ item.title.classes }}"{% endif %}>{{ item.title.html | safe if item.title.html else item.title.text }}</div>
         {% endif %}
         {% if item.hint %}
           <div id="{{ hintId }}" class="govuk-task-list__task_hint">
@@ -20,7 +18,7 @@
           </div>
         {% endif %}
       </div>
-      <div class="govuk-task-list__status {{ item.status.classes }}" id="{{ statusId }}">
+      <div class="govuk-task-list__status {%- if item.status.classes %} {{ item.status.classes }}{% endif %}" id="{{ statusId }}">
         {% if item.status.tag %}
           {{ govukTag({
             text: item.status.tag.text,

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -114,12 +114,38 @@ describe('Task List', () => {
 
     it('associates the hint text with the task link using aria', () => {
       const $hintText = $component.find('.govuk-task-list__task_hint')
-      expect($hintText.attr('id')).toEqual('task-list-example-3-hint')
+      expect($hintText.attr('id')).toEqual('task-list-3-hint')
 
       const $itemAssociatedWithHint = $component.find(
         `.govuk-task-list__link[aria-describedby~="${$hintText.attr('id')}"]`
       )
       expect($itemAssociatedWithHint.text()).toContain('Business plan')
+    })
+  })
+
+  describe('when a custom idPrefix is used', () => {
+    let $component
+
+    beforeAll(function () {
+      const $ = render('task-list', examples['custom id prefix'])
+      $component = $('.govuk-task-list')
+    })
+
+    it('uses the id prefix for the hint id', () => {
+      const $hint = $component.find('.govuk-task-list__task_hint')
+      expect($hint.attr('id')).toEqual('my-custom-id-1-hint')
+    })
+
+    it('uses the id prefix for the status', () => {
+      const $hint = $component.find('.govuk-task-list__status')
+      expect($hint.attr('id')).toEqual('my-custom-id-1-status')
+    })
+
+    it('uses the id prefix for the aria-describedby association', () => {
+      const $hint = $component.find('.govuk-task-list__link')
+      expect($hint.attr('aria-describedby')).toEqual(
+        'my-custom-id-1-hint my-custom-id-1-status'
+      )
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -15,6 +15,34 @@ describe('Task List', () => {
     expect($component.get(0).tagName).toEqual('ul')
   })
 
+  it('allows for custom classes on the root of the component', () => {
+    const $ = render('task-list', examples['custom classes'])
+
+    const $component = $('.govuk-task-list')
+    expect($component.hasClass('custom-class-on-component')).toBeTruthy()
+  })
+
+  it('allows for custom classes on each task', () => {
+    const $ = render('task-list', examples['custom classes'])
+
+    const $listItem = $('.govuk-task-list__item')
+    expect($listItem.hasClass('custom-class-on-task')).toBeTruthy()
+  })
+
+  it('allows for custom classes on each status', () => {
+    const $ = render('task-list', examples['custom classes'])
+
+    const $status = $('.govuk-task-list__status')
+    expect($status.hasClass('custom-class-on-status')).toBeTruthy()
+  })
+
+  it('allows for custom classes on tags', () => {
+    const $ = render('task-list', examples['custom classes'])
+
+    const $tag = $('.govuk-task-list__status .govuk-tag')
+    expect($tag.hasClass('custom-class-on-tag')).toBeTruthy()
+  })
+
   describe('when a task has an href set', () => {
     let $component
 
@@ -34,6 +62,14 @@ describe('Task List', () => {
 
       expect($statusWithId.text()).toContain('Completed')
     })
+
+    it('applies title classes to the link', () => {
+      const $ = render('task-list', examples['custom classes'])
+
+      const $itemWithLink = $('.govuk-task-list__item:first-child')
+      const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
+      expect($itemWithLinkTitle.hasClass('custom-class-on-linked-title')).toBeTruthy()
+    })
   })
 
   describe('when a task does not have an href set', () => {
@@ -43,6 +79,14 @@ describe('Task List', () => {
       const $itemWithNoLink = $('.govuk-task-list__item:last-child')
       const $itemWithNoLinkTitle = $itemWithNoLink.find('div')
       expect($itemWithNoLinkTitle.text()).toContain('Payment')
+    })
+
+    it('applies title classes to the title wrapper div', () => {
+      const $ = render('task-list', examples['custom classes'])
+
+      const $itemWithNoLink = $('.govuk-task-list__item:last-child')
+      const $itemWithNoLinkTitle = $itemWithNoLink.find('.govuk-task-list__task-name-and-hint div')
+      expect($itemWithNoLinkTitle.hasClass('custom-class-on-unlinked-title')).toBeTruthy()
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -8,66 +8,66 @@ describe('Task List', () => {
     examples = await getExamples('task-list')
   })
 
-  describe('default example', () => {
-    it('renders the default example', () => {
+  it('renders the default example', () => {
+    const $ = render('task-list', examples.default)
+
+    const $component = $('.govuk-task-list')
+    expect($component.get(0).tagName).toEqual('ul')
+  })
+
+  describe('when a task has an href set', () => {
+    let $component
+
+    beforeAll(function () {
       const $ = render('task-list', examples.default)
+      $component = $('.govuk-task-list')
+    })
 
-      const $component = $('.govuk-task-list')
-      expect($component.get(0).tagName).toEqual('ul')
-
-      const $items = $component.find('.govuk-task-list__item')
-      expect($items.length).toEqual(3)
-
-      expect($items.get(0).tagName).toEqual('li')
-      expect($items.hasClass('govuk-task-list__item--with-link')).toBeTruthy()
+    it('wraps the task title in a link', async () => {
+      const $itemLink = $component.find('a.govuk-task-list__link')
+      expect($itemLink.attr('href')).toEqual('#')
     })
 
     it('associates the task name link with the status using aria', async () => {
-      const $ = render('task-list', examples.default)
-
-      const $component = $('.govuk-task-list')
-
       const $itemLink = $component.find('.govuk-task-list__link')
-      expect($itemLink.get(0).tagName).toEqual('a')
-      expect($itemLink.attr('href')).toEqual('#')
-
-      const statusId = 'task-list-example-1-status'
-      expect($itemLink.attr('aria-describedby')).toEqual(statusId)
-
-      const $statusWithId = $component.find(`#${statusId}`)
-      expect($statusWithId.get(0).tagName).toEqual('div')
+      const $statusWithId = $component.find(`#${$itemLink.attr('aria-describedby')}`)
 
       expect($statusWithId.text()).toContain('Completed')
-      expect($statusWithId.hasClass('govuk-task-list__status')).toBeTruthy()
     })
   })
 
-  describe('example with no link, hint text and additional states', () => {
-    it('doesn’t include a link in the item with no href', () => {
+  describe('when a task does not have an href set', () => {
+    it('does not link the task title', () => {
       const $ = render('task-list', examples['example with hint text and additional states'])
 
-      const $itemWithNoLink = $('.app-task-list__item--no-link')
-      expect($itemWithNoLink.get(0).tagName).toEqual('li')
-
+      const $itemWithNoLink = $('.govuk-task-list__item:last-child')
       const $itemWithNoLinkTitle = $itemWithNoLink.find('div')
       expect($itemWithNoLinkTitle.text()).toContain('Payment')
     })
+  })
 
-    it('renders hint text', () => {
+  describe('when a task has a hint', () => {
+    let $component
+
+    beforeAll(function () {
       const $ = render('task-list', examples['example with hint text and additional states'])
+      $component = $('.govuk-task-list')
+    })
 
-      const $hintText = $('.govuk-task-list__task_hint')
-      expect($hintText.get(0).tagName).toEqual('div')
-      expect($hintText.text()).toContain('Ensure the plan covers objectives, strategies, sales, marketing and financial forecasts.')
+    it('renders the hint', () => {
+      const $hintText = $component.find('.govuk-task-list__task_hint')
+      expect($hintText.text()).toContain(
+        'Ensure the plan covers objectives, strategies, sales, marketing and financial forecasts.'
+      )
     })
 
     it('associates the hint text with the task link using aria', () => {
-      const $ = render('task-list', examples['example with hint text and additional states'])
-
-      const $hintText = $('.govuk-task-list__task_hint')
+      const $hintText = $component.find('.govuk-task-list__task_hint')
       expect($hintText.attr('id')).toEqual('task-list-example-3-hint')
 
-      const $itemAssociatedWithHint = $(`.govuk-task-list__link[aria-describedby~="${$hintText.attr('id')}"]`)
+      const $itemAssociatedWithHint = $component.find(
+        `.govuk-task-list__link[aria-describedby~="${$hintText.attr('id')}"]`
+      )
       expect($itemAssociatedWithHint.text()).toContain('Business plan')
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -148,6 +148,13 @@ describe('Task List', () => {
       const $tag = $('.govuk-task-list__status .govuk-tag')
       expect($tag.hasClass('custom-class-on-tag')).toBeTruthy()
     })
+
+    it('allows for custom attributes on tags', () => {
+      const $ = render('task-list', examples['custom attributes'])
+
+      const $component = $('.govuk-tag')
+      expect($component.attr('data-tag-attribute')).toEqual('tag-value')
+    })
   })
 
   describe('when a task has a non-tag status', () => {

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -63,6 +63,11 @@ describe('Task List', () => {
       expect($itemLink.attr('href')).toEqual('#')
     })
 
+    it('adds a with-link modifier class to the task', async () => {
+      const $itemLink = $component.find('.govuk-task-list__item')
+      expect($itemLink.hasClass('govuk-task-list__item--with-link')).toBeTruthy()
+    })
+
     it('associates the task name link with the status using aria', async () => {
       const $itemLink = $component.find('.govuk-task-list__link')
       const $statusWithId = $component.find(`#${$itemLink.attr('aria-describedby')}`)

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -36,13 +36,6 @@ describe('Task List', () => {
     expect($status.hasClass('custom-class-on-status')).toBeTruthy()
   })
 
-  it('allows for custom classes on tags', () => {
-    const $ = render('task-list', examples['custom classes'])
-
-    const $tag = $('.govuk-task-list__status .govuk-tag')
-    expect($tag.hasClass('custom-class-on-tag')).toBeTruthy()
-  })
-
   it('allows for custom attributes', () => {
     const $ = render('task-list', examples['custom attributes'])
 
@@ -82,6 +75,22 @@ describe('Task List', () => {
       const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
       expect($itemWithLinkTitle.hasClass('custom-class-on-linked-title')).toBeTruthy()
     })
+
+    it('escapes the title when passed as text', () => {
+      const $ = render('task-list', examples['html passed as text'])
+
+      const $itemWithLink = $('.govuk-task-list__item:first-child')
+      const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
+      expect($itemWithLinkTitle.text()).toEqual('<strong>Linked Title</strong>')
+    })
+
+    it('allows HTML in the title when passed as html', () => {
+      const $ = render('task-list', examples.html)
+
+      const $itemWithLink = $('.govuk-task-list__item:first-child')
+      const $itemWithLinkTitle = $itemWithLink.find('.govuk-task-list__link')
+      expect($itemWithLinkTitle.html()).toEqual('<strong>Linked Title</strong>')
+    })
   })
 
   describe('when a task does not have an href set', () => {
@@ -99,6 +108,61 @@ describe('Task List', () => {
       const $itemWithNoLink = $('.govuk-task-list__item:last-child')
       const $itemWithNoLinkTitle = $itemWithNoLink.find('.govuk-task-list__task-name-and-hint div')
       expect($itemWithNoLinkTitle.hasClass('custom-class-on-unlinked-title')).toBeTruthy()
+    })
+
+    it('escapes the title when passed as text', () => {
+      const $ = render('task-list', examples['html passed as text'])
+
+      const $itemWithoutLink = $('.govuk-task-list__item:last-child')
+      const $itemWithoutLinkTitle = $itemWithoutLink.find('.govuk-task-list__task-name-and-hint')
+      expect($itemWithoutLinkTitle.text()).toContain('<strong>Unlinked Title</strong>')
+    })
+
+    it('allows HTML in the title when passed as html', () => {
+      const $ = render('task-list', examples.html)
+
+      const $itemWithoutLink = $('.govuk-task-list__item:last-child')
+      const $itemWithoutLinkTitle = $itemWithoutLink.find('.govuk-task-list__task-name-and-hint')
+      expect($itemWithoutLinkTitle.html()).toContain('<strong>Unlinked Title</strong>')
+    })
+  })
+
+  describe('when a task has a tag status', () => {
+    it('escapes the tag when passed as text', () => {
+      const $ = render('task-list', examples['html passed as text'])
+
+      const $tag = $('.govuk-tag')
+      expect($tag.text()).toContain('<strong>Tag</strong>')
+    })
+
+    it('allows HTML in the tag when passed as html', () => {
+      const $ = render('task-list', examples.html)
+
+      const $tag = $('.govuk-tag')
+      expect($tag.html()).toContain('<strong>Tag</strong>')
+    })
+
+    it('allows for custom classes on tags', () => {
+      const $ = render('task-list', examples['custom classes'])
+
+      const $tag = $('.govuk-task-list__status .govuk-tag')
+      expect($tag.hasClass('custom-class-on-tag')).toBeTruthy()
+    })
+  })
+
+  describe('when a task has a non-tag status', () => {
+    it('escapes the status when passed as text', () => {
+      const $ = render('task-list', examples['html passed as text'])
+
+      const $status = $('.govuk-task-list__status')
+      expect($status.text()).toContain('<strong>Status</strong>')
+    })
+
+    it('allows HTML in the tag when passed as html', () => {
+      const $ = render('task-list', examples.html)
+
+      const $status = $('.govuk-task-list__status')
+      expect($status.html()).toContain('<strong>Status</strong>')
     })
   })
 
@@ -125,6 +189,20 @@ describe('Task List', () => {
         `.govuk-task-list__link[aria-describedby~="${$hintText.attr('id')}"]`
       )
       expect($itemAssociatedWithHint.text()).toContain('Business plan')
+    })
+
+    it('escapes the hint when passed as text', () => {
+      const $ = render('task-list', examples['html passed as text'])
+
+      const $hint = $('.govuk-task-list__task_hint')
+      expect($hint.text()).toContain('<strong>Hint</strong>')
+    })
+
+    it('allows HTML in the hint when passed as html', () => {
+      const $ = render('task-list', examples.html)
+
+      const $hint = $('.govuk-task-list__task_hint')
+      expect($hint.html()).toContain('<strong>Hint</strong>')
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -43,6 +43,13 @@ describe('Task List', () => {
     expect($tag.hasClass('custom-class-on-tag')).toBeTruthy()
   })
 
+  it('allows for custom attributes', () => {
+    const $ = render('task-list', examples['custom attributes'])
+
+    const $component = $('.govuk-task-list')
+    expect($component.attr('data-custom-attribute')).toEqual('custom-value')
+  })
+
   describe('when a task has an href set', () => {
     let $component
 


### PR DESCRIPTION
Add additional template tests that cover the various options that can be passed to the macro.

See individual commits for details.

Closes #3828.