### PR TITLE
Port exit this page from 4.7

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
@@ -1,0 +1,19 @@
+{% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
+{% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
+
+{% extends "layouts/layout.njk" %}
+
+{% block skipLink %}
+  {{ super() }}
+  {{ govukSkipLink({
+    href: "https://www.gov.uk/",
+    text: "Exit this page",
+    classes: "govuk-js-exit-this-page-skiplink"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  {{ govukExitThisPage({
+    redirectUrl: "https://www.gov.uk/"
+  }) }}
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -11,6 +11,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 {% from "govuk/components/error-message/macro.njk" import govukErrorMessage %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 {% from "govuk/components/footer/macro.njk" import govukFooter %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
@@ -41,6 +42,14 @@
 {% endblock %}
 
 {% block content %}
+  {{ govukExitThisPage({
+    text: "Gadael y dudalen",
+    activatedText: "Tudalen ymadael",
+    timedOutText: "Wedi'i amseru",
+    pressTwoMoreTimesText: "Pwyswch 'Shift' 2 gwaith arall",
+    pressOneMoreTimeText: "Pwyswch 'Shift' 1 mwy o amser"
+  }) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-xl">Translated examples</h1>

--- a/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
@@ -1,0 +1,166 @@
+---
+scenario: >-
+  You are a user looking for information on child maintenance.
+  There is a chance that as a user of this service, you are a victim of domestic
+  abuse, therefore this page includes an Exit this Page component.
+
+  Things to try:
+
+  1. Activate the Exit this Page button by clicking it
+
+  2. Activate the Exit this Page button by pressing the Esc key 3 times
+
+  3. Activating the Exit this Page button on a small screen view
+
+  4. Scoll down the page to see if the Exit this Page button remains sticky
+
+  5. Tabbing through the page to find the Exit this Page "skip link" at the top
+  of the accessibility tree
+---
+
+{% extends "layouts/full-page-example.njk" %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+
+{% set pageTitle = "Child maintenance" %}
+{% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
+
+{% block skipLink %}
+  {{ super() }}
+  {{ govukSkipLink({
+    href: "https://bbc.co.uk/weather/",
+    classes: "govuk-js-exit-this-page-skiplink"
+  }) }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukPhaseBanner({
+    tag: {
+      text: "Beta"
+    },
+    html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+  }) }}
+
+  {{ govukBreadcrumbs({
+    classes: "",
+    collapseOnMobile: true,
+    items: [
+      {
+        html: "Home",
+        href: "/"
+      },
+      {
+        html: "Births, deaths, marriages and care",
+        href: "/"
+      },
+      {
+        html: "Having a child, parenting and adoption",
+        href: "/"
+      }
+    ]
+  }) }}
+{% endblock %}
+
+{% block content %}
+  {{ govukExitThisPage({
+    text: "Exit this page",
+    redirectUrl: "https://bbc.co.uk/weather/"
+  }) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl">Get help arranging child maintenance</h1>
+
+      <p class="govuk-body-m">This service will give you information about the different options available to make a child maintenance arrangement. These are:</p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>making your own arrangement</li>
+        <li>using the Child Maintenance Service</li>
+      </ul>
+
+      <p class="govuk-body-m">
+        <a class="govuk-link" href="contact-child-maintenance-choices">Contact Child Maintenance Choices if you live in Northern Ireland</a>
+      </p>
+
+      <h2 class="govuk-heading-m">Using the Child Maintenance Service</h2>
+      <h3 class="govuk-heading-s">If you already have an active case</h3>
+      <p class="govuk-body-m">If you have a case with the same parent you should <a href="https://www.gov.uk/child-maintenance-service/change-of-circumstances" class="govuk-link"> report a change of circumstances </a>instead of making a new arrangement. You can use this service if you want to set up a new arrangement with a different parent.</p>
+
+      <h3 class="govuk-heading-s">Fees</h3>
+      <p class="govuk-body-m">If you decide to use the Child Maintenance Service the application fee is £20 and cannot be refunded. You’ll need a debit or credit card to pay this. It does not guarantee an arrangement.</p>
+      <p class="govuk-body-m">You will not have to pay the application fee if you:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>are under 19 years old</li>
+        <li>have experienced domestic abuse</li>
+      </ul>
+      <p class="govuk-body-m">
+        <a class="govuk-link" href="https://www.gov.uk/guidance/domestic-abuse-how-to-get-help">Get help if you have experienced domestic abuse</a>
+      </p>
+
+      <h3 class="govuk-heading-s">If you’re worried about contacting the other parent</h3>
+      <p class="govuk-body-m">If you decide to use the Child Maintenance Service, we will try to contact the other parent about setting up child maintenance – you do not need to.</p>
+      <p class="govuk-body-m">We will share the following details with the other parent:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your name</li>
+        <li>your child’s name and date of birth</li>
+        <li>the number of days your child stays with the parent who will be making payments - the other parent will need to confirm this</li>
+      </ul>
+
+      <p class="govuk-body-m">If you are the parent who will be paying child maintenance, we will also share the following details with the other parent:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your income information</li>
+        <li>whether any additional children are taken into account in the calculation - we will not share identifying details about these children, only how many have been taken into account</li>
+      </ul>
+
+      {{ govukInsetText({
+        text: "We will not share any other information with the other parent as a part of your application."
+      }) }}
+
+      {% set doIHaveAnActiveCase %}
+        You will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.
+      {% endset %}
+
+      {% set payingToReceiving %}
+        <p class="govuk-body">You will need to close your existing Child Maintenance case and open a new one.</p>
+        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" target="blank" class="govuk-link">MCMC</a> , or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+      {% endset %}
+
+      {% set receivingToPaying %}
+        <p class="govuk-body">You will need to close your existing Child Maintenance case and open a new one.</p>
+        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" target="blank" class="govuk-link">MCMC</a> , or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+      {% endset %}
+
+      {{ govukDetails({
+        summaryText: "I do not know if I have an active case",
+        html: doIHaveAnActiveCase
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "I need to change from paying to receiving child maintenance",
+        html: payingToReceiving
+      }) }}
+
+      {{ govukDetails({
+        summaryText: "I need to change from receiving to paying child maintenance",
+        html: receivingToPaying
+      }) }}
+
+      {{ govukButton({
+        text: "Start now",
+        href: "#",
+        isStartButton: true
+      }) }}
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <p class="govuk-body">There could be other content here.</p>
+      <p class="govuk-body">In ea ex nulla veniam commodo Lorem labore dolor et ea in deserunt qui. Enim adipisicing dolore est amet magna. Cupidatat adipisicing labore consectetur exercitation Lorem dolor ipsum et deserunt est. Sit laborum dolore sit id eiusmod.</p>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.unit.test.mjs
@@ -72,6 +72,10 @@ describe('GOV.UK Prototype Kit config', () => {
           macroName: 'govukErrorSummary'
         },
         {
+          importFrom: 'govuk/components/exit-this-page/macro.njk',
+          macroName: 'govukExitThisPage'
+        },
+        {
           importFrom: 'govuk/components/fieldset/macro.njk',
           macroName: 'govukFieldset'
         },

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -4,6 +4,7 @@ import { Button } from './components/button/button.mjs'
 import { CharacterCount } from './components/character-count/character-count.mjs'
 import { Checkboxes } from './components/checkboxes/checkboxes.mjs'
 import { ErrorSummary } from './components/error-summary/error-summary.mjs'
+import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs'
 import { Header } from './components/header/header.mjs'
 import { NotificationBanner } from './components/notification-banner/notification-banner.mjs'
 import { Radios } from './components/radios/radios.mjs'
@@ -56,6 +57,11 @@ function initAll (config) {
     new ErrorSummary($errorSummary, config.errorSummary).init()
   }
 
+  const $exitThisPageButtons = $scope.querySelectorAll('[data-module="govuk-exit-this-page"]')
+  $exitThisPageButtons.forEach(($button) => {
+    new ExitThisPage($button, config.exitThisPage).init()
+  })
+
   // Find first header module to enhance.
   const $header = $scope.querySelector('[data-module="govuk-header"]')
   if ($header) {
@@ -94,6 +100,7 @@ export {
   CharacterCount,
   Checkboxes,
   ErrorSummary,
+  ExitThisPage,
   Header,
   NotificationBanner,
   Radios,
@@ -110,6 +117,7 @@ export {
  * @property {ButtonConfig} [button] - Button config
  * @property {CharacterCountConfig} [characterCount] - Character Count config
  * @property {ErrorSummaryConfig} [errorSummary] - Error Summary config
+ * @property {ExitThisPageConfig} [exitThisPage] - Exit This Page config
  * @property {NotificationBannerConfig} [notificationBanner] - Notification Banner config
  */
 
@@ -124,5 +132,7 @@ export {
  * @typedef {import('./components/character-count/character-count.mjs').CharacterCountConfigWithMaxWords} CharacterCountConfigWithMaxWords
  * @typedef {import('./components/character-count/character-count.mjs').CharacterCountTranslations} CharacterCountTranslations
  * @typedef {import('./components/error-summary/error-summary.mjs').ErrorSummaryConfig} ErrorSummaryConfig
+ * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageConfig} ExitThisPageConfig
+ * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageTranslations} ExitThisPageTranslations
  * @typedef {import('./components/notification-banner/notification-banner.mjs').NotificationBannerConfig} NotificationBannerConfig
  */

--- a/packages/govuk-frontend/src/govuk/components/_all.scss
+++ b/packages/govuk-frontend/src/govuk/components/_all.scss
@@ -11,6 +11,7 @@
 @import "details/index";
 @import "error-message/index";
 @import "error-summary/index";
+@import "exit-this-page/index";
 @import "fieldset/index";
 @import "file-upload/index";
 @import "footer/index";

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/README.md
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/README.md
@@ -1,0 +1,15 @@
+# Exit this page
+
+## Installation
+
+See the [main README quick start guide](https://github.com/alphagov/govuk-frontend#quick-start) for how to install this component.
+
+## Guidance and Examples
+
+Find out when to use the exit this page component in your service in the [GOV.UK Design System](https://design-system.service.gov.uk/components/exit-this-page).
+
+## Component options
+
+Use options to customise the appearance, content and behaviour of a component when using a macro, for example, changing the text.
+
+See [options table](https://design-system.service.gov.uk/components/exit-this-page/#options-exit-this-page-example) for details.

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_exit-this-page.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_exit-this-page.scss
@@ -1,0 +1,2 @@
+@import "../../base";
+@import "./index";

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
@@ -1,0 +1,89 @@
+@import "../button/index";
+
+@include govuk-exports("govuk/component/exit-this-page") {
+  $indicator-size: .75em;
+
+  .govuk-exit-this-page {
+    @include govuk-responsive-margin(8, "bottom");
+    position: sticky;
+    z-index: 1000;
+    top: 0;
+    left: 0;
+    width: 100%;
+
+    @include govuk-media-query($from: tablet) {
+      display: inline-block;
+      right: 0;
+      left: auto;
+      width: auto;
+      float: right;
+    }
+  }
+
+  .govuk-exit-this-page__button {
+    margin-bottom: 0;
+  }
+
+  .govuk-exit-this-page__indicator {
+    @include govuk-responsive-padding(2);
+    display: none;
+    padding-bottom: 0;
+    color: inherit;
+    line-height: 0; // removes extra negative space below the indicators
+    text-align: center;
+    pointer-events: none;
+  }
+
+  .govuk-exit-this-page__indicator--visible {
+    display: block;
+  }
+
+  .govuk-exit-this-page__indicator-light {
+    box-sizing: border-box;
+    display: inline-block;
+    width: $indicator-size;
+    height: $indicator-size;
+    margin: 0 .125em;
+    border-width: 2px;
+    border-style: solid;
+    border-radius: 50%;
+    border-color: currentcolor;
+  }
+
+  .govuk-exit-this-page__indicator-light--on {
+    border-width: $indicator-size / 2;
+  }
+
+  @media only print {
+    .govuk-exit-this-page {
+      display: none;
+    }
+  }
+
+  .govuk-exit-this-page-overlay {
+    position: fixed;
+    z-index: 9999;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background-color: govuk-colour("white");
+  }
+
+  // This class is added to the body when the Exit This Page button is activated
+  // in addition to the overlay to both block the entire screen and hide everything
+  // underneath it.
+  //
+  // We do this to ensure that users don't risk interacting with the page underneath
+  // the overlay between activating the button and navigating to the next page.
+  .govuk-exit-this-page-hide-content {
+    // stylelint-disable declaration-no-important
+    * {
+      display: none !important;
+    }
+
+    .govuk-exit-this-page-overlay {
+      display: block !important;
+    }
+  }
+}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.test.mjs
@@ -1,0 +1,22 @@
+import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
+import { getExamples } from 'govuk-frontend-lib/files'
+
+describe('/components/exit-this-page', () => {
+  describe('component examples', () => {
+    let exampleNames
+
+    beforeAll(async () => {
+      exampleNames = Object.keys(await getExamples('exit-this-page'))
+    })
+
+    it('passes accessibility tests', async () => {
+      for (const name of exampleNames) {
+        const exampleName = name.replace(/ /g, '-')
+
+        // Navigation to example, create report
+        await goToComponent(page, 'exit-this-page', { exampleName })
+        await expect(axe(page)).resolves.toHaveNoViolations()
+      }
+    }, 90000)
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,0 +1,408 @@
+import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
+import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { I18n } from '../../i18n.mjs'
+
+/**
+ * Exit this page translation defaults
+ *
+ * @see {@link ExitThisPageConfig.i18n}
+ * @constant
+ * @default
+ * @type {ExitThisPageTranslations}
+ */
+const EXIT_THIS_PAGE_TRANSLATIONS = {
+  activated: 'Loading.',
+  timedOut: 'Exit this page expired.',
+  pressTwoMoreTimes: 'Shift, press 2 more times to exit.',
+  pressOneMoreTime: 'Shift, press 1 more time to exit.'
+}
+
+/**
+ * Exit This Page component
+ */
+export class ExitThisPage {
+  /**
+   * @param {Element} $module - HTML element that wraps the Exit This Page button
+   * @param {ExitThisPageConfig} [config] - Exit This Page config
+   */
+  constructor ($module, config) {
+    if (!($module instanceof HTMLElement) || !document.body.classList.contains('govuk-frontend-supported')) {
+      return this
+    }
+
+    const $button = $module.querySelector('.govuk-exit-this-page__button')
+    if (!($button instanceof HTMLElement)) {
+      return this
+    }
+
+    /** @type {ExitThisPageConfig} */
+    const defaultConfig = {
+      i18n: EXIT_THIS_PAGE_TRANSLATIONS
+    }
+
+    /**
+     * @private
+     * @type {ExitThisPageConfig}
+     */
+    this.config = mergeConfigs(
+      defaultConfig,
+      config || {},
+      normaliseDataset($module.dataset)
+    )
+
+    /** @private */
+    this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'))
+
+    /** @private */
+    this.$module = $module
+
+    /** @private */
+    this.$button = $button
+
+    /**
+     * @private
+     * @type {HTMLAnchorElement | null}
+     */
+    this.$skiplinkButton = null
+
+    const $skiplinkButton = document.querySelector('.govuk-js-exit-this-page-skiplink')
+    if ($skiplinkButton instanceof HTMLAnchorElement) {
+      this.$skiplinkButton = $skiplinkButton
+    }
+
+    /** @private */
+    this.$updateSpan = null
+
+    /** @private */
+    this.$indicatorContainer = null
+
+    /** @private */
+    this.$overlay = null
+
+    /** @private */
+    this.keypressCounter = 0
+
+    /** @private */
+    this.lastKeyWasModified = false
+
+    /** @private */
+    this.timeoutTime = 5000 // milliseconds
+
+    // Store the timeout events so that we can clear them to avoid user keypresses overlapping
+    // setTimeout returns an id that we can use to clear it with clearTimeout,
+    // hence the 'Id' suffix
+
+    /** @private */
+    this.keypressTimeoutId = null
+
+    /** @private */
+    this.timeoutMessageId = null
+  }
+
+  /**
+   * Initialise component
+   */
+  init () {
+    this.buildIndicator()
+    this.initUpdateSpan()
+    this.initButtonClickHandler()
+
+    // Check to see if this has already been done by a previous initialisation of ExitThisPage
+    if (!('govukFrontendExitThisPageKeypress' in document.body.dataset)) {
+      document.addEventListener('keyup', this.handleKeypress.bind(this), true)
+      document.body.dataset.govukFrontendExitThisPageKeypress = 'true'
+    }
+
+    // When the page is restored after navigating 'back' in some browsers the
+    // blank overlay remains present, rendering the page unusable. Here, we check
+    // to see if it's present on page (re)load, and remove it if so.
+    window.addEventListener('pageshow', this.resetPage.bind(this))
+  }
+
+  /**
+   * Create the <span> we use for screen reader announcements.
+   *
+   * @private
+   */
+  initUpdateSpan () {
+    this.$updateSpan = document.createElement('span')
+    this.$updateSpan.setAttribute('role', 'status')
+    this.$updateSpan.className = 'govuk-visually-hidden'
+
+    this.$module.appendChild(this.$updateSpan)
+  }
+
+  /**
+   * Create button click handlers.
+   *
+   * @private
+   */
+  initButtonClickHandler () {
+    // Main EtP button
+    this.$button.addEventListener('click', this.handleClick.bind(this))
+
+    // EtP secondary link
+    if (this.$skiplinkButton) {
+      this.$skiplinkButton.addEventListener('click', this.handleClick.bind(this))
+    }
+  }
+
+  /**
+   * Create the HTML for the 'three lights' indicator on the button.
+   *
+   * @private
+   */
+  buildIndicator () {
+    // Build container
+    // Putting `aria-hidden` on it as it won't contain any readable information
+    this.$indicatorContainer = document.createElement('div')
+    this.$indicatorContainer.className = 'govuk-exit-this-page__indicator'
+    this.$indicatorContainer.setAttribute('aria-hidden', 'true')
+
+    // Create three 'lights' and place them within the container
+    for (let i = 0; i < 3; i++) {
+      const $indicator = document.createElement('div')
+      $indicator.className = 'govuk-exit-this-page__indicator-light'
+      this.$indicatorContainer.appendChild($indicator)
+    }
+
+    // Append it all to the module
+    this.$button.appendChild(this.$indicatorContainer)
+  }
+
+  /**
+   * Update whether the lights are visible and which ones are lit up depending on
+   * the value of `keypressCounter`.
+   *
+   * @private
+   */
+  updateIndicator () {
+    // Show or hide the indicator container depending on keypressCounter value
+    if (this.keypressCounter > 0) {
+      this.$indicatorContainer.classList.add('govuk-exit-this-page__indicator--visible')
+    } else {
+      this.$indicatorContainer.classList.remove('govuk-exit-this-page__indicator--visible')
+    }
+
+    // Turn on only the indicators we want on
+    const $indicators = this.$indicatorContainer.querySelectorAll(
+      '.govuk-exit-this-page__indicator-light'
+    )
+    $indicators.forEach(($indicator, index) => {
+      $indicator.classList.toggle(
+        'govuk-exit-this-page__indicator-light--on',
+        index < this.keypressCounter
+      )
+    })
+  }
+
+  /**
+   * Initiates the redirection away from the current page.
+   * Includes the loading overlay functionality, which covers the current page with a
+   * white overlay so that the contents are not visible during the loading
+   * process. This is particularly important on slow network connections.
+   *
+   * @private
+   */
+  exitPage () {
+    this.$updateSpan.innerText = ''
+
+    // Blank the page
+    // As well as creating an overlay with text, we also set the body to hidden
+    // to prevent screen reader and sequential navigation users potentially
+    // navigating through the page behind the overlay during loading
+    document.body.classList.add('govuk-exit-this-page-hide-content')
+    this.$overlay = document.createElement('div')
+    this.$overlay.className = 'govuk-exit-this-page-overlay'
+    this.$overlay.setAttribute('role', 'alert')
+
+    // we do these this way round, thus incurring a second paint, because changing
+    // the element text after adding it means that screen readers pick up the
+    // announcement more reliably.
+    document.body.appendChild(this.$overlay)
+    this.$overlay.innerText = this.i18n.t('activated')
+
+    window.location.href = this.$button.getAttribute('href')
+  }
+
+  /**
+   * Pre-activation logic for when the button is clicked/activated via mouse or
+   * pointer.
+   *
+   * We do this to differentiate it from the keyboard activation event because we
+   * need to run `e.preventDefault` as the button or skiplink are both links and we
+   * want to apply some additional logic in `exitPage` before navigating.
+   *
+   * @private
+   * @param {MouseEvent} event - mouse click event
+   */
+  handleClick (event) {
+    event.preventDefault()
+    this.exitPage()
+  }
+
+  /**
+   * Logic for the 'quick escape' keyboard sequence functionality (pressing the
+   * Shift key three times without interruption, within a time limit).
+   *
+   * @private
+   * @param {KeyboardEvent} event - keyup event
+   */
+  handleKeypress (event) {
+    // Detect if the 'Shift' key has been pressed. We want to only do things if it
+    // was pressed by itself and not in a combination with another key—so we keep
+    // track of whether the preceding keyup had shiftKey: true on it, and if it
+    // did, we ignore the next Shift keyup event.
+    //
+    // This works because using Shift as a modifier key (e.g. pressing Shift + A)
+    // will fire TWO keyup events, one for A (with e.shiftKey: true) and the other
+    // for Shift (with e.shiftKey: false).
+    if (
+      (event.key === 'Shift' || event.keyCode === 16 || event.which === 16) &&
+      !this.lastKeyWasModified
+    ) {
+      this.keypressCounter += 1
+
+      // Update the indicator before the below if statement can reset it back to 0
+      this.updateIndicator()
+
+      // Clear the timeout for the keypress timeout message clearing itself
+      if (this.timeoutMessageId !== null) {
+        clearTimeout(this.timeoutMessageId)
+        this.timeoutMessageId = null
+      }
+
+      if (this.keypressCounter >= 3) {
+        this.keypressCounter = 0
+
+        if (this.keypressTimeoutId !== null) {
+          clearTimeout(this.keypressTimeoutId)
+          this.keypressTimeoutId = null
+        }
+
+        this.exitPage()
+      } else {
+        if (this.keypressCounter === 1) {
+          this.$updateSpan.innerText = this.i18n.t('pressTwoMoreTimes')
+        } else {
+          this.$updateSpan.innerText = this.i18n.t('pressOneMoreTime')
+        }
+      }
+
+      this.setKeypressTimer()
+    } else if (this.keypressTimeoutId !== null) {
+      // If the user pressed any key other than 'Shift', after having pressed
+      // 'Shift' and activating the timer, stop and reset the timer.
+      this.resetKeypressTimer()
+    }
+
+    // Keep track of whether the Shift modifier key was held during this keypress
+    this.lastKeyWasModified = event.shiftKey
+  }
+
+  /**
+   * Starts the 'quick escape' keyboard sequence timer.
+   *
+   * This can be invoked several times. We want this to be possible so that the
+   * timer is restarted each time the shortcut key is pressed (e.g. the user has
+   * up to n seconds between each keypress, rather than n seconds to invoke the
+   * entire sequence.)
+   *
+   * @private
+   */
+  setKeypressTimer () {
+    // Clear any existing timeout. This is so only one timer is running even if
+    // there are multiple keypresses in quick succession.
+    clearTimeout(this.keypressTimeoutId)
+
+    // Set a fresh timeout
+    this.keypressTimeoutId = setTimeout(
+      this.resetKeypressTimer.bind(this),
+      this.timeoutTime
+    )
+  }
+
+  /**
+   * Stops and resets the 'quick escape' keyboard sequence timer.
+   *
+   * @private
+   */
+  resetKeypressTimer () {
+    clearTimeout(this.keypressTimeoutId)
+    this.keypressTimeoutId = null
+
+    this.keypressCounter = 0
+    this.$updateSpan.innerText = this.i18n.t('timedOut')
+
+    this.timeoutMessageId = setTimeout(() => {
+      this.$updateSpan.innerText = ''
+    }, this.timeoutTime)
+
+    this.updateIndicator()
+  }
+
+  /**
+   * Reset the page using the EtP button
+   *
+   * We use this in situations where a user may re-enter a page using the browser
+   * back button. In these cases, the browser can choose to restore the state of
+   * the page as it was previously, including restoring the 'ghost page' overlay,
+   * the announcement span having it's role set to "alert" and the keypress
+   * indicator still active, leaving the page in an unusable state.
+   *
+   * By running this check when the page is shown, we can programatically restore
+   * the page and the component to a "default" state
+   *
+   * @deprecated Will be made private in v5.0
+   */
+  resetPage () {
+    // If an overlay is set, remove it and reset the value
+    document.body.classList.remove('govuk-exit-this-page-hide-content')
+
+    if (this.$overlay) {
+      this.$overlay.remove()
+      this.$overlay = null
+    }
+
+    // Ensure the announcement span's role is status, not alert and clear any text
+    this.$updateSpan.setAttribute('role', 'status')
+    this.$updateSpan.innerText = ''
+
+    // Sync the keypress indicator lights
+    this.updateIndicator()
+
+    // If the timeouts are active, clear them
+    if (this.keypressTimeoutId) {
+      clearTimeout(this.keypressTimeoutId)
+    }
+
+    if (this.timeoutMessageId) {
+      clearTimeout(this.timeoutMessageId)
+    }
+  }
+}
+
+/**
+ * Exit this Page config
+ *
+ * @typedef {object} ExitThisPageConfig
+ * @property {ExitThisPageTranslations} [i18n=EXIT_THIS_PAGE_TRANSLATIONS] - Exit this page translations
+ */
+
+/**
+ * Exit this Page translations
+ *
+ * @see {@link EXIT_THIS_PAGE_TRANSLATIONS}
+ * @typedef {object} ExitThisPageTranslations
+ *
+ * Messages used by the component programatically inserted text, including
+ * overlay text and screen reader announcements.
+ * @property {string} [activated] - Screen reader announcement for when EtP
+ *   keypress functionality has been successfully activated.
+ * @property {string} [timedOut] - Screen reader announcement for when the EtP
+ *   keypress functionality has timed out.
+ * @property {string} [pressTwoMoreTimes] - Screen reader announcement informing
+ *   the user they must press the activation key two more times.
+ * @property {string} [pressOneMoreTime] - Screen reader announcement informing
+ *   the user they must press the activation key one more time.
+ */

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -1,0 +1,168 @@
+const { goToComponent, goToExample } = require('govuk-frontend-helpers/puppeteer')
+
+const buttonClass = '.govuk-js-exit-this-page-button'
+const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
+const overlayClass = '.govuk-exit-this-page-overlay'
+
+describe('/components/exit-this-page', () => {
+  describe('when JavaScript is unavailable or fails', () => {
+    beforeAll(async () => {
+      await page.setJavaScriptEnabled(false)
+    })
+
+    afterAll(async () => {
+      await page.setJavaScriptEnabled(true)
+    })
+
+    it('navigates to the href of the button', async () => {
+      await goToComponent(page, 'exit-this-page')
+
+      const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(buttonClass)
+      ])
+
+      const url = new URL(await page.url())
+      expect(url.pathname).toBe(pathname)
+    })
+
+    it('navigates to the href of the skiplink', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      const href = await page.$eval(skiplinkClass, el => el.getAttribute('href'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
+  })
+
+  describe('when JavaScript is available', () => {
+    it('navigates to the href of the button', async () => {
+      await goToComponent(page, 'exit-this-page')
+
+      const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.click(buttonClass)
+      ])
+
+      const url = new URL(await page.url())
+      expect(url.pathname).toBe(pathname)
+    })
+
+    it('navigates to the href of the skiplink', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      const href = await page.$eval(skiplinkClass, el => el.getAttribute('href'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      const url = await page.url()
+      expect(url).toBe(href)
+    })
+
+    it('shows the ghost page when the EtP button is clicked', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      // Stop the button from navigating away from the current page as a workaround
+      // to puppeteer struggling to return to previous pages after navigation reliably
+      await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+      await page.click(buttonClass)
+
+      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      expect(ghostOverlay).not.toBeNull()
+    })
+
+    it('shows the ghost page when the skiplink is clicked', async () => {
+      await goToExample(page, 'exit-this-page-with-skiplink')
+
+      // Stop the button from navigating away from the current page as a workaround
+      // to puppeteer struggling to return to previous pages after navigation reliably
+      //
+      // We apply this to the button and not the skiplink because we pull the href
+      // from the button rather than the skiplink
+      await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+      await page.focus(skiplinkClass)
+      await page.click(skiplinkClass)
+
+      const ghostOverlay = await page.evaluate((overlayClass) => document.body.querySelector(overlayClass), overlayClass)
+      expect(ghostOverlay).not.toBeNull()
+    })
+
+    describe('keyboard shortcut activation', () => {
+      it('activates the button functionality when the Shift key is pressed 3 times', async () => {
+        await goToComponent(page, 'exit-this-page')
+
+        const pathname = await page.$eval(buttonClass, el => el.getAttribute('href'))
+
+        await Promise.all([
+          page.keyboard.press('Shift'),
+          page.keyboard.press('Shift'),
+          page.keyboard.press('Shift'),
+          page.waitForNavigation()
+        ])
+
+        const url = new URL(await page.url())
+        expect(url.pathname).toBe(pathname)
+      })
+
+      it('announces when the Shift key has been pressed once', async () => {
+        await goToComponent(page, 'exit-this-page')
+
+        await page.keyboard.press('Shift')
+
+        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        expect(message).toBe('Shift, press 2 more times to exit.')
+      })
+
+      it('announces when the Shift key has been pressed twice', async () => {
+        await goToComponent(page, 'exit-this-page')
+
+        await page.keyboard.press('Shift')
+        await page.keyboard.press('Shift')
+
+        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        expect(message).toBe('Shift, press 1 more time to exit.')
+      })
+
+      it('announces when the keyboard shortcut has been successfully activated', async () => {
+        await goToComponent(page, 'exit-this-page')
+
+        // Make the button not navigate away from the current page
+        await page.$eval(buttonClass, el => el.setAttribute('href', '#'))
+
+        await page.keyboard.press('Shift')
+        await page.keyboard.press('Shift')
+        await page.keyboard.press('Shift')
+
+        const message = await page.$eval(overlayClass, el => el.innerHTML.trim())
+        expect(message).toBe('Loading.')
+      })
+
+      it('announces when the keyboard shortcut has timed out', async () => {
+        await goToComponent(page, 'exit-this-page')
+
+        await page.keyboard.press('Shift')
+
+        // Wait for 6 seconds (one full second over the 5 second limit)
+        await new Promise((resolve) => setTimeout(resolve, 6000))
+
+        const message = await page.$eval(buttonClass, el => el.nextElementSibling.innerHTML.trim())
+        expect(message).toBe('Exit this page expired.')
+      })
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -1,0 +1,72 @@
+params:
+  - name: text
+    type: string
+    required: false
+    description: Text for the link. If `html` is provided, the `text` option will be ignored. Defaults to 'Exit this page'.
+  - name: html
+    type: string
+    required: false
+    description: HTML for the link. If `html` is provided, the `text` option will be ignored.
+  - name: redirectUrl
+    type: string
+    required: false
+    description: URL to redirect the current tab to. Defaults to `https://www.bbc.co.uk/weather`.
+  - name: id
+    type: string
+    required: false
+    description: ID attribute to add to the exit this page container.
+  - name: classes
+    type: string
+    required: false
+    description: Classes to add to the exit this page container.
+  - name: attributes
+    type: object
+    required: false
+    description: HTML attributes (for example data attributes) to add to the exit this page container.
+  - name: activatedText
+    type: string
+    required: false
+    description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Exiting page.'
+  - name: timedOutText
+    type: string
+    required: false
+    description: Text announced by screen readers when the keyboard shortcut has timed out without successful activation. Defaults to 'Exit this page expired.'
+  - name: pressTwoMoreTimesText
+    type: string
+    required: false
+    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> two more times to activate the button. Defaults to 'Shift, press 2 more times to exit.'
+  - name: pressOneMoreTimeText
+    type: string
+    required: false
+    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> one more time to activate the button. Defaults to 'Shift, press 1 more time to exit.'
+
+examples:
+  - name: default
+    data:
+      redirectUrl: '/full-page-examples/announcements'
+      id: null
+      classes: null
+      attributes: {}
+
+  - name: translated
+    data:
+      text: Gadael y dudalen
+      activatedText: Tudalen ymadael
+      timedOutText: Wedi'i amseru
+      pressTwoMoreTimesText: Pwyswch 'Shift' 2 gwaith arall
+      pressOneMoreTimeText: Pwyswch 'Shift' 1 mwy o amser
+
+  # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
+  - name: testing
+    hidden: true
+    data:
+      text: 'Exit this test'
+      redirectUrl: 'https://www.test.co.uk'
+      id: 'test-id'
+      classes: 'test-class'
+      attributes:
+        test-attribute: true
+  - name: testing-html
+    hidden: true
+    data:
+      html: 'Exit <em>this</em> test'

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/macro.njk
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/macro.njk
@@ -1,0 +1,3 @@
+{% macro govukExitThisPage(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
@@ -1,0 +1,16 @@
+{% from "../button/macro.njk" import govukButton -%}
+
+<div
+  {%- if params.id %} id="{{ params.id }}"{% endif %} class="govuk-exit-this-page {%- if params.classes %} {{ params.classes }}{% endif %}" data-module="govuk-exit-this-page" {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}
+  {%- if params.activatedText %} data-i18n.activated="{{ params.activatedText | escape }}"{% endif %}
+  {%- if params.timedOutText %} data-i18n.timed-out="{{ params.timedOutText | escape }}"{% endif %}
+  {%- if params.pressTwoMoreTimesText %} data-i18n.press-two-more-times="{{ params.pressTwoMoreTimesText | escape }}"{% endif %}
+  {%- if params.pressOneMoreTimeText %} data-i18n.press-one-more-time="{{ params.pressOneMoreTimeText | escape }}"{% endif %}
+>
+  {{- govukButton({
+    html: params.html,
+    text: params.text | default("Exit this page"),
+    classes: "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
+    href: params.redirectUrl | default("https://www.bbc.co.uk/weather")
+  }) -}}
+</div>

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
@@ -1,0 +1,77 @@
+const { render } = require('govuk-frontend-helpers/nunjucks')
+const { getExamples } = require('govuk-frontend-lib/files')
+
+describe('Exit this page', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('exit-this-page')
+  })
+
+  describe('default example', () => {
+    it('renders the default example', () => {
+      const $ = render('exit-this-page', examples.default)
+      const $button = $('.govuk-exit-this-page').find('.govuk-button')
+
+      expect($button.hasClass('govuk-button--warning')).toBeTruthy()
+      expect($button.text()).toContain('Exit this page')
+      expect($button.attr('href')).toBe('/full-page-examples/announcements')
+    })
+  })
+
+  describe('Custom options', () => {
+    it('renders with custom text', () => {
+      const $ = render('exit-this-page', examples.testing)
+      const $button = $('.govuk-exit-this-page').find('.govuk-button')
+
+      expect($button.text()).toContain('Exit this test')
+    })
+
+    it('renders with custom HTML', () => {
+      const $ = render('exit-this-page', examples['testing-html'])
+      const $button = $('.govuk-exit-this-page').find('.govuk-button')
+
+      expect($button.html()).toContain('Exit <em>this</em> test')
+    })
+
+    it('renders with a custom URL', () => {
+      const $ = render('exit-this-page', examples.testing)
+      const $button = $('.govuk-exit-this-page').find('.govuk-button')
+
+      expect($button.attr('href')).toBe('https://www.test.co.uk')
+    })
+
+    it('renders with a custom id', () => {
+      const $ = render('exit-this-page', examples.testing)
+      const $component = $('.govuk-exit-this-page')
+
+      expect($component.attr('id')).toBe('test-id')
+    })
+
+    it('renders with a custom class', () => {
+      const $ = render('exit-this-page', examples.testing)
+      const $component = $('.govuk-exit-this-page')
+
+      expect($component.hasClass('test-class')).toBeTruthy()
+    })
+
+    it('renders with custom attributes', () => {
+      const $ = render('exit-this-page', examples.testing)
+      const $component = $('.govuk-exit-this-page')
+
+      expect($component.attr('test-attribute')).toBe('true')
+    })
+  })
+
+  describe('Translated', () => {
+    it('renders with translation data attributes', () => {
+      const $ = render('exit-this-page', examples.translated)
+      const $component = $('.govuk-exit-this-page')
+
+      expect($component.attr('data-i18n.activated')).toBe('Tudalen ymadael')
+      expect($component.attr('data-i18n.timed-out')).toBe("Wedi'i amseru")
+      expect($component.attr('data-i18n.press-two-more-times')).toBe("Pwyswch 'Shift' 2 gwaith arall")
+      expect($component.attr('data-i18n.press-one-more-time')).toBe("Pwyswch 'Shift' 1 mwy o amser")
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/globals.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.test.js
@@ -36,6 +36,7 @@ describe('GOV.UK Frontend', () => {
         'CharacterCount',
         'Checkboxes',
         'ErrorSummary',
+        'ExitThisPage',
         'Header',
         'NotificationBanner',
         'Radios',

--- a/packages/govuk-frontend/src/govuk/objects/_template.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_template.scss
@@ -12,6 +12,26 @@
     // would like the browser to stay on 100% text zoom by default.
     text-size-adjust: 100%;
 
+    // Add scroll padding to the top of govuk-template but remove it if the
+    // exit this page component is present.
+    //
+    // This is a solution to exit this page potentially failing WCAG SC 2.4.12:
+    // Focus Not Obscured (https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html)
+    // due to it's sticky positioning.
+    //
+    // This will apply scroll-padding-top in any browsers that don't support :has
+    // (https://caniuse.com/css-has). This is part of the reason we do this in
+    // a "wrong way round" way as we hypothesise that the risks of having
+    // scroll-padding unnecessarily is better than risking not having scroll-padding
+    // and needing it to account for exit this page.
+    @supports (position: sticky) {
+      scroll-padding-top: govuk-spacing(9);
+
+      &:not(:has(.govuk-exit-this-page)) {
+        scroll-padding-top: 0;
+      }
+    }
+
     // Force the scrollbar to always display in IE, to prevent horizontal page
     // jumps as content height changes (e.g. autocomplete results open).
     @include govuk-media-query($media-type: screen) {

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -146,6 +146,7 @@ describe('packages/govuk-frontend/dist/', () => {
           import { CharacterCount } from './components/character-count/character-count.mjs';
           import { Checkboxes } from './components/checkboxes/checkboxes.mjs';
           import { ErrorSummary } from './components/error-summary/error-summary.mjs';
+          import { ExitThisPage } from './components/exit-this-page/exit-this-page.mjs';
           import { Header } from './components/header/header.mjs';
           import { NotificationBanner } from './components/notification-banner/notification-banner.mjs';
           import { Radios } from './components/radios/radios.mjs';
@@ -154,7 +155,7 @@ describe('packages/govuk-frontend/dist/', () => {
         `)
 
         // Look for ES modules named exports
-        expect(contents).toContain('export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };')
+        expect(contents).toContain('export { Accordion, Button, CharacterCount, Checkboxes, ErrorSummary, ExitThisPage, Header, NotificationBanner, Radios, SkipLink, Tabs, initAll };')
       })
     })
 


### PR DESCRIPTION
Ports the [exit this page component](https://design-system.service.gov.uk/components/exit-this-page/) from the 4.7.0 release to `main`, including refactoring the js to ES2015 in line with https://github.com/alphagov/govuk-frontend/pull/3771

Includes changes from the following PRs:
- https://github.com/alphagov/govuk-frontend/pull/2545
- https://github.com/alphagov/govuk-frontend/pull/3874
- https://github.com/alphagov/govuk-frontend/pull/3878

Additionally supersedes https://github.com/alphagov/govuk-frontend/pull/3880

Fixes https://github.com/alphagov/govuk-frontend/issues/3840 