### PR TITLE
Use exact GitHub Actions versions

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache build
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       id: build-cache
 
       with:

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       id: npm-install-cache
 
       with:

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v3.7.0
       id: setup-node
 
       with:

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -3,7 +3,8 @@ name: Setup
 inputs:
   use-cache:
     description: Restore global `~/.npm` cache
-    required: false
+    default: 'true'
+    required: true
 
 runs:
   using: composite
@@ -14,5 +15,5 @@ runs:
       id: setup-node
 
       with:
-        cache: ${{ inputs.use-cache != 'false' && 'npm' || '' }}
+        cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
         node-version-file: .nvmrc

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ !github.event.pull_request.head.repo.fork }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0 # Need to also checkout the base branch to compare
 
@@ -40,14 +40,14 @@ jobs:
           bin/dist-diff.sh origin/$GITHUB_BASE_REF $GITHUB_WORKSPACE
 
       - name: Save distribution diffs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: Dist diff
           path: dist*.diff
           if-no-files-found: ignore
 
       - name: Add comment to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0 # Need to also checkout the base branch to compare
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version-file: .nvmrc

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 8 # Node.js 8 supported by Dart Sass v1.0.0
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Dart Sass v1
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 4 # Node.js 4 supported by Node Sass v3.4.0
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Node Sass v8.x

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -27,13 +27,13 @@ jobs:
         run: echo "::warning title=GitHub Actions secrets::Workflow requires 'PERCY_TOKEN' secret"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Install dependencies
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: puppeteer-${{ runner.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -256,7 +256,7 @@ jobs:
         uses: ./.github/workflows/actions/build
 
       - name: Change Node.js version
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Install dependencies
         uses: ./.github/workflows/actions/install-node
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -88,14 +88,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache linter
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
@@ -155,7 +155,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -165,7 +165,7 @@ jobs:
 
       - name: Cache task
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
@@ -175,7 +175,7 @@ jobs:
         run: npx jest --color ${{ format('--maxWorkers={0} --selectProjects "{1}"', env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ matrix.task.description }} coverage
           path: coverage
@@ -204,7 +204,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -247,7 +247,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node


### PR DESCRIPTION
This change adds exact version numbers to all GitHub Actions

Dependabot will now raise PRs for minor/patch updates

## Node.js setup

I've also bumped GitHub `actions/setup-node` back to v3.7.0 (see [rollback PR for more info](https://github.com/alphagov/govuk-frontend/pull/3911))

Version v3.7.0 now runs cache checks earlier, [causing issues when `~/.npm` (npm cache) didn't exist](https://github.com/actions/setup-node/issues/797). The update revealed that we hadn't anticipated `null` "Boolean values" (booleans as strings) as shown in:

* https://github.com/actions/runner/issues/2238

Fixed in https://github.com/alphagov/govuk-frontend/commit/7874ca487592e2ed2545df6f452e8e8d622f7cd2