### PR TITLE
Run GitHub Actions tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,24 +10,15 @@ on:
       - 'support/**'
 
   workflow_dispatch:
-    inputs:
-      runner:
-        description: Run tests on
-        type: choice
-        default: ubuntu-latest
-        options:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
 
 concurrency:
-  group: tests-${{ inputs.runner || 'ubuntu-latest' }}-${{ github.head_ref || github.run_id }}
+  group: tests-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   install:
     name: Install
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
@@ -41,7 +32,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install]
 
     steps:
@@ -59,7 +50,7 @@ jobs:
 
   lint:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install]
 
     strategy:
@@ -106,18 +97,21 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
     env:
       # Use 2x CPU cores unless on Windows (runs slower when concurrent)
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-      MAX_WORKERS: ${{ inputs.runner == 'windows-latest' && '1' || '2' }}
+      MAX_WORKERS: ${{ matrix.runner == 'windows-latest' && '1' || '2' }}
 
     strategy:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+
         task:
           - description: Nunjucks macro tests
             name: test-macro
@@ -183,11 +177,8 @@ jobs:
 
   verify:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install, build]
-
-    # Skip when scheduled or run manually
-    if: ${{ !inputs.runner }}
 
     strategy:
       fail-fast: false
@@ -217,11 +208,8 @@ jobs:
 
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install, build]
-
-    # Skip when scheduled or run manually
-    if: ${{ !inputs.runner }}
 
     strategy:
       fail-fast: false
@@ -269,9 +257,6 @@ jobs:
   regression:
     name: Percy
     needs: [install, build]
-
-    # Skip when scheduled or run manually
-    if: ${{ !inputs.runner }}
 
     # Run existing "Percy screenshots" workflow
     # (after install and build have been cached)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,18 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - name: Checkout code
@@ -32,8 +40,16 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: [install]
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - name: Checkout
@@ -49,14 +65,18 @@ jobs:
         run: npm run build:types
 
   lint:
-    name: ${{ matrix.task.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     needs: [install]
 
     strategy:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+
         task:
           - description: Lint Sass
             name: lint-scss
@@ -96,7 +116,7 @@ jobs:
         run: ${{ matrix.task.run }}
 
   test:
-    name: ${{ matrix.task.description }}
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
@@ -111,6 +131,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
+          - windows-latest
 
         task:
           - description: Nunjucks macro tests
@@ -171,19 +192,23 @@ jobs:
       - name: Save test coverage
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: ${{ matrix.task.description }} coverage
+          name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
           path: coverage
           if-no-files-found: ignore
 
   verify:
-    name: ${{ matrix.task.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
     strategy:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+
         task:
           - description: Verify package build
             name: test-build-package


### PR DESCRIPTION
This PR updates our GitHub Actions tests to run on both Ubuntu and Windows:

* https://github.com/alphagov/govuk-frontend/issues/3638

Only Ubuntu runs Percy screenshots and Node.js package export tests

~Branch protection status checks will need updating to include the runner~

**Update:** Thankfully looks like GitHub ignores the `(${{ matrix.runner }})` at the end of the status check name