### PR TITLE
Add GitHub Actions export tests for Node.js v20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -261,9 +261,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.5.3
 
-      - name: Restore dependencies
-        uses: ./.github/workflows/actions/install-node
-
       - name: Restore build
         uses: ./.github/workflows/actions/build
 
@@ -273,10 +270,19 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - run: node --eval "console.log(require.resolve('govuk-frontend'))"${{ env.FLAGS }}
+        working-directory: packages/govuk-frontend
+
       - run: node --eval "console.log(require.resolve('govuk-frontend/package.json'))"${{ env.FLAGS }}
+        working-directory: packages/govuk-frontend
+
       - run: node --eval "console.log(require.resolve('govuk-frontend/dist/govuk/components/accordion/accordion.bundle.js'))"${{ env.FLAGS }}
+        working-directory: packages/govuk-frontend
+
       - run: node --eval "console.log(require.resolve('govuk-frontend/dist/govuk/components/accordion/accordion.bundle.mjs'))"${{ env.FLAGS }}
+        working-directory: packages/govuk-frontend
+
       - run: node --eval "console.log(require.resolve('govuk-frontend/dist/govuk/i18n.mjs'))"${{ env.FLAGS }}
+        working-directory: packages/govuk-frontend
 
   regression:
     name: Percy

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,7 @@ jobs:
         node-version:
           - 12 # Node.js 12.20+ uses package exports with subpath patterns
           - 18 # Node.js 17+ cannot use package exports with trailing slashes
+          - 20
 
         conditions:
           - require

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,17 +241,16 @@ jobs:
 
       matrix:
         node-version:
-          - 12.18 # Node.js 12.18 uses package exports with trailing slashes
-          - 12 # But Node.js 12.20+ uses package exports with subpath patterns
-          - 18
+          - 12 # Node.js 12.20+ uses package exports with subpath patterns
+          - 18 # Node.js 17+ cannot use package exports with trailing slashes
 
         conditions:
           - require
           - import
 
-        exclude:
-          - conditions: import
-            node-version: 12.18
+        include:
+          - conditions: require
+            node-version: 12.18 # Node.js 12.18 uses package exports with trailing slashes
 
     env:
       # Node.js conditions override from "require" to "import" etc


### PR DESCRIPTION
Node.js v20 reaches LTS in October 2023 so good to test early

Also addresses an [unnecessary `node_modules` cache restoration review comment](https://github.com/alphagov/govuk-frontend/pull/3906#issuecomment-1623868041) from:

* https://github.com/alphagov/govuk-frontend/pull/3906