### PR TITLE
Configure Babel to remove non-public comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,11 +43,6 @@ module.exports = {
           }
         ],
 
-        // JSDoc blocks are optional
-        'jsdoc/require-jsdoc': 'off',
-        'jsdoc/require-param-description': 'off',
-        'jsdoc/require-param': 'off',
-
         // Check for valid formatting
         'jsdoc/check-line-alignment': [
           'warn',
@@ -56,6 +51,19 @@ module.exports = {
             wrapIndent: '  '
           }
         ],
+
+        // JSDoc blocks can use `@preserve` to prevent removal
+        'jsdoc/check-tag-names': [
+          'warn',
+          {
+            definedTags: ['preserve']
+          }
+        ],
+
+        // JSDoc blocks are optional
+        'jsdoc/require-jsdoc': 'off',
+        'jsdoc/require-param-description': 'off',
+        'jsdoc/require-param': 'off',
 
         // Require hyphens before param description
         // Aligns with TSDoc style: https://tsdoc.org/pages/tags/param/

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -15,6 +15,8 @@ component
 ```mjs
 /**
  * Component name
+ *
+ * @preserve
  */
 export class Example {
   /**

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -19,9 +19,17 @@ module.exports = function (api) {
 
         // Assume all comments are public unless
         // tagged with `@private` or `@internal`
-        return ['* @internal', '* @private'].every(
-          (tag) => !comment.includes(tag)
+        const isPrivate = ['* @internal', '* @private'].some((tag) =>
+          comment.includes(tag)
         )
+
+        // Flag any JSDoc comments worth keeping
+        const isDocumentation = ['* @param', '* @returns', '* @typedef'].some(
+          (tag) => comment.includes(tag)
+        )
+
+        // Print only public JSDoc comments
+        return !isPrivate && isDocumentation
       }
     },
     presets: [

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -11,6 +11,19 @@ module.exports = function (api) {
   const browserslistEnv = isBrowser ? 'javascripts' : 'node'
 
   return {
+    generatorOpts: {
+      shouldPrintComment(comment) {
+        if (!isBrowser || comment.includes('* @preserve')) {
+          return true
+        }
+
+        // Assume all comments are public unless
+        // tagged with `@private` or `@internal`
+        return ['* @internal', '* @private'].every(
+          (tag) => !comment.includes(tag)
+        )
+      }
+    },
     presets: [
       [
         '@babel/preset-env',

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -13,6 +13,8 @@ import { I18n } from '../../i18n.mjs'
  *
  * The state of each section is saved to the DOM via the `aria-expanded`
  * attribute, which also provides accessibility.
+ *
+ * @preserve
  */
 export class Accordion {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -6,6 +6,8 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
 
 /**
  * JavaScript enhancements for the Button component
+ *
+ * @preserve
  */
 export class Button {
   /** @private */
@@ -24,7 +26,6 @@ export class Button {
   debounceFormSubmitTimer = null
 
   /**
-   *
    * @param {Element} $module - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -12,6 +12,8 @@ import { I18n } from '../../i18n.mjs'
  *
  * You can configure the message to only appear after a certain percentage
  * of the available characters/words has been entered.
+ *
+ * @preserve
  */
 export class CharacterCount {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -1,5 +1,7 @@
 /**
  * Checkboxes component
+ *
+ * @preserve
  */
 export class Checkboxes {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -5,6 +5,8 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
  * Error summary component
  *
  * Takes focus on initialisation for accessible announcement, unless disabled in configuration.
+ *
+ * @preserve
  */
 export class ErrorSummary {
   /** @private */
@@ -17,7 +19,6 @@ export class ErrorSummary {
   config
 
   /**
-   *
    * @param {Element} $module - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -4,6 +4,8 @@ import { I18n } from '../../i18n.mjs'
 
 /**
  * Exit This Page component
+ *
+ * @preserve
  */
 export class ExitThisPage {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -1,5 +1,7 @@
 /**
  * Header component
+ *
+ * @preserve
  */
 export class Header {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -3,6 +3,8 @@ import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 
 /**
  * Notification Banner component
+ *
+ * @preserve
  */
 export class NotificationBanner {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -1,5 +1,7 @@
 /**
  * Radios component
+ *
+ * @preserve
  */
 export class Radios {
   /** @private */

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,5 +1,7 @@
 /**
  * Skip link component
+ *
+ * @preserve
  */
 export class SkipLink {
   /** @private */
@@ -15,7 +17,6 @@ export class SkipLink {
   linkedElementListener = false
 
   /**
-   *
    * @param {Element} $module - HTML element to use for skip link
    */
   constructor($module) {

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -1,5 +1,7 @@
 /**
  * Tabs component
+ *
+ * @preserve
  */
 export class Tabs {
   /** @private */


### PR DESCRIPTION
This PR takes a look at component KB file size without comments

It configures Babel to remove all non-public comments unless tagged with `@preserve` or containing JSDoc tags

# Before

## `v5.0.0-preview`

File sizes from the [`main` branch](https://govuk-frontend-review.herokuapp.com)

| Component module    | File size |
| :---                |      ---: |
| all.mjs             | 114.7 KB  |
| accordion.mjs       | 40.31 KB  |
| character-count.mjs | 39.06 KB  |

## `v4.7.0`

File sizes from the **review app** on the `v4.7.0` tag

| Component module    | File size |
| :---                |      ---: |
| all.mjs             | 161.40 KB  |
| accordion.mjs       | 82.67 KB  |
| character-count.mjs | 76.34 KB  |

# After

## Only non-public comments removed

File sizes from [`rollup-babel-comments` branch](https://govuk-frontend-pr-3958.herokuapp.com/) with all non-public comments removed versus `v5.0.0-preview`

| Component module    | File size | Change  |
| :---                | :---      | :---    |
| all.mjs             | 66.35 KB  | -42.15% |
| accordion.mjs       | 20.77 KB  | -48.47% |
| character-count.mjs | 20.34 KB  | -47.93% |

## Only private and internal comments removed

File sizes from a previous spike with private and internal comments removed versus `v5.0.0-preview`

| Component module    | File size | Change  |
| :---                | :---      | :---    |
| all.mjs             | 94.19 KB  | -17.88% |
| accordion.mjs       | 36 KB  | -10.69% |
| character-count.mjs | 34.13 KB  | -12.62% |

## All comments removed

File sizes from a previous spike with ALL comments removed versus `v5.0.0-preview`

| Component module    | File size | Change  |
| :---                | :---      | :---    |
| all.mjs             | 55.57 KB  | -51.55% |
| accordion.mjs       | 19.98 KB  | -50.43% |
| character-count.mjs | 15.24 KB  | -60.98% |