### PR TITLE
Append card title to action links inside of a Summary Card

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.njk
@@ -1,9 +1,12 @@
-{%- macro _actionLink(action) %}
+{%- macro _actionLink(action, cardTitle) %}
   <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-    {{ action.html | safe if action.html else action.text }}
-    {%- if action.visuallyHiddenText -%}
-      <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
-    {% endif -%}
+    {{- action.html | safe if action.html else action.text -}}
+    {%- if action.visuallyHiddenText or cardTitle -%}
+      <span class="govuk-visually-hidden">
+        {%- if action.visuallyHiddenText %} {{ action.visuallyHiddenText }}{% endif -%}
+        {%- if cardTitle %} ({{ cardTitle.html | safe if cardTitle.html else cardTitle.text }}){% endif -%}
+      </span>
+    {%- endif -%}
   </a>
 {% endmacro -%}
 
@@ -21,13 +24,13 @@
       {%- if params.actions.items.length -%}
         {%- if params.actions.items.length == 1 -%}
           <div class="govuk-summary-card__actions {%- if params.actions.classes %} {{ params.actions.classes }}{% endif %}">
-            {{- _actionLink(params.actions.items[0]) -}}
+            {{- _actionLink(params.actions.items[0], params.title) -}}
           </div>
         {%- else -%}
           <ul class="govuk-summary-card__actions {%- if params.actions.classes %} {{ params.actions.classes }}{% endif %}">
             {%- for action in params.actions.items -%}
               <li class="govuk-summary-card__action">
-                {{- _actionLink(action) -}}
+                {{- _actionLink(action, params.title) -}}
               </li>
             {%- endfor -%}
           </ul>
@@ -61,12 +64,12 @@
           {% if row.actions.items.length %}
             <dd class="govuk-summary-list__actions {%- if row.actions.classes %} {{ row.actions.classes }}{% endif %}">
               {% if row.actions.items.length == 1 %}
-                {{ _actionLink(row.actions.items[0]) | indent(16 if params.card else 12) | trim }}
+                {{ _actionLink(row.actions.items[0], params.card.title) | indent(16 if params.card else 12) | trim }}
               {% else %}
                 <ul class="govuk-summary-list__actions-list">
                   {%- for action in row.actions.items -%}
                     <li class="govuk-summary-list__actions-list-item">
-                      {{- _actionLink(action) | indent(22 if params.card else 18) | trim -}}
+                      {{- _actionLink(action, params.card.title) | indent(22 if params.card else 18) | trim -}}
                     </li>
                   {%- endfor -%}
                 </ul>

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
@@ -268,7 +268,7 @@ describe('Summary list', () => {
         const $singleAction = $('.govuk-summary-card__actions > a')
         const $actionItems = $('.govuk-summary-card__action')
         expect($actionItems.length).toBe(0)
-        expect($singleAction.text().trim()).toBe('My lonely action')
+        expect($singleAction.text().trim()).toBe('My lonely action (Undergraduate teaching assistant)')
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_visually-hidden.scss
@@ -33,6 +33,11 @@
   // causes content to wrap 1 word per line:
   // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
   white-space: nowrap if($important, !important, null);
+
+  // Prevent users from selecting or copying visually-hidden text. This prevents
+  // a user unintentionally copying more text than they intended and needing to
+  // manually trim it down again.
+  user-select: none;
 }
 
 /// Hide an element visually, but have it available for screen readers whilst
@@ -64,6 +69,11 @@
   // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
   white-space: nowrap if($important, !important, null);
 
+  // Prevent users from selecting or copying visually-hidden text. This prevents
+  // a user unintentionally copying more text than they intended and needing to
+  // manually trim it down again.
+  user-select: none;
+
   &:active,
   &:focus {
     position: static if($important, !important, null);
@@ -77,5 +87,8 @@
     clip-path: none if($important, !important, null);
 
     white-space: inherit if($important, !important, null);
+
+    // Allow the text to be selectable now it's visible
+    user-select: text;
   }
 }


### PR DESCRIPTION
It was raised in the recent DAC audit that pages with multiple Summary Cards had the potential to fail the Level A criterion [Link Purpose (In Context)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html) and the Level AAA criterion [Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-link-only), due to the repetition of links with identical labels—unless the implementor went out of their way to manually provide the required distinctions.

This PR modifies the Nunjucks template for Summary Lists so that, if a card title has been provided, the title is automatically appended to any action links within the card. This is applied to both the card-level and individual row's action links. 

This PR resolves #3673 add #3674.

## Changes
- Updated the component's internal `_actionLink` macro now takes a second, optional `cardTitle` parameter.
- Updated instances of `_actionLink` to pass through the `params.card.title` object, if it exists. 

## Thoughts
- This is currently hardcoding a content order (and parentheses) that might not be preferable in all localisations. I'm hoping that, as two distinct pieces of information that are intended as separate phrases, this might be okay, but I'm not sure.
- Piping `params.card.title.html` into a visually-hidden span feels a bit weird and like it may have adverse side effects depending on what HTML is provided, however we have no guarantee that `params.card.title.text` is set in all situations.
