### PR TITLE
Add Percy screenshots for specific component examples

### DIFF
--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -42,6 +42,17 @@ export async function screenshots () {
     }
   }
 
+  // Screenshot specific component examples
+  for (const [componentName, options] of /** @type {const} */ ([
+    ['button', { exampleName: 'start' }],
+    ['button', { exampleName: 'inverse-start' }],
+    ['details', { exampleName: 'expanded' }],
+    ['pagination', { exampleName: 'with-prev-and-next-only' }],
+    ['pagination', { exampleName: 'with-prev-and-next-only-and-labels' }]
+  ])) {
+    await screenshotComponent(await browser.newPage(), componentName, options)
+  }
+
   // Screenshot specific example pages
   for (const exampleName of [
     'text-alignment',

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -26,7 +26,6 @@ export async function launch () {
 export async function screenshots () {
   const browser = await launch()
   const componentNames = await getComponentNames()
-  const exampleNames = ['text-alignment', 'typography']
 
   // Screenshot components
   for (const componentName of componentNames) {
@@ -43,8 +42,11 @@ export async function screenshots () {
     }
   }
 
-  // Screenshot examples
-  for (const exampleName of exampleNames) {
+  // Screenshot specific example pages
+  for (const exampleName of [
+    'text-alignment',
+    'typography'
+  ]) {
     await screenshotExample(await browser.newPage(), exampleName)
   }
 


### PR DESCRIPTION
This PR adds specific component examples for Percy visual regression:

1. Start button
2. Start button (inverse)
3. Details (expanded)
4. Pagination in block style
5. Pagination in block style (with labels)

Mentioned by @querkmachine in https://github.com/alphagov/govuk-frontend/pull/3959#discussion_r1263468923