### PR TITLE
Switch to `@prettier/sync` for sync Nunjucks formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3983,6 +3983,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prettier/sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@prettier/sync/-/sync-0.3.0.tgz",
+      "integrity": "sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==",
+      "funding": {
+        "url": "https://github.com/prettier/prettier-synchronized?sponsor=1"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.5.tgz",
@@ -21378,7 +21389,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
       "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
-      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -27587,6 +27597,7 @@
     "packages/govuk-frontend-review": {
       "license": "MIT",
       "dependencies": {
+        "@prettier/sync": "^0.3.0",
         "chokidar": "^3.5.3",
         "cookie-parser": "^1.4.6",
         "express": "^4.18.2",
@@ -27602,7 +27613,6 @@
         "marked": "^5.1.1",
         "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
-        "prettier": "^2.8.8",
         "shuffle-seed": "^1.1.6",
         "slug": "^8.2.2"
       },
@@ -27629,29 +27639,6 @@
       "engines": {
         "node": "^18.12.0",
         "npm": "^8.1.0 || ^9.1.0"
-      },
-      "optionalDependencies": {
-        "@types/prettier": "^2.7.3"
-      }
-    },
-    "packages/govuk-frontend-review/node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "optional": true
-    },
-    "packages/govuk-frontend-review/node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "shared/config": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -19,6 +19,7 @@
     "test:screenshots": "gulp screenshots --color"
   },
   "dependencies": {
+    "@prettier/sync": "^0.3.0",
     "chokidar": "^3.5.3",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.2",
@@ -34,7 +35,6 @@
     "marked": "^5.1.1",
     "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
-    "prettier": "^2.8.8",
     "shuffle-seed": "^1.1.6",
     "slug": "^8.2.2"
   },
@@ -57,8 +57,5 @@
     "slash": "^5.1.0",
     "supertest": "^6.3.3",
     "typedoc": "^0.24.8"
-  },
-  "optionalDependencies": {
-    "@types/prettier": "^2.7.3"
   }
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -1,7 +1,7 @@
 import { inspect } from 'util'
 
+import prettier from '@prettier/sync'
 import { outdent } from 'outdent'
-import { format } from 'prettier'
 
 import { componentNameToMacroName } from '../filters/index.mjs'
 
@@ -24,7 +24,7 @@ export function getNunjucksCode (componentName, params) {
   })
 
   // Format Nunjucks safely with double quotes
-  const macroFormatted = format(`${macroName}(${paramsFormatted})`, {
+  const macroFormatted = prettier.format(`${macroName}(${paramsFormatted})`, {
     parser: 'espree',
     semi: false,
     singleQuote: false,


### PR DESCRIPTION
Prettier recently switched to a Promise-based API which affects Nunjucks macro options `format()`

**Prettier 3.0: Hello, ECMAScript Modules!**
https://prettier.io/blog/2023/07/05/3.0.0.html

We'd need to [replace Nunjucks `for` loops with `asyncEach`](https://mozilla.github.io/nunjucks/templating.html#asynceach) to give `include` blocks [asynchronous support](https://mozilla.github.io/nunjucks/api.html#asynchronous-support) so we held the Review app on `prettier@2` for now:

* https://github.com/alphagov/govuk-frontend/pull/3939
* https://github.com/alphagov/govuk-frontend/pull/3966

But this PR now takes the advice from the blog article above:

>If you still need sync APIs, you can try [@prettier/sync](https://github.com/prettier/prettier-synchronized)

With thanks to @fisker we can continue using `tsc` and our ESLint plugins:

* https://github.com/prettier/prettier-synchronized/pull/10