### PR TITLE
Internal docs update after repository changes

### DIFF
--- a/docs/contributing/application-architecture.md
+++ b/docs/contributing/application-architecture.md
@@ -71,6 +71,10 @@
 
     Shared libraries for directory listings, component data, naming conventions.
 
+  - `stats/`
+
+    File size measurement and module breakdown of built files
+
   - `tasks/`
 
     Read about [npm and Gulp tasks](tasks.md) for more information about the tasks.

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -53,6 +53,10 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - append version number from `packages/govuk-frontend/package.json` to compiled JavaScript and CSS files
 - runs `npm run postbuild:release` (which will test the output is correct)
 
+**`npm run build:types` will do the following:**
+
+- run the [TypeScript compiler](https://www.typescriptlang.org/docs/handbook/compiler-options.html) to verify the types in our JavaScript files
+
 ## Gulp tasks
 
 Project Gulp tasks are defined in [`gulpfile.mjs`](/gulpfile.mjs) and the [`tasks/`](/shared/tasks) folder.

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -61,25 +61,17 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 
 Project Gulp tasks are defined in [`gulpfile.mjs`](/gulpfile.mjs) and the [`tasks/`](/shared/tasks) folder.
 
-**`gulp --tasks`**
-
-This task will:
-
-- list out all available tasks
-
-Review app Gulp tasks are defined in [`app/gulpfile.mjs`](/app/gulpfile.mjs) and the [`app/tasks/`](/app/tasks) folder.
-
 Gulp tasks from npm workspaces (such as the review app) can be run as shown:
 
 **`npx --workspace govuk-frontend-review -- gulp --tasks`**
 
-This will list out all available tasks for the GOV.UK Frontend package.
+This will list out all available tasks for the review app.
 
 GOV.UK Frontend package build Gulp tasks are defined in [`packages/govuk-frontend/gulpfile.mjs`](/packages/govuk-frontend/gulpfile.mjs) and the [`packages/govuk-frontend/tasks/`](/packages/govuk-frontend/tasks) folder.
 
 **`npx --workspace govuk-frontend -- gulp --tasks`**
 
-This will list out all available tasks for the review app.
+This will list out all available tasks for the GOV.UK Frontend package.
 
 Review app Gulp tasks are defined in [`packages/govuk-frontend-review/gulpfile.mjs`](/packages/govuk-frontend-review/gulpfile.mjs) and the [`packages/govuk-frontend-review/tasks/`](/packages/govuk-frontend-review/tasks) folder.
 


### PR DESCRIPTION
Following [the update of our repository structure](https://github.com/alphagov/govuk-frontend/issues/3291), this PR makes a few last updates to the documentation to ensure it matches the changes we've made lately. 

Thankfully, most things had already been updated along the way (thanks @colinrotherham for the thoroughness), so this PR only:

- adds the missing `shared/stats` folder to the architecture documentation
- adds a decription of the type checking npm task, to point people to the TypeScript docs
- cleans up a reference to the oudated `app` folder 

Closes #3291