### PR TITLE
Add pre-release documentation with version numbers

### DIFF
--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -42,19 +42,13 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    - Use `preminor` to bump from `v4.7.0` to `v4.8.0-beta.0`
    - Use `prepatch` to bump from `v4.7.0` to `v4.7.1-beta.0`
 
+   See the [versioning documentation](/docs/contributing/versioning.md) for more information.
+
    Alternatively, when publishing an update to an existing pre-release:
 
    - Use `prerelease` to bump from `v5.0.0-beta.0` to `v5.0.0-beta.1`
 
-6. Create and check out a new branch (`release-[version-number]`). See the [versioning documentation](/docs/contributing/versioning.md) for more information.
-
-7. If you're publishing a beta pre-release, update the [`CHANGELOG.md`](/CHANGELOG.md) by:
-
-   - changing the 'Unreleased' heading to the new version number and release type. For example, '5.0.0-beta.0 (Pre-release)'
-   - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
-   - saving your changes
-
-8. Apply the new pre-release version number by running:
+6. Apply the new pre-release version number by running:
 
    ```shell
    npm version <PRE-RELEASE TYPE> --preid <PRE-RELEASE IDENTIFIER> --no-git-tag-version --workspace govuk-frontend
@@ -63,6 +57,18 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
+
+7. Create and check out a new branch (`release-[version-number]`)
+
+   ```shell
+   git switch -c "release-$(npm run version --silent --workspace govuk-frontend)"
+   ```
+
+8. If you're publishing a beta pre-release, update the [`CHANGELOG.md`](/CHANGELOG.md) by:
+
+   - changing the 'Unreleased' heading to the new version number and release type. For example, '5.0.0-beta.0 (Pre-release)'
+   - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
+   - saving your changes
 
 9. Run `npm run build-release` to:
 

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -69,14 +69,14 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
     You will now be prompted to continue or cancel.
 
-10. If you're publishing a beta pre-release, create a pull request
+10. Create a pull request.
     When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
-
-11. If you're publishing a beta pre-release, once a reviewer approves the pull request, merge it to **main**.
+    
+11. Once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm
 
-1. If you're publishing a beta pre-release, check out the **main** branch and pull the latest changes.
+1. Check out the **main** branch and pull the latest changes.
 
 2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
 

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -1,15 +1,27 @@
-# Before you publish GOV.UK Frontend
+# Before you publish a pre-release of GOV.UK Frontend
 
-Read the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to ensure you are prepared to publish.
+Decide the kind of pre-release you're publishing. All pre-releases are public, but we distinguish:
+
+- `internal` pre-releases for internal use
+- `beta` pre-releases aimed at external users
+
+We'll use the kind of pre-release as [the pre-release identifier](https://docs.npmjs.com/cli/v8/commands/npm-version#preid) in the package version.
+
+## If you're publishing a beta pre-release
+
+Besides publishing the code itself, beta releases will likely involve
+documentation updates linked to the code, as well as communications, similarly to an actual release.
+
+Review the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to assess which steps you need to follow for your specific pre-release and ensure you are prepared to publish.
 
 See the [documentation on support branches](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/support-branches.html#support-branches) if you need to:
 
-- publish a new release of previous major versions of GOV.UK Frontend
+- publish a new pre-release of previous major versions of GOV.UK Frontend
 - publish a ‘hotfix’ release of GOV.UK Frontend without including other unreleased changes on the `main` branch
 
 # Publish a new version of GOV.UK Frontend
 
-Developers should pair on releases. When remote working, it can be useful to be on a call together.
+Developers should pair on pre-releases. When remote working, it can be useful to be on a call together.
 
 1. Check out the **main** branch and pull the latest changes.
 
@@ -17,49 +29,66 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 
-4. Create and check out a new branch (`release-[version-number]`). See the [versioning documentation](/docs/contributing/versioning.md) for more information.
+4. Determine the pre-release identifier
 
-5. Update the [`CHANGELOG.md`](/CHANGELOG.md) by:
+   - Use `internal` for internal pre-releases
+   - Use `beta` for beta pre-releases
 
-   - changing the 'Unreleased' heading to the new version number and release type. For example, '3.11.0 (Feature release)'
+5. Determine the pre-release version type
+
+   Given the `beta` pre-release identifier:
+
+   - Use `premajor` to bump from `v4.7.0` to `v5.0.0-beta.0`
+   - Use `preminor` to bump from `v4.7.0` to `v4.8.0-beta.0`
+   - Use `prepatch` to bump from `v4.7.0` to `v4.7.1-beta.0`
+
+   Alternatively, when publishing an update to an existing pre-release:
+
+   - Use `prerelease` to bump from `v5.0.0-beta.0` to `v5.0.0-beta.1`
+
+6. Create and check out a new branch (`release-[version-number]`). See the [versioning documentation](/docs/contributing/versioning.md) for more information.
+
+7. If you're publishing a beta pre-release, update the [`CHANGELOG.md`](/CHANGELOG.md) by:
+
+   - changing the 'Unreleased' heading to the new version number and release type. For example, '5.0.0-beta.0 (Pre-release)'
    - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
    - saving your changes
 
-6. Apply the new version number by running:
+8. Apply the new pre-release version number by running:
 
    ```shell
-   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
+   npm version <PRE-RELEASE TYPE> --preid <PRE-RELEASE IDENTIFIER> --no-git-tag-version --workspace govuk-frontend
    ```
 
    This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
 
-7. Run `npm run build-release` to:
+9. Run `npm run build-release` to:
 
-   - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
-   - commit the changes
-   - push a branch to GitHub
+    - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
+    - commit the changes
+    - push a branch to GitHub
 
-   You will now be prompted to continue or cancel.
+    You will now be prompted to continue or cancel.
 
-8. Create a pull request and copy the changelog text.
-   When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
+10. If you're publishing a beta pre-release, create a pull request
+    When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
 
-9. Once a reviewer approves the pull request, merge it to **main**.
+11. If you're publishing a beta pre-release, once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm
 
-1. Check out the **main** branch and pull the latest changes.
+1. If you're publishing a beta pre-release, check out the **main** branch and pull the latest changes.
 
 2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
 
 3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
 
-   If you're following these instructions, you're probably doing a sequential release, meaning
-   the tag should be 'latest'.
+4. Enter `N` to continue to set the npm tag corresponding to the kind of release you're publishing:
 
-4. Enter `y` to continue. If you think the tag should be different, enter `N` to have the option to set your own npm tag.
+   - `internal` for internal pre-releases
+   - `next` for beta pre-releases
 
 5. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
 
@@ -69,7 +98,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 6. Run `npm logout` to log out from npm.
 
-## Create a release on Github
+## If publishing a beta pre-release, create a release on Github
 
 You can view the tag created during step 10 of creating the new version in the [Github interface](https://github.com/alphagov/govuk-frontend/tags). To create a new Github release, do the following:
 
@@ -78,8 +107,9 @@ You can view the tag created during step 10 of creating the new version in the [
 3. Set 'GOV.UK Frontend v[version-number]' as the title
 4. Add release notes from changelog
 5. Attach the ZIP file that has been generated at the root of this project during the npm publishing phase
-6. Publish release
+6. [Select "This is a pre-release"](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to mark the release as a pre-release
+7. Publish release
 
-# After you publish the new release
+# After you publish the new pre-release
 
-Read the docs for [what to do after publishing a release](/docs/releasing/after-publishing-a-release.md).
+If you're publishing a beta pre-release, read the docs for [what to do after publishing a release](/docs/releasing/after-publishing-a-release.md) and assess which parts may be relevant to your pre-release.

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -22,7 +22,10 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
 1. Check out the **main** branch and pull the latest changes.
 
-2. Run `nvm use` to make sure you're using the right version of Node.js and npm.
+2. Ensure you're running the version of NodeJS matching [`.nvmrc`](/.nvmrc).
+
+   - If you use NVM, run `nvm use` to set up the right version
+   - If you use another management system (like [`asdf`](https://asdf-vm.com/guide/getting-started.html)), compare the output of `node --version` and install the right one if necessary
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 
@@ -63,15 +66,15 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
 9. Run `npm run build-release` to:
 
-    - build GOV.UK Frontend into [the package's `/dist`](/packages/govuk-frontend/dist) and [root `/dist`](/dist) directories
-    - commit the changes
-    - push a branch to GitHub
+   - build GOV.UK Frontend into [the package's `/dist`](/packages/govuk-frontend/dist) and [root `/dist`](/dist) directories
+   - commit the changes
+   - push a branch to GitHub
 
-    You will now be prompted to continue or cancel.
+   You will now be prompted to continue or cancel.
 
 10. Create a pull request.
     When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
-    
+
 11. Once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -1,0 +1,85 @@
+# Before you publish GOV.UK Frontend
+
+Read the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to ensure you are prepared to publish.
+
+See the [documentation on support branches](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/support-branches.html#support-branches) if you need to:
+
+- publish a new release of previous major versions of GOV.UK Frontend
+- publish a ‘hotfix’ release of GOV.UK Frontend without including other unreleased changes on the `main` branch
+
+# Publish a new version of GOV.UK Frontend
+
+Developers should pair on releases. When remote working, it can be useful to be on a call together.
+
+1. Check out the **main** branch and pull the latest changes.
+
+2. Run `nvm use` to make sure you're using the right version of Node.js and npm.
+
+3. Run `npm ci` to make sure you have the exact dependencies installed.
+
+4. Create and check out a new branch (`release-[version-number]`). See the [versioning documentation](/docs/contributing/versioning.md) for more information.
+
+5. Update the [`CHANGELOG.md`](/CHANGELOG.md) by:
+
+   - changing the 'Unreleased' heading to the new version number and release type. For example, '3.11.0 (Feature release)'
+   - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
+   - saving your changes
+
+6. Apply the new version number by running:
+
+   ```shell
+   npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
+   ```
+
+   This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.
+
+   Do not commit the changes.
+
+7. Run `npm run build-release` to:
+
+   - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
+   - commit the changes
+   - push a branch to GitHub
+
+   You will now be prompted to continue or cancel.
+
+8. Create a pull request and copy the changelog text.
+   When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
+
+9. Once a reviewer approves the pull request, merge it to **main**.
+
+## Publish a release to npm
+
+1. Check out the **main** branch and pull the latest changes.
+
+2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
+
+3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
+
+   If you're following these instructions, you're probably doing a sequential release, meaning
+   the tag should be 'latest'.
+
+4. Enter `y` to continue. If you think the tag should be different, enter `N` to have the option to set your own npm tag.
+
+5. You will now be prompted to continue or cancel the release. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the release.
+
+   This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
+
+   It will also automatically create a tag in Github which you can use to create a Github release in the following section.
+
+6. Run `npm logout` to log out from npm.
+
+## Create a release on Github
+
+You can view the tag created during step 10 of creating the new version in the [Github interface](https://github.com/alphagov/govuk-frontend/tags). To create a new Github release, do the following:
+
+1. Select the latest tag
+2. Press **Create release from tag**
+3. Set 'GOV.UK Frontend v[version-number]' as the title
+4. Add release notes from changelog
+5. Attach the ZIP file that has been generated at the root of this project during the npm publishing phase
+6. Publish release
+
+# After you publish the new release
+
+Read the docs for [what to do after publishing a release](/docs/releasing/after-publishing-a-release.md).

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -1,6 +1,6 @@
 # Before you publish a pre-release of GOV.UK Frontend
 
-Decide the kind of pre-release you're publishing. All pre-releases are public, but we distinguish:
+Decide the kind of pre-release you're publishing. All pre-releases are public, but we distinguish between:
 
 - `internal` pre-releases for internal use
 - `beta` pre-releases aimed at external users
@@ -9,8 +9,7 @@ We'll use the kind of pre-release as [the pre-release identifier](https://docs.n
 
 ## If you're publishing a beta pre-release
 
-Besides publishing the code itself, beta releases will likely involve
-documentation updates linked to the code, as well as communications, similarly to an actual release.
+Besides publishing the code itself, beta releases will likely involve code-related documentation updates and user communications, much like an actual release.
 
 Review the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to assess which steps you need to follow for your specific pre-release and ensure you are prepared to publish.
 
@@ -18,7 +17,7 @@ See the [documentation on support branches](https://govuk-design-system-team-doc
 
 # Publish a new version of GOV.UK Frontend
 
-Developers should pair on pre-releases. When remote working, it can be useful to be on a call together.
+Developers should pair on pre-releases. When working remotely, it can be useful to be on a call together.
 
 1. Check out the **main** branch and pull the latest changes.
 
@@ -29,14 +28,14 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 
-4. Determine the pre-release identifier
+4. Determine the `< PRE_RELEASE_IDENTIFIER >`
 
    - Use `internal` for internal pre-releases
    - Use `beta` for beta pre-releases
 
-5. Determine the pre-release version type
+5. Determine the `< PRE_RELEASE_VERSION_TYPE >`
 
-   Given the `beta` pre-release identifier:
+   As examples with a `beta` pre-release identifier:
 
    - Use `premajor` to bump from `v4.7.0` to `v5.0.0-beta.0`
    - Use `preminor` to bump from `v4.7.0` to `v4.8.0-beta.0`
@@ -53,14 +52,14 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 6. Apply the new pre-release version number by running:
 
    ```shell
-   npm version <PRE-RELEASE TYPE> --preid <PRE-RELEASE IDENTIFIER> --no-git-tag-version --workspace govuk-frontend
+   npm version < PRE_RELEASE_VERSION_TYPE > --preid < PRE_RELEASE_IDENTIFIER > --no-git-tag-version --workspace govuk-frontend
    ```
 
    This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
 
-7. Create and check out a new branch (`release-[version-number]`)
+7. Create and check out a new branch (`release-[version]`)
 
    ```shell
    git switch -c "release-$(npm run version --silent --workspace govuk-frontend)"
@@ -78,7 +77,7 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    - commit the changes
    - push a branch to GitHub
 
-   You will now be prompted to continue or cancel.
+   You will now be prompted to continue or cancel. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the build and creation of the branch on GitHub.
 
 10. Create a pull request.
     When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
@@ -109,7 +108,7 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
    This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
 
-   It will also automatically create a tag in GitHub which you can use to create a GitHub release in the following section.
+   This step will also automatically create a tag in GitHub which you can use to create a GitHub release in the following section.
 
 6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
@@ -124,7 +123,7 @@ To create a new GitHub release, do the following:
 
 1. Select the tag corresponding to the release in [the list of tags on GitHub](https://github.com/alphagov/govuk-frontend/tags)
 2. Press **Create release from tag**
-3. Set 'GOV.UK Frontend v[version-number]' as the title
+3. Set 'GOV.UK Frontend v[version]' as the title
 4. Add release notes from [`CHANGELOG.md`](/CHANGELOG.md)
 5. Attach as release binary the ZIP file that has been generated at the root of this project during the npm publishing phase
 6. [Select "This is a pre-release"](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to mark the release as a pre-release

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -14,10 +14,7 @@ documentation updates linked to the code, as well as communications, similarly t
 
 Review the docs for [what to do before publishing a release](/docs/releasing/before-publishing-a-release.md) to assess which steps you need to follow for your specific pre-release and ensure you are prepared to publish.
 
-See the [documentation on support branches](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/support-branches.html#support-branches) if you need to:
-
-- publish a new pre-release of previous major versions of GOV.UK Frontend
-- publish a ‘hotfix’ release of GOV.UK Frontend without including other unreleased changes on the `main` branch
+See the [documentation on support branches](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/support-branches.html#support-branches) if you need to publish a new pre-release of previous major versions of GOV.UK Frontend.
 
 # Publish a new version of GOV.UK Frontend
 
@@ -60,13 +57,13 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    npm version <PRE-RELEASE TYPE> --preid <PRE-RELEASE IDENTIFIER> --no-git-tag-version --workspace govuk-frontend
    ```
 
-   This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.
+   This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
 
 9. Run `npm run build-release` to:
 
-    - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
+    - build GOV.UK Frontend into [the package's `/dist`](/packages/govuk-frontend/dist) and [root `/dist`](/dist) directories
     - commit the changes
     - push a branch to GitHub
 
@@ -96,7 +93,12 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
    It will also automatically create a tag in Github which you can use to create a Github release in the following section.
 
-6. Run `npm logout` to log out from npm.
+6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
+
+   If the pre-release has been assigned the wrong tag (mistakes happen),
+   you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
+
+7. Run `npm logout` to log out from npm.
 
 ## If publishing a beta pre-release, create a release on Github
 

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -47,6 +47,8 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    Alternatively, when publishing an update to an existing pre-release:
 
    - Use `prerelease` to bump from `v5.0.0-beta.0` to `v5.0.0-beta.1`
+   - Use `prerelease` to move from `v5.0.0-internal.X` to `v5.0.0-beta.0`.
+     Note that this resets the final number to `.0`, so prefer setting the version manually if a pre-release of the kind you're running has already gone through.
 
 6. Apply the new pre-release version number by running:
 

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -89,6 +89,13 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
 1. Check out the **main** branch and pull the latest changes.
 
+   If there was an interruption between the raising of the PR and its merge,
+   or it's another developer running the publication to npm, rebuild the package with:
+
+   ```shell
+   npm run build:package
+   ```
+
 2. Sign in to npm (`npm login`), using the credentials for the govuk-patterns-and-tools npm user from Bitwarden.
 
 3. Run `npm run publish-release`, which will prompt you to check whether the npm tag looks as expected.
@@ -102,7 +109,7 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
    This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
 
-   It will also automatically create a tag in Github which you can use to create a Github release in the following section.
+   It will also automatically create a tag in GitHub which you can use to create a GitHub release in the following section.
 
 6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
@@ -111,15 +118,15 @@ Developers should pair on pre-releases. When remote working, it can be useful to
 
 7. Run `npm logout` to log out from npm. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
 
-## If publishing a beta pre-release, create a release on Github
+## If publishing a beta pre-release, create a release on GitHub
 
-You can view the tag created during step 10 of creating the new version in the [Github interface](https://github.com/alphagov/govuk-frontend/tags). To create a new Github release, do the following:
+To create a new GitHub release, do the following:
 
-1. Select the latest tag
+1. Select the tag corresponding to the release in [the list of tags on GitHub](https://github.com/alphagov/govuk-frontend/tags)
 2. Press **Create release from tag**
 3. Set 'GOV.UK Frontend v[version-number]' as the title
-4. Add release notes from changelog
-5. Attach the ZIP file that has been generated at the root of this project during the npm publishing phase
+4. Add release notes from [`CHANGELOG.md`](/CHANGELOG.md)
+5. Attach as release binary the ZIP file that has been generated at the root of this project during the npm publishing phase
 6. [Select "This is a pre-release"](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) to mark the release as a pre-release
 7. Publish release
 

--- a/docs/releasing/publishing-a-pre-release.md
+++ b/docs/releasing/publishing-a-pre-release.md
@@ -109,7 +109,7 @@ Developers should pair on pre-releases. When remote working, it can be useful to
    If the pre-release has been assigned the wrong tag (mistakes happen),
    you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
 
-7. Run `npm logout` to log out from npm.
+7. Run `npm logout` to log out from npm. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
 
 ## If publishing a beta pre-release, create a release on Github
 

--- a/docs/releasing/publishing-a-preview.md
+++ b/docs/releasing/publishing-a-preview.md
@@ -23,7 +23,10 @@ Projects can point to this branch in their package.json, instead of to the publi
 
 2. Make any required changes and commit them.
 
-3. Run `nvm use` to make sure you’re using the right version of Node.js and npm.
+3. Ensure you're running the version of NodeJS matching [`.nvmrc`](/.nvmrc).
+
+   - If you use NVM, run `nvm use` to set up the right version
+   - If you use another management system (like [`asdf`](https://asdf-vm.com/guide/getting-started.html)), compare the output of `node --version` and install the right one if necessary
 
 4. Run `npm ci` to make sure you have the exact dependencies installed.
 

--- a/docs/releasing/publishing-a-preview.md
+++ b/docs/releasing/publishing-a-preview.md
@@ -31,7 +31,7 @@ Projects can point to this branch in their package.json, instead of to the publi
 
 ## Preview your changes
 
-1. If you need to update an existing project to use the preview, copy the command that displays after the `Success!`message.
+1. If you need to update an existing project to use the preview, copy the command that displays after the `Success!` message.
 
 2. Navigate to the project in the command line and run the success notification command. Running this command makes the project point to the preview branch, instead of to the published [GOV.UK Frontend npm package](https://www.npmjs.com/package/govuk-frontend). You can now preview your trial changes to GOV.UK Frontend.
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -80,7 +80,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
    If the release has been assigned the wrong tag (mistakes happen),
    you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
 
-7. Run `npm logout` to log out from npm.
+7. Run `npm logout` to log out from npm in the command line. If you've logged in through your browser, remember to log out from <https://npmjs.com> there as well.
 
 ## Create a release on Github
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -23,6 +23,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    - changing the 'Unreleased' heading to the new version number and release type. For example, '3.11.0 (Feature release)'
    - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
+   - if the changelog has headings from [pre-releases](/docs/releasing/publishing-a-pre-release.md#publish-a-new-version-of-govuk-frontend), regroup the content under those headings in a single block
    - saving your changes
 
 6. Apply the new version number by running:

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -20,16 +20,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 
-4. Create and check out a new branch (`release-[version-number]`). See the [versioning documentation](/docs/contributing/versioning.md) for more information.
-
-5. Update the [`CHANGELOG.md`](/CHANGELOG.md) by:
-
-   - changing the 'Unreleased' heading to the new version number and release type. For example, '3.11.0 (Feature release)'
-   - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
-   - if the changelog has headings from [pre-releases](/docs/releasing/publishing-a-pre-release.md#publish-a-new-version-of-govuk-frontend), regroup the content under those headings in a single block
-   - saving your changes
-
-6. Apply the new version number by running:
+4. Pick a new version number according to the [versioning documentation](/docs/contributing/versioning.md) and apply it running:
 
    ```shell
    npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
@@ -38,6 +29,19 @@ Developers should pair on releases. When remote working, it can be useful to be 
    This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
+
+5. Create and check out a new branch (`release-[version-number]`)
+
+   ```shell
+   git switch -c "release-$(npm run version --silent --workspace govuk-frontend)"
+   ```
+
+6. Update the [`CHANGELOG.md`](/CHANGELOG.md) by:
+
+   - changing the 'Unreleased' heading to the new version number and release type. For example, '3.11.0 (Feature release)'
+   - adding a new 'Unreleased' heading above the new version number and release type, so users will know where to add PRs to the changelog
+   - if the changelog has headings from [pre-releases](/docs/releasing/publishing-a-pre-release.md#publish-a-new-version-of-govuk-frontend), regroup the content under those headings in a single block
+   - saving your changes
 
 7. Run `npm run build-release` to:
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -20,7 +20,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 
-4. Pick a new version number according to the [versioning documentation](/docs/contributing/versioning.md) and apply it running:
+4. Pick a new version number according to the [versioning documentation](/docs/contributing/versioning.md) and apply it by running:
 
    ```shell
    npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
@@ -30,7 +30,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    Do not commit the changes.
 
-5. Create and check out a new branch (`release-[version-number]`)
+5. Create and check out a new branch (`release-[version]`)
 
    ```shell
    git switch -c "release-$(npm run version --silent --workspace govuk-frontend)"
@@ -49,7 +49,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
    - commit the changes
    - push a branch to GitHub
 
-   You will now be prompted to continue or cancel.
+   You will now be prompted to continue or cancel. Check the details and enter `y` to continue. If something does not look right, press `N` to cancel the build and creation of the branch on GitHub.
 
 8. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
@@ -73,7 +73,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    This step will create a ZIP file containing the release in the root of your govuk-frontend git directory. You will need this file when creating the GitHub release.
 
-   It will also automatically create a tag in Github which you can use to create a Github release in the following section.
+   This step will also automatically create a tag in Github which you can use to create a Github release in the following section.
 
 6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
 
@@ -88,7 +88,7 @@ To create a new GitHub release, do the following:
 
 1. Select the tag corresponding to the release in [the list of tags on GitHub](https://github.com/alphagov/govuk-frontend/tags)
 2. Press **Create release from tag**
-3. Set 'GOV.UK Frontend v[version-number]' as the title
+3. Set 'GOV.UK Frontend v[version]' as the title
 4. Add release notes from [`CHANGELOG.md`](/CHANGELOG.md)
 5. Attach as release binary the ZIP file that has been generated at the root of this project during the npm publishing phase
 6. Publish release

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -32,13 +32,13 @@ Developers should pair on releases. When remote working, it can be useful to be 
    npm version <NEW VERSION NUMBER> --no-git-tag-version --workspace govuk-frontend
    ```
 
-   This step will update the [`package.json`](/package.json) and project [`package-lock.json`](/package-lock.json) files.
+   This step will update [`govuk-frontend`'s `package.json`](/packages/govuk-frontend/package.json) and project [`package-lock.json`](/package-lock.json) files.
 
    Do not commit the changes.
 
 7. Run `npm run build-release` to:
 
-   - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
+   - build GOV.UK Frontend into [the package's `/dist`](/packages/govuk-frontend/dist) and [root `/dist`](/dist) directories
    - commit the changes
    - push a branch to GitHub
 
@@ -68,7 +68,12 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    It will also automatically create a tag in Github which you can use to create a Github release in the following section.
 
-6. Run `npm logout` to log out from npm.
+6. Verify the presence of the pre-release and its tag on [npm](https://www.npmjs.com/package/govuk-frontend?activeTab=versions)
+
+   If the release has been assigned the wrong tag (mistakes happen),
+   you can use [`npm dist-tag`](https://docs.npmjs.com/cli/v8/commands/npm-dist-tag) to quickly correct.
+
+7. Run `npm logout` to log out from npm.
 
 ## Create a release on Github
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -13,7 +13,10 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 1. Check out the **main** branch and pull the latest changes.
 
-2. Run `nvm use` to make sure you're using the right version of Node.js and npm.
+2. Ensure you're running the version of NodeJS matching [`.nvmrc`](/.nvmrc).
+
+   - If you use NVM, run `nvm use` to set up the right version
+   - If you use another management system (like [`asdf`](https://asdf-vm.com/guide/getting-started.html)), compare the output of `node --version` and install the right one if necessary
 
 3. Run `npm ci` to make sure you have the exact dependencies installed.
 

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -84,13 +84,13 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
 ## Create a release on Github
 
-You can view the tag created during step 10 of creating the new version in the [Github interface](https://github.com/alphagov/govuk-frontend/tags). To create a new Github release, do the following:
+To create a new GitHub release, do the following:
 
-1. Select the latest tag
+1. Select the tag corresponding to the release in [the list of tags on GitHub](https://github.com/alphagov/govuk-frontend/tags)
 2. Press **Create release from tag**
 3. Set 'GOV.UK Frontend v[version-number]' as the title
-4. Add release notes from changelog
-5. Attach the ZIP file that has been generated at the root of this project during the npm publishing phase
+4. Add release notes from [`CHANGELOG.md`](/CHANGELOG.md)
+5. Attach as release binary the ZIP file that has been generated at the root of this project during the npm publishing phase
 6. Publish release
 
 # After you publish the new release


### PR DESCRIPTION
This PR adds pre-release documentation and sets a version number using `npm version`

* https://github.com/alphagov/govuk-frontend/issues/3639

### Pre-release version numbers

For example, for early preview of `v5.0.0` from branch `main` we could:

- Use version `premajor` to bump from `v4.7.0` to `v5.0.0-beta.0`
- Use version `preminor` to bump from `v4.7.0` to `v4.8.0-beta.0`
- Use version `prepatch` to bump from `v4.7.0` to `v4.7.1-beta.0`
- Use version `prerelease` to bump from `v5.0.0-beta.0` to `v5.0.0-beta.1`

This determines the `npm version` command to update **package.json** and **package-lock.json**:

```shell
npm version <VERSION NUMBER> --preid beta --no-git-tag-version --workspace govuk-frontend
```

Unlike previews, pre-releases must pick patch/minor/major bumps so it's hard to automatically version