### PR TITLE
Added stop propagation to debouncer

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -101,6 +101,7 @@ export class Button {
     // If the timer is still running, prevent the click from submitting the form
     if (this.debounceFormSubmitTimer) {
       event.preventDefault()
+      event.stopPropagation()
       return false
     }
 


### PR DESCRIPTION
Currently Edge propagates the submit event to the form, even when debouncing.

I reported this over in the design system repo https://github.com/alphagov/govuk-frontend/issues/3994

I can raise the issue here as well, if required.