### PR TITLE
[support/4.x] Backport: Run GitHub Actions tests on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,18 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - name: Checkout code
@@ -36,8 +44,16 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     needs: [install]
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
 
     steps:
       - name: Checkout
@@ -54,14 +70,18 @@ jobs:
         run: npm run build:types
 
   lint:
-    name: ${{ matrix.task.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     needs: [install]
 
     strategy:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+
         task:
           - description: Lint Sass
             name: lint-scss
@@ -101,7 +121,7 @@ jobs:
         run: ${{ matrix.task.run }}
 
   test:
-    name: ${{ matrix.task.description }}
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
@@ -116,6 +136,7 @@ jobs:
       matrix:
         runner:
           - ubuntu-latest
+          - windows-latest
 
         task:
           - description: Nunjucks macro tests
@@ -176,13 +197,13 @@ jobs:
       - name: Save test coverage
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.task.description }} coverage
+          name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
           path: coverage
           if-no-files-found: ignore
 
   verify:
-    name: ${{ matrix.task.description }}
-    runs-on: ubuntu-latest
+    name: ${{ matrix.task.description }} (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
     # Skip when scheduled or run manually
@@ -192,6 +213,10 @@ jobs:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+          - windows-latest
+
         task:
           - description: Verify package build
             name: test-build-package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,6 @@ on:
 
   workflow_dispatch:
     inputs:
-      runner:
-        description: Run tests on
-        type: choice
-        default: ubuntu-latest
-        options:
-          - macos-latest
-          - ubuntu-latest
-          - windows-latest
       types:
         description: Check type declarations
         type: boolean
@@ -30,7 +22,7 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
@@ -44,7 +36,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install]
 
     steps:
@@ -63,7 +55,7 @@ jobs:
 
   lint:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install]
 
     strategy:
@@ -110,18 +102,21 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
     env:
       # Use 2x CPU cores unless on Windows (runs slower when concurrent)
       # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-      MAX_WORKERS: ${{ inputs.runner == 'windows-latest' && '1' || '2' }}
+      MAX_WORKERS: ${{ matrix.runner == 'windows-latest' && '1' || '2' }}
 
     strategy:
       fail-fast: false
 
       matrix:
+        runner:
+          - ubuntu-latest
+
         task:
           - description: Nunjucks macro tests
             name: test-macro
@@ -187,7 +182,7 @@ jobs:
 
   verify:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install, build]
 
     # Skip when scheduled or run manually
@@ -221,11 +216,8 @@ jobs:
 
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     needs: [install, build]
-
-    # Skip when scheduled or run manually
-    if: ${{ !inputs.runner }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is a port of @colinrotherham's changes in #3955 to the `support/4.x` branch.

It's currently not possible to merge pull requests based off of the `support/4.x` branch (like #3990) because the Windows tests are set up as required status checks but GitHub Actions is not configured to run them.

---

This PR updates our GitHub Actions tests to run on both Ubuntu and Windows:

* https://github.com/alphagov/govuk-frontend/issues/3638

Only Ubuntu runs Percy screenshots and Node.js package export tests

~Branch protection status checks will need updating to include the runner~

~**Update 1:** Thankfully looks like GitHub ignores the `(${{ matrix.runner }})` at the end of the status check name~

**Update 2**: Unfortunately re-running the checks now shows status check renames will be needed