### PR TITLE
Have Dependabot ignore Stylelint major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,12 @@ updates:
     allow:
       - dependency-type: direct
 
+    ignore:
+      # Ignore major updates (causes `stylelint-config-gds` peer dependency conflict)
+      # See pull request: https://github.com/alphagov/stylelint-config-gds/pull/32
+      - dependency-name: stylelint
+        update-types: ['version-update:semver-major']
+
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
stylelint-config-gds is preventing the update to Stylelint 15 for now. Until a new version is released, we'll ignore the next major version bumps.