### PR TITLE
[support/4.x] Backport: Ensure Dart Sass `file://` sources use relative paths

### DIFF
--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -14,15 +14,16 @@ export async function write (filePath, result) {
   const writeTasks = []
 
   // Files to write
+  /** @type {SourceMap | undefined} */
+  const map = result.map ? JSON.parse(result.map.toString()) : undefined
   const code = 'css' in result ? result.css : result.code
-  const map = result.map?.toString()
 
   // 1. Write code (example.js)
   writeTasks.push(writeFile(filePath, code))
 
   // 2. Write source map (example.js.map)
   if (map) {
-    writeTasks.push(writeFile(`${filePath}.map`, map))
+    writeTasks.push(writeFile(`${filePath}.map`, JSON.stringify(map)))
   }
 
   await Promise.all(writeTasks)
@@ -69,4 +70,12 @@ export async function write (filePath, result) {
  * 3. Sass compiler result
  *
  * @typedef {import('rollup').OutputChunk | import('terser').MinifyOutput | import('postcss').Result} AssetOutput
+ */
+
+/**
+ * Asset source maps
+ *
+ * {@link https://github.com/source-map/source-map-spec}
+ *
+ * @typedef {import('@jridgewell/source-map').DecodedSourceMap | import('@jridgewell/source-map').EncodedSourceMap} SourceMap
  */

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from 'fs/promises'
-import { dirname } from 'path'
+import { dirname, relative } from 'path'
 
 /**
  * Write asset helper
@@ -22,7 +22,18 @@ export async function write (filePath, result) {
   writeTasks.push(writeFile(filePath, code))
 
   // 2. Write source map (example.js.map)
-  if (map) {
+  if (map && 'sources' in map) {
+    map.sources = map.sources
+
+      /**
+       * Make source file:// paths relative (e.g. for Dart Sass)
+       * {@link https://sass-lang.com/documentation/js-api/interfaces/CompileResult#sourceMap}
+       */
+      .map((path) => path.startsWith('file://')
+        ? relative(dirname(filePath), new URL(path).pathname)
+        : path
+      )
+
     writeTasks.push(writeFile(`${filePath}.map`, JSON.stringify(map)))
   }
 

--- a/shared/tasks/assets.mjs
+++ b/shared/tasks/assets.mjs
@@ -1,5 +1,8 @@
 import { mkdir, writeFile } from 'fs/promises'
 import { dirname, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+import slash from 'slash'
 
 /**
  * Write asset helper
@@ -29,10 +32,10 @@ export async function write (filePath, result) {
        * Make source file:// paths relative (e.g. for Dart Sass)
        * {@link https://sass-lang.com/documentation/js-api/interfaces/CompileResult#sourceMap}
        */
-      .map((path) => path.startsWith('file://')
-        ? relative(dirname(filePath), new URL(path).pathname)
+      .map((path) => slash(path.startsWith('file://')
+        ? relative(dirname(filePath), fileURLToPath(path))
         : path
-      )
+      ))
 
     writeTasks.push(writeFile(`${filePath}.map`, JSON.stringify(map)))
   }

--- a/shared/tasks/build/dist.test.mjs
+++ b/shared/tasks/build/dist.test.mjs
@@ -46,6 +46,21 @@ describe('dist/', () => {
     })
   })
 
+  describe('govuk-frontend-[version].min.css.map', () => {
+    let filename
+    let sourcemap
+
+    beforeAll(async () => {
+      filename = `govuk-frontend-${pkg.version}.min.css.map`
+      sourcemap = JSON.parse(await readFile(join(paths.dist, filename), 'utf8'))
+    })
+
+    it('should contain relative paths to sources', () => {
+      expect(sourcemap.sources).toContain('../src/govuk/all.scss')
+      expect(sourcemap.sources).toContain('../src/govuk/core/_govuk-frontend-version.scss')
+    })
+  })
+
   describe('govuk-frontend-ie8-[version].min.css', () => {
     let filename
     let stylesheet
@@ -61,6 +76,21 @@ describe('dist/', () => {
 
     it('should contain source mapping URL', () => {
       expect(stylesheet).toMatch(new RegExp(`/\\*# sourceMappingURL=${filename}.map \\*/$`))
+    })
+  })
+
+  describe('govuk-frontend-ie8-[version].min.css.map', () => {
+    let filename
+    let sourcemap
+
+    beforeAll(async () => {
+      filename = `govuk-frontend-ie8-${pkg.version}.min.css.map`
+      sourcemap = JSON.parse(await readFile(join(paths.dist, filename), 'utf8'))
+    })
+
+    it('should contain relative paths to sources', () => {
+      expect(sourcemap.sources).toContain('../src/govuk/all-ie8.scss')
+      expect(sourcemap.sources).toContain('../src/govuk/core/_govuk-frontend-version.scss')
     })
   })
 
@@ -83,6 +113,21 @@ describe('dist/', () => {
 
     it('should contain source mapping URL', () => {
       expect(javascript).toMatch(new RegExp(`//# sourceMappingURL=${filename}.map$`))
+    })
+  })
+
+  describe('govuk-frontend-[version].min.js.map', () => {
+    let filename
+    let sourcemap
+
+    beforeAll(async () => {
+      filename = `govuk-frontend-${pkg.version}.min.js.map`
+      sourcemap = JSON.parse(await readFile(join(paths.dist, filename), 'utf8'))
+    })
+
+    it('should contain relative paths to sources', () => {
+      expect(sourcemap.sources).toContain('../src/govuk/all.mjs')
+      expect(sourcemap.sources).toContain('../src/govuk/common/govuk-frontend-version.mjs')
     })
   })
 

--- a/shared/tasks/build/package.test.mjs
+++ b/shared/tasks/build/package.test.mjs
@@ -70,6 +70,12 @@ describe('package/', () => {
         return output
       }))
 
+      // Add Autoprefixer prefixes to all source '*.scss' files
+      .flatMap(mapPathTo(['**/*.scss'], ({ dir: requirePath, name }) => [
+        join(requirePath, `${name}.scss`),
+        join(requirePath, `${name}.scss.map`) // with source map
+      ]))
+
       // Replaces source component '*.yaml' with:
       // - `fixtures.json` fixtures for tests
       // - `macro-options.json` component options

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -43,10 +43,25 @@ export async function compileStylesheet ([modulePath, { srcPath, destPath, fileP
   let css
   let map
 
-  // Configure PostCSS
+  /**
+   * Configure PostCSS
+   *
+   * @type {import('postcss').ProcessOptions}
+   */
   const options = {
     from: moduleSrcPath,
-    to: moduleDestPath
+    to: moduleDestPath,
+
+    /**
+     * Always generate source maps for either:
+     *
+     * 1. PostCSS on Sass compiler result
+     * 2. PostCSS on Sass sources (Autoprefixer only)
+     */
+    map: {
+      annotation: true,
+      inline: false
+    }
   }
 
   // Compile Sass to CSS
@@ -79,10 +94,8 @@ export async function compileStylesheet ([modulePath, { srcPath, destPath, fileP
     }))
 
     // Pass source maps to PostCSS
-    options.map = {
-      annotation: true,
-      inline: false,
-      prev: map
+    if (typeof options.map === 'object') {
+      options.map.prev = map
     }
   }
 


### PR DESCRIPTION
Backports #3527 to remove local file paths in source maps that affect future **v4.x** releases

For reference, see the [GOV.UK Frontend v4.7.0 `./dist` directory](https://github.com/alphagov/govuk-frontend/tree/8a0f9eda1316e82d130966015721b237c78ce9ad/dist) contains:

**govuk-frontend-4.7.0.min.css.map**
```json
{
  "version":3,
  "sources": [
    "file:///Users/colin/Sites/GDS/govuk-frontend/src/govuk/components/character-count/_index.scss",
    "../src/govuk/all.scss",
    "…"
  ]
}
```

Also cherry picks https://github.com/alphagov/govuk-frontend/commit/6f9156dccf16e83eb2cde811f412e7698971af0d from https://github.com/alphagov/govuk-frontend/pull/3584 to fix a `file://` URL issue on Windows