### PR TITLE
[support/4.x] Backport: Fix config `import()` path with Windows drive letters

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -13,12 +13,6 @@ runs:
         key: build-cache-${{ runner.os }}-${{ github.sha }}
         path: app/dist
 
-    - name: Install dependencies
-      uses: ./.github/workflows/actions/install-node
-
-      # Skip install when build is already cached
-      if: steps.build-cache.outputs.cache-hit != 'true'
-
     - name: Build
       id: build
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Restore dependencies
+        uses: ./.github/workflows/actions/install-node
+
       - name: Build
         uses: ./.github/workflows/actions/build
 

--- a/shared/tasks/configs.mjs
+++ b/shared/tasks/configs.mjs
@@ -1,5 +1,5 @@
-
 import { join } from 'path'
+import { pathToFileURL } from 'url'
 
 import { files } from './index.mjs'
 
@@ -11,7 +11,7 @@ import { files } from './index.mjs'
  * @returns {Promise<void>}
  */
 export async function compile (modulePath, options) {
-  const { default: configFn } = await import(join(options.srcPath, modulePath))
+  const { default: configFn } = await import(pathToFileURL(join(options.srcPath, modulePath)).toString())
 
   // Write to destination
   return files.write(modulePath, {


### PR DESCRIPTION
Partially backports https://github.com/alphagov/govuk-frontend/pull/3584 for **v4.x** config `import()` paths on Windows

**Note:** Changes related to `file://` URL handling were cherry picked into https://github.com/alphagov/govuk-frontend/pull/4004