### PR TITLE
[support/4.x] Backport: GitHub Actions + Jest fixes for Windows

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -9,8 +9,10 @@ runs:
       id: build-cache
 
       with:
+        enableCrossOsArchive: true
+
         # Restore build cache (unless commit SHA changes)
-        key: build-cache-${{ runner.os }}-${{ github.sha }}
+        key: build-${{ runner.os }}-${{ github.sha }}
         path: app/dist
 
     - name: Build

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -9,8 +9,10 @@ runs:
       id: npm-install-cache
 
       with:
+        enableCrossOsArchive: true
+
         # Restore `node_modules` cache (unless packages change)
-        key: npm-install-cache-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
+        key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
         path: |
           node_modules
           app/node_modules

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Cache browser download
         uses: actions/cache@v3
         with:
-          key: puppeteer-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: puppeteer-${{ runner.os }}
           path: .cache/puppeteer
 
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
 
     env:
       PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
@@ -44,7 +44,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     steps:
@@ -63,7 +63,7 @@ jobs:
 
   lint:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
@@ -109,7 +109,7 @@ jobs:
 
   test:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     strategy:
@@ -153,7 +153,7 @@ jobs:
 
   verify:
     name: ${{ matrix.task.description }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
     strategy:
@@ -210,7 +210,7 @@ jobs:
 
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
-    runs-on: ${{ github.event.inputs.runner || 'ubuntu-latest' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install]
 
     # Skip when scheduled or run manually

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -207,7 +207,7 @@ jobs:
   package:
     name: Export ${{ matrix.conditions }}, Node.js ${{ matrix.node-version }}
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-    needs: [install]
+    needs: [install, build]
 
     # Skip when scheduled or run manually
     if: ${{ !inputs.runner }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ on:
         type: boolean
 
 concurrency:
-  group: tests-${{ github.head_ref || github.run_id }}
+  group: tests-${{ inputs.runner || 'ubuntu-latest' }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -190,6 +190,9 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
+    # Skip when scheduled or run manually
+    if: ${{ !inputs.runner }}
+
     strategy:
       fail-fast: false
 
@@ -268,6 +271,9 @@ jobs:
   regression:
     name: Percy
     needs: [install, build]
+
+    # Skip when scheduled or run manually
+    if: ${{ !inputs.runner }}
 
     # Run existing "Percy screenshots" workflow
     # (after install and build have been cached)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,7 +110,7 @@ jobs:
   test:
     name: ${{ matrix.task.description }}
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
-    needs: [install]
+    needs: [install, build]
 
     strategy:
       fail-fast: false
@@ -127,12 +127,34 @@ jobs:
             run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript unit tests" --coverage --testLocationInResults
             cache: .cache/jest
 
+          - description: JavaScript behaviour tests
+            name: test-behaviour
+            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
+            cache: .cache/jest
+
+          - description: JavaScript component tests
+            name: test-component
+            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
+            cache: |
+              .cache/jest
+              .cache/puppeteer
+
+          - description: Accessibility tests
+            name: test-accessibility
+            run: npx jest --color --maxWorkers=2 --selectProjects "Accessibility tests"
+            cache: |
+              .cache/jest
+              .cache/puppeteer
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
+
+      - name: Restore build
+        uses: ./.github/workflows/actions/build
 
       - name: Cache task
         if: ${{ matrix.task.cache }}
@@ -169,25 +191,6 @@ jobs:
             name: test-build-dist
             run: npm run build:dist
 
-          - description: JavaScript behaviour tests
-            name: test-behaviour
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
-            cache: .cache/jest
-
-          - description: JavaScript component tests
-            name: test-component
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
-            cache: |
-              .cache/jest
-              .cache/puppeteer
-
-          - description: Accessibility tests
-            name: test-accessibility
-            run: npx jest --color --maxWorkers=2 --selectProjects "Accessibility tests"
-            cache: |
-              .cache/jest
-              .cache/puppeteer
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -197,13 +200,6 @@ jobs:
 
       - name: Restore build
         uses: ./.github/workflows/actions/build
-
-      - name: Cache Jest
-        if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
-        with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
-          path: ${{ matrix.task.cache }}
 
       - name: Run verify task
         run: ${{ matrix.task.run }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,6 +113,11 @@ jobs:
     runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
     needs: [install, build]
 
+    env:
+      # Use 2x CPU cores unless on Windows (runs slower when concurrent)
+      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+      MAX_WORKERS: ${{ inputs.runner == 'windows-latest' && '1' || '2' }}
+
     strategy:
       fail-fast: false
 
@@ -120,32 +125,37 @@ jobs:
         task:
           - description: Nunjucks macro tests
             name: test-macro
-            run: npx jest --color --selectProjects "Nunjucks macro tests"
             cache: .cache/jest
+            projects:
+              - Nunjucks macro tests
 
           - description: JavaScript unit tests
             name: test-unit
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript unit tests" --coverage --testLocationInResults
             cache: .cache/jest
+            projects:
+              - JavaScript unit tests
 
           - description: JavaScript behaviour tests
             name: test-behaviour
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript behaviour tests"
             cache: .cache/jest
+            projects:
+              - JavaScript behaviour tests
 
           - description: JavaScript component tests
             name: test-component
-            run: npx jest --color --maxWorkers=2 --selectProjects "JavaScript component tests"
             cache: |
               .cache/jest
               .cache/puppeteer
+            projects:
+              - JavaScript component tests
 
           - description: Accessibility tests
             name: test-accessibility
-            run: npx jest --color --maxWorkers=2 --selectProjects "Accessibility tests"
             cache: |
               .cache/jest
               .cache/puppeteer
+            projects:
+              - Accessibility tests
 
     steps:
       - name: Checkout
@@ -166,7 +176,7 @@ jobs:
           path: ${{ matrix.task.cache }}
 
       - name: Run test task
-        run: ${{ matrix.task.run }}
+        run: npx jest --color ${{ format('--maxWorkers={0} --selectProjects "{1}"', env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
         uses: actions/upload-artifact@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,8 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
 
       - name: Run lint task
@@ -160,7 +161,8 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3
         with:
-          key: ${{ matrix.task.name }}-cache-${{ runner.os }}
+          enableCrossOsArchive: true
+          key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
 
       - name: Run test task

--- a/jest-dev-server.config.js
+++ b/jest-dev-server.config.js
@@ -7,6 +7,9 @@ module.exports = {
   command: 'npm start --workspace app',
   port: ports.app,
 
+  // Allow 15 seconds to start server
+  launchTimeout: 15000,
+
   // Skip when already running
   usedPortAction: 'ignore'
 }

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -142,6 +142,6 @@ export default {
   // Enable GitHub Actions reporter UI
   reporters: ['default', 'github-actions'],
 
-  // Browser test increased timeout (5s to 15s)
-  testTimeout: 15000
+  // Browser test increased timeout (5s to 30s)
+  testTimeout: 30000
 }

--- a/src/govuk/components/accordion/accessibility.test.mjs
+++ b/src/govuk/components/accordion/accessibility.test.mjs
@@ -31,6 +31,6 @@ describe('/components/accordion', () => {
         await goToComponent(page, 'accordion', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/accordion/accordion.test.js
+++ b/src/govuk/components/accordion/accordion.test.js
@@ -19,7 +19,7 @@ describe('/components/accordion', () => {
 
         for (let i = 0; i < numberOfExampleSections; i++) {
           const isContentVisible = await page.waitForSelector('.govuk-accordion .govuk-accordion__section:nth-of-type(' + (i + 1) + ') .govuk-accordion__section-content',
-            { visible: true, timeout: 1000 }
+            { visible: true, timeout: 5000 }
           )
           expect(isContentVisible).toBeTruthy()
         }

--- a/src/govuk/components/back-link/accessibility.test.mjs
+++ b/src/govuk/components/back-link/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/back-link', () => {
         await goToComponent(page, 'back-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/breadcrumbs/accessibility.test.mjs
+++ b/src/govuk/components/breadcrumbs/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/breadcrumbs', () => {
         await goToComponent(page, 'breadcrumbs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/button/accessibility.test.mjs
+++ b/src/govuk/components/button/accessibility.test.mjs
@@ -29,6 +29,6 @@ describe('/components/button', () => {
         await goToComponent(page, 'button', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/character-count/accessibility.test.mjs
+++ b/src/govuk/components/character-count/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/character-count', () => {
         await goToComponent(page, 'character-count', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/character-count/character-count.test.js
+++ b/src/govuk/components/character-count/character-count.test.js
@@ -14,7 +14,7 @@ const debouncedWaitTime = headless ? 1500 : 2000
 
 // When headless, keydown-to-keyup time appears to affect event throttling,
 // affecting `lastInputTimestamp` and screen reader status message updates
-const keyupWaitTime = headless ? 0 : 50
+const keyupWaitTime = headless ? 0 : 100
 
 describe('Character count', () => {
   let examples

--- a/src/govuk/components/checkboxes/accessibility.test.mjs
+++ b/src/govuk/components/checkboxes/accessibility.test.mjs
@@ -30,6 +30,6 @@ describe('/components/checkboxes', () => {
         await goToComponent(page, 'checkboxes', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/cookie-banner/accessibility.test.mjs
+++ b/src/govuk/components/cookie-banner/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/cookie-banner', () => {
         await goToComponent(page, 'cookie-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/date-input/accessibility.test.mjs
+++ b/src/govuk/components/date-input/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/date-input', () => {
         await goToComponent(page, 'date-input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/details/accessibility.test.mjs
+++ b/src/govuk/components/details/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/details', () => {
         await goToComponent(page, 'details', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/error-message/accessibility.test.mjs
+++ b/src/govuk/components/error-message/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/error-message', () => {
         await goToComponent(page, 'error-message', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/error-summary/accessibility.test.mjs
+++ b/src/govuk/components/error-summary/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/error-summary', () => {
         await goToComponent(page, 'error-summary', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/exit-this-page/accessibility.test.mjs
+++ b/src/govuk/components/exit-this-page/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/exit-this-page', () => {
         await goToComponent(page, 'exit-this-page', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/fieldset/accessibility.test.mjs
+++ b/src/govuk/components/fieldset/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/fieldset', () => {
         await goToComponent(page, 'fieldset', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/file-upload/accessibility.test.mjs
+++ b/src/govuk/components/file-upload/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/file-upload', () => {
         await goToComponent(page, 'file-upload', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/footer/accessibility.test.mjs
+++ b/src/govuk/components/footer/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/footer', () => {
         await goToComponent(page, 'footer', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/header/accessibility.test.mjs
+++ b/src/govuk/components/header/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/header', () => {
         await goToComponent(page, 'header', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/hint/accessibility.test.mjs
+++ b/src/govuk/components/hint/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/hint', () => {
         await goToComponent(page, 'hint', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/input/accessibility.test.mjs
+++ b/src/govuk/components/input/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/input', () => {
         await goToComponent(page, 'input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/inset-text/accessibility.test.mjs
+++ b/src/govuk/components/inset-text/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/inset-text', () => {
         await goToComponent(page, 'inset-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/label/accessibility.test.mjs
+++ b/src/govuk/components/label/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/label', () => {
         await goToComponent(page, 'label', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/notification-banner/accessibility.test.mjs
+++ b/src/govuk/components/notification-banner/accessibility.test.mjs
@@ -35,6 +35,6 @@ describe('/components/notification-banner', () => {
         await goToComponent(page, 'notification-banner', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/pagination/accessibility.test.mjs
+++ b/src/govuk/components/pagination/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/pagination', () => {
         await goToComponent(page, 'pagination', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/panel/accessibility.test.mjs
+++ b/src/govuk/components/panel/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/panel', () => {
         await goToComponent(page, 'panel', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/phase-banner/accessibility.test.mjs
+++ b/src/govuk/components/phase-banner/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/phase-banner', () => {
         await goToComponent(page, 'phase-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/radios/accessibility.test.mjs
+++ b/src/govuk/components/radios/accessibility.test.mjs
@@ -30,6 +30,6 @@ describe('/components/radios', () => {
         await goToComponent(page, 'radios', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/select/accessibility.test.mjs
+++ b/src/govuk/components/select/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/select', () => {
         await goToComponent(page, 'select', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/skip-link/accessibility.test.mjs
+++ b/src/govuk/components/skip-link/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/skip-link', () => {
         await goToComponent(page, 'skip-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/summary-list/accessibility.test.mjs
+++ b/src/govuk/components/summary-list/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/summary-list', () => {
         await goToComponent(page, 'summary-list', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/table/accessibility.test.mjs
+++ b/src/govuk/components/table/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/table', () => {
         await goToComponent(page, 'table', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/tabs/accessibility.test.mjs
+++ b/src/govuk/components/tabs/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/tabs', () => {
         await goToComponent(page, 'tabs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/tabs/tabs.test.js
+++ b/src/govuk/components/tabs/tabs.test.js
@@ -16,7 +16,7 @@ describe('/components/tabs', () => {
       })
 
       it('falls back to making all tab containers visible', async () => {
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 1000 })
+        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
         expect(isContentVisible).toBeTruthy()
       })
     })
@@ -156,7 +156,7 @@ describe('/components/tabs', () => {
       it('falls back to making the all tab containers visible', async () => {
         await page.emulate(iPhone)
         await goToComponent(page, 'tabs')
-        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 1000 })
+        const isContentVisible = await page.waitForSelector('.govuk-tabs__panel', { visible: true, timeout: 5000 })
         expect(isContentVisible).toBeTruthy()
       })
     })

--- a/src/govuk/components/tag/accessibility.test.mjs
+++ b/src/govuk/components/tag/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/tag', () => {
         await goToComponent(page, 'tag', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/textarea/accessibility.test.mjs
+++ b/src/govuk/components/textarea/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/textarea', () => {
         await goToComponent(page, 'textarea', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })

--- a/src/govuk/components/warning-text/accessibility.test.mjs
+++ b/src/govuk/components/warning-text/accessibility.test.mjs
@@ -17,6 +17,6 @@ describe('/components/warning-text', () => {
         await goToComponent(page, 'warning-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 60000)
+    }, 90000)
   })
 })


### PR DESCRIPTION
Partially backports https://github.com/alphagov/govuk-frontend/pull/3816 and https://github.com/alphagov/govuk-frontend/pull/3863 for **v4.x** for Windows test reliability

**Note:** Changes related to path handling https://github.com/alphagov/govuk-frontend/pull/3756 (v5 only) were excluded