### PR TITLE
Add comments for GitHub Actions `enableCrossOsArchive`

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -9,6 +9,7 @@ runs:
       id: build-cache
 
       with:
+        # Use faster GNU tar for all runners
         enableCrossOsArchive: true
 
         # Restore build cache (unless commit SHA changes)

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -9,6 +9,7 @@ runs:
       id: npm-install-cache
 
       with:
+        # Use faster GNU tar for all runners
         enableCrossOsArchive: true
 
         # Restore `node_modules` cache (unless packages change)

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Cache browser download
         uses: actions/cache@v3.3.1
         with:
+          # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           key: puppeteer-${{ runner.os }}
           path: .cache/puppeteer

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,7 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3.3.1
         with:
+          # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}
@@ -182,6 +183,7 @@ jobs:
         if: ${{ matrix.task.cache }}
         uses: actions/cache@v3.3.1
         with:
+          # Use faster GNU tar for all runners
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
           path: ${{ matrix.task.cache }}


### PR DESCRIPTION
Better explain how we’re using the `enableCrossOsArchive` option to enable the faster GNU tar for all runners

Windows runners use BSD tar without this option

* https://github.com/actions/toolkit/issues/552