### PR TITLE
[SPIKE] Share installed `node_modules` between runners

### DIFF
--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -13,9 +13,10 @@ runs:
         enableCrossOsArchive: true
 
         # Restore `node_modules` cache (unless packages change)
-        key: npm-install-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
+        key: npm-install-${{ hashFiles('package-lock.json', '**/package.json') }}
         path: |
           node_modules
+          !node_modules/.bin
           docs/examples/*/node_modules
           packages/*/node_modules
           shared/*/node_modules
@@ -34,4 +35,28 @@ runs:
       # Skip install when dependencies are cached
       if: steps.npm-install-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: npm ci
+
+      # Install without `node_modules/.bin` executables
+      run: npm ci --bin-links false
+
+    - name: Restore symbolic links to executables
+      uses: actions/cache@v3.3.1
+      id: install-exec
+
+      with:
+        # Use faster GNU tar for all runners
+        enableCrossOsArchive: true
+
+        # Restore `node_modules/.bin` cache (unless packages change)
+        key: npm-exec-${{ runner.os }}-${{ hashFiles('package-lock.json', '**/package.json') }}
+        path: node_modules/.bin
+
+    - name: Create symbolic links to executables
+
+      # Skip install when symbolic links are cached
+      if: steps.install-exec.outputs.cache-hit != 'true'
+      shell: bash
+
+      # Run `npm install` after `node_modules` restore to create
+      # missing `node_modules/.bin` symbolic links for runner OS
+      run: npm install --ignore-scripts --no-save --silent

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,18 +18,13 @@ concurrency:
 jobs:
   install:
     name: Install
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
 
     env:
       PUPPETEER_SKIP_DOWNLOAD: true
 
     strategy:
       fail-fast: false
-
-      matrix:
-        runner:
-          - ubuntu-latest
-          - windows-latest
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR checks how close we are to sharing `node_modules` between runners

Although we use the [`enableCrossOsArchive` option](https://github.com/alphagov/govuk-frontend/pull/4012) we typically hit problems with:

1. **Executable compatibility in `node_modules/.bin`**
   Restoring previously linked `node_modules/.bin` executables into Windows lacks [`--bin-links` `.cmd` shims](https://docs.npmjs.com/cli/v9/commands/npm-install?v=true#bin-links)

2. **Executable compatibility in Dart Sass**
   Restoring previously installed `node_modules` into Windows provides Linux Sass binaries

```console
Error: Embedded Dart Sass couldn't find the embedded compiler executable. Please make sure the optional dependency sass-embedded-win32-x64 is installed in node_modules.
```