### PR TITLE
[support/4.x] Backport: Use exact GitHub Actions versions

### DIFF
--- a/.github/workflows/actions/build/action.yml
+++ b/.github/workflows/actions/build/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache build
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       id: build-cache
 
       with:

--- a/.github/workflows/actions/install-node/action.yml
+++ b/.github/workflows/actions/install-node/action.yml
@@ -5,7 +5,7 @@ runs:
 
   steps:
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v3.3.1
       id: npm-install-cache
 
       with:

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -10,7 +10,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3.6.0
+      uses: actions/setup-node@v3.7.0
       id: setup-node
 
       with:

--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -3,7 +3,8 @@ name: Setup
 inputs:
   use-cache:
     description: Restore global `~/.npm` cache
-    required: false
+    default: 'true'
+    required: true
 
 runs:
   using: composite
@@ -14,5 +15,5 @@ runs:
       id: setup-node
 
       with:
-        cache: ${{ inputs.use-cache != 'false' && 'npm' || '' }}
+        cache: ${{ inputs.use-cache == 'true' && 'npm' || '' }}
         node-version-file: .nvmrc

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0 # Need to also checkout the base branch to compare
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version-file: .nvmrc

--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -14,7 +14,7 @@ jobs:
     # Abort if run from a fork, as token won't have write access to post comment
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.5.3
         with:
           fetch-depth: 0 # Need to also checkout the base branch to compare
 
@@ -37,7 +37,7 @@ jobs:
             > $GITHUB_WORKSPACE/dist.diff
 
       - name: Add comment to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v6.4.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -96,7 +96,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
         uses: actions/setup-node@v3.6.0
@@ -118,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/sass.yaml
+++ b/.github/workflows/sass.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 8 # Node.js 8 supported by Dart Sass v1.0.0
@@ -47,7 +47,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Dart Sass v1
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 4 # Node.js 4 supported by Node Sass v3.4.0
@@ -99,7 +99,7 @@ jobs:
         uses: actions/checkout@v3.5.3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           cache: npm
           node-version: 18 # Node.js 18 supported by Node Sass v8.x

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -26,13 +26,13 @@ jobs:
         run: echo "::warning title=GitHub Actions secrets::Workflow requires 'PERCY_TOKEN' secret"
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Install dependencies
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache browser download
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: puppeteer-${{ runner.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -269,7 +269,7 @@ jobs:
         uses: ./.github/workflows/actions/install-node
 
       - name: Change Node.js version
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.7.0
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Install dependencies
         uses: ./.github/workflows/actions/install-node
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -104,14 +104,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
 
       - name: Cache linter
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
@@ -175,7 +175,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -185,7 +185,7 @@ jobs:
 
       - name: Cache task
         if: ${{ matrix.task.cache }}
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.1
         with:
           enableCrossOsArchive: true
           key: ${{ matrix.task.name }}-${{ runner.os }}
@@ -195,7 +195,7 @@ jobs:
         run: npx jest --color ${{ format('--maxWorkers={0} --selectProjects "{1}"', env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ matrix.task.description }} coverage (${{ matrix.runner }})
           path: coverage
@@ -228,7 +228,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node
@@ -263,7 +263,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.5.3
 
       - name: Restore dependencies
         uses: ./.github/workflows/actions/install-node


### PR DESCRIPTION
Backports https://github.com/alphagov/govuk-frontend/pull/3954 to pin GitHub Actions versions