### PR TITLE
Throw error when instantiating components where GOV.UK Frontend is not supported

### DIFF
--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -136,6 +136,40 @@ Avoid using namespace imports (`import * as namespace`) in code bundled for Comm
 
 Prefer named exports over default exports to avoid compatibility issues with transpiler "synthetic default" as discussed in: https://github.com/alphagov/govuk-frontend/issues/2829
 
+## Throwing errors
+
+### Error types
+
+First, check if one of the [native errors provides](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) the right semantic for the error you're looking to throw, if so, use this class.
+
+If none of the native errors have the right semantics, create a new class for this error. This class should:
+
+- have a name ending in `Error` to match the native conventions
+- extend `GOVUKFrontendError`, so users can separate our custom errors from native ones using `instanceof`
+- have a `name` property set to its class name, as extending classes doesn't set this automatically and grabbing the constructor's name risks being affected by mangling during minification
+
+```js
+class CustomError extends GOVUKFrontendError {
+  name = 'CustomError'
+}
+```
+
+### Error message
+
+Keep the message to the point, but provide the users the information they need to identify the cause of the error.
+
+If the message is the same whatever the situation, you may use the constructor of our custom error to centralise that message, rather than passing it each time an error is thrown.
+
+```js
+class SupportError extends GOVUKFrontendError {
+  name = 'SupportError'
+
+  constructor () {
+    super('GOV.UK Frontend is not supported in this browser')
+  }
+}
+```
+
 ## Polyfilling
 
 If you need polyfills for features that are not yet included in this project, please see the following guide on [how to add polyfills](../polyfilling.md).

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -133,3 +133,17 @@ export function extractConfigByNamespace(configObject, namespace) {
   }
   return newObject
 }
+
+/**
+ * Checks if GOV.UK Frontend is supported on this page
+ *
+ * Some browsers will load and run our JavaScript but GOV.UK Frontend
+ * won't be supported.
+ *
+ * @internal
+ * @param {HTMLElement} [$scope] - The `<body>` element of the document to check for support
+ * @returns {boolean} Whether GOV.UK Frontend is supported on this page
+ */
+export function isSupported($scope = document.body) {
+  return $scope.classList.contains('govuk-frontend-supported')
+}

--- a/packages/govuk-frontend/src/govuk/common/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.unit.test.mjs
@@ -1,4 +1,8 @@
-import { mergeConfigs, extractConfigByNamespace } from './index.mjs'
+import {
+  mergeConfigs,
+  extractConfigByNamespace,
+  isSupported
+} from './index.mjs'
 
 describe('Common JS utilities', () => {
   describe('mergeConfigs', () => {
@@ -110,6 +114,24 @@ describe('Common JS utilities', () => {
     it('throws an error if no `namespace` is provided', () => {
       // @ts-expect-error Parameter 'namespace' not provided
       expect(() => extractConfigByNamespace(flattenedConfig)).toThrow()
+    })
+  })
+
+  describe.only('isSupported', () => {
+    beforeEach(() => {
+      // Jest does not tidy the JSDOM document between tests
+      // so we need to take care of that ourselves
+      document.documentElement.innerHTML = ''
+    })
+
+    it('returns true if the govuk-frontend-supported class is set', () => {
+      document.body.classList.add('govuk-frontend-supported')
+
+      expect(isSupported(document.body)).toBe(true)
+    })
+
+    it('returns false if the govuk-frontend-supported class is not set', () => {
+      expect(isSupported(document.body)).toBe(false)
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -1,5 +1,6 @@
 import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
@@ -113,10 +114,11 @@ export class Accordion {
    * @param {AccordionConfig} [config] - Accordion config
    */
   constructor($module, config) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
@@ -15,7 +15,7 @@ import { I18n } from '../../i18n.mjs'
  * The state of each section is saved to the DOM via the `aria-expanded`
  * attribute, which also provides accessibility.
  */
-export class Accordion {
+export class Accordion extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -114,9 +114,7 @@ export class Accordion {
    * @param {AccordionConfig} [config] - Accordion config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
@@ -712,6 +712,28 @@ describe('/components/accordion', () => {
             )
           })
         })
+
+        describe('errors at instantiation', () => {
+          let examples
+
+          beforeAll(async () => {
+            examples = await getExamples('accordion')
+          })
+
+          it('throws when GOV.UK Frontend is not supported', async () => {
+            await expect(
+              renderAndInitialise(page, 'accordion', {
+                params: examples.default,
+                beforeInitialisation() {
+                  document.body.classList.remove('govuk-frontend-supported')
+                }
+              })
+            ).rejects.toEqual({
+              name: 'SupportError',
+              message: 'GOV.UK Frontend is not supported in this browser'
+            })
+          })
+        })
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -1,6 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 const KEY_SPACE = 32
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
@@ -8,7 +8,7 @@ const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
 /**
  * JavaScript enhancements for the Button component
  */
-export class Button {
+export class Button extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -30,9 +30,7 @@ export class Button {
    * @param {ButtonConfig} [config] - Button config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -1,5 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 
 const KEY_SPACE = 32
 const DEBOUNCE_TIMEOUT_IN_SECONDS = 1
@@ -29,10 +30,11 @@ export class Button {
    * @param {ButtonConfig} [config] - Button config
    */
   constructor($module, config) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -338,5 +338,27 @@ describe('/components/button', () => {
         expect(button2Counts.debounce).toBe(0)
       })
     })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('button')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'button', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
+      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -1,6 +1,7 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { extractConfigByNamespace, mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
@@ -64,10 +65,11 @@ export class CharacterCount {
    * @param {CharacterCountConfig} [config] - Character count config
    */
   constructor($module, config) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -1,7 +1,7 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
 import { extractConfigByNamespace, mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
@@ -14,7 +14,7 @@ import { I18n } from '../../i18n.mjs'
  * You can configure the message to only appear after a certain percentage
  * of the available characters/words has been entered.
  */
-export class CharacterCount {
+export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -65,9 +65,7 @@ export class CharacterCount {
    * @param {CharacterCountConfig} [config] - Character count config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -763,6 +763,28 @@ describe('Character count', () => {
         )
       })
     })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('character-count')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'character-count', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
+      })
+    })
   })
 
   describe('in mismatched locale', () => {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -777,7 +777,7 @@ describe('Character count', () => {
           // Override maxlength to 10
           maxlength: 10
         },
-        initialiser($module) {
+        beforeInitialisation($module) {
           // Set locale to Welsh, which expects translations for 'one', 'two',
           // 'few' 'many' and 'other' forms – with the default English strings
           // provided we only have translations for 'one' and 'other'.

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -1,9 +1,9 @@
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Checkboxes component
  */
-export class Checkboxes {
+export class Checkboxes extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -25,9 +25,7 @@ export class Checkboxes {
    * @param {Element} $module - HTML element to use for checkboxes
    */
   constructor($module) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -1,3 +1,5 @@
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+
 /**
  * Checkboxes component
  */
@@ -23,10 +25,11 @@ export class Checkboxes {
    * @param {Element} $module - HTML element to use for checkboxes
    */
   constructor($module) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
@@ -3,8 +3,10 @@ const {
   goToExample,
   getAttribute,
   getProperty,
-  isVisible
+  isVisible,
+  renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 
 describe('Checkboxes with conditional reveals', () => {
   describe('when JavaScript is unavailable or fails', () => {
@@ -315,6 +317,28 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       // Expect conditional content to have been collapsed
       expect(await isVisible($conditionalPrimary)).toBe(false)
+    })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('checkboxes')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'checkboxes', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -1,5 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 
 /**
  * Error summary component
@@ -22,17 +23,11 @@ export class ErrorSummary {
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($module, config) {
-    // Some consuming code may not be passing a module,
-    // for example if they initialise the component
-    // on their own by directly passing the result
-    // of `document.querySelector`.
-    // To avoid breaking further JavaScript initialisation
-    // we need to safeguard against this so things keep
-    // working the same now we read the elements data attributes
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -1,13 +1,13 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Error summary component
  *
  * Takes focus on initialisation for accessible announcement, unless disabled in configuration.
  */
-export class ErrorSummary {
+export class ErrorSummary extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -23,9 +23,7 @@ export class ErrorSummary {
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
@@ -230,4 +230,26 @@ describe('Error Summary', () => {
       })
     }
   )
+
+  describe('errors at instantiation', () => {
+    let examples
+
+    beforeAll(async () => {
+      examples = await getExamples('error-summary')
+    })
+
+    it('throws when GOV.UK Frontend is not supported', async () => {
+      await expect(
+        renderAndInitialise(page, 'error-summary', {
+          params: examples.default,
+          beforeInitialisation() {
+            document.body.classList.remove('govuk-frontend-supported')
+          }
+        })
+      ).rejects.toEqual({
+        name: 'SupportError',
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,12 +1,12 @@
 import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
  * Exit This Page component
  */
-export class ExitThisPage {
+export class ExitThisPage extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -76,9 +76,7 @@ export class ExitThisPage {
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -1,5 +1,6 @@
 import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 import { I18n } from '../../i18n.mjs'
 
 /**
@@ -75,10 +76,11 @@ export class ExitThisPage {
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
   constructor($module, config) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -1,7 +1,9 @@
 const {
   goToComponent,
-  goToExample
+  goToExample,
+  renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 
 const buttonClass = '.govuk-js-exit-this-page-button'
 const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
@@ -183,6 +185,28 @@ describe('/components/exit-this-page', () => {
           el.nextElementSibling.innerHTML.trim()
         )
         expect(message).toBe('Exit this page expired.')
+      })
+    })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('exit-this-page')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'exit-this-page', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -1,9 +1,9 @@
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Header component
  */
-export class Header {
+export class Header extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -39,9 +39,7 @@ export class Header {
    * @param {Element} $module - HTML element to use for header
    */
   constructor($module) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -1,3 +1,5 @@
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+
 /**
  * Header component
  */
@@ -37,10 +39,11 @@ export class Header {
    * @param {Element} $module - HTML element to use for header
    */
   constructor($module) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.test.js
@@ -1,4 +1,8 @@
-const { goToComponent } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToComponent,
+  renderAndInitialise
+} = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']
@@ -161,6 +165,28 @@ describe('Header navigation', () => {
         )
 
         expect(ariaExpanded).toBe('false')
+      })
+    })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('header')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'header', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,11 +1,11 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Notification Banner component
  */
-export class NotificationBanner {
+export class NotificationBanner extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -20,9 +20,7 @@ export class NotificationBanner {
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
   constructor($module, config) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -1,5 +1,6 @@
 import { mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
 
 /**
  * Notification Banner component
@@ -19,10 +20,11 @@ export class NotificationBanner {
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
   constructor($module, config) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
@@ -203,4 +203,20 @@ describe('Notification banner', () => {
       })
     })
   })
+
+  describe('errors at instantiation', () => {
+    it('throws when GOV.UK Frontend is not supported', async () => {
+      await expect(
+        renderAndInitialise(page, 'notification-banner', {
+          params: examples.default,
+          beforeInitialisation() {
+            document.body.classList.remove('govuk-frontend-supported')
+          }
+        })
+      ).rejects.toEqual({
+        name: 'SupportError',
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
@@ -4,142 +4,19 @@ const {
 } = require('govuk-frontend-helpers/puppeteer')
 const { getExamples } = require('govuk-frontend-lib/files')
 
-describe('Notification banner, when type is set to "success"', () => {
+describe('Notification banner', () => {
   let examples
 
   beforeAll(async () => {
     examples = await getExamples('notification-banner')
   })
 
-  it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-    await goToComponent(page, 'notification-banner', {
-      exampleName: 'with-type-as-success'
-    })
-
-    const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-      el.getAttribute('tabindex')
-    )
-
-    expect(tabindex).toEqual('-1')
-  })
-
-  it('is automatically focused when the page loads', async () => {
-    await goToComponent(page, 'notification-banner', {
-      exampleName: 'with-type-as-success'
-    })
-
-    const activeElement = await page.evaluate(() =>
-      document.activeElement.getAttribute('data-module')
-    )
-
-    expect(activeElement).toBe('govuk-notification-banner')
-  })
-
-  it('removes the tabindex attribute on blur', async () => {
-    await goToComponent(page, 'notification-banner', {
-      exampleName: 'with-type-as-success'
-    })
-
-    await page.$eval(
-      '.govuk-notification-banner',
-      (el) => el instanceof window.HTMLElement && el.blur()
-    )
-
-    const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-      el.getAttribute('tabindex')
-    )
-    expect(tabindex).toBeNull()
-  })
-
-  describe('and auto-focus is disabled using data attributes', () => {
-    beforeAll(async () => {
-      await goToComponent(page, 'notification-banner', {
-        exampleName: 'auto-focus-disabled,-with-type-as-success'
-      })
-    })
-
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBeNull()
-    })
-
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() =>
-        document.activeElement.getAttribute('data-module')
-      )
-
-      expect(activeElement).not.toBe('govuk-notification-banner')
-    })
-  })
-
-  describe('and auto-focus is disabled using JavaScript configuration', () => {
-    beforeAll(async () => {
-      await renderAndInitialise(page, 'notification-banner', {
-        params: examples['with type as success'],
-        config: {
-          disableAutoFocus: true
-        }
-      })
-    })
-
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBeNull()
-    })
-
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() =>
-        document.activeElement.getAttribute('data-module')
-      )
-
-      expect(activeElement).not.toBe('govuk-notification-banner')
-    })
-  })
-
-  describe('and auto-focus is disabled using options passed to initAll', () => {
-    beforeAll(async () => {
-      await renderAndInitialise(page, 'notification-banner', {
-        params: examples['with type as success'],
-        config: {
-          disableAutoFocus: true
-        }
-      })
-    })
-
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBeNull()
-    })
-
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() =>
-        document.activeElement.getAttribute('data-module')
-      )
-
-      expect(activeElement).not.toBe('govuk-notification-banner')
-    })
-  })
-
-  describe('and autofocus is disabled in JS but enabled in data attributes', () => {
-    beforeAll(async () => {
-      await renderAndInitialise(page, 'notification-banner', {
-        params: examples['auto-focus explicitly enabled, with type as success'],
-        config: {
-          disableAutoFocus: true
-        }
-      })
-    })
-
+  describe('when type is set to "success"', () => {
     it('has the correct tabindex attribute to be focused with JavaScript', async () => {
+      await goToComponent(page, 'notification-banner', {
+        exampleName: 'with-type-as-success'
+      })
+
       const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
         el.getAttribute('tabindex')
       )
@@ -148,47 +25,22 @@ describe('Notification banner, when type is set to "success"', () => {
     })
 
     it('is automatically focused when the page loads', async () => {
+      await goToComponent(page, 'notification-banner', {
+        exampleName: 'with-type-as-success'
+      })
+
       const activeElement = await page.evaluate(() =>
         document.activeElement.getAttribute('data-module')
       )
 
       expect(activeElement).toBe('govuk-notification-banner')
     })
-  })
 
-  describe('and role is overridden to "region"', () => {
-    beforeAll(async () => {
+    it('removes the tabindex attribute on blur', async () => {
       await goToComponent(page, 'notification-banner', {
-        exampleName:
-          'role=alert-overridden-to-role=region,-with-type-as-success'
+        exampleName: 'with-type-as-success'
       })
-    })
 
-    it('does not have a tabindex attribute', async () => {
-      const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
-        el.getAttribute('tabindex')
-      )
-
-      expect(tabindex).toBeNull()
-    })
-
-    it('does not focus the notification banner', async () => {
-      const activeElement = await page.evaluate(() =>
-        document.activeElement.getAttribute('data-module')
-      )
-
-      expect(activeElement).not.toBe('govuk-notification-banner')
-    })
-  })
-
-  describe('and a custom tabindex is set', () => {
-    beforeAll(async () => {
-      await goToComponent(page, 'notification-banner', {
-        exampleName: 'custom-tabindex'
-      })
-    })
-
-    it('does not remove the tabindex attribute on blur', async () => {
       await page.$eval(
         '.govuk-notification-banner',
         (el) => el instanceof window.HTMLElement && el.blur()
@@ -197,7 +49,158 @@ describe('Notification banner, when type is set to "success"', () => {
       const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
         el.getAttribute('tabindex')
       )
-      expect(tabindex).toEqual('2')
+      expect(tabindex).toBeNull()
+    })
+
+    describe('and auto-focus is disabled using data attributes', () => {
+      beforeAll(async () => {
+        await goToComponent(page, 'notification-banner', {
+          exampleName: 'auto-focus-disabled,-with-type-as-success'
+        })
+      })
+
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus the notification banner', async () => {
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
+        )
+
+        expect(activeElement).not.toBe('govuk-notification-banner')
+      })
+    })
+
+    describe('and auto-focus is disabled using JavaScript configuration', () => {
+      beforeAll(async () => {
+        await renderAndInitialise(page, 'notification-banner', {
+          params: examples['with type as success'],
+          config: {
+            disableAutoFocus: true
+          }
+        })
+      })
+
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus the notification banner', async () => {
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
+        )
+
+        expect(activeElement).not.toBe('govuk-notification-banner')
+      })
+    })
+
+    describe('and auto-focus is disabled using options passed to initAll', () => {
+      beforeAll(async () => {
+        await renderAndInitialise(page, 'notification-banner', {
+          params: examples['with type as success'],
+          config: {
+            disableAutoFocus: true
+          }
+        })
+      })
+
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus the notification banner', async () => {
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
+        )
+
+        expect(activeElement).not.toBe('govuk-notification-banner')
+      })
+    })
+
+    describe('and autofocus is disabled in JS but enabled in data attributes', () => {
+      beforeAll(async () => {
+        await renderAndInitialise(page, 'notification-banner', {
+          params:
+            examples['auto-focus explicitly enabled, with type as success'],
+          config: {
+            disableAutoFocus: true
+          }
+        })
+      })
+
+      it('has the correct tabindex attribute to be focused with JavaScript', async () => {
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toEqual('-1')
+      })
+
+      it('is automatically focused when the page loads', async () => {
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
+        )
+
+        expect(activeElement).toBe('govuk-notification-banner')
+      })
+    })
+
+    describe('and role is overridden to "region"', () => {
+      beforeAll(async () => {
+        await goToComponent(page, 'notification-banner', {
+          exampleName:
+            'role=alert-overridden-to-role=region,-with-type-as-success'
+        })
+      })
+
+      it('does not have a tabindex attribute', async () => {
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+
+        expect(tabindex).toBeNull()
+      })
+
+      it('does not focus the notification banner', async () => {
+        const activeElement = await page.evaluate(() =>
+          document.activeElement.getAttribute('data-module')
+        )
+
+        expect(activeElement).not.toBe('govuk-notification-banner')
+      })
+    })
+
+    describe('and a custom tabindex is set', () => {
+      beforeAll(async () => {
+        await goToComponent(page, 'notification-banner', {
+          exampleName: 'custom-tabindex'
+        })
+      })
+
+      it('does not remove the tabindex attribute on blur', async () => {
+        await page.$eval(
+          '.govuk-notification-banner',
+          (el) => el instanceof window.HTMLElement && el.blur()
+        )
+
+        const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
+          el.getAttribute('tabindex')
+        )
+        expect(tabindex).toEqual('2')
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -1,9 +1,9 @@
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Radios component
  */
-export class Radios {
+export class Radios extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -25,9 +25,7 @@ export class Radios {
    * @param {Element} $module - HTML element to use for radios
    */
   constructor($module) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -1,3 +1,5 @@
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+
 /**
  * Radios component
  */
@@ -23,10 +25,11 @@ export class Radios {
    * @param {Element} $module - HTML element to use for radios
    */
   constructor($module) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
@@ -6,261 +6,265 @@ const {
   isVisible
 } = require('govuk-frontend-helpers/puppeteer')
 
-describe('Radios with conditional reveals', () => {
-  describe('when JavaScript is unavailable or fails', () => {
-    beforeAll(async () => {
-      await page.setJavaScriptEnabled(false)
-    })
-
-    afterAll(async () => {
-      await page.setJavaScriptEnabled(true)
-    })
-
-    describe('with conditional items', () => {
-      let $component
-      let $inputs
-      let $conditionals
-
+describe('Radios', () => {
+  describe('with conditional reveals', () => {
+    describe('when JavaScript is unavailable or fails', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'radios', {
-          exampleName: 'with-conditional-items'
-        })
-
-        $component = await page.$('.govuk-radios')
-        $inputs = await $component.$$('.govuk-radios__input')
-        $conditionals = await $component.$$('.govuk-radios__conditional')
-
-        expect($inputs.length).toBe(3)
-        expect($conditionals.length).toBe(3)
+        await page.setJavaScriptEnabled(false)
       })
 
-      it('has no ARIA attributes applied', async () => {
-        const $inputsWithAriaExpanded = await $component.$$(
-          '.govuk-radios__input[aria-expanded]'
-        )
-        const $inputsWithAriaControls = await $component.$$(
-          '.govuk-radios__input[aria-controls]'
-        )
-
-        expect($inputsWithAriaExpanded.length).toBe(0)
-        expect($inputsWithAriaControls.length).toBe(0)
+      afterAll(async () => {
+        await page.setJavaScriptEnabled(true)
       })
 
-      it('falls back to making all conditional content visible', async () => {
-        return Promise.all(
-          $conditionals.map(async ($conditional) => {
-            return expect(await isVisible($conditional)).toBe(true)
+      describe('with conditional items', () => {
+        let $component
+        let $inputs
+        let $conditionals
+
+        beforeAll(async () => {
+          await goToComponent(page, 'radios', {
+            exampleName: 'with-conditional-items'
           })
-        )
+
+          $component = await page.$('.govuk-radios')
+          $inputs = await $component.$$('.govuk-radios__input')
+          $conditionals = await $component.$$('.govuk-radios__conditional')
+
+          expect($inputs.length).toBe(3)
+          expect($conditionals.length).toBe(3)
+        })
+
+        it('has no ARIA attributes applied', async () => {
+          const $inputsWithAriaExpanded = await $component.$$(
+            '.govuk-radios__input[aria-expanded]'
+          )
+          const $inputsWithAriaControls = await $component.$$(
+            '.govuk-radios__input[aria-controls]'
+          )
+
+          expect($inputsWithAriaExpanded.length).toBe(0)
+          expect($inputsWithAriaControls.length).toBe(0)
+        })
+
+        it('falls back to making all conditional content visible', async () => {
+          return Promise.all(
+            $conditionals.map(async ($conditional) => {
+              return expect(await isVisible($conditional)).toBe(true)
+            })
+          )
+        })
+      })
+    })
+
+    describe('when JavaScript is available', () => {
+      describe('with conditional item checked', () => {
+        let $component
+        let $inputs
+
+        beforeEach(async () => {
+          await goToComponent(page, 'radios', {
+            exampleName: 'with-conditional-item-checked'
+          })
+
+          $component = await page.$('.govuk-radios')
+          $inputs = await $component.$$('.govuk-radios__input')
+        })
+
+        it('has conditional content revealed that is associated with a checked input', async () => {
+          const $input = $inputs[0] // First input, checked
+          const $conditional = await $component.$(
+            `[id="${await getAttribute($input, 'aria-controls')}"]`
+          )
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await isVisible($conditional)).toBe(true)
+        })
+
+        it('has no conditional content revealed that is associated with an unchecked input', async () => {
+          const $input = $inputs[$inputs.length - 1] // Last input, unchecked
+          const $conditional = await $component.$(
+            `[id="${await getAttribute($input, 'aria-controls')}"]`
+          )
+
+          expect(await getProperty($input, 'checked')).toBe(false)
+          expect(await isVisible($conditional)).toBe(false)
+        })
+      })
+
+      describe('with conditional items', () => {
+        let $component
+        let $inputs
+
+        beforeEach(async () => {
+          await goToComponent(page, 'radios', {
+            exampleName: 'with-conditional-items'
+          })
+
+          $component = await page.$('.govuk-radios')
+          $inputs = await $component.$$('.govuk-radios__input')
+        })
+
+        it('indicates when conditional content is collapsed or revealed', async () => {
+          const $input = $inputs[0] // First input, with conditional content
+
+          // Initially collapsed
+          expect(await getProperty($input, 'checked')).toBe(false)
+          expect(await getAttribute($input, 'aria-expanded')).toBe('false')
+
+          // Toggle revealed
+          await $input.click()
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await getAttribute($input, 'aria-expanded')).toBe('true')
+
+          // Stays revealed (unlike radios)
+          await $input.click()
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await getAttribute($input, 'aria-expanded')).toBe('true')
+        })
+
+        it('toggles the conditional content when clicking an input', async () => {
+          const $input = $inputs[0] // First input, with conditional content
+          const $conditional = await $component.$(
+            `[id="${await getAttribute($input, 'aria-controls')}"]`
+          )
+
+          // Initially collapsed
+          expect(await getProperty($input, 'checked')).toBe(false)
+          expect(await isVisible($conditional)).toBe(false)
+
+          // Toggle revealed
+          await $input.click()
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await isVisible($conditional)).toBe(true)
+
+          // Stays revealed (unlike radios)
+          await $input.click()
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await isVisible($conditional)).toBe(true)
+        })
+
+        it('toggles the conditional content when using an input with a keyboard', async () => {
+          const $input = $inputs[0] // First input, with conditional content
+          const $conditional = await $component.$(
+            `[id="${await getAttribute($input, 'aria-controls')}"]`
+          )
+
+          // Initially collapsed
+          expect(await getProperty($input, 'checked')).toBe(false)
+          expect(await isVisible($conditional)).toBe(false)
+
+          // Toggle revealed
+          await $input.focus()
+          await page.keyboard.press('Space')
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await isVisible($conditional)).toBe(true)
+
+          // Stays revealed (unlike radios)
+          await page.keyboard.press('Space')
+
+          expect(await getProperty($input, 'checked')).toBe(true)
+          expect(await isVisible($conditional)).toBe(true)
+        })
+      })
+
+      describe('with conditional items with special characters', () => {
+        it('does not error when ID of revealed content contains special characters', async () => {
+          // Errors logged to the console will cause this test to fail
+          await goToComponent(page, 'radios', {
+            exampleName: 'with-conditional-items-with-special-characters'
+          })
+        })
       })
     })
   })
 
-  describe('when JavaScript is available', () => {
-    describe('with conditional item checked', () => {
-      let $component
-      let $inputs
+  describe('with multiple groups', () => {
+    describe('when JavaScript is available', () => {
+      let $inputsWarm
+      let $inputsCool
+      let $inputsNotInForm
 
       beforeEach(async () => {
-        await goToComponent(page, 'radios', {
-          exampleName: 'with-conditional-item-checked'
-        })
+        await goToExample(page, 'multiple-radio-groups')
 
-        $component = await page.$('.govuk-radios')
-        $inputs = await $component.$$('.govuk-radios__input')
+        $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
+        $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
+        $inputsNotInForm = await page.$$(
+          '.govuk-radios__input[id^="question-not-in-form"]'
+        )
       })
 
-      it('has conditional content revealed that is associated with a checked input', async () => {
-        const $input = $inputs[0] // First input, checked
-        const $conditional = await $component.$(
-          `[id="${await getAttribute($input, 'aria-controls')}"]`
+      it('toggles conditional reveals in other groups', async () => {
+        const $conditionalWarm = await page.$(
+          `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
+        )
+        const $conditionalCool = await page.$(
+          `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
         )
 
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await isVisible($conditional)).toBe(true)
+        // Select red in warm colours
+        await $inputsWarm[0].click()
+
+        expect(await isVisible($conditionalWarm)).toBe(true)
+        expect(await isVisible($conditionalCool)).toBe(false)
+
+        // Select blue in cool colours
+        await $inputsCool[0].click()
+
+        expect(await isVisible($conditionalWarm)).toBe(false)
+        expect(await isVisible($conditionalCool)).toBe(true)
       })
 
-      it('has no conditional content revealed that is associated with an unchecked input', async () => {
-        const $input = $inputs[$inputs.length - 1] // Last input, unchecked
-        const $conditional = await $component.$(
-          `[id="${await getAttribute($input, 'aria-controls')}"]`
+      it('toggles conditional reveals when not in a form', async () => {
+        const $conditionalWarm = await page.$(
+          `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
         )
 
-        expect(await getProperty($input, 'checked')).toBe(false)
-        expect(await isVisible($conditional)).toBe(false)
+        // Select first input in radios not in a form
+        await $inputsNotInForm[0].click()
+
+        expect(await isVisible($conditionalWarm)).toBe(false)
       })
     })
+  })
 
-    describe('with conditional items', () => {
-      let $component
-      let $inputs
+  describe('with multiple groups and conditional reveals', () => {
+    describe('when JavaScript is available', () => {
+      let $inputsPrimary
+      let $inputsOther
 
       beforeEach(async () => {
-        await goToComponent(page, 'radios', {
-          exampleName: 'with-conditional-items'
-        })
+        await goToExample(page, 'conditional-reveals')
 
-        $component = await page.$('.govuk-radios')
-        $inputs = await $component.$$('.govuk-radios__input')
+        $inputsPrimary = await page.$$(
+          '.govuk-radios__input[id^="fave-primary"]'
+        )
+        $inputsOther = await page.$$('.govuk-radios__input[id^="fave-other"]')
       })
 
-      it('indicates when conditional content is collapsed or revealed', async () => {
-        const $input = $inputs[0] // First input, with conditional content
-
-        // Initially collapsed
-        expect(await getProperty($input, 'checked')).toBe(false)
-        expect(await getAttribute($input, 'aria-expanded')).toBe('false')
-
-        // Toggle revealed
-        await $input.click()
-
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await getAttribute($input, 'aria-expanded')).toBe('true')
-
-        // Stays revealed (unlike radios)
-        await $input.click()
-
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await getAttribute($input, 'aria-expanded')).toBe('true')
-      })
-
-      it('toggles the conditional content when clicking an input', async () => {
-        const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(
-          `[id="${await getAttribute($input, 'aria-controls')}"]`
+      it('hides conditional reveals in other groups', async () => {
+        const $conditionalPrimary = await page.$(
+          `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
         )
 
-        // Initially collapsed
-        expect(await getProperty($input, 'checked')).toBe(false)
-        expect(await isVisible($conditional)).toBe(false)
+        // Choose the second radio in the first group, which reveals additional content
+        await $inputsPrimary[1].click()
 
-        // Toggle revealed
-        await $input.click()
+        // Assert that conditional content is revealed
+        expect(await isVisible($conditionalPrimary)).toBe(true)
 
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await isVisible($conditional)).toBe(true)
+        // Choose a different radio with the same name, but in a different group
+        await $inputsOther[1].click()
 
-        // Stays revealed (unlike radios)
-        await $input.click()
-
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await isVisible($conditional)).toBe(true)
+        // Expect conditional content to have been collapsed
+        expect(await isVisible($conditionalPrimary)).toBe(false)
       })
-
-      it('toggles the conditional content when using an input with a keyboard', async () => {
-        const $input = $inputs[0] // First input, with conditional content
-        const $conditional = await $component.$(
-          `[id="${await getAttribute($input, 'aria-controls')}"]`
-        )
-
-        // Initially collapsed
-        expect(await getProperty($input, 'checked')).toBe(false)
-        expect(await isVisible($conditional)).toBe(false)
-
-        // Toggle revealed
-        await $input.focus()
-        await page.keyboard.press('Space')
-
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await isVisible($conditional)).toBe(true)
-
-        // Stays revealed (unlike radios)
-        await page.keyboard.press('Space')
-
-        expect(await getProperty($input, 'checked')).toBe(true)
-        expect(await isVisible($conditional)).toBe(true)
-      })
-    })
-
-    describe('with conditional items with special characters', () => {
-      it('does not error when ID of revealed content contains special characters', async () => {
-        // Errors logged to the console will cause this test to fail
-        await goToComponent(page, 'radios', {
-          exampleName: 'with-conditional-items-with-special-characters'
-        })
-      })
-    })
-  })
-})
-
-describe('Radios with multiple groups', () => {
-  describe('when JavaScript is available', () => {
-    let $inputsWarm
-    let $inputsCool
-    let $inputsNotInForm
-
-    beforeEach(async () => {
-      await goToExample(page, 'multiple-radio-groups')
-
-      $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
-      $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
-      $inputsNotInForm = await page.$$(
-        '.govuk-radios__input[id^="question-not-in-form"]'
-      )
-    })
-
-    it('toggles conditional reveals in other groups', async () => {
-      const $conditionalWarm = await page.$(
-        `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
-      )
-      const $conditionalCool = await page.$(
-        `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
-      )
-
-      // Select red in warm colours
-      await $inputsWarm[0].click()
-
-      expect(await isVisible($conditionalWarm)).toBe(true)
-      expect(await isVisible($conditionalCool)).toBe(false)
-
-      // Select blue in cool colours
-      await $inputsCool[0].click()
-
-      expect(await isVisible($conditionalWarm)).toBe(false)
-      expect(await isVisible($conditionalCool)).toBe(true)
-    })
-
-    it('toggles conditional reveals when not in a form', async () => {
-      const $conditionalWarm = await page.$(
-        `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
-      )
-
-      // Select first input in radios not in a form
-      await $inputsNotInForm[0].click()
-
-      expect(await isVisible($conditionalWarm)).toBe(false)
-    })
-  })
-})
-
-describe('Radios with multiple groups and conditional reveals', () => {
-  describe('when JavaScript is available', () => {
-    let $inputsPrimary
-    let $inputsOther
-
-    beforeEach(async () => {
-      await goToExample(page, 'conditional-reveals')
-
-      $inputsPrimary = await page.$$('.govuk-radios__input[id^="fave-primary"]')
-      $inputsOther = await page.$$('.govuk-radios__input[id^="fave-other"]')
-    })
-
-    it('hides conditional reveals in other groups', async () => {
-      const $conditionalPrimary = await page.$(
-        `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
-      )
-
-      // Choose the second radio in the first group, which reveals additional content
-      await $inputsPrimary[1].click()
-
-      // Assert that conditional content is revealed
-      expect(await isVisible($conditionalPrimary)).toBe(true)
-
-      // Choose a different radio with the same name, but in a different group
-      await $inputsOther[1].click()
-
-      // Expect conditional content to have been collapsed
-      expect(await isVisible($conditionalPrimary)).toBe(false)
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
@@ -3,8 +3,10 @@ const {
   goToExample,
   getProperty,
   getAttribute,
-  isVisible
+  isVisible,
+  renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 
 describe('Radios', () => {
   describe('with conditional reveals', () => {
@@ -264,6 +266,28 @@ describe('Radios', () => {
 
         // Expect conditional content to have been collapsed
         expect(await isVisible($conditionalPrimary)).toBe(false)
+      })
+    })
+  })
+
+  describe('errors at instantiation', () => {
+    let examples
+
+    beforeAll(async () => {
+      examples = await getExamples('radios')
+    })
+
+    it('throws when GOV.UK Frontend is not supported', async () => {
+      await expect(
+        renderAndInitialise(page, 'radios', {
+          params: examples.default,
+          beforeInitialisation() {
+            document.body.classList.remove('govuk-frontend-supported')
+          }
+        })
+      ).rejects.toEqual({
+        name: 'SupportError',
+        message: 'GOV.UK Frontend is not supported in this browser'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,9 +1,9 @@
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Skip link component
  */
-export class SkipLink {
+export class SkipLink extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -21,9 +21,7 @@ export class SkipLink {
    * @param {Element} $module - HTML element to use for skip link
    */
   constructor($module) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLAnchorElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,3 +1,5 @@
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+
 /**
  * Skip link component
  */
@@ -19,10 +21,11 @@ export class SkipLink {
    * @param {Element} $module - HTML element to use for skip link
    */
   constructor($module) {
-    if (
-      !($module instanceof HTMLAnchorElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLAnchorElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -1,4 +1,8 @@
-const { goToExample } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goToExample,
+  renderAndInitialise
+} = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 
 describe('Skip Link', () => {
   describe('/examples/template-default', () => {
@@ -54,6 +58,28 @@ describe('Skip Link', () => {
       )
 
       expect(cssClass).not.toContain('govuk-skip-link-focused-element')
+    })
+  })
+
+  describe('errors at instantiation', () => {
+    let examples
+
+    beforeAll(async () => {
+      examples = await getExamples('skip-link')
+    })
+
+    it('throws when GOV.UK Frontend is not supported', async () => {
+      await expect(
+        renderAndInitialise(page, 'skip-link', {
+          params: examples.default,
+          beforeInitialisation() {
+            document.body.classList.remove('govuk-frontend-supported')
+          }
+        })
+      ).rejects.toEqual({
+        name: 'SupportError',
+        message: 'GOV.UK Frontend is not supported in this browser'
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -1,7 +1,7 @@
 const { goToExample } = require('govuk-frontend-helpers/puppeteer')
 
-describe('/examples/template-default', () => {
-  describe('skip link', () => {
+describe('Skip Link', () => {
+  describe('/examples/template-default', () => {
     beforeAll(async () => {
       await goToExample(page, 'template-default')
       await page.keyboard.press('Tab')

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -1,9 +1,9 @@
-import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
  * Tabs component
  */
-export class Tabs {
+export class Tabs extends GOVUKFrontendComponent {
   /** @private */
   $module
 
@@ -38,9 +38,7 @@ export class Tabs {
    * @param {Element} $module - HTML element to use for tabs
    */
   constructor($module) {
-    if (!document.body.classList.contains('govuk-frontend-supported')) {
-      throw new GOVUKFrontendSupportError()
-    }
+    super()
 
     if (!($module instanceof HTMLElement)) {
       return this

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -1,3 +1,5 @@
+import { GOVUKFrontendSupportError } from '../../errors/index.mjs'
+
 /**
  * Tabs component
  */
@@ -36,10 +38,11 @@ export class Tabs {
    * @param {Element} $module - HTML element to use for tabs
    */
   constructor($module) {
-    if (
-      !($module instanceof HTMLElement) ||
-      !document.body.classList.contains('govuk-frontend-supported')
-    ) {
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+      throw new GOVUKFrontendSupportError()
+    }
+
+    if (!($module instanceof HTMLElement)) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
@@ -1,4 +1,9 @@
-const { goTo, goToComponent } = require('govuk-frontend-helpers/puppeteer')
+const {
+  goTo,
+  goToComponent,
+  renderAndInitialise
+} = require('govuk-frontend-helpers/puppeteer')
+const { getExamples } = require('govuk-frontend-lib/files.js')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']
@@ -240,6 +245,28 @@ describe('/components/tabs', () => {
           { visible: true, timeout: 5000 }
         )
         expect(isContentVisible).toBeTruthy()
+      })
+    })
+
+    describe('errors at instantiation', () => {
+      let examples
+
+      beforeAll(async () => {
+        examples = await getExamples('tabs')
+      })
+
+      it('throws when GOV.UK Frontend is not supported', async () => {
+        await expect(
+          renderAndInitialise(page, 'tabs', {
+            params: examples.default,
+            beforeInitialisation() {
+              document.body.classList.remove('govuk-frontend-supported')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        })
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -1,0 +1,35 @@
+/**
+ * GOV.UK Frontend error
+ *
+ * A base class for `Error`s thrown by GOV.UK Frontend.
+ *
+ * It is meant to be extended into specific types of errors
+ * to be thrown by our code.
+ *
+ * @example
+ * ```js
+ * class MissingRootError extends GOVUKFrontendError {
+ *   // Setting an explicit name is important as extending the class will not
+ *   // set a new `name` on the subclass. The `name` property is important
+ *   // to ensure intelligible error names even if the class name gets
+ *   // mangled by a minifier
+ *   name = "MissingRootError"
+ * }
+ * ```
+ * @abstract
+ */
+export class GOVUKFrontendError extends Error {
+  name = 'GOVUKFrontendError'
+}
+
+/**
+ * Indicates that GOV.UK Frontend is not supported
+ */
+export class SupportError extends GOVUKFrontendError {
+  name = 'SupportError'
+
+  // eslint-disable-next-line jsdoc/require-jsdoc -- Nothing pertinent to document
+  constructor() {
+    super('GOV.UK Frontend is not supported in this browser')
+  }
+}

--- a/packages/govuk-frontend/src/govuk/errors/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.unit.test.mjs
@@ -1,0 +1,27 @@
+import { GOVUKFrontendError, SupportError } from './index.mjs'
+
+describe('errors', () => {
+  describe('GOVUKFrontendError', () => {
+    it('allows subclasses to set a custom name', () => {
+      class CustomError extends GOVUKFrontendError {
+        name = 'CustomName'
+      }
+
+      expect(new CustomError().name).toBe('CustomName')
+    })
+  })
+
+  describe('SupportError', () => {
+    it('is an instance of GOVUKFrontendError', () => {
+      expect(new SupportError()).toBeInstanceOf(GOVUKFrontendError)
+    })
+    it('has its own name set', () => {
+      expect(new SupportError().name).toBe('SupportError')
+    })
+    it('provides meaningfull feedback to users', () => {
+      expect(new SupportError().message).toBe(
+        'GOV.UK Frontend is not supported in this browser'
+      )
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,0 +1,32 @@
+import { isSupported } from './common/index.mjs'
+import { SupportError } from './errors/index.mjs'
+
+/**
+ * Base Component class
+ *
+ * Centralises the behaviours shared by our components
+ *
+ * @internal
+ * @abstract
+ */
+export class GOVUKFrontendComponent {
+  /**
+   * Constructs a new component, validating that GOV.UK Frontend is supported
+   *
+   * @internal
+   */
+  constructor() {
+    this.checkSupport()
+  }
+
+  /**
+   * Validates whether GOV.UK Frontend is supported
+   *
+   * @private
+   */
+  checkSupport() {
+    if (!isSupported()) {
+      throw new SupportError()
+    }
+  }
+}

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -216,7 +216,10 @@ describe('packages/govuk-frontend/dist/', () => {
         for (const componentName of componentNamesWithJavaScript) {
           const componentClassName = componentNameToClassName(componentName)
 
-          expect(contents).toContain(`class ${componentClassName} {`)
+          expect(contents).toContain(
+            // Trailing space is important to not match `class ${componentClassName}Something`
+            `class ${componentClassName} `
+          )
           expect(contents).toContain(
             `exports.${componentClassName} = ${componentClassName};`
           )


### PR DESCRIPTION
This PR updates all our JavaScript components to throw a `GOVUKFrontendNotSupportedError` if they get instantiated where GOV.UK Frontend is not supported.

Besides updating the components to throw this new error the PR:

- introduces a `GOVUKFrontendError` for our errors to subclass. It allows users to easily [separate our custom errors from regular JavaScript errors using `instanceof`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#handling_a_specific_error_type).
- updates `renderAndInitialise` to make running code before the component's initialisation more reliable (had issues where the `initialiser` – now renamed `beforeInitialisation` for clarity – didn't execute when run in the middle of the block instantiating the component).

Closes #4009 

