### PR TITLE
[SPIKE] Refactor checkboxes and radios

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -5,23 +5,16 @@
 
 @include govuk-exports("govuk/component/checkboxes") {
 
-  $govuk-touch-target-size: 44px;
-  $govuk-checkboxes-size: 40px;
-  $govuk-small-checkboxes-size: 24px;
+  $govuk-checkboxes-size: govuk-spacing(7);
+  $govuk-touch-target-size: ($govuk-checkboxes-size + 4px);
+  $govuk-small-checkboxes-size: (govuk-spacing(4) + 4px);
   $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 
   .govuk-checkboxes__item {
     @include govuk-font($size: 19);
-
-    display: block;
-    position: relative;
-
-    min-height: $govuk-checkboxes-size;
-
+    display: flex;
+    flex-wrap: wrap;
     margin-bottom: govuk-spacing(2);
-    padding-left: $govuk-checkboxes-size;
-
-    clear: left;
   }
 
   .govuk-checkboxes__item:last-child,
@@ -30,79 +23,77 @@
   }
 
   .govuk-checkboxes__input {
-    $input-offset: ($govuk-touch-target-size - $govuk-checkboxes-size) / 2;
-
-    position: absolute;
-
-    z-index: 1;
-    top: $input-offset * -1;
-    left: $input-offset * -1;
-
-    width: $govuk-touch-target-size;
-    height: $govuk-touch-target-size;
-    margin: 0;
-
-    opacity: 0;
-
-    cursor: pointer;
-  }
-
-  .govuk-checkboxes__label {
-    display: inline-block;
-    margin-bottom: 0;
-    padding: 8px $govuk-checkboxes-label-padding-left-right govuk-spacing(1);
-    cursor: pointer;
-    // remove 300ms pause on mobile
-    touch-action: manipulation;
-  }
-
-  // [ ] Check box
-  .govuk-checkboxes__label::before {
-    content: "";
+    appearance: none;
     box-sizing: border-box;
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: $govuk-checkboxes-size;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+    z-index: 1;
+    min-width: $govuk-checkboxes-size;
     height: $govuk-checkboxes-size;
+    margin: 0;
     border: $govuk-border-width-form-element solid currentcolor;
     background: transparent;
+    cursor: pointer;
+  }
+
+  .govuk-checkboxes__input::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: $govuk-touch-target-size;
+    height: $govuk-touch-target-size;
   }
 
   // ✔ Check mark
   //
   // The check mark is a box with a border on the left and bottom side (└──),
   // rotated 45 degrees
-  .govuk-checkboxes__label::after {
+  .govuk-checkboxes__input::after {
     content: "";
     box-sizing: border-box;
-
-    position: absolute;
-    top: 11px;
-    left: 9px;
     width: 23px;
     height: 12px;
-
+    margin-bottom: govuk-spacing(1);
     transform: rotate(-45deg);
     border: solid;
     border-width: 0 0 5px 5px;
     // Fix bug in IE11 caused by transform rotate (-45deg).
     // See: alphagov/govuk_elements/issues/518
     border-top-color: transparent;
-
     opacity: 0;
-
     background: transparent;
+  }
+
+  .govuk-checkboxes__label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    max-width: calc(100% - ($govuk-checkboxes-label-padding-left-right + $govuk-checkboxes-size + govuk-spacing(3)));
+    margin-bottom: 0;
+    padding: (govuk-spacing(1) + $govuk-border-width-form-element) govuk-spacing(3);
+    cursor: pointer;
+    // remove 300ms pause on mobile
+    touch-action: manipulation;
+
+    // to account for when there are multiple children in a label
+    .govuk-radios__label * {
+      width: 100%;
+    }
   }
 
   .govuk-checkboxes__hint {
     display: block;
+    width: 100%;
     padding-right: $govuk-checkboxes-label-padding-left-right;
-    padding-left: $govuk-checkboxes-label-padding-left-right;
+    padding-left: ($govuk-checkboxes-label-padding-left-right + $govuk-checkboxes-size);
   }
 
   // Focused state
-  .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+  .govuk-checkboxes__input:focus {
     border-width: 4px;
 
     // When colours are overridden, the yellow box-shadow becomes invisible
@@ -122,7 +113,7 @@
   }
 
   // Selected state
-  .govuk-checkboxes__input:checked + .govuk-checkboxes__label::after {
+  .govuk-checkboxes__input:checked::after {
     opacity: 1;
   }
 
@@ -184,17 +175,8 @@
   // =========================================================
 
   .govuk-checkboxes--small {
-
     $input-offset: ($govuk-touch-target-size - $govuk-small-checkboxes-size) / 2;
     $label-offset: $govuk-touch-target-size - $input-offset;
-
-    .govuk-checkboxes__item {
-      @include govuk-clearfix;
-      min-height: 0;
-      margin-bottom: 0;
-      padding-left: $label-offset;
-      float: left;
-    }
 
     // Shift the touch target into the left margin so that the visible edge of
     // the control is aligned
@@ -205,8 +187,9 @@
     //  └┆▲──┘
     //  ▲┆└─ Check box pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
-    .govuk-checkboxes__input {
-      left: $input-offset * -1;
+
+    .govuk-checkboxes__item {
+      margin-bottom: 0;
     }
 
     // Adjust the size and position of the label.
@@ -215,31 +198,28 @@
     // 'shrink' it, preventing the hover state from kicking in across the full
     // width of the parent element.
     .govuk-checkboxes__label {
-      margin-top: -2px;
-      padding: 13px govuk-spacing(3) 13px 1px;
-      float: left;
-
-      @include govuk-media-query($from: tablet) {
-        padding: 11px govuk-spacing(3) 10px 1px;
-      }
+      padding-left: 0;
     }
 
     // [ ] Check box
     //
     // Reduce the size of the check box [1], vertically center it within the
     // touch target [2]
-    .govuk-checkboxes__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
-      width: $govuk-small-checkboxes-size; // 1
+    .govuk-checkboxes__input {
+      min-width: $govuk-small-checkboxes-size; // 1
       height: $govuk-small-checkboxes-size; // 1
+      margin: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+    }
+
+    .govuk-checkboxes__input::before {
+      top: -12px;
+      right: -12px;
     }
 
     // ✔ Check mark
     //
     // Reduce the size of the check mark and re-align within the checkbox
-    .govuk-checkboxes__label::after {
-      top: 15px;
-      left: 6px;
+    .govuk-checkboxes__input::after {
       width: 12px;
       height: 6.5px;
       border-width: 0 0 3px 3px;
@@ -254,8 +234,7 @@
     // (If you do use them, they won't look completely broken... but seriously,
     // don't use them)
     .govuk-checkboxes__hint {
-      padding: 0;
-      clear: both;
+      padding-left: (govuk-spacing(2) + $govuk-small-checkboxes-size);
     }
 
     // Align conditional reveals with small checkboxes
@@ -263,7 +242,6 @@
       $margin-left: ($govuk-small-checkboxes-size / 2) - ($conditional-border-width / 2);
       margin-left: $margin-left;
       padding-left: $label-offset - ($margin-left + $conditional-border-width);
-      clear: both;
     }
 
     // Hover state for small checkboxes.
@@ -272,7 +250,7 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which checkbox they will select when their
     // cursor is outside of the visible area.
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+    .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) {
       // Forced colours modes tend to ignore box-shadow.
       // Apply an outline for those modes to use instead.
       outline: $govuk-focus-width dashed transparent;
@@ -285,7 +263,7 @@
     //
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
-    .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+    .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus {
       // Set different HCM colour when we have both hover/focus applied at once
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
         outline-color: Highlight;
@@ -302,11 +280,11 @@
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
     @media (hover: none), (pointer: coarse) {
-      .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) + .govuk-checkboxes__label::before {
+      .govuk-checkboxes__item:hover .govuk-checkboxes__input:not(:disabled) {
         box-shadow: initial;
       }
 
-      .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus + .govuk-checkboxes__label::before {
+      .govuk-checkboxes__item:hover .govuk-checkboxes__input:focus {
         box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
       }
     }

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -82,7 +82,7 @@
               classes: 'govuk-checkboxes__label' + (' ' + item.label.classes if item.label.classes),
               attributes: item.label.attributes,
               for: id
-            }) | indent(6) | trim }}
+              }) | indent(6) | trim }}
             {% if hasHint %}
             {{ govukHint({
               id: itemHintId,

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -5,9 +5,9 @@
 
 @include govuk-exports("govuk/component/radios") {
 
-  $govuk-touch-target-size: 44px;
-  $govuk-radios-size: 40px;
-  $govuk-small-radios-size: 24px;
+  $govuk-radios-size: govuk-spacing(7);
+  $govuk-touch-target-size: ($govuk-radios-size + 4px);
+  $govuk-small-radios-size: (govuk-spacing(4) + 4px);
   $govuk-radios-label-padding-left-right: govuk-spacing(3);
   // When the default focus width is used on a curved edge it looks visually smaller.
   // So for the circular radios we bump the default to make it look visually consistent.
@@ -15,16 +15,9 @@
 
   .govuk-radios__item {
     @include govuk-font($size: 19);
-
-    display: block;
-    position: relative;
-
-    min-height: $govuk-radios-size;
-
+    display: flex;
+    flex-wrap: wrap;
     margin-bottom: govuk-spacing(2);
-    padding-left: $govuk-radios-size;
-
-    clear: left;
   }
 
   .govuk-radios__item:last-child,
@@ -33,76 +26,74 @@
   }
 
   .govuk-radios__input {
-    $input-offset: ($govuk-touch-target-size - $govuk-radios-size) / 2;
-
-    position: absolute;
-
+    // $input-offset: ($govuk-touch-target-size - $govuk-radios-size) / 2;
+    // top: $input-offset * -1;
+    // left: $input-offset * -1;
+    appearance: none;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
     z-index: 1;
-    top: $input-offset * -1;
-    left: $input-offset * -1;
-
-    width: $govuk-touch-target-size;
-    height: $govuk-touch-target-size;
-    margin: 0;
-
-    opacity: 0;
-
-    cursor: pointer;
-  }
-
-  .govuk-radios__label {
-    display: inline-block;
-    margin-bottom: 0;
-    padding: 8px $govuk-radios-label-padding-left-right govuk-spacing(1);
-    cursor: pointer;
-    // remove 300ms pause on mobile
-    touch-action: manipulation;
-  }
-
-  // ( ) Radio ring
-  .govuk-radios__label::before {
-    content: "";
-    box-sizing: border-box;
-    position: absolute;
-    top: 0;
-    left: 0;
-
-    width: $govuk-radios-size;
+    min-width: $govuk-radios-size;
     height: $govuk-radios-size;
-
+    margin: 0;
     border: $govuk-border-width-form-element solid currentcolor;
     border-radius: 50%;
     background: transparent;
+    cursor: pointer;
+  }
+
+  .govuk-radios__input::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: -4px;
+    right: -4px;
+    width: $govuk-touch-target-size;
+    height: $govuk-touch-target-size;
   }
 
   //  •  Radio button
   //
   // We create the 'button' entirely out of 'border' so that they remain
   // 'filled' even when colours are overridden in the browser.
-  .govuk-radios__label::after {
+  .govuk-radios__input::after {
     content: "";
-
-    position: absolute;
-    top: govuk-spacing(2);
-    left: govuk-spacing(2);
-
     width: 0;
     height: 0;
-
     border: govuk-spacing(2) solid currentcolor;
     border-radius: 50%;
     opacity: 0;
     background: currentcolor;
   }
 
+  .govuk-radios__label {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    max-width: calc(100% - ($govuk-radios-label-padding-left-right + $govuk-radios-size + govuk-spacing(3)));
+    margin-bottom: 0;
+    padding: (govuk-spacing(1) + $govuk-border-width-form-element) govuk-spacing(3);
+    cursor: pointer;
+    // remove 300ms pause on mobile
+    touch-action: manipulation;
+  }
+
+  // to account for when there are multiple children in a label
+  .govuk-radios__label * {
+    width: 100%;
+  }
+
   .govuk-radios__hint {
     display: block;
+    width: 100%;
     padding-right: $govuk-radios-label-padding-left-right;
-    padding-left: $govuk-radios-label-padding-left-right;
+    padding-left: ($govuk-radios-label-padding-left-right + $govuk-radios-size);
   }
 
   // Focused state
-  .govuk-radios__input:focus + .govuk-radios__label::before {
+  .govuk-radios__input:focus {
     border-width: 4px;
 
     // When colours are overridden, the yellow box-shadow becomes invisible
@@ -122,7 +113,7 @@
   }
 
   // Selected state
-  .govuk-radios__input:checked + .govuk-radios__label::after {
+  .govuk-radios__input:checked::after {
     opacity: 1;
   }
 
@@ -143,12 +134,11 @@
 
   .govuk-radios--inline {
     @include govuk-media-query ($from: tablet) {
-      @include govuk-clearfix;
+      display: flex;
+      align-items: flex-start;
 
       .govuk-radios__item {
         margin-right: govuk-spacing(4);
-        float: left;
-        clear: none;
       }
     }
   }
@@ -200,16 +190,11 @@
   // =========================================================
 
   .govuk-radios--small {
-
     $input-offset: ($govuk-touch-target-size - $govuk-small-radios-size) / 2;
     $label-offset: $govuk-touch-target-size - $input-offset;
 
     .govuk-radios__item {
-      @include govuk-clearfix;
-      min-height: 0;
       margin-bottom: 0;
-      padding-left: $label-offset;
-      float: left;
     }
 
     // Shift the touch target into the left margin so that the visible edge of
@@ -221,9 +206,6 @@
     //  └┆▲──┘
     //  ▲┆└─ Radio pseudo element, aligned with margin
     //  └─── Touch target (invisible input), shifted into the margin
-    .govuk-radios__input {
-      left: $input-offset * -1;
-    }
 
     // Adjust the size and position of the label.
     //
@@ -231,31 +213,28 @@
     // 'shrink' it, preventing the hover state from kicking in across the full
     // width of the parent element.
     .govuk-radios__label {
-      margin-top: -2px;
-      padding: 13px govuk-spacing(3) 13px 1px;
-      float: left;
-
-      @include govuk-media-query($from: tablet) {
-        padding: 11px govuk-spacing(3) 10px 1px;
-      }
+      padding-left: 0;
     }
 
     // ( ) Radio ring
     //
     // Reduce the size of the control [1], vertically centering it within the
     // touch target [2]
-    .govuk-radios__label::before {
-      top: $input-offset - $govuk-border-width-form-element; // 2
-      width: $govuk-small-radios-size; // 1
+    .govuk-radios__input {
+      min-width: $govuk-small-radios-size; // 1
       height: $govuk-small-radios-size; // 1
+      margin: govuk-spacing(2) govuk-spacing(2) govuk-spacing(2) 0;
+    }
+
+    .govuk-radios__input::before {
+      top: -12px;
+      right: -12px;
     }
 
     //  •  Radio button
     //
     // Reduce the size of the 'button' and center it within the ring
-    .govuk-radios__label::after {
-      top: 15px;
-      left: 7px;
+    .govuk-radios__input::after {
       border-width: 5px;
     }
 
@@ -268,9 +247,7 @@
     // (If you do use them, they won't look completely broken... but seriously,
     // don't use them)
     .govuk-radios__hint {
-      padding: 0;
-      clear: both;
-      pointer-events: none;
+      padding-left: (govuk-spacing(2) + $govuk-small-radios-size);
     }
 
     // Align conditional reveals with small radios
@@ -278,7 +255,6 @@
       $margin-left: ($govuk-small-radios-size / 2) - ($conditional-border-width / 2);
       margin-left: $margin-left;
       padding-left: $label-offset - ($margin-left + $conditional-border-width);
-      clear: both;
     }
 
     .govuk-radios__divider {
@@ -292,7 +268,7 @@
     // is so much larger than their visible size, and so we need to provide
     // feedback to the user as to which radio they will select when their
     // cursor is outside of the visible area.
-    .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+    .govuk-radios__item:hover .govuk-radios__input:not(:disabled) {
       // Forced colours modes tend to ignore box-shadow.
       // Apply an outline for those modes to use instead.
       outline: $govuk-radios-focus-width dashed transparent;
@@ -305,7 +281,7 @@
     //
     // We use two box shadows, one that restores the original focus state [1]
     // and another that then applies the hover state [2].
-    .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+    .govuk-radios__item:hover .govuk-radios__input:focus {
       // Set different HCM colour when we have both hover/focus applied at once
       @media screen and (forced-colors: active), (-ms-high-contrast: active) {
         outline-color: Highlight;
@@ -322,11 +298,11 @@
     // state in browsers that don't support `@media (hover)` (like Internet
     // Explorer) – so we have to 'undo' the hover state instead.
     @media (hover: none), (pointer: coarse) {
-      .govuk-radios__item:hover .govuk-radios__input:not(:disabled) + .govuk-radios__label::before {
+      .govuk-radios__item:hover .govuk-radios__input:not(:disabled) {
         box-shadow: initial;
       }
 
-      .govuk-radios__item:hover .govuk-radios__input:focus + .govuk-radios__label::before {
+      .govuk-radios__item:hover .govuk-radios__input:focus {
         box-shadow: 0 0 0 $govuk-radios-focus-width $govuk-focus-colour;
       }
     }


### PR DESCRIPTION
## What
Makes the following changes to checkboxes and radios:

1. attempt to make the spacing in checkboxes and radios be more dynamic and rely less on magic numbers. I've achieved this primarily using flexbox.
2. refactor checkboxes and radios so that styling of the visual element is handled in the `input` itself via `appearance: none` as opposed to using pseudo elements.

## Why
Change 1 is tied to https://github.com/alphagov/govuk-frontend/issues/3898. Making the spacing more dynamic means that we avoid exacerbating the existing very subtle alignment issue on small radios and checkboxes as well as future proofing us from other architectural changes like the typography scale.

Change 2 manifested whilst trying to figure out change 1 and is the more radical change. The use case for this is that the visual construction of the elements "make more sense" ie: what the user is interacting with visually is the input itself as opposed to pseudo elements with the input operating behind the visual elements aka: it feels less hacky.

## Visual changes
The visual changes here are intended to be minimal aside from the existing alignment issue. It is most prominent on the small variants of checkboxes and radios:

### Before
![Screenshot of current small checkboxes](https://github.com/alphagov/govuk-frontend/assets/64783893/71132d90-3834-49a3-8caa-8191a64312ed)

### After
![Screenshot of new small checkboxes](https://github.com/alphagov/govuk-frontend/assets/64783893/dd7c7505-6962-4af5-b526-0b6d2cf9140f)

## Additional notes
### How checkboxes and radios fit together now

The visual elements within radios and checkboxes have moved around like so:

- the checkbox "box" and the radio "circle" have moved from the `before` of the `label` to be the `input` itself
- the checkbox "check" and the radio "button" have moved from the `after` of the `label` to the `after` of the `input`
- the `before` of the `input` now handles the touch target, which the input was previously doing

The position of the `input` and the `label` and elements within the `label`, including text, are handed by flexbox. ~The `input` and `label` positioning is specifically handled by a new container element: `govuk-[checkboxes/radios]__container`.~

~**The addition of a new element in the macro unfortunately means that this is a breaking change**~

### Differences in older browsers
Because this change uses `appearance`, a feature with no support on IE and below, this is potentially a significant visual regression for IE users. This isn't as much of an issue as we will only be supporting IE "functionally" from 5.0, however here is what these changes look like in versions of IE compared to how they look currently:

| element | IE version | unchecked | checked |
| - | - | - | - |
| Current checkbox | 11 | ![Screenshot of current checkbox in IE11, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/ab954d35-f3db-4b2b-a5c8-c178d4cbe78a) | ![Screenshot of current checkbox in IE11, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/bdb426f1-778e-4c0c-a8c9-c39af5896abb) |
| Current checkbox | 10 | ![Screenshot of current checkbox in IE10, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/dcb22596-fa49-4358-8832-33acda46dea2) | ![Screenshot of current checkbox in IE10, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/eba5e57b-6025-41d1-9e22-061626fcef50) |
| Current checkbox | 9 and 8 | ![Screenshot of current checkbox in IE9/8, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/6843560b-fc76-4c3b-abcb-fd15df6ebaa3) | ![Screenshot of current checkbox in IE9/8, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/e3fa47d8-9e0f-44ad-8ce9-5811153571fa) |
| Current radio | 11 | ![Screenshot of current radio in IE11, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/10d75137-ae3a-4137-bb23-8c1c225adefa) | ![Screenshot of current radio in IE11, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/111b6d16-60be-41c7-aeaa-d9071b3494b6) |
| Current radio | 10 | ![Screenshot of current radio in IE10, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/1e8c5e6a-2c50-4bfa-893a-93cbba72a93a) | ![Screenshot of current radio in IE10, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/b3b92cc3-6afe-4786-ae1a-cb2819c3185f) |
| Current radio | 9 and 8 | ![Screenshot of current radio in IE9/8, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/19675385-7193-4043-9634-e5acfe4c6a65) | ![Screenshot of current radio in IE9/8, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/01d98d0e-c4fe-4640-b135-3cad987a9596) |
| New checkbox | 11 | ![Screenshot of new checkbox in IE11, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/a9989e5f-0e2b-4ba1-a68e-b43dc26bd5fe) | ![Screenshot of new checkbox in IE11, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/289269a4-c181-44eb-ae53-aafca98d43fa) |
| New checkbox | 10 | ![Screenshot of new checkbox in IE10, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/f051f275-2404-44ab-9e91-f85778824c0f) | ![Screenshot of new checkbox in IE10, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/2ae04b33-85d3-47ef-8a2a-0ca2e68cfca1) |
| New checkbox | 9 and 8 | ![Screenshot of new checkbox in IE9/8, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/54ac98dd-8be7-4530-9e6c-acf0901133ee) | ![Screenshot of new checkbox in IE9/8, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/0472e4e8-329f-40ab-9b64-5353993b000e) |
| New radio | 11 | ![Screenshot of new radio in IE11, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/dbd8b960-b4c2-4993-85f4-6cd35e799755) | ![Screenshot of new radio in IE11, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/0abee4b8-0c1b-43a9-bcf9-1d352399ddff) |
| New radio | 10 | ![Screenshot of new radio in IE10, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/4da47e4d-8ba6-4b36-8a6d-3049ae939fd5) | ![Screenshot of new radio in IE10, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/c4c15267-55ff-4e32-9bbc-591e64351cae) |
| New radio | 9 and 8 | ![Screenshot of new radio in IE9/8, unchecked](https://github.com/alphagov/govuk-frontend/assets/64783893/82670b66-a080-4dff-8d16-df76de790d39) | ![Screenshot of new radio in IE9/8, checked](https://github.com/alphagov/govuk-frontend/assets/64783893/bc4a777d-e3f4-42bc-b23f-1eb4786d1450) |

### Code sanitation
Because this is an impromptu spike, I haven't focused as much on keeping the code neat. Therefore there are some comments in odd places that I haven't deleted and some things that probably should have comments that don't. If anything doesn't make sense I can try to explain. Additionally, I'm not looking for advice on code formatting as much as I am on the implementation choices I've made.