### PR TITLE
Use locally installed `govuk-frontend` for component names, files, data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28211,7 +28211,6 @@
         "iframe-resizer": "^4.3.6",
         "js-beautify": "^1.14.9",
         "marked": "^7.0.0",
-        "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "shuffle-seed": "^1.1.6",
         "slug": "^8.2.3"
@@ -28239,6 +28238,9 @@
       "engines": {
         "node": "^18.12.0",
         "npm": "^8.1.0 || ^9.1.0"
+      },
+      "optionalDependencies": {
+        "nunjucks": "^3.2.4"
       }
     },
     "shared/config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28266,7 +28266,6 @@
         "jest-environment-jsdom": "^29.6.2",
         "jest-environment-node-single-context": "^29.1.0",
         "jest-environment-puppeteer": "^9.0.0",
-        "nunjucks": "^3.2.4",
         "outdent": "^0.8.0",
         "puppeteer": "^21.0.1",
         "sass-embedded": "^1.64.2",
@@ -28297,6 +28296,7 @@
         "govuk-frontend-config": "*",
         "js-yaml": "^4.1.0",
         "minimatch": "^9.0.3",
+        "nunjucks": "^3.2.4",
         "slash": "^3.0.0"
       },
       "engines": {

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -33,7 +33,6 @@
     "iframe-resizer": "^4.3.6",
     "js-beautify": "^1.14.9",
     "marked": "^7.0.0",
-    "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "shuffle-seed": "^1.1.6",
     "slug": "^8.2.3"
@@ -57,5 +56,8 @@
     "slash": "^5.1.0",
     "supertest": "^6.3.3",
     "typedoc": "^0.24.8"
+  },
+  "optionalDependencies": {
+    "nunjucks": "^3.2.4"
   }
 }

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -1,9 +1,9 @@
 import express from 'express'
 import {
   getComponentsFixtures,
-  getComponentNames,
-  filterPath
-} from 'govuk-frontend-lib/files'
+  getComponentNames
+} from 'govuk-frontend-lib/components'
+import { filterPath } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName } from 'govuk-frontend-lib/names'
 import { getStats, modulePaths } from 'govuk-frontend-stats'
 import { outdent } from 'outdent'
@@ -208,5 +208,5 @@ export default async () => {
 }
 
 /**
- * @typedef {import('govuk-frontend-lib/files').ComponentFixtures} ComponentFixtures
+ * @typedef {import('govuk-frontend-lib/components').ComponentFixtures} ComponentFixtures
  */

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -1,7 +1,8 @@
 import express from 'express'
 import {
   getComponentsFixtures,
-  getComponentNames
+  getComponentNames,
+  getComponentNamesFiltered
 } from 'govuk-frontend-lib/components'
 import { filterPath } from 'govuk-frontend-lib/files'
 import { componentNameToMacroName } from 'govuk-frontend-lib/names'
@@ -30,7 +31,7 @@ export default async () => {
     getComponentNames(),
 
     // Components list (with JavaScript only)
-    getComponentNames((componentName, componentFiles) =>
+    getComponentNamesFiltered((componentName, componentFiles) =>
       componentFiles.some(filterPath([`**/${componentName}.mjs`]))
     ),
 

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -1,4 +1,5 @@
 import express from 'express'
+import { paths } from 'govuk-frontend-config'
 import {
   getComponentsFixtures,
   getComponentNames,
@@ -16,6 +17,10 @@ import * as routes from './routes/index.mjs'
 export default async () => {
   const app = express()
 
+  // Resolve GOV.UK Frontend from review app `node_modules`
+  // to allow previous versions to be installed locally
+  const packageOptions = { moduleRoot: paths.app }
+
   // Cache mapped components and examples
   const [
     componentsFixtures,
@@ -24,14 +29,16 @@ export default async () => {
     exampleNames,
     fullPageExamples
   ] = await Promise.all([
-    getComponentsFixtures(),
+    getComponentsFixtures(packageOptions),
 
     // Components list
-    getComponentNames(),
+    getComponentNames(packageOptions),
 
     // Components list (with JavaScript only)
-    getComponentNamesFiltered((componentName, componentFiles) =>
-      componentFiles.some(filterPath([`**/${componentName}.mjs`]))
+    getComponentNamesFiltered(
+      (componentName, componentFiles) =>
+        componentFiles.some(filterPath([`**/${componentName}.mjs`])),
+      packageOptions
     ),
 
     getExampleNames(),

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -2,12 +2,11 @@ import express from 'express'
 import {
   getComponentsFixtures,
   getComponentNames,
-  getComponentNamesFiltered
+  getComponentNamesFiltered,
+  renderComponent
 } from 'govuk-frontend-lib/components'
 import { filterPath } from 'govuk-frontend-lib/files'
-import { componentNameToMacroName } from 'govuk-frontend-lib/names'
 import { getStats, modulePaths } from 'govuk-frontend-stats'
-import { outdent } from 'outdent'
 
 import { getExampleNames, getFullPageExamples } from './common/lib/files.mjs'
 import * as middleware from './common/middleware/index.mjs'
@@ -149,15 +148,10 @@ export default async () => {
       }
 
       // Construct and evaluate the component with the data for this example
-      const macroName = componentNameToMacroName(componentName)
-      const macroParameters = JSON.stringify(fixture.options, null, '\t')
-
-      res.locals.componentView = env.renderString(
-        outdent`
-      {% from "govuk/components/${componentName}/macro.njk" import ${macroName} %}
-      {{ ${macroName}(${macroParameters}) }}
-    `,
-        {}
+      res.locals.componentView = renderComponent(
+        componentName,
+        fixture.options,
+        { env }
       )
 
       let bodyClasses = 'app-template__body'

--- a/packages/govuk-frontend-review/src/app.test.mjs
+++ b/packages/govuk-frontend-review/src/app.test.mjs
@@ -1,7 +1,7 @@
 import { load } from 'cheerio'
 import { ports } from 'govuk-frontend-config'
 import { fetchPath } from 'govuk-frontend-helpers/tests'
-import { getComponentNames } from 'govuk-frontend-lib/files'
+import { getComponentNames } from 'govuk-frontend-lib/components'
 
 const expectedPages = [
   '/',

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -1,5 +1,4 @@
-import { paths } from 'govuk-frontend-config'
-import { packageTypeToPath } from 'govuk-frontend-lib/names'
+import { renderComponent } from 'govuk-frontend-lib/components'
 import beautify from 'js-beautify'
 
 /**
@@ -11,13 +10,9 @@ import beautify from 'js-beautify'
  * @returns {string} HTML rendered by the component
  */
 export function getHTMLCode(componentName, params) {
-  const templatePath = packageTypeToPath('govuk-frontend', {
-    modulePath: `components/${componentName}/template.njk`,
-    moduleRoot: paths.app
+  const html = renderComponent(componentName, params, {
+    env: this.env
   })
-
-  // Render to HTML
-  const html = this.env.render(templatePath, { params }).trim()
 
   // Default beautify options
   const options = beautify.html.defaultOptions()

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs
@@ -7,8 +7,8 @@ import beautify from 'js-beautify'
  *
  * @this {{ env: import('nunjucks').Environment }}
  * @param {string} componentName - Component name
- * @param {unknown} params - Component macro params
- * @returns {string} Nunjucks code
+ * @param {MacroOptions} [params] - Nunjucks macro options (or params)
+ * @returns {string} HTML rendered by the component
  */
 export function getHTMLCode(componentName, params) {
   const templatePath = packageTypeToPath('govuk-frontend', {
@@ -32,3 +32,7 @@ export function getHTMLCode(componentName, params) {
     wrap_attributes: 'preserve'
   })
 }
+
+/**
+ * @typedef {import('govuk-frontend-lib/components').MacroOptions} MacroOptions
+ */

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -9,8 +9,8 @@ import { componentNameToMacroName } from '../filters/index.mjs'
  * Component Nunjucks code (formatted)
  *
  * @param {string} componentName - Component name
- * @param {unknown} params - Component macro params
- * @returns {string} Nunjucks code
+ * @param {MacroOptions} [params] - Nunjucks macro options (or params)
+ * @returns {string} Nunjucks code for the component
  */
 export function getNunjucksCode(componentName, params) {
   const macroName = componentNameToMacroName(componentName)
@@ -37,3 +37,7 @@ export function getNunjucksCode(componentName, params) {
     {{ ${macroFormatted.trim()} }}
   `
 }
+
+/**
+ * @typedef {import('govuk-frontend-lib/components').MacroOptions} MacroOptions
+ */

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -1,8 +1,7 @@
 import { join } from 'path'
 
 import { paths } from 'govuk-frontend-config'
-import { packageResolveToPath } from 'govuk-frontend-lib/names'
-import nunjucks from 'nunjucks'
+import { nunjucksEnv } from 'govuk-frontend-lib/components'
 
 import * as filters from './filters/index.mjs'
 import * as globals from './globals/index.mjs'
@@ -14,25 +13,11 @@ import * as globals from './globals/index.mjs'
  * @returns {import('nunjucks').Environment} Nunjucks Environment
  */
 export function renderer(app) {
-  const env = nunjucks.configure(
-    [
-      join(paths.app, 'src/views'),
-
-      // Remove `govuk/` suffix using `modulePath`
-      packageResolveToPath('govuk-frontend', {
-        modulePath: '../',
-        moduleRoot: paths.app
-      })
-    ],
-    {
-      autoescape: true, // output with dangerous characters are escaped automatically
-      express: app, // the Express.js review app that nunjucks should install to
-      noCache: true, // never use a cache and recompile templates each time
-      trimBlocks: true, // automatically remove trailing newlines from a block/tag
-      lstripBlocks: true, // automatically remove leading whitespace from a block/tag
-      watch: true // reload templates when they are changed. needs chokidar dependency to be installed
-    }
-  )
+  const env = nunjucksEnv([join(paths.app, 'src/views')], {
+    express: app, // the Express.js review app that nunjucks should install to
+    noCache: true, // never use a cache and recompile templates each time
+    watch: true // reload templates when they are changed. needs chokidar dependency to be installed
+  })
 
   // Set view engine
   app.set('view engine', 'njk')

--- a/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/index.mjs
@@ -13,11 +13,17 @@ import * as globals from './globals/index.mjs'
  * @returns {import('nunjucks').Environment} Nunjucks Environment
  */
 export function renderer(app) {
-  const env = nunjucksEnv([join(paths.app, 'src/views')], {
-    express: app, // the Express.js review app that nunjucks should install to
-    noCache: true, // never use a cache and recompile templates each time
-    watch: true // reload templates when they are changed. needs chokidar dependency to be installed
-  })
+  const env = nunjucksEnv(
+    [join(paths.app, 'src/views')],
+    {
+      express: app, // the Express.js review app that nunjucks should install to
+      noCache: true, // never use a cache and recompile templates each time
+      watch: true // reload templates when they are changed. needs chokidar dependency to be installed
+    },
+    {
+      moduleRoot: paths.app
+    }
+  )
 
   // Set view engine
   app.set('view engine', 'njk')

--- a/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
+++ b/packages/govuk-frontend/src/govuk-prototype-kit/govuk-prototype-kit.config.mjs
@@ -1,10 +1,7 @@
 import { join } from 'path'
 
-import {
-  filterPath,
-  getComponentNames,
-  getListing
-} from 'govuk-frontend-lib/files'
+import { getComponentNames } from 'govuk-frontend-lib/components'
+import { filterPath, getListing } from 'govuk-frontend-lib/files'
 import {
   componentNameToMacroName,
   packageNameToPath

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -19,7 +19,7 @@ import { Tabs } from './components/tabs/tabs.mjs'
  * Use the `data-module` attributes to find, instantiate and init all of the
  * components provided as part of GOV.UK Frontend.
  *
- * @param {Config} [config] - Config for all components
+ * @param {Config & { scope?: Element }} [config] - Config for all components (with optional scope)
  */
 function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
@@ -124,7 +124,6 @@ export {
  * Config for all components via `initAll()`
  *
  * @typedef {object} Config
- * @property {Element} [scope=document] - Scope to query for components
  * @property {AccordionConfig} [accordion] - Accordion config
  * @property {ButtonConfig} [button] - Button config
  * @property {CharacterCountConfig} [characterCount] - Character Count config

--- a/packages/govuk-frontend/src/govuk/components/accordion/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/accordion', () => {
   let axeRules

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.test.js
@@ -4,7 +4,7 @@ const {
   renderAndInitialise,
   getAccessibleName
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('/components/accordion', () => {
   describe('/components/accordion/preview', () => {

--- a/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Accordion', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/back-link/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/back-link/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/back-link', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/back-link/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/back-link/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('back-link component', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/breadcrumbs', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Breadcrumbs', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/button', () => {
   let axeRules

--- a/packages/govuk-frontend/src/govuk/components/button/button.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.test.js
@@ -3,7 +3,7 @@ const {
   goToComponent,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('/components/button', () => {
   let examples
@@ -92,9 +92,9 @@ describe('/components/button', () => {
                 counts.debounce++
                 el.dataset.debounceCount = `${counts.debounce}`
               }
-            },
 
-            // Add listener during capture phase to spy on event
+              // Add listener during capture phase to spy on event
+            },
             { capture: true }
           ),
         counts

--- a/packages/govuk-frontend/src/govuk/components/button/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Button', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/character-count/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/character-count', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -2,7 +2,7 @@ const {
   goToComponent,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Character count', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/checkboxes', () => {
   let axeRules

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.test.js
@@ -6,7 +6,7 @@ const {
   isVisible,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Checkboxes with conditional reveals', () => {
   describe('when JavaScript is unavailable or fails', () => {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -8,9 +8,6 @@ const {
   renderComponent
 } = require('govuk-frontend-lib/components')
 const { HtmlValidate } = require('html-validate')
-// We can't use the render function from jest-helpers, because we need control
-// over the nunjucks environment.
-const nunjucks = require('nunjucks')
 
 describe('Components', () => {
   let nunjucksEnvCustom
@@ -19,10 +16,10 @@ describe('Components', () => {
   let componentNames
 
   beforeAll(async () => {
-    // Create a new Nunjucks environment that uses the src directory as its
-    // base path, rather than the components folder itself
-    nunjucksEnvCustom = nunjucks.configure(join(paths.package, 'src/govuk'))
-    nunjucksEnvDefault = nunjucksEnv
+    // Create a new Nunjucks environment that uses the `src/govuk` directory as
+    // its first search path, rather than default to `src` (no 'govuk' prefix)
+    nunjucksEnvCustom = nunjucksEnv([join(paths.package, 'src/govuk')])
+    nunjucksEnvDefault = nunjucksEnv()
 
     // Components list
     componentNames = await getComponentNames()

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -1,10 +1,11 @@
 const { join } = require('path')
 
 const { paths } = require('govuk-frontend-config')
-const { nunjucksEnv, renderHTML } = require('govuk-frontend-helpers/nunjucks')
 const {
   getComponentsFixtures,
-  getComponentNames
+  getComponentNames,
+  nunjucksEnv,
+  renderHTML
 } = require('govuk-frontend-lib/components')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -5,7 +5,7 @@ const {
   getComponentsFixtures,
   getComponentNames,
   nunjucksEnv,
-  renderHTML
+  renderComponent
 } = require('govuk-frontend-lib/components')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control
@@ -139,7 +139,7 @@ describe('Components', () => {
       for (const { component: componentName, fixtures } of componentsFixtures) {
         const fixtureTasks = fixtures.map(
           async ({ name: exampleName, options }) => {
-            const html = renderHTML(componentName, options)
+            const html = renderComponent(componentName, options)
 
             // Validate HTML
             return expect({

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -5,7 +5,7 @@ const { nunjucksEnv, renderHTML } = require('govuk-frontend-helpers/nunjucks')
 const {
   getComponentsFixtures,
   getComponentNames
-} = require('govuk-frontend-lib/files')
+} = require('govuk-frontend-lib/components')
 const { HtmlValidate } = require('html-validate')
 // We can't use the render function from jest-helpers, because we need control
 // over the nunjucks environment.

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/cookie-banner', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Cookie Banner', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/date-input/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/date-input/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/date-input', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/details/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/details/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/details', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/details/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/details/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Details', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/details/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/details/template.test.js
@@ -45,7 +45,13 @@ describe('Details', () => {
   })
 
   it('renders nested components using `call`', () => {
-    const $ = render('details', {}, '<div class="app-nested-component"></div>')
+    const $ = render(
+      'details',
+      {},
+      {
+        callBlock: '<div class="app-nested-component"></div>'
+      }
+    )
 
     expect($('.govuk-details .app-nested-component').length).toBeTruthy()
   })

--- a/packages/govuk-frontend/src/govuk/components/error-message/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-message/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/error-message', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-message/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Error message', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/error-summary', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.test.js
@@ -4,7 +4,7 @@ const {
   renderAndInitialise,
   goTo
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Error Summary', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
@@ -91,7 +91,9 @@ describe('Error-summary', () => {
       const $ = render(
         'error-summary',
         {},
-        '<div class="app-nested-component"></div>'
+        {
+          callBlock: '<div class="app-nested-component"></div>'
+        }
       )
 
       expect(

--- a/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Error-summary', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/exit-this-page', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.test.js
@@ -3,7 +3,7 @@ const {
   goToExample,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const buttonClass = '.govuk-js-exit-this-page-button'
 const skiplinkClass = '.govuk-js-exit-this-page-skiplink'

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Exit this page', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/fieldset', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('fieldset', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
@@ -73,7 +73,13 @@ describe('fieldset', () => {
   })
 
   it('renders nested components using `call`', () => {
-    const $ = render('fieldset', {}, '<div class="app-nested-component"></div>')
+    const $ = render(
+      'fieldset',
+      {},
+      {
+        callBlock: '<div class="app-nested-component"></div>'
+      }
+    )
 
     expect($('.govuk-fieldset .app-nested-component').length).toBeTruthy()
   })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/file-upload', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/footer/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/footer/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/footer', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/footer/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('footer', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/header/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/header', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/header/header.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.test.js
@@ -2,7 +2,7 @@ const {
   goToComponent,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']

--- a/packages/govuk-frontend/src/govuk/components/header/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('header', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/hint/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/hint/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/hint', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/hint/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/hint/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Hint', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/input/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/input/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/input', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/inset-text', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Inset text', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/template.test.js
@@ -29,7 +29,9 @@ describe('Inset text', () => {
       const $ = render(
         'inset-text',
         {},
-        '<div class="app-nested-component"></div>'
+        {
+          callBlock: '<div class="app-nested-component"></div>'
+        }
       )
 
       expect($('.govuk-inset-text .app-nested-component').length).toBeTruthy()

--- a/packages/govuk-frontend/src/govuk/components/label/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/label/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/label', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/label/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/label/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Label', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/notification-banner', () => {
   let axeRules

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.test.js
@@ -2,7 +2,7 @@ const {
   renderAndInitialise,
   goToComponent
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Notification banner', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
@@ -172,7 +172,9 @@ describe('Notification-banner', () => {
       const $ = render(
         'notification-banner',
         {},
-        '<div class="app-nested-component"></div>'
+        {
+          callBlock: '<div class="app-nested-component"></div>'
+        }
       )
 
       expect(

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Notification-banner', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/pagination/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/pagination/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/pagination', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Pagination', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/panel', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -63,7 +63,13 @@ describe('Panel', () => {
     })
 
     it('renders nested components using `call`', () => {
-      const $ = render('panel', {}, '<div class="app-nested-component"></div>')
+      const $ = render(
+        'panel',
+        {},
+        {
+          callBlock: '<div class="app-nested-component"></div>'
+        }
+      )
 
       expect($('.govuk-panel .app-nested-component').length).toBeTruthy()
     })

--- a/packages/govuk-frontend/src/govuk/components/panel/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/panel/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Panel', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/phase-banner', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Phase banner', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/radios/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/radios', () => {
   let axeRules

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.test.js
@@ -6,7 +6,7 @@ const {
   isVisible,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Radios', () => {
   describe('with conditional reveals', () => {

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/select/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/select/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/select', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/skip-link', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -2,7 +2,7 @@ const {
   goToExample,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Skip Link', () => {
   describe('/examples/template-default', () => {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Skip link', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/summary-list', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Summary list', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/table/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/table/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/table', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/table/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/table/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Table', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/tabs', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.test.js
@@ -3,7 +3,7 @@ const {
   goToComponent,
   renderAndInitialise
 } = require('govuk-frontend-helpers/puppeteer')
-const { getExamples } = require('govuk-frontend-lib/files.js')
+const { getExamples } = require('govuk-frontend-lib/components')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']

--- a/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Tabs', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/tag/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tag/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/tag', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/tag/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tag/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Tag', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/task-list/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/task-list/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/task-list', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/task-list/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Task List', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/components/textarea/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/textarea/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/textarea', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -1,6 +1,6 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
 const { htmlWithClassName } = require('govuk-frontend-helpers/tests')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 const WORD_BOUNDARY = '\\b'
 const WHITESPACE = '\\s'

--- a/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.test.mjs
@@ -1,5 +1,5 @@
 import { axe, goToComponent } from 'govuk-frontend-helpers/puppeteer'
-import { getExamples } from 'govuk-frontend-lib/files'
+import { getExamples } from 'govuk-frontend-lib/components'
 
 describe('/components/warning-text', () => {
   describe('component examples', () => {

--- a/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/template.test.js
@@ -1,5 +1,5 @@
 const { render } = require('govuk-frontend-helpers/nunjucks')
-const { getExamples } = require('govuk-frontend-lib/files')
+const { getExamples } = require('govuk-frontend-lib/components')
 
 describe('Warning text', () => {
   let examples

--- a/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/macros/i18n.unit.test.mjs
@@ -1,4 +1,4 @@
-import { renderMacro } from 'govuk-frontend-helpers/nunjucks'
+import { renderMacro } from 'govuk-frontend-lib/components'
 
 describe('i18n.njk', () => {
   describe('govukI18nAttributes', () => {

--- a/packages/govuk-frontend/src/govuk/template.test.js
+++ b/packages/govuk-frontend/src/govuk/template.test.js
@@ -1,26 +1,29 @@
 const crypto = require('crypto')
-const { join } = require('path')
 
-const { paths } = require('govuk-frontend-config')
 const { renderTemplate } = require('govuk-frontend-helpers/nunjucks')
-const nunjucks = require('nunjucks')
+const { nunjucksEnv } = require('govuk-frontend-lib/components')
 
 describe('Template', () => {
   describe('with default nunjucks configuration', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(join(paths.package, 'src/govuk'))
-      const output = nunjucks.render('./template.njk')
+      const env = nunjucksEnv([], {
+        trimBlocks: false,
+        lstripBlocks: false
+      })
+
+      const output = env.render('./govuk/template.njk')
       expect(output.charAt(0)).toEqual('<')
     })
   })
 
   describe('with nunjucks block trimming enabled', () => {
     it('should not have any whitespace before the doctype', () => {
-      nunjucks.configure(join(paths.package, 'src/govuk'), {
+      const env = nunjucksEnv([], {
         trimBlocks: true,
         lstripBlocks: true
       })
-      const output = nunjucks.render('./template.njk')
+
+      const output = env.render('./govuk/template.njk')
       expect(output.charAt(0)).toEqual('<')
     })
   })

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -3,7 +3,10 @@ import { join } from 'path'
 
 import { paths, pkg } from 'govuk-frontend-config'
 import { compileSassFile } from 'govuk-frontend-helpers/tests'
-import { getComponentNames } from 'govuk-frontend-lib/components'
+import {
+  getComponentNames,
+  getComponentNamesFiltered
+} from 'govuk-frontend-lib/components'
 import { filterPath, getListing, mapPathTo } from 'govuk-frontend-lib/files'
 import { componentNameToClassName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
@@ -44,7 +47,7 @@ describe('packages/govuk-frontend/dist/', () => {
     componentNames = await getComponentNames()
 
     // Components list (with JavaScript only)
-    componentNamesWithJavaScript = await getComponentNames(
+    componentNamesWithJavaScript = await getComponentNamesFiltered(
       (componentName, componentFiles) =>
         componentFiles.some(filterPath([`**/${componentName}.mjs`]))
     )

--- a/packages/govuk-frontend/tasks/build/package.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.test.mjs
@@ -3,12 +3,8 @@ import { join } from 'path'
 
 import { paths, pkg } from 'govuk-frontend-config'
 import { compileSassFile } from 'govuk-frontend-helpers/tests'
-import {
-  filterPath,
-  getComponentNames,
-  getListing,
-  mapPathTo
-} from 'govuk-frontend-lib/files'
+import { getComponentNames } from 'govuk-frontend-lib/components'
+import { filterPath, getListing, mapPathTo } from 'govuk-frontend-lib/files'
 import { componentNameToClassName } from 'govuk-frontend-lib/names'
 import { outdent } from 'outdent'
 

--- a/packages/govuk-frontend/tasks/fixtures.mjs
+++ b/packages/govuk-frontend/tasks/fixtures.mjs
@@ -1,5 +1,3 @@
-import { join } from 'path'
-
 import { components, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 
@@ -14,19 +12,13 @@ export const compile = (options) =>
      * Generate GOV.UK Frontend fixtures.json from ${componentName}.yaml
      */
     task.name('compile:fixtures', () =>
-      components.generateFixtures('**/*.yaml', {
-        srcPath: join(options.srcPath, 'govuk/components'),
-        destPath: join(options.destPath, 'govuk/components')
-      })
+      components.generateFixtures('**/*.yaml', options)
     ),
 
     /**
      * Generate GOV.UK Frontend macro-options.json from ${componentName}.yaml
      */
     task.name('compile:macro-options', () =>
-      components.generateMacroOptions('**/*.yaml', {
-        srcPath: join(options.srcPath, 'govuk/components'),
-        destPath: join(options.destPath, 'govuk/components')
-      })
+      components.generateMacroOptions('**/*.yaml', options)
     )
   )

--- a/packages/govuk-frontend/tasks/fixtures.mjs
+++ b/packages/govuk-frontend/tasks/fixtures.mjs
@@ -4,7 +4,7 @@ import { components, task } from 'govuk-frontend-tasks'
 import gulp from 'gulp'
 
 /**
- * Component data and macro fixtures (for watch)
+ * Component fixtures and macro options (for watch)
  *
  * @type {import('govuk-frontend-tasks').TaskFunction}
  */

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -13,11 +13,11 @@ const env = nunjucksEnv()
  *
  * @param {string} componentName - Component name
  * @param {MacroOptions} [params] - Nunjucks macro options (or params)
- * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {import('cheerio').CheerioAPI} HTML rendered by the macro
  */
-function render(componentName, params, callBlock) {
-  return cheerio.load(renderComponent(componentName, params, callBlock))
+function render(componentName, params, options) {
+  return cheerio.load(renderComponent(componentName, params, options))
 }
 
 /**
@@ -48,4 +48,5 @@ module.exports = {
 
 /**
  * @typedef {import('govuk-frontend-lib/components').MacroOptions} MacroOptions
+ * @typedef {import('govuk-frontend-lib/components').MacroRenderOptions} MacroRenderOptions
  */

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -5,6 +5,9 @@ const {
 } = require('govuk-frontend-lib/components')
 const { outdent } = require('outdent')
 
+// Nunjucks default environment
+const env = nunjucksEnv()
+
 /**
  * Render component HTML into cheerio
  *
@@ -36,7 +39,7 @@ function renderTemplate(context = {}, blocks = {}) {
       {%- endblock %}`
   }
 
-  return cheerio.load(nunjucksEnv.renderString(viewString, context))
+  return cheerio.load(env.renderString(viewString, context))
 }
 
 module.exports = {

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -12,13 +12,12 @@ const env = nunjucksEnv()
  * Render component HTML into cheerio
  *
  * @param {string} componentName - Component name
- * @param {object} options - options to pass to the component macro
- * @param {string} [callBlock] - if provided, the macro is called using the
- *   Nunjucks call tag, with the callBlock passed as the contents of the block
+ * @param {MacroOptions} [params] - Nunjucks macro options (or params)
+ * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
  * @returns {import('cheerio').CheerioAPI} HTML rendered by the macro
  */
-function render(componentName, options, callBlock) {
-  return cheerio.load(renderComponent(componentName, options, callBlock))
+function render(componentName, params, callBlock) {
+  return cheerio.load(renderComponent(componentName, params, callBlock))
 }
 
 /**
@@ -46,3 +45,7 @@ module.exports = {
   render,
   renderTemplate
 }
+
+/**
+ * @typedef {import('govuk-frontend-lib/components').MacroOptions} MacroOptions
+ */

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -1,35 +1,6 @@
-const { join } = require('path')
-
 const cheerio = require('cheerio')
-const {
-  componentNameToMacroName,
-  packageNameToPath
-} = require('govuk-frontend-lib/names')
-const nunjucks = require('nunjucks')
+const { nunjucksEnv, renderHTML } = require('govuk-frontend-lib/components')
 const { outdent } = require('outdent')
-
-const nunjucksPaths = [join(packageNameToPath('govuk-frontend'), 'src')]
-
-const nunjucksEnv = nunjucks.configure(nunjucksPaths, {
-  trimBlocks: true,
-  lstripBlocks: true
-})
-
-/**
- * Render component HTML
- *
- * @param {string} componentName - Component name
- * @param {{ [key: string]: unknown }} options - options to pass to the component macro
- * @param {string} [callBlock] - if provided, the macro is called using the
- *   Nunjucks call tag, with the callBlock passed as the contents of the block
- * @returns {string} HTML rendered by the macro
- */
-function renderHTML(componentName, options, callBlock) {
-  const macroName = componentNameToMacroName(componentName)
-  const macroPath = `govuk/components/${componentName}/macro.njk`
-
-  return renderMacro(macroName, macroPath, options, callBlock)
-}
 
 /**
  * Render component HTML into cheerio
@@ -42,29 +13,6 @@ function renderHTML(componentName, options, callBlock) {
  */
 function render(componentName, options, callBlock) {
   return cheerio.load(renderHTML(componentName, options, callBlock))
-}
-
-/**
- * Render the string result from calling a macro
- *
- * @param {string} macroName - The name of the macro
- * @param {string} macroPath - The path to the file containing the macro
- * @param {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
- * @param {string} [callBlock] - Content for an optional callBlock, if necessary for the macro to receive one
- * @returns {string} The result of calling the macro
- */
-function renderMacro(macroName, macroPath, options = {}, callBlock) {
-  const macroOptions = JSON.stringify(options, undefined, 2)
-
-  let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
-
-  // If we're nesting child components or text, pass the children to the macro
-  // using the 'caller' Nunjucks feature
-  macroString += callBlock
-    ? `{%- call ${macroName}(${macroOptions}) -%}${callBlock}{%- endcall -%}`
-    : `{{- ${macroName}(${macroOptions}) -}}`
-
-  return nunjucksEnv.renderString(macroString, {})
 }
 
 /**
@@ -89,9 +37,6 @@ function renderTemplate(context = {}, blocks = {}) {
 }
 
 module.exports = {
-  nunjucksEnv,
   render,
-  renderHTML,
-  renderMacro,
   renderTemplate
 }

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -1,12 +1,9 @@
 const cheerio = require('cheerio')
 const {
-  nunjucksEnv,
-  renderComponent
+  renderComponent,
+  renderString
 } = require('govuk-frontend-lib/components')
 const { outdent } = require('outdent')
-
-// Nunjucks default environment
-const env = nunjucksEnv()
 
 /**
  * Render component HTML into cheerio
@@ -38,7 +35,7 @@ function renderTemplate(context = {}, blocks = {}) {
       {%- endblock %}`
   }
 
-  return cheerio.load(env.renderString(viewString, context))
+  return cheerio.load(renderString(viewString, context))
 }
 
 module.exports = {

--- a/shared/helpers/nunjucks.js
+++ b/shared/helpers/nunjucks.js
@@ -1,5 +1,8 @@
 const cheerio = require('cheerio')
-const { nunjucksEnv, renderHTML } = require('govuk-frontend-lib/components')
+const {
+  nunjucksEnv,
+  renderComponent
+} = require('govuk-frontend-lib/components')
 const { outdent } = require('outdent')
 
 /**
@@ -12,7 +15,7 @@ const { outdent } = require('outdent')
  * @returns {import('cheerio').CheerioAPI} HTML rendered by the macro
  */
 function render(componentName, options, callBlock) {
-  return cheerio.load(renderHTML(componentName, options, callBlock))
+  return cheerio.load(renderComponent(componentName, options, callBlock))
 }
 
 /**

--- a/shared/helpers/package.json
+++ b/shared/helpers/package.json
@@ -24,7 +24,6 @@
     "jest-environment-jsdom": "^29.6.2",
     "jest-environment-node-single-context": "^29.1.0",
     "jest-environment-puppeteer": "^9.0.0",
-    "nunjucks": "^3.2.4",
     "outdent": "^0.8.0",
     "puppeteer": "^21.0.1",
     "sass-embedded": "^1.64.2",

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -1,9 +1,8 @@
 const { AxePuppeteer } = require('@axe-core/puppeteer')
 const { ports } = require('govuk-frontend-config')
+const { renderHTML } = require('govuk-frontend-lib/components')
 const { componentNameToClassName } = require('govuk-frontend-lib/names')
 const slug = require('slug')
-
-const { renderHTML } = require('./nunjucks')
 
 /**
  * Axe Puppeteer reporter

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -71,8 +71,8 @@ async function axe(page, overrides = {}) {
  * @param {import('puppeteer').Page} page - Puppeteer page object
  * @param {string} componentName - The kebab-cased name of the component
  * @param {object} options - Render and initialise options
- * @param {object} options.params - Nunjucks macro params
- * @param {object} [options.config] - Component instantiation config
+ * @param {MacroOptions} [options.params] - Nunjucks macro options (or params)
+ * @param {Config[ConfigKey]} [options.config] - Component config (optional)
  * @param {($module: Element) => void} [options.beforeInitialisation] - A function that'll run in the browser
  *   before the component gets initialised
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
@@ -250,3 +250,9 @@ module.exports = {
   getAccessibleName,
   isVisible
 }
+
+/**
+ * @typedef {import('govuk-frontend-lib/components').MacroOptions} MacroOptions
+ * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
+ * @typedef {keyof Config} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
+ */

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -1,6 +1,6 @@
 const { AxePuppeteer } = require('@axe-core/puppeteer')
 const { ports } = require('govuk-frontend-config')
-const { renderHTML } = require('govuk-frontend-lib/components')
+const { renderComponent } = require('govuk-frontend-lib/components')
 const { componentNameToClassName } = require('govuk-frontend-lib/names')
 const slug = require('slug')
 
@@ -80,7 +80,7 @@ async function axe(page, overrides = {}) {
 async function renderAndInitialise(page, componentName, options) {
   await goTo(page, '/tests/boilerplate')
 
-  const html = renderHTML(componentName, options.params)
+  const html = renderComponent(componentName, options.params)
 
   // Inject rendered HTML into the page
   await page.$eval(

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -1,0 +1,141 @@
+const { join } = require('path')
+
+const { getListing, getDirectories } = require('./files')
+const { packageNameToPath } = require('./names')
+
+/**
+ * Load single component fixtures
+ *
+ * @param {string} componentName - Component name
+ * @returns {Promise<ComponentFixtures>} Component data
+ */
+const getComponentFixtures = async (componentName) => {
+  return require(join(
+    packageNameToPath('govuk-frontend'),
+    `dist/govuk/components/${componentName}/fixtures.json`
+  ))
+}
+
+/**
+ * Load all components' data
+ *
+ * @returns {Promise<(ComponentFixtures)[]>} Components' data
+ */
+const getComponentsFixtures = async () => {
+  const componentNames = await getComponentNames()
+  return Promise.all(componentNames.map(getComponentFixtures))
+}
+
+/**
+ * Get component files
+ *
+ * @param {string} [componentName] - Component name
+ * @returns {Promise<string[]>} Component files
+ */
+const getComponentFiles = (componentName = '') =>
+  getListing(
+    join(
+      packageNameToPath('govuk-frontend'),
+      `dist/govuk/components/${componentName}/**/*`
+    )
+  )
+
+/**
+ * Get component names (with optional filter)
+ *
+ * @param {(componentName: string, componentFiles: string[]) => boolean} [filter] - Component names array filter
+ * @returns {Promise<string[]>} Component names
+ */
+const getComponentNames = async (filter) => {
+  const componentNames = await getDirectories(
+    join(packageNameToPath('govuk-frontend'), '**/dist/govuk/components/')
+  )
+
+  if (filter) {
+    const componentFiles = await getComponentFiles()
+
+    // Apply component names filter
+    return componentNames.filter((componentName) =>
+      filter(componentName, componentFiles)
+    )
+  }
+
+  return componentNames
+}
+
+/**
+ * Get examples from component fixtures
+ *
+ * @param {string} componentName - Component name
+ * @returns {Promise<{ [name: string]: ComponentFixture['options'] }>} Component examples as an object
+ */
+async function getExamples(componentName) {
+  const { fixtures } = await getComponentFixtures(componentName)
+
+  /** @type {{ [name: string]: ComponentFixture['options'] }} */
+  const examples = {}
+
+  for (const example of fixtures) {
+    examples[example.name] = example.options
+  }
+
+  return examples
+}
+
+module.exports = {
+  getComponentFixtures,
+  getComponentsFixtures,
+  getComponentFiles,
+  getComponentNames,
+  getExamples
+}
+
+/**
+ * Component data
+ *
+ * @typedef {object} ComponentData
+ * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
+ * @property {ComponentExample[]} [examples] - Component examples with Nunjucks macro options (or params)
+ * @property {string} [previewLayout] - Nunjucks layout for component preview
+ * @property {string} [accessibilityCriteria] - Accessibility criteria
+ */
+
+/**
+ * Nunjucks macro option (or param) config
+ *
+ * @typedef {object} ComponentOption
+ * @property {string} name - Option name
+ * @property {'array' | 'boolean' | 'integer' | 'nunjucks-block' | 'object' | 'string'} type - Option type
+ * @property {boolean} required - Option required
+ * @property {string} description - Option description
+ * @property {boolean} [isComponent] - Option is another component
+ * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
+ */
+
+/**
+ * Component examples with Nunjucks macro options (or params)
+ *
+ * @typedef {object} ComponentExample
+ * @property {string} name - Example name
+ * @property {string} [description] - Example description
+ * @property {boolean} [hidden] - Example hidden from review app
+ * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
+ * @property {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
+ */
+
+/**
+ * Component fixture
+ * (used by the Design System website)
+ *
+ * @typedef {Required<ComponentExample> & { html: string }} ComponentFixture
+ */
+
+/**
+ * Component fixtures
+ * (used by the Design System website)
+ *
+ * @typedef {object} ComponentFixtures
+ * @property {string} component - Component name
+ * @property {ComponentFixture[]} fixtures - Component fixtures with Nunjucks macro options (or params)
+ * @property {string} [previewLayout] - Nunjucks layout for component preview
+ */

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -147,7 +147,7 @@ function renderMacro(macroName, macroPath, params = {}, options) {
     ? `{%- call ${macroName}(${paramsFormatted}) -%}${options.callBlock}{%- endcall -%}`
     : `{{- ${macroName}(${paramsFormatted}) -}}`
 
-  return renderString(macroString)
+  return renderString(macroString, {}, options)
 }
 
 /**
@@ -155,10 +155,12 @@ function renderMacro(macroName, macroPath, params = {}, options) {
  *
  * @param {string} string - Nunjucks string to render
  * @param {object} [context] - Nunjucks context object (optional)
+ * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {string} HTML rendered from the Nunjucks string
  */
-function renderString(string, context) {
-  return env.renderString(string, context)
+function renderString(string, context, options) {
+  const nunjucksEnv = options?.env ?? env
+  return nunjucksEnv.renderString(string, context)
 }
 
 module.exports = {
@@ -225,6 +227,7 @@ module.exports = {
  *
  * @typedef {object} MacroRenderOptions
  * @property {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @property {import('nunjucks').Environment} [env] - Nunjucks environment (optional)
  */
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -143,7 +143,18 @@ function renderMacro(macroName, macroPath, params = {}, options) {
     ? `{%- call ${macroName}(${paramsFormatted}) -%}${options.callBlock}{%- endcall -%}`
     : `{{- ${macroName}(${paramsFormatted}) -}}`
 
-  return env.renderString(macroString, {})
+  return renderString(macroString)
+}
+
+/**
+ * Render string
+ *
+ * @param {string} string - Nunjucks string to render
+ * @param {object} [context] - Nunjucks context object (optional)
+ * @returns {string} HTML rendered from the Nunjucks string
+ */
+function renderString(string, context) {
+  return env.renderString(string, context)
 }
 
 module.exports = {
@@ -154,7 +165,8 @@ module.exports = {
   getExamples,
   nunjucksEnv,
   renderComponent,
-  renderMacro
+  renderMacro,
+  renderString
 }
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -112,37 +112,36 @@ async function getExamples(componentName) {
  * Render component HTML
  *
  * @param {string} componentName - Component name
- * @param {{ [key: string]: unknown }} options - Nunjucks macro options (or params)
- * @param {string} [callBlock] - if provided, the macro is called using the
- *   Nunjucks call tag, with the callBlock passed as the contents of the block
- * @returns {string} HTML rendered by the macro
+ * @param {MacroOptions} [params] - Nunjucks macro options (or params)
+ * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @returns {string} HTML rendered by the component
  */
-function renderComponent(componentName, options, callBlock) {
+function renderComponent(componentName, params, callBlock) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  return renderMacro(macroName, macroPath, options, callBlock)
+  return renderMacro(macroName, macroPath, params, callBlock)
 }
 
 /**
- * Render the string result from calling a macro
+ * Render macro HTML
  *
  * @param {string} macroName - The name of the macro
  * @param {string} macroPath - The path to the file containing the macro
- * @param {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
- * @param {string} [callBlock] - Content for an optional callBlock, if necessary for the macro to receive one
- * @returns {string} The result of calling the macro
+ * @param {MacroOptions} [params] - Nunjucks macro options (or params)
+ * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @returns {string} HTML rendered by the macro
  */
-function renderMacro(macroName, macroPath, options = {}, callBlock) {
-  const macroOptions = JSON.stringify(options, undefined, 2)
+function renderMacro(macroName, macroPath, params = {}, callBlock) {
+  const paramsFormatted = JSON.stringify(params, undefined, 2)
 
   let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
 
   // If we're nesting child components or text, pass the children to the macro
   // using the 'caller' Nunjucks feature
   macroString += callBlock
-    ? `{%- call ${macroName}(${macroOptions}) -%}${callBlock}{%- endcall -%}`
-    : `{{- ${macroName}(${macroOptions}) -}}`
+    ? `{%- call ${macroName}(${paramsFormatted}) -%}${callBlock}{%- endcall -%}`
+    : `{{- ${macroName}(${paramsFormatted}) -}}`
 
   return env.renderString(macroString, {})
 }
@@ -188,7 +187,13 @@ module.exports = {
  * @property {string} [description] - Example description
  * @property {boolean} [hidden] - Example hidden from review app
  * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
- * @property {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
+ * @property {MacroOptions} options - Nunjucks macro options (or params)
+ */
+
+/**
+ * Nunjucks macro options
+ *
+ * @typedef {{ [param: string]: unknown }} MacroOptions
  */
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -113,14 +113,14 @@ async function getExamples(componentName) {
  *
  * @param {string} componentName - Component name
  * @param {MacroOptions} [params] - Nunjucks macro options (or params)
- * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {string} HTML rendered by the component
  */
-function renderComponent(componentName, params, callBlock) {
+function renderComponent(componentName, params, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  return renderMacro(macroName, macroPath, params, callBlock)
+  return renderMacro(macroName, macroPath, params, options)
 }
 
 /**
@@ -129,18 +129,18 @@ function renderComponent(componentName, params, callBlock) {
  * @param {string} macroName - The name of the macro
  * @param {string} macroPath - The path to the file containing the macro
  * @param {MacroOptions} [params] - Nunjucks macro options (or params)
- * @param {string} [callBlock] - Nunjucks macro `caller()` content (optional)
+ * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {string} HTML rendered by the macro
  */
-function renderMacro(macroName, macroPath, params = {}, callBlock) {
+function renderMacro(macroName, macroPath, params = {}, options) {
   const paramsFormatted = JSON.stringify(params, undefined, 2)
 
   let macroString = `{%- from "${macroPath}" import ${macroName} -%}`
 
   // If we're nesting child components or text, pass the children to the macro
   // using the 'caller' Nunjucks feature
-  macroString += callBlock
-    ? `{%- call ${macroName}(${paramsFormatted}) -%}${callBlock}{%- endcall -%}`
+  macroString += options?.callBlock
+    ? `{%- call ${macroName}(${paramsFormatted}) -%}${options.callBlock}{%- endcall -%}`
     : `{{- ${macroName}(${paramsFormatted}) -}}`
 
   return env.renderString(macroString, {})
@@ -201,6 +201,13 @@ module.exports = {
  * (used by the Design System website)
  *
  * @typedef {Required<ComponentExample> & { html: string }} ComponentFixture
+ */
+
+/**
+ * Nunjucks macro render options
+ *
+ * @typedef {object} MacroRenderOptions
+ * @property {string} [callBlock] - Nunjucks macro `caller()` content (optional)
  */
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -58,7 +58,7 @@ const getComponentsFixtures = async () => {
  * @param {string} [componentName] - Component name
  * @returns {Promise<string[]>} Component files
  */
-const getComponentFiles = (componentName = '') =>
+const getComponentFiles = (componentName = '*') =>
   getListing(
     join(
       packageNameToPath('govuk-frontend'),

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -101,7 +101,7 @@ async function getExamples(componentName) {
  *   Nunjucks call tag, with the callBlock passed as the contents of the block
  * @returns {string} HTML rendered by the macro
  */
-function renderHTML(componentName, options, callBlock) {
+function renderComponent(componentName, options, callBlock) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
@@ -138,7 +138,7 @@ module.exports = {
   getComponentNames,
   getExamples,
   nunjucksEnv,
-  renderHTML,
+  renderComponent,
   renderMacro
 }
 

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -67,26 +67,30 @@ const getComponentFiles = (componentName = '') =>
   )
 
 /**
- * Get component names (with optional filter)
+ * Get component names
  *
- * @param {(componentName: string, componentFiles: string[]) => boolean} [filter] - Component names array filter
  * @returns {Promise<string[]>} Component names
  */
-const getComponentNames = async (filter) => {
-  const componentNames = await getDirectories(
+async function getComponentNames() {
+  return getDirectories(
     join(packageNameToPath('govuk-frontend'), '**/dist/govuk/components/')
   )
+}
 
-  if (filter) {
-    const componentFiles = await getComponentFiles()
+/**
+ * Get component names, filtered
+ *
+ * @param {(componentName: string, componentFiles: string[]) => boolean} filter - Component names array filter
+ * @returns {Promise<string[]>} Component names
+ */
+async function getComponentNamesFiltered(filter) {
+  const componentNames = await getComponentNames()
+  const componentFiles = await getComponentFiles()
 
-    // Apply component names filter
-    return componentNames.filter((componentName) =>
-      filter(componentName, componentFiles)
-    )
-  }
-
-  return componentNames
+  // Apply component names filter
+  return componentNames.filter((componentName) =>
+    filter(componentName, componentFiles)
+  )
 }
 
 /**
@@ -162,6 +166,7 @@ module.exports = {
   getComponentsFixtures,
   getComponentFiles,
   getComponentNames,
+  getComponentNamesFiltered,
   getExamples,
   nunjucksEnv,
   renderComponent,

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -5,13 +5,29 @@ const nunjucks = require('nunjucks')
 const { getListing, getDirectories } = require('./files')
 const { packageNameToPath, componentNameToMacroName } = require('./names')
 
-const nunjucksEnv = nunjucks.configure(
-  [join(packageNameToPath('govuk-frontend'), 'src')],
-  {
-    trimBlocks: true,
-    lstripBlocks: true
-  }
-)
+// Nunjucks default environment
+const env = nunjucksEnv()
+
+/**
+ * Nunjucks environment factory
+ *
+ * @param {string[]} [searchPaths] - Nunjucks search paths (optional)
+ * @param {import('nunjucks').ConfigureOptions} [nunjucksOptions] - Nunjucks options (optional)
+ * @returns {import('nunjucks').Environment} Nunjucks environment
+ */
+function nunjucksEnv(searchPaths = [], nunjucksOptions = {}) {
+  const packagePath = packageNameToPath('govuk-frontend')
+
+  // Add to Nunjucks search paths
+  searchPaths.push(join(packagePath, 'src'))
+
+  // Nunjucks environment
+  return nunjucks.configure(searchPaths, {
+    trimBlocks: true, // automatically remove trailing newlines from a block/tag
+    lstripBlocks: true, // automatically remove leading whitespace from a block/tag,
+    ...nunjucksOptions
+  })
+}
 
 /**
  * Load single component fixtures
@@ -128,7 +144,7 @@ function renderMacro(macroName, macroPath, options = {}, callBlock) {
     ? `{%- call ${macroName}(${macroOptions}) -%}${callBlock}{%- endcall -%}`
     : `{{- ${macroName}(${macroOptions}) -}}`
 
-  return nunjucksEnv.renderString(macroString, {})
+  return env.renderString(macroString, {})
 }
 
 module.exports = {

--- a/shared/lib/components.unit.test.js
+++ b/shared/lib/components.unit.test.js
@@ -1,4 +1,4 @@
-const { getComponentFixtures } = require('./files.js')
+const { getComponentFixtures } = require('./components.js')
 
 describe('getComponentFixtures', () => {
   it('rejects if unable to load component fixtures', async () => {

--- a/shared/lib/files.js
+++ b/shared/lib/files.js
@@ -1,13 +1,11 @@
 const { readFile } = require('fs/promises')
-const { join, parse, relative, basename } = require('path')
+const { parse, relative, basename } = require('path')
 
 const { glob } = require('glob')
 const { paths } = require('govuk-frontend-config')
 const yaml = require('js-yaml')
 const { minimatch } = require('minimatch')
 const slash = require('slash')
-
-const { packageNameToPath } = require('./names')
 
 /**
  * Directory listing for path
@@ -16,7 +14,7 @@ const { packageNameToPath } = require('./names')
  * @param {import('glob').GlobOptionsWithFileTypesUnset} [options] - Glob options
  * @returns {Promise<string[]>} File paths
  */
-const getListing = async (directoryPath, options = {}) => {
+async function getListing(directoryPath, options = {}) {
   const listing = await glob(slash(directoryPath), {
     absolute: true,
     nodir: true,
@@ -38,7 +36,7 @@ const getListing = async (directoryPath, options = {}) => {
  * @param {string} directoryPath - Minimatch pattern to directory
  * @returns {Promise<string[]>} Directory names
  */
-const getDirectories = async (directoryPath) => {
+async function getDirectories(directoryPath) {
   const listing = await getListing(`${slash(directoryPath)}/*/`, {
     nodir: false
   })
@@ -79,148 +77,14 @@ const mapPathTo = (patterns, callback) => (entryPath) => {
  * @param {string} configPath - File path to config
  * @returns {Promise<any>} Config from YAML file
  */
-const getYaml = async (configPath) => {
+async function getYaml(configPath) {
   return yaml.load(await readFile(configPath, 'utf8'), { json: true })
-}
-
-/**
- * Load single component fixtures
- *
- * @param {string} componentName - Component name
- * @returns {Promise<ComponentFixtures>} Component data
- */
-const getComponentFixtures = async (componentName) => {
-  return require(join(
-    packageNameToPath('govuk-frontend'),
-    `dist/govuk/components/${componentName}/fixtures.json`
-  ))
-}
-
-/**
- * Load all components' data
- *
- * @returns {Promise<(ComponentFixtures)[]>} Components' data
- */
-const getComponentsFixtures = async () => {
-  const componentNames = await getComponentNames()
-  return Promise.all(componentNames.map(getComponentFixtures))
-}
-
-/**
- * Get component files
- *
- * @param {string} [componentName] - Component name
- * @returns {Promise<string[]>} Component files
- */
-const getComponentFiles = (componentName = '') =>
-  getListing(
-    join(
-      packageNameToPath('govuk-frontend'),
-      `dist/govuk/components/${componentName}/**/*`
-    )
-  )
-
-/**
- * Get component names (with optional filter)
- *
- * @param {(componentName: string, componentFiles: string[]) => boolean} [filter] - Component names array filter
- * @returns {Promise<string[]>} Component names
- */
-const getComponentNames = async (filter) => {
-  const componentNames = await getDirectories(
-    join(packageNameToPath('govuk-frontend'), '**/dist/govuk/components/')
-  )
-
-  if (filter) {
-    const componentFiles = await getComponentFiles()
-
-    // Apply component names filter
-    return componentNames.filter((componentName) =>
-      filter(componentName, componentFiles)
-    )
-  }
-
-  return componentNames
-}
-
-/**
- * Get examples from component fixtures
- *
- * @param {string} componentName - Component name
- * @returns {Promise<{ [name: string]: ComponentFixture['options'] }>} Component examples as an object
- */
-async function getExamples(componentName) {
-  const { fixtures } = await getComponentFixtures(componentName)
-
-  /** @type {{ [name: string]: ComponentFixture['options'] }} */
-  const examples = {}
-
-  for (const example of fixtures) {
-    examples[example.name] = example.options
-  }
-
-  return examples
 }
 
 module.exports = {
   filterPath,
-  getComponentFixtures,
-  getComponentsFixtures,
-  getComponentFiles,
-  getComponentNames,
   getDirectories,
-  getExamples,
   getListing,
   getYaml,
   mapPathTo
 }
-
-/**
- * Component data
- *
- * @typedef {object} ComponentData
- * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
- * @property {ComponentExample[]} [examples] - Component examples with Nunjucks macro options (or params)
- * @property {string} [previewLayout] - Nunjucks layout for component preview
- * @property {string} [accessibilityCriteria] - Accessibility criteria
- */
-
-/**
- * Nunjucks macro option (or param) config
- *
- * @typedef {object} ComponentOption
- * @property {string} name - Option name
- * @property {'array' | 'boolean' | 'integer' | 'nunjucks-block' | 'object' | 'string'} type - Option type
- * @property {boolean} required - Option required
- * @property {string} description - Option description
- * @property {boolean} [isComponent] - Option is another component
- * @property {ComponentOption[]} [params] - Nunjucks macro option (or param) configs
- */
-
-/**
- * Component examples with Nunjucks macro options (or params)
- *
- * @typedef {object} ComponentExample
- * @property {string} name - Example name
- * @property {string} [description] - Example description
- * @property {boolean} [hidden] - Example hidden from review app
- * @property {string[]} [previewLayoutModifiers] - Component preview layout class modifiers
- * @property {{ [param: string]: unknown }} options - Nunjucks macro options (or params)
- */
-
-/**
- * Component fixture
- * (used by the Design System website)
- *
- * @typedef {Required<ComponentExample> & { html: string }} ComponentFixture
- */
-
-/**
- * Component fixtures
- * (used by the Design System website)
- *
- * @typedef {object} ComponentFixtures
- * @property {string} component - Component name
- * @property {ComponentFixture[]} fixtures - Component fixtures with Nunjucks macro options (or params)
- * @property {string} [previewLayout] - Nunjucks layout for component preview
- */

--- a/shared/lib/index.js
+++ b/shared/lib/index.js
@@ -1,10 +1,10 @@
-const files = require('./files')
+const components = require('./components')
 const names = require('./names')
 
 /**
  * Shared library
  */
 module.exports = {
-  files,
+  components,
   names
 }

--- a/shared/lib/package.json
+++ b/shared/lib/package.json
@@ -17,6 +17,7 @@
     "govuk-frontend-config": "*",
     "js-yaml": "^4.1.0",
     "minimatch": "^9.0.3",
+    "nunjucks": "^3.2.4",
     "slash": "^3.0.0"
   }
 }

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -9,7 +9,8 @@ import { filterPath, getYaml } from 'govuk-frontend-lib/files'
  */
 const componentNamesWithJavaScript = await getComponentNamesFiltered(
   (componentName, componentFiles) =>
-    componentFiles.some(filterPath([`**/${componentName}.mjs`]))
+    componentFiles.some(filterPath([`**/${componentName}.mjs`])),
+  { moduleRoot: paths.stats }
 )
 
 /**

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -1,13 +1,13 @@
 import { join, parse } from 'path'
 
 import { paths } from 'govuk-frontend-config'
-import { getComponentNames } from 'govuk-frontend-lib/components'
+import { getComponentNamesFiltered } from 'govuk-frontend-lib/components'
 import { filterPath, getYaml } from 'govuk-frontend-lib/files'
 
 /**
  * Components with JavaScript
  */
-const componentNamesWithJavaScript = await getComponentNames(
+const componentNamesWithJavaScript = await getComponentNamesFiltered(
   (componentName, componentFiles) =>
     componentFiles.some(filterPath([`**/${componentName}.mjs`]))
 )

--- a/shared/stats/src/index.mjs
+++ b/shared/stats/src/index.mjs
@@ -1,11 +1,8 @@
 import { join, parse } from 'path'
 
 import { paths } from 'govuk-frontend-config'
-import {
-  getComponentNames,
-  filterPath,
-  getYaml
-} from 'govuk-frontend-lib/files'
+import { getComponentNames } from 'govuk-frontend-lib/components'
+import { filterPath, getYaml } from 'govuk-frontend-lib/files'
 
 /**
  * Components with JavaScript

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -3,11 +3,11 @@ import { waitForPercyIdle } from '@percy/sdk-utils'
 import { download } from 'govuk-frontend-helpers/jest/browser/download.mjs'
 import { goToComponent, goToExample } from 'govuk-frontend-helpers/puppeteer'
 import {
-  filterPath,
   getComponentFiles,
   getComponentNames,
   getExamples
-} from 'govuk-frontend-lib/files'
+} from 'govuk-frontend-lib/components'
+import { filterPath } from 'govuk-frontend-lib/files'
 import puppeteer from 'puppeteer'
 
 /**

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -112,7 +112,7 @@ async function generateFixture(componentDataPath, options) {
       previewLayoutModifiers: example.previewLayoutModifiers ?? [],
 
       // Render Nunjucks example
-      html: renderComponent(componentName, example.options, { env })
+      html: renderComponent(componentName, example.options, { env }).trim()
     })
   )
 

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -151,9 +151,9 @@ async function generateMacroOption(componentDataPath, options) {
 
 /**
  * @typedef {import('./assets.mjs').AssetEntry} AssetEntry
- * @typedef {import('govuk-frontend-lib/files').ComponentData} ComponentData
- * @typedef {import('govuk-frontend-lib/files').ComponentOption} ComponentOption
- * @typedef {import('govuk-frontend-lib/files').ComponentExample} ComponentExample
- * @typedef {import('govuk-frontend-lib/files').ComponentFixture} ComponentFixture
- * @typedef {import('govuk-frontend-lib/files').ComponentFixtures} ComponentFixtures
+ * @typedef {import('govuk-frontend-lib/components').ComponentData} ComponentData
+ * @typedef {import('govuk-frontend-lib/components').ComponentOption} ComponentOption
+ * @typedef {import('govuk-frontend-lib/components').ComponentExample} ComponentExample
+ * @typedef {import('govuk-frontend-lib/components').ComponentFixture} ComponentFixture
+ * @typedef {import('govuk-frontend-lib/components').ComponentFixtures} ComponentFixtures
  */

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -1,6 +1,6 @@
 import { basename, dirname, join } from 'path'
 
-import { nunjucksEnv } from 'govuk-frontend-lib/components'
+import { nunjucksEnv, renderComponent } from 'govuk-frontend-lib/components'
 import { getListing, getYaml } from 'govuk-frontend-lib/files'
 
 import { files } from './index.mjs'
@@ -94,11 +94,6 @@ async function generateFixture(componentDataPath, options) {
   const env = nunjucksEnv([options.srcPath])
 
   // Nunjucks template
-  const template = join(
-    options.srcPath,
-    dirname(componentDataPath),
-    'template.njk'
-  )
   const componentName = basename(dirname(componentDataPath))
 
   // Loop examples
@@ -116,14 +111,8 @@ async function generateFixture(componentDataPath, options) {
       description: example.description ?? '',
       previewLayoutModifiers: example.previewLayoutModifiers ?? [],
 
-      // Wait for render to complete
-      html: await new Promise((resolve, reject) => {
-        const context = { params: example.options }
-
-        return env.render(template, context, (error, result) => {
-          return error ? reject(error) : resolve(result?.trim() ?? '')
-        })
-      })
+      // Render Nunjucks example
+      html: renderComponent(componentName, example.options, { env })
     })
   )
 

--- a/shared/tasks/components.mjs
+++ b/shared/tasks/components.mjs
@@ -1,7 +1,7 @@
 import { basename, dirname, join } from 'path'
 
+import { nunjucksEnv } from 'govuk-frontend-lib/components'
 import { getListing, getYaml } from 'govuk-frontend-lib/files'
-import nunjucks from 'nunjucks'
 
 import { files } from './index.mjs'
 
@@ -90,6 +90,9 @@ async function generateFixture(componentDataPath, options) {
     throw new Error(`${componentDataPath} is missing "examples"`)
   }
 
+  // Nunjucks environment
+  const env = nunjucksEnv([options.srcPath])
+
   // Nunjucks template
   const template = join(
     options.srcPath,
@@ -117,7 +120,7 @@ async function generateFixture(componentDataPath, options) {
       html: await new Promise((resolve, reject) => {
         const context = { params: example.options }
 
-        return nunjucks.render(template, context, (error, result) => {
+        return env.render(template, context, (error, result) => {
           return error ? reject(error) : resolve(result?.trim() ?? '')
         })
       })

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,13 +16,14 @@
     "types": [],
     "paths": {
       "govuk-frontend": ["./packages/govuk-frontend/src/govuk/all.mjs"],
-      "govuk-frontend-stats": ["./shared/stats/src/index.mjs"],
       "govuk-frontend-config": ["./shared/config/index.js"],
       "govuk-frontend-helpers": ["./shared/helpers/index.js"],
       "govuk-frontend-helpers/*": ["./shared/helpers/*.js"],
       "govuk-frontend-helpers/jest/*": ["./shared/helpers/jest/*"],
       "govuk-frontend-lib": ["./shared/lib/index.js"],
-      "govuk-frontend-lib/*": ["./shared/lib/*.js"]
+      "govuk-frontend-lib/*": ["./shared/lib/*.js"],
+      "govuk-frontend-stats": ["./shared/stats/src/index.mjs"],
+      "govuk-frontend-tasks": ["./shared/tasks/index.mjs"]
     }
   },
   "typeAcquisition": {


### PR DESCRIPTION
This PR introduces an improved ~`renderHTML()`~ `renderComponent()` helper for Nunjucks and HTML previews

By following the [**Stats for previous version**](https://github.com/alphagov/govuk-frontend/blob/main/shared/stats/README.md#stats-for-previous-version) guidance for legacy GOV.UK Frontend versions this also ensures:

1. Nunjucks environment uses locally installed GOV.UK Frontend
2. Component helpers use locally installed GOV.UK Frontend

When a legacy version is installed locally, our helper functions that render components, provide their names, list files or read macro options YAML were doing so from `packages/govuk-frontend` despite legacy CSS and JS being previewed.

```shell
npm install govuk-frontend@4.7.0 --save --workspace govuk-frontend-review
```

It's part of our work to fully test our components:

* https://github.com/alphagov/govuk-frontend/issues/1139

Since a locally installed GOV.UK Frontend won't have an npm published `src` directory, this work requires:

* https://github.com/alphagov/govuk-frontend/pull/4042

## Component rendering
Previously we juggled multiple Nunjucks environments and rendered our components in multiple ways.

The component helper `renderComponent()` now consolidates these four:

### 1. HTML validation using helper `renderHTML()`
https://github.com/alphagov/govuk-frontend/blob/91d0a5d8b694875b34eb4be52ecf155f8b3701d0/packages/govuk-frontend/src/govuk/components/components.template.test.js#L115-L118

### 2. Component previews using Nunjucks `renderString()`
https://github.com/alphagov/govuk-frontend/blob/91d0a5d8b694875b34eb4be52ecf155f8b3701d0/packages/govuk-frontend-review/src/app.mjs#L129-L132

### 3. Component HTML code using Nunjucks `render()`
https://github.com/alphagov/govuk-frontend/blob/91d0a5d8b694875b34eb4be52ecf155f8b3701d0/packages/govuk-frontend-review/src/common/nunjucks/globals/get-html-code.mjs#L13-L19

### 4. Design System HTML fixtures using Nunjucks `render()`
https://github.com/alphagov/govuk-frontend/blob/91d0a5d8b694875b34eb4be52ecf155f8b3701d0/shared/tasks/components.mjs#L106-L110