### PR TITLE
Add ability to customise inverse button colours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,24 @@ These styles can be used in your own code by including the `govuk-focused-box` S
 
 This change was made in [pull request #3819: Add linked image focus style](https://github.com/alphagov/govuk-frontend/pull/3819).
 
+#### Customise inverse button colours
+
+For non-GOV.UK branded websites, you can now change the colours of inverse buttons — buttons intended for use on dark backgrounds.
+
+To change the inverse button's background colour, set the `$govuk-inverse-button-background-colour` Sass variable.
+
+To change the inverse button's text colour, set the `$govuk-inverse-button-text-colour` Sass variable.
+
+```scss
+@import "node_modules/govuk-frontend/govuk/base";
+
+$govuk-inverse-button-background-colour: govuk-colour("yellow");
+$govuk-inverse-button-text-colour: govuk-colour("black");
+@import "node_modules/govuk-frontend/govuk/components/button/index";
+```
+
+This change was made in [pull request #4043: Add ability to customise inverse button colours](https://github.com/alphagov/govuk-frontend/pull/4043).
+
 ### Breaking changes
 
 You must make the following changes when you migrate to this release, or your service might break.
@@ -311,6 +329,21 @@ These changes were introduced in:
 
 - [pull request #3570: Remove IE8-10 JavaScript polyfills, helpers, config](https://github.com/alphagov/govuk-frontend/pull/3570)
 - [pull request #3720: Remove IE11 vendor polyfills](https://github.com/alphagov/govuk-frontend/pull/3720)
+
+#### Check that inverse buttons still look as expected
+
+Inverse button components now use the `$govuk-brand-colour` setting to determine the button's text colour and the button's background tint when hovered or activated. The button will only look different if `$govuk-brand-colour` has been changed from the default.
+
+You can restore the previous blue colour by setting `$govuk-inverse-button-text-colour` before importing the button component's Sass.
+
+```scss
+@import "node_modules/govuk-frontend/govuk/base";
+
+$govuk-inverse-button-text-colour: govuk-colour("blue");
+@import "node_modules/govuk-frontend/govuk/components/button/index";
+```
+
+This change was made in [pull request #4043: Add ability to customise inverse button colours](https://github.com/alphagov/govuk-frontend/pull/4043).
 
 ### Suggested changes
 

--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -16,6 +16,20 @@ $govuk-button-background-colour: govuk-colour("green") !default;
 
 $govuk-button-text-colour: govuk-colour("white") !default;
 
+/// Inverted button component background colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-background-colour: govuk-colour("white") !default;
+
+/// Inverted button component text colour
+///
+/// @type Colour
+/// @access public
+
+$govuk-inverse-button-text-colour: $govuk-brand-colour !default;
+
 @include govuk-exports("govuk/component/button") {
   $govuk-button-colour: $govuk-button-background-colour;
   $govuk-button-text-colour: $govuk-button-text-colour;
@@ -35,8 +49,8 @@ $govuk-button-text-colour: govuk-colour("white") !default;
   $govuk-warning-button-shadow-colour: govuk-shade($govuk-warning-button-colour, 60%);
 
   // Inverse button variables
-  $govuk-inverse-button-colour: govuk-colour("white");
-  $govuk-inverse-button-text-colour: govuk-colour("blue");
+  $govuk-inverse-button-colour: $govuk-inverse-button-background-colour;
+  $govuk-inverse-button-text-colour: $govuk-inverse-button-text-colour;
   $govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
   $govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
 


### PR DESCRIPTION
A "quick-fix" for the inverse button styles using hardcoded blue text and hover colours, where non-GOV.UK branded services probably want this to match the `$govuk-brand-colour` variable.

Related to #3918. Extracted from PR #3925, which includes more significant changes covering all inverse components.

## Changes
- Added public variable `$govuk-inverse-button-background-colour`, which defaults to `govuk-colour("white")`.
- Added public variable `$govuk-inverse-button-text-colour`, which defaults to `$govuk-brand-colour`.
  - This is probably technically a breaking change, as the inverse button's text colour was previously `govuk-colour("blue")`. This will look the same if the brand colour has not been changed, but will be different if it has.
- Mapped the public variables to their scoped equivalents. 