### PR TITLE
Update testing and linting documentation

### DIFF
--- a/docs/contributing/coding-standards/css.md
+++ b/docs/contributing/coding-standards/css.md
@@ -109,18 +109,21 @@ This class is part of the component, rather than a parent of a component.
 **Why?**
 This makes it easier to keep track of different contexts.
 
-# Linting
+## Formatting and linting
 
-To ensure code quality and consistency in our Sass files we check that certain
-style rules are followed. These rules are based on [stylelint-config-gds](https://github.com/alphagov/stylelint-config-gds/blob/main/scss.js), but we also add our own custom rules with a project [config file](/stylelint.config.js).
+To ensure code quality and consistency in our Sass files we check that certain rules are followed. These rules are based on [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds/blob/main/scss.js), but we also add our own custom rules with a project [config file](/stylelint.config.js).
 
 See [testing and linting](/docs/releasing/testing-and-linting.md) for more information.
 
 ## Running the lint task
 
-You can run the linter in Gulp by running `npm run lint:scss`, or use linting in [Sublime Text](https://github.com/SublimeLinter/SublimeLinter-stylelint), [Atom](https://atom.io/packages/linter-stylelint) or [other editors that support stylelint](https://stylelint.io/user-guide/integrations/editor).
+You can run the linter with `npm run lint:scss`, or use linting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=stylelint.vscode-stylelint) and [other editors that support Stylelint](https://stylelint.io/user-guide/customize/#using-stylelint).
 
-See also [testing and linting](/docs/releasing/testing-and-linting.md).
+To automatically fix Stylelint issues, add the `--fix` flag:
+
+```shell
+npm run lint:scss -- --fix
+```
 
 ## Linting rules
 

--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -139,10 +139,20 @@ If you need polyfills for features that are not yet included in this project, pl
 
 ## Formatting and linting
 
-GOV.UK Frontend uses [JavaScript Standard Style](https://standardjs.com), an opinionated JavaScript linter. All JavaScript files follow its conventions, and it runs on GitHub Actions to ensure that new pull requests are in line with them.
+GOV.UK Frontend uses [ESLint](https://eslint.org) with [JavaScript Standard Style](https://standardjs.com), an opinionated JavaScript style guide. All JavaScript files follow its conventions, and it runs on GitHub Actions to ensure that new pull requests are in line with them.
 
 The standard docs have a [complete list of rules and some reasoning behind them](https://standardjs.com/rules.html).
 
 Read more about [running standard manually, or in your editor, on the 'JavaScript coding style' page of the GDS Way](https://gds-way.cloudapps.digital/manuals/programming-languages/js.html#linting).
 
 See also [testing and linting](/docs/releasing/testing-and-linting.md).
+
+## Running the lint task
+
+You can run the linter with `npm run lint:js`, or use linting in [Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) and [other editors that support ESLint](https://eslint.org/docs/latest/use/integrations#editors).
+
+To automatically fix ESLint issues, add the `--fix` flag:
+
+```shell
+npm run lint:js -- --fix
+```

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -1,6 +1,8 @@
 # Testing and linting
 
-GitHub Actions lints Sass and JavaScript, runs unit and functional tests with Node, and generates snapshots for [visual regression testing](https://www.browserstack.com/percy/visual-testing).
+GitHub Actions lints Sass and JavaScript, runs unit and functional tests with Node.js, and generates snapshots for [visual regression testing](https://www.browserstack.com/percy/visual-testing).
+
+See the [GitHub Actions **Tests** workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml) for more information.
 
 ## Testing terminology
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -34,11 +34,15 @@ See [Tasks](../contributing/tasks.md) for details of what `npm test` does.
 
 You can run a subset of the test suite that only tests components by running:
 
-    `npx jest packages/govuk-frontend/src/govuk/components/button`
+```shell
+npx jest packages/govuk-frontend/src/govuk/components/button
+```
 
 Note: There's a watch mode that keeps a testing session open waiting for changes that can be used with:
 
-    `npx jest --watch packages/govuk-frontend/src/govuk/components/button`
+```shell
+npx jest --watch packages/govuk-frontend/src/govuk/components/button
+```
 
 ### Running all linting checks locally
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -55,6 +55,10 @@ This will run the following checks:
 3. [ESLint](https://eslint.org) (using [JavaScript Standard Style](https://standardjs.com))
 4. [Stylelint](https://stylelint.io) (using [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds))
 
+Where possible, issues will be fixed automatically on `git commit` using [Husky](https://typicode.github.io/husky/) and [`.lintstagedrc.js`](/.lintstagedrc.js).
+
+To commit changes without automatic checks use `git commit --no-verify`.
+
 ### Running only EditorConfig linting
 
 ```shell

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -46,9 +46,28 @@ To lint the whole codebase, run:
 npm run lint
 ```
 
-This will trigger [ESLint](https://eslint.org) (using [JavaScript Standard Style](https://standardjs.com)) and [Stylelint](https://stylelint.io) for linting.
+This will run the following checks:
 
-See [Tasks](../contributing/tasks.md) for details of what `npm run lint` does.
+1. [EditorConfig](https://editorconfig.org)
+2. [Prettier](https://prettier.io)
+3. [ESLint](https://eslint.org) (using [JavaScript Standard Style](https://standardjs.com))
+4. [Stylelint](https://stylelint.io) (using [GDS Stylelint Config](https://github.com/alphagov/stylelint-config-gds))
+
+### Running only EditorConfig linting
+
+```shell
+npm run lint:editorconfig
+```
+
+See [.editorconfig](/.editorconfig) for details.
+
+### Running only Prettier linting
+
+```shell
+npm run lint:prettier
+```
+
+See [.prettierrc.js](/.prettierrc.js) for details.
 
 ### Running only Sass linting
 

--- a/docs/releasing/testing-and-linting.md
+++ b/docs/releasing/testing-and-linting.md
@@ -1,6 +1,6 @@
 # Testing and linting
 
-GitHub Actions lints Sass and JavaScript, runs unit and functional tests with Node.js, and generates snapshots for [visual regression testing](https://www.browserstack.com/percy/visual-testing).
+GitHub Actions lints Sass and JavaScript, runs unit and functional tests with Node.js, and generates snapshots for [visual regression testing](#visual-regression-testing-with-percy).
 
 See the [GitHub Actions **Tests** workflow](https://github.com/alphagov/govuk-frontend/actions/workflows/tests.yml) for more information.
 


### PR DESCRIPTION
This PR makes a few testing and linting documentation tweaks

1. Adding EditorConfig info for https://github.com/alphagov/govuk-frontend/pull/3197
2. Added Prettier info for https://github.com/alphagov/govuk-frontend/pull/3201
3. Added auto fixing commands for StyleLint and ESLint

I've included more Prettier info (including auto formatting) where relevant in:

* https://github.com/alphagov/govuk-frontend/pull/3799
* https://github.com/alphagov/govuk-frontend/pull/3875