### PR TITLE
Mark internal things as `@internal` and add access annotations to the I18n class

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/closest-attribute-value.mjs
+++ b/packages/govuk-frontend/src/govuk/common/closest-attribute-value.mjs
@@ -1,7 +1,7 @@
 /**
  * Returns the value of the given attribute closest to the given element (including itself)
  *
- * @private
+ * @internal
  * @param {Element} $element - The element to start walking the DOM tree up
  * @param {string} attributeName - The name of the attribute
  * @returns {string | null} Attribute value

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -15,7 +15,7 @@
  * (e.g. \{'i18n.showSection': 'Show section'\}) and combines them together, with
  * greatest priority on the LAST item passed in.
  *
- * @private
+ * @internal
  * @returns {{ [key: string]: unknown }} A flattened object of key-value pairs.
  */
 export function mergeConfigs (/* configObject1, configObject2, ...configObjects */) {
@@ -90,7 +90,7 @@ export function mergeConfigs (/* configObject1, configObject2, ...configObjects 
  * Extracts keys starting with a particular namespace from a flattened config
  * object, removing the namespace in the process.
  *
- * @private
+ * @internal
  * @param {{ [key: string]: unknown }} configObject - The object to extract key-value pairs from.
  * @param {string} namespace - The namespace to filter keys with.
  * @returns {{ [key: string]: unknown }} Flattened object with dot-separated key namespace removed

--- a/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
+++ b/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
@@ -9,7 +9,7 @@
  * Designed to be used to convert config passed via data attributes (which are
  * always strings) into something sensible.
  *
- * @private
+ * @internal
  * @param {string} value - The value to normalise
  * @returns {string | boolean | number | undefined} Normalised data
  */
@@ -42,7 +42,7 @@ export function normaliseString (value) {
  *
  * Loop over an object and normalise each value using normaliseData function
  *
- * @private
+ * @internal
  * @param {DOMStringMap} dataset - HTML element dataset
  * @returns {{ [key: string]: unknown }} Normalised dataset
  */

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -25,6 +25,7 @@ export class I18n {
    * The most used function - takes the key for a given piece of UI text and
    * returns the appropriate string.
    *
+   * @public
    * @param {string} lookupKey - The lookup key of the string to use.
    * @param {{ [key: string]: unknown }} [options] - Any options passed with the translation string, e.g: for string interpolation.
    * @returns {string} The appropriate translation string.
@@ -70,6 +71,7 @@ export class I18n {
    * Takes a translation string with placeholders, and replaces the placeholders
    * with the provided data
    *
+   * @private
    * @param {string} translationString - The translation string
    * @param {{ [key: string]: unknown }} options - Any options passed with the translation string, e.g: for string interpolation.
    * @returns {string} The translation string to output, with $\{\} placeholders replaced
@@ -125,6 +127,7 @@ export class I18n {
    * - The implementation of Intl supports PluralRules (NOT true in IE11)
    * - The browser/OS has plural rules for the current locale (browser dependent)
    *
+   * @private
    * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
    */
   hasIntlPluralRulesSupport () {
@@ -139,6 +142,7 @@ export class I18n {
    * - The implementation of Intl supports NumberFormat (also true in IE11)
    * - The browser/OS has number formatting rules for the current locale (browser dependent)
    *
+   * @private
    * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
    */
   hasIntlNumberFormatSupport () {
@@ -155,6 +159,7 @@ export class I18n {
    * hasn't, it'll fall back to the 'other' plural form (unless that doesn't exist
    * either, in which case an error will be thrown)
    *
+   * @private
    * @param {string} lookupKey - The lookup key of the string to use.
    * @param {number} count - Number used to determine which pluralisation to use.
    * @returns {PluralRule} The suffix associated with the correct pluralisation for this locale.
@@ -204,6 +209,7 @@ export class I18n {
    * This is split out into a separate function to make it easier to test the
    * fallback behaviour in an environment where Intl.PluralRules exists.
    *
+   * @private
    * @param {number} count - Number used to determine which pluralisation to use.
    * @returns {PluralRule} The pluralisation form for count in this locale.
    */
@@ -229,6 +235,7 @@ export class I18n {
    * regardless of region. There are exceptions, however, (e.g. Portuguese) so
    * this searches by both the full and shortened locale codes, just to be sure.
    *
+   * @private
    * @returns {string | undefined} The name of the pluralisation rule to use (a key for one
    *   of the functions in this.pluralRules)
    */
@@ -280,6 +287,7 @@ export class I18n {
    * Spanish: European Portuguese (pt-PT), Italian (it), Spanish (es)
    * Welsh: Welsh (cy)
    *
+   * @private
    * @type {{ [key: string]: string[] }}
    */
   static pluralRulesMap = {
@@ -308,6 +316,7 @@ export class I18n {
    *
    * The count must be a positive integer. Negative numbers and decimals aren't accounted for
    *
+   * @private
    * @type {{ [key: string]: (count: number) => PluralRule }}
    */
   static pluralRules = {

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -2,7 +2,7 @@
  * Internal support for selecting messages to render, with placeholder
  * interpolation and locale-aware number formatting and pluralisation
  *
- * @private
+ * @internal
  */
 export class I18n {
   translations


### PR DESCRIPTION
When using access related annotations we want to be clearer about whether the annotation refers to:

- access in context of the class – whether a particular method can be called from outside the class, including by other classes in GOV.UK Frontend
- access in context of the library – whether a particular method is considered to be available for use outside of GOV.UK Frontend

Annotate all of our 'internal' classes or functions (like the I18n class and the mergeConfigs function) as https://github.com/internal.

Remove any other access annotations (like `@private`) from classes and functions.

Add access annotations to the I18n class.

Closes #4017 