### PR TITLE
[SPIKE] Run the GOV.UK Prototype Kit locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         ".github/workflows/scripts",
         "packages/govuk-frontend",
         "packages/govuk-frontend-review",
+        "packages/govuk-prototype-kit-review",
         "shared/*",
         "docs/examples/*"
       ],
@@ -2103,6 +2104,10 @@
     },
     "node_modules/@govuk-frontend/config": {
       "resolved": "shared/config",
+      "link": true
+    },
+    "node_modules/@govuk-frontend/govuk-prototype-kit-review": {
+      "resolved": "packages/govuk-prototype-kit-review",
       "link": true
     },
     "node_modules/@govuk-frontend/helpers": {
@@ -30382,6 +30387,17 @@
       },
       "optionalDependencies": {
         "nunjucks": "^3.2.4"
+      }
+    },
+    "packages/govuk-prototype-kit-review": {
+      "name": "@govuk-frontend/govuk-prototype-kit-review",
+      "license": "MIT",
+      "devDependencies": {
+        "govuk-prototype-kit": "^13.13.3"
+      },
+      "engines": {
+        "node": "^18.12.0",
+        "npm": "^8.1.0 || ^9.1.0"
       }
     },
     "shared/config": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     ".github/workflows/scripts",
     "packages/govuk-frontend",
     "packages/govuk-frontend-review",
+    "packages/govuk-prototype-kit-review",
     "shared/*",
     "docs/examples/*"
   ],

--- a/packages/govuk-prototype-kit-review/README.md
+++ b/packages/govuk-prototype-kit-review/README.md
@@ -1,0 +1,8 @@
+# GOV.UK Prototype Kit review
+
+This package is used to review the GOV.UK Prototype Kit using a development version of GOV.UK Frontend.
+
+```shell
+npm run create --workspace govuk-protoype-kit-review
+npm run dev --workspace govuk-protoype-kit-review
+```

--- a/packages/govuk-prototype-kit-review/package.json
+++ b/packages/govuk-prototype-kit-review/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "name": "@govuk-frontend/govuk-prototype-kit-review",
+  "description": "GOV.UK Prototype Kit review",
+  "engines": {
+    "node": "^18.12.0",
+    "npm": "^8.1.0 || ^9.1.0"
+  },
+  "license": "MIT",
+  "scripts": {
+    "dev": "cd dist && govuk-prototype-kit dev",
+    "prebuild": "npm run clean",
+    "build": "govuk-prototype-kit create dist",
+    "postbuild": "cd dist && npm link ../../govuk-frontend",
+    "clean": "del-cli dist"
+  },
+  "devDependencies": {
+    "govuk-prototype-kit": "^13.13.3"
+  }
+}


### PR DESCRIPTION
This PR creates and installs an instance of GOV.UK Prototype Kit locally as part of https://github.com/alphagov/govuk-frontend/issues/3759

After install, we use `npm link` to replace GOV.UK Frontend with [**./packages/govuk-frontend**](https://github.com/alphagov/govuk-frontend/tree/main/packages/govuk-frontend)

I'd like to spike using Percy to:

1. Start the prototype
2. Screenshot the prototype home page
3. Screenshot the **Manage your prototype** page

This spots issues like missing fonts, assets etc