### PR TITLE
Adjust the positioning of the header mobile menu button

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -166,7 +166,7 @@
   .govuk-header__menu-button {
     @include govuk-font($size: 16);
     position: absolute;
-    top: govuk-spacing(4);
+    top: govuk-spacing(3);
     right: 0;
     margin: 0;
     padding: 0;


### PR DESCRIPTION
Adjust the positioning of the header mobile menu button so that it sits in the middle of the header bar on mobile rather than at the baseline of the GOV.UK logo.

Fixes https://github.com/alphagov/govuk-frontend/issues/3896

## Visual changes
### Before
<img width="333" alt="Screenshot of header on mobile before change" src="https://github.com/alphagov/govuk-frontend/assets/64783893/99abb501-cf8a-48fc-b302-dd09183b5ce7">

### After
<img width="326" alt="Screenshot of header on mobile after change" src="https://github.com/alphagov/govuk-frontend/assets/64783893/0e06b0e1-2e95-48b9-9549-b3138cd32163">

## Thoughts
I'm wondering if there's a way to flexbox the header so that we can make this positioning dynamic. Will explore this as part of this PR.