### PR TITLE
Catch errors when instantiating components with `initAll`

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -29,76 +29,40 @@ function initAll(config) {
     return
   }
 
+  const components = [
+    Accordion,
+    Button,
+    CharacterCount,
+    Checkboxes,
+    ErrorSummary,
+    ExitThisPage,
+    Header,
+    NotificationBanner,
+    Radios,
+    SkipLink,
+    Tabs
+  ]
+
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
   const $scope = config.scope instanceof HTMLElement ? config.scope : document
 
-  const $accordions = $scope.querySelectorAll('[data-module="govuk-accordion"]')
-  $accordions.forEach(($accordion) => {
-    new Accordion($accordion, config.accordion)
-  })
+  components.forEach((Component) => {
+    // configKey is the component name converted from PascalCase to camelCase
+    const configKey = Component.name.replace(/^./, (str) => str.toLowerCase())
 
-  const $buttons = $scope.querySelectorAll('[data-module="govuk-button"]')
-  $buttons.forEach(($button) => {
-    new Button($button, config.button)
-  })
+    const $elements = $scope.querySelectorAll(
+      `[data-module="${Component.moduleName}"]`
+    )
 
-  const $characterCounts = $scope.querySelectorAll(
-    '[data-module="govuk-character-count"]'
-  )
-  $characterCounts.forEach(($characterCount) => {
-    new CharacterCount($characterCount, config.characterCount)
-  })
-
-  const $checkboxes = $scope.querySelectorAll(
-    '[data-module="govuk-checkboxes"]'
-  )
-  $checkboxes.forEach(($checkbox) => {
-    new Checkboxes($checkbox)
-  })
-
-  // Find first error summary module to enhance.
-  const $errorSummary = $scope.querySelector(
-    '[data-module="govuk-error-summary"]'
-  )
-  if ($errorSummary) {
-    new ErrorSummary($errorSummary, config.errorSummary)
-  }
-
-  const $exitThisPageButtons = $scope.querySelectorAll(
-    '[data-module="govuk-exit-this-page"]'
-  )
-  $exitThisPageButtons.forEach(($button) => {
-    new ExitThisPage($button, config.exitThisPage)
-  })
-
-  // Find first header module to enhance.
-  const $header = $scope.querySelector('[data-module="govuk-header"]')
-  if ($header) {
-    new Header($header)
-  }
-
-  const $notificationBanners = $scope.querySelectorAll(
-    '[data-module="govuk-notification-banner"]'
-  )
-  $notificationBanners.forEach(($notificationBanner) => {
-    new NotificationBanner($notificationBanner, config.notificationBanner)
-  })
-
-  const $radios = $scope.querySelectorAll('[data-module="govuk-radios"]')
-  $radios.forEach(($radio) => {
-    new Radios($radio)
-  })
-
-  // Find first skip link module to enhance.
-  const $skipLink = $scope.querySelector('[data-module="govuk-skip-link"]')
-  if ($skipLink) {
-    new SkipLink($skipLink)
-  }
-
-  const $tabs = $scope.querySelectorAll('[data-module="govuk-tabs"]')
-  $tabs.forEach(($tabs) => {
-    new Tabs($tabs)
+    $elements.forEach(($element) => {
+      // Only pass config to components that accept it
+      if ('defaults' in Component) {
+        new Component($element, configKey in config ? config[configKey] : {})
+      } else {
+        new Component($element)
+      }
+    })
   })
 }
 

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -29,28 +29,25 @@ function initAll(config) {
     return
   }
 
-  const components = [
-    Accordion,
-    Button,
-    CharacterCount,
-    Checkboxes,
-    ErrorSummary,
-    ExitThisPage,
-    Header,
-    NotificationBanner,
-    Radios,
-    SkipLink,
-    Tabs
-  ]
+  const components = /** @type {const} */ ([
+    [Accordion, config.accordion],
+    [Button, config.button],
+    [CharacterCount, config.characterCount],
+    [Checkboxes],
+    [ErrorSummary, config.errorSummary],
+    [ExitThisPage, config.exitThisPage],
+    [Header],
+    [NotificationBanner, config.notificationBanner],
+    [Radios],
+    [SkipLink],
+    [Tabs]
+  ])
 
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
   const $scope = config.scope instanceof HTMLElement ? config.scope : document
 
-  components.forEach((Component) => {
-    // configKey is the component name converted from PascalCase to camelCase
-    const configKey = Component.name.replace(/^./, (str) => str.toLowerCase())
-
+  components.forEach(([Component, config]) => {
     const $elements = $scope.querySelectorAll(
       `[data-module="${Component.moduleName}"]`
     )
@@ -58,11 +55,9 @@ function initAll(config) {
     $elements.forEach(($element) => {
       try {
         // Only pass config to components that accept it
-        if ('defaults' in Component) {
-          new Component($element, configKey in config ? config[configKey] : {})
-        } else {
-          new Component($element)
-        }
+        'defaults' in Component
+          ? new Component($element, config)
+          : new Component($element)
       } catch (error) {
         console.log(error)
       }

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -56,11 +56,15 @@ function initAll(config) {
     )
 
     $elements.forEach(($element) => {
-      // Only pass config to components that accept it
-      if ('defaults' in Component) {
-        new Component($element, configKey in config ? config[configKey] : {})
-      } else {
-        new Component($element)
+      try {
+        // Only pass config to components that accept it
+        if ('defaults' in Component) {
+          new Component($element, configKey in config ? config[configKey] : {})
+        } else {
+          new Component($element)
+        }
+      } catch (error) {
+        console.log(error)
       }
     })
   })

--- a/packages/govuk-frontend/src/govuk/all.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.unit.test.mjs
@@ -1,0 +1,35 @@
+import * as All from './all.mjs'
+
+jest.mock('./components/accordion/accordion.mjs')
+
+describe('initAll', () => {
+  it('catches errors thrown by components and logs them to the console', () => {
+    // Provide enough of a DOM that we don't return early and we try and
+    // initialise an accordion
+    document.body.classList.add('govuk-frontend-supported')
+    document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
+
+    jest.spyOn(All, 'Accordion').mockImplementation(() => {
+      throw new Error('Error thrown from accordion')
+    })
+
+    // Silence warnings in test output, and allow us to 'expect' them
+    const consoleLog = jest
+      .spyOn(global.console, 'log')
+      .mockImplementation(() => {
+        /* noop */
+      })
+
+    expect(() => {
+      All.initAll()
+    }).not.toThrow()
+
+    expect(consoleLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Error thrown from accordion'
+      })
+    )
+
+    jest.restoreAllMocks()
+  })
+})

--- a/packages/govuk-frontend/src/govuk/all.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.unit.test.mjs
@@ -1,35 +1,126 @@
-import * as All from './all.mjs'
+import {
+  componentNameToClassName,
+  componentNameToConfigName
+} from '@govuk-frontend/lib/names'
 
-jest.mock('./components/accordion/accordion.mjs')
+import * as GOVUKFrontend from './all.mjs'
+
+// Annoyingly these don't get hoisted if done in a loop
+jest.mock(`./components/accordion/accordion.mjs`)
+jest.mock(`./components/button/button.mjs`)
+jest.mock(`./components/character-count/character-count.mjs`)
+jest.mock(`./components/checkboxes/checkboxes.mjs`)
+jest.mock(`./components/error-summary/error-summary.mjs`)
+jest.mock(`./components/exit-this-page/exit-this-page.mjs`)
+jest.mock(`./components/header/header.mjs`)
+jest.mock(`./components/notification-banner/notification-banner.mjs`)
+jest.mock(`./components/radios/radios.mjs`)
+jest.mock(`./components/skip-link/skip-link.mjs`)
+jest.mock(`./components/tabs/tabs.mjs`)
 
 describe('initAll', () => {
+  const components = ['checkboxes', 'header', 'radios', 'skip-link', 'tabs']
+
+  const componentsThatTakeConfig = [
+    'accordion',
+    'button',
+    'character-count',
+    'error-summary',
+    'exit-this-page',
+    'notification-banner'
+  ]
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.body.className = ''
+  })
+
+  it.each(components)(
+    'initialises %s, passing the component root',
+    (componentName) => {
+      const className = componentNameToClassName(componentName)
+      document.body.classList.add('govuk-frontend-supported')
+      document.body.innerHTML = `<div data-module="govuk-${componentName}"></div>`
+
+      GOVUKFrontend.initAll()
+
+      expect(GOVUKFrontend[className]).toHaveBeenCalledWith(
+        document.querySelector(`[data-module="govuk-${componentName}"]`)
+      )
+    }
+  )
+
+  it.each(componentsThatTakeConfig)(
+    'initialises %s, passing the component root and config',
+    (componentName) => {
+      const className = componentNameToClassName(componentName)
+      const configName = componentNameToConfigName(componentName)
+
+      document.body.classList.add('govuk-frontend-supported')
+      document.body.innerHTML = `<div data-module="govuk-${componentName}"></div>`
+
+      GOVUKFrontend.initAll({
+        [configName]: { __test: true }
+      })
+
+      expect(GOVUKFrontend[className]).toHaveBeenCalledWith(
+        document.querySelector(`[data-module="govuk-${componentName}"]`),
+        { __test: true }
+      )
+    }
+  )
+
+  it('returns early if govuk-frontend-supported class is not present', () => {
+    document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
+
+    GOVUKFrontend.initAll()
+
+    expect(GOVUKFrontend.Accordion).not.toHaveBeenCalled()
+  })
+
+  it('only initialises components within a given scope', () => {
+    document.body.classList.add('govuk-frontend-supported')
+    document.body.innerHTML = `
+      <div data-module="govuk-accordion"></div>
+      <div class="not-in-scope">
+        <div data-module="govuk-accordion"></div>
+      </div>'
+      <div class="my-scope">
+        <div data-module="govuk-accordion"></div>
+      </div>`
+
+    GOVUKFrontend.initAll({
+      scope: document.querySelector('.my-scope')
+    })
+
+    // Expect to have been called exactly once with the accordion in .my-scope
+    expect(GOVUKFrontend.Accordion).toHaveBeenCalledTimes(1)
+    expect(GOVUKFrontend.Accordion).toHaveBeenCalledWith(
+      document.querySelector('.my-scope [data-module="govuk-accordion"]'),
+      undefined
+    )
+  })
+
   it('catches errors thrown by components and logs them to the console', () => {
-    // Provide enough of a DOM that we don't return early and we try and
-    // initialise an accordion
     document.body.classList.add('govuk-frontend-supported')
     document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
 
-    jest.spyOn(All, 'Accordion').mockImplementation(() => {
+    jest.mocked(GOVUKFrontend.Accordion).mockImplementation(() => {
       throw new Error('Error thrown from accordion')
     })
 
     // Silence warnings in test output, and allow us to 'expect' them
-    const consoleLog = jest
-      .spyOn(global.console, 'log')
-      .mockImplementation(() => {
-        /* noop */
-      })
+    jest.spyOn(global.console, 'log').mockImplementation()
 
     expect(() => {
-      All.initAll()
+      GOVUKFrontend.initAll()
     }).not.toThrow()
 
-    expect(consoleLog).toHaveBeenCalledWith(
+    expect(global.console.log).toHaveBeenCalledWith(expect.any(Error))
+    expect(global.console.log).toHaveBeenCalledWith(
       expect.objectContaining({
         message: 'Error thrown from accordion'
       })
     )
-
-    jest.restoreAllMocks()
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -572,6 +572,11 @@ export class Accordion extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-accordion'
+
+  /**
    * Accordion default config
    *
    * @see {@link AccordionConfig}

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -109,6 +109,11 @@ export class Button extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-button'
+
+  /**
    * Button default config
    *
    * @see {@link ButtonConfig}

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -411,6 +411,11 @@ export class CharacterCount extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-character-count'
+
+  /**
    * Character count default config
    *
    * @see {@link CharacterCountConfig}

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -202,4 +202,9 @@ export class Checkboxes extends GOVUKFrontendComponent {
       this.unCheckExclusiveInputs($clickedInput)
     }
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-checkboxes'
 }

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -205,6 +205,11 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-error-summary'
+
+  /**
    * Error summary default config
    *
    * @see {@link ErrorSummaryConfig}

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -392,6 +392,11 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-exit-this-page'
+
+  /**
    * Exit this page default config
    *
    * @see {@link ExitThisPageConfig}

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -121,4 +121,9 @@ export class Header extends GOVUKFrontendComponent {
     this.menuIsOpen = !this.menuIsOpen
     this.syncState()
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-header'
 }

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -75,6 +75,11 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   }
 
   /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-notification-banner'
+
+  /**
    * Notification banner default config
    *
    * @see {@link NotificationBannerConfig}

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -150,4 +150,9 @@ export class Radios extends GOVUKFrontendComponent {
       }
     })
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-radios'
 }

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -110,4 +110,9 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     return this.$module.hash.split('#').pop()
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-skip-link'
 }

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -518,4 +518,9 @@ export class Tabs extends GOVUKFrontendComponent {
     const hash = href.slice(href.indexOf('#'), href.length)
     return hash
   }
+
+  /**
+   * Name for the component used when initialising using data-module attributes.
+   */
+  static moduleName = 'govuk-tabs'
 }

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -44,6 +44,18 @@ function componentNameToClassName(componentName) {
 }
 
 /**
+ * Convert component name to its config name as passed to initAll
+ *
+ * @param {string} componentName - A kebab-cased component name
+ * @returns {string} The name of its corresponding config
+ */
+function componentNameToConfigName(componentName) {
+  return componentNameToClassName(componentName).replace(/^./, (str) =>
+    str.toLowerCase()
+  )
+}
+
+/**
  * Convert component path to JavaScript module name
  *
  * Used by Rollup to set Universal Module Definition (UMD) export names for
@@ -148,6 +160,7 @@ function packageNameToPath(packageName, options) {
 
 module.exports = {
   componentNameToClassName,
+  componentNameToConfigName,
   componentNameToMacroName,
   componentPathToModuleName,
   packageResolveToPath,

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -21,6 +21,16 @@ function kebabCaseToPascalCase(value) {
 }
 
 /**
+ * Convert a kebab-cased string to a camelCased one
+ *
+ * @param {string} value - Input kebab-cased string
+ * @returns {string} Output camelCased string
+ */
+function kebabCaseToCamelCase(value) {
+  return kebabCaseToPascalCase(value).replace(/^./, (str) => str.toLowerCase())
+}
+
+/**
  * Convert component name to macro name
  *
  * Component names are kebab-cased (button, date-input), whilst macro names have
@@ -30,7 +40,7 @@ function kebabCaseToPascalCase(value) {
  * @returns {string} The name of its corresponding Nunjucks macro
  */
 function componentNameToMacroName(componentName) {
-  return `govuk${kebabCaseToPascalCase(componentName)}`
+  return kebabCaseToCamelCase(`govuk-${componentName}`)
 }
 
 /**
@@ -50,9 +60,7 @@ function componentNameToClassName(componentName) {
  * @returns {string} The name of its corresponding config
  */
 function componentNameToConfigName(componentName) {
-  return componentNameToClassName(componentName).replace(/^./, (str) =>
-    str.toLowerCase()
-  )
+  return kebabCaseToCamelCase(componentName)
 }
 
 /**

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -4,6 +4,7 @@ import { paths } from '@govuk-frontend/config'
 
 import {
   componentNameToClassName,
+  componentNameToConfigName,
   componentNameToMacroName,
   componentPathToModuleName,
   packageResolveToPath,
@@ -35,6 +36,34 @@ describe('componentNameToClassName', () => {
     "transforms component '$name' to class '$className'",
     ({ name, className }) => {
       expect(componentNameToClassName(name)).toBe(className)
+    }
+  )
+})
+
+describe('componentNameToConfigName', () => {
+  const components = [
+    {
+      name: 'button',
+      configName: 'button'
+    },
+    {
+      name: 'radios',
+      configName: 'radios'
+    },
+    {
+      name: 'skip-link',
+      configName: 'skipLink'
+    },
+    {
+      name: 'character-count',
+      configName: 'characterCount'
+    }
+  ]
+
+  it.each(components)(
+    "transforms component '$name' to class '$configName'",
+    ({ name, configName }) => {
+      expect(componentNameToConfigName(name)).toBe(configName)
     }
   )
 })


### PR DESCRIPTION
Initialise all of the components using a loop in initAll, catching any errors thrown by the components.

Closes #4010