### PR TITLE
Add example demonstrating the `SupportError` in the browser

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/javascript-errors/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/javascript-errors/index.njk
@@ -1,0 +1,55 @@
+{% extends "layouts/layout.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">JavaScript errors</h1>
+  <p class="govuk-body-lead">
+    Open your <a class="govuk-link" href="https://developer.mozilla.org/en-US/docs/Web/API/console#see_also">brower's console</a>
+    to witness the error thrown in browsers where GOV.UK Frontend is not supported.
+  </p>
+  {{ govukCharacterCount({
+    label: {
+      text: "Any other comment"
+    },
+    id: "some-content",
+    name: "some-content"
+  })}}
+{% endblock %}
+
+{% block bodyEnd %}
+  <script type="module" src="/javascripts/govuk-frontend.min.js"></script>
+
+  <!-- SupportError -->
+  <script type="module">
+    // Calling `initAll` would result in errors being logged rather than thrown
+    import { CharacterCount } from '/javascripts/govuk-frontend.min.js'
+
+    // Simulate GOV.UK Frontend not being supported
+    document.body.classList.remove('govuk-frontend-supported')
+
+    const $element = document.querySelector('[data-module="govuk-character-count"]')
+
+    try {
+      // Instantiate the component directly so errors are thrown
+      new CharacterCount($element)
+      // Use `finally` to ensure we tidy up regardless of the error
+    } finally {
+      // Add back the class marking GOV.UK Frontend support for future examples
+      document.body.classList.add('govuk-frontend-supported')
+    }
+  </script>
+
+  <!--
+    Add examples of other types of errors in their own `<script>` tag.
+    This separates each error example, as well as isolate their code
+    from the errors thrown by the other `<script>` tags.
+  -->
+{% endblock %}


### PR DESCRIPTION
Little follow up on https://github.com/alphagov/govuk-frontend/pull/4030 to add [an example for JavaScript errors to the review app](https://govuk-frontend-pr-4075.herokuapp.com/examples/javascript-errors). As we add more errors, we may reshape this example to show multiple kinds of errors or add extra examples for the other kinds of errors.

The example uses a CharacterCount component to trigger the errors as the component should be able to emit all the types of errors we raise, especially the one for invalid configuration that it is the only one to throw.

<img width="1792" alt="Screenshot of the JavaScript errors page showing the SupportError and its stacktrace" src="https://github.com/alphagov/govuk-frontend/assets/396367/21a624ea-dd3f-4454-8b33-cebe304a719c">

> **Note**: The name of the error appears clearly in the logs. Its class name is mangled in the stacktrace (`n`), but I don't think that's a massive issue given:
> 
> - the name of the error is clearly apparent
> - the component raising the error is clear (`Accordion`)
> - sourcemaps show the full sources
>
> I've opened a [separate issue to discuss mangling](https://github.com/alphagov/govuk-frontend/issues/4076) as I think it's worth its own little exploration to keep things maintainable as we add new classes, helpers...

