### PR TITLE
Add type discovery to `src` symlink directories

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../packages/govuk-frontend/tsconfig.json",
+  "include": ["**/*.js", "**/*.mjs"]
+}


### PR DESCRIPTION
We currently don't show TypeScript `tsc` compiler issues for our previous source code symbolic links:

* `src/govuk` → `packages/govuk-frontend/src/govuk`
* `src/govuk-prototype-kit` → `packages/govuk-frontend/src/govuk-prototype-kit`

This PR adds a new **tsconfig.json** file to fix that

But to avoid running our checks twice we can exclude it from `references` by default:

https://github.com/alphagov/govuk-frontend/blob/f22b592608332549b8587a602e577b6fa43ca8b4/tsconfig.json#L4