### PR TITLE
Use new “Open this example in a new tab” link text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4571,6 +4571,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-pTjcqY9E4nOI55Wgpz7eiI8+LzdYnw3qxXCfHyBDdPbYvbyLgWLJGh8EdPvqawwMK1Uo1794AUkkR38Fr0g+2g=="
+    },
     "node_modules/@types/marked": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-5.0.1.tgz",
@@ -18861,6 +18866,14 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "devOptional": true
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "14.0.1",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-14.0.1.tgz",
@@ -19882,6 +19895,29 @@
       },
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/marked-linkify-it": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/marked-linkify-it/-/marked-linkify-it-3.1.4.tgz",
+      "integrity": "sha512-jKssH4Xt82ZriU1esB6aeNmIsFmTnYBiiveXvE+7XNRq4+euiE/zgW/hn+6Y5KhbtBGTMhaFcyibsSF8FYLHIg==",
+      "dependencies": {
+        "@types/linkify-it": "^3.0.3",
+        "linkify-it": "^4.0.1"
+      },
+      "peerDependencies": {
+        "marked": ">=4 <10"
+      }
+    },
+    "node_modules/marked-smartypants": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/marked-smartypants/-/marked-smartypants-1.1.3.tgz",
+      "integrity": "sha512-GfRM03EmgmOw/QhJHJX9gWfA6M1AtO2y5Neo/V5dlLDK0L0gvgWUGcAcnWGLifQwt+OO2rhAQiYcjVe46fSN5A==",
+      "dependencies": {
+        "smartypants": "^0.2.2"
+      },
+      "peerDependencies": {
+        "marked": ">=4 <10"
       }
     },
     "node_modules/matchdep": {
@@ -25957,6 +25993,15 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/smartypants": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/smartypants/-/smartypants-0.2.2.tgz",
+      "integrity": "sha512-TzobUYoEft/xBtb2voRPryAUIvYguG0V7Tt3de79I1WfXgCwelqVsGuZSnu3GFGRZhXR90AeEYIM+icuB/S06Q==",
+      "bin": {
+        "smartypants": "bin/smartypants.js",
+        "smartypantsu": "bin/smartypantsu.js"
+      }
+    },
     "node_modules/smob": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.0.tgz",
@@ -28481,6 +28526,11 @@
         "node": "*"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    },
     "node_modules/uglify-js": {
       "version": "3.4.10",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
@@ -30280,6 +30330,8 @@
         "iframe-resizer": "^4.3.7",
         "js-beautify": "^1.14.9",
         "marked": "^9.0.2",
+        "marked-linkify-it": "^3.1.4",
+        "marked-smartypants": "^1.1.3",
         "outdent": "^0.8.0",
         "shuffle-seed": "^1.1.6",
         "slug": "^8.2.3"

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -34,6 +34,8 @@
     "iframe-resizer": "^4.3.7",
     "js-beautify": "^1.14.9",
     "marked": "^9.0.2",
+    "marked-linkify-it": "^3.1.4",
+    "marked-smartypants": "^1.1.3",
     "outdent": "^0.8.0",
     "shuffle-seed": "^1.1.6",
     "slug": "^8.2.3"

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
@@ -3,5 +3,6 @@
  */
 export { componentNameToMacroName } from '@govuk-frontend/lib/names'
 export { highlight } from './highlight.mjs'
+export { markdown } from './markdown.mjs'
 export { slugify } from './slugify.mjs'
 export { unslugify } from './unslugify.mjs'

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/markdown.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/markdown.mjs
@@ -1,5 +1,12 @@
-import { marked } from 'marked'
+import { Marked } from 'marked'
+import markedLinkifyIt from 'marked-linkify-it'
+import { markedSmartypants } from 'marked-smartypants'
 import filters from 'nunjucks/src/filters.js'
+
+// Custom Marked instance with extensions
+const marked = new Marked()
+  .use(markedLinkifyIt()) // Enable automatic URL linking
+  .use(markedSmartypants()) // Enable "smart" typographic punctuation
 
 /**
  * Render Markdown

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/markdown.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/markdown.mjs
@@ -1,4 +1,5 @@
 import { marked } from 'marked'
+import filters from 'nunjucks/src/filters.js'
 
 /**
  * Render Markdown
@@ -7,5 +8,5 @@ import { marked } from 'marked'
  * @returns {string} Rendered Markdown
  */
 export function markdown(content) {
-  return marked.parse(content)
+  return filters.safe(marked.parse(content))
 }

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/index.mjs
@@ -3,4 +3,3 @@
  */
 export { getHTMLCode } from './get-html-code.mjs'
 export { getNunjucksCode } from './get-nunjucks-code.mjs'
-export { markdown } from './markdown.mjs'

--- a/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
@@ -1,12 +1,10 @@
 ---
-scenario: >-
+scenario: |
   You want to know when the next bank holiday will be.
-
 
   Things to try:
 
   1. Find out when the next bank holiday is in Scotland.
-
   2. Find out when the Boxing Day bank holiday is in 2020.
 
 notes: >-

--- a/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/bank-holidays/index.njk
@@ -7,7 +7,7 @@ scenario: |
   1. Find out when the next bank holiday is in Scotland.
   2. Find out when the Boxing Day bank holiday is in 2020.
 
-notes: >-
+notes: |
   This example is based on https://www.gov.uk/bank-holidays.
   The data is not 'live' and so the answer is unlikely to be correct.
 ---

--- a/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
@@ -1,6 +1,6 @@
 ---
 name: Campaign page
-scenario: >-
+scenario: |
   You want to know the latest updates on the coronavirus pandemic.
   This is an example of a complex campaign page.
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/campaign-page/index.njk
@@ -4,8 +4,7 @@ scenario: |
   You want to know the latest updates on the coronavirus pandemic.
   This is an example of a complex campaign page.
 
-notes: >-
-  Based on https://www.gov.uk/coronavirus
+notes: Based on https://www.gov.uk/coronavirus
 ---
 
 {% extends "layouts/full-page-example.njk" %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/check-your-answers/index.njk
@@ -1,8 +1,7 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to check your answers before
   you send your application.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
@@ -123,19 +123,19 @@ scenario: |
       }) }}
 
       {% set doIHaveAnActiveCase %}
-        You will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.
+        You will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" class="govuk-link" rel="noreferrer noopener" target="_blank">contact child maintenance (opens in new tab)</a>.
       {% endset %}
 
       {% set payingToReceiving %}
         <p class="govuk-body">You will need to close your existing Child Maintenance case and open a new one.</p>
-        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" target="blank" class="govuk-link">MCMC</a> , or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
-        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" class="govuk-link" rel="noreferrer noopener" target="_blank">MCMC (opens in new tab)</a>, or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" class="govuk-link" rel="noreferrer noopener" target="_blank">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" class="govuk-link" rel="noreferrer noopener" target="_blank">contact child maintenance (opens in new tab)</a>.</p>
       {% endset %}
 
       {% set receivingToPaying %}
         <p class="govuk-body">You will need to close your existing Child Maintenance case and open a new one.</p>
-        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" target="blank" class="govuk-link">MCMC</a> , or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
-        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" target="_blank" class="govuk-link">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were the original applicant, you can close your case in <a href="https://childmaintenanceservice.direct.gov.uk/onlinerevive/public/landing-screen" class="govuk-link" rel="noreferrer noopener" target="_blank">MCMC (opens in new tab)</a>, or you can <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" class="govuk-link" rel="noreferrer noopener" target="_blank">contact child maintenance (opens in new tab)</a>.</p>
+        <p class="govuk-body">If you were not the original applicant, you will need to <a href="/get-help-arranging-child-maintenance/contact-child-maintenance-service" class="govuk-link" rel="noreferrer noopener" target="_blank">contact child maintenance (opens in new tab)</a>.</p>
       {% endset %}
 
       {{ govukDetails({

--- a/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/child-maintenance/index.njk
@@ -1,19 +1,16 @@
 ---
-scenario: >-
+scenario: |
   You are a user looking for information on child maintenance.
+
   There is a chance that as a user of this service, you are a victim of domestic
   abuse, therefore this page includes an Exit this Page component.
 
   Things to try:
 
   1. Activate the Exit this Page button by clicking it
-
   2. Activate the Exit this Page button by pressing the Esc key 3 times
-
   3. Activating the Exit this Page button on a small screen view
-
   4. Scoll down the page to see if the Exit this Page button remains sticky
-
   5. Tabbing through the page to find the Exit this Page "skip link" at the top
   of the accessibility tree
 ---

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -2,7 +2,7 @@
 name: Cookie banner (client side)
 scenario: You need to make a choice about whether to accept cookies or not.
 
-notes: >-
+notes: |
   For this example, when the user makes a choice to accept or reject cookies
   their preference is handled entirely on the client side with no page
   navigation, and JavaScript is used to swap out the cookie banner for the

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-client-side/index.njk
@@ -1,7 +1,6 @@
 ---
 name: Cookie banner (client side)
-scenario: >-
-  You need to make a choice about whether to accept cookies or not.
+scenario: You need to make a choice about whether to accept cookies or not.
 
 notes: >-
   For this example, when the user makes a choice to accept or reject cookies

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -1,7 +1,6 @@
 ---
 name: Cookie banner (essential cookies)
-scenario: >-
-  You are told about essential cookies, with a choice to hide the banner.
+scenario: You are told about essential cookies, with a choice to hide the banner.
 
 notes: >-
   When the user hides the cookie banner, we progressively enhance the cookie banner to hide with

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-essential-cookies/index.njk
@@ -2,7 +2,7 @@
 name: Cookie banner (essential cookies)
 scenario: You are told about essential cookies, with a choice to hide the banner.
 
-notes: >-
+notes: |
   When the user hides the cookie banner, we progressively enhance the cookie banner to hide with
   JavaScript. If JavaScript is not enabled, the form is submitted and a page navigation occurs.
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -2,7 +2,7 @@
 name: Cookie banner (server side with progressive enhancement)
 scenario: You need to make a choice about whether to accept cookies or not.
 
-notes: >-
+notes: |
   For this example, when the user makes a choice to accept or reject cookies the
   form is submitted and a page navigation occurs, with the confirmation banner
   shown on the next page.

--- a/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/cookie-banner-server-side/index.njk
@@ -1,7 +1,6 @@
 ---
 name: Cookie banner (server side with progressive enhancement)
-scenario: >-
-  You need to make a choice about whether to accept cookies or not.
+scenario: You need to make a choice about whether to accept cookies or not.
 
 notes: >-
   For this example, when the user makes a choice to accept or reject cookies the

--- a/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/feedback/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   You have used a service called GOV.UK Verify and wish to report an issue.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/have-you-changed-your-name/index.njk
@@ -1,8 +1,6 @@
 ---
-scenario: >-
-
+scenario: |
   As part of an online service, you are asked if you have changed your name.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/how-do-you-want-to-sign-in/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to select how you want to sign in.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -24,14 +24,15 @@
 
       <h2 class="govuk-heading-m"><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | unslugify }}</a></h2>
 
-      {% if example.scenario %}
-      <div class="app-prose-scope">
-        {{ example.scenario | markdown }}
-      </div>
-      {% endif %}
+      {% if example.scenario or example.notes %}
+        <div class="app-prose-scope">
+          {{ example.scenario | markdown if example.scenario }}
 
-      {% if example.notes %}
-        <p class="govuk-body govuk-!-font-size-16">{{ example.notes }}</p>
+          {% if example.notes %}
+            <h3>Notes</h3>
+            {{ example.notes | markdown }}
+          {% endif %}
+        </div>
       {% endif %}
 
       <hr class="govuk-section-break govuk-section-break--l" />

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -21,22 +21,29 @@
     <hr class="govuk-section-break govuk-section-break--l" />
 
     {% for example in fullPageExamples %}
+    <section aria-labelledby="heading-{{ example.name }}">
+      <h2 id="heading-{{ example.name }}" class="govuk-heading-l govuk-!-margin-bottom-2">{{ example.name | unslugify }}</h2>
 
-      <h2 class="govuk-heading-m"><a href="/full-page-examples/{{ example.path }}" class="govuk-link">{{ example.name | unslugify }}</a></h2>
+      <p class="govuk-body">
+        <a href="/full-page-examples/{{ example.path }}" target="_blank" class="govuk-link">
+          Open this example in a new tab<span class="govuk-visually-hidden">: {{ example.name | unslugify | lower }}</span>
+        </a>
+      </p>
 
-      {% if example.scenario or example.notes %}
-        <div class="app-prose-scope">
-          {{ example.scenario | markdown if example.scenario }}
+    {% if example.scenario or example.notes %}
+      <div class="app-prose-scope govuk-!-margin-top-6">
+        {{ example.scenario | markdown if example.scenario }}
 
-          {% if example.notes %}
-            <h3>Notes</h3>
-            {{ example.notes | markdown }}
-          {% endif %}
-        </div>
+      {% if example.notes %}
+        <h3>Notes</h3>
+        {{ example.notes | markdown }}
       {% endif %}
+      </div>
+    {% endif %}
 
-      <hr class="govuk-section-break govuk-section-break--l" />
+    </section>
 
+    <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--xl" />
     {% endfor %}
   </div>
 </div>

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -25,7 +25,7 @@
       <h2 id="heading-{{ example.name }}" class="govuk-heading-l govuk-!-margin-bottom-2">{{ example.name | unslugify }}</h2>
 
       <p class="govuk-body">
-        <a href="/full-page-examples/{{ example.path }}" target="_blank" class="govuk-link">
+        <a href="/full-page-examples/{{ example.path }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
           Open this example in a new tab<span class="govuk-visually-hidden">: {{ example.name | unslugify | lower }}</span>
         </a>
       </p>

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -26,7 +26,7 @@
 
       {% if example.scenario %}
       <div class="app-prose-scope">
-        {{ markdown(example.scenario) | safe }}
+        {{ example.scenario | markdown }}
       </div>
       {% endif %}
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/passport-details/index.njk
@@ -1,12 +1,10 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to provide your passport details.
-
 
   Things to try:
 
   1. Intentionally avoid answering the questions before continuing to the next page.
-
   2. Intentionally only fill in the day (and not month or year) of the expiry date.
 ---
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
@@ -1,13 +1,11 @@
 ---
-scenario: >-
+scenario: |
   You would like to find relevant articles by sorting the results and filtering
   by the organisation(s) that published the articles.
-
 
   Things to try:
 
   1. Sort the list of results so that the oldest results are first.
-
   2. Filter the list of results to show only those published by the Ministry of
       Defence.
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/search/index.njk
@@ -9,7 +9,7 @@ scenario: |
   2. Filter the list of results to show only those published by the Ministry of
       Defence.
 
-notes: >-
+notes: |
   The filtering and sorting may not be accurate – this is just a demonstration
   of the sort of interactions that you would find on a search page.
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
@@ -1,6 +1,6 @@
 ---
 name: Topic page (Service Manual)
-scenario: >-
+scenario: |
   You would like to access information on a given topic, perhaps by finding out
   more about software development processes.
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/start-page/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   You want to apply for a passport.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/task-list/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/task-list/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   You want to apply for a teacher training course
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/update-your-account-details/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you wish to update your account details.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo-success/index.njk
@@ -1,5 +1,5 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to upload your photo.
 
   The upload will always result in a success (alert) message that uses the notification banner.

--- a/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/upload-your-photo/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to upload your photo.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-address/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to provide your address.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-nationality/index.njk
@@ -1,20 +1,15 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to provide your nationality.
-
 
   Things to try:
 
   1. Select 'British' or 'Irish'
-
   2. Select 'Citizen of a different country' and provide a country name
-
   3. Select 'Citizen of a different country' and submit the form without
       providing a country name
-
   4. Do not select any of the options, and use ‘Help with nationality’ to
       provide a reason why you cannot provide your nationality.
-
   5. Intentionally submit the form without selecting any of the options
 ---
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-is-your-postcode/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to provide your postcode.
-
 
   Prompts:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/what-was-the-last-country-you-visited/index.njk
@@ -1,7 +1,6 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are asked to provide the last country you visited.
-
 
   Things to try:
 

--- a/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/work-history/index.njk
@@ -1,5 +1,5 @@
 ---
-scenario: >-
+scenario: |
   As part of an online service, you are providing information about previous jobs
   in the form of multiple job records. You are provided a page to check the records
   you've entered so far, add more or continue with the service.

--- a/packages/govuk-frontend-review/src/views/macros/showExamples.njk
+++ b/packages/govuk-frontend-review/src/views/macros/showExamples.njk
@@ -19,7 +19,7 @@
     <div class="govuk-width-container">
       <h3 id="heading-{{ exampleName }}" class="govuk-heading-m govuk-!-margin-bottom-2">{{ heading | safe }}</h3>
       <p class="govuk-body">
-        <a href="{{ path }}" target="_blank" class="govuk-link">
+        <a href="{{ path }}" class="govuk-link" rel="noreferrer noopener" target="_blank">
           Open this example in a new tab<span class="govuk-visually-hidden">: {{ heading | safe | lower }}</span>
         </a>
       </p>

--- a/packages/govuk-frontend-review/src/views/macros/showExamples.njk
+++ b/packages/govuk-frontend-review/src/views/macros/showExamples.njk
@@ -17,12 +17,12 @@
 
   <section aria-labelledby="heading-{{ exampleName }}" class="govuk-!-margin-bottom-9">
     <div class="govuk-width-container">
-      <div class="govuk-heading-m">
-        <h3 id="heading-{{ exampleName }}" class="govuk-!-display-inline">{{ heading | safe }}</h3>
-        <a href="{{ path }}" class="govuk-link govuk-!-margin-left-1 govuk-!-font-size-16">
-          (open in a new window)
+      <h3 id="heading-{{ exampleName }}" class="govuk-heading-m govuk-!-margin-bottom-2">{{ heading | safe }}</h3>
+      <p class="govuk-body">
+        <a href="{{ path }}" target="_blank" class="govuk-link">
+          Open this example in a new tab<span class="govuk-visually-hidden">: {{ heading | safe | lower }}</span>
         </a>
-      </div>
+      </p>
 
     {% if example.description %}
       <p class="govuk-body">


### PR DESCRIPTION
This PR adds:

1. Improved “Open this example in a new tab” link text [from the Design System](https://github.com/alphagov/govuk-design-system/pull/2994)
1. Markdown formatting on **Full page example** `notes:`
1. Markdown formatting on **Full page example** `scenario:`
1. Automatic "smart" typography and URL linking

# Before

All formatting inside `notes` is removed

<img width="745" alt="Example with notes, before" src="https://github.com/alphagov/govuk-frontend/assets/415517/0785a06f-5f1b-4f59-bb75-48ac8d858cf6">

# After

All formatting inside `notes` is now passed to Markdown with a **Notes** subheading

<img width="725" alt="Example with notes, after" src="https://github.com/alphagov/govuk-frontend/assets/415517/0390e78d-bb7f-4ef1-84ac-b91e6d19b5f0">