### PR TITLE
Fix: remove SASS warnings for govuk-frontend

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -71,7 +71,7 @@ $govuk-inverse-button-text-colour: $govuk-brand-colour !default;
     margin-left: 0;
     @include govuk-responsive-margin(6, "bottom", $adjustment: $button-shadow-size); // s2
     padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2)
-      (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2)); // s1
+      (govuk-spacing(2) - $govuk-border-width-form-element - calc($button-shadow-size / 2)); // s1
     border: $govuk-border-width-form-element solid transparent;
     border-radius: 0;
     color: $govuk-button-text-colour;

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -29,7 +29,7 @@
   }
 
   .govuk-checkboxes__input {
-    $input-offset: ($govuk-touch-target-size - $govuk-checkboxes-size) / 2;
+    $input-offset: calc(($govuk-touch-target-size - $govuk-checkboxes-size) / 2);
 
     position: absolute;
 
@@ -157,7 +157,7 @@
   // to be an even number in order to be centred under the 40px checkbox or radio.
   $conditional-border-width: $govuk-border-width-narrow;
   // Calculate the amount of padding needed to keep the border centered against the checkbox.
-  $conditional-border-padding: ($govuk-checkboxes-size / 2) - ($conditional-border-width / 2);
+  $conditional-border-padding: calc($govuk-checkboxes-size / 2) - calc($conditional-border-width / 2);
   // Move the border centered with the checkbox
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label
@@ -183,7 +183,7 @@
   // =========================================================
 
   .govuk-checkboxes--small {
-    $input-offset: ($govuk-touch-target-size - $govuk-small-checkboxes-size) / 2;
+    $input-offset: calc(($govuk-touch-target-size - $govuk-small-checkboxes-size) / 2);
     $label-offset: $govuk-touch-target-size - $input-offset;
 
     .govuk-checkboxes__item {
@@ -258,7 +258,7 @@
 
     // Align conditional reveals with small checkboxes
     .govuk-checkboxes__conditional {
-      $margin-left: ($govuk-small-checkboxes-size / 2) - ($conditional-border-width / 2);
+      $margin-left: calc($govuk-small-checkboxes-size / 2) - calc($conditional-border-width / 2);
       margin-left: $margin-left;
       padding-left: $label-offset - ($margin-left + $conditional-border-width);
       clear: both;

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/_index.scss
@@ -51,7 +51,7 @@
   }
 
   .govuk-exit-this-page__indicator-light--on {
-    border-width: $indicator-size / 2;
+    border-width: calc($indicator-size / 2);
   }
 
   @media only print {

--- a/packages/govuk-frontend/src/govuk/components/footer/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/footer/_index.scss
@@ -7,8 +7,8 @@
   $govuk-footer-crest-image-width-2x: 250px;
   $govuk-footer-crest-image-height-2x: 204px;
   // Half the 2x image so that it fits the regular 1x size.
-  $govuk-footer-crest-image-width: ($govuk-footer-crest-image-width-2x / 2);
-  $govuk-footer-crest-image-height: ($govuk-footer-crest-image-height-2x / 2);
+  $govuk-footer-crest-image-width: calc($govuk-footer-crest-image-width-2x / 2);
+  $govuk-footer-crest-image-height: calc($govuk-footer-crest-image-height-2x / 2);
 
   .govuk-footer {
     @include govuk-font($size: 16);

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
@@ -52,7 +52,7 @@
       box-sizing: border-box;
 
       // Calculate the internal width of a two-thirds column...
-      $two-col-width: ($govuk-page-width * 2 / 3) - ($govuk-gutter * 1 / 3);
+      $two-col-width: calc($govuk-page-width * 2 / 3) - calc($govuk-gutter * 1 / 3);
 
       // ...and then factor in the left border and padding
       $banner-exterior: ($padding-tablet + $govuk-border-width);

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -32,7 +32,7 @@
   }
 
   .govuk-radios__input {
-    $input-offset: ($govuk-touch-target-size - $govuk-radios-size) / 2;
+    $input-offset: calc(($govuk-touch-target-size - $govuk-radios-size) / 2);
 
     position: absolute;
 
@@ -173,7 +173,7 @@
   // to be an even number in order to be centred under the 40px checkbox or radio.
   $conditional-border-width: $govuk-border-width-narrow;
   // Calculate the amount of padding needed to keep the border centered against the radios.
-  $conditional-border-padding: ($govuk-radios-size / 2) - ($conditional-border-width / 2);
+  $conditional-border-padding: calc($govuk-radios-size / 2) - calc($conditional-border-width / 2);
   // Move the border centered with the radios
   $conditional-margin-left: $conditional-border-padding;
   // Move the contents of the conditional inline with the label
@@ -199,7 +199,7 @@
   // =========================================================
 
   .govuk-radios--small {
-    $input-offset: ($govuk-touch-target-size - $govuk-small-radios-size) / 2;
+    $input-offset: calc(($govuk-touch-target-size - $govuk-small-radios-size) / 2);
     $label-offset: $govuk-touch-target-size - $input-offset;
 
     .govuk-radios__item {
@@ -273,7 +273,7 @@
 
     // Align conditional reveals with small radios
     .govuk-radios__conditional {
-      $margin-left: ($govuk-small-radios-size / 2) - ($conditional-border-width / 2);
+      $margin-left: calc($govuk-small-radios-size / 2) - calc($conditional-border-width / 2);
       margin-left: $margin-left;
       padding-left: $label-offset - ($margin-left + $conditional-border-width);
       clear: both;

--- a/packages/govuk-frontend/src/govuk/helpers/_shape-arrow.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_shape-arrow.scss
@@ -14,7 +14,7 @@
 @function _govuk-equilateral-height($base) {
   $square-root-of-three: 1.732;
 
-  @return ($base / 2) * $square-root-of-three;
+  @return calc($base / 2) * $square-root-of-three;
 }
 
 /// Arrow mixin
@@ -44,7 +44,7 @@
   border-style: solid;
   border-color: transparent; // 1
 
-  $perpendicular: $base / 2;
+  $perpendicular: calc($base / 2);
 
   @if not $height {
     $height: _govuk-equilateral-height($base);

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -74,7 +74,7 @@
 
 @function _govuk-line-height($line-height, $font-size) {
   @if not unitless($line-height) and unit($line-height) == unit($font-size) {
-    $line-height: $line-height / $font-size;
+    $line-height: calc($line-height / $font-size);
   }
 
   @return $line-height;

--- a/packages/govuk-frontend/src/govuk/settings/_measurements.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_measurements.scss
@@ -19,19 +19,19 @@ $govuk-page-width: 960px !default;
 /// @access public
 
 $govuk-grid-widths: (
-  one-quarter: (
+  one-quarter: calc(
     100% / 4
   ),
-  one-third: (
+  one-third: calc(
     100% / 3
   ),
-  one-half: (
+  one-half: calc(
     100% / 2
   ),
-  two-thirds: (
+  two-thirds: calc(
     200% / 3
   ),
-  three-quarters: (
+  three-quarters: calc(
     300% / 4
   ),
   full: 100%
@@ -49,7 +49,7 @@ $govuk-gutter: 30px !default;
 /// @type Number
 /// @access public
 
-$govuk-gutter-half: $govuk-gutter / 2;
+$govuk-gutter-half: calc($govuk-gutter / 2);
 
 // =========================================================
 // Borders

--- a/packages/govuk-frontend/src/govuk/tools/_px-to-em.scss
+++ b/packages/govuk-frontend/src/govuk/tools/_px-to-em.scss
@@ -16,5 +16,5 @@
   @if unitless($context-font-size) {
     $context-font-size: $context-font-size * 1px;
   }
-  @return $value / $context-font-size * 1em;
+  @return calc($value / $context-font-size * 1em);
 }

--- a/packages/govuk-frontend/src/govuk/tools/_px-to-rem.scss
+++ b/packages/govuk-frontend/src/govuk/tools/_px-to-rem.scss
@@ -16,5 +16,5 @@
     $value: $value * 1px;
   }
 
-  @return $value / $govuk-root-font-size * 1rem;
+  @return calc($value / $govuk-root-font-size * 1rem);
 }

--- a/packages/govuk-frontend/src/govuk/vendor/_sass-mq.scss
+++ b/packages/govuk-frontend/src/govuk/vendor/_sass-mq.scss
@@ -95,7 +95,7 @@ $mq-media-type: all !default;
     } @else if unit($px) == em {
         @return $px;
     }
-    @return ($px / $base-font-size) * 1em;
+    @return calc($px / $base-font-size) * 1em;
 }
 
 /// Get a breakpoint's width


### PR DESCRIPTION
Hi, I'm from the the Data Products Team at the Cabinet Office, and I work on the GovSearch app.

SCSS decided to flag lots of deprecated divisions. This PR fixes it.

Thanks for your consideration

![image](https://github.com/alphagov/govuk-frontend/assets/22219650/a38fbf5e-a8f6-4ece-b703-56cf7318d772)
