### PR TITLE
Enable ESLint stylistic typed linting in source code

### DIFF
--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -18,8 +18,8 @@ module.exports = {
       },
       plugins: ['@typescript-eslint', 'es-x'],
       extends: [
-        'plugin:@typescript-eslint/recommended',
-        'plugin:@typescript-eslint/recommended-requiring-type-checking',
+        'plugin:@typescript-eslint/strict-type-checked',
+        'plugin:@typescript-eslint/stylistic-type-checked',
         'plugin:es-x/restrict-to-es2015',
         'prettier'
       ],

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -27,6 +27,14 @@ module.exports = {
         browser: true
       },
       rules: {
+        // Allow void return shorthand in arrow functions
+        '@typescript-eslint/no-confusing-void-expression': [
+          'error',
+          {
+            ignoreArrowShorthand: true
+          }
+        ],
+
         // Check type support for template string implicit `.toString()`
         '@typescript-eslint/restrict-template-expressions': [
           'error',

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path')
+const { join } = require('path')
 
 module.exports = {
   settings: {
@@ -14,7 +14,7 @@ module.exports = {
       parserOptions: {
         // Note: Allow ES2015 for import/export syntax
         ecmaVersion: '2015',
-        project: [resolve(__dirname, 'tsconfig.dev.json')]
+        project: [join(__dirname, 'tsconfig.build.json')]
       },
       plugins: ['@typescript-eslint', 'es-x'],
       extends: [

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -35,6 +35,12 @@ module.exports = {
           }
         ],
 
+        // Turn off known code suggestions until support is confirmed
+        // e.g. Already supported ES2015+ features or via Babel transforms
+        '@typescript-eslint/prefer-includes': 'off',
+        '@typescript-eslint/prefer-nullish-coalescing': 'off',
+        '@typescript-eslint/prefer-optional-chain': 'off',
+
         // Check type support for template string implicit `.toString()`
         '@typescript-eslint/restrict-template-expressions': [
           'error',

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -264,7 +264,7 @@ export class Accordion extends GOVUKFrontendComponent {
     // to the `$headingText` element)
     for (const attr of Array.from($span.attributes)) {
       if (attr.nodeName !== 'id') {
-        $button.setAttribute(attr.nodeName, attr.nodeValue)
+        $button.setAttribute(attr.nodeName, `${attr.nodeValue}`)
       }
     }
 
@@ -326,7 +326,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
       // Get original attributes, and pass them to the replacement
       for (const attr of Array.from($summary.attributes)) {
-        $summarySpan.setAttribute(attr.nodeName, attr.nodeValue)
+        $summarySpan.setAttribute(attr.nodeName, `${attr.nodeValue}`)
       }
 
       // Copy original contents of summary to the new summary span
@@ -437,12 +437,12 @@ export class Accordion extends GOVUKFrontendComponent {
       `.${this.sectionHeadingTextClass}`
     )
     if ($headingText) {
-      ariaLabelParts.push($headingText.textContent.trim())
+      ariaLabelParts.push(`${$headingText.textContent}`.trim())
     }
 
     const $summary = $section.querySelector(`.${this.sectionSummaryClass}`)
     if ($summary) {
-      ariaLabelParts.push($summary.textContent.trim())
+      ariaLabelParts.push(`${$summary.textContent}`.trim())
     }
 
     const ariaLabelMessage = expanded

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -146,7 +146,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     // Inject a description for the textarea if none is present already
     // for when the component was rendered with no maxlength, maxwords
     // nor custom textareaDescriptionText
-    if ($textareaDescription.textContent.match(/^\s*$/)) {
+    if (`${$textareaDescription.textContent}`.match(/^\s*$/)) {
       $textareaDescription.textContent = this.i18n.t('textareaDescription', {
         count: this.maxLength
       })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -110,15 +110,11 @@ export class Tabs extends GOVUKFrontendComponent {
     // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
     // to be able to fall back to the deprecated MediaQueryList.addListener
     if ('addEventListener' in this.mql) {
-      this.mql.addEventListener('change', () => {
-        this.checkMode()
-      })
+      this.mql.addEventListener('change', () => this.checkMode())
     } else {
       // @ts-expect-error Property 'addListener' does not exist
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      this.mql.addListener(() => {
-        this.checkMode()
-      })
+      this.mql.addListener(() => this.checkMode())
     }
 
     this.checkMode()

--- a/packages/govuk-frontend/tsconfig.build.json
+++ b/packages/govuk-frontend/tsconfig.build.json
@@ -4,6 +4,7 @@
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
+    "strict": true,
     "target": "ES2015",
     "types": ["node", "typed-query-selector"]
   }


### PR DESCRIPTION
This PR enables [ESLint stylistic typed linting](https://typescript-eslint.io/linting/configs/#projects-with-type-checking)

It highlights opportunities to replace older JavaScript with new, but also uses [TypeScript `{ "strict": true }`](https://www.typescriptlang.org/tsconfig#strict) to add warnings when our GOV.UK Frontend source code is too loose or unnecessarily defensive

As part of https://github.com/alphagov/govuk-frontend/pull/4323 we've already fixed:

* Class fields with incorrect `null` default
* Selector `null` return values not handled
* Timeout and interval IDs cleared when `null`
* Confg allows `null` as `typeof value === 'object'`

But this PR includes a few more:

1. Potentially `null` attribute `NamedNodeMap` values
1. Potentially `null` element `.parentNode` values
1. Potentially `null` element `.textContent` values

Whilst quite pedantic for internal code, it's a huge safety net as we [clarify our public API](https://github.com/alphagov/govuk-frontend/issues/3478) and catch issues like:

* https://github.com/alphagov/govuk-frontend/pull/4394

## Stylistic typed linting

This change lets ESLint use types to reduce unnecessary code with [suggestions to use modern syntax](https://github.com/alphagov/govuk-frontend/pull/4286)

<img width="767" alt="Unnecessary conditional" src="https://github.com/alphagov/govuk-frontend/assets/415517/1e4b4e83-0aaa-4eee-a029-5003fd47eb1b">

## Strict mode checks (existing)

Here's a list of the compiler options we already enabled in the past:

* [`strictBindCallApply`](https://www.typescriptlang.org/tsconfig#strictBindCallApply) – Function `bind`, `call` and `apply` must be checked (added in https://github.com/alphagov/govuk-frontend/commit/73a706a07b70bdf3c31b876dcb0fbfd6f1bc31e4)
* [`strictFunctionTypes`](https://www.typescriptlang.org/tsconfig#strictFunctionTypes) – Function parameters must be checked (added in https://github.com/alphagov/govuk-frontend/commit/73a706a07b70bdf3c31b876dcb0fbfd6f1bc31e4)
* [`noImplicitThis`](https://www.typescriptlang.org/tsconfig#noImplicitThis) – Context for `this` must be checked (added in https://github.com/alphagov/govuk-frontend/commit/8b3d6f35b1c202ecb1808788e84df93ed56596ed)

## Strict mode checks (new)

Here's a list of the compiler options enabled in this PR:

* [`alwaysStrict`](https://www.typescriptlang.org/tsconfig#alwaysStrict) – Assume code has `"use strict"`
* [`strictNullChecks`](https://www.typescriptlang.org/tsconfig#strictNullChecks) – Possible `null` and `undefined` must be checked
* [`strictPropertyInitialization`](https://www.typescriptlang.org/tsconfig#strictPropertyInitialization) – Class field values must be checked
* [`noImplicitAny`](https://www.typescriptlang.org/tsconfig#noImplicitAny) – All types must be added (e.g. in JSDoc)
* [`noUncheckedIndexedAccess`](https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess) – Array and object key/values must be checked
* [`useUnknownInCatchVariables`](https://www.typescriptlang.org/tsconfig#useUnknownInCatchVariables) – Assume errors are unknown until `error instanceof`