### PR TITLE
Add custom checkboxes and radios examples to percy

### DIFF
--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -51,9 +51,13 @@ export async function screenshots() {
   for (const [componentName, options] of /** @type {const} */ ([
     ['button', { exampleName: 'start' }],
     ['button', { exampleName: 'inverse-start' }],
+    ['checkboxes', { exampleName: 'with-hints-on-items' }],
+    ['checkboxes', { exampleName: 'small' }],
     ['details', { exampleName: 'expanded' }],
     ['pagination', { exampleName: 'with-prev-and-next-only' }],
-    ['pagination', { exampleName: 'with-prev-and-next-only-and-labels' }]
+    ['pagination', { exampleName: 'with-prev-and-next-only-and-labels' }],
+    ['radios', { exampleName: 'with-hints-on-items' }],
+    ['radios', { exampleName: 'small' }]
   ])) {
     await screenshotComponent(await browser.newPage(), componentName, options)
   }


### PR DESCRIPTION
Add examples with hints and small variants of both radios and checkboxes.

The complexity of variation of both these components means that the default examples don't sufficiently cover potential visual changes within these components.

Spun off from https://github.com/alphagov/govuk-frontend/pull/4093