### PR TITLE
Add missing word to changelog intro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-For advice on how to these release notes see [our guidance on staying up to date with changes](https://frontend.design-system.service.gov.uk/staying-up-to-date/).
+For advice on how to use these release notes see [our guidance on staying up to date with changes](https://frontend.design-system.service.gov.uk/staying-up-to-date/).
 
 ## Unreleased
 


### PR DESCRIPTION
Looks like I didn't word good in #4061! Update the introductory sentence that points to the 'staying up to date with changes' guidance so that it makes sense.