### PR TITLE
Header menu button position refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change was introduced in [pull request #4291: Rename `govuk-typography-resp
 We've made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#4157: Dynamically position text within input prefixes and suffixes](https://github.com/alphagov/govuk-frontend/pull/4157)
+- [#4150: Header menu button position refactor](https://github.com/alphagov/govuk-frontend/pull/4150)
 
 ## 5.0.0 (Breaking release)
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -6,6 +6,7 @@
   $govuk-header-link-active: #1d8feb;
   $govuk-header-nav-item-border-color: #2e3133;
   $govuk-header-link-underline-thickness: 3px;
+  $govuk-header-vertical-spacing-value: 2;
 
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
@@ -28,7 +29,7 @@
     @include govuk-clearfix;
     position: relative;
     margin-bottom: -$govuk-header-border-width;
-    padding-top: govuk-spacing(2);
+    padding-top: govuk-spacing($govuk-header-vertical-spacing-value);
     border-bottom: $govuk-header-border-width solid $govuk-header-border-color;
   }
 
@@ -160,8 +161,8 @@
   }
 
   .govuk-header__logo {
-    @include govuk-responsive-margin(2, "bottom");
     padding-right: govuk-spacing(8);
+    @include govuk-responsive-margin($govuk-header-vertical-spacing-value, "bottom");
 
     @include govuk-media-query($from: desktop) {
       width: 33.33%;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -212,6 +212,7 @@
     border: 0;
     color: govuk-colour("white");
     background: none;
+    word-break: break-all;
     cursor: pointer;
 
     &:hover {

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -11,6 +11,7 @@
   // as the crown svg height is the only thing that controls the height of the header
   $govuk-header-crown-height: 30px;
   $govuk-header-menu-button-height: 20px;
+  $govuk-header-menu-button-width: 80px;
 
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
@@ -165,8 +166,10 @@
   }
 
   .govuk-header__logo {
-    padding-right: govuk-spacing(8);
     @include govuk-responsive-margin($govuk-header-vertical-spacing-value, "bottom");
+    // Protect the absolute positioned menu button from overlapping with the
+    // logo with right padding using the button's width
+    padding-right: $govuk-header-menu-button-width;
 
     @include govuk-media-query($from: desktop) {
       width: 33.33%;
@@ -199,9 +202,11 @@
     // - adding that to the crown height
     // - dividing it by 2 so you have the vertical centre of the header
     // - subtracting half the height of the menu button
-    top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) - ($govuk-header-menu-button-height / 2);
+    top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) -
+      ($govuk-header-menu-button-height / 2);
     right: 0;
-    height: $govuk-header-menu-button-height;
+    max-width: $govuk-header-menu-button-width;
+    min-height: $govuk-header-menu-button-height;
     margin: 0;
     padding: 0;
     border: 0;

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -10,7 +10,7 @@
   // This crown height is only used to calculate top offset of mobile menu button
   // as the crown svg height is the only thing that controls the height of the header
   $govuk-header-crown-height: 30px;
-  $govuk-header-menu-button-height: 20px;
+  $govuk-header-menu-button-height: 24px;
   $govuk-header-menu-button-width: 80px;
 
   .govuk-header {

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -7,6 +7,10 @@
   $govuk-header-nav-item-border-color: #2e3133;
   $govuk-header-link-underline-thickness: 3px;
   $govuk-header-vertical-spacing-value: 2;
+  // This crown height is only used to calculate top offset of mobile menu button
+  // as the crown svg height is the only thing that controls the height of the header
+  $govuk-header-crown-height: 30px;
+  $govuk-header-menu-button-height: 20px;
 
   .govuk-header {
     @include govuk-font($size: 16, $line-height: 1);
@@ -190,8 +194,14 @@
   .govuk-header__menu-button {
     @include govuk-font($size: 16);
     position: absolute;
-    top: govuk-spacing(4);
+    // calculate top offset by:
+    // - getting the vertical spacing for the top and the bottom of the header
+    // - adding that to the crown height
+    // - dividing it by 2 so you have the vertical centre of the header
+    // - subtracting half the height of the menu button
+    top: (((govuk-spacing($govuk-header-vertical-spacing-value) * 2) + $govuk-header-crown-height) / 2) - ($govuk-header-menu-button-height / 2);
     right: 0;
+    height: $govuk-header-menu-button-height;
     margin: 0;
     padding: 0;
     border: 0;


### PR DESCRIPTION
## What/Why
Refactor the header component's navigation menu button styling:

- Move specific, repeated values into variables
- Apply a min hight and a max width to the menu button
- Calculates the top offset of the menu button based on the height of the button against the height of the header
- Increases the expected width of the menu button
- Increases the height of the menu button to 24px, allowing us to additionally resolve https://github.com/alphagov/govuk-frontend/issues/4357

Additional details can be found in comments within commits.

Resolves https://github.com/alphagov/govuk-frontend/issues/3896

Reimplementation off of https://github.com/alphagov/govuk-frontend/pull/4065

## Thoughts
I couldn't figure out a good alternative to using right hand padding on the logo and an absolute positioned menu button. Ideally we would dynamically calculate the padding but sass doesn't have the means to fetch dynamic width. This way at least there's a relationship between the padding and the button width and it's easier to change the padding/button width. Open to ideas.

I'm wondering if there's a more explicit way to define the height of the header or if our assumption that the crown is always 30px is enough. We want it to stay at 50px but that's entirely human memory driven. There's nothing in our code to reflect that. Nothing to lose sleep over.