### PR TITLE
Fix missing full stops in macro option descriptions

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -42,7 +42,7 @@ params:
   - name: preventDoubleClick
     type: boolean
     required: false
-    description: Prevent accidental double clicks on submit buttons from submitting forms multiple times
+    description: Prevent accidental double clicks on submit buttons from submitting forms multiple times.
   - name: isStartButton
     type: boolean
     required: false

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.yaml
@@ -111,7 +111,7 @@ examples:
         text: Can you provide more detail?
 
   - name: with custom textarea description
-    description: with textarea description translated into Welsh
+    description: with textarea description translated into Welsh.
     options:
       name: custom-textarea-description
       id: custom-textarea-description

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -85,7 +85,7 @@ params:
         params:
           - name: html
             type: string
-            description: The HTML to reveal when the checkbox is checked
+            description: The HTML to reveal when the checkbox is checked.
             required: true
       - name: behaviour
         type: string

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.yaml
@@ -22,7 +22,7 @@ params:
   - name: errorList
     type: array
     required: true
-    description: The list of errors to include in the summary
+    description: The list of errors to include in the summary.
     params:
       - name: href
         type: string

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -26,7 +26,7 @@ params:
   - name: activatedText
     type: string
     required: false
-    description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Exiting page.'.
+    description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Loading.'.
   - name: timedOutText
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.yaml
@@ -26,19 +26,19 @@ params:
   - name: activatedText
     type: string
     required: false
-    description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Exiting page.'
+    description: Text announced by screen readers when Exit this Page has been activated via the keyboard shortcut. Defaults to 'Exiting page.'.
   - name: timedOutText
     type: string
     required: false
-    description: Text announced by screen readers when the keyboard shortcut has timed out without successful activation. Defaults to 'Exit this page expired.'
+    description: Text announced by screen readers when the keyboard shortcut has timed out without successful activation. Defaults to 'Exit this page expired.'.
   - name: pressTwoMoreTimesText
     type: string
     required: false
-    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> two more times to activate the button. Defaults to 'Shift, press 2 more times to exit.'
+    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> two more times to activate the button. Defaults to 'Shift, press 2 more times to exit.'.
   - name: pressOneMoreTimeText
     type: string
     required: false
-    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> one more time to activate the button. Defaults to 'Shift, press 1 more time to exit.'
+    description: Text announced by screen readers when the user must press <kbd>Shift</kbd> one more time to activate the button. Defaults to 'Shift, press 1 more time to exit.'.
 
 examples:
   - name: default

--- a/packages/govuk-frontend/src/govuk/components/fieldset/fieldset.yaml
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/fieldset.yaml
@@ -6,7 +6,7 @@ params:
   - name: legend
     type: object
     required: false
-    description: Options for the legend
+    description: Options for the legend.
     params:
       - name: text
         type: string

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -181,7 +181,7 @@ examples:
           text: Navigation item 4
 
   - name: with large navigation
-    description: An edge case example with a large number of navitation items with long names used to test wrapping
+    description: An edge case example with a large number of navigation items with long names used to test wrapping
     options:
       navigation:
         - href: '/browse/benefits'

--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -2,11 +2,11 @@ params:
   - name: homepageUrl
     type: string
     required: false
-    description: The URL of the homepage. Defaults to `/`
+    description: The URL of the homepage. Defaults to `/`.
   - name: assetsPath
     type: string
     required: false
-    description: The public path for the assets folder. If not provided it defaults to /assets/images
+    description: The public path for the assets folder. If not provided it defaults to /assets/images.
   - name: productName
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -77,7 +77,7 @@ params:
         params:
           - name: html
             type: string
-            description: The HTML to reveal when the radio is checked
+            description: The HTML to reveal when the radio is checked.
             required: true
       - name: disabled
         type: boolean

--- a/packages/govuk-frontend/src/govuk/components/table/table.yaml
+++ b/packages/govuk-frontend/src/govuk/components/table/table.yaml
@@ -68,7 +68,7 @@ params:
   - name: caption
     type: string
     required: false
-    description: Caption text
+    description: Caption text.
   - name: captionClasses
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.yaml
@@ -29,7 +29,7 @@ params:
         required: false
         description: HTML attributes (for example data attributes) to add to the tab.
       - name: panel
-        description: Content for the panel
+        description: Content for the panel.
         type: object
         required: true
         params:

--- a/packages/govuk-frontend/src/govuk/components/warning-text/warning-text.yaml
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/warning-text.yaml
@@ -10,7 +10,7 @@ params:
   - name: iconFallbackText
     type: string
     required: false
-    description: The fallback text for the icon. Defaults to 'Warning'
+    description: The fallback text for the icon. Defaults to 'Warning'.
   - name: classes
     type: string
     required: false


### PR DESCRIPTION
Just a few more typos and missing full stops spotted in recent testing

Builds on other fixes in https://github.com/alphagov/govuk-frontend/pull/4122

<img width="763" alt="Description with missing full stop" src="https://github.com/alphagov/govuk-frontend/assets/415517/7dc70646-277e-4ddf-901c-15e95ab98a27">
