### PR TITLE
Export type declaration maps `*.d.mts.map`

### DIFF
--- a/packages/govuk-frontend/.npmignore
+++ b/packages/govuk-frontend/.npmignore
@@ -1,2 +1,8 @@
+# Ignore diff fixtures
 *.html
+
+# Ignore test files
 *.test.*
+
+# Ignore config build tools
+src/govuk-prototype-kit/*.mjs

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -7,6 +7,7 @@
   "types": "dist/govuk/all.d.mts",
   "sass": "dist/govuk/all.scss",
   "files": [
+    "src",
     "dist",
     "govuk-prototype-kit.config.json",
     "package.json",

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -75,7 +75,8 @@ describe('packages/govuk-frontend/dist/', () => {
         mapPathTo(['**/*.mjs'], ({ dir: requirePath, name }) => [
           join(requirePath, `${name}.mjs`),
           join(requirePath, `${name}.mjs.map`), // with source map
-          join(requirePath, `${name}.d.mts`) // with type declaration
+          join(requirePath, `${name}.d.mts`), // with type declaration
+          join(requirePath, `${name}.d.mts.map`) // with type declaration map
         ])
       )
 

--- a/packages/govuk-frontend/tsconfig.build.json
+++ b/packages/govuk-frontend/tsconfig.build.json
@@ -4,11 +4,13 @@
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
     "declaration": true,
+    "declarationMap": true,
     "emitDeclarationOnly": true,
     "lib": ["ESNext", "DOM"],
     "noEmit": false,
     "outDir": "./dist",
     "rootDir": "./src",
+    "sourceMap": true,
     "strict": true,
     "target": "ES2015",
     "types": ["node", "typed-query-selector"]

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -92,7 +92,8 @@ export async function compileJavaScript([
           preserveModulesRoot: relative(basePath, srcPath),
 
           // Enable source maps
-          sourcemap: true
+          sourcemap: true,
+          sourcemapExcludeSources: !!output.preserveModules
         })
       })
     )

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -71,7 +71,8 @@ export async function compileStylesheet([
      */
     map: {
       annotation: true,
-      inline: false
+      inline: false,
+      sourcesContent: false
     }
   }
 
@@ -114,6 +115,7 @@ export async function compileStylesheet([
     // Pass source maps to PostCSS
     if (typeof options.map === 'object') {
       options.map.prev = map
+      options.map.sourcesContent = true
     }
   }
 


### PR DESCRIPTION
Follow up to https://github.com/alphagov/govuk-frontend/issues/2835 and up for discussion

Enables editor and IDE “Go to definition” (to original sources) via `npm install govuk-frontend`