### PR TITLE
Increase the space between the tag and the text in the phase banner

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
@@ -18,7 +18,11 @@
 
   .govuk-phase-banner__content__tag {
     @include govuk-font($size: 16);
-    margin-right: govuk-spacing(2);
+    margin-right: govuk-spacing(3);
+
+    @include govuk-media-query($from: tablet) {
+      margin-right: govuk-spacing(2);
+    }
 
     // When forced colour mode is active, for example to provide high contrast,
     // the background colour of the tag is the same as the rest of the page. To ensure


### PR DESCRIPTION
Increase the margin between the tag and the text in the phase banner on small screens only.

Fixes https://github.com/alphagov/govuk-frontend/issues/3905

More details in the issue itself.