### PR TITLE
Remove responsive spacing from form group

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -66,10 +66,7 @@ $govuk-inverse-button-text-colour: $govuk-brand-colour !default;
     display: inline-block;
     position: relative;
     width: 100%;
-    margin-top: 0;
-    margin-right: 0;
-    margin-left: 0;
-    @include govuk-responsive-margin(6, "bottom", $adjustment: $button-shadow-size); // s2
+    margin: 0 0 (govuk-spacing(6) + $button-shadow-size); // s2
     padding: (govuk-spacing(2) - $govuk-border-width-form-element) govuk-spacing(2)
       (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2)); // s1
     border: $govuk-border-width-form-element solid transparent;

--- a/packages/govuk-frontend/src/govuk/objects/_button-group.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_button-group.scss
@@ -19,8 +19,6 @@
 
     $link-spacing: govuk-spacing(1);
 
-    @include govuk-responsive-margin(6, "bottom", $adjustment: $vertical-gap * -1);
-
     // Flexbox is used to center-align links on mobile, align everything along
     // the baseline on tablet and above, and to removes extra whitespace that
     // we'd get between the buttons and links because they're inline-blocks.
@@ -32,6 +30,8 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+
+    margin-bottom: (govuk-spacing(6) - $vertical-gap);
 
     // Give links within the button group the same font-size and line-height
     // as buttons.

--- a/packages/govuk-frontend/src/govuk/objects/_form-group.scss
+++ b/packages/govuk-frontend/src/govuk/objects/_form-group.scss
@@ -3,7 +3,7 @@
 @include govuk-exports("govuk/objects/form-group") {
   .govuk-form-group {
     @include govuk-clearfix;
-    @include govuk-responsive-margin(6, "bottom");
+    margin-bottom: govuk-spacing(6);
 
     .govuk-form-group:last-of-type {
       margin-bottom: 0; // Remove margin from last item in nested groups


### PR DESCRIPTION
Remove the responsive margin from form group so that the bottom margin is 30px across all breakpoints.

Fixes https://github.com/alphagov/govuk-frontend/issues/3924. More details in the issue.