### PR TITLE
Remove unused `assetsPath` for IE8 fallback GOV.UK logo

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.yaml
+++ b/packages/govuk-frontend/src/govuk/components/header/header.yaml
@@ -3,10 +3,6 @@ params:
     type: string
     required: false
     description: The URL of the homepage. Defaults to `/`.
-  - name: assetsPath
-    type: string
-    required: false
-    description: The public path for the assets folder. If not provided it defaults to /assets/images.
   - name: productName
     type: string
     required: false


### PR DESCRIPTION
We no longer use [**Header** `params.assetsPath`](https://design-system.service.gov.uk/components/header/#options-default-1--primary) since we merged:

* https://github.com/alphagov/govuk-frontend/pull/3641

We can remove it from the Nunjucks macro options