### PR TITLE
Remove incorrect `params.text` Button description etc

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -6,11 +6,11 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined.
+    description: If `html` is set, this is not required. Text for the `input`, `button` or `a` element. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined.
   - name: html
     type: string
     required: true
-    description: If `text` is set, this is not required. HTML for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This option has no effect if `element` is set to `input`.
+    description: If `text` is set, this is not required. HTML for the `button` or `a` element only. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This option has no effect if `element` is set to `input`.
   - name: name
     type: string
     required: false
@@ -22,11 +22,11 @@ params:
   - name: value
     type: string
     required: false
-    description: Value for the `button` tag. This has no effect on `a` or `input` elements.
+    description: Value for the `button` element only. This has no effect on `a` or `input` elements.
   - name: disabled
     type: boolean
     required: false
-    description: Whether the button should be disabled. For button and input elements, `disabled` and `aria-disabled` attributes will be set automatically. This has no effect on `a` elements.
+    description: Whether the button should be disabled. For `input` and `button` elements, `disabled` and `aria-disabled` attributes will be set automatically. This has no effect on `a` elements.
   - name: href
     type: string
     required: false

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -2,7 +2,7 @@ params:
   - name: element
     type: string
     required: false
-    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.
+    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if `href` is provided.
   - name: text
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -6,7 +6,7 @@ params:
   - name: text
     type: string
     required: true
-    description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined. This option has no effect if `element` is set to `input`.
+    description: If `html` is set, this is not required. Text for the button or link. If `html` is provided, the `text` option will be ignored and `element` will be automatically set to `button` unless `href` is also set, or it has already been defined.
   - name: html
     type: string
     required: true

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -2,7 +2,7 @@ params:
   - name: element
     type: string
     required: false
-    description: Whether to use an `input`, `button` or `a` element to create the button. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.
+    description: HTML element for the button component – `input`, `button` or `a`. In most cases you will not need to set this as it will be configured automatically if you use `href` or `html`.
   - name: text
     type: string
     required: true
@@ -26,11 +26,11 @@ params:
   - name: disabled
     type: boolean
     required: false
-    description: Whether the button should be disabled. For `input` and `button` elements, `disabled` and `aria-disabled` attributes will be set automatically. This has no effect on `a` elements.
+    description: Whether the button component should be disabled. For `input` and `button` elements, `disabled` and `aria-disabled` attributes will be set automatically. This has no effect on `a` elements.
   - name: href
     type: string
     required: false
-    description: The URL that the button should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.
+    description: The URL that the button component should link to. If this is set, `element` will be automatically set to `a` if it has not already been defined.
   - name: classes
     type: string
     required: false


### PR DESCRIPTION
Documentation for the [Button component](https://design-system.service.gov.uk/components/button/) is quite complicated

As a quick fix I've removed the Button description stating `params.text` has no effect on inputs

We actually use `params.text` in `<input value="{{ params.text }}">`

Plus some other suggested tweaks for where:

1. We sometimes say **"button or link"** to mean the element
1. We sometimes say **"button tag"** versus **"button element"**
1. We sometimes say **"button"** to mean **"button component"**

It's still complicated, but correct