### PR TITLE
Throw `ConfigError` when component configs are invalid

### DIFF
--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -26,6 +26,6 @@ module.exports = {
     strict: false
   },
 
-  // Ignore warnings about class fields using I18n (@private)
-  intentionallyNotExported: ['I18n', 'TranslationPluralForms']
+  // Ignore known undocumented types (@internal, @private etc)
+  intentionallyNotExported: ['I18n', 'Schema', 'TranslationPluralForms']
 }

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -39,6 +39,10 @@ module.exports = {
         // Babel transpiles ES2020 class fields
         'es-x/no-class-fields': 'off',
 
+        // ES modules include ES2017 'Object.entries()' coverage
+        // https://browsersl.ist/#q=supports+es6-module+and+not+supports+object-entries
+        'es-x/no-object-entries': 'off',
+
         // JSDoc blocks are mandatory in source code
         'jsdoc/require-jsdoc': [
           'error',

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -111,3 +111,9 @@ export {
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageTranslations} ExitThisPageTranslations
  * @typedef {import('./components/notification-banner/notification-banner.mjs').NotificationBannerConfig} NotificationBannerConfig
  */
+
+/**
+ * Component config keys, e.g. `accordion` and `characterCount`
+ *
+ * @typedef {keyof Config} ConfigKey
+ */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -180,7 +180,21 @@ export function validateConfig(schema, config) {
 }
 
 /**
+ * Schema for component config
+ *
+ * @typedef {object} Schema
+ * @property {SchemaCondition[]} [anyOf] - List of schema conditions
+ */
+
+/**
+ * Schema condition for component config
+ *
+ * @typedef {object} SchemaCondition
+ * @property {string[]} required - List of required config fields
+ * @property {string} errorMessage - Error message when required config fields not provided
+ */
+
+/**
  * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
  * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
- * @typedef {import('../govuk-frontend-component.mjs').Schema} Schema - Schema for component config
  */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -149,12 +149,12 @@ export function isSupported($scope = document.body) {
 }
 
 /**
- * Validates Component config against a schema
+ * Validate component config by schema
  *
- * @protected
- * @param {Schema} schema
- * @param {Config[ConfigKey]} config
- * @returns {string[]} An array of errors, or an empty array if there are no errors
+ * @internal
+ * @param {Schema} schema - Config schema
+ * @param {Config[ConfigKey]} config - Component config
+ * @returns {string[]} List of validation errors
  */
 export function validateConfig(schema, config) {
   /**
@@ -180,7 +180,7 @@ export function validateConfig(schema, config) {
 /**
  * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
  * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
- * @typedef {import('../govuk-frontend-component.mjs').Schema} Schema - Component config schema
- * @typedef {import('../govuk-frontend-component.mjs').SchemaAnyOf} SchemaAnyOf - Component "Any Of" schema rule
- * @typedef {import('../govuk-frontend-component.mjs').SchemaCondition} SchemaCondition - Schema required array
+ * @typedef {import('../govuk-frontend-component.mjs').Schema} Schema - Schema for component config
+ * @typedef {import('../govuk-frontend-component.mjs').SchemaAnyOf} SchemaAnyOf - Schema rule "Any of" for component config
+ * @typedef {import('../govuk-frontend-component.mjs').SchemaCondition} SchemaCondition - Schema condition for component config
  */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -147,3 +147,40 @@ export function extractConfigByNamespace(configObject, namespace) {
 export function isSupported($scope = document.body) {
   return $scope.classList.contains('govuk-frontend-supported')
 }
+
+/**
+ * Validates Component config against a schema
+ *
+ * @protected
+ * @param {Schema} schema
+ * @param {Config[ConfigKey]} config
+ * @returns {string[]} An array of errors, or an empty array if there are no errors
+ */
+export function validateConfig(schema, config) {
+  /**
+   * @type {string[]}
+   */
+  const errors = []
+
+  if (!schema.anyOf) {
+    return errors
+  }
+
+  const satisfiesAnyOf = schema.anyOf.conditions.some(({ required }) =>
+    required.every((prop) => prop in config && config[prop])
+  )
+
+  if (!satisfiesAnyOf) {
+    errors.push(schema.anyOf.errorMessage)
+  }
+
+  return errors
+}
+
+/**
+ * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
+ * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
+ * @typedef {import('../govuk-frontend-component.mjs').Schema} Schema - Component config schema
+ * @typedef {import('../govuk-frontend-component.mjs').SchemaAnyOf} SchemaAnyOf - Component "Any Of" schema rule
+ * @typedef {import('../govuk-frontend-component.mjs').SchemaCondition} SchemaCondition - Schema required array
+ */

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -157,30 +157,30 @@ export function isSupported($scope = document.body) {
  * @returns {string[]} List of validation errors
  */
 export function validateConfig(schema, config) {
-  /**
-   * @type {string[]}
-   */
-  const errors = []
+  const validationErrors = []
 
-  if (!schema.anyOf) {
-    return errors
+  // Check errors for each schema
+  for (const [name, conditions] of Object.entries(schema)) {
+    const errors = []
+
+    // Check errors for each schema condition
+    for (const { required, errorMessage } of conditions) {
+      if (!required.every((key) => !!config[key])) {
+        errors.push(errorMessage) // Missing config key value
+      }
+    }
+
+    // Check one condition passes or add errors
+    if (name === 'anyOf' && !(conditions.length - errors.length >= 1)) {
+      validationErrors.push(...errors)
+    }
   }
 
-  const satisfiesAnyOf = schema.anyOf.conditions.some(({ required }) =>
-    required.every((prop) => prop in config && config[prop])
-  )
-
-  if (!satisfiesAnyOf) {
-    errors.push(schema.anyOf.errorMessage)
-  }
-
-  return errors
+  return validationErrors
 }
 
 /**
  * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
  * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
  * @typedef {import('../govuk-frontend-component.mjs').Schema} Schema - Schema for component config
- * @typedef {import('../govuk-frontend-component.mjs').SchemaAnyOf} SchemaAnyOf - Schema rule "Any of" for component config
- * @typedef {import('../govuk-frontend-component.mjs').SchemaCondition} SchemaCondition - Schema condition for component config
  */

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -1,6 +1,11 @@
 import { closestAttributeValue } from '../../common/closest-attribute-value.mjs'
-import { extractConfigByNamespace, mergeConfigs } from '../../common/index.mjs'
+import {
+  extractConfigByNamespace,
+  mergeConfigs,
+  validateConfig
+} from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
+import { ConfigError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 import { I18n } from '../../i18n.mjs'
 
@@ -108,7 +113,11 @@ export class CharacterCount extends GOVUKFrontendComponent {
       datasetConfig
     )
 
-    this.checkConfig(CharacterCount.schema, this.config)
+    // Check for valid config
+    const errors = validateConfig(CharacterCount.schema, this.config)
+    if (errors[0]) {
+      throw new ConfigError(`Character count: ${errors[0]}`)
+    }
 
     this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
       // Read the fallback if necessary rather than have it set in the defaults
@@ -529,6 +538,6 @@ export class CharacterCount extends GOVUKFrontendComponent {
  */
 
 /**
- * @typedef {import('../../govuk-frontend-component.mjs').Schema} Schema
+ * @typedef {import('../../common/index.mjs').Schema} Schema
  * @typedef {import('../../i18n.mjs').TranslationPluralForms} TranslationPluralForms
  */

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -62,6 +62,21 @@ export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
   maxLength = Infinity
 
+  /** @private */
+  configSchema = {
+    anyOf: {
+      conditions: [
+        {
+          required: ['maxwords']
+        },
+        {
+          required: ['maxlength']
+        }
+      ],
+      errorMessage: 'Either `maxlength` or `maxwords` must be provided'
+    }
+  }
+
   /**
    * @param {Element} $module - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
@@ -107,6 +122,8 @@ export class CharacterCount extends GOVUKFrontendComponent {
       configOverrides,
       datasetConfig
     )
+
+    this.checkConfig(this.configSchema, this.config)
 
     this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
       // Read the fallback if necessary rather than have it set in the defaults

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -62,21 +62,6 @@ export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
   maxLength = Infinity
 
-  /** @private */
-  configSchema = {
-    anyOf: {
-      conditions: [
-        {
-          required: ['maxwords']
-        },
-        {
-          required: ['maxlength']
-        }
-      ],
-      errorMessage: 'Either `maxlength` or `maxwords` must be provided'
-    }
-  }
-
   /**
    * @param {Element} $module - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
@@ -123,7 +108,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
       datasetConfig
     )
 
-    this.checkConfig(this.configSchema, this.config)
+    this.checkConfig(CharacterCount.schema, this.config)
 
     this.i18n = new I18n(extractConfigByNamespace(this.config, 'i18n'), {
       // Read the fallback if necessary rather than have it set in the defaults
@@ -460,6 +445,25 @@ export class CharacterCount extends GOVUKFrontendComponent {
       }
     }
   })
+
+  /**
+   * Character count config schema
+   *
+   * @constant
+   * @satisfies {Schema}
+   */
+  static schema = Object.freeze({
+    anyOf: [
+      {
+        required: ['maxwords'],
+        errorMessage: 'Either "maxlength" or "maxwords" must be provided'
+      },
+      {
+        required: ['maxlength'],
+        errorMessage: 'Either "maxlength" or "maxwords" must be provided'
+      }
+    ]
+  })
 }
 
 /**
@@ -525,5 +529,6 @@ export class CharacterCount extends GOVUKFrontendComponent {
  */
 
 /**
+ * @typedef {import('../../govuk-frontend-component.mjs').Schema} Schema
  * @typedef {import('../../i18n.mjs').TranslationPluralForms} TranslationPluralForms
  */

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -792,7 +792,7 @@ describe('Character count', () => {
           })
         ).rejects.toEqual({
           name: 'ConfigError',
-          message: 'Either `maxlength` or `maxwords` must be provided'
+          message: 'Either "maxlength" or "maxwords" must be provided'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -784,6 +784,17 @@ describe('Character count', () => {
           message: 'GOV.UK Frontend is not supported in this browser'
         })
       })
+
+      it('throws when receiving invalid configuration', async () => {
+        await expect(
+          renderAndInitialise(page, 'character-count', {
+            params: {}
+          })
+        ).rejects.toEqual({
+          name: 'ConfigError',
+          message: 'Either `maxlength` or `maxwords` must be provided'
+        })
+      })
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.test.js
@@ -792,7 +792,8 @@ describe('Character count', () => {
           })
         ).rejects.toEqual({
           name: 'ConfigError',
-          message: 'Either "maxlength" or "maxwords" must be provided'
+          message:
+            'Character count: Either "maxlength" or "maxwords" must be provided'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.unit.test.mjs
@@ -18,11 +18,13 @@ describe('CharacterCount', () => {
 
   describe('formatCountMessage', () => {
     describe('default configuration', () => {
-      let component
+      let componentWithMaxLength
+      let componentWithMaxWords
 
       beforeAll(() => {
         const $div = $container.cloneNode(true)
-        component = new CharacterCount($div)
+        componentWithMaxLength = new CharacterCount($div, { maxlength: 100 })
+        componentWithMaxWords = new CharacterCount($div, { maxwords: 100 })
       })
 
       const cases = [
@@ -60,17 +62,25 @@ describe('CharacterCount', () => {
       it.each(cases)(
         'picks the relevant translation for $number $type',
         function test({ number, type, expected }) {
-          expect(component.formatCountMessage(number, type)).toEqual(expected)
+          if (type === 'characters') {
+            expect(
+              componentWithMaxLength.formatCountMessage(number, type)
+            ).toEqual(expected)
+          } else {
+            expect(
+              componentWithMaxWords.formatCountMessage(number, type)
+            ).toEqual(expected)
+          }
         }
       )
 
       it('formats the number inserted in the message', () => {
-        expect(component.formatCountMessage(10000, 'words')).toEqual(
-          'You have 10,000 words remaining'
-        )
-        expect(component.formatCountMessage(-10000, 'words')).toEqual(
-          'You have 10,000 words too many'
-        )
+        expect(
+          componentWithMaxWords.formatCountMessage(10000, 'words')
+        ).toEqual('You have 10,000 words remaining')
+        expect(
+          componentWithMaxWords.formatCountMessage(-10000, 'words')
+        ).toEqual('You have 10,000 words too many')
       })
     })
 
@@ -79,6 +89,7 @@ describe('CharacterCount', () => {
         it('overrides the default translation keys', () => {
           const $div = $container.cloneNode(true)
           const component = new CharacterCount($div, {
+            maxlength: 100,
             i18n: {
               charactersUnderLimit: { one: 'Custom text. Count: %{count}' }
             }
@@ -98,20 +109,26 @@ describe('CharacterCount', () => {
 
         it('uses specific keys for when limit is reached', () => {
           const $div = $container.cloneNode(true)
-          const component = new CharacterCount($div, {
+          const componentWithMaxLength = new CharacterCount($div, {
+            maxlength: 100,
             i18n: {
-              charactersAtLimit: 'Custom text.',
+              charactersAtLimit: 'Custom text.'
+            }
+          })
+          const componentWithMaxWords = new CharacterCount($div, {
+            maxwords: 100,
+            i18n: {
               wordsAtLimit: 'Different custom text.'
             }
           })
 
-          // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(0, 'characters')).toEqual(
-            'Custom text.'
-          )
+          expect(
+            // @ts-expect-error Property 'formatCountMessage' is private
+            componentWithMaxLength.formatCountMessage(0, 'characters')
+          ).toEqual('Custom text.')
 
           // @ts-expect-error Property 'formatCountMessage' is private
-          expect(component.formatCountMessage(0, 'words')).toEqual(
+          expect(componentWithMaxWords.formatCountMessage(0, 'words')).toEqual(
             'Different custom text.'
           )
         })
@@ -122,7 +139,7 @@ describe('CharacterCount', () => {
           const $div = $container.cloneNode(true)
           $div.setAttribute('lang', 'de')
 
-          const component = new CharacterCount($div)
+          const component = new CharacterCount($div, { maxwords: 20000 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
           expect(component.formatCountMessage(10000, 'words')).toEqual(
@@ -137,7 +154,7 @@ describe('CharacterCount', () => {
           const $div = $container.cloneNode(true)
           $parent.appendChild($div)
 
-          const component = new CharacterCount($div)
+          const component = new CharacterCount($div, { maxwords: 20000 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
           expect(component.formatCountMessage(10000, 'words')).toEqual(
@@ -154,7 +171,7 @@ describe('CharacterCount', () => {
             'Custom text. Count: %{count}'
           )
 
-          const component = new CharacterCount($div)
+          const component = new CharacterCount($div, { maxlength: 100 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
           expect(component.formatCountMessage(1, 'characters')).toEqual(
@@ -177,6 +194,7 @@ describe('CharacterCount', () => {
             )
 
             const component = new CharacterCount($div, {
+              maxlength: 100,
               i18n: {
                 charactersUnderLimit: {
                   one: 'Different custom text. Count: %{count}'

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -40,3 +40,10 @@ export class SupportError extends GOVUKFrontendError {
     super('GOV.UK Frontend is not supported in this browser')
   }
 }
+
+/**
+ * Indicates that a component has received an illegal configuration
+ */
+export class ConfigError extends GOVUKFrontendError {
+  name = 'ConfigError'
+}

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,5 +1,5 @@
-import { validateConfig, isSupported } from './common/index.mjs'
-import { ConfigError, SupportError } from './errors/index.mjs'
+import { isSupported } from './common/index.mjs'
+import { SupportError } from './errors/index.mjs'
 
 /**
  * Base Component class
@@ -29,37 +29,4 @@ export class GOVUKFrontendComponent {
       throw new SupportError()
     }
   }
-
-  /**
-   * @protected
-   * @param {Schema} schema - Config schema
-   * @param {Config[ConfigKey]} config - Component config
-   */
-  checkConfig(schema, config) {
-    const errors = validateConfig(schema, config)
-
-    if (errors.length) {
-      throw new ConfigError(errors[0])
-    }
-  }
 }
-
-/**
- * Schema for component config
- *
- * @typedef {object} Schema
- * @property {SchemaCondition[]} [anyOf] - List of schema conditions
- */
-
-/**
- * Schema condition for component config
- *
- * @typedef {object} SchemaCondition
- * @property {string[]} required - List of required config fields
- * @property {string} errorMessage - Error message when required config fields not provided
- */
-
-/**
- * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
- * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
- */

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,5 +1,5 @@
-import { isSupported } from './common/index.mjs'
-import { SupportError } from './errors/index.mjs'
+import { validateConfig, isSupported } from './common/index.mjs'
+import { ConfigError, SupportError } from './errors/index.mjs'
 
 /**
  * Base Component class
@@ -29,4 +29,44 @@ export class GOVUKFrontendComponent {
       throw new SupportError()
     }
   }
+
+  /**
+   * @protected
+   * @param {Schema} schema
+   * @param {Config[ConfigKey]} config
+   */
+  checkConfig(schema, config) {
+    const errors = validateConfig(schema, config)
+
+    if (errors.length) {
+      throw new ConfigError(errors[0])
+    }
+  }
 }
+
+/**
+ * Schema for components
+ *
+ * @typedef {object} Schema
+ * @property {SchemaAnyOf} [anyOf] - An array of conditions
+ */
+
+/**
+ * Component "Any Of" schema rule
+ *
+ * @typedef {object} SchemaAnyOf
+ * @property {string} errorMessage - The error message to display if the condition fails
+ * @property {SchemaCondition[]} conditions - Whether the current item is required
+ */
+
+/**
+ * Schema required array
+ *
+ * @typedef {object} SchemaCondition
+ * @property {string[]} required - Whether the current item is required
+ */
+
+/**
+ * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
+ * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
+ */

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -48,15 +48,7 @@ export class GOVUKFrontendComponent {
  * Schema for component config
  *
  * @typedef {object} Schema
- * @property {SchemaAnyOf} [anyOf] - List of schema conditions
- */
-
-/**
- * Schema rule "Any of" for component config
- *
- * @typedef {object} SchemaAnyOf
- * @property {string} errorMessage - The error message to display if the condition fails
- * @property {SchemaCondition[]} conditions - Whether the current item is required
+ * @property {SchemaCondition[]} [anyOf] - List of schema conditions
  */
 
 /**
@@ -64,6 +56,7 @@ export class GOVUKFrontendComponent {
  *
  * @typedef {object} SchemaCondition
  * @property {string[]} required - List of required config fields
+ * @property {string} errorMessage - Error message when required config fields not provided
  */
 
 /**

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -32,8 +32,8 @@ export class GOVUKFrontendComponent {
 
   /**
    * @protected
-   * @param {Schema} schema
-   * @param {Config[ConfigKey]} config
+   * @param {Schema} schema - Config schema
+   * @param {Config[ConfigKey]} config - Component config
    */
   checkConfig(schema, config) {
     const errors = validateConfig(schema, config)
@@ -45,14 +45,14 @@ export class GOVUKFrontendComponent {
 }
 
 /**
- * Schema for components
+ * Schema for component config
  *
  * @typedef {object} Schema
- * @property {SchemaAnyOf} [anyOf] - An array of conditions
+ * @property {SchemaAnyOf} [anyOf] - List of schema conditions
  */
 
 /**
- * Component "Any Of" schema rule
+ * Schema rule "Any of" for component config
  *
  * @typedef {object} SchemaAnyOf
  * @property {string} errorMessage - The error message to display if the condition fails
@@ -60,10 +60,10 @@ export class GOVUKFrontendComponent {
  */
 
 /**
- * Schema required array
+ * Schema condition for component config
  *
  * @typedef {object} SchemaCondition
- * @property {string[]} required - Whether the current item is required
+ * @property {string[]} required - List of required config fields
  */
 
 /**

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -254,5 +254,5 @@ module.exports = {
 /**
  * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions
  * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
- * @typedef {keyof Config} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
+ * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
  */


### PR DESCRIPTION
Closes #4037 

## What

I've got two approaches here:

### Validate within the component class
At the moment, we only need this validation on Character Count, so we _could_ just do a specific validation in that class. Might be good enough for now.

### Use a schema
It'd be nice to just use something like AJV and validate a schema, but that'd add weight to our code, so I've implemented a custom validation method on the base component that we can build on as necessary.

It'd also be nice to somehow use our YAML (or compiled JSON fixtures) here, but that's a lot trickier to unpick than is required for this work (for example: how to separate out nunjucks and JS properties, how to document more complex rules like `anyOf`, etc).

---

**Update:** We've gone with the schema approach and loosely followed:
https://ajv.js.org/packages/ajv-errors.html#single-message