### PR TITLE
Add MissingElementError and use it within the Skip Link

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,3 +1,4 @@
+import { MissingElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
 /**
@@ -33,7 +34,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     // Check for linked element
     const $linkedElement = this.getLinkedElement()
     if (!$linkedElement) {
-      return
+      throw new MissingElementError('The linked HTML element does not exist')
     }
 
     this.$linkedElement = $linkedElement

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -21,6 +21,7 @@ export class SkipLink extends GOVUKFrontendComponent {
 
   /**
    * @param {Element} $module - HTML element to use for skip link
+   * @throws {MissingElementError} If the element with the specified ID is not found
    */
   constructor($module) {
     super()
@@ -35,12 +36,11 @@ export class SkipLink extends GOVUKFrontendComponent {
     try {
       const $linkedElement = this.getLinkedElement()
       this.$linkedElement = $linkedElement
-    } catch (cause) {
+    } catch (error) {
       throw new MissingElementError(
-        'Skip link: the linked HTML element does not exist',
-        {
-          cause: cause instanceof Error ? cause : undefined
-        }
+        `Skip link: ${
+          error instanceof Error ? error.message : 'Linked element not found'
+        }`
       )
     }
 
@@ -52,22 +52,20 @@ export class SkipLink extends GOVUKFrontendComponent {
    *
    * @private
    * @throws {Error} If the "href" attribute does not contain a hash
-   * @throws {Error} If the element with the specified ID does not exist
+   * @throws {TypeError} If the element with the specified ID is not found
    * @returns {HTMLElement} $linkedElement - DOM element linked to from the skip link
    */
   getLinkedElement() {
     const linkedElementId = this.getFragmentFromUrl()
     if (!linkedElementId) {
-      throw new Error(
-        `Skip link: $module "href" attribute does not contain a hash`
-      )
+      throw new Error(`$module "href" attribute does not contain a hash`)
     }
 
     const linkedElement = document.getElementById(linkedElementId)
 
     if (!linkedElement) {
-      throw new Error(
-        `Skip link: Target selector "#${linkedElementId}" not found`
+      throw new TypeError(
+        `Linked element selector "#${linkedElementId}" not found`
       )
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -32,12 +32,18 @@ export class SkipLink extends GOVUKFrontendComponent {
     this.$module = $module
 
     // Check for linked element
-    const $linkedElement = this.getLinkedElement()
-    if (!$linkedElement) {
-      throw new MissingElementError('The linked HTML element does not exist')
+    try {
+      const $linkedElement = this.getLinkedElement()
+      this.$linkedElement = $linkedElement
+    } catch (cause) {
+      throw new MissingElementError(
+        'Skip link: the linked HTML element does not exist',
+        {
+          cause: cause instanceof Error ? cause : undefined
+        }
+      )
     }
 
-    this.$linkedElement = $linkedElement
     this.$module.addEventListener('click', () => this.focusLinkedElement())
   }
 
@@ -45,15 +51,27 @@ export class SkipLink extends GOVUKFrontendComponent {
    * Get linked element
    *
    * @private
-   * @returns {HTMLElement | null} $linkedElement - DOM element linked to from the skip link
+   * @throws {Error} If the "href" attribute does not contain a hash
+   * @throws {Error} If the element with the specified ID does not exist
+   * @returns {HTMLElement} $linkedElement - DOM element linked to from the skip link
    */
   getLinkedElement() {
     const linkedElementId = this.getFragmentFromUrl()
     if (!linkedElementId) {
-      return null
+      throw new Error(
+        `Skip link: $module "href" attribute does not contain a hash`
+      )
     }
 
-    return document.getElementById(linkedElementId)
+    const linkedElement = document.getElementById(linkedElementId)
+
+    if (!linkedElement) {
+      throw new Error(
+        `Skip link: Target selector "#${linkedElementId}" not found`
+      )
+    }
+
+    return linkedElement
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -92,7 +92,22 @@ describe('Skip Link', () => {
         })
       ).rejects.toEqual({
         name: 'MissingElementError',
-        message: 'Skip link: the linked HTML element does not exist'
+        message:
+          'Skip link: Linked element selector "#this-element-does-not-exist" not found'
+      })
+    })
+
+    it('throws when the href does not contain a hash', async () => {
+      await expect(
+        renderAndInitialise(page, 'skip-link', {
+          params: {
+            text: 'Skip to main content',
+            href: 'this-element-does-not-exist'
+          }
+        })
+      ).rejects.toEqual({
+        name: 'MissingElementError',
+        message: 'Skip link: $module "href" attribute does not contain a hash'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -81,5 +81,19 @@ describe('Skip Link', () => {
         message: 'GOV.UK Frontend is not supported in this browser'
       })
     })
+
+    it('throws when the linked element is missing', async () => {
+      await expect(
+        renderAndInitialise(page, 'skip-link', {
+          params: {
+            text: 'Skip to main content',
+            href: '#this-element-does-not-exist'
+          }
+        })
+      ).rejects.toEqual({
+        name: 'MissingElementError',
+        message: 'The linked HTML element does not exist'
+      })
+    })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.test.js
@@ -92,7 +92,7 @@ describe('Skip Link', () => {
         })
       ).rejects.toEqual({
         name: 'MissingElementError',
-        message: 'The linked HTML element does not exist'
+        message: 'Skip link: the linked HTML element does not exist'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -23,6 +23,13 @@ export class GOVUKFrontendError extends Error {
 }
 
 /**
+ * Indicates that a Component's required HTML element is missing
+ */
+export class MissingElementError extends GOVUKFrontendError {
+  name = 'MissingElementError'
+}
+
+/**
  * Indicates that GOV.UK Frontend is not supported
  */
 export class SupportError extends GOVUKFrontendError {


### PR DESCRIPTION
Closes #4128 

Throws an error instead of returning if the linked element is missing.

I considered implementing a separate method to check for this, but that feels a bit needless for Skip Link - it may be necessary for more complex components, though.

There's also an argument for throwing errors _within_ `getLinkedElement` and `getFragmentFromUrl` (our error message could potentially be more helpful if we could provide the `linkedElementId`, for example), but since these get caught by the existing check, I kept things simple.