### PR TITLE
Set Percy's target branch to the PR base [v4.x] 

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -15,7 +15,8 @@ jobs:
 
     env:
       PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
-      PERCY_TARGET_BRANCH: ${{ github.base_ref }}
+      PERCY_TARGET_BRANCH: ${{ github.event.pull_request.base.ref }}
+      PERCY_TARGET_COMMIT: ${{ github.event.pull_request.base.sha }}
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
     # Skip when secrets are unavailable on forks

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -15,6 +15,7 @@ jobs:
 
     env:
       PERCY_PARALLEL_NONCE: ${{ github.run_id }}-${{ github.run_attempt }}
+      PERCY_TARGET_BRANCH: ${{ github.base_ref }}
       PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
     # Skip when secrets are unavailable on forks


### PR DESCRIPTION
Modify GitHub actions config so that Percy runs comparisons against the PR's base branch rather than always using `main`.

This is particularly needed on the v4 support branch as `main` has diverged quite significantly, however we still intend to make v4 releases and want visual regression tests to work as expected.