### PR TITLE
Remove stray `.only()` from PR #4030

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.unit.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.unit.test.mjs
@@ -117,7 +117,7 @@ describe('Common JS utilities', () => {
     })
   })
 
-  describe.only('isSupported', () => {
+  describe('isSupported', () => {
     beforeEach(() => {
       // Jest does not tidy the JSDOM document between tests
       // so we need to take care of that ourselves


### PR DESCRIPTION
Accidentally added in:

* https://github.com/alphagov/govuk-frontend/pull/4030