### PR TITLE
Update character count types to show `maxlength` can be ignored

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -105,8 +105,6 @@ export {
  * @typedef {import('./components/accordion/accordion.mjs').AccordionTranslations} AccordionTranslations
  * @typedef {import('./components/button/button.mjs').ButtonConfig} ButtonConfig
  * @typedef {import('./components/character-count/character-count.mjs').CharacterCountConfig} CharacterCountConfig
- * @typedef {import('./components/character-count/character-count.mjs').CharacterCountConfigWithMaxLength} CharacterCountConfigWithMaxLength
- * @typedef {import('./components/character-count/character-count.mjs').CharacterCountConfigWithMaxWords} CharacterCountConfigWithMaxWords
  * @typedef {import('./components/character-count/character-count.mjs').CharacterCountTranslations} CharacterCountTranslations
  * @typedef {import('./components/error-summary/error-summary.mjs').ErrorSummaryConfig} ErrorSummaryConfig
  * @typedef {import('./components/exit-this-page/exit-this-page.mjs').ExitThisPageConfig} ExitThisPageConfig

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -114,13 +114,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     })
 
     // Determine the limit attribute (characters or words)
-    if ('maxwords' in this.config && this.config.maxwords) {
-      this.maxLength = this.config.maxwords
-    } else if ('maxlength' in this.config && this.config.maxlength) {
-      this.maxLength = this.config.maxlength
-    } else {
-      return this
-    }
+    this.maxLength = this.config.maxwords || this.config.maxlength
 
     this.$module = $module
     this.$textarea = $textarea
@@ -340,7 +334,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
    * @returns {number} the number of characters (or words) in the text
    */
   count(text) {
-    if ('maxwords' in this.config && this.config.maxwords) {
+    if (this.config.maxwords) {
       const tokens = text.match(/\S+/g) || [] // Matches consecutive non-whitespace chars
       return tokens.length
     } else {
@@ -356,9 +350,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
    */
   getCountMessage() {
     const remainingNumber = this.maxLength - this.count(this.$textarea.value)
-
-    const countType =
-      'maxwords' in this.config && this.config.maxwords ? 'words' : 'characters'
+    const countType = this.config.maxwords ? 'words' : 'characters'
     return this.formatCountMessage(remainingNumber, countType)
   }
 
@@ -457,27 +449,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
  * Character count config
  *
  * @see {@link CharacterCount.defaults}
- * @typedef {CharacterCountConfigWithMaxLength | CharacterCountConfigWithMaxWords} CharacterCountConfig
- */
-
-/**
- * Character count config (with maximum number of characters)
- *
- * @see {@link CharacterCount.defaults}
- * @typedef {object} CharacterCountConfigWithMaxLength
+ * @typedef {object} CharacterCountConfig
  * @property {number} [maxlength] - The maximum number of characters.
  *   If maxwords is provided, the maxlength option will be ignored.
- * @property {number} [threshold=0] - The percentage value of the limit at
- *   which point the count message is displayed. If this attribute is set, the
- *   count message will be hidden by default.
- * @property {CharacterCountTranslations} [i18n=CharacterCount.defaults.i18n] - Character count translations
- */
-
-/**
- * Character count config (with maximum number of words)
- *
- * @see {@link CharacterCount.defaults}
- * @typedef {object} CharacterCountConfigWithMaxWords
  * @property {number} [maxwords] - The maximum number of words. If maxwords is
  *   provided, the maxlength option will be ignored.
  * @property {number} [threshold=0] - The percentage value of the limit at


### PR DESCRIPTION
We’d previously assumed Character count `maxlength` and `maxwords` were mutually exclusive

But in our [**Character count** JavaScript API reference](https://frontend.design-system.service.gov.uk/javascript-api-reference/#charactercount) we say both can be provided:

> If maxwords is provided, the maxlength option will be ignored.

This PR updates the config types to show that both can be provided to resolve https://github.com/alphagov/govuk-frontend/pull/4176#discussion_r1318846115