### PR TITLE
Configure ESLint for required JSDoc `@param` descriptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -60,10 +60,13 @@ module.exports = {
           }
         ],
 
-        // JSDoc blocks are optional
+        // JSDoc blocks are optional by default
         'jsdoc/require-jsdoc': 'off',
+
+        // JSDoc @param required in (optional) blocks but
+        // @param description is not necessary by default
         'jsdoc/require-param-description': 'off',
-        'jsdoc/require-param': 'off',
+        'jsdoc/require-param': 'error',
 
         // Require hyphens before param description
         // Aligns with TSDoc style: https://tsdoc.org/pages/tags/param/

--- a/packages/govuk-frontend/.eslintrc.js
+++ b/packages/govuk-frontend/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
         // Babel transpiles ES2020 class fields
         'es-x/no-class-fields': 'off',
 
-        // JSDoc blocks are mandatory
+        // JSDoc blocks are mandatory in source code
         'jsdoc/require-jsdoc': [
           'error',
           {
@@ -51,7 +51,12 @@ module.exports = {
               MethodDefinition: true
             }
           }
-        ]
+        ],
+
+        // JSDoc @param required in (mandatory) blocks but
+        // @param description is necessary in source code
+        'jsdoc/require-param-description': 'warn',
+        'jsdoc/require-param': 'error'
       }
     },
     {


### PR DESCRIPTION
This PR ensures we don't forget JSDoc `@param` descriptions during our API work https://github.com/alphagov/govuk-frontend/issues/3478

We try to stick to the following rules:

1. JSDoc blocks are optional by default for the project
2. JSDoc blocks are mandatory in `govuk-frontend` source code

But when either optional or mandatory JSDoc blocks are used, they must:

* have `@param` by default for the project
* have `@param` descriptions in `govuk-frontend` source code

Which ensures our JSDoc JavaScript API documentation is populated:  
https://govuk-frontend-review.herokuapp.com/docs/javascript/