### PR TITLE
Remove export warning for `Schema` from TypeDoc

### DIFF
--- a/packages/govuk-frontend-review/typedoc.config.js
+++ b/packages/govuk-frontend-review/typedoc.config.js
@@ -27,5 +27,5 @@ module.exports = {
   },
 
   // Ignore known undocumented types (@internal, @private etc)
-  intentionallyNotExported: ['I18n', 'Schema', 'TranslationPluralForms']
+  intentionallyNotExported: ['I18n', 'TranslationPluralForms']
 }


### PR DESCRIPTION
We previously ignored `Schema` as an undocumented type (for internal or private use only) in https://github.com/alphagov/govuk-frontend/pull/4176

But we now see the following warning:

> [warning] The following symbols were marked as intentionally not exported, but were either not referenced in the documentation, or were exported: Schema

This is because since we moved `Schema` it into **./govuk/common** via 55a54b7edd4311ace02ec08d1362dbe91f47ceee it’s not exported directly from `govuk-frontend` anymore and doesn’t need ignoring