### PR TITLE
Fix typo in release build task

### DIFF
--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -16,7 +16,7 @@ export default (options) =>
 
     // Copy GOV.UK Frontend static assets
     task.name('copy:assets', () =>
-      files.copy('*/**', {
+      files.copy('**/*', {
         srcPath: join(options.srcPath, 'govuk/assets'),
         destPath: join(options.destPath, 'assets')
       })


### PR DESCRIPTION
The typo'd glob meant that only files in nested folders (e.g. `govuk/assets/images`) were copied successfully, whilst files hosted directly within `govuk/assets` were ignored.