### PR TITLE
Throw `ElementError` when "Exit this page" button is missing

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -90,7 +90,11 @@ export class ExitThisPage extends GOVUKFrontendComponent {
 
     const $button = $module.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLElement)) {
-      return this
+      throw new ElementError($button, {
+        componentName: 'Exit this page',
+        identifier: 'Button',
+        expectedType: HTMLElement
+      })
     }
 
     this.config = mergeConfigs(

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -237,6 +237,20 @@ describe('/components/exit-this-page', () => {
           message: 'Exit this page: $module is not an instance of "HTMLElement"'
         })
       })
+
+      it('throws when the button is missing', async () => {
+        await expect(
+          renderAndInitialise(page, 'exit-this-page', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module.querySelector('.govuk-exit-this-page__button').remove()
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Exit this page: Button not found'
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
~Wording to match that of the Skip link component, but to be reviewed in #4072.~ Wording is now handled by the `ElementError` class and will match the other `ElementError` being thrown.

Closes #4129