### PR TITLE
Fix missing update for `actions/setup-node@v3.8.1`

### DIFF
--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3.7.0
+      uses: actions/setup-node@v3.8.1
       id: setup-node
 
       with:


### PR DESCRIPTION
Unlikely fix, but a missing update to `actions/setup-node@v3.8.1` came up whilst looking into:

* https://github.com/alphagov/govuk-frontend/issues/4169