### PR TITLE
Pin to `rollup@3.28.0` to fix `Unexpected token`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30094,7 +30094,7 @@
         "postcss": "^8.4.29",
         "postcss-scss": "^4.0.8",
         "puppeteer": "^21.1.1",
-        "rollup": "^3.29.1",
+        "rollup": "^3.28.0",
         "sass-color-helpers": "^2.1.1",
         "sass-embedded": "^1.66.1",
         "sassdoc": "^2.7.4",
@@ -30146,7 +30146,7 @@
         "nodemon": "^3.0.1",
         "postcss-pseudo-classes": "^0.2.1",
         "puppeteer": "^21.1.1",
-        "rollup": "^3.29.1",
+        "rollup": "^3.28.0",
         "sassdoc": "^2.7.4",
         "slash": "^5.1.0",
         "supertest": "^6.3.3",
@@ -30243,7 +30243,7 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.2.1",
         "govuk-frontend": "*",
-        "rollup": "^3.29.1",
+        "rollup": "^3.28.0",
         "rollup-plugin-visualizer": "^5.9.2"
       },
       "engines": {
@@ -30271,7 +30271,7 @@
         "postcss": "^8.4.29",
         "postcss-load-config": "^4.0.1",
         "puppeteer": "^21.1.1",
-        "rollup": "^3.29.1",
+        "rollup": "^3.28.0",
         "sass-embedded": "^1.66.1",
         "slash": "^5.1.0",
         "yargs-parser": "^21.1.1"

--- a/packages/govuk-frontend-review/package.json
+++ b/packages/govuk-frontend-review/package.json
@@ -53,7 +53,7 @@
     "nodemon": "^3.0.1",
     "postcss-pseudo-classes": "^0.2.1",
     "puppeteer": "^21.1.1",
-    "rollup": "^3.29.1",
+    "rollup": "^3.28.0",
     "sassdoc": "^2.7.4",
     "slash": "^5.1.0",
     "supertest": "^6.3.3",

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -73,7 +73,7 @@
     "postcss": "^8.4.29",
     "postcss-scss": "^4.0.8",
     "puppeteer": "^21.1.1",
-    "rollup": "^3.29.1",
+    "rollup": "^3.28.0",
     "sass-color-helpers": "^2.1.1",
     "sass-embedded": "^1.66.1",
     "sassdoc": "^2.7.4",

--- a/shared/stats/package.json
+++ b/shared/stats/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.2.1",
     "govuk-frontend": "*",
-    "rollup": "^3.29.1",
+    "rollup": "^3.28.0",
     "rollup-plugin-visualizer": "^5.9.2"
   }
 }

--- a/shared/tasks/package.json
+++ b/shared/tasks/package.json
@@ -25,7 +25,7 @@
     "postcss": "^8.4.29",
     "postcss-load-config": "^4.0.1",
     "puppeteer": "^21.1.1",
-    "rollup": "^3.29.1",
+    "rollup": "^3.28.0",
     "sass-embedded": "^1.66.1",
     "slash": "^5.1.0",
     "yargs-parser": "^21.1.1"


### PR DESCRIPTION
Pins our Rollup version to avoid a flaky test issue in:

* https://github.com/alphagov/govuk-frontend/issues/4169

```console
[!] RollupError: Unexpected token (Note that you need plugins to import files that are not JavaScript)
../../packages/govuk-frontend/dist/govuk/common/index.mjs (27:2)
25: export { isSupported };
26: //# sourceMappingURL=index.mjs.map
27: bj) {
      ^
```

The issue appears to come from https://github.com/rollup/rollup/pull/5099 in [`rollup@3.28.1`](https://github.com/rollup/rollup/releases/tag/v3.28.1) even though the fix fits our use case:

* https://github.com/rollup/rollup/pull/5099

After pinning to `rollup@3.28.0` we can see builds are working again:

> [actions/runs/6149881425/attempts/1?pr=4203](https://github.com/alphagov/govuk-frontend/actions/runs/6149881425/attempts/1?pr=4203)
> [actions/runs/6149881425/attempts/2?pr=4203](https://github.com/alphagov/govuk-frontend/actions/runs/6149881425/attempts/2?pr=4203)
> [actions/runs/6149881425/attempts/3?pr=4203](https://github.com/alphagov/govuk-frontend/actions/runs/6149881425/attempts/3?pr=4203)
> [actions/runs/6149881425/attempts/4?pr=4203](https://github.com/alphagov/govuk-frontend/actions/runs/6149881425/attempts/4?pr=4203)