### PR TITLE
Use absolute Rollup input paths to fix `Unexpected token`

### DIFF
--- a/shared/stats/rollup.config.mjs
+++ b/shared/stats/rollup.config.mjs
@@ -1,4 +1,4 @@
-import { dirname, join, parse, relative } from 'path'
+import { dirname, join, parse } from 'path'
 
 import { paths } from '@govuk-frontend/config'
 import { packageTypeToPath } from '@govuk-frontend/lib/names'
@@ -18,10 +18,10 @@ export default defineConfig(
   modulePaths.map(
     (modulePath) =>
       /** @satisfies {import('rollup').RollupOptions} */ ({
-        input: relative(
-          paths.stats,
-          packageTypeToPath('govuk-frontend', { ...packageOptions, modulePath })
-        ),
+        input: packageTypeToPath('govuk-frontend', {
+          ...packageOptions,
+          modulePath
+        }),
 
         /**
          * Output options


### PR DESCRIPTION
Further to #4203, this PR uses absolute Rollup input paths as an alternative workaround for:

```console
[!] RollupError: Unexpected token (Note that you need plugins to import files that are not JavaScript)
../../packages/govuk-frontend/dist/govuk/common/index.mjs (27:2)
25: export { isSupported };
26: //# sourceMappingURL=index.mjs.map
27: bj) {
      ^
```

The issue appears to come from https://github.com/rollup/rollup/pull/5099 in [`rollup@3.28.1`](https://github.com/rollup/rollup/releases/tag/v3.28.1) even though the fix fits our use case:

* https://github.com/rollup/rollup/pull/5099

After switching to absolute paths we can also see builds are working again:

> [actions/runs/6150443464/attempts/1?pr=4204](https://github.com/alphagov/govuk-frontend/actions/runs/6150443464/attempts/1?pr=4204)
> [actions/runs/6150443464/attempts/2?pr=4204](https://github.com/alphagov/govuk-frontend/actions/runs/6150443464/attempts/2?pr=4204) — except for known [`fetchPath()` issue](https://github.com/alphagov/govuk-frontend/issues/4169)
> [actions/runs/6150443464/attempts/3?pr=4204](https://github.com/alphagov/govuk-frontend/actions/runs/6150443464/attempts/3?pr=4204) — except for known [`fetchPath()` issue](https://github.com/alphagov/govuk-frontend/issues/4169)
> [actions/runs/6150443464/attempts/4?pr=4204](https://github.com/alphagov/govuk-frontend/actions/runs/6150443464/attempts/4?pr=4204) — except for known [`fetchPath()` issue](https://github.com/alphagov/govuk-frontend/issues/4169)