### PR TITLE
Throw `ElementError` when the menu of the header is missing but a toggle is present

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -61,9 +61,16 @@ export class Header extends GOVUKFrontendComponent {
       return this
     }
 
-    const $menu = $module.querySelector(
-      `#${$menuButton.getAttribute('aria-controls')}`
-    )
+    const menuId = $menuButton.getAttribute('aria-controls')
+    if (!menuId) {
+      throw new ElementError($menuButton, {
+        componentName: 'Header',
+        identifier: '$menuButton["aria-controls"]',
+        expectedType: 'string'
+      })
+    }
+
+    const $menu = document.getElementById(menuId)
 
     if (!($menuButton instanceof HTMLElement)) {
       throw new ElementError($menu, {

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -61,28 +61,27 @@ export class Header extends GOVUKFrontendComponent {
       return this
     }
 
-    const menuId = $menuButton.getAttribute('aria-controls')
-    if (!menuId) {
+    if (!($menuButton instanceof HTMLElement)) {
       throw new ElementError($menuButton, {
         componentName: 'Header',
-        identifier: '$menuButton["aria-controls"]',
-        expectedType: 'string'
+        identifier: '.govuk-js-header-toggle'
+      })
+    }
+
+    const menuId = $menuButton.getAttribute('aria-controls')
+    if (!menuId) {
+      throw new ElementError(null, {
+        componentName: 'Header',
+        identifier: '.govuk-js-header-toggle[aria-controls]'
       })
     }
 
     const $menu = document.getElementById(menuId)
 
-    if (!($menuButton instanceof HTMLElement)) {
-      throw new ElementError($menu, {
-        componentName: 'Header',
-        identifier: 'Menu'
-      })
-    }
-
     if (!($menu instanceof HTMLElement)) {
       throw new ElementError($menu, {
         componentName: 'Header',
-        identifier: 'Menu'
+        identifier: `#${menuId}`
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -52,21 +52,35 @@ export class Header extends GOVUKFrontendComponent {
     }
 
     this.$module = $module
-    this.$menuButton = $module.querySelector('.govuk-js-header-toggle')
-    this.$menu =
-      this.$menuButton &&
-      $module.querySelector(
-        `#${this.$menuButton.getAttribute('aria-controls')}`
-      )
+    const $menuButton = $module.querySelector('.govuk-js-header-toggle')
 
-    if (
-      !(
-        this.$menuButton instanceof HTMLElement ||
-        this.$menu instanceof HTMLElement
-      )
-    ) {
+    // Headers don't necessarily have a navigation.
+    // When they don't, the menu toggle won't be rendered
+    // by our macro (or may be omitted when writing plain HTML)
+    if (!$menuButton) {
       return this
     }
+
+    const $menu = $module.querySelector(
+      `#${$menuButton.getAttribute('aria-controls')}`
+    )
+
+    if (!($menuButton instanceof HTMLElement)) {
+      throw new ElementError($menu, {
+        componentName: 'Header',
+        identifier: 'Menu'
+      })
+    }
+
+    if (!($menu instanceof HTMLElement)) {
+      throw new ElementError($menu, {
+        componentName: 'Header',
+        identifier: 'Menu'
+      })
+    }
+
+    this.$menu = $menu
+    this.$menuButton = $menuButton
 
     // Set the matchMedia to the govuk-frontend desktop breakpoint
     this.mql = window.matchMedia('(min-width: 48.0625em)')

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -230,6 +230,23 @@ describe('Header navigation', () => {
         })
       })
 
+      it("throws when the toggle's aria-control attribute is missing", async () => {
+        await expect(
+          renderAndInitialise(page, 'header', {
+            params: examples['with navigation'],
+            beforeInitialisation($module) {
+              $module
+                .querySelector('.govuk-js-header-toggle')
+                .removeAttribute('aria-controls')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message:
+            'Header: $menuButton["aria-controls"] is not of type "string"'
+        })
+      })
+
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
           renderAndInitialise(page, 'header', {

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -219,6 +219,31 @@ describe('Header navigation', () => {
           message: 'Header: $module is not an instance of "HTMLElement"'
         })
       })
+
+      it('does not throw if the toggle is absent', async () => {
+        // The default example is rendered without navigation
+        // and should keep rendering. No expectations as the JavaScript
+        // will just return early. All we ask of that test is for it not
+        // to throw during the initialisation
+        await renderAndInitialise(page, 'header', {
+          params: examples.default
+        })
+      })
+
+      it('throws when the menu is missing, but a toggle is present', async () => {
+        await expect(
+          renderAndInitialise(page, 'header', {
+            params: examples['with navigation'],
+            beforeInitialisation($module) {
+              // Remove the menu `<ul>` referenced by $menuButton's `aria-controls`
+              $module.querySelector('#navigation').remove()
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Header: Menu not found'
+        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -230,6 +230,24 @@ describe('Header navigation', () => {
         })
       })
 
+      it('throws when the toggle is of the wrong type', async () => {
+        await expect(
+          renderAndInitialise(page, 'header', {
+            params: examples['with navigation'],
+            beforeInitialisation($module) {
+              // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
+              $module.querySelector(
+                '.govuk-js-header-toggle'
+              ).outerHTML = `<svg class="govuk-js-header-toggle" ></svg>`
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message:
+            'Header: .govuk-js-header-toggle is not an instance of "HTMLElement"'
+        })
+      })
+
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
           renderAndInitialise(page, 'header', {
@@ -242,8 +260,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Header: $menuButton["aria-controls"] is not of type "string"'
+          message: 'Header: .govuk-js-header-toggle[aria-controls] not found'
         })
       })
 
@@ -258,7 +275,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Header: Menu not found'
+          message: 'Header: #navigation not found'
         })
       })
     })


### PR DESCRIPTION
We need to keep the early return if the toggle is absent, as it's not mandatory for the header to have a navigation.

Closes #4130