### PR TITLE
[SPIKE] Reproduce Rollup issue on every build

### DIFF
--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -12,10 +12,23 @@ import gulp from 'gulp'
 export const compile = (options) =>
   gulp.series(
     /**
-     * Compile GOV.UK Frontend JavaScript for all entry points
+     * Compile GOV.UK Frontend JavaScript for main entry point only
      */
-    task.name("compile:js 'modules'", () =>
-      scripts.compile('**/{all,components/*/!(*.test)}.mjs', {
+    task.name("compile:js 'entry'", () =>
+      scripts.compile('**/all.mjs', {
+        ...options,
+
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'rollup.publish.config.mjs')
+      })
+    ),
+
+    /**
+     * Compile GOV.UK Frontend JavaScript for component entry points
+     */
+    task.name("compile:js 'components'", () =>
+      scripts.compile('**/components/*/!(*.test).mjs', {
         ...options,
 
         srcPath: join(options.srcPath, 'govuk'),


### PR DESCRIPTION
I've split out our `modulePath` glob to reproduce the Rollup issue every time

It explains why we didn't always see the issue

Diff added in the comments to show what looks like multiple builds merged together

### Before
Using concurrent builds in [`scripts.compile()`](https://github.com/alphagov/govuk-frontend/blob/main/shared/tasks/scripts.mjs#L14) we roll a dice to get a malformed Rollup build

```mjs
gulp.series(
  scripts.compile('**/{all,components/*/!(*.test)}.mjs', options)
)
```

### After
Building nested components last reliably gets a malformed Rollup build

```mjs
gulp.series(
  scripts.compile('**/all.mjs', options),
  scripts.compile('**/components/*/!(*.test).mjs', options),
)
```

Is the bug found in [`{ preserveModulesRoot }`](https://rollupjs.org/configuration-options/#output-preservemodulesroot) perhaps?

Other things tried:

1. Setting `{ treeshake: false }` prevents the issue
2. Setting `{ cache: false }` or `{ cache: {} }` has no effect