### PR TITLE
Always run Rollup build for `all.mjs` last

### DIFF
--- a/packages/govuk-frontend/tasks/scripts.mjs
+++ b/packages/govuk-frontend/tasks/scripts.mjs
@@ -12,10 +12,23 @@ import gulp from 'gulp'
 export const compile = (options) =>
   gulp.series(
     /**
-     * Compile GOV.UK Frontend JavaScript for all entry points
+     * Compile GOV.UK Frontend JavaScript for component entry points
      */
-    task.name("compile:js 'modules'", () =>
-      scripts.compile('**/{all,components/*/!(*.test)}.mjs', {
+    task.name("compile:js 'components'", () =>
+      scripts.compile('**/components/*/!(*.test).mjs', {
+        ...options,
+
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'rollup.publish.config.mjs')
+      })
+    ),
+
+    /**
+     * Compile GOV.UK Frontend JavaScript for main entry point only
+     */
+    task.name("compile:js 'entry'", () =>
+      scripts.compile('**/all.mjs', {
         ...options,
 
         srcPath: join(options.srcPath, 'govuk'),

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -16,16 +16,10 @@ export async function compile(pattern, options) {
     cwd: options.srcPath
   })
 
-  // Increase Node.js max listeners warning threshold to silence
-  // Rollup calling `process.on('warning')` once per bundle
-  process.setMaxListeners(1 + modulePaths.length)
-
   try {
-    const compileTasks = modulePaths.map((modulePath) =>
-      compileJavaScript([modulePath, options])
-    )
-
-    await Promise.all(compileTasks)
+    for (const modulePath of modulePaths) {
+      await compileJavaScript([modulePath, options])
+    }
   } catch (cause) {
     throw new PluginError('shared/tasks/scripts', cause)
   }

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -25,11 +25,9 @@ export async function compile(pattern, options) {
   })
 
   try {
-    const compileTasks = modulePaths.map((modulePath) =>
+    for (const modulePath of modulePaths) {
       compileStylesheet([modulePath, options])
-    )
-
-    await Promise.all(compileTasks)
+    }
   } catch (cause) {
     throw new PluginError('shared/tasks/styles', cause)
   }


### PR DESCRIPTION
We've been having fun and games with Rollup builds recently in https://github.com/alphagov/govuk-frontend/issues/4169

It now appears to be an old problem that got much worse once `validateConfig` was added:

* https://github.com/alphagov/govuk-frontend/pull/4176

### Some key facts

1. Rollup builds run concurrently in `scripts.compile()`
2. Rollup builds for `button.mjs` etc will tree shake _unused_ exports like `validateConfig`
3. Rollup builds for `all.mjs` (our entry point) won't tree shake _used_ exports like `validateConfig`

Due to 1) we see builds [with write conflicts](https://github.com/rollup/rollup/issues/5132) as shown in https://github.com/alphagov/govuk-frontend/issues/4169
Due to 1) we sometimes see `button.mjs` remove exports needed by `accordion.mjs` etc
Due to 1) we sometimes see `all.mjs` preserve exports needed by `accordion.mjs` etc

### Some workarounds

This PR runs our Rollup build for `all.mjs` _after_ the components to ensure vital exports are not missed

But we're also running Rollup builds in series to [prevent write conflicts](https://github.com/rollup/rollup/issues/5132) until that can be resolved

### Log output

Rollup stats output is now clear when exports have been removed due to tree shaking:

```console
[!] RollupError: "mergeConfigs" is not exported by "../../packages/govuk-frontend/dist/govuk/common/index.mjs", imported by "../../packages/govuk-frontend/dist/govuk/components/accordion/accordion.mjs".
https://rollupjs.org/troubleshooting/#error-name-is-not-exported-by-module
../../packages/govuk-frontend/dist/govuk/components/accordion/accordion.mjs (1:9)
1: import { mergeConfigs, extractConfigByNamespace } from '../../common/index.mjs';
```