### PR TITLE
[SPIKE] Try using `typed-query-selector` again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,9 @@
         "shared/*",
         "docs/examples/*"
       ],
+      "dependencies": {
+        "typed-query-selector": "*"
+      },
       "devDependencies": {
         "@babel/core": "^7.22.17",
         "@babel/preset-env": "^7.22.15",
@@ -71,7 +74,8 @@
         "@types/node": "^20.6.2",
         "@types/nunjucks": "^3.2.3",
         "@types/slug": "^5.0.3",
-        "puppeteer": "^21.1.1"
+        "puppeteer": "^21.1.1",
+        "typed-query-selector": "^2.11.0"
       }
     },
     ".github/workflows/scripts": {
@@ -28286,6 +28290,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.0.tgz",
+      "integrity": "sha512-qBs4sfmnLlPOyo2oSdvHbIFHe2CPgU54/1UGfSNceb7LARpIEVxUaeRX0Doje6oKpuySS2stqy90R3YrynR8Kg==",
+      "optional": true
     },
     "node_modules/typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "@types/node": "^20.6.2",
     "@types/nunjucks": "^3.2.3",
     "@types/slug": "^5.0.3",
-    "puppeteer": "^21.1.1"
+    "puppeteer": "^21.1.1",
+    "typed-query-selector": "^2.11.0"
   },
   "overrides": {
     "chokidar@^2": {

--- a/packages/govuk-frontend-review/tsconfig.build.json
+++ b/packages/govuk-frontend-review/tsconfig.build.json
@@ -3,6 +3,13 @@
   "include": ["./src/**/*.mjs"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "types": ["express", "marked", "node", "nunjucks", "slug"]
+    "types": [
+      "express",
+      "marked",
+      "node",
+      "nunjucks",
+      "slug",
+      "typed-query-selector"
+    ]
   }
 }

--- a/packages/govuk-frontend-review/tsconfig.dev.json
+++ b/packages/govuk-frontend-review/tsconfig.dev.json
@@ -12,7 +12,8 @@
       "marked",
       "node",
       "nunjucks",
-      "slug"
+      "slug",
+      "typed-query-selector"
     ]
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -390,19 +390,18 @@ export class Accordion extends GOVUKFrontendComponent {
    * @param {Element} $section - Section element
    */
   setExpanded(expanded, $section) {
-    const $showHideIcon = $section.querySelector(`.${this.upChevronIconClass}`)
-    const $showHideText = $section.querySelector(
-      `.${this.sectionShowHideTextClass}`
+    const $showHideIcon = $section.querySelector(
+      `span.${this.upChevronIconClass}`
     )
+
+    const $showHideText = $section.querySelector(
+      `span.${this.sectionShowHideTextClass}`
+    )
+
     const $button = $section.querySelector(`.${this.sectionButtonClass}`)
     const $content = $section.querySelector(`.${this.sectionContentClass}`)
 
-    if (
-      !$showHideIcon ||
-      !($showHideText instanceof HTMLElement) ||
-      !$button ||
-      !$content
-    ) {
+    if (!$showHideIcon || !$showHideText || !$button || !$content) {
       return
     }
 
@@ -416,15 +415,15 @@ export class Accordion extends GOVUKFrontendComponent {
     // Update aria-label combining
     const ariaLabelParts = []
 
-    const $headingText = $section.querySelector(
-      `.${this.sectionHeadingTextClass}`
+    const $headingText = $button.querySelector(
+      `span.${this.sectionHeadingTextClass}`
     )
-    if ($headingText instanceof HTMLElement) {
+    if ($headingText) {
       ariaLabelParts.push($headingText.innerText.trim())
     }
 
-    const $summary = $section.querySelector(`.${this.sectionSummaryClass}`)
-    if ($summary instanceof HTMLElement) {
+    const $summary = $button.querySelector(`span.${this.sectionSummaryClass}`)
+    if ($summary) {
       ariaLabelParts.push($summary.innerText.trim())
     }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -37,7 +37,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       return this
@@ -126,7 +125,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {HTMLInputElement} $input - Checkbox input
    */
   unCheckAllInputsExcept($input) {
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const allInputsWithSameName = document.querySelectorAll(
       `input[type="checkbox"][name="${$input.name}"]`
     )
@@ -151,7 +149,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {HTMLInputElement} $input - Checkbox input
    */
   unCheckExclusiveInputs($input) {
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const allInputsWithSameNameAndExclusiveBehaviour =
       document.querySelectorAll(
         `input[data-behaviour="exclusive"][type="checkbox"][name="${$input.name}"]`

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -108,9 +108,9 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.$button = $button
 
     const $skiplinkButton = document.querySelector(
-      '.govuk-js-exit-this-page-skiplink'
+      'a.govuk-js-exit-this-page-skiplink'
     )
-    if ($skiplinkButton instanceof HTMLAnchorElement) {
+    if ($skiplinkButton) {
       this.$skiplinkButton = $skiplinkButton
     }
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -52,19 +52,14 @@ export class Header extends GOVUKFrontendComponent {
     }
 
     this.$module = $module
-    this.$menuButton = $module.querySelector('.govuk-js-header-toggle')
+    this.$menuButton = $module.querySelector('button.govuk-js-header-toggle')
     this.$menu =
       this.$menuButton &&
       $module.querySelector(
-        `#${this.$menuButton.getAttribute('aria-controls')}`
+        `ul#${this.$menuButton.getAttribute('aria-controls')}`
       )
 
-    if (
-      !(
-        this.$menuButton instanceof HTMLElement ||
-        this.$menu instanceof HTMLElement
-      )
-    ) {
+    if (!this.$menuButton || !this.$menu) {
       return this
     }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -37,7 +37,6 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       return this
@@ -137,7 +136,6 @@ export class Radios extends GOVUKFrontendComponent {
 
     // We only need to consider radios with conditional reveals, which will have
     // aria-controls attributes.
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $allInputs = document.querySelectorAll(
       'input[type="radio"][aria-controls]'
     )

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -60,7 +60,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     const $linkedElement = document.getElementById(linkedElementId)
 
     // Check for link target element
-    if (!($linkedElement instanceof HTMLElement)) {
+    if (!$linkedElement) {
       throw new ElementError($linkedElement, {
         componentName: 'Skip link',
         identifier: `$module.hash target #${linkedElementId}`

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -50,7 +50,6 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLAnchorElement>} */
     const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       return this
@@ -380,7 +379,6 @@ export class Tabs extends GOVUKFrontendComponent {
       return
     }
 
-    /** @satisfies {HTMLAnchorElement} */
     const $nextTab = $nextTabListItem.querySelector('a.govuk-tabs__tab')
     if (!$nextTab) {
       return
@@ -409,7 +407,6 @@ export class Tabs extends GOVUKFrontendComponent {
       return
     }
 
-    /** @satisfies {HTMLAnchorElement} */
     const $previousTab = $previousTabListItem.querySelector('a.govuk-tabs__tab')
     if (!$previousTab) {
       return

--- a/packages/govuk-frontend/tsconfig.build.json
+++ b/packages/govuk-frontend/tsconfig.build.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["node"]
+    "types": ["node", "typed-query-selector"]
   }
 }

--- a/packages/govuk-frontend/tsconfig.dev.json
+++ b/packages/govuk-frontend/tsconfig.dev.json
@@ -5,6 +5,13 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["gulp", "jest", "jest-axe", "jest-puppeteer", "node"]
+    "types": [
+      "gulp",
+      "jest",
+      "jest-axe",
+      "jest-puppeteer",
+      "node",
+      "typed-query-selector"
+    ]
   }
 }

--- a/shared/helpers/tsconfig.json
+++ b/shared/helpers/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["**/*.js", "**/*.mjs"],
   "exclude": ["./node_modules"],
   "compilerOptions": {
-    "types": ["jest", "node", "nunjucks", "slug"]
+    "types": ["jest", "node", "nunjucks", "slug", "typed-query-selector"]
   }
 }

--- a/shared/tasks/tsconfig.json
+++ b/shared/tasks/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["**/*.js", "**/*.mjs"],
   "compilerOptions": {
-    "types": ["gulp", "jest", "node", "nunjucks"]
+    "types": ["gulp", "jest", "node", "nunjucks", "typed-query-selector"]
   }
 }


### PR DESCRIPTION
5 minute spike to see how many `instanceof` and `@satisfies` we no longer need

Remember we removed [typed-query-selector](https://github.com/g-plane/typed-query-selector) in the past?

* https://github.com/alphagov/govuk-frontend/pull/3561

It couldn’t figure out types from concatenated selector strings:

```mjs
// NodeListOf<Element> ❌
const $sections = this.$module.querySelectorAll('.' + this.sectionClass)
```

But we have string literals now:

```mjs
// NodeListOf<Element> ❌
const $sections = this.$module.querySelectorAll(`.${this.sectionClass}`)
```

So types can be inferred once again when adding tag names (e.g. prepending `div`)

```mjs
// NodeListOf<HTMLDivElement> ✅
const $sections = this.$module.querySelectorAll(`div.${this.sectionClass}`)
```