### PR TITLE
Add changelog entry for #4113

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,6 +389,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#3777: Fix hover style on small checkboxes and radio buttons in High Contrast Mode](https://github.com/alphagov/govuk-frontend/pull/3777)
 - [#3791: Refactor mobile menu button label/text handling](https://github.com/alphagov/govuk-frontend/pull/3791)
 - [#3862: Fix focus style being overlapped by summary action links](https://github.com/alphagov/govuk-frontend/pull/3862)
+- [#4113: Always set an explicit button `type`](https://github.com/alphagov/govuk-frontend/pull/4113)
 
 ## 4.7.0 (Feature release)
 


### PR DESCRIPTION
As part of a Dependabot update for `html-validate`, we made a change so that the button `type` attribute is always set (defaulting to `submit`, which is the same behaviour as if the `type` attribute is omittted)

Although this isn’t a breaking change, I think it’s worth mentioning in the release notes.

I’ve also updated the PR title to mention the change. This means the fix and the PR title are not identical, as I’ve omitted the `html-validate` bump here, but I think that’s OK.