### PR TITLE
[support/3.x] Add note on how support branches work

### DIFF
--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -1,5 +1,9 @@
 # Before you release a new version of GOV.UK Frontend
 
+This is a support branch, which we use to release additional v3.x versions now that the `main` branch reflects a newer major version.
+
+Make sure you understand how this branch is meant to be used be reading the [documentation on support branches](https://govuk-design-system-team-docs.netlify.app/how-we-work/version-control/support-branches.html#support-branches) in our team docs.
+
 1. At stand up, tell the GOV.UK Design System team we are close to releasing so we can coordinate the final cutoff date. Once the cutoff date passes, do not add any further major changes to the release. We can still add small fixes before step 7 as long as we notify the content designer and technical writer. However, we should try to avoid adding too many fixes in this way, as it requires us to repeat some of steps 4-6.
 
 2. Developers to raise new issues in the team GitHub repositories ([govuk-frontend](https://github.com/alphagov/govuk-frontend), [govuk-frontend-docs](https://github.com/alphagov/govuk-frontend-docs), [govuk-prototype-kit](https://github.com/alphagov/govuk-prototype-kit)) to:


### PR DESCRIPTION
We’re adding docs on using support branches to our team docs as part of alphagov/design-system-team-docs#21.

Update our release docs for v3.x to reflect the fact that this branch is a support branch and to link to the new docs.