### PR TITLE
Fix Review app Sass compile after error

### DIFF
--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -28,6 +28,12 @@ export async function run(name, args = [], options) {
       throw new Error(`Task '${name}' not found in '${pkgPath}'`)
     }
   } catch (cause) {
+    // Skip Nodemon (SIGINT) exit or aborted task error codes
+    // https://github.com/open-cli-tools/concurrently/pull/359/files
+    if (cause.signal === 'SIGINT' || [130, 3221225786].includes(cause.code)) {
+      return
+    }
+
     throw new PluginError(`npm run ${name}`, cause, {
       // Hide error properties already formatted by npm
       showProperties: false

--- a/shared/tasks/npm.mjs
+++ b/shared/tasks/npm.mjs
@@ -28,17 +28,10 @@ export async function run(name, args = [], options) {
       throw new Error(`Task '${name}' not found in '${pkgPath}'`)
     }
   } catch (cause) {
-    const error = new Error(`Task for npm script '${name}' failed`, { cause })
-
-    // Skip errors by default to allow Gulp to resume tasks
-    if (['test', 'production'].includes(process.env.NODE_ENV)) {
-      throw new PluginError(`npm run ${name}`, error, {
-        showProperties: false,
-        showStack: false
-      })
-    }
-
-    console.error(error.message)
+    throw new PluginError(`npm run ${name}`, cause, {
+      // Hide error properties already formatted by npm
+      showProperties: false
+    })
   }
 }
 

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -21,7 +21,10 @@ export async function compile(pattern, options) {
       await compileJavaScript([modulePath, options])
     }
   } catch (cause) {
-    throw new PluginError('shared/tasks/scripts', cause)
+    throw new PluginError(`scripts.compile('${pattern}')`, cause, {
+      // Show additional error properties from Babel etc
+      showProperties: true
+    })
   }
 }
 

--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -9,7 +9,7 @@ import { loadConfigFile } from 'rollup/dist/loadConfigFile.js'
  * Compile JavaScript task
  *
  * @param {string} pattern - Minimatch pattern
- * @param {AssetEntry[1]} [options] - Asset options for script(s)
+ * @param {AssetEntry[1]} options - Asset options for script(s)
  */
 export async function compile(pattern, options) {
   const modulePaths = await getListing(pattern, {

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -26,7 +26,7 @@ export async function compile(pattern, options) {
 
   try {
     for (const modulePath of modulePaths) {
-      compileStylesheet([modulePath, options])
+      await compileStylesheet([modulePath, options])
     }
   } catch (cause) {
     throw new PluginError('shared/tasks/styles', cause)

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -17,7 +17,7 @@ import { assets } from './index.mjs'
  * Compile Sass to CSS task
  *
  * @param {string} pattern - Minimatch pattern
- * @param {AssetEntry[1]} options - Asset options
+ * @param {AssetEntry[1]} options - Asset options for stylesheet(s)
  */
 export async function compile(pattern, options) {
   const modulePaths = await getListing(pattern, {

--- a/shared/tasks/styles.mjs
+++ b/shared/tasks/styles.mjs
@@ -29,7 +29,10 @@ export async function compile(pattern, options) {
       await compileStylesheet([modulePath, options])
     }
   } catch (cause) {
-    throw new PluginError('shared/tasks/styles', cause)
+    throw new PluginError(`styles.compile('${pattern}')`, cause, {
+      // Hide error properties already formatted by Sass
+      showProperties: false
+    })
   }
 }
 


### PR DESCRIPTION
This PR fixes Gulp "Did you forget to signal async completion?" when Sass compilation errors occur in:

* https://github.com/alphagov/govuk-frontend/issues/4237

### The issue

Spot my missing `await` in https://github.com/alphagov/govuk-frontend/commit/8f74d0265903b199b91f21425e7bb357d55bee39 🤦‍♂️

### Error logging

I've made sure all "watch + reload" tasks use Gulp's [`new PluginError()`](https://github.com/gulpjs/plugin-error#readme) for consistent output, as currently:

1. Sass tasks via `scripts.compile()` throw `new PluginError()`
2. Rollup tasks via `styles.compile()` throw `new PluginError()`
3. npm tasks via `npm.script()` log [`console.error(error.message)` without error](https://github.com/alphagov/govuk-frontend/blob/2ad331924779ed1ff17cc19c261e299410ae7671/shared/tasks/npm.mjs#L33-L41)

But Gulp is now aware of npm task errors too, without interrupting watch tasks:

<img width="1004" alt="ESLint errors now known to Gulp" src="https://github.com/alphagov/govuk-frontend/assets/415517/bb486cd0-1458-407b-b6d7-f05181b7a564">
