### PR TITLE
Add new `govuk-frontend.min.css` package bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+#### Precompiled CSS and JavaScript
+
+The precompiled CSS and JavaScript files found in our [GitHub releases](https://github.com/alphagov/govuk-frontend/releases) are now also published to [`govuk-frontend` on npm](https://www.npmjs.com/package/govuk-frontend).
+
+These changes were introduced in:
+
+- [pull request #3726: Default to ES modules with single Rollup config](https://github.com/alphagov/govuk-frontend/pull/3726)
+- [pull request #4241: Add new `govuk-frontend.min.css` package bundle](https://github.com/alphagov/govuk-frontend/pull/4241)
+
 #### Task list component added
 
 A new component has been added which creates lists of tasks that users need to complete.

--- a/docs/contributing/tasks.md
+++ b/docs/contributing/tasks.md
@@ -39,6 +39,7 @@ npm scripts are defined in `package.json`. These trigger a number of Gulp tasks.
 - copy Sass files, applying Autoprefixer via PostCSS
 - copy Nunjucks component template/macro files, including JSON configs
 - copy GOV.UK Prototype Kit config files
+- compile Sass to CSS
 - compile JavaScript to ECMAScript (ES) modules
 - compile JavaScript to Universal Module Definition (UMD) bundles
 - compile Rollup build stats into `./shared/stats/dist`
@@ -83,13 +84,6 @@ This task will:
 
 - check Sass code quality via Stylelint (`npm run lint:scss`)
 - compile Sass to CSS into `./packages/govuk-frontend-review/dist/stylesheets`
-- compile Sass documentation into `./packages/govuk-frontend-review/dist/docs/sassdoc`
-
-**`npx --workspace @govuk-frontend/review -- gulp scripts`**
-
-This task will:
-
-- compile JavaScript documentation into `./packages/govuk-frontend-review/dist/docs/jsdoc`
 
 ## Review app only
 

--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -37,7 +37,7 @@ export const watch = (options) =>
         [
           `${slash(paths.app)}/sassdoc.config.yaml`,
           `${slash(paths.app)}/src/**/*.scss`,
-          `${slash(paths.package)}/dist/govuk/**/*.scss`
+          `${slash(paths.package)}/dist/govuk/all.scss`
         ],
         styles(options)
       )

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -107,6 +107,17 @@ describe('packages/govuk-frontend/dist/', () => {
         ])
       )
 
+      // Only sass package entry is compiled to minified CSS bundle
+      .flatMap(
+        mapPathTo(['**/govuk/all.scss'], ({ dir: requirePath }) => [
+          join(requirePath, 'all.scss'),
+
+          // CSS bundle, minified
+          join(requirePath, 'govuk-frontend.min.css'),
+          join(requirePath, 'govuk-frontend.min.css.map') // with source map
+        ])
+      )
+
       // Add Autoprefixer prefixes to all source '*.scss' files
       .flatMap(
         mapPathTo(['**/*.scss'], ({ dir: requirePath, name }) => [

--- a/packages/govuk-frontend/tasks/build/release.mjs
+++ b/packages/govuk-frontend/tasks/build/release.mjs
@@ -43,18 +43,15 @@ export default (options) =>
 
     // Compile GOV.UK Frontend Sass
     task.name('compile:scss', () =>
-      styles.compile('**/[!_]*.scss', {
+      styles.compile('all.scss', {
         ...options,
 
         srcPath: join(options.srcPath, 'govuk'),
         configPath: join(options.basePath, 'postcss.config.mjs'),
 
         // Rename using package name (versioned) and `*.min.css` extension
-        filePath({ dir, name }) {
-          return join(
-            dir,
-            `${name.replace(/^all/, pkg.name)}-${pkg.version}.min.css`
-          )
+        filePath({ dir }) {
+          return join(dir, `${pkg.name}-${pkg.version}.min.css`)
         }
       })
     ),

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -1,5 +1,6 @@
 import { join } from 'path'
 
+import { pkg } from '@govuk-frontend/config'
 import { styles, task } from '@govuk-frontend/tasks'
 import gulp from 'gulp'
 
@@ -10,6 +11,24 @@ import gulp from 'gulp'
  */
 export const compile = (options) =>
   gulp.series(
+    /**
+     * Compile GOV.UK Frontend Sass
+     */
+    task.name('compile:scss', () =>
+      styles.compile('all.scss', {
+        ...options,
+
+        srcPath: join(options.srcPath, 'govuk'),
+        destPath: join(options.destPath, 'govuk'),
+        configPath: join(options.basePath, 'postcss.config.mjs'),
+
+        // Rename using package name and `*.min.css` extension
+        filePath({ dir }) {
+          return join(dir, `${pkg.name}.min.css`)
+        }
+      })
+    ),
+
     /**
      * Apply CSS prefixes to GOV.UK Frontend Sass
      */

--- a/packages/govuk-frontend/tasks/styles.mjs
+++ b/packages/govuk-frontend/tasks/styles.mjs
@@ -13,7 +13,7 @@ export const compile = (options) =>
     /**
      * Apply CSS prefixes to GOV.UK Frontend Sass
      */
-    task.name('compile:scss', () =>
+    task.name('postcss:scss', () =>
       styles.compile('**/*.scss', {
         ...options,
 
@@ -26,7 +26,7 @@ export const compile = (options) =>
     /**
      * Apply CSS prefixes to GOV.UK Prototype Kit Sass
      */
-    task.name("compile:scss 'govuk-prototype-kit'", () =>
+    task.name("postcss:scss 'govuk-prototype-kit'", () =>
       styles.compile('init.scss', {
         ...options,
 


### PR DESCRIPTION
To make sure we catch Sass compilation problems early, our npm package has a new minified bundle

Previously we ran PostCSS-only tasks during `npm run build:package` and missed https://github.com/alphagov/govuk-frontend/pull/4239

### Package minified bundles

Output using `npm run build:package`

* **`govuk-frontend.min.js`**
* **`govuk-frontend.min.css`** ✅ Added

### GitHub Release minified bundles

**Using** `npm run build:release`

* **`govuk-frontend-X.Y.Z.min.js`**
* **`govuk-frontend-X-Y-Z.min.css`**