### PR TITLE
Increase Jest + Puppeteer timeouts for Windows

### DIFF
--- a/jest-dev-server.config.js
+++ b/jest-dev-server.config.js
@@ -7,8 +7,8 @@ module.exports = {
   command: 'npm start --workspace @govuk-frontend/review',
   port: ports.app,
 
-  // Allow 15 seconds to start server
-  launchTimeout: 15000,
+  // Allow 30 seconds to start server
+  launchTimeout: 30000,
 
   // Skip when already running
   usedPortAction: 'ignore'

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -145,6 +145,6 @@ export default {
   // Enable GitHub Actions reporter UI
   reporters: ['default', 'github-actions'],
 
-  // Browser test increased timeout (5s to 30s)
-  testTimeout: 30000
+  // Browser test increased timeout (5s to 60s)
+  testTimeout: 60000
 }

--- a/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
@@ -29,6 +29,6 @@ describe('/components/accordion', () => {
         await goToComponent(page, 'accordion', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -27,7 +27,7 @@ describe('/components/accordion', () => {
             `.govuk-accordion .govuk-accordion__section:nth-of-type(${
               i + 1
             }) .govuk-accordion__section-content`,
-            { visible: true, timeout: 5000 }
+            { visible: true, timeout: 10000 }
           )
           expect(isContentVisible).toBeTruthy()
         }

--- a/packages/govuk-frontend/src/govuk/components/back-link/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/back-link/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/back-link', () => {
         await goToComponent(page, 'back-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/breadcrumbs', () => {
         await goToComponent(page, 'breadcrumbs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
@@ -27,6 +27,6 @@ describe('/components/button', () => {
         await goToComponent(page, 'button', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/character-count', () => {
         await goToComponent(page, 'character-count', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.puppeteer.test.mjs
@@ -28,6 +28,6 @@ describe('/components/checkboxes', () => {
         await goToComponent(page, 'checkboxes', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/cookie-banner', () => {
         await goToComponent(page, 'cookie-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/date-input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/date-input/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/date-input', () => {
         await goToComponent(page, 'date-input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/details', () => {
         await goToComponent(page, 'details', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-message/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-message/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/error-message', () => {
         await goToComponent(page, 'error-message', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/error-summary', () => {
         await goToComponent(page, 'error-summary', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
@@ -17,6 +17,6 @@ describe('/components/exit-this-page', () => {
         await goToComponent(page, 'exit-this-page', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/fieldset', () => {
         await goToComponent(page, 'fieldset', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/file-upload', () => {
         await goToComponent(page, 'file-upload', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/footer/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/footer/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/footer', () => {
         await goToComponent(page, 'footer', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/header', () => {
         await goToComponent(page, 'header', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/hint', () => {
         await goToComponent(page, 'hint', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/input/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/input', () => {
         await goToComponent(page, 'input', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/inset-text', () => {
         await goToComponent(page, 'inset-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/label/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/label/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/label', () => {
         await goToComponent(page, 'label', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
@@ -33,6 +33,6 @@ describe('/components/notification-banner', () => {
         await goToComponent(page, 'notification-banner', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/pagination', () => {
         await goToComponent(page, 'pagination', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/panel', () => {
         await goToComponent(page, 'panel', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/phase-banner', () => {
         await goToComponent(page, 'phase-banner', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/accessibility.puppeteer.test.mjs
@@ -28,6 +28,6 @@ describe('/components/radios', () => {
         await goToComponent(page, 'radios', { exampleName })
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/select/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/select/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/select', () => {
         await goToComponent(page, 'select', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/skip-link', () => {
         await goToComponent(page, 'skip-link', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/summary-list', () => {
         await goToComponent(page, 'summary-list', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/table/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/table/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/table', () => {
         await goToComponent(page, 'table', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/tabs', () => {
         await goToComponent(page, 'tabs', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -23,7 +23,7 @@ describe('/components/tabs', () => {
       it('falls back to making all tab containers visible', async () => {
         const isContentVisible = await page.waitForSelector(
           '.govuk-tabs__panel',
-          { visible: true, timeout: 5000 }
+          { visible: true, timeout: 10000 }
         )
         expect(isContentVisible).toBeTruthy()
       })
@@ -242,7 +242,7 @@ describe('/components/tabs', () => {
         await goToComponent(page, 'tabs')
         const isContentVisible = await page.waitForSelector(
           '.govuk-tabs__panel',
-          { visible: true, timeout: 5000 }
+          { visible: true, timeout: 10000 }
         )
         expect(isContentVisible).toBeTruthy()
       })

--- a/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/tag', () => {
         await goToComponent(page, 'tag', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/textarea/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/textarea/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/textarea', () => {
         await goToComponent(page, 'textarea', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.puppeteer.test.mjs
@@ -15,6 +15,6 @@ describe('/components/warning-text', () => {
         await goToComponent(page, 'warning-text', { exampleName })
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
-    }, 90000)
+    }, 120000)
   })
 })


### PR DESCRIPTION
Quick PR to fix a few more flaky tests for https://github.com/alphagov/govuk-frontend/issues/4223

Each test now has 60 seconds to run (see [example 1](https://github.com/alphagov/govuk-frontend/actions/runs/6272041552/job/17032886950), [example 2](https://github.com/alphagov/govuk-frontend/actions/runs/6259852128/job/16996825141)) to fix:

```console
thrown: "Exceeded timeout of 30000 ms for a hook.
Add a timeout value to this test to increase the timeout, if this is a long-running test. See https://jestjs.io/docs/api#testname-fn-timeout."
```

But following on from https://github.com/alphagov/govuk-frontend/commit/6106aa0562d0ea4a414526dbfe73059fc595a733 I've bumped all of the following too:

* 5 seconds → **10 seconds** for Accordion section visibility
* 5 seconds → **10 seconds** for Tab panel visibility
* 15 seconds → **30 seconds** for [Review app to start](https://github.com/alphagov/govuk-frontend/actions/runs/6261933084/job/17003196500)
* 90 seconds → **120 seconds** for Accessibility tests