### PR TITLE
Add word breaking for long single word tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This change was made in:
 
 - [pull request #3502: Tag design changes](https://github.com/alphagov/govuk-frontend/pull/3502).
 - [pull request #3731: Remove the first letter modifier from the tag component](https://github.com/alphagov/govuk-frontend/pull/3731)
+- [pull request #4259: Add word breaking for long single word tags](https://github.com/alphagov/govuk-frontend/pull/4259)
 
 #### New link styles are now enabled by default
 

--- a/packages/govuk-frontend/src/govuk/components/tag/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tag/_index.scss
@@ -1,8 +1,16 @@
 @include govuk-exports("govuk/component/tag") {
+  $govuk-tag-max-width: if(map-has-key($govuk-breakpoints, "mobile"), map-get($govuk-breakpoints, "mobile") / 2, 160px);
+
   .govuk-tag {
     @include govuk-font($size: 19);
 
     display: inline-block;
+
+    // set a max-width along with overflow-wrap: break-word below for instances
+    // where a tag has a single long word and could overflow its boundaries.
+    // The max-width is necessary as break-word requires a bounding box to base
+    // where to break off of.
+    max-width: $govuk-tag-max-width;
 
     // These negative margins make sure that the tag component doesn’t increase the
     // size of its container. Otherwise, for example, a table row containing a tag
@@ -16,11 +24,10 @@
     padding-right: 8px;
     padding-bottom: 3px;
     padding-left: 8px;
-
     color: govuk-shade(govuk-colour("blue"), 60%);
     background-color: govuk-tint(govuk-colour("blue"), 70%);
-
     text-decoration: none;
+    overflow-wrap: break-word;
 
     // When forced colour mode is active, for example to provide high contrast,
     // the background colour of the tag is the same as the rest of the page. To ensure

--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -264,6 +264,30 @@ examples:
               text: Yellow
               classes: govuk-tag--yellow
 
+  - name: example with very long single word tags
+    options:
+      items:
+        - title:
+            text: Company Directors
+          href: '#'
+          status:
+            text: Completed
+
+        - title:
+            text: Registered company details
+          href: '#'
+          status:
+            tag:
+              text: Incomplete
+              classes: govuk-tag--blue
+
+        - title:
+            text: A very very very long Business plan
+          href: '#'
+          status:
+            tag:
+              text: Thisisaverylongwaytosaythatsomethingisincomplete
+              classes: govuk-tag--blue
   # Hidden examples are not shown in the review app, but are used for tests and HTML fixtures
   - name: custom classes
     hidden: true


### PR DESCRIPTION
Adds `overflow-wrap: break-word` to tags to split them in instances where we have very long tags in small paces like the task list.

More details can be found in the comments of https://github.com/alphagov/govuk-frontend/issues/3923

Some extra details on what else I tried can be found [in this comment](https://github.com/alphagov/govuk-frontend/issues/3923#issuecomment-1715690396).