### PR TITLE
Fix double redirect to HTML specification

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -35,7 +35,7 @@ params:
       - name: pattern
         type: string
         required: false
-        description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+        description: Attribute to [provide a regular expression pattern](https://html.spec.whatwg.org/multipage/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
       - name: classes
         type: string
         required: false

--- a/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
+++ b/packages/govuk-frontend/src/govuk/components/footer/footer.yaml
@@ -126,7 +126,7 @@ accessibilityCriteria: |
 
   Landmarks and Roles in the Footer should:
   - avoid navigation landmarks or roles
-    "The footer element alone is sufficient for such cases; while a nav element can be used in such cases, it is usually unnecessary." - (https://www.w3.org/TR/html52/sections.html#the-nav-element)
+    "The footer element alone is sufficient for such cases; while a nav element can be used in such cases, it is usually unnecessary." - (https://html.spec.whatwg.org/multipage/sections.html#the-nav-element)
     Note: This decision has been made based on prior experience seeing removal of overuse of `<nav>` elements from www.GOV.UK, which made it confusing for users of assistive technologies to know what were the most important navigation aspects of GOV.UK.
     Should be challenged if user research indicates this is an issue.
 

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -104,7 +104,7 @@ params:
   - name: pattern
     type: string
     required: false
-    description: Attribute to [provide a regular expression pattern](https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
+    description: Attribute to [provide a regular expression pattern](https://html.spec.whatwg.org/multipage/sec-forms.html#the-pattern-attribute), used to match allowed character combinations for the input value.
   - name: spellcheck
     type: boolean
     required: false


### PR DESCRIPTION
Just a few specification links that are double-redirecting at the moment

[**https://www.w3.org/TR/html51**/sec-forms.html](https://www.w3.org/TR/html51/sec-forms.html)
→ [**https://www.w3.org/TR/html**/sec-forms.html](https://www.w3.org/TR/html/sec-forms.html)
→ [**https://html.spec.whatwg.org/multipage**/sec-forms.html](https://html.spec.whatwg.org/multipage/sec-forms.html)