### PR TITLE
Throw `ElementError` for missing elements during Character count instantiation

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -410,7 +410,7 @@ export class Accordion extends GOVUKFrontendComponent {
       ? this.i18n.t('hideSection')
       : this.i18n.t('showSection')
 
-    $showHideText.innerText = newButtonText
+    $showHideText.textContent = newButtonText
     $button.setAttribute('aria-expanded', `${expanded}`)
 
     // Update aria-label combining
@@ -420,12 +420,12 @@ export class Accordion extends GOVUKFrontendComponent {
       `.${this.sectionHeadingTextClass}`
     )
     if ($headingText instanceof HTMLElement) {
-      ariaLabelParts.push($headingText.innerText.trim())
+      ariaLabelParts.push($headingText.textContent.trim())
     }
 
     const $summary = $section.querySelector(`.${this.sectionSummaryClass}`)
     if ($summary instanceof HTMLElement) {
-      ariaLabelParts.push($summary.innerText.trim())
+      ariaLabelParts.push($summary.textContent.trim())
     }
 
     const ariaLabelMessage = expanded
@@ -497,7 +497,7 @@ export class Accordion extends GOVUKFrontendComponent {
       : this.i18n.t('showAllSections')
 
     this.$showAllButton.setAttribute('aria-expanded', expanded.toString())
-    this.$showAllText.innerText = newButtonText
+    this.$showAllText.textContent = newButtonText
 
     // Swap icon, toggle class
     if (expanded) {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -759,7 +759,7 @@ describe('/components/accordion', () => {
               })
             ).rejects.toEqual({
               name: 'ElementError',
-              message: 'Accordion: $module is not an instance of "HTMLElement"'
+              message: 'Accordion: $module is not an instance of HTMLElement'
             })
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -364,7 +364,7 @@ describe('/components/button', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Button: $module is not an instance of "HTMLElement"'
+          message: 'Button: $module is not an instance of HTMLElement'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
@@ -1,38 +1,22 @@
+import { getExamples, renderComponent } from '@govuk-frontend/lib/components'
+
 import { CharacterCount } from './character-count.mjs'
 
 describe('CharacterCount', () => {
-  let $container
-  let $textarea
-  let $textareaDescription
+  let html
 
-  function cloneContainerAndAddToDocument() {
-    const $clone = $container.cloneNode(true)
-    document.body.appendChild($clone)
-    return $clone
-  }
-
-  // Jest JSDOM does not clear the body between tests in the same file
-  // so we need to do it ourselves
-  // https://github.com/jestjs/jest/issues/1224#issuecomment-443661330
-  beforeEach(() => {
-    document.body.innerHTML = ''
+  beforeAll(async () => {
+    const examples = await getExamples('character-count')
+    html = renderComponent(
+      'character-count',
+      examples['to configure in JavaScript']
+    )
   })
 
-  beforeAll(() => {
-    $container = document.createElement('div')
-    $textarea = document.createElement('textarea')
-    $textareaDescription = document.createElement('span')
-
-    // Component checks that GOV.UK Frontend is supported
-    document.body.classList.add('govuk-frontend-supported')
-
-    // Component checks that required elements are present
-    $textarea.classList.add('govuk-js-character-count')
-    $textarea.id = 'textarea-id'
-    $container.appendChild($textarea)
-
-    $textareaDescription.id = 'textarea-id-info'
-    $container.appendChild($textareaDescription)
+  beforeEach(async () => {
+    // Some tests add attributes to `document.body` so we need
+    // to reset it alongside the component's markup
+    document.body.outerHTML = `<body class="govuk-frontend-supported">${html}</body>`
   })
 
   describe('formatCountMessage', () => {
@@ -40,8 +24,8 @@ describe('CharacterCount', () => {
       let componentWithMaxLength
       let componentWithMaxWords
 
-      beforeAll(() => {
-        const $div = cloneContainerAndAddToDocument()
+      beforeEach(() => {
+        const $div = document.querySelector('[data-module]')
         componentWithMaxLength = new CharacterCount($div, { maxlength: 100 })
         componentWithMaxWords = new CharacterCount($div, { maxwords: 100 })
       })
@@ -106,7 +90,7 @@ describe('CharacterCount', () => {
     describe('i18n', () => {
       describe('JavaScript configuration', () => {
         it('overrides the default translation keys', () => {
-          const $div = cloneContainerAndAddToDocument()
+          const $div = document.querySelector('[data-module]')
           const component = new CharacterCount($div, {
             maxlength: 100,
             i18n: {
@@ -127,7 +111,7 @@ describe('CharacterCount', () => {
         })
 
         it('uses specific keys for when limit is reached', () => {
-          const $div = cloneContainerAndAddToDocument()
+          const $div = document.querySelector('[data-module]')
           const componentWithMaxLength = new CharacterCount($div, {
             maxlength: 100,
             i18n: {
@@ -155,7 +139,7 @@ describe('CharacterCount', () => {
 
       describe('lang attribute configuration', () => {
         it('overrides the locale when set on the element', () => {
-          const $div = cloneContainerAndAddToDocument()
+          const $div = document.querySelector('[data-module]')
           $div.setAttribute('lang', 'de')
 
           const component = new CharacterCount($div, { maxwords: 20000 })
@@ -167,13 +151,9 @@ describe('CharacterCount', () => {
         })
 
         it('overrides the locale when set on an ancestor', () => {
-          const $parent = document.createElement('div')
-          $parent.setAttribute('lang', 'de')
+          document.body.setAttribute('lang', 'de')
 
-          const $div = $container.cloneNode(true)
-          $parent.appendChild($div)
-
-          document.body.appendChild($parent)
+          const $div = document.querySelector('[data-module]')
 
           const component = new CharacterCount($div, { maxwords: 20000 })
 
@@ -186,7 +166,7 @@ describe('CharacterCount', () => {
 
       describe('Data attribute configuration', () => {
         it('overrides the default translation keys', () => {
-          const $div = cloneContainerAndAddToDocument()
+          const $div = document.querySelector('[data-module]')
           $div.setAttribute(
             'data-i18n.characters-under-limit.one',
             'Custom text. Count: %{count}'
@@ -208,13 +188,11 @@ describe('CharacterCount', () => {
 
         describe('precedence over JavaScript configuration', () => {
           it('overrides translation keys', () => {
-            const $div = cloneContainerAndAddToDocument()
+            const $div = document.querySelector('[data-module]')
             $div.setAttribute(
               'data-i18n.characters-under-limit.one',
               'Custom text. Count: %{count}'
             )
-
-            console.log($div.outerHTML)
 
             const component = new CharacterCount($div, {
               maxlength: 100,

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.jsdom.test.mjs
@@ -3,17 +3,36 @@ import { CharacterCount } from './character-count.mjs'
 describe('CharacterCount', () => {
   let $container
   let $textarea
+  let $textareaDescription
+
+  function cloneContainerAndAddToDocument() {
+    const $clone = $container.cloneNode(true)
+    document.body.appendChild($clone)
+    return $clone
+  }
+
+  // Jest JSDOM does not clear the body between tests in the same file
+  // so we need to do it ourselves
+  // https://github.com/jestjs/jest/issues/1224#issuecomment-443661330
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
 
   beforeAll(() => {
     $container = document.createElement('div')
     $textarea = document.createElement('textarea')
+    $textareaDescription = document.createElement('span')
 
     // Component checks that GOV.UK Frontend is supported
     document.body.classList.add('govuk-frontend-supported')
 
     // Component checks that required elements are present
     $textarea.classList.add('govuk-js-character-count')
+    $textarea.id = 'textarea-id'
     $container.appendChild($textarea)
+
+    $textareaDescription.id = 'textarea-id-info'
+    $container.appendChild($textareaDescription)
   })
 
   describe('formatCountMessage', () => {
@@ -22,7 +41,7 @@ describe('CharacterCount', () => {
       let componentWithMaxWords
 
       beforeAll(() => {
-        const $div = $container.cloneNode(true)
+        const $div = cloneContainerAndAddToDocument()
         componentWithMaxLength = new CharacterCount($div, { maxlength: 100 })
         componentWithMaxWords = new CharacterCount($div, { maxwords: 100 })
       })
@@ -87,7 +106,7 @@ describe('CharacterCount', () => {
     describe('i18n', () => {
       describe('JavaScript configuration', () => {
         it('overrides the default translation keys', () => {
-          const $div = $container.cloneNode(true)
+          const $div = cloneContainerAndAddToDocument()
           const component = new CharacterCount($div, {
             maxlength: 100,
             i18n: {
@@ -108,7 +127,7 @@ describe('CharacterCount', () => {
         })
 
         it('uses specific keys for when limit is reached', () => {
-          const $div = $container.cloneNode(true)
+          const $div = cloneContainerAndAddToDocument()
           const componentWithMaxLength = new CharacterCount($div, {
             maxlength: 100,
             i18n: {
@@ -136,7 +155,7 @@ describe('CharacterCount', () => {
 
       describe('lang attribute configuration', () => {
         it('overrides the locale when set on the element', () => {
-          const $div = $container.cloneNode(true)
+          const $div = cloneContainerAndAddToDocument()
           $div.setAttribute('lang', 'de')
 
           const component = new CharacterCount($div, { maxwords: 20000 })
@@ -154,6 +173,8 @@ describe('CharacterCount', () => {
           const $div = $container.cloneNode(true)
           $parent.appendChild($div)
 
+          document.body.appendChild($parent)
+
           const component = new CharacterCount($div, { maxwords: 20000 })
 
           // @ts-expect-error Property 'formatCountMessage' is private
@@ -165,7 +186,7 @@ describe('CharacterCount', () => {
 
       describe('Data attribute configuration', () => {
         it('overrides the default translation keys', () => {
-          const $div = $container.cloneNode(true)
+          const $div = cloneContainerAndAddToDocument()
           $div.setAttribute(
             'data-i18n.characters-under-limit.one',
             'Custom text. Count: %{count}'
@@ -187,11 +208,13 @@ describe('CharacterCount', () => {
 
         describe('precedence over JavaScript configuration', () => {
           it('overrides translation keys', () => {
-            const $div = $container.cloneNode(true)
+            const $div = cloneContainerAndAddToDocument()
             $div.setAttribute(
               'data-i18n.characters-under-limit.one',
               'Custom text. Count: %{count}'
             )
+
+            console.log($div.outerHTML)
 
             const component = new CharacterCount($div, {
               maxlength: 100,

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -137,11 +137,13 @@ export class CharacterCount extends GOVUKFrontendComponent {
     this.$module = $module
     this.$textarea = $textarea
 
-    const $textareaDescription = document.getElementById(
-      `${this.$textarea.id}-info`
-    )
+    const textareaDescriptionId = `${this.$textarea.id}-info`
+    const $textareaDescription = document.getElementById(textareaDescriptionId)
     if (!$textareaDescription) {
-      return
+      throw new ElementError($textareaDescription, {
+        componentName: 'Character count',
+        identifier: `#${textareaDescriptionId}`
+      })
     }
 
     // Inject a description for the textarea if none is present already

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -149,8 +149,8 @@ export class CharacterCount extends GOVUKFrontendComponent {
     // Inject a description for the textarea if none is present already
     // for when the component was rendered with no maxlength, maxwords
     // nor custom textareaDescriptionText
-    if ($textareaDescription.innerText.match(/^\s*$/)) {
-      $textareaDescription.innerText = this.i18n.t('textareaDescription', {
+    if ($textareaDescription.textContent.match(/^\s*$/)) {
+      $textareaDescription.textContent = this.i18n.t('textareaDescription', {
         count: this.maxLength
       })
     }
@@ -324,7 +324,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Update message
-    this.$visibleCountMessage.innerText = this.getCountMessage()
+    this.$visibleCountMessage.textContent = this.getCountMessage()
   }
 
   /**
@@ -342,7 +342,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     }
 
     // Update message
-    this.$screenReaderCountMessage.innerText = this.getCountMessage()
+    this.$screenReaderCountMessage.textContent = this.getCountMessage()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -91,7 +91,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
       throw new ElementError($textarea, {
         componentName: 'Character count',
         identifier: '.govuk-js-character-count',
-        expectedType: 'HTMLTextareaElement" or "HTMLInputElement'
+        expectedType: 'HTMLTextareaElement or HTMLInputElement'
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -88,7 +88,11 @@ export class CharacterCount extends GOVUKFrontendComponent {
         $textarea instanceof HTMLInputElement
       )
     ) {
-      return this
+      throw new ElementError($textarea, {
+        componentName: 'Character count',
+        identifier: '.govuk-js-character-count',
+        expectedType: 'HTMLTextareaElement" or "HTMLInputElement'
+      })
     }
 
     // Read config set using dataset ('data-' values)

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -846,6 +846,20 @@ describe('Character count', () => {
         })
       })
 
+      it('throws when the textarea description is missing', async () => {
+        await expect(
+          renderAndInitialise(page, 'character-count', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module.querySelector('#more-detail-info').remove()
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Character count: #more-detail-info not found'
+        })
+      })
+
       it('throws when receiving invalid configuration', async () => {
         await expect(
           renderAndInitialise(page, 'character-count', {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -815,6 +815,37 @@ describe('Character count', () => {
         })
       })
 
+      it('throws when the textarea is missing', async () => {
+        await expect(
+          renderAndInitialise(page, 'character-count', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module.querySelector('.govuk-js-character-count').remove()
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Character count: .govuk-js-character-count not found'
+        })
+      })
+
+      it('throws when the textarea is not the right type', async () => {
+        await expect(
+          renderAndInitialise(page, 'character-count', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              // Replace with a tag that's neither an `<input>` or `<textarea>`
+              $module.querySelector('.govuk-js-character-count').outerHTML =
+                '<div class="govuk-js-character-count"></div>'
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message:
+            'Character count: .govuk-js-character-count is not of type "HTMLTextareaElement" or "HTMLInputElement"'
+        })
+      })
+
       it('throws when receiving invalid configuration', async () => {
         await expect(
           renderAndInitialise(page, 'character-count', {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -810,8 +810,7 @@ describe('Character count', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Character count: $module is not an instance of "HTMLElement"'
+          message: 'Character count: $module is not an instance of HTMLElement'
         })
       })
 
@@ -842,7 +841,7 @@ describe('Character count', () => {
         ).rejects.toEqual({
           name: 'ElementError',
           message:
-            'Character count: .govuk-js-character-count is not of type "HTMLTextareaElement" or "HTMLInputElement"'
+            'Character count: .govuk-js-character-count is not of type HTMLTextareaElement or HTMLInputElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -366,7 +366,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
         ).rejects.toEqual({
           name: 'ElementError',
           message:
-            'Checkboxes: [data-module="govuk-checkboxes"] is not an instance of "HTMLElement"'
+            'Checkboxes: [data-module="govuk-checkboxes"] is not an instance of HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -256,7 +256,7 @@ describe('Error Summary', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message: 'Error summary: $module is not an instance of "HTMLElement"'
+        message: 'Error summary: $module is not an instance of HTMLElement'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -223,7 +223,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
    * @private
    */
   exitPage() {
-    this.$updateSpan.innerText = ''
+    this.$updateSpan.textContent = ''
 
     // Blank the page
     // As well as creating an overlay with text, we also set the body to hidden
@@ -238,7 +238,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     // the element text after adding it means that screen readers pick up the
     // announcement more reliably.
     document.body.appendChild(this.$overlay)
-    this.$overlay.innerText = this.i18n.t('activated')
+    this.$overlay.textContent = this.i18n.t('activated')
 
     window.location.href = this.$button.getAttribute('href')
   }
@@ -301,9 +301,9 @@ export class ExitThisPage extends GOVUKFrontendComponent {
         this.exitPage()
       } else {
         if (this.keypressCounter === 1) {
-          this.$updateSpan.innerText = this.i18n.t('pressTwoMoreTimes')
+          this.$updateSpan.textContent = this.i18n.t('pressTwoMoreTimes')
         } else {
-          this.$updateSpan.innerText = this.i18n.t('pressOneMoreTime')
+          this.$updateSpan.textContent = this.i18n.t('pressOneMoreTime')
         }
       }
 
@@ -350,10 +350,10 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     this.keypressTimeoutId = null
 
     this.keypressCounter = 0
-    this.$updateSpan.innerText = this.i18n.t('timedOut')
+    this.$updateSpan.textContent = this.i18n.t('timedOut')
 
     this.timeoutMessageId = window.setTimeout(() => {
-      this.$updateSpan.innerText = ''
+      this.$updateSpan.textContent = ''
     }, this.timeoutTime)
 
     this.updateIndicator()
@@ -384,7 +384,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
 
     // Ensure the announcement span's role is status, not alert and clear any text
     this.$updateSpan.setAttribute('role', 'status')
-    this.$updateSpan.innerText = ''
+    this.$updateSpan.textContent = ''
 
     // Sync the keypress indicator lights
     this.updateIndicator()

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -234,7 +234,7 @@ describe('/components/exit-this-page', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Exit this page: $module is not an instance of "HTMLElement"'
+          message: 'Exit this page: $module is not an instance of HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -216,7 +216,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Header: $module is not an instance of "HTMLElement"'
+          message: 'Header: $module is not an instance of HTMLElement'
         })
       })
 
@@ -244,7 +244,7 @@ describe('Header navigation', () => {
         ).rejects.toEqual({
           name: 'ElementError',
           message:
-            'Header: .govuk-js-header-toggle is not an instance of "HTMLElement"'
+            'Header: .govuk-js-header-toggle is not an instance of HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -245,7 +245,7 @@ describe('Notification banner', () => {
       ).rejects.toEqual({
         name: 'ElementError',
         message:
-          'Notification banner: $module is not an instance of "HTMLElement"'
+          'Notification banner: $module is not an instance of HTMLElement'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -317,7 +317,7 @@ describe('Radios', () => {
       ).rejects.toEqual({
         name: 'ElementError',
         message:
-          'Radios: [data-module="govuk-radios"] is not an instance of "HTMLElement"'
+          'Radios: [data-module="govuk-radios"] is not an instance of HTMLElement'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -107,7 +107,7 @@ describe('Skip Link', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message: 'Skip link: $module is not an instance of "HTMLAnchorElement"'
+        message: 'Skip link: $module is not an instance of HTMLAnchorElement'
       })
     })
 
@@ -136,7 +136,7 @@ describe('Skip Link', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message: 'Skip link: $module.hash is not of type "string"'
+        message: 'Skip link: $module.hash is not of type string'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -294,7 +294,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Tabs: $module is not an instance of "HTMLElement"'
+          message: 'Tabs: $module is not an instance of HTMLElement'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -60,7 +60,7 @@ describe('errors', () => {
           expectedType: window.HTMLAnchorElement
         }).message
       ).toBe(
-        'Component name: variableName is not an instance of "HTMLAnchorElement"'
+        'Component name: variableName is not an instance of HTMLAnchorElement'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -63,8 +63,8 @@ export class ElementError extends GOVUKFrontendError {
 
       reason =
         typeof expectedType === 'string'
-          ? `${identifier} is not of type "${expectedType}"`
-          : `${identifier} is not an instance of "${expectedType.name}"`
+          ? `${identifier} is not of type ${expectedType}`
+          : `${identifier} is not an instance of ${expectedType.name}`
     }
 
     super(`${componentName}: ${reason}`)


### PR DESCRIPTION
Adds two errors thrown when:
- The textarea is missing or not an `HTMLTextareaElement` or an `HTMLInputElement`
- The textarea description is missing (preventing the component to replace its content with the live count)

Closes #4125