### PR TITLE
Throw errors during Tabs initialisation if key HTML elements are missing

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -141,9 +141,6 @@ export class Tabs extends GOVUKFrontendComponent {
 
     // Show either the active tab according to the URL's hash or the first tab
     const $activeTab = this.getTab(window.location.hash) || this.$tabs[0]
-    if (!$activeTab) {
-      return
-    }
 
     this.showTab($activeTab)
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -81,11 +81,15 @@ export class Tabs extends GOVUKFrontendComponent {
     // MediaQueryList.addEventListener isn't supported by Safari < 14 so we need
     // to be able to fall back to the deprecated MediaQueryList.addListener
     if ('addEventListener' in this.mql) {
-      this.mql.addEventListener('change', () => this.checkMode())
+      this.mql.addEventListener('change', () => {
+        this.checkMode()
+      })
     } else {
       // @ts-expect-error Property 'addListener' does not exist
       // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-      this.mql.addListener(() => this.checkMode())
+      this.mql.addListener(() => {
+        this.checkMode()
+      })
     }
 
     this.checkMode()
@@ -112,12 +116,10 @@ export class Tabs extends GOVUKFrontendComponent {
   setup() {
     const $tabList = this.$module.querySelector('.govuk-tabs__list')
     const $tabListItems = this.$module.querySelectorAll(
-      '.govuk-tabs__list-item'
+      'li.govuk-tabs__list-item'
     )
 
-    if (!this.$tabs || !$tabList || !$tabListItems) {
-      return
-    }
+    this.checkTabList($tabList, $tabListItems)
 
     $tabList.setAttribute('role', 'tablist')
 
@@ -157,12 +159,10 @@ export class Tabs extends GOVUKFrontendComponent {
   teardown() {
     const $tabList = this.$module.querySelector('.govuk-tabs__list')
     const $tabListItems = this.$module.querySelectorAll(
-      'a.govuk-tabs__list-item'
+      'li.govuk-tabs__list-item'
     )
 
-    if (!this.$tabs || !$tabList || !$tabListItems) {
-      return
-    }
+    this.checkTabList($tabList, $tabListItems)
 
     $tabList.removeAttribute('role')
 
@@ -524,6 +524,31 @@ export class Tabs extends GOVUKFrontendComponent {
     const href = $tab.getAttribute('href')
     const hash = href.slice(href.indexOf('#'), href.length)
     return hash
+  }
+
+  /**
+   * Checks the tab list for missing HTML elements
+   *
+   * @private
+   * @param {Element} $tabList - The tab list
+   * @param {NodeListOf<Element>} $tabListItems - The tab list items
+   * @throws {ElementError} when the tab list is missing
+   * @throws {ElementError} when there are no tab list items
+   */
+  checkTabList($tabList, $tabListItems) {
+    if (!$tabList) {
+      throw new ElementError($tabList, {
+        componentName: 'Tabs',
+        identifier: '.govuk-tabs__list'
+      })
+    }
+
+    if (!$tabListItems.length) {
+      throw new ElementError(null, {
+        componentName: 'Tabs',
+        identifier: '.govuk-tabs__list-item'
+      })
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -53,7 +53,10 @@ export class Tabs extends GOVUKFrontendComponent {
     /** @satisfies {NodeListOf<HTMLAnchorElement>} */
     const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
-      return this
+      throw new ElementError(null, {
+        componentName: 'Tabs',
+        identifier: 'a.govuk-tabs__tab'
+      })
     }
 
     this.$module = $module

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -14,6 +14,12 @@ export class Tabs extends GOVUKFrontendComponent {
   $tabs
 
   /** @private */
+  $tabList
+
+  /** @private */
+  $tabListItems
+
+  /** @private */
   keys = { left: 37, right: 39, up: 38, down: 40 }
 
   /** @private */
@@ -55,7 +61,7 @@ export class Tabs extends GOVUKFrontendComponent {
     if (!$tabs.length) {
       throw new ElementError(null, {
         componentName: 'Tabs',
-        identifier: 'a.govuk-tabs__tab'
+        identifier: `[data-module="${Tabs.moduleName}"] a.govuk-tabs__tab`
       })
     }
 
@@ -66,6 +72,28 @@ export class Tabs extends GOVUKFrontendComponent {
     this.boundTabClick = this.onTabClick.bind(this)
     this.boundTabKeydown = this.onTabKeydown.bind(this)
     this.boundOnHashChange = this.onHashChange.bind(this)
+
+    const $tabList = this.$module.querySelector('.govuk-tabs__list')
+    const $tabListItems = this.$module.querySelectorAll(
+      'li.govuk-tabs__list-item'
+    )
+
+    if (!$tabList) {
+      throw new ElementError(null, {
+        componentName: 'Tabs',
+        identifier: `[data-module="${Tabs.moduleName}"] .govuk-tabs__list`
+      })
+    }
+
+    if (!$tabListItems.length) {
+      throw new ElementError(null, {
+        componentName: 'Tabs',
+        identifier: `[data-module="${Tabs.moduleName}"] .govuk-tabs__list-item`
+      })
+    }
+
+    this.$tabList = $tabList
+    this.$tabListItems = $tabListItems
 
     this.setupResponsiveChecks()
   }
@@ -114,16 +142,9 @@ export class Tabs extends GOVUKFrontendComponent {
    * @private
    */
   setup() {
-    const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll(
-      'li.govuk-tabs__list-item'
-    )
+    this.$tabList.setAttribute('role', 'tablist')
 
-    this.checkTabList($tabList, $tabListItems)
-
-    $tabList.setAttribute('role', 'tablist')
-
-    $tabListItems.forEach(($item) => {
+    this.$tabListItems.forEach(($item) => {
       $item.setAttribute('role', 'presentation')
     })
 
@@ -154,16 +175,9 @@ export class Tabs extends GOVUKFrontendComponent {
    * @private
    */
   teardown() {
-    const $tabList = this.$module.querySelector('.govuk-tabs__list')
-    const $tabListItems = this.$module.querySelectorAll(
-      'li.govuk-tabs__list-item'
-    )
+    this.$tabList.removeAttribute('role')
 
-    this.checkTabList($tabList, $tabListItems)
-
-    $tabList.removeAttribute('role')
-
-    $tabListItems.forEach(($item) => {
+    this.$tabListItems.forEach(($item) => {
       $item.removeAttribute('role')
     })
 
@@ -521,31 +535,6 @@ export class Tabs extends GOVUKFrontendComponent {
     const href = $tab.getAttribute('href')
     const hash = href.slice(href.indexOf('#'), href.length)
     return hash
-  }
-
-  /**
-   * Checks the tab list for missing HTML elements
-   *
-   * @private
-   * @param {Element} $tabList - The tab list
-   * @param {NodeListOf<Element>} $tabListItems - The tab list items
-   * @throws {ElementError} when the tab list is missing
-   * @throws {ElementError} when there are no tab list items
-   */
-  checkTabList($tabList, $tabListItems) {
-    if (!$tabList) {
-      throw new ElementError($tabList, {
-        componentName: 'Tabs',
-        identifier: '.govuk-tabs__list'
-      })
-    }
-
-    if (!$tabListItems.length) {
-      throw new ElementError(null, {
-        componentName: 'Tabs',
-        identifier: '.govuk-tabs__list-item'
-      })
-    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -61,7 +61,7 @@ export class Tabs extends GOVUKFrontendComponent {
     if (!$tabs.length) {
       throw new ElementError(null, {
         componentName: 'Tabs',
-        identifier: `[data-module="${Tabs.moduleName}"] a.govuk-tabs__tab`
+        identifier: `a.govuk-tabs__tab`
       })
     }
 
@@ -81,14 +81,14 @@ export class Tabs extends GOVUKFrontendComponent {
     if (!$tabList) {
       throw new ElementError(null, {
         componentName: 'Tabs',
-        identifier: `[data-module="${Tabs.moduleName}"] .govuk-tabs__list`
+        identifier: `.govuk-tabs__list`
       })
     }
 
     if (!$tabListItems.length) {
       throw new ElementError(null, {
         componentName: 'Tabs',
-        identifier: `[data-module="${Tabs.moduleName}"] .govuk-tabs__list-item`
+        identifier: `.govuk-tabs__list-item`
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -298,7 +298,7 @@ describe('/components/tabs', () => {
         })
       })
 
-      it('throws when the input list is empty', async () => {
+      it('throws when there are no tabs', async () => {
         await expect(
           renderAndInitialise(page, 'tabs', {
             params: examples.default,
@@ -311,6 +311,40 @@ describe('/components/tabs', () => {
         ).rejects.toEqual({
           name: 'ElementError',
           message: 'Tabs: a.govuk-tabs__tab not found'
+        })
+      })
+
+      it('throws when the tab list is missing', async () => {
+        await expect(
+          renderAndInitialise(page, 'tabs', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module
+                .querySelector('.govuk-tabs__list')
+                .setAttribute('class', 'govuk-tabs__typo')
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Tabs: .govuk-tabs__list not found'
+        })
+      })
+
+      it('throws when there the tab list is empty', async () => {
+        await expect(
+          renderAndInitialise(page, 'tabs', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module
+                .querySelectorAll('.govuk-tabs__list-item')
+                .forEach((item) =>
+                  item.setAttribute('class', '.govuk-tabs__list-typo')
+                )
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Tabs: .govuk-tabs__list-item not found'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -297,6 +297,22 @@ describe('/components/tabs', () => {
           message: 'Tabs: $module is not an instance of HTMLElement'
         })
       })
+
+      it('throws when the input list is empty', async () => {
+        await expect(
+          renderAndInitialise(page, 'tabs', {
+            params: examples.default,
+            beforeInitialisation($module) {
+              $module.querySelectorAll('a.govuk-tabs__tab').forEach((item) => {
+                item.remove()
+              })
+            }
+          })
+        ).rejects.toEqual({
+          name: 'ElementError',
+          message: 'Tabs: a.govuk-tabs__tab not found'
+        })
+      })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -310,7 +310,8 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Tabs: a.govuk-tabs__tab not found'
+          message:
+            'Tabs: [data-module="govuk-tabs"] a.govuk-tabs__tab not found'
         })
       })
 
@@ -326,7 +327,8 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Tabs: .govuk-tabs__list not found'
+          message:
+            'Tabs: [data-module="govuk-tabs"] .govuk-tabs__list not found'
         })
       })
 
@@ -344,7 +346,8 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Tabs: .govuk-tabs__list-item not found'
+          message:
+            'Tabs: [data-module="govuk-tabs"] .govuk-tabs__list-item not found'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -310,8 +310,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Tabs: [data-module="govuk-tabs"] a.govuk-tabs__tab not found'
+          message: 'Tabs: a.govuk-tabs__tab not found'
         })
       })
 
@@ -327,8 +326,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Tabs: [data-module="govuk-tabs"] .govuk-tabs__list not found'
+          message: 'Tabs: .govuk-tabs__list not found'
         })
       })
 
@@ -346,8 +344,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Tabs: [data-module="govuk-tabs"] .govuk-tabs__list-item not found'
+          message: 'Tabs: .govuk-tabs__list-item not found'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -48,7 +48,7 @@ export class ElementError extends GOVUKFrontendError {
   name = 'ElementError'
 
   /**
-   * @param {Element} element - The element in error
+   * @param {Element | null} element - The element in error
    * @param {object} options - Element error options
    * @param {string} options.componentName - The name of the component throwing the error
    * @param {string} options.identifier - An identifier that'll let the user understand which element has an error (variable name, CSS selector)


### PR DESCRIPTION
Closes #4127 

A coupla notes:

- So far, I've limited this PR to replacing empty returns in the initialisation of the component. There are 17 more empty returns in the component, some of which are bound during initialisation. These are in event handlers, however, which we can refactor as and when we add things to the API.
- I've removed a check in `setup()` as unnecessary. Some checks will need to replace it if `setup()` becomes an API method that can be called separately from initialisation, but I figure we'd probably do a slight code refactor then anyway.