### PR TITLE
Remove unnecessary duplicated use of govuk-font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -400,6 +400,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#3791: Refactor mobile menu button label/text handling](https://github.com/alphagov/govuk-frontend/pull/3791)
 - [#3862: Fix focus style being overlapped by summary action links](https://github.com/alphagov/govuk-frontend/pull/3862)
 - [#4113: Always set an explicit button `type`](https://github.com/alphagov/govuk-frontend/pull/4113)
+- [#4267: Remove unnecessary duplicated use of govuk-font](https://github.com/alphagov/govuk-frontend/pull/4267)
 
 ## 4.7.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/_index.scss
@@ -10,8 +10,6 @@
   $govuk-checkboxes-label-padding-left-right: govuk-spacing(3);
 
   .govuk-checkboxes__item {
-    @include govuk-font($size: 19);
-
     display: block;
     position: relative;
 
@@ -141,9 +139,9 @@
   // =========================================================
 
   .govuk-checkboxes__divider {
-    $govuk-divider-size: $govuk-checkboxes-size !default;
     @include govuk-font($size: 19);
     @include govuk-text-colour;
+    $govuk-divider-size: $govuk-checkboxes-size !default;
     width: $govuk-divider-size;
     margin-bottom: govuk-spacing(2);
     text-align: center;

--- a/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
@@ -2,6 +2,7 @@
 
 @include govuk-exports("govuk/component/error-summary") {
   .govuk-error-summary {
+    @include govuk-font($size: 19);
     @include govuk-text-colour;
     @include govuk-responsive-padding(4);
     @include govuk-responsive-margin(8, "bottom");
@@ -14,15 +15,14 @@
   }
 
   .govuk-error-summary__title {
-    @include govuk-font($size: 24, $weight: bold);
+    @include govuk-typography-responsive($size: 24);
+    @include govuk-typography-weight-bold;
 
     margin-top: 0;
     @include govuk-responsive-margin(4, "bottom");
   }
 
   .govuk-error-summary__body {
-    @include govuk-font($size: 19);
-
     p {
       margin-top: 0;
       @include govuk-responsive-margin(4, "bottom");

--- a/packages/govuk-frontend/src/govuk/components/fieldset/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/_index.scss
@@ -35,24 +35,27 @@
   }
 
   // Modifiers that make legends look more like their equivalent headings
+  .govuk-fieldset__legend--xl,
+  .govuk-fieldset__legend--l,
+  .govuk-fieldset__legend--m {
+    @include govuk-typography-weight-bold;
+    margin-bottom: govuk-spacing(3);
+  }
 
   .govuk-fieldset__legend--xl {
-    @include govuk-font($size: 48, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 48);
   }
 
   .govuk-fieldset__legend--l {
-    @include govuk-font($size: 36, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 36);
   }
 
   .govuk-fieldset__legend--m {
-    @include govuk-font($size: 24, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 24);
   }
 
   .govuk-fieldset__legend--s {
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-typography-weight-bold;
   }
 
   // When the legend contains an H1, we want the H1 to inherit all styles from

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -62,7 +62,8 @@
   }
 
   .govuk-header__product-name {
-    @include govuk-font($size: 24, $line-height: 1);
+    @include govuk-typography-responsive($size: 24, $override-line-height: 1);
+    @include govuk-typography-weight-regular;
     display: inline-table;
   }
 
@@ -74,7 +75,6 @@
     // - all links get a 3px underline regardless of text size, as there are
     //   multiple grouped elements close to one another and having slightly
     //   different underline widths looks unbalanced
-    @include govuk-typography-common;
     @include govuk-link-style-inverse;
 
     text-decoration: none;
@@ -96,8 +96,7 @@
   .govuk-header__link--homepage {
     // Font size needs to be set on the link so that the box sizing is correct
     // in Firefox
-    @include govuk-font($size: false, $weight: bold);
-
+    @include govuk-typography-weight-bold;
     display: inline-block;
     margin-right: govuk-spacing(2);
     font-size: 30px; // We don't have a mixin that produces 30px font size
@@ -135,7 +134,8 @@
   .govuk-header__service-name {
     display: inline-block;
     margin-bottom: govuk-spacing(2);
-    @include govuk-font($size: 24, $weight: bold);
+    @include govuk-typography-responsive($size: 24);
+    @include govuk-typography-weight-bold;
   }
 
   .govuk-header__logo,
@@ -248,7 +248,8 @@
     }
 
     a {
-      @include govuk-font($size: 16, $weight: bold);
+      @include govuk-typography-responsive($size: 16);
+      @include govuk-typography-weight-bold;
       white-space: nowrap;
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/label/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/label/_index.scss
@@ -9,24 +9,27 @@
   }
 
   // Modifiers that make labels look more like their equivalent headings
+  .govuk-label--xl,
+  .govuk-label--l,
+  .govuk-label--m {
+    @include govuk-typography-weight-bold;
+    margin-bottom: govuk-spacing(3);
+  }
 
   .govuk-label--xl {
-    @include govuk-font($size: 48, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 48);
   }
 
   .govuk-label--l {
-    @include govuk-font($size: 36, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 36);
   }
 
   .govuk-label--m {
-    @include govuk-font($size: 24, $weight: bold);
-    margin-bottom: govuk-spacing(2);
+    @include govuk-typography-responsive($size: 24);
   }
 
   .govuk-label--s {
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-typography-weight-bold;
   }
 
   // When the label is nested inside a heading, override the heading so that it

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
@@ -24,12 +24,12 @@
   }
 
   .govuk-notification-banner__title {
-    @include govuk-font($size: 19, $weight: bold);
-
+    // Set the size again because this element is a heading and the user agent
+    // font size overrides the inherited font size
+    @include govuk-typography-responsive($size: 19);
+    @include govuk-typography-weight-bold;
     margin: 0;
-
     padding: 0;
-
     color: govuk-colour("white");
   }
 
@@ -65,7 +65,8 @@
   }
 
   .govuk-notification-banner__heading {
-    @include govuk-font($size: 24, $weight: bold);
+    @include govuk-typography-responsive($size: 24);
+    @include govuk-typography-weight-bold;
 
     margin: 0 0 govuk-spacing(3) 0;
 

--- a/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/pagination/_index.scss
@@ -148,7 +148,7 @@
   }
 
   .govuk-pagination__link-label {
-    @include govuk-font($size: 19, $weight: "regular");
+    @include govuk-typography-weight-regular;
     @include govuk-link-decoration;
     display: inline-block;
     padding-left: govuk-spacing(6);

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -1,6 +1,6 @@
 @include govuk-exports("govuk/component/panel") {
   .govuk-panel {
-    @include govuk-font($size: 19);
+    @include govuk-font($size: 36);
 
     box-sizing: border-box;
 
@@ -40,17 +40,13 @@
   }
 
   .govuk-panel__title {
+    @include govuk-typography-responsive($size: 48);
+    @include govuk-typography-weight-bold;
     margin-top: 0;
     margin-bottom: govuk-spacing(6);
-
-    @include govuk-font($size: 48, $weight: bold);
   }
 
   .govuk-panel__title:last-child {
     margin-bottom: 0;
-  }
-
-  .govuk-panel__body {
-    @include govuk-font($size: 36);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
@@ -17,7 +17,7 @@
   }
 
   .govuk-phase-banner__content__tag {
-    @include govuk-font($size: 16);
+    @include govuk-typography-responsive($size: 16);
     margin-right: govuk-spacing(2);
 
     // When forced colour mode is active, for example to provide high contrast,

--- a/packages/govuk-frontend/src/govuk/components/radios/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/radios/_index.scss
@@ -13,8 +13,6 @@
   $govuk-radios-focus-width: $govuk-focus-width + 1px;
 
   .govuk-radios__item {
-    @include govuk-font($size: 19);
-
     display: block;
     position: relative;
 
@@ -157,9 +155,9 @@
   // =========================================================
 
   .govuk-radios__divider {
-    $govuk-divider-size: $govuk-radios-size !default;
     @include govuk-font($size: 19);
     @include govuk-text-colour;
+    $govuk-divider-size: $govuk-radios-size !default;
     width: $govuk-divider-size;
     margin-bottom: govuk-spacing(2);
     text-align: center;

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -201,7 +201,8 @@
   }
 
   .govuk-summary-card__actions {
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-typography-responsive($size: 19);
+    @include govuk-typography-weight-bold;
     display: flex;
     flex-wrap: wrap;
     row-gap: 10px;

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -193,6 +193,7 @@
 
   .govuk-summary-card__title {
     @include govuk-font($size: 19, $weight: bold);
+    @include govuk-text-colour;
     margin: govuk-spacing(1) govuk-spacing(4) govuk-spacing(2) 0;
 
     @include govuk-media-query($from: "tablet") {

--- a/packages/govuk-frontend/src/govuk/components/table/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/table/_index.scss
@@ -43,23 +43,21 @@
   }
 
   // Modifiers that make captions look more like their equivalent headings
+  .govuk-table__caption--xl,
+  .govuk-table__caption--l,
+  .govuk-table__caption--m {
+    margin-bottom: govuk-spacing(3);
+  }
 
   .govuk-table__caption--xl {
-    @include govuk-font($size: 48, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 48);
   }
 
   .govuk-table__caption--l {
-    @include govuk-font($size: 36, $weight: bold);
-    margin-bottom: govuk-spacing(3);
+    @include govuk-typography-responsive($size: 36);
   }
 
   .govuk-table__caption--m {
-    @include govuk-font($size: 24, $weight: bold);
-    margin-bottom: govuk-spacing(3);
-  }
-
-  .govuk-table__caption--s {
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-typography-responsive($size: 24);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/table/table.yaml
+++ b/packages/govuk-frontend/src/govuk/components/table/table.yaml
@@ -132,7 +132,7 @@ examples:
   - name: table with head and caption
     options:
       caption: 'Caption 1: Months and rates'
-      captionClasses: govuk-heading-m
+      captionClasses: govuk-table__caption--m
       firstCellIsHeader: true
       head:
         - text: Month you apply

--- a/packages/govuk-frontend/src/govuk/components/table/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/table/template.test.js
@@ -36,7 +36,7 @@ describe('Table', () => {
       const $ = render('table', examples['table with head and caption'])
       const $caption = $('.govuk-table__caption')
 
-      expect($caption.hasClass('govuk-heading-m')).toBeTruthy()
+      expect($caption.hasClass('govuk-table__caption--m')).toBeTruthy()
     })
   })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
@@ -2,10 +2,14 @@
   .govuk-tabs {
     @include govuk-responsive-margin(1, "top");
     @include govuk-responsive-margin(6, "bottom");
+    @include govuk-font($size: 19);
   }
 
   .govuk-tabs__title {
-    @include govuk-font($size: 19);
+    // Set the size and weight again because this element is a heading and the
+    // user agent font size overrides the inherited font size
+    @include govuk-typography-responsive($size: 19);
+    @include govuk-typography-weight-regular;
     @include govuk-text-colour;
     margin-bottom: govuk-spacing(2);
   }
@@ -18,7 +22,6 @@
   }
 
   .govuk-tabs__list-item {
-    @include govuk-font($size: 19);
     margin-left: govuk-spacing(5);
 
     &::before {

--- a/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/_index.scss
@@ -1,13 +1,15 @@
 @include govuk-exports("govuk/component/warning-text") {
   .govuk-warning-text {
-    position: relative;
+    @include govuk-font($size: 19);
     @include govuk-responsive-margin(6, "bottom");
+    position: relative;
     padding: govuk-spacing(2) 0;
   }
 
   .govuk-warning-text__icon {
-    @include govuk-font($size: false, $weight: bold);
-
+    // We apply this here and not at the parent level because the actual text is
+    // a <strong> and so will always be bold
+    @include govuk-typography-weight-bold;
     box-sizing: border-box;
 
     display: inline-block;
@@ -52,7 +54,6 @@
   }
 
   .govuk-warning-text__text {
-    @include govuk-font($size: 19, $weight: bold);
     @include govuk-text-colour;
     display: block;
     padding-left: 45px;


### PR DESCRIPTION
## What/Why

Remove instances of when our components are using `govuk-font` more than once when they don't need to.

Fixes https://github.com/alphagov/govuk-frontend/issues/4242. More details in the issue.

## Notes
At time of writing, building `main` locally produces minified CSS of 123kb and a CSS map of 408kb. Building this branch locally produces minified CSS of 117kb and a CSS map of 397kb.

The only 2 components that still have more than one use of `govuk-font` are the header and input component. Both of these are because of user agent styles that override the inherited font size, weight and font family. Specifically the `button` element that `govuk-header__menu-button` is using and the `input` for `govuk-input`.

This change makes the following classes redundant:

- `govuk-panel__body`
- `govuk-table__caption--s`

Should we deprecate these classes?

This change additionally adds our default text colour to `govuk-summary-card` which was missed when we initially launched this.

