### PR TITLE
Allow border and hover colours to be overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,6 +401,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#3862: Fix focus style being overlapped by summary action links](https://github.com/alphagov/govuk-frontend/pull/3862)
 - [#4113: Always set an explicit button `type`](https://github.com/alphagov/govuk-frontend/pull/4113)
 - [#4267: Remove unnecessary duplicated use of govuk-font](https://github.com/alphagov/govuk-frontend/pull/4267)
+- [#4268: Allow border and hover colours to be overridden](https://github.com/alphagov/govuk-frontend/pull/4268)
 
 ## 4.7.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-applied.scss
@@ -102,7 +102,7 @@ $govuk-success-colour: govuk-colour("green") !default;
 /// @type Colour
 /// @access public
 
-$govuk-border-colour: govuk-colour("mid-grey");
+$govuk-border-colour: govuk-colour("mid-grey") !default;
 
 /// Input border colour
 ///
@@ -120,7 +120,7 @@ $govuk-input-border-colour: govuk-colour("black") !default;
 /// @type Colour
 /// @access public
 
-$govuk-hover-colour: govuk-colour("mid-grey");
+$govuk-hover-colour: govuk-colour("mid-grey") !default;
 
 // =============================================================================
 // Links


### PR DESCRIPTION
`$govuk-border-colour` and `$govuk-hover-colour` are missing `!default` declarations, meaning its not possible to override these values in upstream projects as it is with other colour values in this file.