### PR TITLE
Rename `govuk-typography-responsive` to `govuk-font-size`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Replace instances of `govuk-typography-responsive` with `govuk-font-size`
+
+We've renamed the Sass mixin `govuk-typography-responsive` to `govuk-font-size` and have deprecated `govuk-typography-responsive`. You can still use `govuk-typography-responsive` but we'll be removing it in a future breaking release (6.0.0).
+
+This is an experimental change, based on our hypothesis that `govuk-font-size` as a name better communicates the Sass mixin's intended use than `govuk-typography-responsive`. We're interested in feedback from the community on this name change so please let us know what you think.
+
+This change was introduced in [pull request #4291: Rename `govuk-typography-responsive` to `govuk-font-size`](https://github.com/alphagov/govuk-frontend/pull/4291)
+
 ### Fixes
 
 We've made fixes to GOV.UK Frontend in the following pull requests:

--- a/docs/contributing/managing-change.md
+++ b/docs/contributing/managing-change.md
@@ -62,11 +62,11 @@ Use the `_warning` mixin when deprecating a mixin:
 ```scss
 /// XL headings
 ///
-/// @deprecated Use govuk-typography-responsive($size: 80) instead.
+/// @deprecated Use govuk-font-size($size: 80) instead.
 ///   See https://github.com/alphagov/govuk-frontend/issues/1234
 @mixin govuk-heading-xl {
-  @include _warning("heading-xl", "govuk-heading-xl is deprecated. Use govuk-typography-responsive(80) instead.");
-  @include govuk-typography-responsive($size: 80);
+  @include _warning("heading-xl", "govuk-heading-xl is deprecated. Use govuk-font-size(80) instead.");
+  @include govuk-font-size($size: 80);
 }
 ```
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/accordion/_index.scss
@@ -294,7 +294,7 @@
 
     // Add toggle link with Chevron icon on left.
     .govuk-accordion__section-toggle {
-      @include govuk-typography-responsive($size: 19);
+      @include govuk-font-size($size: 19);
       @include govuk-typography-weight-regular;
       color: $govuk-link-colour;
     }

--- a/packages/govuk-frontend/src/govuk/components/back-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/back-link/_index.scss
@@ -13,7 +13,7 @@
   $chevron-border-colour: $govuk-secondary-text-colour;
 
   .govuk-back-link {
-    @include govuk-typography-responsive($size: $font-size);
+    @include govuk-font-size($size: $font-size);
     @include govuk-link-common;
     @include govuk-link-style-text;
 

--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -236,7 +236,7 @@ $govuk-inverse-button-text-colour: $govuk-brand-colour !default;
 
   .govuk-button--start {
     @include govuk-typography-weight-bold;
-    @include govuk-typography-responsive($size: 24, $override-line-height: 1);
+    @include govuk-font-size($size: 24, $override-line-height: 1);
 
     display: inline-flex;
     min-height: auto;

--- a/packages/govuk-frontend/src/govuk/components/button/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/button/_index.scss
@@ -236,7 +236,7 @@ $govuk-inverse-button-text-colour: $govuk-brand-colour !default;
 
   .govuk-button--start {
     @include govuk-typography-weight-bold;
-    @include govuk-font-size($size: 24, $override-line-height: 1);
+    @include govuk-font-size($size: 24, $line-height: 1);
 
     display: inline-flex;
     min-height: auto;

--- a/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/_index.scss
@@ -15,7 +15,7 @@
   }
 
   .govuk-error-summary__title {
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
     @include govuk-typography-weight-bold;
 
     margin-top: 0;

--- a/packages/govuk-frontend/src/govuk/components/fieldset/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/_index.scss
@@ -43,15 +43,15 @@
   }
 
   .govuk-fieldset__legend--xl {
-    @include govuk-typography-responsive($size: 48);
+    @include govuk-font-size($size: 48);
   }
 
   .govuk-fieldset__legend--l {
-    @include govuk-typography-responsive($size: 36);
+    @include govuk-font-size($size: 36);
   }
 
   .govuk-fieldset__legend--m {
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
   }
 
   .govuk-fieldset__legend--s {

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -61,7 +61,7 @@
     $product-name-offset: 10px;
     $product-name-offset-tablet: 5px;
 
-    @include govuk-font-size($size: 24, $override-line-height: 1);
+    @include govuk-font-size($size: 24, $line-height: 1);
     @include govuk-typography-weight-regular;
     display: inline-table;
 

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -61,7 +61,7 @@
     $product-name-offset: 10px;
     $product-name-offset-tablet: 5px;
 
-    @include govuk-typography-responsive($size: 24, $override-line-height: 1);
+    @include govuk-font-size($size: 24, $override-line-height: 1);
     @include govuk-typography-weight-regular;
     display: inline-table;
 
@@ -150,7 +150,7 @@
   .govuk-header__service-name {
     display: inline-block;
     margin-bottom: govuk-spacing(2);
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
     @include govuk-typography-weight-bold;
   }
 
@@ -271,7 +271,7 @@
     }
 
     a {
-      @include govuk-typography-responsive($size: 16);
+      @include govuk-font-size($size: 16);
       @include govuk-typography-weight-bold;
       white-space: nowrap;
     }

--- a/packages/govuk-frontend/src/govuk/components/label/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/label/_index.scss
@@ -17,15 +17,15 @@
   }
 
   .govuk-label--xl {
-    @include govuk-typography-responsive($size: 48);
+    @include govuk-font-size($size: 48);
   }
 
   .govuk-label--l {
-    @include govuk-typography-responsive($size: 36);
+    @include govuk-font-size($size: 36);
   }
 
   .govuk-label--m {
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
   }
 
   .govuk-label--s {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/_index.scss
@@ -26,7 +26,7 @@
   .govuk-notification-banner__title {
     // Set the size again because this element is a heading and the user agent
     // font size overrides the inherited font size
-    @include govuk-typography-responsive($size: 19);
+    @include govuk-font-size($size: 19);
     @include govuk-typography-weight-bold;
     margin: 0;
     padding: 0;
@@ -65,7 +65,7 @@
   }
 
   .govuk-notification-banner__heading {
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
     @include govuk-typography-weight-bold;
 
     margin: 0 0 govuk-spacing(3) 0;

--- a/packages/govuk-frontend/src/govuk/components/panel/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/panel/_index.scss
@@ -40,7 +40,7 @@
   }
 
   .govuk-panel__title {
-    @include govuk-typography-responsive($size: 48);
+    @include govuk-font-size($size: 48);
     @include govuk-typography-weight-bold;
     margin-top: 0;
     margin-bottom: govuk-spacing(6);

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/_index.scss
@@ -17,7 +17,7 @@
   }
 
   .govuk-phase-banner__content__tag {
-    @include govuk-typography-responsive($size: 16);
+    @include govuk-font-size($size: 16);
     margin-right: govuk-spacing(2);
 
     // When forced colour mode is active, for example to provide high contrast,

--- a/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/_index.scss
@@ -4,7 +4,7 @@
     @include govuk-typography-common;
     @include govuk-link-decoration;
     @include govuk-link-style-text;
-    @include govuk-typography-responsive($size: 16);
+    @include govuk-font-size($size: 16);
 
     display: block;
     padding: govuk-spacing(2) govuk-spacing(3);

--- a/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/_index.scss
@@ -202,7 +202,7 @@
   }
 
   .govuk-summary-card__actions {
-    @include govuk-typography-responsive($size: 19);
+    @include govuk-font-size($size: 19);
     @include govuk-typography-weight-bold;
     display: flex;
     flex-wrap: wrap;

--- a/packages/govuk-frontend/src/govuk/components/table/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/table/_index.scss
@@ -50,14 +50,14 @@
   }
 
   .govuk-table__caption--xl {
-    @include govuk-typography-responsive($size: 48);
+    @include govuk-font-size($size: 48);
   }
 
   .govuk-table__caption--l {
-    @include govuk-typography-responsive($size: 36);
+    @include govuk-font-size($size: 36);
   }
 
   .govuk-table__caption--m {
-    @include govuk-typography-responsive($size: 24);
+    @include govuk-font-size($size: 24);
   }
 }

--- a/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/tabs/_index.scss
@@ -8,7 +8,7 @@
   .govuk-tabs__title {
     // Set the size and weight again because this element is a heading and the
     // user agent font size overrides the inherited font size
-    @include govuk-typography-responsive($size: 19);
+    @include govuk-font-size($size: 19);
     @include govuk-typography-weight-regular;
     @include govuk-text-colour;
     margin-bottom: govuk-spacing(2);

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -129,7 +129,7 @@
 ///
 /// @param {Number} $size - Point from the spacing scale (the size as it would
 ///   appear on tablet and above)
-/// @param {Number} $override-line-height [false] - Non responsive custom line
+/// @param {Number} $line-height [false] - Non responsive custom line
 ///   height. Omit to use the line height from the font map.
 /// @param {Boolean} $important [false] - Whether to mark declarations as
 ///   `!important`.
@@ -138,7 +138,7 @@
 ///
 /// @access public
 
-@mixin govuk-font-size($size, $override-line-height: false, $important: false) {
+@mixin govuk-font-size($size, $line-height: false, $important: false) {
   @if not map-has-key($govuk-typography-scale, $size) {
     @error "Unknown font size `#{$size}` - expected a point from the typography scale.";
   }
@@ -149,8 +149,14 @@
     $font-size: map-get($breakpoint-map, "font-size");
     $font-size-rem: govuk-px-to-rem($font-size);
 
-    $line-height: _govuk-line-height(
-      $line-height: if($override-line-height, $override-line-height, map-get($breakpoint-map, "line-height")),
+    // $calculated-line-height is a separate variable from $line-height,
+    // as otherwise the value would get redefined with each loop and
+    // eventually break _govuk-line-height.
+    //
+    // We continue to call the param $line-height to stay consistent with the
+    // naming with govuk-font.
+    $calculated-line-height: _govuk-line-height(
+      $line-height: if($line-height, $line-height, map-get($breakpoint-map, "line-height")),
       $font-size: $font-size
     );
 
@@ -159,20 +165,20 @@
     // are used in calculations
     $font-size: $font-size if($important, !important, null);
     $font-size-rem: $font-size-rem if($important, !important, null);
-    $line-height: $line-height if($important, !important, null);
+    $calculated-line-height: $calculated-line-height if($important, !important, null);
 
     @if not $breakpoint {
       font-size: $font-size-rem;
-      line-height: $line-height;
+      line-height: $calculated-line-height;
     } @else if $breakpoint == "print" {
       @include govuk-media-query($media-type: print) {
         font-size: $font-size;
-        line-height: $line-height;
+        line-height: $calculated-line-height;
       }
     } @else {
       @include govuk-media-query($from: $breakpoint) {
         font-size: $font-size-rem;
-        line-height: $line-height;
+        line-height: $calculated-line-height;
       }
     }
   }
@@ -210,6 +216,6 @@
   }
 
   @if $size {
-    @include govuk-font-size($size, $override-line-height: $line-height);
+    @include govuk-font-size($size, $line-height);
   }
 }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -210,6 +210,6 @@
   }
 
   @if $size {
-    @include govuk-typography-responsive($size, $override-line-height: $line-height);
+    @include govuk-font-size($size, $override-line-height: $line-height);
   }
 }

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -80,7 +80,31 @@
   @return $line-height;
 }
 
-/// Responsive typography helper
+/// Font size and line height helper
+///
+/// @param {Number} $size - Point from the spacing scale (the size as it would
+///   appear on tablet and above)
+/// @param {Number} $override-line-height [false] - Non responsive custom line
+///   height. Omit to use the line height from the font map.
+/// @param {Boolean} $important [false] - Whether to mark declarations as
+///   `!important`.
+///
+/// @throw if `$size` is not a valid point from the spacing scale
+///
+/// @access public
+///
+/// @alias govuk-font-size
+/// @deprecated Use `govuk-font-size` instead
+
+@mixin govuk-typography-responsive($size, $override-line-height: false, $important: false) {
+  @include _warning(
+    "govuk-typography-responsive",
+    "govuk-typography-responsive is deprecated. Use govuk-font-size instead."
+  );
+  @include govuk-font-size($size, $override-line-height, $important);
+}
+
+/// Font size and line height helper
 ///
 /// Takes a point from the responsive 'font map' as an argument (the size as it
 /// would appear on tablet and above), and uses it to create font-size and
@@ -114,7 +138,7 @@
 ///
 /// @access public
 
-@mixin govuk-typography-responsive($size, $override-line-height: false, $important: false) {
+@mixin govuk-font-size($size, $override-line-height: false, $important: false) {
   @if not map-has-key($govuk-typography-scale, $size) {
     @error "Unknown font size `#{$size}` - expected a point from the typography scale.";
   }

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -293,13 +293,13 @@ describe('@mixin govuk-font-size', () => {
     })
   })
 
-  describe('when $override-line-height is set', () => {
+  describe('when $line-height is set', () => {
     it('overrides the line height', async () => {
       const sass = `
         ${sassBootstrap}
 
         .foo {
-          @include govuk-font-size($size: 14, $override-line-height: 21px);
+          @include govuk-font-size($size: 14, $line-height: 21px);
         }
       `
 
@@ -504,7 +504,7 @@ describe('@mixin govuk-font-size', () => {
         .foo {
           @include govuk-font-size(
             $size: 14,
-            $override-line-height: 40px,
+            $line-height: 40px,
             $important: true
           )
         }

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -176,13 +176,13 @@ describe('@function _govuk-line-height', () => {
   })
 })
 
-describe('@mixin govuk-typography-responsive', () => {
+describe('@mixin govuk-font-size', () => {
   it('outputs CSS with suitable media queries', async () => {
     const sass = `
       ${sassBootstrap}
 
       .foo {
-        @include govuk-typography-responsive($size: 14)
+        @include govuk-font-size($size: 14)
       }
     `
 
@@ -207,7 +207,7 @@ describe('@mixin govuk-typography-responsive', () => {
       ${sassBootstrap}
 
       .foo {
-        @include govuk-typography-responsive($size: 12)
+        @include govuk-font-size($size: 12)
       }
     `
 
@@ -232,7 +232,7 @@ describe('@mixin govuk-typography-responsive', () => {
       ${sassBootstrap}
 
       .foo {
-        @include govuk-typography-responsive(3.1415926536)
+        @include govuk-font-size(3.1415926536)
       }
     `
 
@@ -247,7 +247,7 @@ describe('@mixin govuk-typography-responsive', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-typography-responsive($size: 14, $important: true);
+          @include govuk-font-size($size: 14, $important: true);
         }
       `
 
@@ -272,7 +272,7 @@ describe('@mixin govuk-typography-responsive', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-typography-responsive($size: 12, $important: true);
+          @include govuk-font-size($size: 12, $important: true);
         }
       `
 
@@ -299,7 +299,7 @@ describe('@mixin govuk-typography-responsive', () => {
         ${sassBootstrap}
 
         .foo {
-          @include govuk-typography-responsive($size: 14, $override-line-height: 21px);
+          @include govuk-font-size($size: 14, $override-line-height: 21px);
         }
       `
 

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -482,4 +482,59 @@ describe('@mixin govuk-font-size', () => {
       })
     })
   })
+
+  // govuk-typography-responsive is the previous, deprecated version of govuk-font-size
+  describe('@mixin govuk-typography-responsive', () => {
+    it('outputs the same CSS as govuk-font-size', async () => {
+      const sass = `
+        ${sassBootstrap}
+
+        .foo {
+          @include govuk-typography-responsive(
+            $size: 14,
+            $override-line-height: 40px,
+            $important: true
+          )
+        }
+      `
+
+      const expectedSass = `
+        ${sassBootstrap}
+
+        .foo {
+          @include govuk-font-size(
+            $size: 14,
+            $override-line-height: 40px,
+            $important: true
+          )
+        }
+      `
+
+      await expect(compileSassString(sass)).resolves.toMatchObject({
+        css: (await compileSassString(expectedSass)).css
+      })
+    })
+
+    it('throws a deprecation warning if govuk-typography-responsive is used', async () => {
+      const sass = `
+        ${sassBootstrap}
+
+        .foo {
+          @include govuk-typography-responsive($size: 14)
+        }
+      `
+
+      await compileSassString(sass, sassConfig)
+
+      // Expect our mocked @warn function to have been called once with a single
+      // argument, which should be the deprecation notice
+      expect(mockWarnFunction.mock.calls[0]).toEqual(
+        expect.arrayContaining([
+          'govuk-typography-responsive is deprecated. Use govuk-font-size instead. ' +
+            'To silence this warning, update $govuk-suppressed-warnings with key: ' +
+            '"govuk-typography-responsive"'
+        ])
+      )
+    })
+  })
 })

--- a/packages/govuk-frontend/src/govuk/overrides/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/overrides/_typography.scss
@@ -5,7 +5,7 @@
   // typography scale eg .govuk-\!-font-size-80
   @each $size in map-keys($govuk-typography-scale) {
     .govuk-\!-font-size-#{$size} {
-      @include govuk-typography-responsive($size, $important: true);
+      @include govuk-font-size($size, $important: true);
     }
   }
 


### PR DESCRIPTION
Renames `govuk-typography-responsive` to `govuk-font-size`, deprecates `govuk-typography-responsive`, removes internal use of the old name and adds a test to check for the deprecation waring.

Fixes https://github.com/alphagov/govuk-frontend/issues/4243. More details in the issue.