### PR TITLE
[SPIKE] Configure Babel to add ES shims polyfills

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -7,13 +7,7 @@ module.exports = function (api) {
   api.cache.forever()
 
   return {
-    presets: [
-      [
-        '@babel/preset-env',
-        {
-          browserslistEnv: 'node'
-        }
-      ]
-    ]
+    browserslistEnv: 'node',
+    presets: ['@babel/preset-env']
   }
 }

--- a/docs/examples/webpack/babel.config.js
+++ b/docs/examples/webpack/babel.config.js
@@ -12,12 +12,11 @@ module.exports = function (api) {
   const browserslistEnv = isBrowser ? 'javascripts' : 'node'
 
   return {
+    browserslistEnv,
     presets: [
       [
         '@babel/preset-env',
         {
-          browserslistEnv,
-
           // Apply bug fixes to avoid transforms
           bugfixes: true,
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31473,6 +31473,8 @@
         "@govuk-frontend/lib": "*",
         "@govuk-frontend/tasks": "*",
         "@rollup/plugin-babel": "^6.0.4",
+        "@rollup/plugin-commonjs": "^25.0.7",
+        "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6626,6 +6626,18 @@
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
     },
+    "node_modules/babel-plugin-polyfill-es-shims": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-es-shims/-/babel-plugin-polyfill-es-shims-0.10.2.tgz",
+      "integrity": "sha512-O44oPdkc22bpX1sK6ZMFVJvirbKFJHkfAqeSQyBwThfpvLKy6DUe4+mUqSCIvfNnoBuM54SJkdmGqYjnV+f4vg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.5.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
@@ -31478,6 +31490,7 @@
         "@rollup/plugin-replace": "^5.0.5",
         "@rollup/plugin-terser": "^0.4.4",
         "autoprefixer": "^10.4.17",
+        "babel-plugin-polyfill-es-shims": "^0.10.2",
         "cssnano": "^6.0.3",
         "cssnano-preset-default": "^6.0.1",
         "govuk-prototype-kit": "^13.16.0",

--- a/packages/govuk-frontend/.browserslistrc
+++ b/packages/govuk-frontend/.browserslistrc
@@ -3,6 +3,7 @@
 
 [javascripts]
 supports es6-module
+not OperaMobile > 0
 
 [stylesheets]
 > 0.1% in GB and not dead

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -14,6 +14,7 @@ module.exports = function (api) {
   const browserslistEnv = isBrowser ? 'javascripts' : 'node'
 
   return {
+    browserslistEnv,
     generatorOpts: {
       shouldPrintComment(comment) {
         if (!isBrowser || comment.includes('* @preserve')) {
@@ -39,8 +40,6 @@ module.exports = function (api) {
       [
         '@babel/preset-env',
         {
-          browserslistEnv,
-
           // Apply bug fixes to avoid transforms
           bugfixes: true,
 

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -47,6 +47,11 @@ module.exports = function (api) {
 
           // Browser support polyfills to exclude
           exclude: [
+            // ES2016 '[].includes()' sparse array fix is unnecessary
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1767541
+            // https://github.com/zloirock/core-js/commit/66be5f0b673714bc7cc72a3b5e437fe277465973
+            'Array.prototype.includes',
+
             // ES2022 Error cause is unused
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
             'Error cause'

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -45,6 +45,13 @@ module.exports = function (api) {
           // Add logging for required polyfills
           debug: isProduction,
 
+          // Browser support polyfills to exclude
+          exclude: [
+            // ES2022 Error cause is unused
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+            'Error cause'
+          ],
+
           // Replace unsupported code with polyfills
           // without modifying window globals
           method: 'usage-pure'

--- a/packages/govuk-frontend/babel.config.js
+++ b/packages/govuk-frontend/babel.config.js
@@ -4,6 +4,8 @@
  * @type {import('@babel/core').ConfigFunction}
  */
 module.exports = function (api) {
+  const isProduction = !api.env('development')
+
   // Assume browser environment via Rollup plugin
   const isBrowser = api.caller(
     (caller) => caller?.name === '@rollup/plugin-babel'
@@ -36,6 +38,19 @@ module.exports = function (api) {
         return !isPrivate && isDocumentation
       }
     },
+    plugins: [
+      [
+        'polyfill-es-shims',
+        {
+          // Add logging for required polyfills
+          debug: isProduction,
+
+          // Replace unsupported code with polyfills
+          // without modifying window globals
+          method: 'usage-pure'
+        }
+      ]
+    ],
     presets: [
       [
         '@babel/preset-env',

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -73,6 +73,7 @@
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.17",
+    "babel-plugin-polyfill-es-shims": "^0.10.2",
     "cssnano": "^6.0.3",
     "cssnano-preset-default": "^6.0.1",
     "govuk-prototype-kit": "^13.16.0",

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -68,6 +68,8 @@
     "@govuk-frontend/lib": "*",
     "@govuk-frontend/tasks": "*",
     "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^25.0.7",
+    "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
     "@rollup/plugin-terser": "^0.4.4",
     "autoprefixer": "^10.4.17",

--- a/packages/govuk-frontend/rollup.publish.config.mjs
+++ b/packages/govuk-frontend/rollup.publish.config.mjs
@@ -1,5 +1,7 @@
 import config from '@govuk-frontend/config'
 import { babel } from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
+import resolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import { defineConfig } from 'rollup'
 
@@ -54,6 +56,9 @@ export default defineConfig(({ i: input }) => ({
    * Input plugins
    */
   plugins: [
+    resolve({
+      browser: true
+    }),
     replace({
       include: '**/common/govuk-frontend-version.mjs',
       preventAssignment: true,
@@ -61,8 +66,13 @@ export default defineConfig(({ i: input }) => ({
       // Add GOV.UK Frontend release version
       development: config.version
     }),
+    commonjs({
+      requireReturnsDefault: 'preferred',
+      defaultIsModuleExports: true
+    }),
     babel({
-      babelHelpers: 'bundled'
+      babelHelpers: 'bundled',
+      exclude: '**/node_modules/**'
     })
   ]
 }))

--- a/packages/govuk-frontend/rollup.release.config.mjs
+++ b/packages/govuk-frontend/rollup.release.config.mjs
@@ -1,5 +1,7 @@
 import config from '@govuk-frontend/config'
 import { babel } from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
+import resolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
 import terser from '@rollup/plugin-terser'
 import * as GOVUKFrontend from 'govuk-frontend/src/govuk/all.mjs'
@@ -54,6 +56,9 @@ export default defineConfig(({ i: input }) => ({
    * Input plugins
    */
   plugins: [
+    resolve({
+      browser: true
+    }),
     replace({
       include: '**/common/govuk-frontend-version.mjs',
       preventAssignment: true,
@@ -61,8 +66,13 @@ export default defineConfig(({ i: input }) => ({
       // Add GOV.UK Frontend release version
       development: config.version
     }),
+    commonjs({
+      requireReturnsDefault: 'preferred',
+      defaultIsModuleExports: true
+    }),
     babel({
-      babelHelpers: 'bundled'
+      babelHelpers: 'bundled',
+      exclude: '**/node_modules/**'
     })
   ]
 }))


### PR DESCRIPTION
This PR adds the Babel polyfill provider ES shims via:
https://www.npmjs.com/package/babel-plugin-polyfill-es-shims

This is part of a two spike series:

* https://github.com/alphagov/govuk-frontend/pull/4301
* https://github.com/alphagov/govuk-frontend/pull/4557

## Findings

Lots of polyfills are missing in ES shims when compared to core-js in https://github.com/alphagov/govuk-frontend/pull/4557

We also have some unwanted bug fixes:

* ES shims adds `Array.prototype.includes` polyfill [to avoid bugs](https://bugzilla.mozilla.org/show_bug.cgi?id=1767541)
* ES shims adds `Error.prototype.cause` polyfill [to avoid bugs](https://bugs.chromium.org/p/v8/issues/detail?id=12006)

### Remaining issues

* Browserslist matches Opera Mobile 73 under `es6-module` but [Babel disagrees](https://github.com/alphagov/govuk-frontend/pull/4301/commits/41468a62818d6c5d57e219a149690b9bdb62a5d8)
* Rollup plugin [`@rollup/plugin-commonjs`](https://www.npmjs.com/package/@rollup/plugin-commonjs) adds ES module wrappers to polyfills
* Rollup plugin [`@rollup/plugin-babel`](https://www.npmjs.com/package/@rollup/plugin-babel) adds helpers to avoid ES module wrappers
* Rollup outputs `dist/govuk/node_modules` not `dist/govuk/vendor`

---

### Automatic polyfills

When Babel was added we chose "transforms only" without polyfills (see [decision record](https://github.com/alphagov/govuk-design-system-architecture/blob/main/decision-records/006-javascript-compatibility.md))

* https://github.com/alphagov/govuk-frontend/pull/3820

This PR ensures early investigations aren't lost for:

* https://github.com/alphagov/govuk-frontend/issues/3082
* https://github.com/alphagov/govuk-frontend/issues/3287
* https://github.com/alphagov/govuk-frontend/issues/3948
* https://github.com/alphagov/govuk-frontend/issues/4287

### Decision record implications

Since Babel with "transforms only" silently skips polyfills, we noted that [care must be taken](https://github.com/alphagov/govuk-design-system-architecture/blob/main/decision-records/006-javascript-compatibility.md#implications):

>When writing or changing JavaScript we currently have to remember not to use features that aren't available in the oldest browsers we support, or to manually add a polyfill. We also rely heavily on manual testing across multiple browsers.

This spike PR ensures:

1. Babel logger lists required polyfills
2. Babel injects imports for required polyfills
3. Rollup builds fail when imports are missing

i.e. Support for both polyfills and protection from missed polyfills all-in-one