### PR TITLE
Log formatted warnings from Rollup

### DIFF
--- a/shared/tasks/scripts.mjs
+++ b/shared/tasks/scripts.mjs
@@ -43,14 +43,15 @@ export async function compileJavaScript([
 
   // Create Rollup bundle(s)
   for (const options of config.options) {
-    const bundle = await rollup({
-      ...options,
+    const bundle = await rollup(options)
 
-      // Handle warnings as errors
-      onwarn(message) {
-        throw message
-      }
-    })
+    // Log warnings
+    config.warnings.flush()
+
+    // Handle warnings as errors
+    if (config.warnings.warningOccurred) {
+      throw new Error(`Rollup input '${modulePath}' logged warnings`)
+    }
 
     // Compile JavaScript to output format
     await Promise.all(


### PR DESCRIPTION
This PR replaces our custom [`onwarn` handler](https://rollupjs.org/configuration-options/#onwarn) with the [Rollup config `warnings.flush()`](https://rollupjs.org/javascript-api/#programmatically-loading-a-config-file)

We still break the build on logged warnings, but now includes:

1. Warnings are formatted by Rollup (exclamation marks, yellow text)
2. Warnings are included for config plugins like Babel, Terser

Probably a great way to test Rollup v4 in https://github.com/alphagov/govuk-frontend/pull/4304 and split out from https://github.com/alphagov/govuk-frontend/pull/4301