### PR TITLE
Refactor tabular number activation into their own mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
-### Replace instances of `govuk-typography-responsive` with `govuk-font-size`
+### New features
+
+#### Use tabular numbers with the `govuk-font-tabular-numbers` mixin
+
+You can now use tabular numbers in your authored Sass by including the new `govuk-font-tabular-numbers` mixin.
+
+Previously, you would use the `govuk-font` mixin with the `$tabular` parameter. However, the `govuk-font` mixin includes styles that are unrelated to tabular numbers, which are unnecessary in some contexts.
+
+These additional styles are not included if you use `govuk-font-tabular-numbers`. Switching to the new mixin can reduce the size of your compiled CSS without affecting the appearance of pages.
+
+This change was introduced in [pull request #4307: Refactor tabular number activation into their own mixin](https://github.com/alphagov/govuk-frontend/pull/4307)
+
+### Recommended changes
+
+#### Replace instances of `govuk-typography-responsive` with `govuk-font-size`
 
 We've renamed the Sass mixin `govuk-typography-responsive` to `govuk-font-size` and have deprecated `govuk-typography-responsive`. You can still use `govuk-typography-responsive` but we'll be removing it in a future breaking release (6.0.0).
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/character-count/_index.scss
@@ -14,7 +14,7 @@
   }
 
   .govuk-character-count__message {
-    @include govuk-font($size: false, $tabular: true);
+    @include govuk-font-tabular-numbers;
     margin-top: 0;
     margin-bottom: 0;
 

--- a/packages/govuk-frontend/src/govuk/components/input/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/input/_index.scss
@@ -57,7 +57,7 @@
   }
 
   .govuk-input--extra-letter-spacing {
-    @include govuk-font(false, $tabular: true);
+    @include govuk-font-tabular-numbers;
     letter-spacing: 0.05em;
   }
 

--- a/packages/govuk-frontend/src/govuk/components/table/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/table/_index.scss
@@ -22,7 +22,7 @@
   }
 
   .govuk-table__cell--numeric {
-    @include govuk-font($size: false, $tabular: true);
+    @include govuk-font-tabular-numbers;
   }
 
   .govuk-table__header--numeric,

--- a/packages/govuk-frontend/src/govuk/helpers/_typography.scss
+++ b/packages/govuk-frontend/src/govuk/helpers/_typography.scss
@@ -62,6 +62,23 @@
   font-weight: $govuk-font-weight-bold if($important, !important, null);
 }
 
+/// Tabular number helper
+///
+/// Switches numerical glyphs (0–9) to use alternative forms with a
+/// monospaced bounding box. This ensures that columns of numbers, such
+/// as those in tables, remain horizontally aligned with one another.
+/// This also has the useful side effect of making numbers more legible
+/// in some situations, such as reference codes, as the numbers are more
+/// distinct and visually separated from one another.
+///
+/// @param {Boolean} $important [false] - Whether to mark declarations as
+///   `!important`. Generally Used to create override classes.
+/// @access public
+
+@mixin govuk-font-tabular-numbers($important: false) {
+  font-variant-numeric: tabular-nums if($important, !important, null);
+}
+
 /// Convert line-heights specified in pixels into a relative value, unless
 /// they are already unit-less (and thus already treated as relative values)
 /// or the units do not match the units used for the font size.
@@ -201,12 +218,7 @@
   @include govuk-typography-common;
 
   @if $tabular {
-    font-feature-settings: "tnum" 1;
-
-    @supports (font-variant-numeric: tabular-nums) {
-      font-feature-settings: normal;
-      font-variant-numeric: tabular-nums;
-    }
+    @include govuk-font-tabular-numbers;
   }
 
   @if $weight == regular {

--- a/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
+++ b/packages/govuk-frontend/src/govuk/helpers/typography.unit.test.js
@@ -120,6 +120,42 @@ describe('@mixin govuk-typography-common', () => {
   })
 })
 
+describe('@mixin govuk-font-tabular-numbers', () => {
+  it('enables tabular numbers opentype feature flags', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        @include govuk-font-tabular-numbers;
+      }
+    `
+
+    const results = compileSassString(sass)
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining('font-variant-numeric: tabular-nums;')
+    })
+  })
+
+  it('marks font-variant-numeric as important if $important is set to true', async () => {
+    const sass = `
+      ${sassBootstrap}
+
+      .foo {
+        @include govuk-font-tabular-numbers($important: true);
+      }
+    `
+
+    const results = compileSassString(sass)
+
+    await expect(results).resolves.toMatchObject({
+      css: expect.stringContaining(
+        'font-variant-numeric: tabular-nums !important;'
+      )
+    })
+  })
+})
+
 describe('@function _govuk-line-height', () => {
   it('preserves line-height if already unitless', async () => {
     const sass = `
@@ -369,18 +405,7 @@ describe('@mixin govuk-font-size', () => {
       const results = compileSassString(sass)
 
       await expect(results).resolves.toMatchObject({
-        css: expect.stringContaining('font-feature-settings: "tnum" 1;')
-      })
-
-      await expect(results).resolves.toMatchObject({
-        css: expect.stringContaining(outdent`
-          @supports (font-variant-numeric: tabular-nums) {
-            .foo {
-              font-feature-settings: normal;
-              font-variant-numeric: tabular-nums;
-            }
-          }
-        `)
+        css: expect.stringContaining('font-variant-numeric: tabular-nums;')
       })
     })
 


### PR DESCRIPTION
Splits the code that activates tabular numbers out of the `govuk-font` mixin into its own standalone mixin. Resolves #3778.

> [!WARNING]
> This PR is for future v5.x work. It should not be merged until after v5.0 has been released. 

## Changes
- Creates a new mixin, `govuk-font-tabular-numbers`, to contain the existing CSS rules.
  - This name of the mixin is intended to be 'self explanatory', insomuch as it closely matches the CSS properties and values it's setting, similar to my suggestion for the `font-weight` mixins [in this comment](https://github.com/alphagov/govuk-frontend/issues/4243#issuecomment-1740680964). 
- Simplifies the CSS rules for enabling tabular numbers.
  - Removes the use of `font-feature-settings` to define tabular numbers. This was only still needed for IE 11 support, and as it's only a stylistic flag, IE having proportional figures seems an acceptable fallback.
  - I'm not sure exactly why we were setting `font-feature-settings: normal` in the `@supports` query. This will override any customisations that a user may have made (see the thoughts below), and resetting the value doesn't do anything for our use case here. I think we can remove both it and the `@supports` query without causing any issues. 
- Changes `govuk-font` to call the new mixin instead.
- Updates all instances where `govuk-font` was being called solely to activate tabular numbers to call the new mixin instead.

## Thoughts
- I've opted to keep and not deprecate `govuk-font`'s `$tabular` parameter. I think it's Mostly Harmless and am inclined to leave it be unless a compelling reason to deprecate it is presented.
- I've made this new mixin accept a parameter that sets `!important` to be consistent with the others and to potentially facilitiate a future utility or override class, which could help implement https://github.com/alphagov/govuk-design-system/issues/1233.
- I'm not a fan of`font-feature-settings`. It's a very 'broad' property that is prone to overreach and the way we were using it would override or will be overridden by any other use of `font-feature-settings` that a user may set. As we now only had `font-feature-settings` for IE 11 support, it's not functionally critical in any way, and as we don't make any guarantee that IE will render identically, I've removed the property entirely. 
