### PR TITLE
Comment gardening 🪴

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -199,7 +199,6 @@ export class Accordion extends GOVUKFrontendComponent {
    * @private
    */
   initSectionHeaders() {
-    // Loop through sections
     this.$sections.forEach(($section, i) => {
       const $header = $section.querySelector(`.${this.sectionHeaderClass}`)
       if (!$header) {
@@ -213,8 +212,8 @@ export class Accordion extends GOVUKFrontendComponent {
       // Handle events
       $header.addEventListener('click', () => this.onSectionToggle($section))
 
-      // See if there is any state stored in sessionStorage and set the sections to
-      // open or closed.
+      // See if there is any state stored in sessionStorage and set the sections
+      // to open or closed.
       this.setInitialState($section)
     })
   }
@@ -235,7 +234,8 @@ export class Accordion extends GOVUKFrontendComponent {
       return
     }
 
-    // Create a button element that will replace the '.govuk-accordion__section-button' span
+    // Create a button element that will replace the
+    // '.govuk-accordion__section-button' span
     const $button = document.createElement('button')
     $button.setAttribute('type', 'button')
     $button.setAttribute(
@@ -243,11 +243,10 @@ export class Accordion extends GOVUKFrontendComponent {
       `${this.$module.id}-content-${index + 1}`
     )
 
-    // Copy all attributes (https://developer.mozilla.org/en-US/docs/Web/API/Element/attributes) from $span to $button
+    // Copy all attributes from $span to $button (except `id`, which gets added
+    // to the `$headingText` element)
     for (let i = 0; i < $span.attributes.length; i++) {
       const attr = $span.attributes.item(i)
-      // Add all attributes but not ID as this is being added to
-      // the section heading ($headingText)
       if (attr.nodeName !== 'id') {
         $button.setAttribute(attr.nodeName, attr.nodeValue)
       }
@@ -256,23 +255,25 @@ export class Accordion extends GOVUKFrontendComponent {
     // Create container for heading text so it can be styled
     const $headingText = document.createElement('span')
     $headingText.classList.add(this.sectionHeadingTextClass)
-    // Copy the span ID to the heading text to allow it to be referenced by `aria-labelledby` on the
-    // hidden content area without "Show this section"
+    // Copy the span ID to the heading text to allow it to be referenced by
+    // `aria-labelledby` on the hidden content area without "Show this section"
     $headingText.id = $span.id
 
-    // Create an inner heading text container to limit the width of the focus state
+    // Create an inner heading text container to limit the width of the focus
+    // state
     const $headingTextFocus = document.createElement('span')
     $headingTextFocus.classList.add(this.sectionHeadingTextFocusClass)
     $headingText.appendChild($headingTextFocus)
-    // span could contain HTML elements (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
+    // span could contain HTML elements
+    // (see https://www.w3.org/TR/2011/WD-html5-20110525/content-models.html#phrasing-content)
     $headingTextFocus.innerHTML = $span.innerHTML
 
     // Create container for show / hide icons and text.
     const $showHideToggle = document.createElement('span')
     $showHideToggle.classList.add(this.sectionShowHideToggleClass)
-    // Tell Google not to index the 'show' text as part of the heading
-    // For the snippet to work with JavaScript, it must be added before adding the page element to the
-    // page's DOM. See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
+    // Tell Google not to index the 'show' text as part of the heading. Must be
+    // set on the element before it's added to the DOM.
+    // See https://developers.google.com/search/docs/advanced/robots/robots_meta_tag#data-nosnippet-attr
     $showHideToggle.setAttribute('data-nosnippet', '')
     // Create an inner container to limit the width of the focus state
     const $showHideToggleFocus = document.createElement('span')
@@ -296,12 +297,13 @@ export class Accordion extends GOVUKFrontendComponent {
 
     // If summary content exists add to DOM in correct order
     if ($summary) {
-      // Create a new `span` element and copy the summary line content from the original `div` to the
-      // new `span`
-      // This is because the summary line text is now inside a button element, which can only contain
-      // phrasing content
+      // Create a new `span` element and copy the summary line content from the
+      // original `div` to the new `span`. This is because the summary line text
+      // is now inside a button element, which can only contain phrasing
+      // content.
       const $summarySpan = document.createElement('span')
-      // Create an inner summary container to limit the width of the summary focus state
+      // Create an inner summary container to limit the width of the summary
+      // focus state
       const $summarySpanFocus = document.createElement('span')
       $summarySpanFocus.classList.add(this.sectionSummaryFocusClass)
       $summarySpan.appendChild($summarySpanFocus)
@@ -372,10 +374,8 @@ export class Accordion extends GOVUKFrontendComponent {
   onShowOrHideAllToggle() {
     const nowExpanded = !this.checkIfAllSectionsOpen()
 
-    // Loop through sections
     this.$sections.forEach(($section) => {
       this.setExpanded(nowExpanded, $section)
-      // Store the state in sessionStorage when a change is triggered
       this.storeState($section)
     })
 
@@ -474,9 +474,7 @@ export class Accordion extends GOVUKFrontendComponent {
    * @returns {boolean} True if all sections are open
    */
   checkIfAllSectionsOpen() {
-    // Get a count of all the Accordion sections
     const sectionsCount = this.$sections.length
-    // Get a count of all Accordion sections that are expanded
     const expandedSectionCount = this.$module.querySelectorAll(
       `.${this.sectionExpandedClass}`
     ).length
@@ -499,7 +497,6 @@ export class Accordion extends GOVUKFrontendComponent {
     this.$showAllButton.setAttribute('aria-expanded', expanded.toString())
     this.$showAllText.textContent = newButtonText
 
-    // Swap icon, toggle class
     if (expanded) {
       this.$showAllIcon.classList.remove(this.downChevronIconClass)
     } else {
@@ -515,16 +512,17 @@ export class Accordion extends GOVUKFrontendComponent {
    */
   storeState($section) {
     if (this.browserSupportsSessionStorage && this.config.rememberExpanded) {
-      // We need a unique way of identifying each content in the Accordion. Since
-      // an `#id` should be unique and an `id` is required for `aria-` attributes
-      // `id` can be safely used.
+      // We need a unique way of identifying each content in the Accordion.
+      // Since an `#id` should be unique and an `id` is required for `aria-`
+      // attributes `id` can be safely used.
       const $button = $section.querySelector(`.${this.sectionButtonClass}`)
 
       if ($button) {
         const contentId = $button.getAttribute('aria-controls')
         const contentState = $button.getAttribute('aria-expanded')
 
-        // Only set the state when both `contentId` and `contentState` are taken from the DOM.
+        // Only set the state when both `contentId` and `contentState` are taken
+        // from the DOM.
         if (contentId && contentState) {
           window.sessionStorage.setItem(contentId, contentState)
         }
@@ -556,11 +554,12 @@ export class Accordion extends GOVUKFrontendComponent {
   }
 
   /**
-   * Create an element to improve semantics of the section button with punctuation
+   * Create an element to improve semantics of the section button with
+   * punctuation
    *
-   * Adding punctuation to the button can also improve its general semantics by dividing its contents
-   * into thematic chunks.
-   * See https://github.com/alphagov/govuk-frontend/issues/2327#issuecomment-922957442
+   * Adding punctuation to the button can also improve its general semantics by
+   * dividing its contents into thematic chunks. See
+   * https://github.com/alphagov/govuk-frontend/issues/2327#issuecomment-922957442
    *
    * @private
    * @returns {Element} DOM element

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -58,8 +58,9 @@ export class Button extends GOVUKFrontendComponent {
   /**
    * Trigger a click event when the space key is pressed
    *
-   * Some screen readers tell users they can activate things with the 'button'
-   * role, so we need to match the functionality of native HTML buttons
+   * Some screen readers tell users they can use the space bar to activate
+   * things with the 'button' role, so we need to match the functionality of
+   * native HTML buttons.
    *
    * See https://github.com/alphagov/govuk_elements/pull/272#issuecomment-233028270
    *
@@ -87,8 +88,8 @@ export class Button extends GOVUKFrontendComponent {
   /**
    * Debounce double-clicks
    *
-   * If the click quickly succeeds a previous click then nothing will happen. This
-   * stops people accidentally causing multiple form submissions by double
+   * If the click quickly succeeds a previous click then nothing will happen.
+   * This stops people accidentally causing multiple form submissions by double
    * clicking buttons.
    *
    * @private

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -98,9 +98,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
     // Read config set using dataset ('data-' values)
     const datasetConfig = normaliseDataset($module.dataset)
 
-    // To ensure data-attributes take complete precedence, even if they change the
-    // type of count, we need to reset the `maxlength` and `maxwords` from the
-    // JavaScript config.
+    // To ensure data-attributes take complete precedence, even if they change
+    // the type of count, we need to reset the `maxlength` and `maxwords` from
+    // the JavaScript config.
     //
     // We can't mutate `config`, though, as it may be shared across multiple
     // components inside `initAll`.
@@ -232,12 +232,12 @@ export class CharacterCount extends GOVUKFrontendComponent {
   /**
    * Handle focus event
    *
-   * Speech recognition software such as Dragon NaturallySpeaking will modify the
-   * fields by directly changing its `value`. These changes don't trigger events
-   * in JavaScript, so we need to poll to handle when and if they occur.
+   * Speech recognition software such as Dragon NaturallySpeaking will modify
+   * the fields by directly changing its `value`. These changes don't trigger
+   * events in JavaScript, so we need to poll to handle when and if they occur.
    *
-   * Once the keyup event hasn't been detected for at least 1000 ms (1s), check if
-   * the textarea value has changed and update the count message if it has.
+   * Once the keyup event hasn't been detected for at least 1000 ms (1s), check
+   * if the textarea value has changed and update the count message if it has.
    *
    * This is so that the update triggered by the manual comparison doesn't
    * conflict with debounced KeyboardEvent updates.
@@ -300,8 +300,8 @@ export class CharacterCount extends GOVUKFrontendComponent {
   updateVisibleCountMessage() {
     const remainingNumber = this.maxLength - this.count(this.$textarea.value)
 
-    // If input is over the threshold, remove the disabled class which renders the
-    // counter invisible.
+    // If input is over the threshold, remove the disabled class which renders
+    // the counter invisible.
     if (this.isOverThreshold()) {
       this.$visibleCountMessage.classList.remove(
         'govuk-character-count__message--disabled'

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -14,16 +14,16 @@ export class Checkboxes extends GOVUKFrontendComponent {
   $inputs
 
   /**
-   * Checkboxes can be associated with a 'conditionally revealed' content block –
-   * for example, a checkbox for 'Phone' could reveal an additional form field for
-   * the user to enter their phone number.
+   * Checkboxes can be associated with a 'conditionally revealed' content block
+   * – for example, a checkbox for 'Phone' could reveal an additional form field
+   * for the user to enter their phone number.
    *
-   * These associations are made using a `data-aria-controls` attribute, which is
-   * promoted to an aria-controls attribute during initialisation.
+   * These associations are made using a `data-aria-controls` attribute, which
+   * is promoted to an aria-controls attribute during initialisation.
    *
-   * We also need to restore the state of any conditional reveals on the page (for
-   * example if the user has navigated back), and set up event handlers to keep
-   * the reveal in sync with the checkbox state.
+   * We also need to restore the state of any conditional reveals on the page
+   * (for example if the user has navigated back), and set up event handlers to
+   * keep the reveal in sync with the checkbox state.
    *
    * @param {Element} $module - HTML element to use for checkboxes
    */
@@ -153,9 +153,9 @@ export class Checkboxes extends GOVUKFrontendComponent {
   /**
    * Uncheck exclusive checkboxes
    *
-   * Find any checkbox inputs with the same name value and the 'exclusive' behaviour,
-   * and uncheck them. This helps prevent someone checking both a regular checkbox and a
-   * "None of these" checkbox in the same fieldset.
+   * Find any checkbox inputs with the same name value and the 'exclusive'
+   * behaviour, and uncheck them. This helps prevent someone checking both a
+   * regular checkbox and a "None of these" checkbox in the same fieldset.
    *
    * @private
    * @param {HTMLInputElement} $input - Checkbox input
@@ -179,8 +179,9 @@ export class Checkboxes extends GOVUKFrontendComponent {
   /**
    * Click event handler
    *
-   * Handle a click within the $module – if the click occurred on a checkbox, sync
-   * the state of any associated conditional reveal with the checkbox state.
+   * Handle a click within the $module – if the click occurred on a checkbox,
+   * sync the state of any associated conditional reveal with the checkbox
+   * state.
    *
    * @private
    * @param {MouseEvent} event - Click event

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -6,7 +6,8 @@ import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 /**
  * Error summary component
  *
- * Takes focus on initialisation for accessible announcement, unless disabled in configuration.
+ * Takes focus on initialisation for accessible announcement, unless disabled in
+ * configuration.
  *
  * @preserve
  */
@@ -83,17 +84,17 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   /**
    * Focus the target element
    *
-   * By default, the browser will scroll the target into view. Because our labels
-   * or legends appear above the input, this means the user will be presented with
-   * an input without any context, as the label or legend will be off the top of
-   * the screen.
+   * By default, the browser will scroll the target into view. Because our
+   * labels or legends appear above the input, this means the user will be
+   * presented with an input without any context, as the label or legend will be
+   * off the top of the screen.
    *
-   * Manually handling the click event, scrolling the question into view and then
-   * focussing the element solves this.
+   * Manually handling the click event, scrolling the question into view and
+   * then focussing the element solves this.
    *
    * This also results in the label and/or legend being announced correctly in
-   * NVDA (as tested in 2018.3.2) - without this only the field type is announced
-   * (e.g. "Edit, has autocomplete").
+   * NVDA (as tested in 2018.3.2) - without this only the field type is
+   * announced (e.g. "Edit, has autocomplete").
    *
    * @private
    * @param {EventTarget} $target - Event target
@@ -120,9 +121,9 @@ export class ErrorSummary extends GOVUKFrontendComponent {
       return false
     }
 
-    // Scroll the legend or label into view *before* calling focus on the input to
-    // avoid extra scrolling in browsers that don't support `preventScroll` (which
-    // at time of writing is most of them...)
+    // Scroll the legend or label into view *before* calling focus on the input
+    // to avoid extra scrolling in browsers that don't support `preventScroll`
+    // (which at time of writing is most of them...)
     $legendOrLabel.scrollIntoView()
     $input.focus({ preventScroll: true })
 
@@ -132,8 +133,8 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   /**
    * Get fragment from URL
    *
-   * Extract the fragment (everything after the hash) from a URL, but not including
-   * the hash.
+   * Extract the fragment (everything after the hash) from a URL, but not
+   * including the hash.
    *
    * @private
    * @param {string} url - URL
@@ -160,8 +161,8 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    *
    * @private
    * @param {Element} $input - The input
-   * @returns {Element | null} Associated legend or label, or null if no associated
-   *   legend or label can be found
+   * @returns {Element | null} Associated legend or label, or null if no
+   *   associated legend or label can be found
    */
   getAssociatedLegendOrLabel($input) {
     const $fieldset = $input.closest('fieldset')
@@ -172,8 +173,8 @@ export class ErrorSummary extends GOVUKFrontendComponent {
       if ($legends.length) {
         const $candidateLegend = $legends[0]
 
-        // If the input type is radio or checkbox, always use the legend if there
-        // is one.
+        // If the input type is radio or checkbox, always use the legend if
+        // there is one.
         if (
           $input instanceof HTMLInputElement &&
           ($input.type === 'checkbox' || $input.type === 'radio')
@@ -181,9 +182,9 @@ export class ErrorSummary extends GOVUKFrontendComponent {
           return $candidateLegend
         }
 
-        // For other input types, only scroll to the fieldset’s legend (instead of
-        // the label associated with the input) if the input would end up in the
-        // top half of the screen.
+        // For other input types, only scroll to the fieldset’s legend (instead
+        // of the label associated with the input) if the input would end up in
+        // the top half of the screen.
         //
         // This should avoid situations where the input either ends up off the
         // screen, or obscured by a software keyboard.

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -18,17 +18,17 @@ export class Header extends GOVUKFrontendComponent {
 
   /**
    * Save the opened/closed state for the nav in memory so that we can
-   * accurately maintain state when the screen is changed from small to
-   * big and back to small
+   * accurately maintain state when the screen is changed from small to big and
+   * back to small
    *
    * @private
    */
   menuIsOpen = false
 
   /**
-   * A global const for storing a matchMedia instance which we'll use to
-   * detect when a screen size change happens. We rely on it being null if the
-   * feature isn't available to initially apply hidden attributes
+   * A global const for storing a matchMedia instance which we'll use to detect
+   * when a screen size change happens. We rely on it being null if the feature
+   * isn't available to initially apply hidden attributes
    *
    * @private
    * @type {MediaQueryList | null}
@@ -36,8 +36,8 @@ export class Header extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * Apply a matchMedia for desktop which will trigger a state sync if the browser
-   * viewport moves between states.
+   * Apply a matchMedia for desktop which will trigger a state sync if the
+   * browser viewport moves between states.
    *
    * @param {Element} $module - HTML element to use for header
    */
@@ -54,9 +54,9 @@ export class Header extends GOVUKFrontendComponent {
     this.$module = $module
     const $menuButton = $module.querySelector('.govuk-js-header-toggle')
 
-    // Headers don't necessarily have a navigation.
-    // When they don't, the menu toggle won't be rendered
-    // by our macro (or may be omitted when writing plain HTML)
+    // Headers don't necessarily have a navigation. When they don't, the menu
+    // toggle won't be rendered by our macro (or may be omitted when writing
+    // plain HTML)
     if (!$menuButton) {
       return this
     }

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -46,12 +46,13 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   /**
    * Focus the element
    *
-   * If `role="alert"` is set, focus the element to help some assistive technologies
-   * prioritise announcing it.
+   * If `role="alert"` is set, focus the element to help some assistive
+   * technologies prioritise announcing it.
    *
-   * You can turn off the auto-focus functionality by setting `data-disable-auto-focus="true"` in the
-   * component HTML. You might wish to do this based on user research findings, or to avoid a clash
-   * with another element which should be focused when the page loads.
+   * You can turn off the auto-focus functionality by setting
+   * `data-disable-auto-focus="true"` in the component HTML. You might wish to
+   * do this based on user research findings, or to avoid a clash with another
+   * element which should be focused when the page loads.
    *
    * @private
    */
@@ -64,9 +65,9 @@ export class NotificationBanner extends GOVUKFrontendComponent {
       return
     }
 
-    // Set tabindex to -1 to make the element focusable with JavaScript.
-    // Remove the tabindex on blur as the component doesn't need to be focusable after the page has
-    // loaded.
+    // Set tabindex to -1 to make the element focusable with JavaScript. Remove
+    // the tabindex on blur as the component doesn't need to be focusable after
+    // the page has loaded.
     if (!this.$module.getAttribute('tabindex')) {
       this.$module.setAttribute('tabindex', '-1')
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -14,16 +14,16 @@ export class Radios extends GOVUKFrontendComponent {
   $inputs
 
   /**
-   * Radios can be associated with a 'conditionally revealed' content block – for
-   * example, a radio for 'Phone' could reveal an additional form field for the
-   * user to enter their phone number.
+   * Radios can be associated with a 'conditionally revealed' content block –
+   * for example, a radio for 'Phone' could reveal an additional form field for
+   * the user to enter their phone number.
    *
-   * These associations are made using a `data-aria-controls` attribute, which is
-   * promoted to an aria-controls attribute during initialisation.
+   * These associations are made using a `data-aria-controls` attribute, which
+   * is promoted to an aria-controls attribute during initialisation.
    *
-   * We also need to restore the state of any conditional reveals on the page (for
-   * example if the user has navigated back), and set up event handlers to keep
-   * the reveal in sync with the radio state.
+   * We also need to restore the state of any conditional reveals on the page
+   * (for example if the user has navigated back), and set up event handlers to
+   * keep the reveal in sync with the radio state.
    *
    * @param {Element} $module - HTML element to use for radios
    */
@@ -128,8 +128,8 @@ export class Radios extends GOVUKFrontendComponent {
    *
    * Handle a click within the $module – if the click occurred on a radio, sync
    * the state of the conditional reveal for all radio buttons in the same form
-   * with the same name (because checking one radio could have un-checked a radio
-   * in another $module)
+   * with the same name (because checking one radio could have un-checked a
+   * radio in another $module)
    *
    * @private
    * @param {MouseEvent} event - Click event

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -43,7 +43,7 @@ export class SkipLink extends GOVUKFrontendComponent {
    * Get linked element
    *
    * @private
-   * @returns {HTMLElement} $linkedElement - DOM element linked to from the skip link
+   * @returns {HTMLElement} $linkedElement - Target of the skip link
    */
   getLinkedElement() {
     const linkedElementId = this.getFragmentFromUrl(this.$module.hash)
@@ -83,7 +83,8 @@ export class SkipLink extends GOVUKFrontendComponent {
       this.$linkedElement.setAttribute('tabindex', '-1')
       this.$linkedElement.classList.add('govuk-skip-link-focused-element')
 
-      // Add listener for blur on the focused element (unless the listener has previously been added)
+      // Add listener for blur on the focused element (unless the listener has
+      // previously been added)
       if (!this.linkedElementListener) {
         this.$linkedElement.addEventListener('blur', () =>
           this.removeFocusProperties()
@@ -96,8 +97,9 @@ export class SkipLink extends GOVUKFrontendComponent {
   }
 
   /**
-   * Remove the tabindex that makes the linked element focusable because the element only needs to be
-   * focusable until it has received programmatic focus and a screen reader has announced it.
+   * Remove the tabindex that makes the linked element focusable because the
+   * element only needs to be focusable until it has received programmatic focus
+   * and a screen reader has announced it.
    *
    * Remove the CSS class that removes the native focus styles.
    *
@@ -111,8 +113,8 @@ export class SkipLink extends GOVUKFrontendComponent {
   /**
    * Get fragment from URL
    *
-   * Extract the fragment (everything after the hash) from a URL, but not including
-   * the hash.
+   * Extract the fragment (everything after the hash) from a URL, but not
+   * including the hash.
    *
    * @private
    * @param {string} url - URL

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -68,7 +68,7 @@ export class Tabs extends GOVUKFrontendComponent {
     this.$module = $module
     this.$tabs = $tabs
 
-    // Save bounded functions to use when removing event listeners during teardown
+    // Save bound functions so we can remove event listeners during teardown
     this.boundTabClick = this.onTabClick.bind(this)
     this.boundTabKeydown = this.onTabKeydown.bind(this)
     this.boundOnHashChange = this.onHashChange.bind(this)
@@ -345,8 +345,8 @@ export class Tabs extends GOVUKFrontendComponent {
       return
     }
 
-    // Save and restore the id
-    // so the page doesn't jump when a user clicks a tab (which changes the hash)
+    // Save and restore the id so the page doesn't jump when a user clicks a tab
+    // (which changes the hash)
     const panelId = $panel.id
     $panel.id = ''
     this.changingHash = true
@@ -523,8 +523,8 @@ export class Tabs extends GOVUKFrontendComponent {
   /**
    * Get link hash fragment for href attribute
    *
-   * this is because IE doesn't always return the actual value but a relative full path
-   * should be a utility function most prob
+   * this is because IE doesn't always return the actual value but a relative
+   * full path should be a utility function most prob
    * {@link http://labs.thesedays.com/blog/2010/01/08/getting-the-href-value-with-jquery-in-ie/}
    *
    * @private


### PR DESCRIPTION
The JSDoc for most of our functions is ever so slightly too wide as all of the comments were indented by 2 characters when we moved to native ES6 classes.

- Wrap comments at 80 characters where possible
- Remove self-explanatory comments (e.g. ‘loop over X’)
- Small edits for clarity / conciseness