### PR TITLE
Move `getFragmentFromUrl()` to common utilities

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -1,7 +1,8 @@
 import {
   mergeConfigs,
   extractConfigByNamespace,
-  isSupported
+  isSupported,
+  getFragmentFromUrl
 } from './index.mjs'
 
 describe('Common JS utilities', () => {
@@ -132,6 +133,49 @@ describe('Common JS utilities', () => {
 
     it('returns false if the govuk-frontend-supported class is not set', () => {
       expect(isSupported(document.body)).toBe(false)
+    })
+  })
+
+  describe('getFragmentFromUrl', () => {
+    it.each([
+      {
+        url: 'https://www.gov.uk/#content',
+        fragment: 'content'
+      },
+      {
+        url: 'https://www.gov.uk/example/#content',
+        fragment: 'content'
+      },
+      {
+        url: 'https://www.gov.uk/example/?keywords=123#content',
+        fragment: 'content'
+      },
+      {
+        url: '/#content',
+        fragment: 'content'
+      },
+      {
+        url: '/example/#content',
+        fragment: 'content'
+      },
+      {
+        url: '/?keywords=123#content',
+        fragment: 'content'
+      },
+      {
+        url: '#content',
+        fragment: 'content'
+      },
+      {
+        url: '/',
+        fragment: undefined
+      },
+      {
+        url: '',
+        fragment: undefined
+      }
+    ])("returns '$fragment' for '$url'", ({ url, fragment }) => {
+      expect(getFragmentFromUrl(url)).toBe(fragment)
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -135,6 +135,24 @@ export function extractConfigByNamespace(configObject, namespace) {
 }
 
 /**
+ * Get hash fragment from URL
+ *
+ * Extract the hash fragment (everything after the hash) from a URL,
+ * but not including the hash symbol
+ *
+ * @private
+ * @param {string} url - URL
+ * @returns {string | undefined} Fragment from URL, without the hash
+ */
+export function getFragmentFromUrl(url) {
+  if (url.indexOf('#') === -1) {
+    return undefined
+  }
+
+  return url.split('#').pop()
+}
+
+/**
  * Checks if GOV.UK Frontend is supported on this page
  *
  * Some browsers will load and run our JavaScript but GOV.UK Frontend

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -1,4 +1,4 @@
-import { mergeConfigs } from '../../common/index.mjs'
+import { getFragmentFromUrl, mergeConfigs } from '../../common/index.mjs'
 import { normaliseDataset } from '../../common/normalise-dataset.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
@@ -106,7 +106,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
       return false
     }
 
-    const inputId = this.getFragmentFromUrl($target.href)
+    const inputId = getFragmentFromUrl($target.href)
     if (!inputId) {
       return false
     }
@@ -128,24 +128,6 @@ export class ErrorSummary extends GOVUKFrontendComponent {
     $input.focus({ preventScroll: true })
 
     return true
-  }
-
-  /**
-   * Get fragment from URL
-   *
-   * Extract the fragment (everything after the hash) from a URL, but not
-   * including the hash.
-   *
-   * @private
-   * @param {string} url - URL
-   * @returns {string | undefined} Fragment from URL, without the hash
-   */
-  getFragmentFromUrl(url) {
-    if (url.indexOf('#') === -1) {
-      return undefined
-    }
-
-    return url.split('#').pop()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -1,3 +1,4 @@
+import { getFragmentFromUrl } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
@@ -46,7 +47,7 @@ export class SkipLink extends GOVUKFrontendComponent {
    * @returns {HTMLElement} $linkedElement - Target of the skip link
    */
   getLinkedElement() {
-    const linkedElementId = this.getFragmentFromUrl(this.$module.hash)
+    const linkedElementId = getFragmentFromUrl(this.$module.hash)
 
     // Check for link hash fragment
     if (!linkedElementId) {
@@ -108,24 +109,6 @@ export class SkipLink extends GOVUKFrontendComponent {
   removeFocusProperties() {
     this.$linkedElement.removeAttribute('tabindex')
     this.$linkedElement.classList.remove('govuk-skip-link-focused-element')
-  }
-
-  /**
-   * Get fragment from URL
-   *
-   * Extract the fragment (everything after the hash) from a URL, but not
-   * including the hash.
-   *
-   * @private
-   * @param {string} url - URL
-   * @returns {string | undefined} Fragment from URL, without the hash
-   */
-  getFragmentFromUrl(url) {
-    if (url.indexOf('#') === -1) {
-      return undefined
-    }
-
-    return url.split('#').pop()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -1,3 +1,4 @@
+import { getFragmentFromUrl } from '../../common/index.mjs'
 import { ElementError } from '../../errors/index.mjs'
 import { GOVUKFrontendComponent } from '../../govuk-frontend-component.mjs'
 
@@ -264,7 +265,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @param {HTMLAnchorElement} $tab - Tab link
    */
   setAttributes($tab) {
-    const panelId = this.getFragmentFromUrl($tab.href)
+    const panelId = getFragmentFromUrl($tab.href)
     if (!panelId) {
       return
     }
@@ -447,7 +448,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {Element | null} Tab panel
    */
   getPanel($tab) {
-    const panelId = this.getFragmentFromUrl($tab.href)
+    const panelId = getFragmentFromUrl($tab.href)
     if (!panelId) {
       return null
     }
@@ -527,24 +528,6 @@ export class Tabs extends GOVUKFrontendComponent {
     return this.$module.querySelector(
       '.govuk-tabs__list-item--selected a.govuk-tabs__tab'
     )
-  }
-
-  /**
-   * Get fragment from URL
-   *
-   * Extract the fragment (everything after the hash) from a URL, but not
-   * including the hash.
-   *
-   * @private
-   * @param {string} url - URL
-   * @returns {string | undefined} Fragment from URL, without the hash
-   */
-  getFragmentFromUrl(url) {
-    if (!url.includes('#')) {
-      return undefined
-    }
-
-    return url.split('#').pop()
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -264,15 +264,19 @@ export class Tabs extends GOVUKFrontendComponent {
    * @param {HTMLAnchorElement} $tab - Tab link
    */
   setAttributes($tab) {
-    // set tab attributes
-    const panelId = this.getHref($tab).slice(1)
+    const panelId = this.getFragmentFromUrl($tab.href)
+    if (!panelId) {
+      return
+    }
+
+    // Set tab attributes
     $tab.setAttribute('id', `tab_${panelId}`)
     $tab.setAttribute('role', 'tab')
     $tab.setAttribute('aria-controls', panelId)
     $tab.setAttribute('aria-selected', 'false')
     $tab.setAttribute('tabindex', '-1')
 
-    // set panel attributes
+    // Set panel attributes
     const $panel = this.getPanel($tab)
     if (!$panel) {
       return
@@ -350,7 +354,7 @@ export class Tabs extends GOVUKFrontendComponent {
     const panelId = $panel.id
     $panel.id = ''
     this.changingHash = true
-    window.location.hash = this.getHref($tab).slice(1)
+    window.location.hash = panelId
     $panel.id = panelId
   }
 
@@ -443,7 +447,12 @@ export class Tabs extends GOVUKFrontendComponent {
    * @returns {Element | null} Tab panel
    */
   getPanel($tab) {
-    return this.$module.querySelector(this.getHref($tab))
+    const panelId = this.getFragmentFromUrl($tab.href)
+    if (!panelId) {
+      return null
+    }
+
+    return this.$module.querySelector(`#${panelId}`)
   }
 
   /**
@@ -521,20 +530,21 @@ export class Tabs extends GOVUKFrontendComponent {
   }
 
   /**
-   * Get link hash fragment for href attribute
+   * Get fragment from URL
    *
-   * this is because IE doesn't always return the actual value but a relative
-   * full path should be a utility function most prob
-   * {@link http://labs.thesedays.com/blog/2010/01/08/getting-the-href-value-with-jquery-in-ie/}
+   * Extract the fragment (everything after the hash) from a URL, but not
+   * including the hash.
    *
    * @private
-   * @param {HTMLAnchorElement} $tab - Tab link
-   * @returns {string} Hash fragment including #
+   * @param {string} url - URL
+   * @returns {string | undefined} Fragment from URL, without the hash
    */
-  getHref($tab) {
-    const href = $tab.getAttribute('href')
-    const hash = href.slice(href.indexOf('#'), href.length)
-    return hash
+  getFragmentFromUrl(url) {
+    if (!url.includes('#')) {
+      return undefined
+    }
+
+    return url.split('#').pop()
   }
 
   /**


### PR DESCRIPTION
This PR moves duplicate `getFragmentFromUrl()` methods into a common utility + tests

This has highlighted a few areas where we hadn't checked for missing hash fragments:

```patch
- const panelId = this.getHref($tab).slice(1)
+ const panelId = getFragmentFromUrl($tab.href)
+ if (!panelId) {
+   return
+ }
```

### Total bundle size
`all.mjs` ~68.5 KiB~ 68.33 KiB