### PR TITLE
Reduce file size using `for...of` loops + other optimisations

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -105,16 +105,6 @@ describe('Common JS utilities', () => {
       const result = extractConfigByNamespace(flattenedConfig, 'b')
       expect(result).toEqual({ a: 'bat', e: 'bear', o: 'boar' })
     })
-
-    it('throws an error if no `configObject` is provided', () => {
-      // @ts-expect-error Parameter 'configObject' not provided
-      expect(() => extractConfigByNamespace()).toThrow()
-    })
-
-    it('throws an error if no `namespace` is provided', () => {
-      // @ts-expect-error Parameter 'namespace' not provided
-      expect(() => extractConfigByNamespace(flattenedConfig)).toThrow()
-    })
   })
 
   describe('isSupported', () => {

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -49,11 +49,10 @@ export function mergeConfigs(...configObjects) {
         // If the value is a nested object, recurse over that too
         if (typeof value === 'object') {
           flattenLoop(value, prefixedKey)
-          continue
+        } else {
+          // Otherwise, add this value to our return object
+          flattenedObject[prefixedKey] = value
         }
-
-        // Otherwise, add this value to our return object
-        flattenedObject[prefixedKey] = value
       }
     }
 

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -88,21 +88,8 @@ export function mergeConfigs(...configObjects) {
  * @param {{ [key: string]: unknown }} configObject - The object to extract key-value pairs from.
  * @param {string} namespace - The namespace to filter keys with.
  * @returns {{ [key: string]: unknown }} Flattened object with dot-separated key namespace removed
- * @throws {Error} Config object required
- * @throws {Error} Namespace string required
  */
 export function extractConfigByNamespace(configObject, namespace) {
-  // Check we have what we need
-  if (!configObject || typeof configObject !== 'object') {
-    throw new Error('Provide a `configObject` of type "object".')
-  }
-
-  if (!namespace || typeof namespace !== 'string') {
-    throw new Error(
-      'Provide a `namespace` of type "string" to filter the `configObject` by.'
-    )
-  }
-
   /** @type {{ [key: string]: unknown }} */
   const newObject = {}
 

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -14,9 +14,10 @@
  * greatest priority on the LAST item passed in.
  *
  * @internal
+ * @param {...{ [key: string]: unknown }} configObjects - Config object to merge
  * @returns {{ [key: string]: unknown }} A flattened object of key-value pairs.
  */
-export function mergeConfigs(/* configObject1, configObject2, ...configObjects */) {
+export function mergeConfigs(...configObjects) {
   /**
    * Function to take nested objects and flatten them to a dot-separated keyed
    * object. Doing this means we don't need to do any deep/recursive merging of
@@ -27,7 +28,7 @@ export function mergeConfigs(/* configObject1, configObject2, ...configObjects *
    * @param {{ [key: string]: unknown }} configObject - Deeply nested object
    * @returns {{ [key: string]: unknown }} Flattened object with dot-separated keys
    */
-  const flattenObject = function (configObject) {
+  function flattenObject(configObject) {
     // Prepare an empty return object
     /** @type {{ [key: string]: unknown }} */
     const flattenedObject = {}
@@ -41,23 +42,18 @@ export function mergeConfigs(/* configObject1, configObject2, ...configObjects *
      * @param {Partial<{ [key: string]: unknown }>} obj - Object to flatten
      * @param {string} [prefix] - Optional dot-separated prefix
      */
-    const flattenLoop = function (obj, prefix) {
-      // Loop through keys...
-      for (const key in obj) {
-        // Check to see if this is a prototypical key/value,
-        // if it is, skip it.
-        if (!Object.prototype.hasOwnProperty.call(obj, key)) {
+    function flattenLoop(obj, prefix) {
+      for (const [key, value] of Object.entries(obj)) {
+        const prefixedKey = prefix ? `${prefix}.${key}` : key
+
+        // If the value is a nested object, recurse over that too
+        if (typeof value === 'object') {
+          flattenLoop(value, prefixedKey)
           continue
         }
-        const value = obj[key]
-        const prefixedKey = prefix ? `${prefix}.${key}` : key
-        if (typeof value === 'object') {
-          // If the value is a nested object, recurse over that too
-          flattenLoop(value, prefixedKey)
-        } else {
-          // Otherwise, add this value to our return object
-          flattenedObject[prefixedKey] = value
-        }
+
+        // Otherwise, add this value to our return object
+        flattenedObject[prefixedKey] = value
       }
     }
 
@@ -70,16 +66,14 @@ export function mergeConfigs(/* configObject1, configObject2, ...configObjects *
   /** @type {{ [key: string]: unknown }} */
   const formattedConfigObject = {}
 
-  // Loop through each of the remaining passed objects and push their keys
-  // one-by-one into configObject. Any duplicate keys will override the existing
-  // key with the new value.
-  for (let i = 0; i < arguments.length; i++) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- Ignore mismatch between arguments types
-    const obj = flattenObject(arguments[i])
-    for (const key in obj) {
-      if (Object.prototype.hasOwnProperty.call(obj, key)) {
-        formattedConfigObject[key] = obj[key]
-      }
+  // Loop through each of the passed objects
+  for (const configObject of configObjects) {
+    const obj = flattenObject(configObject)
+
+    // Push their keys one-by-one into formattedConfigObject. Any duplicate
+    // keys will override the existing key with the new value.
+    for (const [key, value] of Object.entries(obj)) {
+      formattedConfigObject[key] = value
     }
   }
 
@@ -112,25 +106,26 @@ export function extractConfigByNamespace(configObject, namespace) {
   /** @type {{ [key: string]: unknown }} */
   const newObject = {}
 
-  for (const key in configObject) {
+  for (const [key, value] of Object.entries(configObject)) {
     // Split the key into parts, using . as our namespace separator
     const keyParts = key.split('.')
+
     // Check if the first namespace matches the configured namespace
-    if (
-      Object.prototype.hasOwnProperty.call(configObject, key) &&
-      keyParts[0] === namespace
-    ) {
+    if (keyParts[0] === namespace) {
       // Remove the first item (the namespace) from the parts array,
       // but only if there is more than one part (we don't want blank keys!)
       if (keyParts.length > 1) {
         keyParts.shift()
       }
+
       // Join the remaining parts back together
       const newKey = keyParts.join('.')
+
       // Add them to our new object
-      newObject[newKey] = configObject[key]
+      newObject[newKey] = value
     }
   }
+
   return newObject
 }
 
@@ -153,7 +148,7 @@ export function isSupported($scope = document.body) {
  *
  * @internal
  * @param {Schema} schema - Config schema
- * @param {Config[ConfigKey]} config - Component config
+ * @param {{ [key: string]: unknown }} config - Component config
  * @returns {string[]} List of validation errors
  */
 export function validateConfig(schema, config) {
@@ -192,9 +187,4 @@ export function validateConfig(schema, config) {
  * @typedef {object} SchemaCondition
  * @property {string[]} required - List of required config fields
  * @property {string} errorMessage - Error message when required config fields not provided
- */
-
-/**
- * @typedef {import('govuk-frontend').Config} Config - Config for all components via `initAll()`
- * @typedef {import('govuk-frontend').ConfigKey} ConfigKey - Component config keys, e.g. `accordion` and `characterCount`
  */

--- a/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
+++ b/packages/govuk-frontend/src/govuk/common/normalise-dataset.mjs
@@ -10,7 +10,7 @@
  * always strings) into something sensible.
  *
  * @internal
- * @param {string} value - The value to normalise
+ * @param {string | undefined} value - The value to normalise
  * @returns {string | boolean | number | undefined} Normalised data
  */
 export function normaliseString(value) {
@@ -44,14 +44,14 @@ export function normaliseString(value) {
  *
  * @internal
  * @param {DOMStringMap} dataset - HTML element dataset
- * @returns {{ [key: string]: unknown }} Normalised dataset
+ * @returns {{ [key: string]: string | boolean | number | undefined }} Normalised dataset
  */
 export function normaliseDataset(dataset) {
-  /** @type {{ [key: string]: unknown }} */
+  /** @type {ReturnType<typeof normaliseDataset>} */
   const out = {}
 
-  for (const key in dataset) {
-    out[key] = normaliseString(dataset[key])
+  for (const [key, value] of Object.entries(dataset)) {
+    out[key] = normaliseString(value)
   }
 
   return out

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -245,8 +245,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     // Copy all attributes from $span to $button (except `id`, which gets added
     // to the `$headingText` element)
-    for (let i = 0; i < $span.attributes.length; i++) {
-      const attr = $span.attributes.item(i)
+    for (const attr of Array.from($span.attributes)) {
       if (attr.nodeName !== 'id') {
         $button.setAttribute(attr.nodeName, attr.nodeValue)
       }
@@ -309,10 +308,8 @@ export class Accordion extends GOVUKFrontendComponent {
       $summarySpan.appendChild($summarySpanFocus)
 
       // Get original attributes, and pass them to the replacement
-      for (let j = 0, l = $summary.attributes.length; j < l; ++j) {
-        const nodeName = $summary.attributes.item(j).nodeName
-        const nodeValue = $summary.attributes.item(j).nodeValue
-        $summarySpan.setAttribute(nodeName, nodeValue)
+      for (const attr of Array.from($summary.attributes)) {
+        $summarySpan.setAttribute(attr.nodeName, attr.nodeValue)
       }
 
       // Copy original contents of summary to the new summary span

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -116,7 +116,7 @@ export class Accordion extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element to use for accordion
    * @param {AccordionConfig} [config] - Accordion config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -130,7 +130,7 @@ export class Accordion extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       Accordion.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -574,7 +574,6 @@ export class Accordion extends GOVUKFrontendComponent {
    *
    * @see {@link AccordionConfig}
    * @constant
-   * @default
    * @type {AccordionConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -31,7 +31,7 @@ export class Button extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -45,7 +45,7 @@ export class Button extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       Button.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -123,7 +123,6 @@ export class Button extends GOVUKFrontendComponent {
    *
    * @see {@link ButtonConfig}
    * @constant
-   * @default
    * @type {ButtonConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -71,7 +71,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -115,7 +115,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       CharacterCount.defaults,
-      config || {},
+      config,
       configOverrides,
       datasetConfig
     )
@@ -422,7 +422,6 @@ export class CharacterCount extends GOVUKFrontendComponent {
    *
    * @see {@link CharacterCountConfig}
    * @constant
-   * @default
    * @type {CharacterCountConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -25,7 +25,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -39,7 +39,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       ErrorSummary.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -219,7 +219,6 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    *
    * @see {@link ErrorSummaryConfig}
    * @constant
-   * @default
    * @type {ErrorSummaryConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -78,7 +78,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element that wraps the Exit This Page button
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -99,7 +99,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       ExitThisPage.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -404,7 +404,6 @@ export class ExitThisPage extends GOVUKFrontendComponent {
    *
    * @see {@link ExitThisPageConfig}
    * @constant
-   * @default
    * @type {ExitThisPageConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -22,7 +22,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
    * @param {Element} $module - HTML element to use for notification banner
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
-  constructor($module, config) {
+  constructor($module, config = {}) {
     super()
 
     if (!($module instanceof HTMLElement)) {
@@ -36,7 +36,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
 
     this.config = mergeConfigs(
       NotificationBanner.defaults,
-      config || {},
+      config,
       normaliseDataset($module.dataset)
     )
 
@@ -89,7 +89,6 @@ export class NotificationBanner extends GOVUKFrontendComponent {
    *
    * @see {@link NotificationBannerConfig}
    * @constant
-   * @default
    * @type {NotificationBannerConfig}
    */
   static defaults = Object.freeze({

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -266,20 +266,14 @@ export class I18n {
    *   of the functions in this.pluralRules)
    */
   getPluralRulesForLocale() {
-    const locale = this.locale
-    const localeShort = locale.split('-')[0]
+    const localeShort = this.locale.split('-')[0]
 
     // Look through the plural rules map to find which `pluralRule` is
     // appropriate for our current `locale`.
     for (const pluralRule in I18n.pluralRulesMap) {
-      if (
-        Object.prototype.hasOwnProperty.call(I18n.pluralRulesMap, pluralRule)
-      ) {
-        const languages = I18n.pluralRulesMap[pluralRule]
-        for (let i = 0; i < languages.length; i++) {
-          if (languages[i] === locale || languages[i] === localeShort) {
-            return pluralRule
-          }
+      for (const language of I18n.pluralRulesMap[pluralRule]) {
+        if (language === this.locale || language === localeShort) {
+          return pluralRule
         }
       }
     }

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -84,12 +84,9 @@ export class I18n {
    * @returns {string} The translation string to output, with $\{\} placeholders replaced
    */
   replacePlaceholders(translationString, options) {
-    /** @type {Intl.NumberFormat | undefined} */
-    let formatter
-
-    if (this.hasIntlNumberFormatSupport()) {
-      formatter = new Intl.NumberFormat(this.locale)
-    }
+    const formatter = Intl.NumberFormat.supportedLocalesOf(this.locale).length
+      ? new Intl.NumberFormat(this.locale)
+      : undefined
 
     return translationString.replace(
       /%{(.\S+)}/g,
@@ -149,25 +146,6 @@ export class I18n {
       window.Intl &&
         'PluralRules' in window.Intl &&
         Intl.PluralRules.supportedLocalesOf(this.locale).length
-    )
-  }
-
-  /**
-   * Check to see if the browser supports Intl and Intl.NumberFormat.
-   *
-   * It requires all conditions to be met in order to be supported:
-   * - The browser supports the Intl class (true in IE11)
-   * - The implementation of Intl supports NumberFormat (also true in IE11)
-   * - The browser/OS has number formatting rules for the current locale (browser dependent)
-   *
-   * @internal
-   * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
-   */
-  hasIntlNumberFormatSupport() {
-    return Boolean(
-      window.Intl &&
-        'NumberFormat' in window.Intl &&
-        Intl.NumberFormat.supportedLocalesOf(this.locale).length
     )
   }
 

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -131,20 +131,20 @@ export class I18n {
   }
 
   /**
-   * Check to see if the browser supports Intl and Intl.PluralRules.
+   * Check to see if the browser supports Intl.PluralRules
    *
    * It requires all conditions to be met in order to be supported:
-   * - The browser supports the Intl class (true in IE11)
-   * - The implementation of Intl supports PluralRules (NOT true in IE11)
+   * - The implementation of Intl supports PluralRules (NOT true in Safari 10–12)
    * - The browser/OS has plural rules for the current locale (browser dependent)
+   *
+   * {@link https://browsersl.ist/#q=supports+es6-module+and+not+supports+intl-pluralrules}
    *
    * @internal
    * @returns {boolean} Returns true if all conditions are met. Returns false otherwise.
    */
   hasIntlPluralRulesSupport() {
     return Boolean(
-      window.Intl &&
-        'PluralRules' in window.Intl &&
+      'PluralRules' in window.Intl &&
         Intl.PluralRules.supportedLocalesOf(this.locale).length
     )
   }

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -14,13 +14,12 @@ export class I18n {
    * @param {object} [config] - Configuration options for the function.
    * @param {string} [config.locale] - An overriding locale for the PluralRules functionality.
    */
-  constructor(translations, config) {
+  constructor(translations = {}, config = {}) {
     // Make list of translations available throughout function
-    this.translations = translations || {}
+    this.translations = translations
 
     // The locale to use for PluralRules and NumberFormat
-    this.locale =
-      (config && config.locale) || document.documentElement.lang || 'en'
+    this.locale = config.locale || document.documentElement.lang || 'en'
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -64,14 +64,14 @@ export class I18n {
         }
 
         return this.replacePlaceholders(translationString, options)
-      } else {
-        return translationString
       }
-    } else {
-      // If the key wasn't found in our translations object,
-      // return the lookup key itself as the fallback
-      return lookupKey
+
+      return translationString
     }
+
+    // If the key wasn't found in our translations object,
+    // return the lookup key itself as the fallback
+    return lookupKey
   }
 
   /**
@@ -124,11 +124,11 @@ export class I18n {
           }
 
           return placeholderValue
-        } else {
-          throw new Error(
-            `i18n: no data found to replace ${placeholderWithBraces} placeholder in string`
-          )
         }
+
+        throw new Error(
+          `i18n: no data found to replace ${placeholderWithBraces} placeholder in string`
+        )
       }
     )
   }
@@ -197,16 +197,12 @@ export class I18n {
       return 'other'
     }
 
-    let preferredForm
-
     // Check to verify that all the requirements for Intl.PluralRules are met.
     // If so, we can use that instead of our custom implementation. Otherwise,
     // use the hardcoded fallback.
-    if (this.hasIntlPluralRulesSupport()) {
-      preferredForm = new Intl.PluralRules(this.locale).select(count)
-    } else {
-      preferredForm = this.selectPluralFormUsingFallbackRules(count)
-    }
+    const preferredForm = this.hasIntlPluralRulesSupport()
+      ? new Intl.PluralRules(this.locale).select(count)
+      : this.selectPluralFormUsingFallbackRules(count)
 
     // Use the correct plural form if provided
     if (`${lookupKey}.${preferredForm}` in this.translations) {
@@ -214,19 +210,17 @@ export class I18n {
       // Fall back to `other` if the plural form is missing, but log a warning
       // to the console
     } else if (`${lookupKey}.other` in this.translations) {
-      if (console && 'warn' in console) {
-        console.warn(
-          `i18n: Missing plural form ".${preferredForm}" for "${this.locale}" locale. Falling back to ".other".`
-        )
-      }
+      console.warn(
+        `i18n: Missing plural form ".${preferredForm}" for "${this.locale}" locale. Falling back to ".other".`
+      )
 
       return 'other'
-      // If the required `other` plural form is missing, all we can do is error
-    } else {
-      throw new Error(
-        `i18n: Plural form ".other" is required for "${this.locale}" locale`
-      )
     }
+
+    // If the required `other` plural form is missing, all we can do is error
+    throw new Error(
+      `i18n: Plural form ".other" is required for "${this.locale}" locale`
+    )
   }
 
   /**


### PR DESCRIPTION
With IE11 not running JavaScript `type="module"` we can now:

1. Loop using [`for...of`](https://caniuse.com/mdn-javascript_statements_for_of)
2. Map attributes using `Array.from()`
3. Map objects with `Object.entries()`
4. Add default and [`...` rest parameters](https://browsersl.ist/#q=supports+es6-module+and+not+supports+rest-parameters)
5. [Remove `Intl.NumberFormat` guards](https://browsersl.ist/#q=supports+es6-module+and+not+supports+internationalization)

Saves just over 1KB from `all.mjs` when bundled

### Total bundle size
`all.mjs` ~68.5 KiB~ 67.33 KiB