### PR TITLE
Review and guard all missing fields/attributes

### DIFF
--- a/docs/contributing/coding-standards/js.md
+++ b/docs/contributing/coding-standards/js.md
@@ -20,7 +20,7 @@ component
  */
 export class Example {
   /**
-   * @param {Element} $module - HTML element to use for component
+   * @param {Element | null} $module - HTML element to use for component
    */
   constructor($module) {
     if (

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -47,7 +47,7 @@ export function mergeConfigs(...configObjects) {
         const prefixedKey = prefix ? `${prefix}.${key}` : key
 
         // If the value is a nested object, recurse over that too
-        if (typeof value === 'object') {
+        if (value && typeof value === 'object') {
           flattenLoop(value, prefixedKey)
         } else {
           // Otherwise, add this value to our return object

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -312,7 +312,7 @@ export class Accordion extends GOVUKFrontendComponent {
     $button.appendChild(this.getButtonPunctuationEl())
 
     // If summary content exists add to DOM in correct order
-    if ($summary) {
+    if ($summary && $summary.parentNode) {
       // Create a new `span` element and copy the summary line content from the
       // original `div` to the new `span`. This is because the summary line text
       // is now inside a button element, which can only contain phrasing
@@ -507,6 +507,10 @@ export class Accordion extends GOVUKFrontendComponent {
    * @param {boolean} expanded - Section expanded
    */
   updateShowAllButton(expanded) {
+    if (!this.$showAllButton || !this.$showAllText || !this.$showAllIcon) {
+      return
+    }
+
     this.$showAllButton.setAttribute('aria-expanded', expanded.toString())
     this.$showAllText.textContent = expanded
       ? this.i18n.t('hideAllSections')

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -113,7 +113,7 @@ export class Accordion extends GOVUKFrontendComponent {
   $showAllText = null
 
   /**
-   * @param {Element} $module - HTML element to use for accordion
+   * @param {Element | null} $module - HTML element to use for accordion
    * @param {AccordionConfig} [config] - Accordion config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -28,7 +28,7 @@ export class Button extends GOVUKFrontendComponent {
   debounceFormSubmitTimer = null
 
   /**
-   * @param {Element} $module - HTML element to use for button
+   * @param {Element | null} $module - HTML element to use for button
    * @param {ButtonConfig} [config] - Button config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -261,7 +261,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
    */
   handleBlur() {
     // Cancel value checking on blur
-    clearInterval(this.valueChecker)
+    if (this.valueChecker) {
+      window.clearInterval(this.valueChecker)
+    }
   }
 
   /**

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -62,7 +62,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
   maxLength = Infinity
 
   /**
-   * @param {Element} $module - HTML element to use for character count
+   * @param {Element | null} $module - HTML element to use for character count
    * @param {CharacterCountConfig} [config] - Character count config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -59,7 +59,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
   i18n
 
   /** @private */
-  maxLength = Infinity
+  maxLength
 
   /**
    * @param {Element | null} $module - HTML element to use for character count
@@ -128,7 +128,7 @@ export class CharacterCount extends GOVUKFrontendComponent {
     })
 
     // Determine the limit attribute (characters or words)
-    this.maxLength = this.config.maxwords || this.config.maxlength
+    this.maxLength = this.config.maxwords || this.config.maxlength || Infinity
 
     this.$module = $module
     this.$textarea = $textarea

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -28,17 +28,11 @@ export class CharacterCount extends GOVUKFrontendComponent {
   /** @private */
   $textarea
 
-  /**
-   * @private
-   * @type {HTMLElement | null}
-   */
-  $visibleCountMessage = null
+  /** @private */
+  $visibleCountMessage
 
-  /**
-   * @private
-   * @type {HTMLElement | null}
-   */
-  $screenReaderCountMessage = null
+  /** @private */
+  $screenReaderCountMessage
 
   /**
    * @private

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -25,7 +25,7 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the checkbox state.
    *
-   * @param {Element} $module - HTML element to use for checkboxes
+   * @param {Element | null} $module - HTML element to use for checkboxes
    */
   constructor($module) {
     super()

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -22,7 +22,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element} $module - HTML element to use for error summary
+   * @param {Element | null} $module - HTML element to use for error summary
    * @param {ErrorSummaryConfig} [config] - Error summary config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -77,7 +77,7 @@ export class ErrorSummary extends GOVUKFrontendComponent {
    */
   handleClick(event) {
     const $target = event.target
-    if (this.focusTarget($target)) {
+    if ($target && this.focusTarget($target)) {
       event.preventDefault()
     }
   }

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -75,7 +75,7 @@ export class ExitThisPage extends GOVUKFrontendComponent {
   timeoutMessageId = null
 
   /**
-   * @param {Element} $module - HTML element that wraps the Exit This Page button
+   * @param {Element | null} $module - HTML element that wraps the Exit This Page button
    * @param {ExitThisPageConfig} [config] - Exit This Page config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -39,7 +39,7 @@ export class Header extends GOVUKFrontendComponent {
    * Apply a matchMedia for desktop which will trigger a state sync if the
    * browser viewport moves between states.
    *
-   * @param {Element} $module - HTML element to use for header
+   * @param {Element | null} $module - HTML element to use for header
    */
   constructor($module) {
     super()

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -113,6 +113,10 @@ export class Header extends GOVUKFrontendComponent {
    * @private
    */
   syncState() {
+    if (!this.mql || !this.$menu || !this.$menuButton) {
+      return
+    }
+
     if (this.mql.matches) {
       this.$menu.removeAttribute('hidden')
       this.$menuButton.setAttribute('hidden', '')

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -19,7 +19,7 @@ export class NotificationBanner extends GOVUKFrontendComponent {
   config
 
   /**
-   * @param {Element} $module - HTML element to use for notification banner
+   * @param {Element | null} $module - HTML element to use for notification banner
    * @param {NotificationBannerConfig} [config] - Notification banner config
    */
   constructor($module, config = {}) {

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -25,7 +25,7 @@ export class Radios extends GOVUKFrontendComponent {
    * (for example if the user has navigated back), and set up event handlers to
    * keep the reveal in sync with the radio state.
    *
-   * @param {Element} $module - HTML element to use for radios
+   * @param {Element | null} $module - HTML element to use for radios
    */
   constructor($module) {
     super()

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -18,7 +18,7 @@ export class SkipLink extends GOVUKFrontendComponent {
   linkedElementListener = false
 
   /**
-   * @param {Element} $module - HTML element to use for skip link
+   * @param {Element | null} $module - HTML element to use for skip link
    * @throws {ElementError} when $module is not set or the wrong type
    * @throws {ElementError} when $module.hash does not contain a hash
    * @throws {ElementError} when the linked element is missing or the wrong type

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -130,7 +130,7 @@ export class Tabs extends GOVUKFrontendComponent {
    * @private
    */
   checkMode() {
-    if (this.mql.matches) {
+    if (this.mql && this.mql.matches) {
       this.setup()
     } else {
       this.teardown()

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -45,7 +45,7 @@ export class Tabs extends GOVUKFrontendComponent {
   mql = null
 
   /**
-   * @param {Element} $module - HTML element to use for tabs
+   * @param {Element | null} $module - HTML element to use for tabs
    */
   constructor($module) {
     super()

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -64,7 +64,7 @@ export class ElementError extends GOVUKFrontendError {
    * @param {string | ElementErrorOptions} messageOrOptions - Element error message or options
    */
   constructor(messageOrOptions) {
-    let message = typeof messageOrOptions === 'string' && messageOrOptions
+    let message = typeof messageOrOptions === 'string' ? messageOrOptions : ''
 
     // Build message from options
     if (typeof messageOrOptions === 'object') {

--- a/packages/govuk-frontend/src/govuk/i18n.mjs
+++ b/packages/govuk-frontend/src/govuk/i18n.mjs
@@ -12,7 +12,7 @@ export class I18n {
    * @internal
    * @param {{ [key: string]: unknown }} translations - Key-value pairs of the translation strings to use.
    * @param {object} [config] - Configuration options for the function.
-   * @param {string} [config.locale] - An overriding locale for the PluralRules functionality.
+   * @param {string | null} [config.locale] - An overriding locale for the PluralRules functionality.
    */
   constructor(translations = {}, config = {}) {
     // Make list of translations available throughout function


### PR DESCRIPTION
Ahead of https://github.com/alphagov/govuk-frontend/issues/4036 I've spent some time reviewing all optional things accessed without guards

We should follow this PR up with any extra errors we'd like to throw, although I've already split out:

1. https://github.com/alphagov/govuk-frontend/pull/4321
2. https://github.com/alphagov/govuk-frontend/pull/4320

For example, in PR https://github.com/alphagov/govuk-frontend/pull/4320 we've identified tab links without hash fragments ([already handled in **Skip link**](https://github.com/alphagov/govuk-frontend/pull/4177))

### Missing elements, attributes etc

* Class fields with incorrect `null` default
* Selector `null` return values not handled
* Timeout and interval IDs cleared when `null`
* Confg allows `null` as `typeof value === 'object'`