### PR TITLE
Ignore tests in watch tasks

### DIFF
--- a/packages/govuk-frontend-review/tasks/watch.mjs
+++ b/packages/govuk-frontend-review/tasks/watch.mjs
@@ -51,7 +51,8 @@ export const watch = (options) =>
      */
     task.name('lint:js watch', () =>
       gulp.watch(
-        [join(options.srcPath, '**/*.{cjs,js,mjs}')],
+        join(options.srcPath, '**/*.{cjs,js,mjs}'),
+        { ignored: ['**/*.test.*'] },
         gulp.parallel(
           // Run TypeScript compiler
           npm.script('build:types', ['--incremental', '--pretty'], options),

--- a/packages/govuk-frontend/tasks/watch.mjs
+++ b/packages/govuk-frontend/tasks/watch.mjs
@@ -45,7 +45,8 @@ export const watch = (options) =>
      */
     task.name('lint:js watch', () =>
       gulp.watch(
-        [join(options.srcPath, '**/*.{cjs,js,mjs}')],
+        join(options.srcPath, '**/*.{cjs,js,mjs}'),
+        { ignored: ['**/*.test.*'] },
         gulp.parallel(
           // Run TypeScript compiler
           npm.script('build:types', ['--incremental', '--pretty'], options),
@@ -62,7 +63,11 @@ export const watch = (options) =>
      * JavaScripts build watcher
      */
     task.name('compile:js watch', () =>
-      gulp.watch([join(options.srcPath, '**/*.{cjs,js,mjs}')], scripts(options))
+      gulp.watch(
+        join(options.srcPath, '**/*.{cjs,js,mjs}'),
+        { ignored: ['**/*.test.*'] },
+        scripts(options)
+      )
     ),
 
     /**


### PR DESCRIPTION
Minor tweak to the work we did in https://github.com/alphagov/govuk-frontend/pull/4241

Configures [**`gulp.watch()`**](https://gulpjs.com/docs/en/api/watch/) with `{ ignored: ['**/*.test.*'] }` to skip tests