### PR TITLE
Review types used in `instanceof` checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,8 @@
         "@types/node": "^20.8.6",
         "@types/nunjucks": "^3.2.4",
         "@types/slug": "^5.0.5",
-        "puppeteer": "^21.3.8"
+        "puppeteer": "^21.3.8",
+        "typed-query-selector": "^2.11.0"
       }
     },
     ".github/workflows/scripts": {
@@ -28519,6 +28520,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.11.0.tgz",
+      "integrity": "sha512-qBs4sfmnLlPOyo2oSdvHbIFHe2CPgU54/1UGfSNceb7LARpIEVxUaeRX0Doje6oKpuySS2stqy90R3YrynR8Kg==",
+      "optional": true
     },
     "node_modules/typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "@types/node": "^20.8.6",
     "@types/nunjucks": "^3.2.4",
     "@types/slug": "^5.0.5",
-    "puppeteer": "^21.3.8"
+    "puppeteer": "^21.3.8",
+    "typed-query-selector": "^2.11.0"
   },
   "overrides": {
     "chokidar@^2": {

--- a/packages/govuk-frontend-review/tsconfig.build.json
+++ b/packages/govuk-frontend-review/tsconfig.build.json
@@ -3,6 +3,6 @@
   "include": ["./src/**/*.mjs"],
   "exclude": ["**/*.test.*"],
   "compilerOptions": {
-    "types": ["express", "node", "nunjucks", "slug"]
+    "types": ["express", "node", "nunjucks", "slug", "typed-query-selector"]
   }
 }

--- a/packages/govuk-frontend-review/tsconfig.dev.json
+++ b/packages/govuk-frontend-review/tsconfig.dev.json
@@ -11,7 +11,8 @@
       "jest-puppeteer",
       "node",
       "nunjucks",
-      "slug"
+      "slug",
+      "typed-query-selector"
     ]
   }
 }

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -48,7 +48,7 @@ function initAll(config) {
 
   // Allow the user to initialise GOV.UK Frontend in only certain sections of the page
   // Defaults to the entire document if nothing is set.
-  const $scope = config.scope instanceof HTMLElement ? config.scope : document
+  const $scope = config.scope || document
 
   components.forEach(([Component, config]) => {
     const $elements = $scope.querySelectorAll(

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -394,12 +394,7 @@ export class Accordion extends GOVUKFrontendComponent {
     const $button = $section.querySelector(`.${this.sectionButtonClass}`)
     const $content = $section.querySelector(`.${this.sectionContentClass}`)
 
-    if (
-      !$showHideIcon ||
-      !($showHideText instanceof HTMLElement) ||
-      !$button ||
-      !$content
-    ) {
+    if (!$showHideIcon || !$showHideText || !$button || !$content) {
       return
     }
 
@@ -416,12 +411,12 @@ export class Accordion extends GOVUKFrontendComponent {
     const $headingText = $section.querySelector(
       `.${this.sectionHeadingTextClass}`
     )
-    if ($headingText instanceof HTMLElement) {
+    if ($headingText) {
       ariaLabelParts.push($headingText.textContent.trim())
     }
 
     const $summary = $section.querySelector(`.${this.sectionSummaryClass}`)
-    if ($summary instanceof HTMLElement) {
+    if ($summary) {
       ariaLabelParts.push($summary.textContent.trim())
     }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -37,7 +37,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
       throw new ElementError('input[type="checkbox"]', {
@@ -134,7 +133,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {HTMLInputElement} $input - Checkbox input
    */
   unCheckAllInputsExcept($input) {
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const allInputsWithSameName = document.querySelectorAll(
       `input[type="checkbox"][name="${$input.name}"]`
     )
@@ -159,7 +157,6 @@ export class Checkboxes extends GOVUKFrontendComponent {
    * @param {HTMLInputElement} $input - Checkbox input
    */
   unCheckExclusiveInputs($input) {
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const allInputsWithSameNameAndExclusiveBehaviour =
       document.querySelectorAll(
         `input[data-behaviour="exclusive"][type="checkbox"][name="${$input.name}"]`

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -44,7 +44,7 @@ export class Header extends GOVUKFrontendComponent {
   constructor($module) {
     super()
 
-    if (!($module instanceof HTMLElement)) {
+    if (!$module) {
       throw new ElementError('$module', {
         componentName: 'Header',
         element: $module
@@ -61,13 +61,6 @@ export class Header extends GOVUKFrontendComponent {
       return this
     }
 
-    if (!($menuButton instanceof HTMLElement)) {
-      throw new ElementError('.govuk-js-header-toggle', {
-        componentName: 'Header',
-        element: $menuButton
-      })
-    }
-
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
       throw new ElementError('.govuk-js-header-toggle[aria-controls]', {
@@ -76,8 +69,7 @@ export class Header extends GOVUKFrontendComponent {
     }
 
     const $menu = document.getElementById(menuId)
-
-    if (!($menu instanceof HTMLElement)) {
+    if (!$menu) {
       throw new ElementError(`#${menuId}`, {
         componentName: 'Header',
         element: $menu

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -203,45 +203,12 @@ describe('Header navigation', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
-        await expect(
-          renderAndInitialise(page, 'header', examples.default, {
-            beforeInitialisation($module) {
-              // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-header"></svg>`
-            }
-          })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Header: $module is not of type HTMLElement'
-        })
-      })
-
       it('does not throw if the toggle is absent', async () => {
         // The default example is rendered without navigation
         // and should keep rendering. No expectations as the JavaScript
         // will just return early. All we ask of that test is for it not
         // to throw during the initialisation
         await renderAndInitialise(page, 'header', examples.default)
-      })
-
-      it('throws when the toggle is of the wrong type', async () => {
-        await expect(
-          renderAndInitialise(page, 'header', examples['with navigation'], {
-            beforeInitialisation($module, { selector }) {
-              // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.querySelector(
-                selector
-              ).outerHTML = `<svg class="govuk-js-header-toggle"></svg>`
-            },
-            context: {
-              selector: '.govuk-js-header-toggle'
-            }
-          })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Header: .govuk-js-header-toggle is not of type HTMLElement'
-        })
       })
 
       it("throws when the toggle's aria-control attribute is missing", async () => {

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -37,7 +37,6 @@ export class Radios extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
       throw new ElementError('input[type="radio"]', {
@@ -145,7 +144,6 @@ export class Radios extends GOVUKFrontendComponent {
 
     // We only need to consider radios with conditional reveals, which will have
     // aria-controls attributes.
-    /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $allInputs = document.querySelectorAll(
       'input[type="radio"][aria-controls]'
     )

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -61,7 +61,7 @@ export class SkipLink extends GOVUKFrontendComponent {
     const $linkedElement = document.getElementById(linkedElementId)
 
     // Check for link target element
-    if (!($linkedElement instanceof HTMLElement)) {
+    if (!$linkedElement) {
       throw new ElementError(`$module.hash target #${linkedElementId}`, {
         componentName: 'Skip link',
         element: $linkedElement

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -50,7 +50,7 @@ export class Tabs extends GOVUKFrontendComponent {
   constructor($module) {
     super()
 
-    if (!($module instanceof HTMLElement)) {
+    if (!$module) {
       throw new ElementError('$module', {
         componentName: 'Tabs',
         element: $module

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -57,7 +57,6 @@ export class Tabs extends GOVUKFrontendComponent {
       })
     }
 
-    /** @satisfies {NodeListOf<HTMLAnchorElement>} */
     const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
       throw new ElementError(`a.govuk-tabs__tab`, {
@@ -396,7 +395,6 @@ export class Tabs extends GOVUKFrontendComponent {
       return
     }
 
-    /** @satisfies {HTMLAnchorElement} */
     const $nextTab = $nextTabListItem.querySelector('a.govuk-tabs__tab')
     if (!$nextTab) {
       return
@@ -425,7 +423,6 @@ export class Tabs extends GOVUKFrontendComponent {
       return
     }
 
-    /** @satisfies {HTMLAnchorElement} */
     const $previousTab = $previousTabListItem.querySelector('a.govuk-tabs__tab')
     if (!$previousTab) {
       return

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -281,20 +281,6 @@ describe('/components/tabs', () => {
         })
       })
 
-      it('throws when receiving the wrong type for $module', async () => {
-        await expect(
-          renderAndInitialise(page, 'tabs', examples.default, {
-            beforeInitialisation($module) {
-              // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
-              $module.outerHTML = `<svg data-module="govuk-tabs"></svg>`
-            }
-          })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Tabs: $module is not of type HTMLElement'
-        })
-      })
-
       it('throws when there are no tabs', async () => {
         await expect(
           renderAndInitialise(page, 'tabs', examples.default, {

--- a/packages/govuk-frontend/tsconfig.build.json
+++ b/packages/govuk-frontend/tsconfig.build.json
@@ -5,6 +5,6 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["node"]
+    "types": ["node", "typed-query-selector"]
   }
 }

--- a/packages/govuk-frontend/tsconfig.dev.json
+++ b/packages/govuk-frontend/tsconfig.dev.json
@@ -5,6 +5,13 @@
   "compilerOptions": {
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["gulp", "jest", "jest-axe", "jest-puppeteer", "node"]
+    "types": [
+      "gulp",
+      "jest",
+      "jest-axe",
+      "jest-puppeteer",
+      "node",
+      "typed-query-selector"
+    ]
   }
 }

--- a/shared/helpers/tsconfig.json
+++ b/shared/helpers/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["**/*.js", "**/*.mjs"],
   "exclude": ["./node_modules"],
   "compilerOptions": {
-    "types": ["jest", "node", "nunjucks", "slug"]
+    "types": ["jest", "node", "nunjucks", "slug", "typed-query-selector"]
   }
 }

--- a/shared/tasks/tsconfig.json
+++ b/shared/tasks/tsconfig.json
@@ -2,6 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["**/*.js", "**/*.mjs"],
   "compilerOptions": {
-    "types": ["gulp", "jest", "node", "nunjucks"]
+    "types": ["gulp", "jest", "node", "nunjucks", "typed-query-selector"]
   }
 }


### PR DESCRIPTION
This PR removes all `instanceof HTMLElement` checks unless required

For example, we’re generally happy that `document.querySelector()` returns Element (or null) types but will check specifically for `HTMLElement` etc when guarding APIs such as:

```mjs
$element.dataset
$element.click()
$element.focus()
```

This also removes `'throws when receiving the wrong type for $module'` tests no longer needed

Closes #4244