### PR TITLE
Fix empty spaces `" >` on opening tags

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/typography/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/typography/index.njk
@@ -373,7 +373,7 @@
         <br>
         </p>
 
-        <h2 class="govuk-heading-l" >After you’ve applied</h2>
+        <h2 class="govuk-heading-l">After you’ve applied</h2>
 
         <p class="govuk-body-m">You’ll receive your badge within 4 weeks or you’ll be contacted if you need to provide more information.</p>
       </section>

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -238,7 +238,7 @@ describe('Header navigation', () => {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.querySelector(
                 '.govuk-js-header-toggle'
-              ).outerHTML = `<svg class="govuk-js-header-toggle" ></svg>`
+              ).outerHTML = `<svg class="govuk-js-header-toggle"></svg>`
             }
           })
         ).rejects.toEqual({

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
@@ -32,7 +32,7 @@
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-notification-banner__header">
-    <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title" id="{{ params.titleId | default('govuk-notification-banner-title') }}" >
+    <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title" id="{{ params.titleId | default('govuk-notification-banner-title') }}">
       {{ title }}
     </h{{ params.titleHeadingLevel | default(2) }}>
   </div>


### PR DESCRIPTION
Few empty spaces had slipped in