### PR TITLE
Fix Nunjucks `default()` values when `null`, `false` or `""` is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -402,6 +402,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 - [#4113: Always set an explicit button `type`](https://github.com/alphagov/govuk-frontend/pull/4113)
 - [#4267: Remove unnecessary duplicated use of govuk-font](https://github.com/alphagov/govuk-frontend/pull/4267)
 - [#4268: Allow border and hover colours to be overridden](https://github.com/alphagov/govuk-frontend/pull/4268)
+- [#4327: Fix Nunjucks `default()` values when `null`, `false` or `""` is provided](https://github.com/alphagov/govuk-frontend/pull/4327)
 
 ## 4.7.0 (Feature release)
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -63,7 +63,7 @@
         {%- if item.divider %}
           <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
         {%- else %}
-          {% set isChecked = item.checked | default(params.values and item.value in params.values) %}
+          {% set isChecked = item.checked | default(item.value in params.values if params.values else false, true) %}
           {% set hasHint = true if item.hint.text or item.hint.html %}
           {% set itemHintId = id + "-item-hint" if hasHint else "" %}
           {% set itemDescribedBy = describedBy if not hasFieldset else "" %}

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.njk
@@ -63,7 +63,7 @@
         {%- if item.divider %}
           <div class="govuk-checkboxes__divider">{{ item.divider }}</div>
         {%- else %}
-          {% set isChecked = item.checked | default(item.value in params.values if params.values else false, true) %}
+          {% set isChecked = item.checked | default((item.value in params.values and item.checked != false) if params.values else false, true) %}
           {% set hasHint = true if item.hint.text or item.hint.html %}
           {% set itemHintId = id + "-item-hint" if hasHint else "" %}
           {% set itemDescribedBy = describedBy if not hasFieldset else "" %}

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/template.njk
@@ -1,6 +1,6 @@
 {% from "../button/macro.njk" import govukButton -%}
 
-<div class="govuk-cookie-banner {{ params.classes if params.classes }}" data-nosnippet role="region" aria-label="{{ params.ariaLabel | default("Cookie banner") }}"
+<div class="govuk-cookie-banner {{ params.classes if params.classes }}" data-nosnippet role="region" aria-label="{{ params.ariaLabel | default("Cookie banner", true) }}"
   {%- if params.hidden %} hidden{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/template.njk
@@ -15,7 +15,7 @@
     html: params.html if (params.html or params.text) else defaultHtml,
     text: params.text,
     classes: "govuk-button--warning govuk-exit-this-page__button govuk-js-exit-this-page-button",
-    href: params.redirectUrl | default("https://www.bbc.co.uk/weather"),
+    href: params.redirectUrl | default("https://www.bbc.co.uk/weather", true),
     attributes: {
       rel: "nofollow noreferrer"
     }

--- a/packages/govuk-frontend/src/govuk/components/footer/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/footer/template.njk
@@ -4,7 +4,7 @@
     {% if params.navigation | length %}
       <div class="govuk-footer__navigation">
         {% for nav in params.navigation %}
-          <div class="govuk-footer__section govuk-grid-column-{{ nav.width | default('full') }}">
+          <div class="govuk-footer__section govuk-grid-column-{{ nav.width | default("full", true) }}">
             <h2 class="govuk-footer__heading govuk-heading-m">{{ nav.title }}</h2>
             {% if nav.items | length %}
               {% set listClasses %}
@@ -32,7 +32,7 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         {% if params.meta %}
-          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links") }}</h2>
+          <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle | default("Support links", true) }}</h2>
           {% if params.meta.items | length %}
             <ul class="govuk-footer__inline-list">
               {% for item in params.meta.items %}

--- a/packages/govuk-frontend/src/govuk/components/header/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/header/template.njk
@@ -2,9 +2,9 @@
 
 <header class="govuk-header {{ params.classes if params.classes }}" role="banner" data-module="govuk-header"
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
-  <div class="govuk-header__container {{ params.containerClasses | default('govuk-width-container') }}">
+  <div class="govuk-header__container {{ params.containerClasses | default("govuk-width-container", true) }}">
     <div class="govuk-header__logo">
-      <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
+      <a href="{{ params.homepageUrl | default("/", true) }}" class="govuk-header__link govuk-header__link--homepage">
         <span class="govuk-header__logotype">
           {#- We use an inline SVG for the crown so that we can cascade the
           currentColor into the crown whilst continuing to support older browsers
@@ -57,7 +57,7 @@
     {% endif %}
     {% endif %}
     {% if params.navigation %}
-    <nav aria-label="{{ params.navigationLabel | default(menuButtonText) }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
+    <nav aria-label="{{ params.navigationLabel | default(menuButtonText, true) }}" class="govuk-header__navigation {{ params.navigationClasses if params.navigationClasses }}">
       <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation"{%- if params.menuButtonLabel and params.menuButtonLabel != menuButtonText %} aria-label="{{ params.menuButtonLabel }}"{% endif %} hidden>{{ menuButtonText }}</button>
 
       <ul id="navigation" class="govuk-header__navigation-list">

--- a/packages/govuk-frontend/src/govuk/components/input/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/input/template.njk
@@ -46,7 +46,7 @@
     </div>
   {% endif -%}
 
-  <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default('text') }}"
+  <input class="govuk-input {%- if params.classes %} {{ params.classes }}{% endif %} {%- if params.errorMessage %} govuk-input--error{% endif %}" id="{{ params.id }}" name="{{ params.name }}" type="{{ params.type | default("text", true) }}"
   {%- if (params.spellcheck === false) or (params.spellcheck === true) %} spellcheck="{{ params.spellcheck }}"{% endif %}
   {%- if params.value %} value="{{ params.value}}"{% endif %}
   {%- if params.disabled %} disabled{% endif %}

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/template.njk
@@ -27,14 +27,14 @@
 {%- endif -%}
 
 <div class="govuk-notification-banner{% if typeClass %} {{ typeClass }}{% endif %}{% if params.classes %} {{ params.classes }}{% endif %}" role="{{ role }}"
-  aria-labelledby="{{ params.titleId | default('govuk-notification-banner-title')}}"
+  aria-labelledby="{{ params.titleId | default("govuk-notification-banner-title", true) }}"
   data-module="govuk-notification-banner"
   {%- if params.disableAutoFocus !== undefined %} data-disable-auto-focus="{{ params.disableAutoFocus }}"{% endif %}
   {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
   <div class="govuk-notification-banner__header">
-    <h{{ params.titleHeadingLevel | default(2) }} class="govuk-notification-banner__title" id="{{ params.titleId | default('govuk-notification-banner-title') }}">
+    <h{{ params.titleHeadingLevel | default(2, true) }} class="govuk-notification-banner__title" id="{{ params.titleId | default("govuk-notification-banner-title", true) }}">
       {{ title }}
-    </h{{ params.titleHeadingLevel | default(2) }}>
+    </h{{ params.titleHeadingLevel | default(2, true) }}>
   </div>
   <div class="govuk-notification-banner__content">
     {%- if caller or params.html -%}

--- a/packages/govuk-frontend/src/govuk/components/pagination/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/pagination/template.njk
@@ -1,6 +1,6 @@
 {% set blockLevel = not params.items and (params.next or params.previous) %}
 
-<nav class="govuk-pagination {{- ' ' + params.classes if params.classes }} {{- ' govuk-pagination--block' if blockLevel }}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination") }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
+<nav class="govuk-pagination {{- ' ' + params.classes if params.classes }} {{- ' govuk-pagination--block' if blockLevel }}" role="navigation" aria-label="{{ params.landmarkLabel | default("Pagination", true) }}" {%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>
   {%- if params.previous and params.previous.href -%}
     <div class="govuk-pagination__prev">
       <a class="govuk-link govuk-pagination__link" href="{{ params.previous.href }}" rel="prev" {%- for attribute, value in params.previous.attributes %} {{ attribute }}="{{ value }}" {%- endfor -%}>

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -56,7 +56,7 @@
         {%- if item.divider %}
         <div class="govuk-radios__divider">{{ item.divider }}</div>
         {%- else %}
-        {% set isChecked = item.checked | default(params.value and item.value == params.value) %}
+        {% set isChecked = item.checked | default(item.value == params.value if params.value else false, true) %}
         {% set hasHint = true if item.hint.text or item.hint.html %}
         {% set itemHintId = id + '-item-hint' %}
         <div class="govuk-radios__item">

--- a/packages/govuk-frontend/src/govuk/components/radios/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.njk
@@ -56,7 +56,7 @@
         {%- if item.divider %}
         <div class="govuk-radios__divider">{{ item.divider }}</div>
         {%- else %}
-        {% set isChecked = item.checked | default(item.value == params.value if params.value else false, true) %}
+        {% set isChecked = item.checked | default((item.value == params.value and item.checked != false) if params.value else false, true) %}
         {% set hasHint = true if item.hint.text or item.hint.html %}
         {% set itemHintId = id + '-item-hint' %}
         <div class="govuk-radios__item">

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -47,7 +47,7 @@
       {# Allow selecting by text content (the value for an option when no value attribute is specified) #}
       {% set effectiveValue = item.value | default(item.text) %}
       <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
-        {{-" selected" if item.selected | default(effectiveValue == params.value if params.value else false, true) }}
+        {{-" selected" if item.selected | default((effectiveValue == params.value and item.selected != false) if params.value else false, true) }}
         {{-" disabled" if item.disabled }}
         {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>{{ item.text }}</option>
     {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/select/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/select/template.njk
@@ -47,7 +47,7 @@
       {# Allow selecting by text content (the value for an option when no value attribute is specified) #}
       {% set effectiveValue = item.value | default(item.text) %}
       <option {%- if item.value !== undefined %} value="{{ item.value }}"{% endif %}
-        {{-" selected" if item.selected | default(params.value and effectiveValue == params.value) }}
+        {{-" selected" if item.selected | default(effectiveValue == params.value if params.value else false, true) }}
         {{-" disabled" if item.disabled }}
         {%- for attribute, value in item.attributes %} {{ attribute }}="{{ value }}"{% endfor -%}>{{ item.text }}</option>
     {% endif %}

--- a/packages/govuk-frontend/src/govuk/components/skip-link/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/template.njk
@@ -1,3 +1,3 @@
-<a href="{{ params.href | default('#content') }}" class="govuk-skip-link{%- if params.classes %} {{ params.classes }}{% endif -%}"{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-skip-link">
+<a href="{{ params.href | default("#content", true) }}" class="govuk-skip-link{%- if params.classes %} {{ params.classes }}{% endif -%}"{%- for attribute, value in params.attributes %} {{ attribute }}="{{ value }}"{% endfor %} data-module="govuk-skip-link">
   {{- params.html | safe if params.html else params.text -}}
 </a>

--- a/packages/govuk-frontend/src/govuk/components/warning-text/template.njk
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/template.njk
@@ -3,7 +3,7 @@
   >
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
-    <span class="govuk-visually-hidden">{{ params.iconFallbackText | default("Warning") }}</span>
+    <span class="govuk-visually-hidden">{{ params.iconFallbackText | default("Warning", true) }}</span>
     {{ params.html | safe if params.html else params.text }}
   </strong>
 </div>

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -2,29 +2,29 @@
 {% from "./components/header/macro.njk" import govukHeader -%}
 {% from "./components/footer/macro.njk" import govukFooter -%}
 <!DOCTYPE html>
-<html lang="{{ htmlLang | default('en') }}" class="govuk-template {{ htmlClasses }}">
+<html lang="{{ htmlLang | default("en", true) }}" class="govuk-template {{ htmlClasses }}">
   <head>
     <meta charset="utf-8">
     <title{% if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
+    <meta name="theme-color" content="{{ themeColor | default("#0b0c0c", true) }}"> {# Hardcoded value of $govuk-black #}
     {# Ensure that older IE versions always render with the correct rendering engine #}
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     {% block headIcons %}
-      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default('/assets') }}/images/favicon.ico" type="image/x-icon">
-      <link rel="mask-icon" href="{{ assetPath | default('/assets') }}/images/govuk-mask-icon.svg" color="{{ themeColor | default('#0b0c0c') }}"> {# Hardcoded value of $govuk-black #}
-      <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-180x180.png">
-      <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-167x167.png">
-      <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon-152x152.png">
-      <link rel="apple-touch-icon" href="{{ assetPath | default('/assets') }}/images/govuk-apple-touch-icon.png">
+      <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default("/assets", true) }}/images/favicon.ico" type="image/x-icon">
+      <link rel="mask-icon" href="{{ assetPath | default("/assets") }}/images/govuk-mask-icon.svg" color="{{ themeColor | default("#0b0c0c", true) }}"> {# Hardcoded value of $govuk-black #}
+      <link rel="apple-touch-icon" sizes="180x180" href="{{ assetPath | default("/assets", true) }}/images/govuk-apple-touch-icon-180x180.png">
+      <link rel="apple-touch-icon" sizes="167x167" href="{{ assetPath | default("/assets", true) }}/images/govuk-apple-touch-icon-167x167.png">
+      <link rel="apple-touch-icon" sizes="152x152" href="{{ assetPath | default("/assets", true) }}/images/govuk-apple-touch-icon-152x152.png">
+      <link rel="apple-touch-icon" href="{{ assetPath | default("/assets", true) }}/images/govuk-apple-touch-icon.png">
     {% endblock %}
 
     {% block head %}{% endblock %}
 
     {# OpenGraph images needs to be absolute, so we need either a URL for the image or for assetUrl to be set #}
     {% if opengraphImageUrl or assetUrl %}
-    <meta property="og:image" content="{{ opengraphImageUrl | default(assetUrl + '/images/govuk-opengraph-image.png') }}">
+    <meta property="og:image" content="{{ opengraphImageUrl | default(assetUrl + "/images/govuk-opengraph-image.png", true) }}">
     {% endif %}
   </head>
   <body class="govuk-template__body {{ bodyClasses }}" {%- for attribute, value in bodyAttributes %} {{attribute}}="{{value}}"{% endfor %}>


### PR DESCRIPTION
This PR ensures Nunjucks `default()` handles all possible "falsey" values

It closes https://github.com/alphagov/govuk-frontend/issues/4305 which shows that `undefined` values fall back to `defaults()` but not `null`, `false`, `""` etc

### Nunjucks default example

For example, passing `redirectUrl: null` into [**Exit this page**](https://design-system.service.gov.uk/components/exit-this-page/) renders a default submit button 😮

```njk
{{ govukExitThisPage({
  redirectUrl: null
}) }}
```

The fallback `href` value isn't used:

```html
<button type="submit">…</button>
```