### PR TITLE
Add examples of date inputs with only two fields

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -97,6 +97,34 @@ examples:
           classes: govuk-input--width-2
         - name: year
           classes: govuk-input--width-4
+  - name: day and month
+    options:
+      id: bday
+      namePrefix: bday
+      fieldset:
+        legend:
+          text: What is your birthday?
+      hint:
+        text: For example, 5 12
+      items:
+        - name: day
+          classes: govuk-input--width-2
+        - name: month
+          classes: govuk-input--width-2
+  - name: month and year
+    options:
+      id: dob
+      namePrefix: dob
+      fieldset:
+        legend:
+          text: When did you move to this property?
+      hint:
+        text: For example, 3 1980
+      items:
+        - name: month
+          classes: govuk-input--width-2
+        - name: year
+          classes: govuk-input--width-4
   - name: with errors only
     options:
       id: dob-errors


### PR DESCRIPTION
The date input component supports asking for only day and month or only month and year, but we don’t currently have any examples in the review app to show this.

Add examples for both.