### PR TITLE
Support `beforeInitialisation()` options, multiple modules

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -685,8 +685,7 @@ describe('/components/accordion', () => {
           })
 
           it('injects the localised strings as text not HTML', async () => {
-            await renderAndInitialise(page, 'accordion', {
-              params: examples.default,
+            await renderAndInitialise(page, 'accordion', examples.default, {
               config: {
                 i18n: {
                   showAllSections: 'Show <strong>all sections</strong>',
@@ -722,8 +721,7 @@ describe('/components/accordion', () => {
 
           it('throws when GOV.UK Frontend is not supported', async () => {
             await expect(
-              renderAndInitialise(page, 'accordion', {
-                params: examples.default,
+              renderAndInitialise(page, 'accordion', examples.default, {
                 beforeInitialisation() {
                   document.body.classList.remove('govuk-frontend-supported')
                 }
@@ -736,8 +734,7 @@ describe('/components/accordion', () => {
 
           it('throws when $module is not set', async () => {
             await expect(
-              renderAndInitialise(page, 'accordion', {
-                params: examples.default,
+              renderAndInitialise(page, 'accordion', examples.default, {
                 beforeInitialisation($module) {
                   $module.remove()
                 }
@@ -750,8 +747,7 @@ describe('/components/accordion', () => {
 
           it('throws when receiving the wrong type for $module', async () => {
             await expect(
-              renderAndInitialise(page, 'accordion', {
-                params: examples.default,
+              renderAndInitialise(page, 'accordion', examples.default, {
                 beforeInitialisation($module) {
                   // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
                   $module.outerHTML = `<svg data-module="govuk-accordion"></svg>`

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -178,8 +178,7 @@ describe('/components/button', () => {
       let $button
 
       beforeEach(async () => {
-        await renderAndInitialise(page, 'button', {
-          params: examples.default,
+        await renderAndInitialise(page, 'button', examples.default, {
           config: {
             preventDoubleClick: true
           }
@@ -238,12 +237,16 @@ describe('/components/button', () => {
       let $button
 
       beforeEach(async () => {
-        await renderAndInitialise(page, 'button', {
-          params: examples["don't prevent double click"],
-          config: {
-            preventDoubleClick: true
+        await renderAndInitialise(
+          page,
+          'button',
+          examples["don't prevent double click"],
+          {
+            config: {
+              preventDoubleClick: true
+            }
           }
-        })
+        )
 
         $button = await setButtonTracking(await page.$('button'))
       })
@@ -263,8 +266,7 @@ describe('/components/button', () => {
       let $button
 
       beforeEach(async () => {
-        await renderAndInitialise(page, 'button', {
-          params: examples.default,
+        await renderAndInitialise(page, 'button', examples.default, {
           config: {
             preventDoubleClick: true
           }
@@ -327,8 +329,7 @@ describe('/components/button', () => {
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'button', {
-            params: examples.default,
+          renderAndInitialise(page, 'button', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -341,8 +342,7 @@ describe('/components/button', () => {
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'button', {
-            params: examples.default,
+          renderAndInitialise(page, 'button', examples.default, {
             beforeInitialisation($module) {
               $module.remove()
             }
@@ -355,8 +355,7 @@ describe('/components/button', () => {
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'button', {
-            params: examples.default,
+          renderAndInitialise(page, 'button', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-button"></svg>`

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -496,12 +496,16 @@ describe('Character count', () => {
     describe('JavaScript configuration', () => {
       describe('at instantiation', () => {
         it('configures the number of characters', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxlength: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxlength: 10
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11), {
             delay: 50
@@ -515,12 +519,16 @@ describe('Character count', () => {
         })
 
         it('configures the number of words', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxwords: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxwords: 10
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11), {
             delay: 50
@@ -534,13 +542,17 @@ describe('Character count', () => {
         })
 
         it('configures the threshold', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxlength: 10,
-              threshold: 75
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxlength: 10,
+                threshold: 75
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'A'.repeat(8), {
             delay: 50
@@ -557,20 +569,23 @@ describe('Character count', () => {
           // This tests that a description can be provided through JavaScript attributes
           // and interpolated with the limit provided to the character count in JS.
 
-          await renderAndInitialise(page, 'character-count', {
-            params:
-              examples[
-                'when neither maxlength/maxwords nor textarea description are set'
-              ],
-            config: {
-              maxlength: 10,
-              i18n: {
-                textareaDescription: {
-                  other: 'No more than %{count} characters'
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples[
+              'when neither maxlength/maxwords nor textarea description are set'
+            ],
+            {
+              config: {
+                maxlength: 10,
+                i18n: {
+                  textareaDescription: {
+                    other: 'No more than %{count} characters'
+                  }
                 }
               }
             }
-          })
+          )
 
           const message = await page.$eval(
             '.govuk-character-count__message',
@@ -582,12 +597,16 @@ describe('Character count', () => {
 
       describe('via `initAll`', () => {
         it('configures the number of characters', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxlength: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxlength: 10
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11), {
             delay: 50
@@ -601,12 +620,16 @@ describe('Character count', () => {
         })
 
         it('configures the number of words', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxwords: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxwords: 10
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11), {
             delay: 50
@@ -620,13 +643,17 @@ describe('Character count', () => {
         })
 
         it('configures the threshold', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['to configure in JavaScript'],
-            config: {
-              maxlength: 10,
-              threshold: 75
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['to configure in JavaScript'],
+            {
+              config: {
+                maxlength: 10,
+                threshold: 75
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'A'.repeat(8), {
             delay: 50
@@ -642,8 +669,7 @@ describe('Character count', () => {
 
       describe('when data-attributes are present', () => {
         it('uses `maxlength` data attribute instead of the JS one', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples.default,
+          await renderAndInitialise(page, 'character-count', examples.default, {
             config: {
               maxlength: 12 // JS configuration that would tell 1 character remaining
             }
@@ -661,8 +687,7 @@ describe('Character count', () => {
         })
 
         it("uses `maxlength` data attribute instead of JS's `maxwords`", async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples.default, // Default example counts characters
+          await renderAndInitialise(page, 'character-count', examples.default, {
             config: {
               maxwords: 12
             }
@@ -680,12 +705,16 @@ describe('Character count', () => {
         })
 
         it('uses `maxwords` data attribute instead of the JS one', async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['with word count'],
-            config: {
-              maxwords: 12 // JS configuration that would tell 1 word remaining
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['with word count'],
+            {
+              config: {
+                maxwords: 12 // JS configuration that would tell 1 word remaining
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11), {
             delay: 50
@@ -699,12 +728,16 @@ describe('Character count', () => {
         })
 
         it("uses `maxwords` data attribute instead of the JS's `maxlength`", async () => {
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['with word count'],
-            config: {
-              maxlength: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['with word count'],
+            {
+              config: {
+                maxlength: 10
+              }
             }
-          })
+          )
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11), {
             delay: 50
@@ -724,12 +757,16 @@ describe('Character count', () => {
           // element holding the textarea's accessible description
           // (and interpolated to replace `%{count}` with the maximum)
 
-          await renderAndInitialise(page, 'character-count', {
-            params: examples['when neither maxlength nor maxwords are set'],
-            config: {
-              maxlength: 10
+          await renderAndInitialise(
+            page,
+            'character-count',
+            examples['when neither maxlength nor maxwords are set'],
+            {
+              config: {
+                maxlength: 10
+              }
             }
-          })
+          )
 
           const message = await page.$eval(
             '.govuk-character-count__message',
@@ -742,17 +779,21 @@ describe('Character count', () => {
 
     describe('Cross Side Scripting prevention', () => {
       it('injects the localised strings as text not HTML', async () => {
-        await renderAndInitialise(page, 'character-count', {
-          params: examples['to configure in JavaScript'],
-          config: {
-            maxlength: 10,
-            i18n: {
-              charactersUnderLimit: {
-                other: '<strong>%{count}</strong> characters left'
+        await renderAndInitialise(
+          page,
+          'character-count',
+          examples['to configure in JavaScript'],
+          {
+            config: {
+              maxlength: 10,
+              i18n: {
+                charactersUnderLimit: {
+                  other: '<strong>%{count}</strong> characters left'
+                }
               }
             }
           }
-        })
+        )
 
         const message = await page.$eval(
           '.govuk-character-count__status',
@@ -773,8 +814,7 @@ describe('Character count', () => {
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
+          renderAndInitialise(page, 'character-count', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -787,8 +827,7 @@ describe('Character count', () => {
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
+          renderAndInitialise(page, 'character-count', examples.default, {
             beforeInitialisation($module) {
               $module.remove()
             }
@@ -801,8 +840,7 @@ describe('Character count', () => {
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
+          renderAndInitialise(page, 'character-count', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-character-count"></svg>`
@@ -816,10 +854,12 @@ describe('Character count', () => {
 
       it('throws when the textarea is missing', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
-            beforeInitialisation($module) {
-              $module.querySelector('.govuk-js-character-count').remove()
+          renderAndInitialise(page, 'character-count', examples.default, {
+            beforeInitialisation($module, { selector }) {
+              $module.querySelector(selector).remove()
+            },
+            context: {
+              selector: '.govuk-js-character-count'
             }
           })
         ).rejects.toEqual({
@@ -830,12 +870,14 @@ describe('Character count', () => {
 
       it('throws when the textarea is not the right type', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'character-count', examples.default, {
+            beforeInitialisation($module, { selector }) {
               // Replace with a tag that's neither an `<input>` or `<textarea>`
-              $module.querySelector('.govuk-js-character-count').outerHTML =
+              $module.querySelector(selector).outerHTML =
                 '<div class="govuk-js-character-count"></div>'
+            },
+            context: {
+              selector: '.govuk-js-character-count'
             }
           })
         ).rejects.toEqual({
@@ -847,10 +889,12 @@ describe('Character count', () => {
 
       it('throws when the textarea description is missing', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: examples.default,
-            beforeInitialisation($module) {
-              $module.querySelector('#more-detail-info').remove()
+          renderAndInitialise(page, 'character-count', examples.default, {
+            beforeInitialisation($module, { selector }) {
+              $module.querySelector(selector).remove()
+            },
+            context: {
+              selector: '#more-detail-info'
             }
           })
         ).rejects.toEqual({
@@ -861,9 +905,7 @@ describe('Character count', () => {
 
       it('throws when receiving invalid configuration', async () => {
         await expect(
-          renderAndInitialise(page, 'character-count', {
-            params: {}
-          })
+          renderAndInitialise(page, 'character-count')
         ).rejects.toEqual({
           name: 'ConfigError',
           message:
@@ -879,8 +921,7 @@ describe('Character count', () => {
       const pageErrorListener = jest.fn()
       page.on('pageerror', pageErrorListener)
 
-      await renderAndInitialise(page, 'character-count', {
-        params: examples.default,
+      await renderAndInitialise(page, 'character-count', examples.default, {
         config: {
           // Override maxlength to 10
           maxlength: 10

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -328,8 +328,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'checkboxes', {
-            params: examples.default,
+          renderAndInitialise(page, 'checkboxes', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -342,8 +341,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'checkboxes', {
-            params: examples.default,
+          renderAndInitialise(page, 'checkboxes', examples.default, {
             beforeInitialisation($module) {
               $module.remove()
             }
@@ -356,8 +354,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'checkboxes', {
-            params: examples.default,
+          renderAndInitialise(page, 'checkboxes', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
@@ -372,14 +369,14 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       it('throws when the input list is empty', async () => {
         await expect(
-          renderAndInitialise(page, 'checkboxes', {
-            params: examples.default,
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'checkboxes', examples.default, {
+            beforeInitialisation($module, { selector }) {
               $module
-                .querySelectorAll('.govuk-checkboxes__item')
-                .forEach((item) => {
-                  item.remove()
-                })
+                .querySelectorAll(selector)
+                .forEach((item) => item.remove())
+            },
+            context: {
+              selector: '.govuk-checkboxes__item'
             }
           })
         ).rejects.toEqual({
@@ -390,12 +387,19 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
 
       it('throws when a conditional target element is not found', async () => {
         await expect(
-          renderAndInitialise(page, 'checkboxes', {
-            params: examples['with conditional items'],
-            beforeInitialisation($module) {
-              $module.querySelector('.govuk-checkboxes__conditional').remove()
+          renderAndInitialise(
+            page,
+            'checkboxes',
+            examples['with conditional items'],
+            {
+              beforeInitialisation($module, { selector }) {
+                $module.querySelector(selector).remove()
+              },
+              context: {
+                selector: '.govuk-checkboxes__conditional'
+              }
             }
-          })
+          )
         ).rejects.toEqual({
           name: 'ElementError',
           message: 'Checkboxes: #conditional-how-contacted not found'

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -68,8 +68,7 @@ describe('Error Summary', () => {
 
     describe('using JavaScript configuration', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'error-summary', {
-          params: examples.default,
+        await renderAndInitialise(page, 'error-summary', examples.default, {
           config: {
             disableAutoFocus: true
           }
@@ -95,9 +94,11 @@ describe('Error Summary', () => {
 
     describe('using JavaScript configuration, but enabled via data-attributes', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'error-summary', {
-          params: examples['autofocus explicitly enabled']
-        })
+        await renderAndInitialise(
+          page,
+          'error-summary',
+          examples['autofocus explicitly enabled']
+        )
       })
 
       it('adds the tabindex attribute on page load', async () => {
@@ -117,8 +118,7 @@ describe('Error Summary', () => {
 
     describe('using `initAll`', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'error-summary', {
-          params: examples.default,
+        await renderAndInitialise(page, 'error-summary', examples.default, {
           config: {
             disableAutoFocus: true
           }
@@ -219,8 +219,7 @@ describe('Error Summary', () => {
 
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
-        renderAndInitialise(page, 'error-summary', {
-          params: examples.default,
+        renderAndInitialise(page, 'error-summary', examples.default, {
           beforeInitialisation() {
             document.body.classList.remove('govuk-frontend-supported')
           }
@@ -233,8 +232,7 @@ describe('Error Summary', () => {
 
     it('throws when $module is not set', async () => {
       await expect(
-        renderAndInitialise(page, 'error-summary', {
-          params: examples.default,
+        renderAndInitialise(page, 'error-summary', examples.default, {
           beforeInitialisation($module) {
             $module.remove()
           }
@@ -247,8 +245,7 @@ describe('Error Summary', () => {
 
     it('throws when receiving the wrong type for $module', async () => {
       await expect(
-        renderAndInitialise(page, 'error-summary', {
-          params: examples.default,
+        renderAndInitialise(page, 'error-summary', examples.default, {
           beforeInitialisation($module) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $module.outerHTML = `<svg data-module="govuk-error-summary"></svg>`

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -197,8 +197,7 @@ describe('/components/exit-this-page', () => {
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'exit-this-page', {
-            params: examples.default,
+          renderAndInitialise(page, 'exit-this-page', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -211,8 +210,7 @@ describe('/components/exit-this-page', () => {
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'exit-this-page', {
-            params: examples.default,
+          renderAndInitialise(page, 'exit-this-page', examples.default, {
             beforeInitialisation($module) {
               $module.remove()
             }
@@ -225,8 +223,7 @@ describe('/components/exit-this-page', () => {
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'exit-this-page', {
-            params: examples.default,
+          renderAndInitialise(page, 'exit-this-page', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
@@ -240,10 +237,12 @@ describe('/components/exit-this-page', () => {
 
       it('throws when the button is missing', async () => {
         await expect(
-          renderAndInitialise(page, 'exit-this-page', {
-            params: examples.default,
-            beforeInitialisation($module) {
-              $module.querySelector('.govuk-exit-this-page__button').remove()
+          renderAndInitialise(page, 'exit-this-page', examples.default, {
+            beforeInitialisation($module, { selector }) {
+              $module.querySelector(selector).remove()
+            },
+            context: {
+              selector: '.govuk-exit-this-page__button'
             }
           })
         ).rejects.toEqual({

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -177,8 +177,7 @@ describe('Header navigation', () => {
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples.default,
+          renderAndInitialise(page, 'header', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -191,8 +190,7 @@ describe('Header navigation', () => {
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples.default,
+          renderAndInitialise(page, 'header', examples.default, {
             beforeInitialisation($module) {
               // Remove the root of the components as a way
               // for the constructor to receive the wrong type for `$module`
@@ -207,8 +205,7 @@ describe('Header navigation', () => {
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples.default,
+          renderAndInitialise(page, 'header', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-header"></svg>`
@@ -225,20 +222,20 @@ describe('Header navigation', () => {
         // and should keep rendering. No expectations as the JavaScript
         // will just return early. All we ask of that test is for it not
         // to throw during the initialisation
-        await renderAndInitialise(page, 'header', {
-          params: examples.default
-        })
+        await renderAndInitialise(page, 'header', examples.default)
       })
 
       it('throws when the toggle is of the wrong type', async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples['with navigation'],
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'header', examples['with navigation'], {
+            beforeInitialisation($module, { selector }) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.querySelector(
-                '.govuk-js-header-toggle'
+                selector
               ).outerHTML = `<svg class="govuk-js-header-toggle"></svg>`
+            },
+            context: {
+              selector: '.govuk-js-header-toggle'
             }
           })
         ).rejects.toEqual({
@@ -250,12 +247,12 @@ describe('Header navigation', () => {
 
       it("throws when the toggle's aria-control attribute is missing", async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples['with navigation'],
-            beforeInitialisation($module) {
-              $module
-                .querySelector('.govuk-js-header-toggle')
-                .removeAttribute('aria-controls')
+          renderAndInitialise(page, 'header', examples['with navigation'], {
+            beforeInitialisation($module, { selector }) {
+              $module.querySelector(selector).removeAttribute('aria-controls')
+            },
+            context: {
+              selector: '.govuk-js-header-toggle'
             }
           })
         ).rejects.toEqual({
@@ -266,11 +263,13 @@ describe('Header navigation', () => {
 
       it('throws when the menu is missing, but a toggle is present', async () => {
         await expect(
-          renderAndInitialise(page, 'header', {
-            params: examples['with navigation'],
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'header', examples['with navigation'], {
+            beforeInitialisation($module, { selector }) {
               // Remove the menu `<ul>` referenced by $menuButton's `aria-controls`
-              $module.querySelector('#navigation').remove()
+              $module.querySelector(selector).remove()
+            },
+            context: {
+              selector: '#navigation'
             }
           })
         ).rejects.toEqual({

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -78,12 +78,16 @@ describe('Notification banner', () => {
 
     describe('and auto-focus is disabled using JavaScript configuration', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'notification-banner', {
-          params: examples['with type as success'],
-          config: {
-            disableAutoFocus: true
+        await renderAndInitialise(
+          page,
+          'notification-banner',
+          examples['with type as success'],
+          {
+            config: {
+              disableAutoFocus: true
+            }
           }
-        })
+        )
       })
 
       it('does not have a tabindex attribute', async () => {
@@ -105,12 +109,16 @@ describe('Notification banner', () => {
 
     describe('and auto-focus is disabled using options passed to initAll', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'notification-banner', {
-          params: examples['with type as success'],
-          config: {
-            disableAutoFocus: true
+        await renderAndInitialise(
+          page,
+          'notification-banner',
+          examples['with type as success'],
+          {
+            config: {
+              disableAutoFocus: true
+            }
           }
-        })
+        )
       })
 
       it('does not have a tabindex attribute', async () => {
@@ -132,13 +140,16 @@ describe('Notification banner', () => {
 
     describe('and autofocus is disabled in JS but enabled in data attributes', () => {
       beforeAll(async () => {
-        await renderAndInitialise(page, 'notification-banner', {
-          params:
-            examples['auto-focus explicitly enabled, with type as success'],
-          config: {
-            disableAutoFocus: true
+        await renderAndInitialise(
+          page,
+          'notification-banner',
+          examples['auto-focus explicitly enabled, with type as success'],
+          {
+            config: {
+              disableAutoFocus: true
+            }
           }
-        })
+        )
       })
 
       it('has the correct tabindex attribute to be focused with JavaScript', async () => {
@@ -207,8 +218,7 @@ describe('Notification banner', () => {
   describe('errors at instantiation', () => {
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
-        renderAndInitialise(page, 'notification-banner', {
-          params: examples.default,
+        renderAndInitialise(page, 'notification-banner', examples.default, {
           beforeInitialisation() {
             document.body.classList.remove('govuk-frontend-supported')
           }
@@ -221,8 +231,7 @@ describe('Notification banner', () => {
 
     it('throws when $module is not set', async () => {
       await expect(
-        renderAndInitialise(page, 'notification-banner', {
-          params: examples.default,
+        renderAndInitialise(page, 'notification-banner', examples.default, {
           beforeInitialisation($module) {
             $module.remove()
           }
@@ -235,8 +244,7 @@ describe('Notification banner', () => {
 
     it('throws when receiving the wrong type for $module', async () => {
       await expect(
-        renderAndInitialise(page, 'notification-banner', {
-          params: examples.default,
+        renderAndInitialise(page, 'notification-banner', examples.default, {
           beforeInitialisation($module) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $module.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -279,8 +279,7 @@ describe('Radios', () => {
 
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
-        renderAndInitialise(page, 'radios', {
-          params: examples.default,
+        renderAndInitialise(page, 'radios', examples.default, {
           beforeInitialisation() {
             document.body.classList.remove('govuk-frontend-supported')
           }
@@ -293,8 +292,7 @@ describe('Radios', () => {
 
     it('throws when $module is not set', async () => {
       await expect(
-        renderAndInitialise(page, 'radios', {
-          params: examples.default,
+        renderAndInitialise(page, 'radios', examples.default, {
           beforeInitialisation($module) {
             $module.remove()
           }
@@ -307,8 +305,7 @@ describe('Radios', () => {
 
     it('throws when receiving the wrong type for $module', async () => {
       await expect(
-        renderAndInitialise(page, 'radios', {
-          params: examples.default,
+        renderAndInitialise(page, 'radios', examples.default, {
           beforeInitialisation($module) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $module.outerHTML = `<svg data-module="govuk-radios"></svg>`
@@ -323,12 +320,12 @@ describe('Radios', () => {
 
     it('throws when the input list is empty', async () => {
       await expect(
-        renderAndInitialise(page, 'radios', {
-          params: examples.default,
-          beforeInitialisation($module) {
-            $module.querySelectorAll('.govuk-radios__item').forEach((item) => {
-              item.remove()
-            })
+        renderAndInitialise(page, 'radios', examples.default, {
+          beforeInitialisation($module, { selector }) {
+            $module.querySelectorAll(selector).forEach((item) => item.remove())
+          },
+          context: {
+            selector: '.govuk-radios__item'
           }
         })
       ).rejects.toEqual({
@@ -339,12 +336,16 @@ describe('Radios', () => {
 
     it('throws when a conditional target element is not found', async () => {
       await expect(
-        renderAndInitialise(page, 'radios', {
-          params: examples['with conditional items'],
-          beforeInitialisation($module) {
-            $module.querySelector('.govuk-radios__conditional').remove()
+        renderAndInitialise(
+          page,
+          'radios',
+          examples['with conditional items'],
+          {
+            beforeInitialisation($module) {
+              $module.querySelector('.govuk-radios__conditional').remove()
+            }
           }
-        })
+        )
       ).rejects.toEqual({
         name: 'ElementError',
         message: 'Radios: #conditional-how-contacted not found'

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -70,8 +70,7 @@ describe('Skip Link', () => {
 
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
-        renderAndInitialise(page, 'skip-link', {
-          params: examples.default,
+        renderAndInitialise(page, 'skip-link', examples.default, {
           beforeInitialisation() {
             document.body.classList.remove('govuk-frontend-supported')
           }
@@ -84,8 +83,7 @@ describe('Skip Link', () => {
 
     it('throws when $module is not set', async () => {
       await expect(
-        renderAndInitialise(page, 'skip-link', {
-          params: examples.default,
+        renderAndInitialise(page, 'skip-link', examples.default, {
           beforeInitialisation($module) {
             $module.remove()
           }
@@ -98,8 +96,7 @@ describe('Skip Link', () => {
 
     it('throws when receiving the wrong type for $module', async () => {
       await expect(
-        renderAndInitialise(page, 'skip-link', {
-          params: examples.default,
+        renderAndInitialise(page, 'skip-link', examples.default, {
           beforeInitialisation($module) {
             // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
             $module.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
@@ -114,10 +111,8 @@ describe('Skip Link', () => {
     it('throws when the linked element is missing', async () => {
       await expect(
         renderAndInitialise(page, 'skip-link', {
-          params: {
-            text: 'Skip to main content',
-            href: '#this-element-does-not-exist'
-          }
+          text: 'Skip to main content',
+          href: '#this-element-does-not-exist'
         })
       ).rejects.toEqual({
         name: 'ElementError',
@@ -129,10 +124,8 @@ describe('Skip Link', () => {
     it('throws when the href does not contain a hash', async () => {
       await expect(
         renderAndInitialise(page, 'skip-link', {
-          params: {
-            text: 'Skip to main content',
-            href: 'this-element-does-not-exist'
-          }
+          text: 'Skip to main content',
+          href: 'this-element-does-not-exist'
         })
       ).rejects.toEqual({
         name: 'ElementError',

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -257,8 +257,7 @@ describe('/components/tabs', () => {
 
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
+          renderAndInitialise(page, 'tabs', examples.default, {
             beforeInitialisation() {
               document.body.classList.remove('govuk-frontend-supported')
             }
@@ -271,8 +270,7 @@ describe('/components/tabs', () => {
 
       it('throws when $module is not set', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
+          renderAndInitialise(page, 'tabs', examples.default, {
             beforeInitialisation($module) {
               $module.remove()
             }
@@ -285,8 +283,7 @@ describe('/components/tabs', () => {
 
       it('throws when receiving the wrong type for $module', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
+          renderAndInitialise(page, 'tabs', examples.default, {
             beforeInitialisation($module) {
               // Replace with an `<svg>` element which is not an `HTMLElement` in the DOM (but an `SVGElement`)
               $module.outerHTML = `<svg data-module="govuk-tabs"></svg>`
@@ -300,12 +297,14 @@ describe('/components/tabs', () => {
 
       it('throws when there are no tabs', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
-            beforeInitialisation($module) {
-              $module.querySelectorAll('a.govuk-tabs__tab').forEach((item) => {
-                item.remove()
-              })
+          renderAndInitialise(page, 'tabs', examples.default, {
+            beforeInitialisation($module, { selector }) {
+              $module
+                .querySelectorAll(selector)
+                .forEach((item) => item.remove())
+            },
+            context: {
+              selector: 'a.govuk-tabs__tab'
             }
           })
         ).rejects.toEqual({
@@ -316,12 +315,14 @@ describe('/components/tabs', () => {
 
       it('throws when the tab list is missing', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'tabs', examples.default, {
+            beforeInitialisation($module, { selector }) {
               $module
-                .querySelector('.govuk-tabs__list')
+                .querySelector(selector)
                 .setAttribute('class', 'govuk-tabs__typo')
+            },
+            context: {
+              selector: '.govuk-tabs__list'
             }
           })
         ).rejects.toEqual({
@@ -332,14 +333,15 @@ describe('/components/tabs', () => {
 
       it('throws when there the tab list is empty', async () => {
         await expect(
-          renderAndInitialise(page, 'tabs', {
-            params: examples.default,
-            beforeInitialisation($module) {
+          renderAndInitialise(page, 'tabs', examples.default, {
+            beforeInitialisation($module, { selector, className }) {
               $module
-                .querySelectorAll('.govuk-tabs__list-item')
-                .forEach((item) =>
-                  item.setAttribute('class', '.govuk-tabs__list-typo')
-                )
+                .querySelectorAll(selector)
+                .forEach((item) => item.setAttribute('class', className))
+            },
+            context: {
+              selector: '.govuk-tabs__list-item',
+              className: 'govuk-tabs__list-typo'
             }
           })
         ).rejects.toEqual({

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -119,13 +119,17 @@ async function renderAndInitialise(
   // them when back in Jest (to keep them triggering a Promise rejection)
   const error = await page.evaluate(
     async (exportName, config) => {
-      const $module = document.querySelector('[data-module]')
-
       const namespace = await import('govuk-frontend')
 
+      // Find all matching modules
+      const $modules = document.querySelectorAll('[data-module]')
+
       try {
-        /* eslint-disable-next-line no-new */
-        new namespace[exportName]($module, config)
+        // Loop and initialise all $modules or use default
+        // selector `null` return value when none found
+        ;($modules.length ? $modules : [null]).forEach(
+          ($module) => new namespace[exportName]($module, config)
+        )
       } catch ({ name, message }) {
         return { name, message }
       }

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -68,19 +68,22 @@ async function axe(page, overrides = {}) {
  * components, allowing to tweak the state of the page before the component gets
  * instantiated.
  *
+ * @template {object} HandlerContext
  * @param {import('puppeteer').Page} page - Puppeteer page object
  * @param {string} componentName - The kebab-cased name of the component
- * @param {object} options - Render and initialise options
- * @param {MacroOptions} [options.params] - Nunjucks macro options (or params)
- * @param {Config[ConfigKey]} [options.config] - Component config (optional)
- * @param {($module: Element) => void} [options.beforeInitialisation] - A function that'll run in the browser
- *   before the component gets initialised
+ * @param {MacroOptions} [renderOptions] - Component options
+ * @param {BrowserRenderOptions<HandlerContext>} [browserOptions] - Component options
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-async function renderAndInitialise(page, componentName, options) {
+async function renderAndInitialise(
+  page,
+  componentName,
+  renderOptions,
+  browserOptions
+) {
   await goTo(page, '/tests/boilerplate')
 
-  const html = renderComponent(componentName, options.params)
+  const html = renderComponent(componentName, renderOptions)
 
   // Inject rendered HTML into the page
   await page.$eval(
@@ -94,8 +97,12 @@ async function renderAndInitialise(page, componentName, options) {
   // Call `beforeInitialisation` in a separate `$eval` call
   // as running it inside the body of the next `evaluate`
   // didn't provide a reliable execution
-  if (options.beforeInitialisation) {
-    await page.$eval('[data-module]', options.beforeInitialisation)
+  if (browserOptions?.beforeInitialisation) {
+    await page.$eval(
+      '[data-module]',
+      browserOptions.beforeInitialisation,
+      browserOptions.context
+    )
   }
 
   // Run a script to init the JavaScript component
@@ -111,20 +118,20 @@ async function renderAndInitialise(page, componentName, options) {
   // gather and `return` the values we need from inside the browser, and throw
   // them when back in Jest (to keep them triggering a Promise rejection)
   const error = await page.evaluate(
-    async (exportName, options) => {
+    async (exportName, config) => {
       const $module = document.querySelector('[data-module]')
 
       const namespace = await import('govuk-frontend')
 
       try {
         /* eslint-disable-next-line no-new */
-        new namespace[exportName]($module, options.config)
+        new namespace[exportName]($module, config)
       } catch ({ name, message }) {
         return { name, message }
       }
     },
     componentNameToClassName(componentName),
-    options
+    browserOptions?.config
   )
 
   if (error) {
@@ -250,6 +257,23 @@ module.exports = {
   getAccessibleName,
   isVisible
 }
+
+/**
+ * Browser render options
+ *
+ * @template {object} HandlerContext
+ * @typedef {object} BrowserRenderOptions - Component render options
+ * @property {Config[ConfigKey]} [config] - Component JavaScript config
+ * @property {HandlerContext} [context] - Context options for custom functions
+ * @property {HandlerFunction<HandlerContext>} [beforeInitialisation] - Custom function to run before initialisation
+ */
+
+/**
+ * Browser handler function with context options
+ *
+ * @template {object} HandlerContext
+ * @typedef {import('puppeteer').EvaluateFuncWith<Element, [HandlerContext]>} HandlerFunction
+ */
 
 /**
  * @typedef {import('@govuk-frontend/lib/components').MacroOptions} MacroOptions


### PR DESCRIPTION
This PR is split out from https://github.com/alphagov/govuk-frontend/pull/4266 and includes:

1. Support custom `beforeInitialisation()` browser options
1. Support multiple `$modules` being initialised in `renderAndInitialise()`

This follows a "Custom Puppeteer browser options" [discussion on Slack](https://gds.slack.com/archives/C05P6FJ1YH2/p1695976340212499) and [first suggested](https://gds.slack.com/archives/C05P6FJ1YH2/p1695898993278089?thread_ts=1695827768.160929&cid=C05P6FJ1YH2) by @romaricpascal

### Custom initialisation example
Render a single button but clone it before both are initialised together

```mjs
const examples = await getExamples('button')

// Render single button
renderAndInitialise(page, 'button', {
  params: examples.default,

  // Duplicate button before initialisation
  beforeInitialisation($module, { className }) {
    const $button1 = $module
    
    // Create 2nd button
    const $button2 = el.cloneNode(true)

    // Append 2nd button, configure
    $button1.parentNode.appendChild($button2)
    $button2.setAttribute('class', className)
  },
  
  // Pass custom options to browser
  beforeInitialisationOptions: {
    className: 'govuk-button--dodgy'
  }
})
```