### PR TITLE
Add  brand class name for Department for Business Innovation and Skills 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ### New features
 
+### Fixes
+
+#### Update brand class name for Department for Energy Security & Net Zero
+
+This was added in [pull request #4331: Add new brand colour for Department for Business Innovation and Skills](https://github.com/alphagov/govuk-frontend/pull/4331).
+
 #### Precompiled CSS and JavaScript
 
 The precompiled CSS and JavaScript files found in our [GitHub releases](https://github.com/alphagov/govuk-frontend/releases) are now also published to [`govuk-frontend` on npm](https://www.npmjs.com/package/govuk-frontend).

--- a/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
+++ b/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss
@@ -42,6 +42,10 @@ $govuk-colours-organisations: (
     colour: #003a69,
     colour-websafe: #347ca9
   ),
+  "department-for-energy-security-and-net-zero": (
+    colour: #003479,
+    colour-websafe: #347da4
+  ),
   "department-for-environment-food-rural-affairs": (
     colour: #00a33b,
     colour-websafe: #008938


### PR DESCRIPTION
## Description

Department for Business Innovation and Skills has been broken into several departments. We've been asked to update the branding class to department-for-energy-security-and-net-zero.

## Trello card

https://trello.com/c/XYjCuXRz/1325-update-old-bis-colour-name-in-whitehall