### PR TITLE
Update accessibility tests to bypass Review app

### DIFF
--- a/packages/govuk-frontend/.htmlvalidate.js
+++ b/packages/govuk-frontend/.htmlvalidate.js
@@ -15,9 +15,6 @@ module.exports = {
     // Allow pattern attribute on input type="number"
     'input-attributes': 'off',
 
-    // Allow for conditional comments (used in header for fallback png)
-    'no-conditional-comment': 'off',
-
     // Allow inline styles for testing purposes
     'no-inline-style': 'off',
 

--- a/packages/govuk-frontend/.htmlvalidate.js
+++ b/packages/govuk-frontend/.htmlvalidate.js
@@ -1,0 +1,71 @@
+/**
+ * HTML validation config
+ *
+ * {@link https://html-validate.org/rules/}
+ *
+ * @satisfies {import('html-validate').ConfigData}
+ */
+module.exports = {
+  extends: ['html-validate:recommended'],
+  rules: {
+    // Allow for multiple buttons in the same form to have the same name
+    // (as in the cookie banner examples)
+    'form-dup-name': ['error', { shared: ['radio', 'checkbox', 'submit'] }],
+
+    // Allow pattern attribute on input type="number"
+    'input-attributes': 'off',
+
+    // Allow for conditional comments (used in header for fallback png)
+    'no-conditional-comment': 'off',
+
+    // Allow inline styles for testing purposes
+    'no-inline-style': 'off',
+
+    // Allow for explicit roles on regions that have implict roles
+    // We do this to better support AT with older versions of IE that
+    // have partial support for HTML5 semantic elements
+    'no-redundant-role': 'off',
+
+    // More hassle than it's worth 👾
+    'no-trailing-whitespace': 'off',
+
+    // We still support creating `input type=button` with the button
+    // component, but you have to explicitly choose to use them over
+    // buttons
+    'prefer-button': 'off',
+
+    // Allow use of roles where there are native elements that would give
+    // us that role automatically, e.g. <section> instead of
+    // <div role="region">
+    //
+    // This is mainly needed for links styled as buttons, but we do this
+    // in the cookie banner and notification banner too
+    'prefer-native-element': 'off',
+
+    // HTML Validate is opinionated about IDs beginning with a letter and
+    // only containing letters, numbers, underscores and dashes – which is
+    // more restrictive than the spec allows.
+    //
+    // Relax the rule to allow anything that is valid according to the
+    // spec.
+    'valid-id': ['error', { relaxed: true }]
+  },
+  elements: [
+    'html5',
+    {
+      // Allow textarea autocomplete attribute to be street-address
+      // (html-validate only allows on/off in default rules)
+      textarea: {
+        attributes: {
+          autocomplete: { enum: ['on', 'off', 'street-address'] }
+        }
+      },
+      // Allow buttons to omit the type attribute (defaults to 'submit')
+      button: {
+        attributes: {
+          type: { required: false }
+        }
+      }
+    }
+  ]
+}

--- a/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accessibility.puppeteer.test.mjs
@@ -1,4 +1,4 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/accordion', () => {
@@ -17,16 +17,11 @@ describe('/components/accordion', () => {
   })
 
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('accordion'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'accordion', { exampleName })
+      const examples = await getExamples('accordion')
+
+      for (const exampleName in examples) {
+        await render(page, 'accordion', examples[exampleName])
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/back-link/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/back-link/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/back-link', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('back-link'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'back-link', { exampleName })
+      const examples = await getExamples('back-link')
+
+      for (const exampleName in examples) {
+        await render(page, 'back-link', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/breadcrumbs/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/breadcrumbs', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('breadcrumbs'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'breadcrumbs', { exampleName })
+      const examples = await getExamples('breadcrumbs')
+
+      for (const exampleName in examples) {
+        await render(page, 'breadcrumbs', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
@@ -1,4 +1,4 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/button', () => {
@@ -15,16 +15,11 @@ describe('/components/button', () => {
   })
 
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('button'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'button', { exampleName })
+      const examples = await getExamples('button')
+
+      for (const exampleName in examples) {
+        await render(page, 'button', examples[exampleName])
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/accessibility.puppeteer.test.mjs
@@ -2,25 +2,13 @@ import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/button', () => {
-  let axeRules
-
-  beforeAll(() => {
-    axeRules = {
-      /**
-       * Ignore 'Invalid ARIA attribute value: aria-controls="example-id"'
-       * for missing IDs
-       */
-      'aria-valid-attr-value': { enabled: false }
-    }
-  })
-
   describe('component examples', () => {
     it('passes accessibility tests', async () => {
       const examples = await getExamples('button')
 
       for (const exampleName in examples) {
         await render(page, 'button', examples[exampleName])
-        await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
+        await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)
   })

--- a/packages/govuk-frontend/src/govuk/components/button/button.yaml
+++ b/packages/govuk-frontend/src/govuk/components/button/button.yaml
@@ -186,7 +186,7 @@ examples:
       element: button
       text: Submit
       attributes:
-        aria-controls: example-id
+        aria-controls: content
         data-tracking-dimension: 123
   - name: link attributes
     hidden: true
@@ -194,7 +194,7 @@ examples:
       element: a
       text: Submit
       attributes:
-        aria-controls: example-id
+        aria-controls: content
         data-tracking-dimension: 123
   - name: input attributes
     hidden: true
@@ -202,7 +202,7 @@ examples:
       element: input
       text: Submit
       attributes:
-        aria-controls: example-id
+        aria-controls: content
         data-tracking-dimension: 123
   - name: classes
     hidden: true

--- a/packages/govuk-frontend/src/govuk/components/button/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/template.test.js
@@ -23,7 +23,7 @@ describe('Button', () => {
       const $ = render('button', examples.attributes)
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('example-id')
+      expect($component.attr('aria-controls')).toEqual('content')
       expect($component.attr('data-tracking-dimension')).toEqual('123')
     })
 
@@ -123,7 +123,7 @@ describe('Button', () => {
       const $ = render('button', examples['link attributes'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('example-id')
+      expect($component.attr('aria-controls')).toEqual('content')
       expect($component.attr('data-tracking-dimension')).toEqual('123')
     })
 
@@ -148,7 +148,7 @@ describe('Button', () => {
       const $ = render('button', examples['input attributes'])
 
       const $component = $('.govuk-button')
-      expect($component.attr('aria-controls')).toEqual('example-id')
+      expect($component.attr('aria-controls')).toEqual('content')
       expect($component.attr('data-tracking-dimension')).toEqual('123')
     })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/character-count', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('character-count'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'character-count', { exampleName })
+      const examples = await getExamples('character-count')
+
+      for (const exampleName in examples) {
+        await render(page, 'character-count', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/accessibility.puppeteer.test.mjs
@@ -8,6 +8,9 @@ describe('/components/character-count', () => {
 
       for (const exampleName in examples) {
         await render(page, 'character-count', examples[exampleName])
+          // Log errors for invalid examples
+          .catch(({ message }) => console.warn(message))
+
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/checkboxes', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('checkboxes'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'checkboxes', { exampleName })
+      const examples = await getExamples('checkboxes')
+
+      for (const exampleName in examples) {
+        await render(page, 'checkboxes', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.yaml
@@ -696,7 +696,7 @@ examples:
     options:
       name: example-name
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: Which option?
       items:
@@ -804,7 +804,7 @@ examples:
       errorMessage:
         text: Please select an option
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: What is your nationality?
       hint:
@@ -858,7 +858,7 @@ examples:
   - name: with single option set 'aria-describedby' on input, and describedBy
     hidden: true
     options:
-      describedBy: some-id
+      describedBy: content
       name: t-and-c
       errorMessage:
         text: Please accept the terms and conditions
@@ -868,7 +868,7 @@ examples:
   - name: with single option (and hint) set 'aria-describedby' on input, and describedBy
     hidden: true
     options:
-      describedBy: some-id
+      describedBy: content
       name: t-and-c-with-hint
       errorMessage:
         text: Please accept the terms and conditions
@@ -894,7 +894,7 @@ examples:
       errorMessage:
         text: Please select an option
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: What is your nationality?
       items:

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/template.test.js
@@ -82,7 +82,7 @@ describe('Checkboxes', () => {
     const $ = render('checkboxes', examples['with fieldset describedBy'])
 
     const $fieldset = $('.govuk-fieldset')
-    expect($fieldset.attr('aria-describedby')).toMatch('some-id')
+    expect($fieldset.attr('aria-describedby')).toMatch('content')
   })
 
   it('render attributes', () => {
@@ -404,7 +404,7 @@ describe('Checkboxes', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
@@ -461,7 +461,7 @@ describe('Checkboxes', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
@@ -495,7 +495,7 @@ describe('Checkboxes', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedByCombined = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)
@@ -548,7 +548,7 @@ describe('Checkboxes', () => {
       const $ = render('checkboxes', examples[exampleName])
       const $input = $('input')
 
-      expect($input.attr('aria-describedby')).toMatch('some-id t-and-c-error')
+      expect($input.attr('aria-describedby')).toMatch('content t-and-c-error')
     })
   })
 
@@ -573,7 +573,7 @@ describe('Checkboxes', () => {
       const $input = $('input')
 
       expect($input.attr('aria-describedby')).toMatch(
-        'some-id t-and-c-with-hint-error t-and-c-with-hint-item-hint'
+        'content t-and-c-with-hint-error t-and-c-with-hint-item-hint'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -7,6 +7,7 @@ const {
   nunjucksEnv,
   render
 } = require('@govuk-frontend/lib/components')
+const validatorConfig = require('govuk-frontend/.htmlvalidate.js')
 const { HtmlValidate } = require('html-validate')
 
 describe('Components', () => {
@@ -56,78 +57,7 @@ describe('Components', () => {
   })
 
   describe('Nunjucks HTML validation', () => {
-    /** @type {HtmlValidate} */
-    let validator
-
-    beforeAll(() => {
-      validator = new HtmlValidate({
-        extends: ['html-validate:recommended'],
-        rules: {
-          // Allow for multiple buttons in the same form to have the same name
-          // (as in the cookie banner examples)
-          'form-dup-name': [
-            'error',
-            { shared: ['radio', 'checkbox', 'submit'] }
-          ],
-
-          // Allow pattern attribute on input type="number"
-          'input-attributes': 'off',
-
-          // Allow for conditional comments (used in header for fallback png)
-          'no-conditional-comment': 'off',
-
-          // Allow inline styles for testing purposes
-          'no-inline-style': 'off',
-
-          // Allow for explicit roles on regions that have implict roles
-          // We do this to better support AT with older versions of IE that
-          // have partial support for HTML5 semantic elements
-          'no-redundant-role': 'off',
-
-          // More hassle than it's worth 👾
-          'no-trailing-whitespace': 'off',
-
-          // We still support creating `input type=button` with the button
-          // component, but you have to explicitly choose to use them over
-          // buttons
-          'prefer-button': 'off',
-
-          // Allow use of roles where there are native elements that would give
-          // us that role automatically, e.g. <section> instead of
-          // <div role="region">
-          //
-          // This is mainly needed for links styled as buttons, but we do this
-          // in the cookie banner and notification banner too
-          'prefer-native-element': 'off',
-
-          // HTML Validate is opinionated about IDs beginning with a letter and
-          // only containing letters, numbers, underscores and dashes – which is
-          // more restrictive than the spec allows.
-          //
-          // Relax the rule to allow anything that is valid according to the
-          // spec.
-          'valid-id': ['error', { relaxed: true }]
-        },
-        elements: [
-          'html5',
-          {
-            // Allow textarea autocomplete attribute to be street-address
-            // (html-validate only allows on/off in default rules)
-            textarea: {
-              attributes: {
-                autocomplete: { enum: ['on', 'off', 'street-address'] }
-              }
-            },
-            // Allow buttons to omit the type attribute (defaults to 'submit')
-            button: {
-              attributes: {
-                type: { required: false }
-              }
-            }
-          }
-        ]
-      })
-    })
+    const validator = new HtmlValidate(validatorConfig)
 
     it('renders valid HTML for each component example', async () => {
       const componentsFixtures = await getComponentsFixtures()

--- a/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/cookie-banner/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/cookie-banner', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('cookie-banner'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'cookie-banner', { exampleName })
+      const examples = await getExamples('cookie-banner')
+
+      for (const exampleName in examples) {
+        await render(page, 'cookie-banner', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/date-input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/date-input/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/date-input', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('date-input'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'date-input', { exampleName })
+      const examples = await getExamples('date-input')
+
+      for (const exampleName in examples) {
+        await render(page, 'date-input', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/date-input/date-input.yaml
@@ -349,7 +349,7 @@ examples:
     options:
       id: dob-errors
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: What is your date of birth?
       hint:
@@ -359,7 +359,7 @@ examples:
     options:
       id: dob-errors
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: What is your date of birth?
       errorMessage:

--- a/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/date-input/template.test.js
@@ -206,7 +206,7 @@ describe('Date input', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
@@ -246,7 +246,7 @@ describe('Date input', () => {
       const $fieldset = $('.govuk-fieldset')
 
       expect($fieldset.attr('aria-describedby')).toMatch(
-        'some-id dob-errors-error'
+        'content dob-errors-error'
       )
     })
 

--- a/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/details/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/details', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('details'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'details', { exampleName })
+      const examples = await getExamples('details')
+
+      for (const exampleName in examples) {
+        await render(page, 'details', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/error-message/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-message/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/error-message', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('error-message'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'error-message', { exampleName })
+      const examples = await getExamples('error-message')
+
+      for (const exampleName in examples) {
+        await render(page, 'error-message', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/error-summary', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('error-summary'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'error-summary', { exampleName })
+      const examples = await getExamples('error-summary')
+
+      for (const exampleName in examples) {
+        await render(page, 'error-summary', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/accessibility.puppeteer.test.mjs
@@ -1,20 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/exit-this-page', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('exit-this-page'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const name of exampleNames) {
-        const exampleName = name.replace(/ /g, '-')
+      const examples = await getExamples('exit-this-page')
 
-        // Navigation to example, create report
-        await goToComponent(page, 'exit-this-page', { exampleName })
+      for (const exampleName in examples) {
+        await render(page, 'exit-this-page', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/fieldset', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('fieldset'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'fieldset', { exampleName })
+      const examples = await getExamples('fieldset')
+
+      for (const exampleName in examples) {
+        await render(page, 'fieldset', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/fieldset/fieldset.yaml
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/fieldset.yaml
@@ -113,7 +113,7 @@ examples:
   - name: with describedBy
     hidden: true
     options:
-      describedBy: some-id
+      describedBy: content
       legend:
         text: Which option?
   - name: html as text

--- a/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/fieldset/template.test.js
@@ -40,7 +40,7 @@ describe('fieldset', () => {
     const $ = render('fieldset', examples['with describedBy'])
 
     const $component = $('.govuk-fieldset')
-    expect($component.attr('aria-describedby')).toEqual('some-id')
+    expect($component.attr('aria-describedby')).toEqual('content')
   })
 
   it('escapes HTML in the text argument', () => {

--- a/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/file-upload', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('file-upload'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'file-upload', { exampleName })
+      const examples = await getExamples('file-upload')
+
+      for (const exampleName in examples) {
+        await render(page, 'file-upload', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/file-upload.yaml
@@ -126,7 +126,7 @@ examples:
       name: file-upload-describedby
       label:
         text: Upload a file
-      describedBy: some-id
+      describedBy: content
   - name: with hint and describedBy
     hidden: true
     options:
@@ -134,7 +134,7 @@ examples:
       name: file-upload-hint-describedby
       label:
         text: Upload a file
-      describedBy: some-id
+      describedBy: content
       hint:
         text: Your photo may be in your Pictures, Photos, Downloads or Desktop folder. Or in an app like iPhoto.
   - name: error
@@ -153,7 +153,7 @@ examples:
       name: file-upload-error-describedby
       label:
         text: Upload a file
-      describedBy: some-id
+      describedBy: content
       errorMessage:
         text: Error message
   - name: with error, describedBy and hint
@@ -163,7 +163,7 @@ examples:
       name: file-upload-error-describedby-hint
       label:
         text: Upload a file
-      describedBy: some-id
+      describedBy: content
       errorMessage:
         text: Error message
       hint:

--- a/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/file-upload/template.test.js
@@ -56,7 +56,7 @@ describe('File upload', () => {
       const $ = render('file-upload', examples['with describedBy'])
 
       const $component = $('.govuk-file-upload')
-      expect($component.attr('aria-describedby')).toMatch('some-id')
+      expect($component.attr('aria-describedby')).toMatch('content')
     })
 
     it('renders with attributes', () => {
@@ -104,7 +104,7 @@ describe('File upload', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
       expect($component.attr('aria-describedby')).toMatch(describedBy)
@@ -138,7 +138,7 @@ describe('File upload', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($component.attr('aria-describedby')).toMatch(describedBy)
@@ -175,7 +175,7 @@ describe('File upload', () => {
     })
 
     it('associates the input as described by the hint, error message and parent fieldset', () => {
-      const describedById = 'some-id'
+      const describedById = 'content'
 
       const $ = render(
         'file-upload',

--- a/packages/govuk-frontend/src/govuk/components/footer/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/footer/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/footer', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('footer'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'footer', { exampleName })
+      const examples = await getExamples('footer')
+
+      for (const exampleName in examples) {
+        await render(page, 'footer', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/header', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('header'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'header', { exampleName })
+      const examples = await getExamples('header')
+
+      for (const exampleName in examples) {
+        await render(page, 'header', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/hint/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/hint', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('hint'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'hint', { exampleName })
+      const examples = await getExamples('hint')
+
+      for (const exampleName in examples) {
+        await render(page, 'hint', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/input/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/input/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/input', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('input'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'input', { exampleName })
+      const examples = await getExamples('input')
+
+      for (const exampleName in examples) {
+        await render(page, 'input', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/input/input.yaml
+++ b/packages/govuk-frontend/src/govuk/components/input/input.yaml
@@ -351,7 +351,7 @@ examples:
       name: with-describedby
       label:
         text: With describedBy
-      describedBy: some-id
+      describedBy: content
   - name: attributes
     hidden: true
     options:
@@ -368,7 +368,7 @@ examples:
       name: with-hint-describedby
       label:
         text: With hint describedBy
-      describedBy: some-id
+      describedBy: content
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
   - name: error with describedBy
@@ -378,7 +378,7 @@ examples:
       name: with-error-describedby
       label:
         text: With error describedBy
-      describedBy: some-id
+      describedBy: content
       errorMessage:
         text: Error message
   - name: with error and hint
@@ -403,7 +403,7 @@ examples:
         text: Error message
       hint:
         text: Hint
-      describedBy: some-id
+      describedBy: content
   - name: inputmode
     hidden: true
     options:

--- a/packages/govuk-frontend/src/govuk/components/input/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/input/template.test.js
@@ -75,7 +75,7 @@ describe('Input', () => {
       const $ = render('input', examples['with describedBy'])
 
       const $component = $('.govuk-input')
-      expect($component.attr('aria-describedby')).toMatch('some-id')
+      expect($component.attr('aria-describedby')).toMatch('content')
     })
 
     it('renders with attributes', () => {
@@ -127,7 +127,7 @@ describe('Input', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
       expect($input.attr('aria-describedby')).toMatch(describedBy)
@@ -161,7 +161,7 @@ describe('Input', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($input.attr('aria-describedby')).toMatch(describedBy)
@@ -228,7 +228,7 @@ describe('Input', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedByCombined = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($component.attr('aria-describedby')).toMatch(describedByCombined)

--- a/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/inset-text/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/inset-text', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('inset-text'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'inset-text', { exampleName })
+      const examples = await getExamples('inset-text')
+
+      for (const exampleName in examples) {
+        await render(page, 'inset-text', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/label/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/label/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/label', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('label'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'label', { exampleName })
+      const examples = await getExamples('label')
+
+      for (const exampleName in examples) {
+        await render(page, 'label', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/label/label.yaml
+++ b/packages/govuk-frontend/src/govuk/components/label/label.yaml
@@ -93,7 +93,7 @@ examples:
   - name: for
     hidden: true
     options:
-      for: '#dummy-input'
+      for: content
       text: National Insurance number
   - name: attributes
     hidden: true

--- a/packages/govuk-frontend/src/govuk/components/label/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/label/template.test.js
@@ -58,7 +58,7 @@ describe('Label', () => {
       const $ = render('label', examples.for)
 
       const labelForAttr = $('.govuk-label').attr('for')
-      expect(labelForAttr).toEqual('#dummy-input')
+      expect(labelForAttr).toEqual('content')
     })
 
     it('can be nested inside an H1 using isPageHeading', () => {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/accessibility.puppeteer.test.mjs
@@ -1,4 +1,4 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/notification-banner', () => {
@@ -6,12 +6,6 @@ describe('/components/notification-banner', () => {
 
   beforeAll(() => {
     axeRules = {
-      /**
-       * Ignore 'The banner landmark is contained in another landmark'
-       * for wrapping 'main'
-       */
-      'landmark-banner-is-top-level': { enabled: false },
-
       /**
        * Ignore 'Element has a tabindex greater than 0' for custom
        * tabindex tests
@@ -21,16 +15,11 @@ describe('/components/notification-banner', () => {
   })
 
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('notification-banner'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'notification-banner', { exampleName })
+      const examples = await getExamples('notification-banner')
+
+      for (const exampleName in examples) {
+        await render(page, 'notification-banner', examples[exampleName])
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/pagination/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/pagination', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('pagination'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'pagination', { exampleName })
+      const examples = await getExamples('pagination')
+
+      for (const exampleName in examples) {
+        await render(page, 'pagination', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/panel/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/panel', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('panel'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'panel', { exampleName })
+      const examples = await getExamples('panel')
+
+      for (const exampleName in examples) {
+        await render(page, 'panel', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/phase-banner/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/phase-banner', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('phase-banner'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'phase-banner', { exampleName })
+      const examples = await getExamples('phase-banner')
+
+      for (const exampleName in examples) {
+        await render(page, 'phase-banner', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/radios/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/accessibility.puppeteer.test.mjs
@@ -1,4 +1,4 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/radios', () => {
@@ -16,16 +16,11 @@ describe('/components/radios', () => {
   })
 
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('radios'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'radios', { exampleName })
+      const examples = await getExamples('radios')
+
+      for (const exampleName in examples) {
+        await render(page, 'radios', examples[exampleName])
         await expect(axe(page, axeRules)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.yaml
@@ -689,7 +689,7 @@ examples:
     options:
       name: example-name
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: Which option?
       items:
@@ -767,7 +767,7 @@ examples:
     options:
       name: example-hint-describedby
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: Have you changed your name?
       hint:
@@ -823,7 +823,7 @@ examples:
       errorMessage:
         text: Please select an option
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: Have you changed your name?
       hint:
@@ -882,7 +882,7 @@ examples:
       errorMessage:
         text: Please select an option
       fieldset:
-        describedBy: some-id
+        describedBy: content
         legend:
           text: Have you changed your name?
       items:

--- a/packages/govuk-frontend/src/govuk/components/radios/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/template.test.js
@@ -47,7 +47,7 @@ describe('Radios', () => {
   })
 
   it('renders initial aria-describedby on fieldset', () => {
-    const describedById = 'some-id'
+    const describedById = 'content'
 
     const $ = render('radios', examples['fieldset with describedBy'])
 
@@ -309,7 +309,7 @@ describe('Radios', () => {
       const $ = render('radios', examples['with describedBy and hint'])
       const $fieldset = $('.govuk-fieldset')
 
-      expect($fieldset.attr('aria-describedby')).toMatch('some-id')
+      expect($fieldset.attr('aria-describedby')).toMatch('content')
     })
   })
 
@@ -358,7 +358,7 @@ describe('Radios', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedBy)
@@ -398,7 +398,7 @@ describe('Radios', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedByCombined = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($fieldset.attr('aria-describedby')).toMatch(describedByCombined)

--- a/packages/govuk-frontend/src/govuk/components/select/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/select/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/select', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('select'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'select', { exampleName })
+      const examples = await getExamples('select')
+
+      for (const exampleName in examples) {
+        await render(page, 'select', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/select/select.yaml
+++ b/packages/govuk-frontend/src/govuk/components/select/select.yaml
@@ -197,7 +197,7 @@ examples:
           text: GOV.UK frontend option 1
         - value: 2
           text: GOV.UK frontend option 2
-      describedBy: some-id
+      describedBy: content
   - name: attributes
     hidden: true
     options:
@@ -262,7 +262,7 @@ examples:
       name: select-with-hint
       label:
         text: Label text goes here
-      describedBy: some-id
+      describedBy: content
       hint:
         text: Hint text goes here
       items:
@@ -291,7 +291,7 @@ examples:
       name: select-with-error
       label:
         text: Label text goes here
-      describedBy: some-id
+      describedBy: content
       errorMessage:
         text: Error message
       items:

--- a/packages/govuk-frontend/src/govuk/components/select/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/select/template.test.js
@@ -146,7 +146,7 @@ describe('Select', () => {
       const $ = render('select', examples['with describedBy'])
 
       const $component = $('.govuk-select')
-      expect($component.attr('aria-describedby')).toMatch('some-id')
+      expect($component.attr('aria-describedby')).toMatch('content')
     })
 
     it('renders with attributes', () => {
@@ -196,7 +196,7 @@ describe('Select', () => {
 
       const $select = $('.govuk-select')
 
-      expect($select.attr('aria-describedby')).toMatch('some-id')
+      expect($select.attr('aria-describedby')).toMatch('content')
     })
   })
 
@@ -225,7 +225,7 @@ describe('Select', () => {
 
       const $input = $('.govuk-select')
 
-      expect($input.attr('aria-describedby')).toMatch('some-id')
+      expect($input.attr('aria-describedby')).toMatch('content')
     })
 
     it('adds the error class to the select', () => {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
@@ -8,6 +8,9 @@ describe('/components/skip-link', () => {
 
       for (const exampleName in examples) {
         await render(page, 'skip-link', examples[exampleName])
+          // Log errors for invalid examples
+          .catch(({ message }) => console.warn(message))
+
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/skip-link', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('skip-link'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'skip-link', { exampleName })
+      const examples = await getExamples('skip-link')
+
+      for (const exampleName in examples) {
+        await render(page, 'skip-link', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/summary-list/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/summary-list', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('summary-list'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'summary-list', { exampleName })
+      const examples = await getExamples('summary-list')
+
+      for (const exampleName in examples) {
+        await render(page, 'summary-list', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/table/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/table/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/table', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('table'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'table', { exampleName })
+      const examples = await getExamples('table')
+
+      for (const exampleName in examples) {
+        await render(page, 'table', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
@@ -8,6 +8,9 @@ describe('/components/tabs', () => {
 
       for (const exampleName in examples) {
         await render(page, 'tabs', examples[exampleName])
+          // Log errors for invalid examples
+          .catch(({ message }) => console.warn(message))
+
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/tabs', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('tabs'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'tabs', { exampleName })
+      const examples = await getExamples('tabs')
+
+      for (const exampleName in examples) {
+        await render(page, 'tabs', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tag/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/tag', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('tag'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'tag', { exampleName })
+      const examples = await getExamples('tag')
+
+      for (const exampleName in examples) {
+        await render(page, 'tag', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/task-list/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/task-list/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/task-list', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('task-list'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'task-list', { exampleName })
+      const examples = await getExamples('task-list')
+
+      for (const exampleName in examples) {
+        await render(page, 'task-list', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 60000)

--- a/packages/govuk-frontend/src/govuk/components/textarea/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/textarea/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/textarea', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('textarea'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'textarea', { exampleName })
+      const examples = await getExamples('textarea')
+
+      for (const exampleName in examples) {
+        await render(page, 'textarea', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/textarea/template.test.js
@@ -68,7 +68,7 @@ describe('Textarea', () => {
       const $ = render('textarea', examples['with describedBy'])
 
       const $component = $('.govuk-textarea')
-      expect($component.attr('aria-describedby')).toMatch('some-id')
+      expect($component.attr('aria-describedby')).toMatch('content')
     })
 
     it('renders with rows', () => {
@@ -136,7 +136,7 @@ describe('Textarea', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WORD_BOUNDARY}`
       )
 
       expect($textarea.attr('aria-describedby')).toMatch(describedBy)
@@ -173,7 +173,7 @@ describe('Textarea', () => {
       const errorMessageId = $('.govuk-error-message').attr('id')
 
       const describedBy = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($component.attr('aria-describedby')).toMatch(describedBy)
@@ -220,7 +220,7 @@ describe('Textarea', () => {
       const hintId = $('.govuk-hint').attr('id')
 
       const describedByCombined = new RegExp(
-        `${WORD_BOUNDARY}some-id${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
+        `${WORD_BOUNDARY}content${WHITESPACE}${hintId}${WHITESPACE}${errorMessageId}${WORD_BOUNDARY}`
       )
 
       expect($component.attr('aria-describedby')).toMatch(describedByCombined)

--- a/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
+++ b/packages/govuk-frontend/src/govuk/components/textarea/textarea.yaml
@@ -175,7 +175,7 @@ examples:
       name: with-describedby
       label:
         text: With describedBy
-      describedBy: some-id
+      describedBy: content
   - name: with hint and described by
     hidden: true
     options:
@@ -183,7 +183,7 @@ examples:
       name: with-hint-describedby
       label:
         text: With hint and describedBy
-      describedBy: some-id
+      describedBy: content
       hint:
         text: It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.
   - name: with error message and described by
@@ -192,7 +192,7 @@ examples:
       name: textarea-with-error
       label:
         text: Textarea with error
-      describedBy: some-id
+      describedBy: content
       id: textarea-with-error
       errorMessage:
         text: Error message
@@ -214,7 +214,7 @@ examples:
       name: with-hint-error-describedby
       label:
         text: With hint, error and describedBy
-      describedBy: some-id
+      describedBy: content
       errorMessage:
         text: Error message
       hint:

--- a/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.puppeteer.test.mjs
+++ b/packages/govuk-frontend/src/govuk/components/warning-text/accessibility.puppeteer.test.mjs
@@ -1,18 +1,13 @@
-import { axe, goToComponent } from '@govuk-frontend/helpers/puppeteer'
+import { axe, render } from '@govuk-frontend/helpers/puppeteer'
 import { getExamples } from '@govuk-frontend/lib/components'
 
 describe('/components/warning-text', () => {
   describe('component examples', () => {
-    let exampleNames
-
-    beforeAll(async () => {
-      exampleNames = Object.keys(await getExamples('warning-text'))
-    })
-
     it('passes accessibility tests', async () => {
-      for (const exampleName of exampleNames) {
-        // Navigation to example, create report
-        await goToComponent(page, 'warning-text', { exampleName })
+      const examples = await getExamples('warning-text')
+
+      for (const exampleName in examples) {
+        await render(page, 'warning-text', examples[exampleName])
         await expect(axe(page)).resolves.toHaveNoViolations()
       }
     }, 120000)

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -55,7 +55,10 @@ async function axe(page, overrides = {}) {
 
   // Add preview URL to report violations
   report.violations.forEach((violation) => {
-    violation.helpUrl = `${violation.helpUrl}\n${page.url()}`
+    const { pathname } = new URL(page.url())
+
+    // Replace file:// URLs with Review app
+    violation.helpUrl = `${violation.helpUrl}\n${new URL(pathname, urls.app)}`
   })
 
   return report

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -67,9 +67,8 @@ async function axe(page, overrides = {}) {
 /**
  * Render component HTML with browser preview
  *
- * Renders a component's Nunjucks macro with the given params, injects it into
- * the test boilerplate page, and instantiates the component class, passing the
- * provided JavaScript configuration.
+ * Uses Nunjucks component {@link renderPreview} for HTML output, but runs
+ * component JavaScript (where available) or `initAll()` in the browser
  *
  * It runs an optional `beforeInitialisation` function before initialising the
  * components, allowing to tweak the state of the page before the component gets

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -132,6 +132,11 @@ async function render(page, componentName, renderOptions, browserOptions) {
       async (selector, exportName, config) => {
         const namespace = await import('govuk-frontend')
 
+        // Skip custom initialisation without export
+        if (!namespace[exportName]) {
+          return namespace.initAll()
+        }
+
         // Find all matching modules
         const $modules = document.querySelectorAll(selector)
 

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -128,6 +128,10 @@ async function render(page, componentName, renderOptions, browserOptions) {
   // property, which means we get a mangled value). As a workaround, we can
   // gather and `return` the values we need from inside the browser
   try {
+    if (!page.isJavaScriptEnabled()) {
+      return page
+    }
+
     const error = await page.evaluate(
       async (selector, exportName, config) => {
         const namespace = await import('govuk-frontend')

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -58,7 +58,19 @@ async function axe(page, overrides = {}) {
     const { pathname } = new URL(page.url())
 
     // Replace file:// URLs with Review app
-    violation.helpUrl = `${violation.helpUrl}\n${new URL(pathname, urls.app)}`
+    const previewUrl = new URL(pathname, urls.app)
+
+    /**
+     * Add Review app preview URL below link to violation
+     *
+     * @example
+     * ```console
+     * You can find more information on this issue here:
+     * https://dequeuniversity.com/rules/axe/4.8/aria-allowed-attr?application=axe-puppeteer
+     * http://localhost:8080/components/radios/with-conditional-items/preview
+     * ```
+     */
+    violation.helpUrl += `\n${previewUrl}`
   })
 
   return report

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -155,7 +155,8 @@ function render(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
   const macroPath = `govuk/components/${componentName}/macro.njk`
 
-  return renderMacro(macroName, macroPath, options)
+  // Return built fixture or render
+  return options?.fixture?.html ?? renderMacro(macroName, macroPath, options)
 }
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -206,7 +206,7 @@ function renderPreview(componentName, options) {
       footer: '',
 
       main: outdent`
-        <div class="govuk-width-container">
+        <div id="content" class="govuk-width-container">
           ${render(componentName, options)}
         </div>
       `,

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -184,6 +184,9 @@ function renderMacro(macroName, macroPath, options) {
 /**
  * Render component preview on boilerplate page
  *
+ * Uses {@link renderTemplate} with the default `govuk/template.njk` to
+ * render components via {@link render} into the `main` content block
+ *
  * @param {string} componentName - Component name
  * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {string} HTML rendered from the Nunjucks template


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/4103

This allows Accessibility tests to run without the Review app

For these tests, we've [chosen to log errors as warnings](https://github.com/alphagov/govuk-frontend/actions/runs/6610937177/job/17954246976#step:6:15) (rather than throw) due to invalid component examples:

1. Skip link with `#custom` target
2. Character count without "maxlength" or "maxwords"
3. Tabs with missing items

### Test performance

Worth mentioning that we went to 11-12 minutes per PR run by adding Windows tests

We’re down to [6 minutes without the Review app](https://github.com/alphagov/govuk-frontend/actions/runs/6724671614) once https://github.com/alphagov/govuk-frontend/pull/4359 merges :raised_hands: