### PR TITLE
Refactor ElementError

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.mjs
@@ -120,9 +120,9 @@ export class Accordion extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Accordion',
-        identifier: '$module'
+        element: $module
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -755,7 +755,7 @@ describe('/components/accordion', () => {
               })
             ).rejects.toEqual({
               name: 'ElementError',
-              message: 'Accordion: $module is not an instance of HTMLElement'
+              message: 'Accordion: $module is not of type HTMLElement'
             })
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.mjs
+++ b/packages/govuk-frontend/src/govuk/components/button/button.mjs
@@ -35,9 +35,9 @@ export class Button extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Button',
-        identifier: '$module'
+        element: $module
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -363,7 +363,7 @@ describe('/components/button', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Button: $module is not an instance of HTMLElement'
+          message: 'Button: $module is not of type HTMLElement'
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -75,9 +75,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Character count',
-        identifier: '$module'
+        element: $module
       })
     }
 
@@ -88,9 +88,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
         $textarea instanceof HTMLInputElement
       )
     ) {
-      throw new ElementError($textarea, {
+      throw new ElementError('.govuk-js-character-count', {
         componentName: 'Character count',
-        identifier: '.govuk-js-character-count',
+        element: $textarea,
         expectedType: 'HTMLTextareaElement or HTMLInputElement'
       })
     }
@@ -140,9 +140,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
     const textareaDescriptionId = `${this.$textarea.id}-info`
     const $textareaDescription = document.getElementById(textareaDescriptionId)
     if (!$textareaDescription) {
-      throw new ElementError($textareaDescription, {
+      throw new ElementError(`#${textareaDescriptionId}`, {
         componentName: 'Character count',
-        identifier: `#${textareaDescriptionId}`
+        element: $textareaDescription
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -848,7 +848,7 @@ describe('Character count', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Character count: $module is not an instance of HTMLElement'
+          message: 'Character count: $module is not of type HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.mjs
@@ -31,18 +31,17 @@ export class Checkboxes extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError(`[data-module="${Checkboxes.moduleName}"]`, {
         componentName: 'Checkboxes',
-        identifier: `[data-module="${Checkboxes.moduleName}"]`
+        element: $module
       })
     }
 
     /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="checkbox"]')
     if (!$inputs.length) {
-      throw new ElementError(null, {
-        componentName: 'Checkboxes',
-        identifier: 'input[type="checkbox"]'
+      throw new ElementError('input[type="checkbox"]', {
+        componentName: 'Checkboxes'
       })
     }
 
@@ -59,9 +58,8 @@ export class Checkboxes extends GOVUKFrontendComponent {
 
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
-        throw new ElementError(null, {
-          componentName: 'Checkboxes',
-          identifier: `#${targetId}`
+        throw new ElementError(`#${targetId}`, {
+          componentName: 'Checkboxes'
         })
       }
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -363,7 +363,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
         ).rejects.toEqual({
           name: 'ElementError',
           message:
-            'Checkboxes: [data-module="govuk-checkboxes"] is not an instance of HTMLElement'
+            'Checkboxes: [data-module="govuk-checkboxes"] is not of type HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.mjs
@@ -29,9 +29,9 @@ export class ErrorSummary extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Error summary',
-        identifier: '$module'
+        element: $module
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -253,7 +253,7 @@ describe('Error Summary', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message: 'Error summary: $module is not an instance of HTMLElement'
+        message: 'Error summary: $module is not of type HTMLElement'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.mjs
@@ -82,18 +82,18 @@ export class ExitThisPage extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Exit this page',
-        identifier: '$module'
+        element: $module
       })
     }
 
     const $button = $module.querySelector('.govuk-exit-this-page__button')
     if (!($button instanceof HTMLAnchorElement)) {
-      throw new ElementError($button, {
+      throw new ElementError('Button', {
         componentName: 'Exit this page',
-        identifier: 'Button',
-        expectedType: HTMLAnchorElement
+        element: $button,
+        expectedType: 'HTMLAnchorElement'
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -231,7 +231,7 @@ describe('/components/exit-this-page', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Exit this page: $module is not an instance of HTMLElement'
+          message: 'Exit this page: $module is not of type HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.mjs
+++ b/packages/govuk-frontend/src/govuk/components/header/header.mjs
@@ -45,9 +45,9 @@ export class Header extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Header',
-        identifier: '$module'
+        element: $module
       })
     }
 
@@ -62,26 +62,25 @@ export class Header extends GOVUKFrontendComponent {
     }
 
     if (!($menuButton instanceof HTMLElement)) {
-      throw new ElementError($menuButton, {
+      throw new ElementError('.govuk-js-header-toggle', {
         componentName: 'Header',
-        identifier: '.govuk-js-header-toggle'
+        element: $menuButton
       })
     }
 
     const menuId = $menuButton.getAttribute('aria-controls')
     if (!menuId) {
-      throw new ElementError(null, {
-        componentName: 'Header',
-        identifier: '.govuk-js-header-toggle[aria-controls]'
+      throw new ElementError('.govuk-js-header-toggle[aria-controls]', {
+        componentName: 'Header'
       })
     }
 
     const $menu = document.getElementById(menuId)
 
     if (!($menu instanceof HTMLElement)) {
-      throw new ElementError($menu, {
+      throw new ElementError(`#${menuId}`, {
         componentName: 'Header',
-        identifier: `#${menuId}`
+        element: $menu
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -213,7 +213,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Header: $module is not an instance of HTMLElement'
+          message: 'Header: $module is not of type HTMLElement'
         })
       })
 
@@ -240,8 +240,7 @@ describe('Header navigation', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message:
-            'Header: .govuk-js-header-toggle is not an instance of HTMLElement'
+          message: 'Header: .govuk-js-header-toggle is not of type HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.mjs
@@ -26,9 +26,9 @@ export class NotificationBanner extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Notification banner',
-        identifier: '$module'
+        element: $module
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -252,8 +252,7 @@ describe('Notification banner', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message:
-          'Notification banner: $module is not an instance of HTMLElement'
+        message: 'Notification banner: $module is not of type HTMLElement'
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.mjs
@@ -31,18 +31,17 @@ export class Radios extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError(`[data-module="${Radios.moduleName}"]`, {
         componentName: 'Radios',
-        identifier: `[data-module="${Radios.moduleName}"]`
+        element: $module
       })
     }
 
     /** @satisfies {NodeListOf<HTMLInputElement>} */
     const $inputs = $module.querySelectorAll('input[type="radio"]')
     if (!$inputs.length) {
-      throw new ElementError(null, {
-        componentName: 'Radios',
-        identifier: 'input[type="radio"]'
+      throw new ElementError('input[type="radio"]', {
+        componentName: 'Radios'
       })
     }
 
@@ -59,9 +58,8 @@ export class Radios extends GOVUKFrontendComponent {
 
       // Throw if target conditional element does not exist.
       if (!document.getElementById(targetId)) {
-        throw new ElementError(null, {
-          componentName: 'Radios',
-          identifier: `#${targetId}`
+        throw new ElementError(`#${targetId}`, {
+          componentName: 'Radios'
         })
       }
 

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -314,7 +314,7 @@ describe('Radios', () => {
       ).rejects.toEqual({
         name: 'ElementError',
         message:
-          'Radios: [data-module="govuk-radios"] is not an instance of HTMLElement'
+          'Radios: [data-module="govuk-radios"] is not of type HTMLElement'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.mjs
@@ -27,10 +27,10 @@ export class SkipLink extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLAnchorElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Skip link',
-        identifier: '$module',
-        expectedType: HTMLAnchorElement
+        element: $module,
+        expectedType: 'HTMLAnchorElement'
       })
     }
 
@@ -51,9 +51,9 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     // Check for link hash fragment
     if (!linkedElementId) {
-      throw new ElementError(this.$module, {
+      throw new ElementError('$module.hash', {
         componentName: 'Skip link',
-        identifier: '$module.hash',
+        element: this.$module,
         expectedType: 'string'
       })
     }
@@ -62,9 +62,9 @@ export class SkipLink extends GOVUKFrontendComponent {
 
     // Check for link target element
     if (!($linkedElement instanceof HTMLElement)) {
-      throw new ElementError($linkedElement, {
+      throw new ElementError(`$module.hash target #${linkedElementId}`, {
         componentName: 'Skip link',
-        identifier: `$module.hash target #${linkedElementId}`
+        element: $linkedElement
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -104,7 +104,7 @@ describe('Skip Link', () => {
         })
       ).rejects.toEqual({
         name: 'ElementError',
-        message: 'Skip link: $module is not an instance of HTMLAnchorElement'
+        message: 'Skip link: $module is not of type HTMLAnchorElement'
       })
     })
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.mjs
@@ -51,18 +51,17 @@ export class Tabs extends GOVUKFrontendComponent {
     super()
 
     if (!($module instanceof HTMLElement)) {
-      throw new ElementError($module, {
+      throw new ElementError('$module', {
         componentName: 'Tabs',
-        identifier: '$module'
+        element: $module
       })
     }
 
     /** @satisfies {NodeListOf<HTMLAnchorElement>} */
     const $tabs = $module.querySelectorAll('a.govuk-tabs__tab')
     if (!$tabs.length) {
-      throw new ElementError(null, {
-        componentName: 'Tabs',
-        identifier: `a.govuk-tabs__tab`
+      throw new ElementError(`a.govuk-tabs__tab`, {
+        componentName: 'Tabs'
       })
     }
 
@@ -80,16 +79,14 @@ export class Tabs extends GOVUKFrontendComponent {
     )
 
     if (!$tabList) {
-      throw new ElementError(null, {
-        componentName: 'Tabs',
-        identifier: `.govuk-tabs__list`
+      throw new ElementError(`.govuk-tabs__list`, {
+        componentName: 'Tabs'
       })
     }
 
     if (!$tabListItems.length) {
-      throw new ElementError(null, {
-        componentName: 'Tabs',
-        identifier: `.govuk-tabs__list-item`
+      throw new ElementError(`.govuk-tabs__list-item`, {
+        componentName: 'Tabs'
       })
     }
 

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -291,7 +291,7 @@ describe('/components/tabs', () => {
           })
         ).rejects.toEqual({
           name: 'ElementError',
-          message: 'Tabs: $module is not an instance of HTMLElement'
+          message: 'Tabs: $module is not of type HTMLElement'
         })
       })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -28,25 +28,22 @@ describe('errors', () => {
   describe('ElementError', () => {
     it('is an instance of GOVUKFrontendError', () => {
       expect(
-        new ElementError(null, {
-          componentName: 'Component name',
-          identifier: 'variableName'
+        new ElementError('variableName', {
+          componentName: 'Component name'
         })
       ).toBeInstanceOf(GOVUKFrontendError)
     })
     it('has its own name set', () => {
       expect(
-        new ElementError(null, {
-          componentName: 'Component name',
-          identifier: 'variableName'
+        new ElementError('variableName', {
+          componentName: 'Component name'
         }).name
       ).toBe('ElementError')
     })
     it('formats the message when the element is not found', () => {
       expect(
-        new ElementError(null, {
-          componentName: 'Component name',
-          identifier: 'variableName'
+        new ElementError('variableName', {
+          componentName: 'Component name'
         }).message
       ).toBe('Component name: variableName not found')
     })
@@ -54,14 +51,12 @@ describe('errors', () => {
       const element = document.createElement('div')
 
       expect(
-        new ElementError(element, {
+        new ElementError('variableName', {
           componentName: 'Component name',
-          identifier: 'variableName',
-          expectedType: window.HTMLAnchorElement
+          element,
+          expectedType: 'HTMLAnchorElement'
         }).message
-      ).toBe(
-        'Component name: variableName is not an instance of HTMLAnchorElement'
-      )
+      ).toBe('Component name: variableName is not of type HTMLAnchorElement')
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -48,23 +48,18 @@ export class ElementError extends GOVUKFrontendError {
   name = 'ElementError'
 
   /**
-   * @param {Element | null} element - The element in error
+   * @param {string} identifier - An identifier that'll let the user understand which element has an error (variable name, CSS selector)
    * @param {object} options - Element error options
    * @param {string} options.componentName - The name of the component throwing the error
-   * @param {string} options.identifier - An identifier that'll let the user understand which element has an error (variable name, CSS selector)
-   * @param {string | typeof HTMLElement} [options.expectedType] - The type that was expected for the identifier
+   * @param {Element | null} [options.element] - The element in error
+   * @param {string} [options.expectedType] - The type that was expected for the identifier
    */
-  constructor(element, { componentName, identifier, expectedType }) {
+  constructor(identifier, { componentName, element, expectedType }) {
     let reason = `${identifier} not found`
 
     // Otherwise check for type mismatch
     if (element) {
-      expectedType = expectedType || window.HTMLElement
-
-      reason =
-        typeof expectedType === 'string'
-          ? `${identifier} is not of type ${expectedType}`
-          : `${identifier} is not an instance of ${expectedType.name}`
+      reason = `${identifier} is not of type ${expectedType || 'HTMLElement'}`
     }
 
     super(`${componentName}: ${reason}`)


### PR DESCRIPTION
Closes #4300 

- rearranges params in the constructor:
`constructor(identifier, {componentName, element, expectedType})`
- Expected type is now always a string when present
- Expected type errors have been simplified