### PR TITLE
Log component example with Puppeteer JavaScript errors

### DIFF
--- a/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/all.jsdom.test.mjs
@@ -71,6 +71,11 @@ describe('initAll', () => {
   )
 
   describe('govuk-frontend-supported not present', () => {
+    beforeAll(() => {
+      // Silence warnings in test output, and allow us to 'expect' them
+      jest.spyOn(global.console, 'log').mockImplementation()
+    })
+
     it('returns early', () => {
       document.body.innerHTML = '<div data-module="govuk-accordion"></div>'
 
@@ -80,9 +85,6 @@ describe('initAll', () => {
     })
 
     it('logs why it did not initialise components', () => {
-      // Silence warnings in test output, and allow us to 'expect' them
-      jest.spyOn(global.console, 'log').mockImplementation()
-
       GOVUKFrontend.initAll()
 
       // Only validate the message as it's the important part for the user

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -726,9 +726,11 @@ describe('/components/accordion', () => {
                   document.body.classList.remove('govuk-frontend-supported')
                 }
               })
-            ).rejects.toEqual({
-              name: 'SupportError',
-              message: 'GOV.UK Frontend is not supported in this browser'
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'SupportError',
+                message: 'GOV.UK Frontend is not supported in this browser'
+              }
             })
           })
 
@@ -739,9 +741,11 @@ describe('/components/accordion', () => {
                   $module.remove()
                 }
               })
-            ).rejects.toEqual({
-              name: 'ElementError',
-              message: 'Accordion: Root element (`$module`) not found'
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message: 'Accordion: Root element (`$module`) not found'
+              }
             })
           })
 
@@ -753,10 +757,12 @@ describe('/components/accordion', () => {
                   $module.outerHTML = `<svg data-module="govuk-accordion"></svg>`
                 }
               })
-            ).rejects.toEqual({
-              name: 'ElementError',
-              message:
-                'Accordion: Root element (`$module`) is not of type HTMLElement'
+            ).rejects.toMatchObject({
+              cause: {
+                name: 'ElementError',
+                message:
+                  'Accordion: Root element (`$module`) is not of type HTMLElement'
+              }
             })
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -326,9 +326,11 @@ describe('/components/button', () => {
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -339,9 +341,11 @@ describe('/components/button', () => {
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Button: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Button: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -353,9 +357,12 @@ describe('/components/button', () => {
               $module.outerHTML = `<svg data-module="govuk-button"></svg>`
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Button: Root element (`$module`) is not of type HTMLElement'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Button: Root element (`$module`) is not of type HTMLElement'
+          }
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -806,9 +806,11 @@ describe('Character count', () => {
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -819,9 +821,11 @@ describe('Character count', () => {
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Character count: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Character count: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -833,10 +837,12 @@ describe('Character count', () => {
               $module.outerHTML = `<svg data-module="govuk-character-count"></svg>`
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Character count: Root element (`$module`) is not of type HTMLElement'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Character count: Root element (`$module`) is not of type HTMLElement'
+          }
         })
       })
 
@@ -850,10 +856,12 @@ describe('Character count', () => {
               selector: '.govuk-js-character-count'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Character count: Form field (`.govuk-js-character-count`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Character count: Form field (`.govuk-js-character-count`) not found'
+          }
         })
       })
 
@@ -869,10 +877,12 @@ describe('Character count', () => {
               selector: '.govuk-js-character-count'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Character count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Character count: Form field (`.govuk-js-character-count`) is not of type HTMLTextareaElement or HTMLInputElement'
+          }
         })
       })
 
@@ -886,10 +896,12 @@ describe('Character count', () => {
               selector: '#more-detail-info'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Character count: Count message (`id="more-detail-info"`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Character count: Count message (`id="more-detail-info"`) not found'
+          }
         })
       })
 
@@ -900,10 +912,12 @@ describe('Character count', () => {
             'character-count',
             examples['to configure in JavaScript']
           )
-        ).rejects.toEqual({
-          name: 'ConfigError',
-          message:
-            'Character count: Either "maxlength" or "maxwords" must be provided'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ConfigError',
+            message:
+              'Character count: Either "maxlength" or "maxwords" must be provided'
+          }
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -333,9 +333,11 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -346,9 +348,11 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Checkboxes: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Checkboxes: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -360,10 +364,12 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
               $module.outerHTML = `<svg data-module="govuk-checkboxes"></svg>`
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Checkboxes: Root element (`$module`) is not of type HTMLElement'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Checkboxes: Root element (`$module`) is not of type HTMLElement'
+          }
         })
       })
 
@@ -379,10 +385,12 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
               selector: '.govuk-checkboxes__item'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Checkboxes: Form inputs (`<input type="checkbox">`) not found'
+          }
         })
       })
 
@@ -396,10 +404,12 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
               selector: '.govuk-checkboxes__conditional'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Checkboxes: Conditional reveal (`id="conditional-how-contacted"`) not found'
+          }
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -224,9 +224,11 @@ describe('Error Summary', () => {
             document.body.classList.remove('govuk-frontend-supported')
           }
         })
-      ).rejects.toEqual({
-        name: 'SupportError',
-        message: 'GOV.UK Frontend is not supported in this browser'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        }
       })
     })
 
@@ -237,9 +239,11 @@ describe('Error Summary', () => {
             $module.remove()
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Error summary: Root element (`$module`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Error summary: Root element (`$module`) not found'
+        }
       })
     })
 
@@ -251,10 +255,12 @@ describe('Error Summary', () => {
             $module.outerHTML = `<svg data-module="govuk-error-summary"></svg>`
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Error summary: Root element (`$module`) is not of type HTMLElement'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Error summary: Root element (`$module`) is not of type HTMLElement'
+        }
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -202,9 +202,11 @@ describe('/components/exit-this-page', () => {
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -215,9 +217,11 @@ describe('/components/exit-this-page', () => {
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Exit this page: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Exit this page: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -229,10 +233,12 @@ describe('/components/exit-this-page', () => {
               $module.outerHTML = `<svg data-module="govuk-exit-this-page"></svg>`
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Exit this page: Root element (`$module`) is not of type HTMLElement'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Exit this page: Root element (`$module`) is not of type HTMLElement'
+          }
         })
       })
 
@@ -246,10 +252,12 @@ describe('/components/exit-this-page', () => {
               selector: '.govuk-exit-this-page__button'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Exit this page: Button (`.govuk-exit-this-page__button`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Exit this page: Button (`.govuk-exit-this-page__button`) not found'
+          }
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -179,9 +179,11 @@ describe('Header navigation', () => {
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -194,9 +196,11 @@ describe('Header navigation', () => {
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Header: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Header: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -218,10 +222,12 @@ describe('Header navigation', () => {
               selector: '.govuk-js-header-toggle'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Header: Navigation button (`<button class="govuk-js-header-toggle">`) attribute (`aria-controls`) not found'
+          }
         })
       })
 
@@ -236,9 +242,11 @@ describe('Header navigation', () => {
               selector: '#navigation'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Header: Navigation (`<ul id="navigation">`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Header: Navigation (`<ul id="navigation">`) not found'
+          }
         })
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -220,9 +220,11 @@ describe('Notification banner', () => {
             document.body.classList.remove('govuk-frontend-supported')
           }
         })
-      ).rejects.toEqual({
-        name: 'SupportError',
-        message: 'GOV.UK Frontend is not supported in this browser'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        }
       })
     })
 
@@ -233,9 +235,11 @@ describe('Notification banner', () => {
             $module.remove()
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Notification banner: Root element (`$module`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Notification banner: Root element (`$module`) not found'
+        }
       })
     })
 
@@ -247,10 +251,12 @@ describe('Notification banner', () => {
             $module.outerHTML = `<svg data-module="govuk-notification-banner"></svg>`
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Notification banner: Root element (`$module`) is not of type HTMLElement'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Notification banner: Root element (`$module`) is not of type HTMLElement'
+        }
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -284,9 +284,11 @@ describe('Radios', () => {
             document.body.classList.remove('govuk-frontend-supported')
           }
         })
-      ).rejects.toEqual({
-        name: 'SupportError',
-        message: 'GOV.UK Frontend is not supported in this browser'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        }
       })
     })
 
@@ -297,9 +299,11 @@ describe('Radios', () => {
             $module.remove()
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Radios: Root element (`$module`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Radios: Root element (`$module`) not found'
+        }
       })
     })
 
@@ -311,9 +315,11 @@ describe('Radios', () => {
             $module.outerHTML = `<svg data-module="govuk-radios"></svg>`
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Radios: Root element (`$module`) is not of type HTMLElement'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Radios: Root element (`$module`) is not of type HTMLElement'
+        }
       })
     })
 
@@ -327,9 +333,11 @@ describe('Radios', () => {
             selector: '.govuk-radios__item'
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Radios: Form inputs (`<input type="radio">`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Radios: Form inputs (`<input type="radio">`) not found'
+        }
       })
     })
 
@@ -340,10 +348,12 @@ describe('Radios', () => {
             $module.querySelector('.govuk-radios__conditional').remove()
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Radios: Conditional reveal (`id="conditional-how-contacted"`) not found'
+        }
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -72,9 +72,11 @@ describe('Skip Link', () => {
             document.body.classList.remove('govuk-frontend-supported')
           }
         })
-      ).rejects.toEqual({
-        name: 'SupportError',
-        message: 'GOV.UK Frontend is not supported in this browser'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'SupportError',
+          message: 'GOV.UK Frontend is not supported in this browser'
+        }
       })
     })
 
@@ -85,9 +87,11 @@ describe('Skip Link', () => {
             $module.remove()
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message: 'Skip link: Root element (`$module`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message: 'Skip link: Root element (`$module`) not found'
+        }
       })
     })
 
@@ -99,10 +103,12 @@ describe('Skip Link', () => {
             $module.outerHTML = `<svg data-module="govuk-skip-link"></svg>`
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Skip link: Root element (`$module`) is not of type HTMLAnchorElement'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Skip link: Root element (`$module`) is not of type HTMLAnchorElement'
+        }
       })
     })
 
@@ -114,10 +120,12 @@ describe('Skip Link', () => {
             href: '#this-element-does-not-exist'
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Skip link: Target content (`id="this-element-does-not-exist"`) not found'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Skip link: Target content (`id="this-element-does-not-exist"`) not found'
+        }
       })
     })
 
@@ -129,10 +137,12 @@ describe('Skip Link', () => {
             href: 'this-element-does-not-exist'
           }
         })
-      ).rejects.toEqual({
-        name: 'ElementError',
-        message:
-          'Skip link: Root element (`$module`) attribute (`href`) has no URL fragment'
+      ).rejects.toMatchObject({
+        cause: {
+          name: 'ElementError',
+          message:
+            'Skip link: Root element (`$module`) attribute (`href`) has no URL fragment'
+        }
       })
     })
   })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -262,9 +262,11 @@ describe('/components/tabs', () => {
               document.body.classList.remove('govuk-frontend-supported')
             }
           })
-        ).rejects.toEqual({
-          name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'SupportError',
+            message: 'GOV.UK Frontend is not supported in this browser'
+          }
         })
       })
 
@@ -275,9 +277,11 @@ describe('/components/tabs', () => {
               $module.remove()
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Tabs: Root element (`$module`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Tabs: Root element (`$module`) not found'
+          }
         })
       })
 
@@ -293,9 +297,11 @@ describe('/components/tabs', () => {
               selector: 'a.govuk-tabs__tab'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Tabs: Links (`<a class="govuk-tabs__tab">`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Tabs: Links (`<a class="govuk-tabs__tab">`) not found'
+          }
         })
       })
 
@@ -311,9 +317,11 @@ describe('/components/tabs', () => {
               selector: '.govuk-tabs__list'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message: 'Tabs: List (`<ul class="govuk-tabs__list">`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message: 'Tabs: List (`<ul class="govuk-tabs__list">`) not found'
+          }
         })
       })
 
@@ -330,10 +338,12 @@ describe('/components/tabs', () => {
               className: 'govuk-tabs__list-typo'
             }
           })
-        ).rejects.toEqual({
-          name: 'ElementError',
-          message:
-            'Tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
+        ).rejects.toMatchObject({
+          cause: {
+            name: 'ElementError',
+            message:
+              'Tabs: List items (`<li class="govuk-tabs__list-item">`) not found'
+          }
         })
       })
     })

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -126,7 +126,8 @@ async function getExamples(componentName, packageOptions) {
 
   for (const fixture of fixtures) {
     examples[fixture.name] = {
-      context: fixture.options
+      context: fixture.options,
+      fixture
     }
   }
 
@@ -322,6 +323,7 @@ module.exports = {
  * @property {MacroOptions} [context] - Nunjucks context object (optional)
  * @property {string} [callBlock] - Nunjucks macro `caller()` content (optional)
  * @property {import('nunjucks').Environment} [env] - Nunjucks environment (optional)
+ * @property {ComponentFixture} [fixture] - Component fixture (optional)
  */
 
 /**


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/4103 and includes:

1. Puppeteer render errors output component and example information
1. Test helper `getExamples()` now includes component fixture data too

### Error log output before

<img width="1140" alt="Error log output from browser with unknown example" src="https://github.com/alphagov/govuk-frontend/assets/415517/77c50e0d-695d-461d-ac8b-57134732a028">

### Error log output after

<img width="1188" alt="Error log output from browser with component and example information" src="https://github.com/alphagov/govuk-frontend/assets/415517/7b3f7add-cf22-46c2-a278-08da10874a08">
