### PR TITLE
Update component tests to bypass Review app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -123,11 +123,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [install, build]
 
-    env:
-      # Use 2x CPU cores unless on Windows (runs slower when concurrent)
-      # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-      MAX_WORKERS: ${{ matrix.runner == 'windows-latest' && '1' || '2' }}
-
     strategy:
       fail-fast: false
 
@@ -193,7 +188,10 @@ jobs:
           path: ${{ matrix.task.cache }}
 
       - name: Run test task
-        run: npx jest --color ${{ format('--coverage={0} --maxWorkers={1} --selectProjects "{2}"', matrix.task.coverage || false, env.MAX_WORKERS, join(matrix.task.projects, '", "')) }}
+
+        # Use 2x CPU cores for hosted GitHub runners
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        run: npx jest --color ${{ format('--coverage={0} --maxWorkers=2 --selectProjects "{1}"', matrix.task.coverage || false, join(matrix.task.projects, '", "')) }}
 
       - name: Save test coverage
         uses: actions/upload-artifact@v3.1.3

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -160,7 +160,8 @@ export default async () => {
       // Construct and evaluate the component with the data for this example
       res.locals.componentView = render(componentName, {
         context: fixture.options,
-        env
+        env,
+        fixture
       })
 
       let bodyClasses = 'app-template__body'

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToComponent,
   goToExample,
   render,
   getAccessibleName
@@ -7,6 +6,12 @@ const {
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('/components/accordion', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('accordion')
+  })
+
   describe('/components/accordion/preview', () => {
     describe('when JavaScript is unavailable or fails', () => {
       beforeAll(async () => {
@@ -18,7 +23,7 @@ describe('/components/accordion', () => {
       })
 
       it('falls back to making all accordion sections visible', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const numberOfExampleSections = 2
 
@@ -34,7 +39,7 @@ describe('/components/accordion', () => {
       })
 
       it('does not display "↓/↑" in the section headings', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const numberOfIcons = await page.evaluate(
           () =>
@@ -53,7 +58,7 @@ describe('/components/accordion', () => {
       })
 
       it('should indicate that the sections are not expanded', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const numberOfExampleSections = 2
 
@@ -73,7 +78,7 @@ describe('/components/accordion', () => {
       })
 
       it('should change the Show all sections button to Hide all sections when both sections are opened', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         await page.click(
           '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
@@ -93,7 +98,7 @@ describe('/components/accordion', () => {
       })
 
       it('should open both sections when the Show all sections button is clicked', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         await page.click('.govuk-accordion__show-all')
 
@@ -119,9 +124,11 @@ describe('/components/accordion', () => {
       })
 
       it('should already have all sections open if they have the expanded class', async () => {
-        await goToComponent(page, 'accordion', {
-          exampleName: 'with-all-sections-already-open'
-        })
+        await render(
+          page,
+          'accordion',
+          examples['with all sections already open']
+        )
 
         const numberOfExampleSections = 2
 
@@ -152,7 +159,7 @@ describe('/components/accordion', () => {
         const sectionHeaderButton =
           '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
 
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
         await page.click(sectionHeaderButton)
 
         const expandedState = await page.evaluate((sectionHeaderButton) => {
@@ -181,9 +188,8 @@ describe('/components/accordion', () => {
         const sectionHeaderButton =
           '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-button'
 
-        await goToComponent(page, 'accordion', {
-          exampleName: 'with-remember-expanded-off'
-        })
+        await render(page, 'accordion', examples['with remember expanded off'])
+
         await page.click(sectionHeaderButton)
 
         const expandedState = await page.evaluate((sectionHeaderButton) => {
@@ -209,7 +215,7 @@ describe('/components/accordion', () => {
       })
 
       it('should transform the button span to <button>', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const buttonTag = await page.evaluate(
           () =>
@@ -222,7 +228,7 @@ describe('/components/accordion', () => {
       })
 
       it('should contain a heading text container', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const headingTextContainer = await page.evaluate(() =>
           document.body.querySelector(
@@ -235,7 +241,7 @@ describe('/components/accordion', () => {
 
       describe('focus containers', () => {
         it('should contain a heading text focus container', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const headingTextFocusContainer = await page.evaluate(() =>
             document.body.querySelector(
@@ -246,9 +252,11 @@ describe('/components/accordion', () => {
           expect(headingTextFocusContainer).toBeTruthy()
         })
         it('should contain a summary focus container', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-additional-descriptions'
-          })
+          await render(
+            page,
+            'accordion',
+            examples['with additional descriptions']
+          )
 
           const summaryFocusContainer = await page.evaluate(() =>
             document.body.querySelector(
@@ -259,7 +267,7 @@ describe('/components/accordion', () => {
           expect(summaryFocusContainer).toBeTruthy()
         })
         it('should contain a show/hide focus container', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const headingTextFocusContainer = await page.evaluate(() =>
             document.body.querySelector(
@@ -273,7 +281,7 @@ describe('/components/accordion', () => {
 
       describe('"↓/↑" icon', () => {
         it('should display "↓/↑" in the section headings', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const numberOfExampleSections = 2
           const numberOfIcons = await page.evaluate(
@@ -289,7 +297,7 @@ describe('/components/accordion', () => {
 
       describe('hidden comma', () => {
         it('should contain hidden comma " ," after the heading text for when CSS does not load', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const commaAfterHeadingTextClassName = await page.evaluate(
             () =>
@@ -313,9 +321,11 @@ describe('/components/accordion', () => {
         })
 
         it('should contain hidden comma " ," after the summary line for when CSS does not load', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-additional-descriptions'
-          })
+          await render(
+            page,
+            'accordion',
+            examples['with additional descriptions']
+          )
 
           const commaAfterHeadingTextClassName = await page.evaluate(
             () =>
@@ -340,9 +350,11 @@ describe('/components/accordion', () => {
       describe('summary line', () => {
         describe('location of summary', () => {
           it('should move the additional description to the button text in the correct order', async () => {
-            await goToComponent(page, 'accordion', {
-              exampleName: 'with-additional-descriptions'
-            })
+            await render(
+              page,
+              'accordion',
+              examples['with additional descriptions']
+            )
 
             const summaryClass = 'govuk-accordion__section-summary govuk-body'
             const firstSummaryElement = await page.evaluate(
@@ -357,9 +369,11 @@ describe('/components/accordion', () => {
 
         describe('div to span', () => {
           it('should have converted the div to a span tag', async () => {
-            await goToComponent(page, 'accordion', {
-              exampleName: 'with-additional-descriptions'
-            })
+            await render(
+              page,
+              'accordion',
+              examples['with additional descriptions']
+            )
 
             const firstSummaryElement = await page.evaluate(
               () =>
@@ -374,7 +388,7 @@ describe('/components/accordion', () => {
       })
 
       it('should change the Show text to Hide when sections are opened', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
         await page.click(
           '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
         )
@@ -392,7 +406,7 @@ describe('/components/accordion', () => {
       })
 
       it('should have a data-nosnippet attribute on the "Show / hide" container to hide it from search result snippets', async () => {
-        await goToComponent(page, 'accordion')
+        await render(page, 'accordion', examples.default)
 
         const dataNoSnippetAttribute = await page.evaluate(() =>
           document.body
@@ -405,7 +419,7 @@ describe('/components/accordion', () => {
 
       describe('accessible name', () => {
         it('Should set the accessible name of the show/hide section buttons', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const $element = await page.$('.govuk-accordion__section-button')
 
@@ -421,9 +435,11 @@ describe('/components/accordion', () => {
         })
 
         it('Includes the heading summary', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-additional-descriptions'
-          })
+          await render(
+            page,
+            'accordion',
+            examples['with additional descriptions']
+          )
 
           const $element = await page.$('.govuk-accordion__section-button')
 
@@ -441,7 +457,7 @@ describe('/components/accordion', () => {
 
       describe('expandable content', () => {
         it('should have an aria-labelledby that matches the heading text ID', async () => {
-          await goToComponent(page, 'accordion')
+          await render(page, 'accordion', examples.default)
 
           const ariaLabelledByValue = await page.evaluate(() =>
             document.body
@@ -461,9 +477,7 @@ describe('/components/accordion', () => {
 
       describe('localisation', () => {
         it('should localise "Show all sections" based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
 
           const showAllSectionsDataAttribute = await page.evaluate(() =>
             document.body
@@ -492,9 +506,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide all sections" based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
           await page.click(
             '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
           )
@@ -530,9 +542,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Show section" based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
 
           const showSectionDataAttribute = await page.evaluate(() =>
             document.body
@@ -563,9 +573,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Show section" aria-label based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
 
           const showSectionDataAttribute = await page.evaluate(() =>
             document.body
@@ -598,9 +606,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide section" based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
           await page.click(
             '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
           )
@@ -637,9 +643,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide section" aria-label based on data attribute', async () => {
-          await goToComponent(page, 'accordion', {
-            exampleName: 'with-translations'
-          })
+          await render(page, 'accordion', examples['with translations'])
           await page.click(
             '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
           )
@@ -678,12 +682,6 @@ describe('/components/accordion', () => {
         })
 
         describe('Cross Side Scripting prevention', () => {
-          let examples
-
-          beforeAll(async () => {
-            examples = await getExamples('accordion')
-          })
-
           it('injects the localised strings as text not HTML', async () => {
             await render(page, 'accordion', examples.default, {
               config: {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -168,9 +168,8 @@ describe('/components/accordion', () => {
             .getAttribute('aria-expanded')
         }, sectionHeaderButton)
 
-        await page.reload({
-          waitUntil: 'load'
-        })
+        // Render again to simulate page refresh
+        await render(page, 'accordion', examples.default)
 
         const expandedStateAfterRefresh = await page.evaluate(
           (sectionHeaderButton) => {
@@ -198,9 +197,8 @@ describe('/components/accordion', () => {
             .getAttribute('aria-expanded')
         }, sectionHeaderButton)
 
-        await page.reload({
-          waitUntil: 'load'
-        })
+        // Render again to simulate page refresh
+        await render(page, 'accordion', examples['with remember expanded off'])
 
         const expandedStateAfterRefresh = await page.evaluate(
           (sectionHeaderButton) => {

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -492,7 +492,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Show all sections" based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
 
           const allSectionsToggleText = await page.evaluate(
             () =>
@@ -527,7 +527,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide all sections" based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
           await page.click('.govuk-accordion .govuk-accordion__show-all')
 
           const allSectionsToggleText = await page.evaluate(
@@ -558,7 +558,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Show section" based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
 
           const firstSectionToggleText = await page.evaluate(
             () =>
@@ -590,7 +590,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Show section" aria-label based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
 
           const firstSectionToggleAriaLabel = await page.evaluate(() =>
             document.body
@@ -625,7 +625,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide section" based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
           await page.click(
             '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
           )
@@ -663,7 +663,7 @@ describe('/components/accordion', () => {
         })
 
         it('should localise "Hide section" aria-label based on JavaScript configuration', async () => {
-          await goToExample(page, 'translated')
+          const page = await goToExample(browser, 'translated')
           await page.click(
             '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
           )

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -1,4 +1,4 @@
-const { goToComponent, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('/components/button', () => {
@@ -16,9 +16,7 @@ describe('/components/button', () => {
 
   describe('/components/button/link', () => {
     beforeAll(async () => {
-      await goToComponent(page, 'button', {
-        exampleName: 'link'
-      })
+      await render(page, 'button', examples.link)
     })
 
     it('triggers the click event when the space key is pressed', async () => {
@@ -97,8 +95,7 @@ describe('/components/button', () => {
       let $button
 
       beforeEach(async () => {
-        await goToComponent(page, 'button')
-
+        await render(page, 'button', examples.default)
         $button = await setButtonTracking(await page.$('button'))
       })
 
@@ -118,10 +115,7 @@ describe('/components/button', () => {
       let $button
 
       beforeEach(async () => {
-        await goToComponent(page, 'button', {
-          exampleName: 'prevent-double-click'
-        })
-
+        await render(page, 'button', examples['prevent double click'])
         $button = await setButtonTracking(await page.$('button'))
       })
 

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -1,4 +1,4 @@
-const { goToComponent, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Character count', () => {
@@ -25,7 +25,8 @@ describe('Character count', () => {
     })
 
     it('shows the textarea description', async () => {
-      await goToComponent(page, 'character-count')
+      await render(page, 'character-count', examples.default)
+
       const message = await page.$eval(
         '.govuk-character-count__message',
         (el) => el.innerHTML.trim()
@@ -38,7 +39,7 @@ describe('Character count', () => {
   describe('when JavaScript is available', () => {
     describe('on page load', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'character-count')
+        await render(page, 'character-count', examples.default)
       })
 
       it('injects the visual counter', async () => {
@@ -64,7 +65,7 @@ describe('Character count', () => {
 
     describe('when counting characters', () => {
       it('shows the dynamic message', async () => {
-        await goToComponent(page, 'character-count')
+        await render(page, 'character-count', examples.default)
 
         const message = await page.$eval(
           '.govuk-character-count__status',
@@ -80,9 +81,7 @@ describe('Character count', () => {
       })
 
       it('shows the characters remaining if the field is pre-filled', async () => {
-        await goToComponent(page, 'character-count', {
-          exampleName: 'with-default-value'
-        })
+        await render(page, 'character-count', examples['with default value'])
 
         const message = await page.$eval(
           '.govuk-character-count__status',
@@ -98,7 +97,7 @@ describe('Character count', () => {
       })
 
       it('counts down to the character limit', async () => {
-        await goToComponent(page, 'character-count')
+        await render(page, 'character-count', examples.default)
 
         await page.type('.govuk-js-character-count', 'A', {
           delay: 50
@@ -121,7 +120,7 @@ describe('Character count', () => {
       })
 
       it('uses the singular when there is only one character remaining', async () => {
-        await goToComponent(page, 'character-count')
+        await render(page, 'character-count', examples.default)
 
         await page.type('.govuk-js-character-count', 'A'.repeat(9), {
           delay: 50
@@ -145,7 +144,7 @@ describe('Character count', () => {
 
       describe('when the character limit is exceeded', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count')
+          await render(page, 'character-count', examples.default)
 
           await page.type('.govuk-js-character-count', 'A'.repeat(11), {
             delay: 50
@@ -209,9 +208,11 @@ describe('Character count', () => {
 
       describe('when the character limit is exceeded on page load', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-default-value-exceeding-limit'
-          })
+          await render(
+            page,
+            'character-count',
+            examples['with default value exceeding limit']
+          )
         })
 
         it('shows the number of characters over the limit', async () => {
@@ -247,9 +248,7 @@ describe('Character count', () => {
 
       describe('when a threshold is set', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-threshold'
-          })
+          await render(page, 'character-count', examples['with threshold'])
         })
 
         it('does not show the limit until the threshold is reached', async () => {
@@ -296,9 +295,11 @@ describe('Character count', () => {
       // Errors logged to the console will cause these tests to fail
       describe('when the textarea ID starts with a number', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-id-starting-with-number'
-          })
+          await render(
+            page,
+            'character-count',
+            examples['with id starting with number']
+          )
         })
 
         it('still works correctly', async () => {
@@ -318,9 +319,11 @@ describe('Character count', () => {
 
       describe('when the textarea ID contains CSS syntax characters', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-id-with-special-characters'
-          })
+          await render(
+            page,
+            'character-count',
+            examples['with id with special characters']
+          )
         })
 
         it('still works correctly', async () => {
@@ -340,9 +343,11 @@ describe('Character count', () => {
 
       describe('when a maxlength attribute is specified on the textarea', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-textarea-maxlength-attribute'
-          })
+          await render(
+            page,
+            'character-count',
+            examples['with textarea maxlength attribute']
+          )
         })
 
         it('should not have a maxlength attribute once the JS has run', async () => {
@@ -356,9 +361,7 @@ describe('Character count', () => {
 
     describe('when counting words', () => {
       it('shows the dynamic message', async () => {
-        await goToComponent(page, 'character-count', {
-          exampleName: 'with-word-count'
-        })
+        await render(page, 'character-count', examples['with word count'])
 
         const message = await page.$eval(
           '.govuk-character-count__status',
@@ -374,9 +377,7 @@ describe('Character count', () => {
       })
 
       it('counts down to the word limit', async () => {
-        await goToComponent(page, 'character-count', {
-          exampleName: 'with-word-count'
-        })
+        await render(page, 'character-count', examples['with word count'])
 
         await page.type('.govuk-js-character-count', 'Hello world', {
           delay: 50
@@ -399,9 +400,7 @@ describe('Character count', () => {
       })
 
       it('uses the singular when there is only one word remaining', async () => {
-        await goToComponent(page, 'character-count', {
-          exampleName: 'with-word-count'
-        })
+        await render(page, 'character-count', examples['with word count'])
 
         await page.type('.govuk-js-character-count', 'Hello '.repeat(9), {
           delay: 50
@@ -414,7 +413,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 1 word remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+        await setTimeout(debouncedWaitTime)
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
@@ -425,9 +424,7 @@ describe('Character count', () => {
 
       describe('when the word limit is exceeded', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'character-count', {
-            exampleName: 'with-word-count'
-          })
+          await render(page, 'character-count', examples['with word count'])
 
           await page.type('.govuk-js-character-count', 'Hello '.repeat(11), {
             delay: 50

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -1,3 +1,5 @@
+const { setTimeout } = require('timers/promises')
+
 const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -110,7 +112,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 9 characters remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+        await setTimeout(debouncedWaitTime)
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
@@ -133,7 +135,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 1 character remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+        await setTimeout(debouncedWaitTime)
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
@@ -159,7 +161,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 character too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
@@ -180,7 +182,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 2 characters too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
@@ -259,7 +261,7 @@ describe('Character count', () => {
           expect(visibility).toEqual('hidden')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           // Ensure threshold is hidden for users of assistive technologies
           const ariaHidden = await page.$eval(
@@ -281,7 +283,7 @@ describe('Character count', () => {
           expect(visibility).toEqual('visible')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           // Ensure threshold is visible for users of assistive technologies
           const ariaHidden = await page.$eval(
@@ -390,7 +392,7 @@ describe('Character count', () => {
         expect(message).toEqual('You have 8 words remaining')
 
         // Wait for debounced update to happen
-        await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+        await setTimeout(debouncedWaitTime)
 
         const srMessage = await page.$eval(
           '.govuk-character-count__sr-status',
@@ -439,7 +441,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 1 word too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',
@@ -460,7 +462,7 @@ describe('Character count', () => {
           expect(message).toEqual('You have 2 words too many')
 
           // Wait for debounced update to happen
-          await new Promise((resolve) => setTimeout(resolve, debouncedWaitTime))
+          await setTimeout(debouncedWaitTime)
 
           const srMessage = await page.$eval(
             '.govuk-character-count__sr-status',

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToComponent,
   goToExample,
   getAttribute,
   getProperty,
@@ -9,6 +8,12 @@ const {
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Checkboxes with conditional reveals', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('checkboxes')
+  })
+
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
@@ -24,9 +29,7 @@ describe('Checkboxes with conditional reveals', () => {
       let $conditionals
 
       beforeAll(async () => {
-        await goToComponent(page, 'checkboxes', {
-          exampleName: 'with-conditional-items'
-        })
+        await render(page, 'checkboxes', examples['with conditional items'])
 
         $component = await page.$('.govuk-checkboxes')
         $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -64,9 +67,11 @@ describe('Checkboxes with conditional reveals', () => {
       let $inputs
 
       beforeAll(async () => {
-        await goToComponent(page, 'checkboxes', {
-          exampleName: 'with-conditional-item-checked'
-        })
+        await render(
+          page,
+          'checkboxes',
+          examples['with conditional item checked']
+        )
 
         $component = await page.$('.govuk-checkboxes')
         $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -98,9 +103,7 @@ describe('Checkboxes with conditional reveals', () => {
       let $inputs
 
       beforeEach(async () => {
-        await goToComponent(page, 'checkboxes', {
-          exampleName: 'with-conditional-items'
-        })
+        await render(page, 'checkboxes', examples['with conditional items'])
 
         $component = await page.$('.govuk-checkboxes')
         $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -177,23 +180,29 @@ describe('Checkboxes with conditional reveals', () => {
     describe('with conditional items with special characters', () => {
       it('does not error when ID of revealed content contains special characters', async () => {
         // Errors logged to the console will cause this test to fail
-        await goToComponent(page, 'checkboxes', {
-          exampleName: 'with-conditional-items-with-special-characters'
-        })
+        await render(
+          page,
+          'checkboxes',
+          examples['with conditional items with special characters']
+        )
       })
     })
   })
 })
 
 describe('Checkboxes with a "None" checkbox', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('checkboxes')
+  })
+
   describe('when JavaScript is available', () => {
     let $component
     let $inputs
 
     beforeEach(async () => {
-      await goToComponent(page, 'checkboxes', {
-        exampleName: 'with-divider-and-None'
-      })
+      await render(page, 'checkboxes', examples['with divider and None'])
 
       $component = await page.$('.govuk-checkboxes')
       $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -228,14 +237,22 @@ describe('Checkboxes with a "None" checkbox', () => {
 })
 
 describe('Checkboxes with a "None" checkbox and conditional reveals', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('checkboxes')
+  })
+
   describe('when JavaScript is available', () => {
     let $component
     let $inputs
 
     beforeEach(async () => {
-      await goToComponent(page, 'checkboxes', {
-        exampleName: 'with-divider,-None-and-conditional-items'
-      })
+      await render(
+        page,
+        'checkboxes',
+        examples['with divider, None and conditional items']
+      )
 
       $component = await page.$('.govuk-checkboxes')
       $inputs = await $component.$$('.govuk-checkboxes__input')
@@ -266,6 +283,12 @@ describe('Checkboxes with a "None" checkbox and conditional reveals', () => {
 })
 
 describe('Checkboxes with multiple groups and a "None" checkbox and conditional reveals', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('checkboxes')
+  })
+
   describe('when JavaScript is available', () => {
     let $inputsPrimary
     let $inputsSecondary
@@ -320,12 +343,6 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
     })
 
     describe('errors at instantiation', () => {
-      let examples
-
-      beforeAll(async () => {
-        examples = await getExamples('checkboxes')
-      })
-
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
           render(page, 'checkboxes', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -290,12 +290,15 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
   })
 
   describe('when JavaScript is available', () => {
+    /** @type {globalThis.page} */
+    let page
+
     let $inputsPrimary
     let $inputsSecondary
     let $inputsOther
 
     beforeEach(async () => {
-      await goToExample(page, 'conditional-reveals')
+      page = await goToExample(browser, 'conditional-reveals')
 
       $inputsPrimary = await page.$$(
         '.govuk-checkboxes__input[id^="colour-primary"]'

--- a/packages/govuk-frontend/src/govuk/components/components.template.test.js
+++ b/packages/govuk-frontend/src/govuk/components/components.template.test.js
@@ -64,22 +64,23 @@ describe('Components', () => {
 
       // Validate component examples
       for (const { component: componentName, fixtures } of componentsFixtures) {
-        const fixtureTasks = fixtures.map(
-          async ({ name: exampleName, options }) => {
-            const html = render(componentName, { context: options })
+        const fixtureTasks = fixtures.map(async (fixture) => {
+          const html = render(componentName, {
+            context: fixture.options,
+            fixture
+          })
 
-            // Validate HTML
-            return expect({
-              componentName,
-              exampleName,
-              report: await validator.validateString(html)
-            }).toEqual({
-              componentName,
-              exampleName,
-              report: expect.objectContaining({ valid: true })
-            })
-          }
-        )
+          // Validate HTML
+          return expect({
+            componentName,
+            exampleName: fixture.name,
+            report: await validator.validateString(html)
+          }).toEqual({
+            componentName,
+            exampleName: fixture.name,
+            report: expect.objectContaining({ valid: true })
+          })
+        })
 
         // Validate all component examples in parallel
         await Promise.all(fixtureTasks)

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -1,8 +1,4 @@
-const {
-  goToComponent,
-  goToExample,
-  render
-} = require('@govuk-frontend/helpers/puppeteer')
+const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Error Summary', () => {
@@ -13,23 +9,28 @@ describe('Error Summary', () => {
   })
 
   it('adds the tabindex attribute on page load', async () => {
-    await goToComponent(page, 'error-summary')
+    await render(page, 'error-summary', examples.default)
+
     const tabindex = await page.$eval('.govuk-error-summary', (el) =>
       el.getAttribute('tabindex')
     )
+
     expect(tabindex).toEqual('-1')
   })
 
   it('is automatically focused when the page loads', async () => {
-    await goToComponent(page, 'error-summary')
+    await render(page, 'error-summary', examples.default)
+
     const moduleName = await page.evaluate(() =>
       document.activeElement.getAttribute('data-module')
     )
+
     expect(moduleName).toBe('govuk-error-summary')
   })
 
   it('removes the tabindex attribute on blur', async () => {
-    await goToComponent(page, 'error-summary')
+    await render(page, 'error-summary', examples.default)
+
     await page.$eval(
       '.govuk-error-summary',
       (el) => el instanceof window.HTMLElement && el.blur()
@@ -38,15 +39,14 @@ describe('Error Summary', () => {
     const tabindex = await page.$eval('.govuk-error-summary', (el) =>
       el.getAttribute('tabindex')
     )
+
     expect(tabindex).toBeNull()
   })
 
   describe('when auto-focus is disabled', () => {
     describe('using data-attributes', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'error-summary', {
-          exampleName: 'autofocus-disabled'
-        })
+        await render(page, 'error-summary', examples['autofocus disabled'])
       })
 
       it('does not have a tabindex attribute', async () => {

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -180,8 +180,11 @@ describe('Error Summary', () => {
   describe.each(inputTypes)(
     'when linking to %s',
     (_, inputId, legendOrLabelSelector) => {
+      /** @type {globalThis.page} */
+      let page
+
       beforeAll(async () => {
-        await goToExample(page, 'error-summary')
+        page = await goToExample(browser, 'error-summary')
         await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
       })
 

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -1,8 +1,4 @@
-const {
-  goToComponent,
-  goToExample,
-  render
-} = require('@govuk-frontend/helpers/puppeteer')
+const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 const buttonClass = '.govuk-js-exit-this-page-button'
@@ -10,6 +6,12 @@ const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
 const overlayClass = '.govuk-exit-this-page-overlay'
 
 describe('/components/exit-this-page', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('exit-this-page')
+  })
+
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
@@ -20,7 +22,7 @@ describe('/components/exit-this-page', () => {
     })
 
     it('navigates to the href of the button', async () => {
-      await goToComponent(page, 'exit-this-page')
+      await render(page, 'exit-this-page', examples.default)
 
       const pathname = await page.$eval(buttonClass, (el) =>
         el.getAttribute('href')
@@ -29,6 +31,7 @@ describe('/components/exit-this-page', () => {
       await Promise.all([page.waitForNavigation(), page.click(buttonClass)])
 
       const url = new URL(await page.url())
+
       expect(url.pathname).toBe(pathname)
     })
 
@@ -52,7 +55,7 @@ describe('/components/exit-this-page', () => {
 
   describe('when JavaScript is available', () => {
     it('navigates to the href of the button', async () => {
-      await goToComponent(page, 'exit-this-page')
+      await render(page, 'exit-this-page', examples.default)
 
       const pathname = await page.$eval(buttonClass, (el) =>
         el.getAttribute('href')
@@ -117,7 +120,7 @@ describe('/components/exit-this-page', () => {
 
     describe('keyboard shortcut activation', () => {
       it('activates the button functionality when the Shift key is pressed 3 times', async () => {
-        await goToComponent(page, 'exit-this-page')
+        await render(page, 'exit-this-page', examples.default)
 
         const pathname = await page.$eval(buttonClass, (el) =>
           el.getAttribute('href')
@@ -135,7 +138,7 @@ describe('/components/exit-this-page', () => {
       })
 
       it('announces when the Shift key has been pressed once', async () => {
-        await goToComponent(page, 'exit-this-page')
+        await render(page, 'exit-this-page', examples.default)
 
         await page.keyboard.press('Shift')
 
@@ -146,7 +149,7 @@ describe('/components/exit-this-page', () => {
       })
 
       it('announces when the Shift key has been pressed twice', async () => {
-        await goToComponent(page, 'exit-this-page')
+        await render(page, 'exit-this-page', examples.default)
 
         await page.keyboard.press('Shift')
         await page.keyboard.press('Shift')
@@ -158,7 +161,7 @@ describe('/components/exit-this-page', () => {
       })
 
       it('announces when the keyboard shortcut has been successfully activated', async () => {
-        await goToComponent(page, 'exit-this-page')
+        await render(page, 'exit-this-page', examples.default)
 
         // Make the button not navigate away from the current page
         await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
@@ -174,7 +177,7 @@ describe('/components/exit-this-page', () => {
       })
 
       it('announces when the keyboard shortcut has timed out', async () => {
-        await goToComponent(page, 'exit-this-page')
+        await render(page, 'exit-this-page', examples.default)
 
         await page.keyboard.press('Shift')
 
@@ -189,12 +192,6 @@ describe('/components/exit-this-page', () => {
     })
 
     describe('errors at instantiation', () => {
-      let examples
-
-      beforeAll(async () => {
-        examples = await getExamples('exit-this-page')
-      })
-
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -1,3 +1,5 @@
+const { setTimeout } = require('timers/promises')
+
 const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
@@ -182,7 +184,7 @@ describe('/components/exit-this-page', () => {
         await page.keyboard.press('Shift')
 
         // Wait for 6 seconds (one full second over the 5 second limit)
-        await new Promise((resolve) => setTimeout(resolve, 6000))
+        await setTimeout(6000)
 
         const message = await page.$eval(buttonClass, (el) =>
           el.nextElementSibling.innerHTML.trim()

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -26,23 +26,30 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the button', async () => {
       await render(page, 'exit-this-page', examples.default)
 
-      const pathname = await page.$eval(buttonClass, (el) =>
-        el.getAttribute('href')
+      const exitPageURL = await page
+        .$eval(buttonClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
+
+      await page.setRequestInterception(true)
+
+      // Mock page navigation
+      page.once('request', (request) =>
+        request.respond({ body: 'Mock response' })
       )
 
-      await Promise.all([page.waitForNavigation(), page.click(buttonClass)])
+      // Click button, check URL
+      await page.click(buttonClass)
+      expect(page.url()).toBe(exitPageURL.href)
 
-      const url = new URL(await page.url())
-
-      expect(url.pathname).toBe(pathname)
+      await page.setRequestInterception(false)
     })
 
     it('navigates to the href of the skiplink', async () => {
       await goToExample(page, 'exit-this-page-with-skiplink')
 
-      const href = await page.$eval(skiplinkClass, (el) =>
-        el.getAttribute('href')
-      )
+      const exitPageURL = await page
+        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
 
       await Promise.all([
         page.waitForNavigation(),
@@ -50,8 +57,7 @@ describe('/components/exit-this-page', () => {
         page.click(skiplinkClass)
       ])
 
-      const url = await page.url()
-      expect(url).toBe(href)
+      expect(page.url()).toBe(exitPageURL.href)
     })
   })
 
@@ -59,22 +65,30 @@ describe('/components/exit-this-page', () => {
     it('navigates to the href of the button', async () => {
       await render(page, 'exit-this-page', examples.default)
 
-      const pathname = await page.$eval(buttonClass, (el) =>
-        el.getAttribute('href')
+      const exitPageURL = await page
+        .$eval(buttonClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
+
+      await page.setRequestInterception(true)
+
+      // Mock page navigation
+      page.once('request', (request) =>
+        request.respond({ body: 'Mock response' })
       )
 
-      await Promise.all([page.waitForNavigation(), page.click(buttonClass)])
+      // Click button, check URL
+      await page.click(buttonClass)
+      expect(page.url()).toBe(exitPageURL.href)
 
-      const url = new URL(await page.url())
-      expect(url.pathname).toBe(pathname)
+      await page.setRequestInterception(false)
     })
 
     it('navigates to the href of the skiplink', async () => {
       await goToExample(page, 'exit-this-page-with-skiplink')
 
-      const href = await page.$eval(skiplinkClass, (el) =>
-        el.getAttribute('href')
-      )
+      const exitPageURL = await page
+        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
 
       await Promise.all([
         page.waitForNavigation(),
@@ -82,8 +96,7 @@ describe('/components/exit-this-page', () => {
         page.click(skiplinkClass)
       ])
 
-      const url = await page.url()
-      expect(url).toBe(href)
+      expect(page.url()).toBe(exitPageURL.href)
     })
 
     it('shows the ghost page when the EtP button is clicked', async () => {
@@ -124,8 +137,15 @@ describe('/components/exit-this-page', () => {
       it('activates the button functionality when the Shift key is pressed 3 times', async () => {
         await render(page, 'exit-this-page', examples.default)
 
-        const pathname = await page.$eval(buttonClass, (el) =>
-          el.getAttribute('href')
+        const exitPageURL = await page
+          .$eval(buttonClass, (el) => el.getAttribute('href'))
+          .then((path) => new URL(path, 'file://'))
+
+        await page.setRequestInterception(true)
+
+        // Mock page navigation
+        page.once('request', (request) =>
+          request.respond({ body: 'Mock response' })
         )
 
         await Promise.all([
@@ -135,8 +155,9 @@ describe('/components/exit-this-page', () => {
           page.waitForNavigation()
         ])
 
-        const url = new URL(await page.url())
-        expect(url.pathname).toBe(pathname)
+        expect(page.url()).toBe(exitPageURL.href)
+
+        await page.setRequestInterception(false)
       })
 
       it('announces when the Shift key has been pressed once', async () => {

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -45,7 +45,7 @@ describe('/components/exit-this-page', () => {
     })
 
     it('navigates to the href of the skiplink', async () => {
-      await goToExample(page, 'exit-this-page-with-skiplink')
+      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
 
       const exitPageURL = await page
         .$eval(skiplinkClass, (el) => el.getAttribute('href'))
@@ -84,7 +84,7 @@ describe('/components/exit-this-page', () => {
     })
 
     it('navigates to the href of the skiplink', async () => {
-      await goToExample(page, 'exit-this-page-with-skiplink')
+      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
 
       const exitPageURL = await page
         .$eval(skiplinkClass, (el) => el.getAttribute('href'))
@@ -100,7 +100,7 @@ describe('/components/exit-this-page', () => {
     })
 
     it('shows the ghost page when the EtP button is clicked', async () => {
-      await goToExample(page, 'exit-this-page-with-skiplink')
+      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
 
       // Stop the button from navigating away from the current page as a workaround
       // to puppeteer struggling to return to previous pages after navigation reliably
@@ -115,7 +115,7 @@ describe('/components/exit-this-page', () => {
     })
 
     it('shows the ghost page when the skiplink is clicked', async () => {
-      await goToExample(page, 'exit-this-page-with-skiplink')
+      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
 
       // Stop the button from navigating away from the current page as a workaround
       // to puppeteer struggling to return to previous pages after navigation reliably

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -1,28 +1,27 @@
-const { goTo, goToExample } = require('@govuk-frontend/helpers/puppeteer')
+const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
+const { scriptsPath } = require('@govuk-frontend/lib/components')
 
 describe('GOV.UK Frontend', () => {
   describe('JavaScript', () => {
     let exported
 
     beforeEach(async () => {
-      await goTo(page, '/')
+      await render(page)
 
       // Exports available via browser dynamic import
       exported = await page.evaluate(
         async (importPath) => Object.keys(await import(importPath)),
-        '/javascripts/govuk-frontend.min.js'
+        scriptsPath.href
       )
     })
 
     it('exports `initAll` function', async () => {
-      await goTo(page, '/')
-
       const typeofInitAll = await page.evaluate(
         async (importPath, exportName) => {
           const namespace = await import(importPath)
           return typeof namespace[exportName]
         },
-        '/javascripts/govuk-frontend.min.js',
+        scriptsPath.href,
         'initAll'
       )
 

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -50,7 +50,7 @@ describe('GOV.UK Frontend', () => {
     })
 
     it('can be initialised scoped to certain sections of the page', async () => {
-      await goToExample(page, 'scoped-initialisation')
+      const page = await goToExample(browser, 'scoped-initialisation')
 
       // To test that certain parts of the page are scoped we have two similar components
       // that we can interact with to check if they're interactive.

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -1,10 +1,16 @@
-const { goToComponent, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']
 
 describe('Header navigation', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('header')
+  })
+
   beforeAll(async () => {
     await page.emulate(iPhone)
   })
@@ -12,10 +18,7 @@ describe('Header navigation', () => {
   describe('when JavaScript is unavailable or fails', () => {
     beforeAll(async () => {
       await page.setJavaScriptEnabled(false)
-
-      await goToComponent(page, 'header', {
-        exampleName: 'with-navigation'
-      })
+      await render(page, 'header', examples['with navigation'])
     })
 
     afterAll(async () => {
@@ -44,15 +47,13 @@ describe('Header navigation', () => {
     describe('when no navigation is present', () => {
       it('exits gracefully with no errors', async () => {
         // Errors logged to the console will cause this test to fail
-        await goToComponent(page, 'header')
+        await render(page, 'header', examples.default)
       })
     })
 
     describe('on page load', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'header', {
-          exampleName: 'with-navigation'
-        })
+        await render(page, 'header', examples['with navigation'])
       })
 
       it('reveals the menu button', async () => {
@@ -96,9 +97,7 @@ describe('Header navigation', () => {
 
     describe('when menu button is pressed', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'header', {
-          exampleName: 'with-navigation'
-        })
+        await render(page, 'header', examples['with navigation'])
 
         await page.waitForSelector('.govuk-js-header-toggle')
         await page.click('.govuk-js-header-toggle')
@@ -131,9 +130,7 @@ describe('Header navigation', () => {
 
     describe('when menu button is pressed twice', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'header', {
-          exampleName: 'with-navigation'
-        })
+        await render(page, 'header', examples['with navigation'])
 
         await page.waitForSelector('.govuk-js-header-toggle')
         await page.click('.govuk-js-header-toggle')
@@ -166,12 +163,6 @@ describe('Header navigation', () => {
     })
 
     describe('errors at instantiation', () => {
-      let examples
-
-      beforeAll(async () => {
-        examples = await getExamples('header')
-      })
-
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
           render(page, 'header', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -1,4 +1,4 @@
-const { render, goToComponent } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Notification banner', () => {
@@ -10,9 +10,11 @@ describe('Notification banner', () => {
 
   describe('when type is set to "success"', () => {
     it('has the correct tabindex attribute to be focused with JavaScript', async () => {
-      await goToComponent(page, 'notification-banner', {
-        exampleName: 'with-type-as-success'
-      })
+      await render(
+        page,
+        'notification-banner',
+        examples['with type as success']
+      )
 
       const tabindex = await page.$eval('.govuk-notification-banner', (el) =>
         el.getAttribute('tabindex')
@@ -22,9 +24,11 @@ describe('Notification banner', () => {
     })
 
     it('is automatically focused when the page loads', async () => {
-      await goToComponent(page, 'notification-banner', {
-        exampleName: 'with-type-as-success'
-      })
+      await render(
+        page,
+        'notification-banner',
+        examples['with type as success']
+      )
 
       const activeElement = await page.evaluate(() =>
         document.activeElement.getAttribute('data-module')
@@ -34,9 +38,11 @@ describe('Notification banner', () => {
     })
 
     it('removes the tabindex attribute on blur', async () => {
-      await goToComponent(page, 'notification-banner', {
-        exampleName: 'with-type-as-success'
-      })
+      await render(
+        page,
+        'notification-banner',
+        examples['with type as success']
+      )
 
       await page.$eval(
         '.govuk-notification-banner',
@@ -51,9 +57,11 @@ describe('Notification banner', () => {
 
     describe('and auto-focus is disabled using data attributes', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'notification-banner', {
-          exampleName: 'auto-focus-disabled,-with-type-as-success'
-        })
+        await render(
+          page,
+          'notification-banner',
+          examples['auto-focus disabled, with type as success']
+        )
       })
 
       it('does not have a tabindex attribute', async () => {
@@ -168,10 +176,11 @@ describe('Notification banner', () => {
 
     describe('and role is overridden to "region"', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'notification-banner', {
-          exampleName:
-            'role=alert-overridden-to-role=region,-with-type-as-success'
-        })
+        await render(
+          page,
+          'notification-banner',
+          examples['role=alert overridden to role=region, with type as success']
+        )
       })
 
       it('does not have a tabindex attribute', async () => {
@@ -193,9 +202,7 @@ describe('Notification banner', () => {
 
     describe('and a custom tabindex is set', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'notification-banner', {
-          exampleName: 'custom-tabindex'
-        })
+        await render(page, 'notification-banner', examples['custom tabindex'])
       })
 
       it('does not remove the tabindex attribute on blur', async () => {

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToComponent,
   goToExample,
   getProperty,
   getAttribute,
@@ -9,6 +8,12 @@ const {
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Radios', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('radios')
+  })
+
   describe('with conditional reveals', () => {
     describe('when JavaScript is unavailable or fails', () => {
       beforeAll(async () => {
@@ -25,9 +30,7 @@ describe('Radios', () => {
         let $conditionals
 
         beforeAll(async () => {
-          await goToComponent(page, 'radios', {
-            exampleName: 'with-conditional-items'
-          })
+          await render(page, 'radios', examples['with conditional items'])
 
           $component = await page.$('.govuk-radios')
           $inputs = await $component.$$('.govuk-radios__input')
@@ -65,9 +68,11 @@ describe('Radios', () => {
         let $inputs
 
         beforeEach(async () => {
-          await goToComponent(page, 'radios', {
-            exampleName: 'with-conditional-item-checked'
-          })
+          await render(
+            page,
+            'radios',
+            examples['with conditional item checked']
+          )
 
           $component = await page.$('.govuk-radios')
           $inputs = await $component.$$('.govuk-radios__input')
@@ -99,9 +104,7 @@ describe('Radios', () => {
         let $inputs
 
         beforeEach(async () => {
-          await goToComponent(page, 'radios', {
-            exampleName: 'with-conditional-items'
-          })
+          await render(page, 'radios', examples['with conditional items'])
 
           $component = await page.$('.govuk-radios')
           $inputs = await $component.$$('.govuk-radios__input')
@@ -178,9 +181,11 @@ describe('Radios', () => {
       describe('with conditional items with special characters', () => {
         it('does not error when ID of revealed content contains special characters', async () => {
           // Errors logged to the console will cause this test to fail
-          await goToComponent(page, 'radios', {
-            exampleName: 'with-conditional-items-with-special-characters'
-          })
+          await render(
+            page,
+            'radios',
+            examples['with conditional items with special characters']
+          )
         })
       })
     })
@@ -271,12 +276,6 @@ describe('Radios', () => {
   })
 
   describe('errors at instantiation', () => {
-    let examples
-
-    beforeAll(async () => {
-      examples = await getExamples('radios')
-    })
-
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
         render(page, 'radios', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -193,12 +193,15 @@ describe('Radios', () => {
 
   describe('with multiple groups', () => {
     describe('when JavaScript is available', () => {
+      /** @type {globalThis.page} */
+      let page
+
       let $inputsWarm
       let $inputsCool
       let $inputsNotInForm
 
       beforeEach(async () => {
-        await goToExample(page, 'multiple-radio-groups')
+        page = await goToExample(browser, 'multiple-radio-groups')
 
         $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
         $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
@@ -243,11 +246,14 @@ describe('Radios', () => {
 
   describe('with multiple groups and conditional reveals', () => {
     describe('when JavaScript is available', () => {
+      /** @type {globalThis.page} */
+      let page
+
       let $inputsPrimary
       let $inputsOther
 
       beforeEach(async () => {
-        await goToExample(page, 'conditional-reveals')
+        page = await goToExample(browser, 'conditional-reveals')
 
         $inputsPrimary = await page.$$(
           '.govuk-radios__input[id^="fave-primary"]'

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -16,9 +16,11 @@ describe('Skip Link', () => {
     })
 
     it('focuses the linked element', async () => {
-      const activeElement = await page.evaluate(() => document.activeElement.id)
+      const activeElementId = await page.evaluate(
+        () => document.activeElement.id
+      )
 
-      expect(activeElement).toBe('main-content')
+      expect(activeElementId).toBe('content')
     })
 
     it('adds the tabindex attribute to the linked element', async () => {

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -24,7 +24,7 @@ describe('Skip Link', () => {
     })
 
     it('adds the tabindex attribute to the linked element', async () => {
-      const tabindex = await page.$eval('.govuk-main-wrapper', (el) =>
+      const tabindex = await page.$eval('#content', (el) =>
         el.getAttribute('tabindex')
       )
 
@@ -32,7 +32,7 @@ describe('Skip Link', () => {
     })
 
     it('adds the class for removing the native focus style to the linked element', async () => {
-      const cssClass = await page.$eval('.govuk-main-wrapper', (el) =>
+      const cssClass = await page.$eval('#content', (el) =>
         el.classList.contains('govuk-skip-link-focused-element')
       )
 
@@ -41,11 +41,11 @@ describe('Skip Link', () => {
 
     it('removes the tabindex attribute from the linked element on blur', async () => {
       await page.$eval(
-        '.govuk-main-wrapper',
+        '#content',
         (el) => el instanceof window.HTMLElement && el.blur()
       )
 
-      const tabindex = await page.$eval('.govuk-main-wrapper', (el) =>
+      const tabindex = await page.$eval('#content', (el) =>
         el.getAttribute('tabindex')
       )
 
@@ -54,11 +54,11 @@ describe('Skip Link', () => {
 
     it('removes the class for removing the native focus style from the linked element on blur', async () => {
       await page.$eval(
-        '.govuk-main-wrapper',
+        '#content',
         (el) => el instanceof window.HTMLElement && el.blur()
       )
 
-      const cssClass = await page.$eval('.govuk-main-wrapper', (el) =>
+      const cssClass = await page.$eval('#content', (el) =>
         el.getAttribute('class')
       )
 

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -1,10 +1,16 @@
-const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Skip Link', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('skip-link')
+  })
+
   describe('/examples/template-default', () => {
     beforeAll(async () => {
-      await goToExample(page, 'template-default')
+      await render(page, 'skip-link', examples.default)
       await page.keyboard.press('Tab')
       await page.keyboard.press('Enter')
     })
@@ -59,12 +65,6 @@ describe('Skip Link', () => {
   })
 
   describe('errors at instantiation', () => {
-    let examples
-
-    beforeAll(async () => {
-      examples = await getExamples('skip-link')
-    })
-
     it('throws when GOV.UK Frontend is not supported', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -1,19 +1,21 @@
-const {
-  goTo,
-  goToComponent,
-  render
-} = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 const { KnownDevices } = require('puppeteer')
 
 const iPhone = KnownDevices['iPhone 6']
 
 describe('/components/tabs', () => {
+  let examples
+
+  beforeAll(async () => {
+    examples = await getExamples('tabs')
+  })
+
   describe('/components/tabs/preview', () => {
     describe('when JavaScript is unavailable or fails', () => {
       beforeAll(async () => {
         await page.setJavaScriptEnabled(false)
-        await goToComponent(page, 'tabs')
+        await render(page, 'tabs', examples.default)
       })
 
       afterAll(async () => {
@@ -31,7 +33,7 @@ describe('/components/tabs', () => {
 
     describe('when JavaScript is available', () => {
       beforeAll(async () => {
-        await goToComponent(page, 'tabs')
+        await render(page, 'tabs', examples.default)
       })
 
       it('should indicate the open state of the first tab', async () => {
@@ -75,7 +77,7 @@ describe('/components/tabs', () => {
 
     describe('when a tab is pressed', () => {
       beforeEach(async () => {
-        await goToComponent(page, 'tabs')
+        await render(page, 'tabs', examples.default)
       })
 
       it('should indicate the open state of the pressed tab', async () => {
@@ -118,7 +120,7 @@ describe('/components/tabs', () => {
 
       describe('when the tab contains a DOM element', () => {
         beforeAll(async () => {
-          await goToComponent(page, 'tabs')
+          await render(page, 'tabs', examples.default)
         })
 
         it('should display the tab panel associated with the selected tab', async () => {
@@ -152,7 +154,7 @@ describe('/components/tabs', () => {
 
     describe('when first tab is focused and the right arrow key is pressed', () => {
       beforeEach(async () => {
-        await goToComponent(page, 'tabs')
+        await render(page, 'tabs', examples.default)
       })
 
       it('should indicate the open state of the next tab', async () => {
@@ -198,7 +200,11 @@ describe('/components/tabs', () => {
 
     describe('when a hash associated with a tab panel is passed in the URL', () => {
       it('should indicate the open state of the associated tab', async () => {
-        await goTo(page, '/components/tabs/preview/#past-week')
+        await render(page, 'tabs', examples.default)
+
+        await page.evaluate(() => {
+          window.location.hash = '#past-week'
+        })
 
         const currentTabAriaSelected = await page.evaluate(() =>
           document.body
@@ -223,9 +229,7 @@ describe('/components/tabs', () => {
       })
 
       it('should only update based on hashes that are tabs', async () => {
-        await goToComponent(page, 'tabs', {
-          exampleName: 'tabs-with-anchor-in-panel'
-        })
+        await render(page, 'tabs', examples['tabs-with-anchor-in-panel'])
 
         await page.click('[href="#anchor"]')
 
@@ -239,7 +243,7 @@ describe('/components/tabs', () => {
     describe('when rendered on a small device', () => {
       it('falls back to making the all tab containers visible', async () => {
         await page.emulate(iPhone)
-        await goToComponent(page, 'tabs')
+        await render(page, 'tabs', examples.default)
         const isContentVisible = await page.waitForSelector(
           '.govuk-tabs__panel',
           { visible: true, timeout: 10000 }
@@ -249,12 +253,6 @@ describe('/components/tabs', () => {
     })
 
     describe('errors at instantiation', () => {
-      let examples
-
-      beforeAll(async () => {
-        examples = await getExamples('tabs')
-      })
-
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(
           render(page, 'tabs', examples.default, {

--- a/shared/helpers/puppeteer.js
+++ b/shared/helpers/puppeteer.js
@@ -257,26 +257,26 @@ async function goTo(page, path, options) {
 /**
  * Navigate to example
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {import('puppeteer').Browser} browser - Puppeteer browser object
  * @param {string} exampleName - Example name
  * @param {object} [options] - Navigation options
  * @param {URL} [options.baseURL] - Base URL to override
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-function goToExample(page, exampleName, options) {
-  return goTo(page, `/examples/${exampleName}`, options)
+async function goToExample(browser, exampleName, options) {
+  return goTo(await browser.newPage(), `/examples/${exampleName}`, options)
 }
 
 /**
  * Navigate to component preview page
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {import('puppeteer').Browser} browser - Puppeteer browser object
  * @param {string} [componentName] - Component name
  * @param {Parameters<typeof getComponentURL>[1]} [options] - Navigation options
  * @returns {Promise<import('puppeteer').Page>} Puppeteer page object
  */
-function goToComponent(page, componentName, options) {
-  return goTo(page, getComponentURL(componentName, options))
+async function goToComponent(browser, componentName, options) {
+  return goTo(await browser.newPage(), getComponentURL(componentName, options))
 }
 
 /**

--- a/shared/lib/components.js
+++ b/shared/lib/components.js
@@ -187,7 +187,7 @@ function renderMacro(macroName, macroPath, options) {
  * Uses {@link renderTemplate} with the default `govuk/template.njk` to
  * render components via {@link render} into the `main` content block
  *
- * @param {string} componentName - Component name
+ * @param {string} [componentName] - Component name
  * @param {MacroRenderOptions} [options] - Nunjucks macro render options
  * @returns {string} HTML rendered from the Nunjucks template
  */
@@ -211,7 +211,7 @@ function renderPreview(componentName, options) {
 
       main: outdent`
         <div id="content" class="govuk-width-container">
-          ${render(componentName, options)}
+          ${componentName ? render(componentName, options) : ''}
         </div>
       `,
 
@@ -273,7 +273,10 @@ module.exports = {
   renderMacro,
   renderPreview,
   renderString,
-  renderTemplate
+  renderTemplate,
+  stylesPath,
+  scriptsPath,
+  assetPath
 }
 
 /**

--- a/shared/tasks/browser.mjs
+++ b/shared/tasks/browser.mjs
@@ -37,11 +37,11 @@ export async function screenshots() {
     const componentExamples = await getExamples(componentName)
 
     // Screenshot "default" example
-    await screenshotComponent(await browser.newPage(), componentName)
+    await screenshotComponent(browser, componentName)
 
     // Screenshot "inverse" example
     if (Object.keys(componentExamples).includes('inverse')) {
-      await screenshotComponent(await browser.newPage(), componentName, {
+      await screenshotComponent(browser, componentName, {
         exampleName: 'inverse'
       })
     }
@@ -59,12 +59,12 @@ export async function screenshots() {
     ['radios', { exampleName: 'with-hints-on-items' }],
     ['radios', { exampleName: 'small' }]
   ])) {
-    await screenshotComponent(await browser.newPage(), componentName, options)
+    await screenshotComponent(browser, componentName, options)
   }
 
   // Screenshot specific example pages
   for (const exampleName of ['text-alignment', 'typography']) {
-    await screenshotExample(await browser.newPage(), exampleName)
+    await screenshotExample(browser, exampleName)
   }
 
   // Close browser
@@ -78,17 +78,17 @@ export async function screenshots() {
  * Send single component screenshots to Percy
  * for visual regression testing
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {import('puppeteer').Browser} browser - Puppeteer browser object
  * @param {string} componentName - Component name
  * @param {object} [options] - Component options
  * @param {string} options.exampleName - Example name
  * @returns {Promise<void>}
  */
-export async function screenshotComponent(page, componentName, options) {
+export async function screenshotComponent(browser, componentName, options) {
   const componentFiles = await getComponentFiles(componentName)
 
   // Navigate to component
-  await goToComponent(page, componentName, options)
+  const page = await goToComponent(browser, componentName, options)
 
   // Add optional example to screenshot name
   const screenshotName = options?.exampleName
@@ -115,12 +115,12 @@ export async function screenshotComponent(page, componentName, options) {
  * Send single example screenshot to Percy
  * for visual regression testing
  *
- * @param {import('puppeteer').Page} page - Puppeteer page object
+ * @param {import('puppeteer').Browser} browser - Puppeteer browser object
  * @param {string} exampleName - Component name
  * @returns {Promise<void>}
  */
-export async function screenshotExample(page, exampleName) {
-  await goToExample(page, exampleName)
+export async function screenshotExample(browser, exampleName) {
+  const page = await goToExample(browser, exampleName)
 
   // Dismiss app banner
   await page.setCookie({


### PR DESCRIPTION
Part of https://github.com/alphagov/govuk-frontend/issues/4103, closes https://github.com/alphagov/govuk-frontend/issues/2565 and continues work from https://github.com/alphagov/govuk-frontend/pull/4346

This PR ensures that all component tests avoid `initAll()` to throw errors into Puppeteer

## Review app component tests

Once merged, GOV.UK Frontend component tests will no longer need the Review app, with updates to:

1. Allow an empty `renderPreview()` for testing ES module exports
2. Update tests with `page.reload()` refreshes to re-render instead
3. Update tests with page navigation (e.g. Exit this page) to mock their requests

All Review app [component previews](https://govuk-frontend-pr-4359.herokuapp.com/components/all) are unaffected
