### PR TITLE
Add optional `.gitignore` files to package:clean task

### DIFF
--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -55,7 +55,7 @@
     "build:stats": "npm run stats --workspace @govuk-frontend/stats",
     "build:types": "tsc --build tsconfig.build.json",
     "clean": "npm run clean:package",
-    "clean:package": "del-cli dist",
+    "clean:package": "del-cli dist govuk-prototype-kit.config.json",
     "clean:release": "del-cli ../../dist --force",
     "postbuild:package": "npm run build:stats && govuk-prototype-kit validate-plugin .",
     "version": "echo $npm_package_version"

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -55,7 +55,7 @@
     "build:stats": "npm run stats --workspace @govuk-frontend/stats",
     "build:types": "tsc --build tsconfig.build.json",
     "clean": "npm run clean:package",
-    "clean:package": "del-cli dist govuk-prototype-kit.config.json",
+    "clean:package": "del-cli *.tsbuildinfo dist govuk-prototype-kit.config.json",
     "clean:release": "del-cli ../../dist --force",
     "postbuild:package": "npm run build:stats && govuk-prototype-kit validate-plugin .",
     "version": "echo $npm_package_version"


### PR DESCRIPTION
Updates the `npm run package:clean` task to also remove:

1. Built config file `govuk-prototype-kit.config.json`
2. Built cache file [`tsconfig.build.tsbuildinfo`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html) (watch task `lint:types` output, optional)

### Verify package tests

These files are part of the tests to verify `npm run build:package` and should be "cleaned" before run

https://github.com/alphagov/govuk-frontend/blob/ffe159528d89c2f0544bd00d2621177465224efd/packages/govuk-frontend/tasks/build/package.unit.test.mjs#L140-L144

