### PR TITLE
Add Dependabot `caniuse-lite` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,12 +79,6 @@ updates:
     allow:
       - dependency-type: direct
 
-    ignore:
-      # Ignore major updates (causes `stylelint-config-gds` peer dependency conflict)
-      # See pull request: https://github.com/alphagov/stylelint-config-gds/pull/32
-      - dependency-name: stylelint
-        update-types: ['version-update:semver-major']
-
   # Update GitHub Actions
   - package-ecosystem: github-actions
     directory: /

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -77,7 +77,12 @@ updates:
     versioning-strategy: increase
 
     allow:
+      # Include direct package.json updates
       - dependency-type: direct
+
+      # Include indirect browser data updates
+      # https://caniuse.com
+      - dependency-name: caniuse-lite
 
   # Update GitHub Actions
   - package-ecosystem: github-actions

--- a/docs/releasing/publishing.md
+++ b/docs/releasing/publishing.md
@@ -35,15 +35,7 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    Do not commit the changes.
 
-7. Update browser data from ["Can I use"](https://caniuse.com) by running:
-
-   ```shell
-   npx update-browserslist-db@latest
-   ```
-
-   This step will update the project [`package-lock.json`](/package-lock.json) file if updates are found.
-
-8. Run `npm run build-release` to:
+7. Run `npm run build-release` to:
 
    - build GOV.UK Frontend into the [`/package`](/package) and [`/dist`](/dist) directories
    - commit the changes
@@ -51,10 +43,10 @@ Developers should pair on releases. When remote working, it can be useful to be 
 
    You will now be prompted to continue or cancel.
 
-9. Create a pull request and copy the changelog text.
+8. Create a pull request and copy the changelog text.
    When reviewing the PR, check that the version numbers have been updated and that the compiled assets use this version number.
 
-10. Once a reviewer approves the pull request, merge it to **main**.
+9. Once a reviewer approves the pull request, merge it to **main**.
 
 ## Publish a release to npm
 


### PR DESCRIPTION
Browser data from ["Can I use"](https://caniuse.com) is used by Autoprefixer, Babel and CSSNANO but it's not updated automatically

This PR configures Dependabot to update the [`caniuse-lite`](https://www.npmjs.com/package/caniuse-lite) nested **package-lock.json** dependency

We currently only allow [direct **package.json** dependencies](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow)

### Release instructions

By checking for [`caniuse-lite`](https://www.npmjs.com/package/caniuse-lite) updates using Dependabot weekly checks, we can review [potentially breaking changes](https://github.com/alphagov/govuk-design-system/pull/3051#issuecomment-1680267867) before merging, yet also remove the update step from our release instructions:

>   ```shell
>   npx update-browserslist-db@latest
>   ```
>
>   This step will update the project [`package-lock.json`](/package-lock.json) file if updates are found.