### PR TITLE
Fix publish script `package.json` version etc

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -30,7 +30,7 @@ npm run test
 npm run build:package
 npm run build:release
 
-ALL_PACKAGE_VERSION=$(node -p "require('./packages/govuk-frontend/package.json').version")
+ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
 TAG="v$ALL_PACKAGE_VERSION"
 CURRENT_BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
 

--- a/bin/generate-npm-tag.sh
+++ b/bin/generate-npm-tag.sh
@@ -5,7 +5,7 @@ set -e
 HIGHEST_PUBLISHED_VERSION=$(git tag --list 2>/dev/null | sort -V | tail -n1 2>/dev/null | sed 's/v//g')
 
 # Extract tag version from ./packages/govuk-frontend/package.json
-CURRENT_VERSION=$(node -p "require('./packages/govuk-frontend/package.json').version")
+CURRENT_VERSION=$(npm run version --silent --workspace govuk-frontend)
 
 function version() { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -54,7 +54,7 @@ echo "🗒 Package published!"
 cd ..
 
 # Extract tag version from ./packages/govuk-frontend/package.json
-ALL_PACKAGE_VERSION=$(node -p "require('./packages/govuk-frontend/package.json').version")
+ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)
 TAG="v$ALL_PACKAGE_VERSION"
 
 if [ $(git tag -l "$TAG") ]; then

--- a/bin/publish-release.sh
+++ b/bin/publish-release.sh
@@ -47,11 +47,12 @@ fi
 
 echo "📦  Publishing package..."
 
+NPM_ARGS=( --workspace govuk-frontend )
+[ $NPM_TAG = "latest" ] || NPM_ARGS+=( --tag $NPM_TAG )
+
 # Try publishing
-cd packages/govuk-frontend/dist
-[ $NPM_TAG = "latest" ] && npm publish || npm publish --tag $NPM_TAG
+npm publish "${NPM_ARGS[@]}"
 echo "🗒 Package published!"
-cd ..
 
 # Extract tag version from ./packages/govuk-frontend/package.json
 ALL_PACKAGE_VERSION=$(npm run version --silent --workspace govuk-frontend)


### PR DESCRIPTION
This PR fixes a bug in our publish-release script

The path to **package.json** is incorrect since https://github.com/alphagov/govuk-frontend/commit/102601ec1d7a7294b601e7f0c1141e785c0207dd

```patch
- ALL_PACKAGE_VERSION=$(node -p "require('./packages/govuk-frontend/package.json').version")
+ ALL_PACKAGE_VERSION=$(node -p "require('./govuk-frontend/package.json').version")
```

But we can use [npm workspaces](https://docs.npmjs.com/cli/v10/using-npm/workspaces) instead to remove hard-coded paths:

1. Version number using `npm run version --silent --workspace govuk-frontend`
2. Publish package using `npm publish --workspace govuk-frontend`