### PR TITLE
Move private workspace packages to `devDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30386,6 +30386,10 @@
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
+        "@govuk-frontend/config": "*",
+        "@govuk-frontend/helpers": "*",
+        "@govuk-frontend/lib": "*",
+        "@govuk-frontend/tasks": "*",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-replace": "^5.0.4",
         "@rollup/plugin-terser": "^0.4.4",
@@ -30409,12 +30413,6 @@
       },
       "engines": {
         "node": ">= 4.2.0"
-      },
-      "optionalDependencies": {
-        "@govuk-frontend/config": "*",
-        "@govuk-frontend/helpers": "*",
-        "@govuk-frontend/lib": "*",
-        "@govuk-frontend/tasks": "*"
       }
     },
     "packages/govuk-frontend-review": {

--- a/packages/govuk-frontend/package.json
+++ b/packages/govuk-frontend/package.json
@@ -61,6 +61,10 @@
     "version": "echo $npm_package_version"
   },
   "devDependencies": {
+    "@govuk-frontend/config": "*",
+    "@govuk-frontend/helpers": "*",
+    "@govuk-frontend/lib": "*",
+    "@govuk-frontend/tasks": "*",
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
     "@rollup/plugin-babel": "^6.0.4",
@@ -83,11 +87,5 @@
     "sass-embedded": "^1.69.4",
     "sassdoc": "^2.7.4",
     "slash": "^5.1.0"
-  },
-  "optionalDependencies": {
-    "@govuk-frontend/config": "*",
-    "@govuk-frontend/helpers": "*",
-    "@govuk-frontend/lib": "*",
-    "@govuk-frontend/tasks": "*"
   }
 }


### PR DESCRIPTION
Unlike npm, yarn is not happy unless `optionalDependencies` are published

Addresses user feedback from https://github.com/alphagov/govuk-frontend/discussions/4389#discussioncomment-7401425