### PR TITLE
Improve SupportError when `document.body` is not set

### DIFF
--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -124,6 +124,12 @@ describe('Common JS utilities', () => {
     it('returns false if the govuk-frontend-supported class is not set', () => {
       expect(isSupported(document.body)).toBe(false)
     })
+
+    it('returns false when `document.body` is not set', () => {
+      // For example, running `initAll()` in `<head>` without `type="module"`
+      // will see support checks run when document.body is still `null`
+      expect(isSupported(null)).toBe(false)
+    })
   })
 
   describe('getFragmentFromUrl', () => {

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -140,10 +140,14 @@ export function getFragmentFromUrl(url) {
  * won't be supported.
  *
  * @internal
- * @param {HTMLElement} [$scope] - The `<body>` element of the document to check for support
+ * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
  * @returns {boolean} Whether GOV.UK Frontend is supported on this page
  */
 export function isSupported($scope = document.body) {
+  if (!$scope) {
+    return false
+  }
+
   return $scope.classList.contains('govuk-frontend-supported')
 }
 

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -13,14 +13,24 @@ describe('errors', () => {
 
   describe('SupportError', () => {
     it('is an instance of GOVUKFrontendError', () => {
-      expect(new SupportError()).toBeInstanceOf(GOVUKFrontendError)
+      expect(new SupportError(document.body)).toBeInstanceOf(GOVUKFrontendError)
     })
+
     it('has its own name set', () => {
-      expect(new SupportError().name).toBe('SupportError')
+      expect(new SupportError(document.body).name).toBe('SupportError')
     })
-    it('provides meaningful feedback to users', () => {
-      expect(new SupportError().message).toBe(
+
+    it('provides feedback regarding browser support', () => {
+      expect(new SupportError(document.body).message).toBe(
         'GOV.UK Frontend is not supported in this browser'
+      )
+    })
+
+    it('provides feedback when `document.body` is not set', () => {
+      // For example, running `initAll()` in `<head>` without `type="module"`
+      // will see support checks run when document.body is still `null`
+      expect(new SupportError(null).message).toBe(
+        'GOV.UK Frontend initialised without `<script type="module">`'
       )
     })
   })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -28,9 +28,17 @@ export class GOVUKFrontendError extends Error {
 export class SupportError extends GOVUKFrontendError {
   name = 'SupportError'
 
-  // eslint-disable-next-line jsdoc/require-jsdoc -- Nothing pertinent to document
-  constructor() {
-    super('GOV.UK Frontend is not supported in this browser')
+  /**
+   * Checks if GOV.UK Frontend is supported on this page
+   *
+   * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
+   */
+  constructor($scope = document.body) {
+    super(
+      $scope
+        ? 'GOV.UK Frontend is not supported in this browser'
+        : 'GOV.UK Frontend initialised without `<script type="module">`'
+    )
   }
 }
 


### PR DESCRIPTION
This PR addresses feedback from https://github.com/alphagov/govuk-frontend/discussions/4389#discussioncomment-7402623

Running `initAll()` in `<head>` currently throws because we trust `document.body` is never `null` :fire:

```html
<head>
  <!-- // ... -->
  <script src="/javascripts/all.bundle.js"></script>
  <script>
    window.GOVUKFrontend.initAll()
  </script>
</head>
```

But even if we fix this to guard `document.body` we'd incorrectly log to the console:

>GOV.UK Frontend is not supported in this browser

Additionally, we may want to catch `null` element property access before our users do in:

* https://github.com/alphagov/govuk-frontend/pull/4106

## Informing users that forget `type="module"`

Either way, we should fix this issue so users realise when they run `initAll()` too early

This PR clarifies the **SupportError** text to do this:

```mjs
$scope
  ? 'GOV.UK Frontend is not supported in this browser'
  : 'GOV.UK Frontend initialised before the body element (`<body>`) was available'
```