### PR TITLE
Fix Dependabot by removing npm `engine-strict=true`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true


### PR DESCRIPTION
The Node.js LTS v20 update in #4201 has stopped Dependabot from running

Rather than allow Node.js v18 and npm v9.6.5 we can remove `engine-strict=true`

```
Dependabot uses Node.js v18.18.2
 and NPM 9.6.5
. Due to the engine-strict setting, the update will not succeed.
```

## Other options considered

1. **Wait for [Dependabot to update to Node.js v20](https://github.com/dependabot/dependabot-core/pull/8275)**
But we'd still be blocked by Node.js v20 using `npm@10.1.0`

2. **Update `package.json` to support Node.js v18 (and npm v9.6.5)**

   ```patch
     "engines": {
   -   "node": "^20.9.0",
   -   "npm": "^10.1.0"
   +   "node": "^18.12.0 || ^20.9.0",
   +   "npm": "^9.1.0 || ^10.1.0"
     },
   ```