### PR TITLE
Remove custom attribute on status in task list example

### DIFF
--- a/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
+++ b/packages/govuk-frontend/src/govuk/components/task-list/task-list.yaml
@@ -324,8 +324,6 @@ examples:
           status:
             tag:
               text: Status
-              attributes:
-                data-tag-attribute: tag-value
 
   - name: custom id prefix
     hidden: true


### PR DESCRIPTION
Custom attributes aren't currently supported on the status within the task list, only for the overall task list itself.

We could chose to support custom attributes on other elements within the task list (such as the status, title and hint) – but I'm not sure what the convention is for this across govuk-frontend?