### PR TITLE
Move Review app "Other examples" tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,6 +160,14 @@ jobs:
             projects:
               - JavaScript component tests
 
+          - description: Review app browser tests
+            name: test-review-app-browser
+            cache: |
+              .cache/jest
+              .cache/puppeteer
+            projects:
+              - Review app browser tests
+
           - description: Accessibility tests
             name: test-accessibility
             cache: |

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -119,10 +119,22 @@ export default {
       displayName: 'JavaScript component tests',
       testEnvironment: '@govuk-frontend/helpers/jest/environment/puppeteer.mjs',
       testMatch: [
-        '**/*.puppeteer.test.{js,mjs}',
+        '**/packages/govuk-frontend/**/*.puppeteer.test.{js,mjs}',
 
         // Exclude accessibility tests
         '!**/accessibility.puppeteer.test.mjs'
+      ],
+
+      // Web server and browser required
+      globalSetup: '@govuk-frontend/helpers/jest/browser/open.mjs',
+      globalTeardown: '@govuk-frontend/helpers/jest/browser/close.mjs'
+    },
+    {
+      ...config,
+      displayName: 'Review app browser tests',
+      testEnvironment: '@govuk-frontend/helpers/jest/environment/puppeteer.mjs',
+      testMatch: [
+        '**/packages/govuk-frontend-review/**/*.puppeteer.test.{js,mjs}'
       ],
 
       // Web server and browser required

--- a/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.puppeteer.test.mjs
@@ -1,0 +1,99 @@
+import {
+  getAttribute,
+  getProperty,
+  goToExample,
+  isVisible
+} from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Conditional reveals', () => {
+  describe('with multiple groups and conditional reveals', () => {
+    /** @type {globalThis.page} */
+    let page
+
+    beforeEach(async () => {
+      page = await goToExample(browser, 'conditional-reveals')
+    })
+
+    describe('Radios', () => {
+      let $inputsPrimary
+      let $inputsOther
+
+      beforeEach(async () => {
+        $inputsPrimary = await page.$$(
+          '.govuk-radios__input[id^="fave-primary"]'
+        )
+        $inputsOther = await page.$$('.govuk-radios__input[id^="fave-other"]')
+      })
+
+      it('hides conditional reveals in other groups', async () => {
+        const $conditionalPrimary = await page.$(
+          `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
+        )
+
+        // Choose the second radio in the first group, which reveals additional content
+        await $inputsPrimary[1].click()
+
+        // Assert that conditional content is revealed
+        expect(await isVisible($conditionalPrimary)).toBe(true)
+
+        // Choose a different radio with the same name, but in a different group
+        await $inputsOther[1].click()
+
+        // Expect conditional content to have been collapsed
+        expect(await isVisible($conditionalPrimary)).toBe(false)
+      })
+    })
+
+    describe('Checkboxes', () => {
+      let $inputsPrimary
+      let $inputsSecondary
+      let $inputsOther
+
+      beforeEach(async () => {
+        $inputsPrimary = await page.$$(
+          '.govuk-checkboxes__input[id^="colour-primary"]'
+        )
+        $inputsSecondary = await page.$$(
+          '.govuk-checkboxes__input[id^="colour-secondary"]'
+        )
+        $inputsOther = await page.$$(
+          '.govuk-checkboxes__input[id^="colour-other"]'
+        )
+      })
+
+      it('hides conditional reveals in other groups', async () => {
+        const $conditionalPrimary = await page.$(
+          `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
+        )
+
+        // Check the second checkbox in the first group, which reveals additional content
+        await $inputsPrimary[1].click()
+
+        // Assert that conditional content is revealed
+        expect(await isVisible($conditionalPrimary)).toBe(true)
+
+        // Check the "None" checkbox in the third group
+        await $inputsOther[1].click()
+
+        // Assert that the second checkbox in the first group is unchecked
+        expect(await getProperty($inputsPrimary[1], 'checked')).toBe(false)
+
+        // Expect conditional content to have been collapsed
+        expect(await isVisible($conditionalPrimary)).toBe(false)
+      })
+
+      it('none checkbox unchecks other checkboxes in other groups', async () => {
+        // Check some checkboxes in the first and second groups
+        await $inputsPrimary[2].click()
+        await $inputsSecondary[1].click()
+
+        // Check the "None" checkbox in the third group
+        await $inputsOther[1].click()
+
+        // Expect the checkboxes in the first and second groups to be unchecked
+        expect(await getProperty($inputsPrimary[2], 'checked')).toBe(false)
+        expect(await getProperty($inputsSecondary[1], 'checked')).toBe(false)
+      })
+    })
+  })
+})

--- a/packages/govuk-frontend-review/src/views/examples/error-summary/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary/index.puppeteer.test.mjs
@@ -1,0 +1,73 @@
+import { goToExample } from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Error summary', () => {
+  const inputTypes = [
+    // [description, input id, selector for label or legend]
+    ['an input', 'input', 'label[for="input"]'],
+    ['a textarea', 'textarea', 'label[for="textarea"]'],
+    ['a select', 'select', 'label[for="select"]'],
+    ['a date input', 'dateinput-day', '.test-date-input-legend'],
+    [
+      'a specific field in a date input',
+      'dateinput2-year',
+      '.test-date-input2-legend'
+    ],
+    ['a file upload', 'file', 'label[for="file"]'],
+    ['a group of radio buttons', 'radios', '#test-radios legend'],
+    ['a group of checkboxes', 'checkboxes', '#test-checkboxes legend'],
+    ['a single checkbox', 'single-checkbox', 'label[for="single-checkbox"]'],
+    [
+      'a conditionally revealed input',
+      'yes-input',
+      '#test-conditional-reveal legend'
+    ],
+    [
+      'a group of radio buttons after a particularly long heading',
+      'radios-big-heading',
+      '.test-radios-big-heading-legend'
+    ],
+    // Rather than scrolling to the fieldset, we expect to scroll to the label
+    // because of the distance between the input and the fieldset
+    [
+      'an input within a large fieldset',
+      'address-postcode',
+      'label[for="address-postcode"]'
+    ]
+  ]
+
+  describe.each(inputTypes)(
+    'when linking to %s',
+    (_, inputId, legendOrLabelSelector) => {
+      /** @type {globalThis.page} */
+      let page
+
+      beforeAll(async () => {
+        page = await goToExample(browser, 'error-summary')
+        await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
+      })
+
+      it('focuses the target input', async () => {
+        const activeElement = await page.evaluate(
+          () => document.activeElement.id
+        )
+        expect(activeElement).toBe(inputId)
+      })
+
+      it('scrolls the label or legend to the top of the screen', async () => {
+        const legendOrLabelOffsetFromTop = await page.$eval(
+          legendOrLabelSelector,
+          ($) => $.getBoundingClientRect().top
+        )
+
+        // Allow for high DPI displays (device pixel ratio)
+        expect(legendOrLabelOffsetFromTop).toBeGreaterThanOrEqual(0)
+        expect(legendOrLabelOffsetFromTop).toBeLessThan(1)
+      })
+
+      it('does not include a hash in the URL', async () => {
+        const hash = await page.evaluate(() => window.location.hash)
+        expect(hash).toBe('')
+      })
+    }
+  )
+})

--- a/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.puppeteer.test.mjs
@@ -1,0 +1,85 @@
+import { goToExample } from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Exit this page with skip link', () => {
+  /** @type {globalThis.page} */
+  let page
+
+  const buttonClass = '.govuk-js-exit-this-page-button'
+  const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
+  const overlayClass = '.govuk-exit-this-page-overlay'
+
+  beforeEach(async () => {
+    page = await goToExample(browser, 'exit-this-page-with-skiplink')
+  })
+
+  describe('when JavaScript is unavailable or fails', () => {
+    beforeEach(async () => {
+      await page.setJavaScriptEnabled(false)
+      await page.reload()
+    })
+
+    afterEach(async () => {
+      await page.setJavaScriptEnabled(true)
+    })
+
+    it('navigates to the href of the skiplink', async () => {
+      const exitPageURL = await page
+        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      expect(page.url()).toBe(exitPageURL.href)
+    })
+  })
+
+  describe('when JavaScript is available', () => {
+    it('navigates to the href of the skiplink', async () => {
+      const exitPageURL = await page
+        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
+        .then((path) => new URL(path, 'file://'))
+
+      await Promise.all([
+        page.waitForNavigation(),
+        page.focus(skiplinkClass),
+        page.click(skiplinkClass)
+      ])
+
+      expect(page.url()).toBe(exitPageURL.href)
+    })
+
+    it('shows the ghost page when the EtP button is clicked', async () => {
+      // Stop the button from navigating away from the current page as a workaround
+      // to puppeteer struggling to return to previous pages after navigation reliably
+      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
+      await page.click(buttonClass)
+
+      const ghostOverlay = await page.evaluate(
+        (overlayClass) => document.body.querySelector(overlayClass),
+        overlayClass
+      )
+      expect(ghostOverlay).not.toBeNull()
+    })
+
+    it('shows the ghost page when the skiplink is clicked', async () => {
+      // Stop the button from navigating away from the current page as a workaround
+      // to puppeteer struggling to return to previous pages after navigation reliably
+      //
+      // We apply this to the button and not the skiplink because we pull the href
+      // from the button rather than the skiplink
+      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
+      await page.focus(skiplinkClass)
+      await page.click(skiplinkClass)
+
+      const ghostOverlay = await page.evaluate(
+        (overlayClass) => document.body.querySelector(overlayClass),
+        overlayClass
+      )
+      expect(ghostOverlay).not.toBeNull()
+    })
+  })
+})

--- a/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.puppeteer.test.mjs
@@ -1,0 +1,56 @@
+import {
+  getAttribute,
+  goToExample,
+  isVisible
+} from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Multiple radio groups', () => {
+  /** @type {globalThis.page} */
+  let page
+
+  let $inputsWarm
+  let $inputsCool
+  let $inputsNotInForm
+
+  beforeEach(async () => {
+    page = await goToExample(browser, 'multiple-radio-groups')
+
+    $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
+    $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
+    $inputsNotInForm = await page.$$(
+      '.govuk-radios__input[id^="question-not-in-form"]'
+    )
+  })
+
+  it('toggles conditional reveals in other groups', async () => {
+    const $conditionalWarm = await page.$(
+      `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
+    )
+    const $conditionalCool = await page.$(
+      `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
+    )
+
+    // Select red in warm colours
+    await $inputsWarm[0].click()
+
+    expect(await isVisible($conditionalWarm)).toBe(true)
+    expect(await isVisible($conditionalCool)).toBe(false)
+
+    // Select blue in cool colours
+    await $inputsCool[0].click()
+
+    expect(await isVisible($conditionalWarm)).toBe(false)
+    expect(await isVisible($conditionalCool)).toBe(true)
+  })
+
+  it('toggles conditional reveals when not in a form', async () => {
+    const $conditionalWarm = await page.$(
+      `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
+    )
+
+    // Select first input in radios not in a form
+    await $inputsNotInForm[0].click()
+
+    expect(await isVisible($conditionalWarm)).toBe(false)
+  })
+})

--- a/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.puppeteer.test.mjs
@@ -1,0 +1,31 @@
+import { goToExample } from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Scoped initialisation', () => {
+  /** @type {globalThis.page} */
+  let page
+
+  beforeEach(async () => {
+    page = await goToExample(browser, 'scoped-initialisation')
+  })
+
+  it('GOV.UK Frontend can be scoped to initialise certain sections of the page', async () => {
+    // To test that certain parts of the page are scoped we have two similar components
+    // that we can interact with to check if they're interactive.
+
+    // Check that the conditional reveal component has a conditional section that would open if enhanced.
+    await page.waitForSelector('#conditional-not-scoped', { hidden: true })
+
+    await page.click('[for="not-scoped"]')
+
+    // Check that when it is clicked that nothing opens, which shows that it has not been enhanced.
+    await page.waitForSelector('#conditional-not-scoped', { hidden: true })
+
+    // Check the other conditional reveal which has been enhanced based on it's scope.
+    await page.waitForSelector('#conditional-scoped', { hidden: true })
+
+    await page.click('[for="scoped"]')
+
+    // Check that it has opened as expected.
+    await page.waitForSelector('#conditional-scoped', { hidden: false })
+  })
+})

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.puppeteer.test.mjs
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.puppeteer.test.mjs
@@ -1,0 +1,87 @@
+import { goToExample } from '@govuk-frontend/helpers/puppeteer'
+
+describe('Example: Translated', () => {
+  describe('Accordion', () => {
+    /** @type {globalThis.page} */
+    let page
+
+    beforeEach(async () => {
+      page = await goToExample(browser, 'translated')
+    })
+
+    afterEach(async () => {
+      // Clear accordion state
+      await page.evaluate(() => window.sessionStorage.clear())
+    })
+
+    it('should localise "Show all sections" based on JavaScript configuration', async () => {
+      const allSectionsToggleText = await page.evaluate(
+        () =>
+          document.body.querySelector('.govuk-accordion__show-all-text')
+            .innerHTML
+      )
+
+      expect(allSectionsToggleText).toBe('Dangos adrannau')
+    })
+
+    it('should localise "Hide all sections" based on JavaScript configuration', async () => {
+      await page.click('.govuk-accordion .govuk-accordion__show-all')
+
+      const allSectionsToggleText = await page.evaluate(
+        () =>
+          document.body.querySelector('.govuk-accordion__show-all-text')
+            .innerHTML
+      )
+
+      expect(allSectionsToggleText).toBe('Cuddio adrannau')
+    })
+
+    it('should localise "Show section" based on JavaScript configuration', async () => {
+      const firstSectionToggleText = await page.evaluate(
+        () =>
+          document.body.querySelector('.govuk-accordion__section-toggle-text')
+            .innerHTML
+      )
+
+      expect(firstSectionToggleText).toBe('Dangos')
+    })
+
+    it('should localise "Show section" aria-label based on JavaScript configuration', async () => {
+      const firstSectionToggleAriaLabel = await page.evaluate(() =>
+        document.body
+          .querySelector('.govuk-accordion__section-button')
+          .getAttribute('aria-label')
+      )
+
+      expect(firstSectionToggleAriaLabel.endsWith('Dangos adran')).toBeTruthy()
+    })
+
+    it('should localise "Hide section" based on JavaScript configuration', async () => {
+      await page.click(
+        '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+      )
+
+      const firstSectionToggleText = await page.evaluate(
+        () =>
+          document.body.querySelector('.govuk-accordion__section-toggle-text')
+            .innerHTML
+      )
+
+      expect(firstSectionToggleText).toBe('Cuddio')
+    })
+
+    it('should localise "Hide section" aria-label based on JavaScript configuration', async () => {
+      await page.click(
+        '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
+      )
+
+      const firstSectionToggleAriaLabel = await page.evaluate(() =>
+        document.body
+          .querySelector('.govuk-accordion__section-button')
+          .getAttribute('aria-label')
+      )
+
+      expect(firstSectionToggleAriaLabel.endsWith('Cuddio adran')).toBeTruthy()
+    })
+  })
+})

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToExample,
   render,
   getAccessibleName
 } = require('@govuk-frontend/helpers/puppeteer')
@@ -53,7 +52,7 @@ describe('/components/accordion', () => {
 
     describe('when JavaScript is available', () => {
       afterEach(async () => {
-        // clear accordion state
+        // Clear accordion state
         await page.evaluate(() => window.sessionStorage.clear())
       })
 
@@ -491,18 +490,6 @@ describe('/components/accordion', () => {
           expect(allSectionsToggleText).toEqual(showAllSectionsDataAttribute)
         })
 
-        it('should localise "Show all sections" based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-
-          const allSectionsToggleText = await page.evaluate(
-            () =>
-              document.body.querySelector('.govuk-accordion__show-all-text')
-                .innerHTML
-          )
-
-          expect(allSectionsToggleText).toBe('Dangos adrannau')
-        })
-
         it('should localise "Hide all sections" based on data attribute', async () => {
           await render(page, 'accordion', examples['with translations'])
           await page.click(
@@ -526,19 +513,6 @@ describe('/components/accordion', () => {
           expect(allSectionsToggleText).toEqual(hideAllSectionsDataAttribute)
         })
 
-        it('should localise "Hide all sections" based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-          await page.click('.govuk-accordion .govuk-accordion__show-all')
-
-          const allSectionsToggleText = await page.evaluate(
-            () =>
-              document.body.querySelector('.govuk-accordion__show-all-text')
-                .innerHTML
-          )
-
-          expect(allSectionsToggleText).toBe('Cuddio adrannau')
-        })
-
         it('should localise "Show section" based on data attribute', async () => {
           await render(page, 'accordion', examples['with translations'])
 
@@ -557,19 +531,6 @@ describe('/components/accordion', () => {
           expect(firstSectionToggleText).toEqual(showSectionDataAttribute)
         })
 
-        it('should localise "Show section" based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-
-          const firstSectionToggleText = await page.evaluate(
-            () =>
-              document.body.querySelector(
-                '.govuk-accordion__section-toggle-text'
-              ).innerHTML
-          )
-
-          expect(firstSectionToggleText).toBe('Dangos')
-        })
-
         it('should localise "Show section" aria-label based on data attribute', async () => {
           await render(page, 'accordion', examples['with translations'])
 
@@ -586,20 +547,6 @@ describe('/components/accordion', () => {
 
           expect(
             firstSectionToggleAriaLabel.endsWith(showSectionDataAttribute)
-          ).toBeTruthy()
-        })
-
-        it('should localise "Show section" aria-label based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-
-          const firstSectionToggleAriaLabel = await page.evaluate(() =>
-            document.body
-              .querySelector('.govuk-accordion__section-button')
-              .getAttribute('aria-label')
-          )
-
-          expect(
-            firstSectionToggleAriaLabel.endsWith('Dangos adran')
           ).toBeTruthy()
         })
 
@@ -624,22 +571,6 @@ describe('/components/accordion', () => {
           expect(firstSectionToggleText).toEqual(hideSectionDataAttribute)
         })
 
-        it('should localise "Hide section" based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-          await page.click(
-            '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
-          )
-
-          const firstSectionToggleText = await page.evaluate(
-            () =>
-              document.body.querySelector(
-                '.govuk-accordion__section-toggle-text'
-              ).innerHTML
-          )
-
-          expect(firstSectionToggleText).toBe('Cuddio')
-        })
-
         it('should localise "Hide section" aria-label based on data attribute', async () => {
           await render(page, 'accordion', examples['with translations'])
           await page.click(
@@ -659,23 +590,6 @@ describe('/components/accordion', () => {
 
           expect(
             firstSectionToggleAriaLabel.endsWith(hideSectionDataAttribute)
-          ).toBeTruthy()
-        })
-
-        it('should localise "Hide section" aria-label based on JavaScript configuration', async () => {
-          const page = await goToExample(browser, 'translated')
-          await page.click(
-            '.govuk-accordion .govuk-accordion__section:nth-of-type(2) .govuk-accordion__section-header'
-          )
-
-          const firstSectionToggleAriaLabel = await page.evaluate(() =>
-            document.body
-              .querySelector('.govuk-accordion__section-button')
-              .getAttribute('aria-label')
-          )
-
-          expect(
-            firstSectionToggleAriaLabel.endsWith('Cuddio adran')
           ).toBeTruthy()
         })
 

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToExample,
   getAttribute,
   getProperty,
   isVisible,
@@ -290,61 +289,6 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
   })
 
   describe('when JavaScript is available', () => {
-    /** @type {globalThis.page} */
-    let page
-
-    let $inputsPrimary
-    let $inputsSecondary
-    let $inputsOther
-
-    beforeEach(async () => {
-      page = await goToExample(browser, 'conditional-reveals')
-
-      $inputsPrimary = await page.$$(
-        '.govuk-checkboxes__input[id^="colour-primary"]'
-      )
-      $inputsSecondary = await page.$$(
-        '.govuk-checkboxes__input[id^="colour-secondary"]'
-      )
-      $inputsOther = await page.$$(
-        '.govuk-checkboxes__input[id^="colour-other"]'
-      )
-    })
-
-    it('none checkbox unchecks other checkboxes in other groups', async () => {
-      // Check some checkboxes in the first and second groups
-      await $inputsPrimary[2].click()
-      await $inputsSecondary[1].click()
-
-      // Check the "None" checkbox in the third group
-      await $inputsOther[1].click()
-
-      // Expect the checkboxes in the first and second groups to be unchecked
-      expect(await getProperty($inputsPrimary[2], 'checked')).toBe(false)
-      expect(await getProperty($inputsSecondary[1], 'checked')).toBe(false)
-    })
-
-    it('hides conditional reveals in other groups', async () => {
-      const $conditionalPrimary = await page.$(
-        `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
-      )
-
-      // Check the second checkbox in the first group, which reveals additional content
-      await $inputsPrimary[1].click()
-
-      // Assert that conditional content is revealed
-      expect(await isVisible($conditionalPrimary)).toBe(true)
-
-      // Check the "None" checkbox in the third group
-      await $inputsOther[1].click()
-
-      // Assert that the second checkbox in the first group is unchecked
-      expect(await getProperty($inputsPrimary[1], 'checked')).toBe(false)
-
-      // Expect conditional content to have been collapsed
-      expect(await isVisible($conditionalPrimary)).toBe(false)
-    })
-
     describe('errors at instantiation', () => {
       it('throws when GOV.UK Frontend is not supported', async () => {
         await expect(

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -1,4 +1,4 @@
-const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
 describe('Error Summary', () => {
@@ -142,76 +142,6 @@ describe('Error Summary', () => {
       })
     })
   })
-
-  const inputTypes = [
-    // [description, input id, selector for label or legend]
-    ['an input', 'input', 'label[for="input"]'],
-    ['a textarea', 'textarea', 'label[for="textarea"]'],
-    ['a select', 'select', 'label[for="select"]'],
-    ['a date input', 'dateinput-day', '.test-date-input-legend'],
-    [
-      'a specific field in a date input',
-      'dateinput2-year',
-      '.test-date-input2-legend'
-    ],
-    ['a file upload', 'file', 'label[for="file"]'],
-    ['a group of radio buttons', 'radios', '#test-radios legend'],
-    ['a group of checkboxes', 'checkboxes', '#test-checkboxes legend'],
-    ['a single checkbox', 'single-checkbox', 'label[for="single-checkbox"]'],
-    [
-      'a conditionally revealed input',
-      'yes-input',
-      '#test-conditional-reveal legend'
-    ],
-    [
-      'a group of radio buttons after a particularly long heading',
-      'radios-big-heading',
-      '.test-radios-big-heading-legend'
-    ],
-    // Rather than scrolling to the fieldset, we expect to scroll to the label
-    // because of the distance between the input and the fieldset
-    [
-      'an input within a large fieldset',
-      'address-postcode',
-      'label[for="address-postcode"]'
-    ]
-  ]
-
-  describe.each(inputTypes)(
-    'when linking to %s',
-    (_, inputId, legendOrLabelSelector) => {
-      /** @type {globalThis.page} */
-      let page
-
-      beforeAll(async () => {
-        page = await goToExample(browser, 'error-summary')
-        await page.click(`.govuk-error-summary a[href="#${inputId}"]`)
-      })
-
-      it('focuses the target input', async () => {
-        const activeElement = await page.evaluate(
-          () => document.activeElement.id
-        )
-        expect(activeElement).toBe(inputId)
-      })
-
-      it('scrolls the label or legend to the top of the screen', async () => {
-        const legendOrLabelOffsetFromTop = await page.$eval(
-          legendOrLabelSelector,
-          ($) => $.getBoundingClientRect().top
-        )
-
-        // Allow for high DPI displays (device pixel ratio)
-        expect(legendOrLabelOffsetFromTop).toBeGreaterThanOrEqual(0)
-        expect(legendOrLabelOffsetFromTop).toBeLessThan(1)
-      })
-
-      it('does not include a hash in the URL', async () => {
-        const hash = await page.evaluate(() => window.location.hash)
-        expect(hash).toBe('')
-      })
-    }
-  )
 
   describe('errors at instantiation', () => {
     let examples

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -1,13 +1,12 @@
 const { setTimeout } = require('timers/promises')
 
-const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { getExamples } = require('@govuk-frontend/lib/components')
 
-const buttonClass = '.govuk-js-exit-this-page-button'
-const skiplinkClass = '.govuk-js-exit-this-page-skiplink'
-const overlayClass = '.govuk-exit-this-page-overlay'
-
 describe('/components/exit-this-page', () => {
+  const buttonClass = '.govuk-js-exit-this-page-button'
+  const overlayClass = '.govuk-exit-this-page-overlay'
+
   let examples
 
   beforeAll(async () => {
@@ -43,22 +42,6 @@ describe('/components/exit-this-page', () => {
 
       await page.setRequestInterception(false)
     })
-
-    it('navigates to the href of the skiplink', async () => {
-      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
-
-      const exitPageURL = await page
-        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
-        .then((path) => new URL(path, 'file://'))
-
-      await Promise.all([
-        page.waitForNavigation(),
-        page.focus(skiplinkClass),
-        page.click(skiplinkClass)
-      ])
-
-      expect(page.url()).toBe(exitPageURL.href)
-    })
   })
 
   describe('when JavaScript is available', () => {
@@ -81,56 +64,6 @@ describe('/components/exit-this-page', () => {
       expect(page.url()).toBe(exitPageURL.href)
 
       await page.setRequestInterception(false)
-    })
-
-    it('navigates to the href of the skiplink', async () => {
-      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
-
-      const exitPageURL = await page
-        .$eval(skiplinkClass, (el) => el.getAttribute('href'))
-        .then((path) => new URL(path, 'file://'))
-
-      await Promise.all([
-        page.waitForNavigation(),
-        page.focus(skiplinkClass),
-        page.click(skiplinkClass)
-      ])
-
-      expect(page.url()).toBe(exitPageURL.href)
-    })
-
-    it('shows the ghost page when the EtP button is clicked', async () => {
-      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
-
-      // Stop the button from navigating away from the current page as a workaround
-      // to puppeteer struggling to return to previous pages after navigation reliably
-      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
-      await page.click(buttonClass)
-
-      const ghostOverlay = await page.evaluate(
-        (overlayClass) => document.body.querySelector(overlayClass),
-        overlayClass
-      )
-      expect(ghostOverlay).not.toBeNull()
-    })
-
-    it('shows the ghost page when the skiplink is clicked', async () => {
-      const page = await goToExample(browser, 'exit-this-page-with-skiplink')
-
-      // Stop the button from navigating away from the current page as a workaround
-      // to puppeteer struggling to return to previous pages after navigation reliably
-      //
-      // We apply this to the button and not the skiplink because we pull the href
-      // from the button rather than the skiplink
-      await page.$eval(buttonClass, (el) => el.setAttribute('href', '#'))
-      await page.focus(skiplinkClass)
-      await page.click(skiplinkClass)
-
-      const ghostOverlay = await page.evaluate(
-        (overlayClass) => document.body.querySelector(overlayClass),
-        overlayClass
-      )
-      expect(ghostOverlay).not.toBeNull()
     })
 
     describe('keyboard shortcut activation', () => {

--- a/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/globals.puppeteer.test.js
@@ -1,4 +1,4 @@
-const { goToExample, render } = require('@govuk-frontend/helpers/puppeteer')
+const { render } = require('@govuk-frontend/helpers/puppeteer')
 const { scriptsPath } = require('@govuk-frontend/lib/components')
 
 describe('GOV.UK Frontend', () => {
@@ -47,29 +47,6 @@ describe('GOV.UK Frontend', () => {
         'SkipLink',
         'Tabs'
       ])
-    })
-
-    it('can be initialised scoped to certain sections of the page', async () => {
-      const page = await goToExample(browser, 'scoped-initialisation')
-
-      // To test that certain parts of the page are scoped we have two similar components
-      // that we can interact with to check if they're interactive.
-
-      // Check that the conditional reveal component has a conditional section that would open if enhanced.
-      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
-
-      await page.click('[for="not-scoped"]')
-
-      // Check that when it is clicked that nothing opens, which shows that it has not been enhanced.
-      await page.waitForSelector('#conditional-not-scoped', { hidden: true })
-
-      // Check the other conditional reveal which has been enhanced based on it's scope.
-      await page.waitForSelector('#conditional-scoped', { hidden: true })
-
-      await page.click('[for="scoped"]')
-
-      // Check that it has opened as expected.
-      await page.waitForSelector('#conditional-scoped', { hidden: false })
     })
   })
 })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -1,5 +1,4 @@
 const {
-  goToExample,
   getProperty,
   getAttribute,
   isVisible,
@@ -187,96 +186,6 @@ describe('Radios', () => {
             examples['with conditional items with special characters']
           )
         })
-      })
-    })
-  })
-
-  describe('with multiple groups', () => {
-    describe('when JavaScript is available', () => {
-      /** @type {globalThis.page} */
-      let page
-
-      let $inputsWarm
-      let $inputsCool
-      let $inputsNotInForm
-
-      beforeEach(async () => {
-        page = await goToExample(browser, 'multiple-radio-groups')
-
-        $inputsWarm = await page.$$('.govuk-radios__input[id^="warm"]')
-        $inputsCool = await page.$$('.govuk-radios__input[id^="cool"]')
-        $inputsNotInForm = await page.$$(
-          '.govuk-radios__input[id^="question-not-in-form"]'
-        )
-      })
-
-      it('toggles conditional reveals in other groups', async () => {
-        const $conditionalWarm = await page.$(
-          `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
-        )
-        const $conditionalCool = await page.$(
-          `[id="${await getAttribute($inputsCool[0], 'aria-controls')}"]`
-        )
-
-        // Select red in warm colours
-        await $inputsWarm[0].click()
-
-        expect(await isVisible($conditionalWarm)).toBe(true)
-        expect(await isVisible($conditionalCool)).toBe(false)
-
-        // Select blue in cool colours
-        await $inputsCool[0].click()
-
-        expect(await isVisible($conditionalWarm)).toBe(false)
-        expect(await isVisible($conditionalCool)).toBe(true)
-      })
-
-      it('toggles conditional reveals when not in a form', async () => {
-        const $conditionalWarm = await page.$(
-          `[id="${await getAttribute($inputsWarm[0], 'aria-controls')}"]`
-        )
-
-        // Select first input in radios not in a form
-        await $inputsNotInForm[0].click()
-
-        expect(await isVisible($conditionalWarm)).toBe(false)
-      })
-    })
-  })
-
-  describe('with multiple groups and conditional reveals', () => {
-    describe('when JavaScript is available', () => {
-      /** @type {globalThis.page} */
-      let page
-
-      let $inputsPrimary
-      let $inputsOther
-
-      beforeEach(async () => {
-        page = await goToExample(browser, 'conditional-reveals')
-
-        $inputsPrimary = await page.$$(
-          '.govuk-radios__input[id^="fave-primary"]'
-        )
-        $inputsOther = await page.$$('.govuk-radios__input[id^="fave-other"]')
-      })
-
-      it('hides conditional reveals in other groups', async () => {
-        const $conditionalPrimary = await page.$(
-          `[id="${await getAttribute($inputsPrimary[1], 'aria-controls')}"]`
-        )
-
-        // Choose the second radio in the first group, which reveals additional content
-        await $inputsPrimary[1].click()
-
-        // Assert that conditional content is revealed
-        expect(await isVisible($conditionalPrimary)).toBe(true)
-
-        // Choose a different radio with the same name, but in a different group
-        await $inputsOther[1].click()
-
-        // Expect conditional content to have been collapsed
-        expect(await isVisible($conditionalPrimary)).toBe(false)
       })
     })
   })


### PR DESCRIPTION
This PR was split out from https://github.com/alphagov/govuk-frontend/pull/4359

As mentioned in https://github.com/alphagov/govuk-frontend/pull/4359#issuecomment-1772741697 we use `goToExample()` to visit Review app routes to **Other examples**

These remaining Review app tests have been moved to the `@govuk-frontend/review` package

## Review app browser tests

Tests for [Conditional reveals](https://govuk-frontend-review.herokuapp.com/examples/conditional-reveals), [Error summary](https://govuk-frontend-pr-4359.herokuapp.com/examples/error-summary) [Multiple radio groups](https://govuk-frontend-pr-4359.herokuapp.com/examples/multiple-radio-groups), [Translated](https://govuk-frontend-review.herokuapp.com/examples/translated) etc have been consolidated with the existing Review app tests [App](https://github.com/alphagov/govuk-frontend/blob/cbc6fcd35cc4494c10592cf228a0b8e108cb8868/packages/govuk-frontend-review/src/app.puppeteer.test.mjs), [Banner](https://github.com/alphagov/govuk-frontend/blob/cbc6fcd35cc4494c10592cf228a0b8e108cb8868/packages/govuk-frontend-review/src/routes/banner.puppeteer.test.mjs) and [Full page examples](https://github.com/alphagov/govuk-frontend/blob/cbc6fcd35cc4494c10592cf228a0b8e108cb8868/packages/govuk-frontend-review/src/routes/full-page-examples.puppeteer.test.mjs) as a new Jest project:

```shell
npx jest --selectProjects "Review app browser tests"
```

To list the test files included you can run:

```shell
npx jest --selectProjects "Review app browser tests" --listTests
```

<img width="376" alt="Other examples via Review app" src="https://github.com/alphagov/govuk-frontend/assets/415517/d068396a-754c-494a-b482-a15c3779e80b">