### PR TITLE
Fix rate limit issue with EditorConfig checker CLI

### DIFF
--- a/.github/workflows/diff-change-to-dist.yaml
+++ b/.github/workflows/diff-change-to-dist.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Add comment to PR
         uses: actions/github-script@v6.4.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { commentDiffs } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
 

--- a/.github/workflows/stats-comment.yml
+++ b/.github/workflows/stats-comment.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Add comment to PR
         uses: actions/github-script@v6.4.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { commentStats } = await import('${{ github.workspace }}/.github/workflows/scripts/comments.mjs')
             // PR information

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,6 +66,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [install]
 
+    env:
+      # Authorise GitHub API requests for EditorConfig checker binary
+      # https://www.npmjs.com/package/editorconfig-checker
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     strategy:
       fail-fast: false
 


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/4224 as part of https://github.com/alphagov/govuk-frontend/issues/4223

This PR fixes an issue where the [`editorconfig-checker` npm package](https://www.npmjs.com/package/editorconfig-checker) throws a GitHub REST API error:

```console
Failed to download binary:
HttpError: API rate limit exceeded for 40.84.178.209. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

On first run, the [`editorconfig-checker` npm package](https://www.npmjs.com/package/editorconfig-checker) ([Node.js](https://nodejs.org/en)) downloads its binary ([Go](https://go.dev)) from GitHub releases

* **EditorConfig checker** (Node.js wrapper): [editorconfig-checker.javascript](https://github.com/editorconfig-checker/editorconfig-checker.javascript)
* **EditorConfig checker** (Go binary): [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)

## Steps to reproduce

Run these steps too many times:

1. Use GitHub Actions to run `npm run lint:editorconfig`
2. EditorConfig checker Node.js from [`editorconfig-checker`](https://www.npmjs.com/package/editorconfig-checker) hits GitHub REST API [to check for latest release](https://github.com/editorconfig-checker/editorconfig-checker.javascript/blob/master/src/release.ts#L34-L40)
3. EditorConfig checker binary from [`editorconfig-checker` releases](https://github.com/editorconfig-checker/editorconfig-checker/releases) is downloaded to `/home/runner/work/_temp/`
4. EditorConfig checker binary runs

## The problem

The error throws from step 2) above via [`@octokit/rest`](https://www.npmjs.com/package/@octokit/rest) (GitHub REST API client for JavaScript) in lines:

https://github.com/editorconfig-checker/editorconfig-checker.javascript/blob/b6f19742da5d22e47ca09884b13c0bed03b551f1/src/release.ts#L12-L15

## The fix

This PR adds `GITHUB_TOKEN` similar to our own GitHub REST API calls (https://github.com/alphagov/govuk-frontend/issues/3229, https://github.com/alphagov/govuk-frontend/issues/3282)