### PR TITLE
Make review app page titles meaningful

### DIFF
--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -185,6 +185,7 @@ export default async () => {
 
   // Example view
   app.get('/examples/:exampleName', function (req, res, next) {
+    res.locals.exampleName = req.params.exampleName
     // Passing a random number used for the links so that they will be unique and not display as "visited"
     const randomPageHash = (Math.random() * 1000000).toFixed()
     res.render(

--- a/packages/govuk-frontend-review/src/app.mjs
+++ b/packages/govuk-frontend-review/src/app.mjs
@@ -143,14 +143,15 @@ export default async () => {
     '/components/:componentName/:exampleName?/preview',
     function (req, res, next) {
       // Find the data for the specified example (or the default example)
-      const componentName = req.params.componentName
-      const exampleName = req.params.exampleName || 'default'
+      res.locals.componentName = req.params.componentName
+      res.locals.exampleName = req.params.exampleName || 'default'
 
       /** @type {ComponentFixtures | undefined} */
       const componentFixtures = res.locals.componentFixtures
 
       const fixture = componentFixtures?.fixtures.find(
-        (fixture) => nunjucks.filters.slugify(fixture.name) === exampleName
+        (fixture) =>
+          nunjucks.filters.slugify(fixture.name) === res.locals.exampleName
       )
 
       if (!fixture) {
@@ -158,7 +159,7 @@ export default async () => {
       }
 
       // Construct and evaluate the component with the data for this example
-      res.locals.componentView = render(componentName, {
+      res.locals.componentView = render(res.locals.componentName, {
         context: fixture.options,
         env,
         fixture

--- a/packages/govuk-frontend-review/src/views/all-components.njk
+++ b/packages/govuk-frontend-review/src/views/all-components.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "macros/showExamples.njk" import showExamples %}
 
+{% block pageTitle %}All components - GOV.UK Frontend{% endblock %}
+
 {% set bodyClasses %}
   language-markup
 {% endset %}

--- a/packages/govuk-frontend-review/src/views/component-preview.njk
+++ b/packages/govuk-frontend-review/src/views/component-preview.njk
@@ -1,5 +1,9 @@
 {% extends "layouts/" + previewLayout | default('layout') + ".njk" %}
 
+{% set templateTitle = ("Default " + componentName if exampleName == "default" else componentName + " " + exampleName) | unslugify %}
+
+{% block pageTitle %}{{ templateTitle }} - GOV.UK Frontend{% endblock %}
+
 {% set bodyClasses %}
   {{ bodyClasses }}
 {% endset %}

--- a/packages/govuk-frontend-review/src/views/component.njk
+++ b/packages/govuk-frontend-review/src/views/component.njk
@@ -3,6 +3,8 @@
 
 {% extends "layouts/full-width-landmarks.njk" %}
 
+{% block pageTitle %}{{ componentName | unslugify }} - GOV.UK Frontend{% endblock %}
+
 {% set bodyClasses %}
   language-markup
 {% endset %}

--- a/packages/govuk-frontend-review/src/views/examples/button-groups/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/button-groups/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/conditional-reveals/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/packages/govuk-frontend-review/src/views/examples/error-messages/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-messages/index.njk
@@ -9,7 +9,7 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block styles %}
 <style>

--- a/packages/govuk-frontend-review/src/views/examples/error-summary-with-messages/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary-with-messages/index.njk
@@ -4,7 +4,7 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/error-summary-with-one-thing-per-page/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary-with-one-thing-per-page/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/error-summary/index.njk
@@ -10,7 +10,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/exit-this-page-with-skiplink/index.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/exit-this-page/macro.njk" import govukExitThisPage %}
 {% from "govuk/components/skip-link/macro.njk" import govukSkipLink %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block skipLink %}
   {{ super() }}

--- a/packages/govuk-frontend-review/src/views/examples/footer-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/footer-alignment/index.njk
@@ -3,6 +3,8 @@
 
 {% extends "layouts/full-width-landmarks.njk" %}
 
+{% block pageTitle %}{{ exampleName | unslugify }} - GOV.UK Frontend{% endblock %}
+
 {% block beforeContent %}
   {{ govukBackLink({
     href: "/"

--- a/packages/govuk-frontend-review/src/views/examples/form-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-alignment/index.njk
@@ -8,7 +8,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block styles %}
 <style>

--- a/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-controls-states/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}

--- a/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/form-elements/index.njk
@@ -8,7 +8,7 @@
 {% from "govuk/components/select/macro.njk" import govukSelect %}
 {% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/grid/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/grid/index.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/javascript-errors/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/javascript-errors/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}

--- a/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/labels-legends-and-headings/index.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/links/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/links/index.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/multiple-radio-groups/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}

--- a/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/scoped-initialisation/index.njk
@@ -1,4 +1,4 @@
-{% extends "govuk/template.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 

--- a/packages/govuk-frontend-review/src/views/examples/small-form-controls/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/small-form-controls/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}

--- a/packages/govuk-frontend-review/src/views/examples/text-alignment/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/text-alignment/index.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/packages/govuk-frontend-review/src/views/examples/translated/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/translated/index.njk
@@ -31,7 +31,7 @@
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% block pageTitle %}Translated examples - GOV.UK Frontend{% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/examples/typography/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/typography/index.njk
@@ -1,4 +1,4 @@
-{% extends "layouts/layout.njk" %}
+{% extends "layouts/examples.njk" %}
 
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/table/macro.njk" import govukTable %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -1,6 +1,8 @@
 {% extends "layouts/layout.njk" %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
+{% block pageTitle %}Full page examples - GOV.UK Frontend{% endblock %}
+
 {% block beforeContent %}
   {{ govukBackLink({
     href: "/"

--- a/packages/govuk-frontend-review/src/views/layouts/examples.njk
+++ b/packages/govuk-frontend-review/src/views/layouts/examples.njk
@@ -1,0 +1,3 @@
+{% extends "layouts/layout.njk" %}
+
+{% block pageTitle %}{{ exampleName | unslugify }} - GOV.UK Frontend{% endblock %}


### PR DESCRIPTION
## What
Gives our examples meaningful page titles beyond just "GOV.UK Frontend". I've gone with the following format:

- Component pages: {{ Component name }} - GOV.UK Frontend
- Component example previews: {{ Component name }}, {{ Example name }} - GOV.UK Frontend
- Non-full page example pages: {{ Example name }} - GOV.UK Frontend
- All components: All components - GOV.UK Frontend
- List of full page examples: Full page examples - GOV.UK Frontend

The homepage is still just "GOV.UK Fronted".

## Why
It's an accessibility best practice to have pages with different meaningful titles across a website. This in theory isn't as critical for us since the review app is mostly internal, however it also has a general productivity benefit of enabling folks working with the review app to clearly see differences between tabs when working across multiple examples.

To illustrate this, here's what main looks like now if you are working across multiple different pages:
![List of browser tabs that all have the page title GOV.UK Frontend](https://github.com/alphagov/govuk-frontend/assets/64783893/9ec6c410-2dd7-4cae-ad15-249fcb7b7876)

 Here's what those same tabs look like with this change:
![List of browser tabs with different page titles](https://github.com/alphagov/govuk-frontend/assets/64783893/c307bb87-2a0e-444b-878d-18d31c76f466)