### PR TITLE
Remove X-UA-Compatible meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ For advice on how to use these release notes see [our guidance on staying up to 
 
 ## Unreleased
 
+### Recommended changes
+
+We've recently made some non-breaking changes to GOV.UK Frontend. Implementing these changes will make your service work better.
+
+#### Remove the X-UA-Compatible meta tag
+
+Remove the `<meta http-equiv="X-UA-Compatible" content="IE=edge">` meta tag from your page template.
+
+Internet Explorer versions 8, 9 and 10 included a feature that would try to determine if the page was built for an older version of IE and would silently enable compatibility mode, which would modify the rendering engine's behaviour to match the older version of IE. Setting this meta tag prevented that behaviour.
+
+IE11 deprecated this meta tag and defaulted to always using IE11's renderer when the page has a HTML5 doctype (`<!DOCTYPE html>`).
+
+As Frontend no longer supports Internet Explorer versions older than 11, this meta tag can now be removed.
+
+This change was made in [pull request #4434: Remove X-UA-Compatible meta tag](https://github.com/alphagov/govuk-frontend/pull/4434).
+
 ## 5.0.0-beta.1 (Pre-release)
 
 ### Fixes
@@ -23,7 +39,7 @@ We’ve added a new component which creates lists of tasks that users need to co
 
 Each task in the list can have a title, status, link and an optional hint. When a link is added, the whole row is clickable.
 
-This change was made in [pull request #2261: Task list component.](https://github.com/alphagov/govuk-frontend/pull/2261).
+This change was made in [pull request #2261: Task list component](https://github.com/alphagov/govuk-frontend/pull/2261).
 
 #### Added focus style for links containing non-text content
 
@@ -435,7 +451,7 @@ We no longer supply a dedicated class for headers with navigation but no service
 
 This change was introduced in [pull request #3595: Remove deprecated `.govuk-header__navigation--no-service-name` class](https://github.com/alphagov/govuk-frontend/pull/3595).
 
-### Suggested changes
+### Recommended changes
 
 #### Update the Pagination component's default `aria-label`
 

--- a/docs/examples/webpack/src/index.html
+++ b/docs/examples/webpack/src/index.html
@@ -6,7 +6,6 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#0b0c0c">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     <link rel="stylesheet" href="/stylesheets/app.min.css">
   </head>

--- a/packages/govuk-frontend/src/govuk/template.njk
+++ b/packages/govuk-frontend/src/govuk/template.njk
@@ -8,8 +8,6 @@
     <title{% if pageTitleLang %} lang="{{ pageTitleLang }}"{% endif %}>{% block pageTitle %}GOV.UK - The best place to find government services and information{% endblock %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="{{ themeColor | default("#0b0c0c", true) }}"> {# Hardcoded value of $govuk-black #}
-    {# Ensure that older IE versions always render with the correct rendering engine #}
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
     {% block headIcons %}
       <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{{ assetPath | default("/assets", true) }}/images/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
This meta tag ensured that older versions of Internet Explorer (specifically IE8 to IE10) used the most recent renderer and rendering rules available to them, rather than relying on the browser's in-built heuristics that could silently 'downgrade' the renderer. For example: if IE10 thought you were viewing a Sharepoint intranet site, it might automatically switch itself to use IE9's rendering rules.

IE11 does not require this meta tag. It deprecates the X-UA-Compatible meta tag and now uses the most recent renderer automatically if the HTML5 doctype (`<!DOCTYPE html>`) is being used.

Both the EdgeHTML and Chromium versions of Edge ignore the meta tag entirely. No non-Microsoft browsers ever supported it, as far as I can find. 

As Frontend now only supports Internet Explorer 11, I think we can safely remove this meta tag. 

Info from Microsoft regarding the deprecation in IE11: https://learn.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/bg182625(v=vs.85)#document-mode-changes