### PR TITLE
Enable no-continue and no-else-return ESLint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -88,7 +88,12 @@ module.exports = {
 
         // Automatically use template strings
         'no-useless-concat': 'error',
-        'prefer-template': 'error'
+        'prefer-template': 'error',
+
+        // Flow control – avoid continue and else blocks after return statements
+        // in if statements
+        'no-continue': 'error',
+        'no-else-return': 'error'
       },
       settings: {
         jsdoc: {

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.mjs
@@ -346,9 +346,9 @@ export class CharacterCount extends GOVUKFrontendComponent {
     if (this.config.maxwords) {
       const tokens = text.match(/\S+/g) || [] // Matches consecutive non-whitespace chars
       return tokens.length
-    } else {
-      return text.length
     }
+
+    return text.length
   }
 
   /**


### PR DESCRIPTION
As agreed, enable these ESLint rules:

- https://eslint.org/docs/latest/rules/no-continue
- https://eslint.org/docs/latest/rules/no-else-return

Fix the one violation of the `no-else-return` rule in the character count.

We should be open to revisiting this if we find these linting rules get in our way.