### PR TITLE
Fix UMD component exports with duplicate names

### DIFF
--- a/packages/govuk-frontend/rollup.publish.config.mjs
+++ b/packages/govuk-frontend/rollup.publish.config.mjs
@@ -1,5 +1,4 @@
 import { pkg } from '@govuk-frontend/config'
-import { componentPathToModuleName } from '@govuk-frontend/lib/names'
 import { babel } from '@rollup/plugin-babel'
 import replace from '@rollup/plugin-replace'
 import { defineConfig } from 'rollup'
@@ -46,9 +45,8 @@ export default defineConfig(({ i: input }) => ({
       // Bundled modules
       preserveModules: false,
 
-      // Components are given names (e.g window.GOVUKFrontend.Accordion)
-      amd: { id: componentPathToModuleName(input) },
-      name: componentPathToModuleName(input)
+      // Export via `window.GOVUKFrontend.${exportName}`
+      name: 'GOVUKFrontend'
     }
   ],
 

--- a/packages/govuk-frontend/tasks/build/package.unit.test.mjs
+++ b/packages/govuk-frontend/tasks/build/package.unit.test.mjs
@@ -220,7 +220,7 @@ describe('packages/govuk-frontend/dist/', () => {
 
         // Look for AMD module definition for 'GOVUKFrontend'
         expect(contents).toContain(
-          "typeof define === 'function' && define.amd ? define('GOVUKFrontend', ['exports'], factory)"
+          "(global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.GOVUKFrontend = {}));"
         )
 
         // Look for bundled components with CommonJS named exports

--- a/shared/lib/names.js
+++ b/shared/lib/names.js
@@ -1,7 +1,6 @@
-const { dirname, join, parse } = require('path')
+const { dirname, join } = require('path')
 
 const { paths } = require('@govuk-frontend/config')
-const { minimatch } = require('minimatch')
 
 /**
  * Convert a kebab-cased string to a PascalCased one
@@ -61,27 +60,6 @@ function componentNameToClassName(componentName) {
  */
 function componentNameToConfigName(componentName) {
   return kebabCaseToCamelCase(componentName)
-}
-
-/**
- * Convert component path to JavaScript module name
- *
- * Used by Rollup to set Universal Module Definition (UMD) export names for
- * `window` globals maintaining compatibility with CommonJS and AMD `require()`
- *
- * Component paths have kebab-cased file names (button.mjs, date-input.mjs),
- * whilst module names have a `GOVUKFrontend.` prefix and are PascalCased
- * (GOVUKFrontend.Button, GOVUKFrontend.CharacterCount)
- *
- * @param {string} componentPath - Path to component with kebab-cased file name
- * @returns {string} The name of its corresponding module
- */
-function componentPathToModuleName(componentPath) {
-  const { name } = parse(componentPath)
-
-  return minimatch(componentPath, '**/components/**', { matchBase: true })
-    ? `GOVUKFrontend.${componentNameToClassName(name)}`
-    : 'GOVUKFrontend'
 }
 
 /**
@@ -170,7 +148,6 @@ module.exports = {
   componentNameToClassName,
   componentNameToConfigName,
   componentNameToMacroName,
-  componentPathToModuleName,
   packageResolveToPath,
   packageTypeToPath,
   packageNameToPath

--- a/shared/lib/names.unit.test.mjs
+++ b/shared/lib/names.unit.test.mjs
@@ -1,4 +1,4 @@
-import { join, relative } from 'path'
+import { join } from 'path'
 
 import { paths } from '@govuk-frontend/config'
 
@@ -6,7 +6,6 @@ import {
   componentNameToClassName,
   componentNameToConfigName,
   componentNameToMacroName,
-  componentPathToModuleName,
   packageResolveToPath,
   packageTypeToPath,
   packageNameToPath
@@ -92,74 +91,6 @@ describe('componentNameToMacroName', () => {
     "transforms component '$name' to macro '$macroName'",
     ({ name, macroName }) => {
       expect(componentNameToMacroName(name)).toBe(macroName)
-    }
-  )
-})
-
-describe('componentPathToModuleName', () => {
-  const components = [
-    {
-      path: 'components/button/button.mjs',
-      moduleName: 'GOVUKFrontend.Button'
-    },
-    {
-      path: 'components/radios/radios.mjs',
-      moduleName: 'GOVUKFrontend.Radios'
-    },
-    {
-      path: 'components/skip-link/skip-link.mjs',
-      moduleName: 'GOVUKFrontend.SkipLink'
-    },
-    {
-      path: 'components/character-count/character-count.mjs',
-      moduleName: 'GOVUKFrontend.CharacterCount'
-    }
-  ]
-
-  const others = ['common/index.mjs', 'common/normalise-dataset.mjs']
-
-  it.each(components)(
-    "transforms '$path' to '$moduleName'",
-    ({ path, moduleName }) => {
-      const srcPath = join(paths.package, 'src/govuk')
-
-      // Path variations
-      const pathAbsolute = join(srcPath, path)
-      const pathRelativeToRoot = relative(paths.root, pathAbsolute)
-      const pathRelativeToSource = relative(srcPath, pathAbsolute)
-
-      // Absolute path
-      // For example `/path/to/project/packages/govuk-frontend/src/govuk/components/button/button.mjs`
-      expect(componentPathToModuleName(pathAbsolute)).toBe(moduleName)
-
-      // Relative path (to project)
-      // For example `packages/govuk-frontend/src/govuk/components/button/button.mjs`
-      expect(componentPathToModuleName(pathRelativeToRoot)).toBe(moduleName)
-
-      // Relative path (to source)
-      // For example `components/button/button.mjs`
-      expect(componentPathToModuleName(pathRelativeToSource)).toBe(moduleName)
-    }
-  )
-
-  it.each(others)(
-    "transforms unknown components to 'GOVUKFrontend'",
-    (path) => {
-      const srcPath = join(paths.package, 'src/govuk')
-
-      // Path variations
-      const pathAbsolute = join(srcPath, path)
-      const pathRelativeToRoot = relative(paths.root, pathAbsolute)
-      const pathRelativeToSource = relative(srcPath, pathAbsolute)
-
-      // Unknown components always named 'GOVUKFrontend'
-      expect(componentPathToModuleName(pathAbsolute)).toBe('GOVUKFrontend')
-      expect(componentPathToModuleName(pathRelativeToRoot)).toBe(
-        'GOVUKFrontend'
-      )
-      expect(componentPathToModuleName(pathRelativeToSource)).toBe(
-        'GOVUKFrontend'
-      )
     }
   )
 })


### PR DESCRIPTION
Closes https://github.com/alphagov/govuk-frontend/issues/4443 by removing the `componentPathToModuleName()` helper

Rollup is now configured to automatically add named exports to `window.GOVUKFrontend`