### PR TITLE
Add error pages to Review app

### DIFF
--- a/packages/govuk-frontend-review/src/common/lib/files.mjs
+++ b/packages/govuk-frontend-review/src/common/lib/files.mjs
@@ -55,6 +55,7 @@ export async function getFullPageExamples() {
  *
  * @typedef {object} FullPageExample
  * @property {string} name - Example name
+ * @property {string} path - Example directory name
  * @property {string} [scenario] - Description explaining the example
  * @property {string} [notes] - Additional notes about the example
  */

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/index.mjs
@@ -3,6 +3,7 @@
  */
 export { componentNameToMacroName } from '@govuk-frontend/lib/names'
 export { highlight } from './highlight.mjs'
+export { inspect } from './inspect.mjs'
 export { markdown } from './markdown.mjs'
 export { slugify } from './slugify.mjs'
 export { unslugify } from './unslugify.mjs'

--- a/packages/govuk-frontend-review/src/common/nunjucks/filters/inspect.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/filters/inspect.mjs
@@ -1,0 +1,16 @@
+import util from 'util'
+
+/**
+ * Format JavaScript objects as strings
+ *
+ * @param {unknown} object - JavaScript object to format
+ * @returns {string} Formatted string
+ */
+export function inspect(object) {
+  return util.inspect(object, {
+    compact: false,
+    depth: Infinity,
+    maxArrayLength: Infinity,
+    maxStringLength: Infinity
+  })
+}

--- a/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
+++ b/packages/govuk-frontend-review/src/common/nunjucks/globals/get-nunjucks-code.mjs
@@ -1,9 +1,7 @@
-import { inspect } from 'util'
-
 import prettier from '@prettier/sync'
 import { outdent } from 'outdent'
 
-import { componentNameToMacroName } from '../filters/index.mjs'
+import { inspect, componentNameToMacroName } from '../filters/index.mjs'
 
 /**
  * Component Nunjucks code (formatted)
@@ -16,12 +14,7 @@ export function getNunjucksCode(componentName, options) {
   const macroName = componentNameToMacroName(componentName)
 
   // Allow nested HTML strings to wrap at `\n`
-  const paramsFormatted = inspect(options.context, {
-    compact: false,
-    depth: Infinity,
-    maxArrayLength: Infinity,
-    maxStringLength: Infinity
-  })
+  const paramsFormatted = inspect(options.context)
 
   // Format Nunjucks safely with double quotes
   const macroFormatted = prettier.format(`${macroName}(${paramsFormatted})`, {

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -23,13 +23,18 @@ export default (app) => {
   routes.whatIsYourPostcode(app)
   routes.whatWasTheLastCountryYouVisited(app)
 
+  /**
+   * Full page examples index
+   */
   app.get('/full-page-examples', async (req, res) => {
     res.render('full-page-examples/index', {
       fullPageExamples
     })
   })
 
-  // Display full page examples index by default if not handled already
+  /**
+   * Full page example
+   */
   app.get('/full-page-examples/:exampleName', (req, res, next) => {
     const { exampleName } = req.params
 

--- a/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
+++ b/packages/govuk-frontend-review/src/routes/full-page-examples.mjs
@@ -2,6 +2,7 @@ import { getFullPageExamples } from '../common/lib/files.mjs'
 import * as routes from '../views/full-page-examples/index.mjs'
 
 const fullPageExamples = await getFullPageExamples()
+const fullPageExampleNames = fullPageExamples.map(({ path }) => path)
 
 /**
  * @param {import('express').Application} app
@@ -29,8 +30,13 @@ export default (app) => {
   })
 
   // Display full page examples index by default if not handled already
-  app.get('/full-page-examples/:exampleName', (req, res) => {
+  app.get('/full-page-examples/:exampleName', (req, res, next) => {
     const { exampleName } = req.params
+
+    // No matching example so continue to page not found
+    if (!fullPageExampleNames.includes(exampleName)) {
+      return next()
+    }
 
     res.render(`full-page-examples/${exampleName}/index`)
   })

--- a/packages/govuk-frontend-review/src/views/component.njk
+++ b/packages/govuk-frontend-review/src/views/component.njk
@@ -15,10 +15,14 @@
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
-    "items": [
+    items: [
       {
-        text: 'GOV.UK Frontend',
+        text: "GOV.UK Frontend",
         href: "/"
+      },
+      {
+        text: "All components",
+        href: "/components"
       },
       {
         text: componentName | unslugify

--- a/packages/govuk-frontend-review/src/views/components.njk
+++ b/packages/govuk-frontend-review/src/views/components.njk
@@ -1,6 +1,6 @@
 {% extends "layouts/full-width-landmarks.njk" %}
 
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 {% from "macros/showExamples.njk" import showExamples %}
 
 {% block pageTitle %}All components - GOV.UK Frontend{% endblock %}
@@ -10,8 +10,16 @@
 {% endset %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: "/"
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "GOV.UK Frontend",
+        href: "/"
+      },
+      {
+        text: "All components"
+      }
+    ]
   }) }}
 {% endblock %}
 

--- a/packages/govuk-frontend-review/src/views/errors/404.njk
+++ b/packages/govuk-frontend-review/src/views/errors/404.njk
@@ -1,0 +1,18 @@
+{% extends "layouts/layout.njk" %}
+
+{% block pageTitle %}Page not found - GOV.UK Frontend{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">Page not found</h1>
+
+      <p class="govuk-body">If you typed the web address, check it is correct.</p>
+      <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="https://design-system.service.gov.uk/get-in-touch/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/errors/404.njk
+++ b/packages/govuk-frontend-review/src/views/errors/404.njk
@@ -1,6 +1,22 @@
 {% extends "layouts/layout.njk" %}
 
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
 {% block pageTitle %}Page not found - GOV.UK Frontend{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "GOV.UK Frontend",
+        href: "/"
+      },
+      {
+        text: "Page not found"
+      }
+    ]
+  }) }}
+{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/packages/govuk-frontend-review/src/views/errors/500.njk
+++ b/packages/govuk-frontend-review/src/views/errors/500.njk
@@ -1,6 +1,22 @@
 {% extends "layouts/layout.njk" %}
 
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+
 {% block pageTitle %}Sorry, there is a problem with the service - GOV.UK Frontend{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "GOV.UK Frontend",
+        href: "/"
+      },
+      {
+        text: "Server error"
+      }
+    ]
+  }) }}
+{% endblock %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/packages/govuk-frontend-review/src/views/errors/500.njk
+++ b/packages/govuk-frontend-review/src/views/errors/500.njk
@@ -1,0 +1,24 @@
+{% extends "layouts/layout.njk" %}
+
+{% block pageTitle %}Sorry, there is a problem with the service - GOV.UK Frontend{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-three-quarters govuk-grid-column-two-thirds-from-desktop">
+      <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+
+      <p class="govuk-body">Try again later.</p>
+
+      <p class="govuk-body">
+        <a class="govuk-link" href="https://design-system.service.gov.uk/get-in-touch/" rel="noreferrer noopener" target="_blank">Contact the Design System team (opens in new tab)</a> if you believe you are seeing this message in error.
+      </p>
+    </div>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <pre class="app-code"><code tabindex="0" class="app-code__container">
+        {{- error | inspect | safe -}}
+      </code></pre>
+  </div>
+{% endblock %}

--- a/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/index.njk
@@ -1,11 +1,19 @@
 {% extends "layouts/layout.njk" %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
 
 {% block pageTitle %}Full page examples - GOV.UK Frontend{% endblock %}
 
 {% block beforeContent %}
-  {{ govukBackLink({
-    href: "/"
+  {{ govukBreadcrumbs({
+    items: [
+      {
+        text: "GOV.UK Frontend",
+        href: "/"
+      },
+      {
+        text: "Full page examples"
+      }
+    ]
   }) }}
 {% endblock %}
 


### PR DESCRIPTION
This PR adds Express.js default routes to handle errors

This ensures our own Review app tests correctly catch issues since a few URLs currently crash:

>https://govuk-frontend-review.herokuapp.com/components/fdsfdsfds
>https://govuk-frontend-review.herokuapp.com/components/accordion/gdfgdfgd/preview
>https://govuk-frontend-review.herokuapp.com/examples/fdsfdsfsd
>https://govuk-frontend-review.herokuapp.com/full-page-examples/fdhgdfga

These are handled in the following PR but lacked error pages:

* https://github.com/alphagov/govuk-frontend/pull/4462

<img width="754" alt="Error 500 page" src="https://github.com/alphagov/govuk-frontend/assets/415517/cd0a78a2-bc9a-48c3-b3e9-89b29bdbd35b">