### PR TITLE
[WIP][SPIKE] SupportError updates

### DIFF
--- a/packages/govuk-frontend-review/src/views/examples/javascript-head-error/index.njk
+++ b/packages/govuk-frontend-review/src/views/examples/javascript-head-error/index.njk
@@ -1,0 +1,39 @@
+{% extends "layouts/examples.njk" %}
+
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+
+{% block head %}
+  <link rel="stylesheet" href="/stylesheets/app.min.css">
+
+  {% block styles %}{% endblock %}
+  <script src="/javascripts/all.bundle.js"></script>
+  <script>
+    window.GOVUKFrontend.initAll()
+  </script>
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    href: "/"
+  }) }}
+{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-l">JavaScript in &lt;head&gt; error</h1>
+  <p class="govuk-body-lead">
+    Open your <a class="govuk-link" href="https://developer.mozilla.org/en-US/docs/Web/API/console#see_also">brower's console</a>
+    to witness the error thrown in browsers where GOV.UK Frontend is not supported.
+  </p>
+  {{ govukCharacterCount({
+    label: {
+      text: "Any other comment"
+    },
+    id: "some-content",
+    name: "some-content",
+    maxlength: "100"
+  })}}
+{% endblock %}
+
+{% block bodyEnd %}
+{% endblock %}

--- a/packages/govuk-frontend/src/govuk/all.mjs
+++ b/packages/govuk-frontend/src/govuk/all.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable no-new */
 
 import { version } from './common/govuk-frontend-version.mjs'
-import { isSupported } from './common/index.mjs'
+import { getSupportedLevelMessage } from './common/index.mjs'
 import { Accordion } from './components/accordion/accordion.mjs'
 import { Button } from './components/button/button.mjs'
 import { CharacterCount } from './components/character-count/character-count.mjs'
@@ -27,8 +27,9 @@ function initAll(config) {
   config = typeof config !== 'undefined' ? config : {}
 
   // Skip initialisation when GOV.UK Frontend is not supported
-  if (!isSupported()) {
-    console.log(new SupportError())
+  const supportLevelMessage = getSupportedLevelMessage()
+  if (supportLevelMessage !== 'OK') {
+    console.log(new SupportError(supportLevelMessage))
     return
   }
 

--- a/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.jsdom.test.mjs
@@ -1,8 +1,8 @@
 import {
   mergeConfigs,
   extractConfigByNamespace,
-  isSupported,
-  getFragmentFromUrl
+  getFragmentFromUrl,
+  getSupportedLevelMessage
 } from './index.mjs'
 
 describe('Common JS utilities', () => {
@@ -108,28 +108,34 @@ describe('Common JS utilities', () => {
     })
   })
 
-  describe('isSupported', () => {
+  describe('getSupportedLevelMessage', () => {
     beforeEach(() => {
       // Jest does not tidy the JSDOM document between tests
       // so we need to take care of that ourselves
       document.documentElement.innerHTML = ''
     })
 
-    it('returns true if the govuk-frontend-supported class is set', () => {
+    it('returns "OK" if there are no errors', () => {
       document.body.classList.add('govuk-frontend-supported')
 
-      expect(isSupported(document.body)).toBe(true)
+      expect(getSupportedLevelMessage(document.body)).toBe('OK')
     })
 
-    it('returns false if the govuk-frontend-supported class is not set', () => {
-      expect(isSupported(document.body)).toBe(false)
+    it('returns appropriate message if the govuk-frontend-supported class is not set', () => {
+      expect(getSupportedLevelMessage(document.body)).toBe(
+        '<body> tag is missing the `govuk-frontend-supported` class'
+      )
     })
 
-    it('returns false when `document.body` is not set', () => {
+    it('returns appropriate message when `document.body` is not set', () => {
       // For example, running `initAll()` in `<head>` without `type="module"`
       // will see support checks run when document.body is still `null`
-      expect(isSupported(null)).toBe(false)
+      expect(getSupportedLevelMessage(null)).toBe(
+        'GOV.UK Frontend initialised without `<script type="module">`'
+      )
     })
+
+    it.todo('returns appropriate message when noModule not supported', () => {})
   })
 
   describe('getFragmentFromUrl', () => {

--- a/packages/govuk-frontend/src/govuk/common/index.mjs
+++ b/packages/govuk-frontend/src/govuk/common/index.mjs
@@ -134,21 +134,33 @@ export function getFragmentFromUrl(url) {
 }
 
 /**
- * Checks if GOV.UK Frontend is supported on this page
- *
- * Some browsers will load and run our JavaScript but GOV.UK Frontend
- * won't be supported.
  *
  * @internal
  * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
- * @returns {boolean} Whether GOV.UK Frontend is supported on this page
+ * @returns {string} Support level
  */
-export function isSupported($scope = document.body) {
-  if (!$scope) {
-    return false
+export function getSupportedLevelMessage($scope = document.body) {
+  const LEVELS = {
+    OK: 'OK',
+    NO_SUPPORT: 'GOV.UK Frontend is not supported in this browser',
+    NO_MODULE: 'GOV.UK Frontend initialised without `<script type="module">`',
+    MISSING_CLASS: '<body> tag is missing the `govuk-frontend-supported` class'
   }
+  let supportedLevel = LEVELS.OK
 
-  return $scope.classList.contains('govuk-frontend-supported')
+  // The currentScript property only exists on <script> tags with no module.
+  // $scope will be null if `initAll` was called from the <head> with no module
+  if (document.currentScript ?? !$scope) {
+    supportedLevel = LEVELS.NO_MODULE
+  } else if (!document.body.classList.contains('govuk-frontend-supported')) {
+    supportedLevel = LEVELS.MISSING_CLASS
+  } else if (!('noModule' in HTMLScriptElement.prototype)) {
+    // For browsers that support es-module, but not noModule
+    supportedLevel = LEVELS.NO_SUPPORT
+  }
+  // All other browsers either don't load the JavaScript, or fully support GOV.UK Frontend
+
+  return supportedLevel
 }
 
 /**

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -726,7 +726,8 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'SupportError',
-              message: 'GOV.UK Frontend is not supported in this browser'
+              message:
+                '<body> tag is missing the `govuk-frontend-supported` class'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -323,7 +323,8 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -808,7 +808,8 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -356,7 +356,8 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -230,7 +230,7 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message: '<body> tag is missing the `govuk-frontend-supported` class'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -225,7 +225,8 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -173,7 +173,8 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -230,7 +230,7 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message: '<body> tag is missing the `govuk-frontend-supported` class'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -292,7 +292,7 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message: '<body> tag is missing the `govuk-frontend-supported` class'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -77,7 +77,7 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message: '<body> tag is missing the `govuk-frontend-supported` class'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -263,7 +263,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              '<body> tag is missing the `govuk-frontend-supported` class'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -31,14 +31,10 @@ export class SupportError extends GOVUKFrontendError {
   /**
    * Checks if GOV.UK Frontend is supported on this page
    *
-   * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
+   * @param {string} message - Element error message
    */
-  constructor($scope = document.body) {
-    super(
-      $scope
-        ? 'GOV.UK Frontend is not supported in this browser'
-        : 'GOV.UK Frontend initialised without `<script type="module">`'
-    )
+  constructor(message = 'GOV.UK Frontend is not supported in this browser') {
+    super(message)
   }
 }
 

--- a/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
+++ b/packages/govuk-frontend/src/govuk/govuk-frontend-component.mjs
@@ -1,4 +1,4 @@
-import { isSupported } from './common/index.mjs'
+import { getSupportedLevelMessage } from './common/index.mjs'
 import { SupportError } from './errors/index.mjs'
 
 /**
@@ -25,8 +25,9 @@ export class GOVUKFrontendComponent {
    * @private
    */
   checkSupport() {
-    if (!isSupported()) {
-      throw new SupportError()
+    const supportLevelMessage = getSupportedLevelMessage()
+    if (supportLevelMessage !== 'OK') {
+      throw new SupportError(supportLevelMessage)
     }
   }
 }


### PR DESCRIPTION
Closes #4477

## What and why

We want to improve our `SupportError` messages, since plenty of users in the research session were getting a "GOV.UK Frontend is not supported" message when the only issue was they hadn't added the `.govuk-frontend-supported` class to the body.

## Approach

### What SHOULD trigger the "not supported" message?
It's actually very rare that we want to trigger a "not supported" message. Any browser which doesn't support ES-module simply won't run the JavaScript, so the only folks who see this error are:

1. Services that skip adding `.govuk-frontend-supported` to the `<body>`
2. Safari 10.1 (because it supports es-module and runs our code, but doesn't support `noModule`, which we use in a check and thus fails)

So it looks like only Safari 10.1 users should see "GOV.UK Frontend is not supported".

### getSupportedLevelMessage

For this spike, I've added a `getSupportedLevelMessage` in place of `isSupported`. Where `isSupported` returned true or false depending on whether there was support, `getSupportedLevelMessage` runs checks to return an appropriate message by these cases:

- `OK`, by default
- `NO_MODULE`: when GOV.UK Frontend is initialised without `<script type="module">`
- `MISSING_CLASS`: when the `.govuk-frontend-supported` class has not been added to `<body>`
- `NO_SUPPORT`: for all other cases (ie: Safari 10.1) where there is no support

### SupportError

This has been simplified to just take a message like any other error.

## TO DO
- I'm not sure how to test in jest for browsers which don't support `noModule`
- We might want to protect browsers which don't support `noModule` and let them run GOV.UK Frontend anyway? In which case, we wouldn't even need the "not supported" message at all.
- Would we prefer to `warn` rather than `error` in some cases? If no other conditions trigger except that the `.govuk-frontend-supported` class is missing, for example, then everything should function just fine. If so, we can do a little logic based on `getSupportedLevelMessage`'s return value.
- Tests need updating - we're currently only testing for the case where `.govuk-frontend-supported` is removed, and there are a few errors in other tests I haven't had time to look at.
- Do we want to give a nice console message to services which don't load the JavaScript saying "You're fine, everything works, you just don't have our JavaScript enhancements"?