### PR TITLE
Improve SupportError when `<body class="govuk-frontend-supported">` is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#4416: Review and fix HTML attribute trailing spaces etc](https://github.com/alphagov/govuk-frontend/pull/4416)
 - [#4444: Fix UMD component exports with duplicate names](https://github.com/alphagov/govuk-frontend/pull/4444)
+- [#4492: Improve SupportError when `<body class="govuk-frontend-supported">` is not set](https://github.com/alphagov/govuk-frontend/pull/4492)
 - [#4450: Update descriptions for Nunjucks macro options + fixes](https://github.com/alphagov/govuk-frontend/pull/4450)
 
 ## 5.0.0-beta.1 (Pre-release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ As Frontend no longer supports Internet Explorer versions older than 11, this me
 
 This change was made in [pull request #4434: Remove X-UA-Compatible meta tag](https://github.com/alphagov/govuk-frontend/pull/4434).
 
+### Fixes
+
 We’ve made fixes to GOV.UK Frontend in the following pull requests:
 
 - [#4416: Review and fix HTML attribute trailing spaces etc](https://github.com/alphagov/govuk-frontend/pull/4416)

--- a/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/accordion/accordion.puppeteer.test.js
@@ -716,7 +716,7 @@ describe('/components/accordion', () => {
           examples = await getExamples('accordion')
         })
 
-        it('throws when GOV.UK Frontend is not supported', async () => {
+        it('can throw a SupportError if appropriate', async () => {
           await expect(
             render(page, 'accordion', examples.default, {
               beforeInitialisation() {
@@ -726,7 +726,8 @@ describe('/components/accordion', () => {
           ).rejects.toMatchObject({
             cause: {
               name: 'SupportError',
-              message: 'GOV.UK Frontend is not supported in this browser'
+              message:
+                'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
             }
           })
         })

--- a/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/button/button.puppeteer.test.js
@@ -313,7 +313,7 @@ describe('/components/button', () => {
         examples = await getExamples('button')
       })
 
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'button', examples.default, {
             beforeInitialisation() {
@@ -323,7 +323,8 @@ describe('/components/button', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/character-count/character-count.puppeteer.test.js
@@ -798,7 +798,7 @@ describe('Character count', () => {
         examples = await getExamples('character-count')
       })
 
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'character-count', examples.default, {
             beforeInitialisation() {
@@ -808,7 +808,8 @@ describe('Character count', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/checkboxes/checkboxes.puppeteer.test.js
@@ -346,7 +346,7 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
     })
 
     describe('errors at instantiation', () => {
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'checkboxes', examples.default, {
             beforeInitialisation() {
@@ -356,7 +356,8 @@ describe('Checkboxes with multiple groups and a "None" checkbox and conditional 
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/error-summary/error-summary.puppeteer.test.js
@@ -220,7 +220,7 @@ describe('Error Summary', () => {
       examples = await getExamples('error-summary')
     })
 
-    it('throws when GOV.UK Frontend is not supported', async () => {
+    it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'error-summary', examples.default, {
           beforeInitialisation() {
@@ -230,7 +230,8 @@ describe('Error Summary', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message:
+            'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/exit-this-page/exit-this-page.puppeteer.test.js
@@ -215,7 +215,7 @@ describe('/components/exit-this-page', () => {
     })
 
     describe('errors at instantiation', () => {
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'exit-this-page', examples.default, {
             beforeInitialisation() {
@@ -225,7 +225,8 @@ describe('/components/exit-this-page', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/header/header.puppeteer.test.js
@@ -163,7 +163,7 @@ describe('Header navigation', () => {
     })
 
     describe('errors at instantiation', () => {
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'header', examples.default, {
             beforeInitialisation() {
@@ -173,7 +173,8 @@ describe('Header navigation', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/notification-banner/notification-banner.puppeteer.test.js
@@ -220,7 +220,7 @@ describe('Notification banner', () => {
   })
 
   describe('errors at instantiation', () => {
-    it('throws when GOV.UK Frontend is not supported', async () => {
+    it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'notification-banner', examples.default, {
           beforeInitialisation() {
@@ -230,7 +230,8 @@ describe('Notification banner', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message:
+            'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/radios/radios.puppeteer.test.js
@@ -282,7 +282,7 @@ describe('Radios', () => {
   })
 
   describe('errors at instantiation', () => {
-    it('throws when GOV.UK Frontend is not supported', async () => {
+    it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'radios', examples.default, {
           beforeInitialisation() {
@@ -292,7 +292,8 @@ describe('Radios', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message:
+            'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/skip-link/skip-link.puppeteer.test.js
@@ -67,7 +67,7 @@ describe('Skip Link', () => {
   })
 
   describe('errors at instantiation', () => {
-    it('throws when GOV.UK Frontend is not supported', async () => {
+    it('can throw a SupportError if appropriate', async () => {
       await expect(
         render(page, 'skip-link', examples.default, {
           beforeInitialisation() {
@@ -77,7 +77,8 @@ describe('Skip Link', () => {
       ).rejects.toMatchObject({
         cause: {
           name: 'SupportError',
-          message: 'GOV.UK Frontend is not supported in this browser'
+          message:
+            'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
         }
       })
     })

--- a/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
+++ b/packages/govuk-frontend/src/govuk/components/tabs/tabs.puppeteer.test.js
@@ -253,7 +253,7 @@ describe('/components/tabs', () => {
     })
 
     describe('errors at instantiation', () => {
-      it('throws when GOV.UK Frontend is not supported', async () => {
+      it('can throw a SupportError if appropriate', async () => {
         await expect(
           render(page, 'tabs', examples.default, {
             beforeInitialisation() {
@@ -263,7 +263,8 @@ describe('/components/tabs', () => {
         ).rejects.toMatchObject({
           cause: {
             name: 'SupportError',
-            message: 'GOV.UK Frontend is not supported in this browser'
+            message:
+              'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
           }
         })
       })

--- a/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.jsdom.test.mjs
@@ -12,6 +12,11 @@ describe('errors', () => {
   })
 
   describe('SupportError', () => {
+    beforeEach(() => {
+      // JSDOM hasn't yet implemented `noModule`, so we have to mock this
+      window.HTMLScriptElement.prototype.noModule = true
+    })
+
     it('is an instance of GOVUKFrontendError', () => {
       expect(new SupportError(document.body)).toBeInstanceOf(GOVUKFrontendError)
     })
@@ -21,8 +26,15 @@ describe('errors', () => {
     })
 
     it('provides feedback regarding browser support', () => {
+      delete window.HTMLScriptElement.prototype.noModule
       expect(new SupportError(document.body).message).toBe(
         'GOV.UK Frontend is not supported in this browser'
+      )
+    })
+
+    it('provides feedback when <body> class is missing', () => {
+      expect(new SupportError(document.body).message).toBe(
+        'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
       )
     })
 

--- a/packages/govuk-frontend/src/govuk/errors/index.mjs
+++ b/packages/govuk-frontend/src/govuk/errors/index.mjs
@@ -34,9 +34,14 @@ export class SupportError extends GOVUKFrontendError {
    * @param {HTMLElement | null} [$scope] - HTML element `<body>` checked for browser support
    */
   constructor($scope = document.body) {
+    const supportMessage =
+      'noModule' in HTMLScriptElement.prototype
+        ? 'GOV.UK Frontend initialised without `<body class="govuk-frontend-supported">` from template `<script>` snippet'
+        : 'GOV.UK Frontend is not supported in this browser'
+
     super(
       $scope
-        ? 'GOV.UK Frontend is not supported in this browser'
+        ? supportMessage
         : 'GOV.UK Frontend initialised without `<script type="module">`'
     )
   }


### PR DESCRIPTION
Closes #4477

## What and why

We want to improve our `SupportError` messages, since plenty of users in the research session were getting a "GOV.UK Frontend is not supported" message when the only issue was they hadn't added the `.govuk-frontend-supported` class to the body.

## Approach

### What SHOULD trigger the "not supported" message?
It's actually very rare that we want to trigger a "not supported" message. Any browser which doesn't support ES-module simply won't run the JavaScript, so the only folks who see this error are:

1. Services that skip adding `.govuk-frontend-supported` to the `<body>`
2. Safari 10.1 (because it supports es-module and runs our code, but doesn't support `noModule`, which we use in a check and thus fails)

So it looks like only Safari 10.1 users should see "GOV.UK Frontend is not supported".

This PR takes @colinrotherham's suggestion of sticking with the simpler option of more granular error messages, revisiting https://github.com/alphagov/govuk-frontend/pull/4491 if/when components need different levels of support.