### PR TITLE
Add CHANGELOG entries for fix PRs since `5.0.0-beta.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,12 @@ As Frontend no longer supports Internet Explorer versions older than 11, this me
 
 This change was made in [pull request #4434: Remove X-UA-Compatible meta tag](https://github.com/alphagov/govuk-frontend/pull/4434).
 
+We’ve made fixes to GOV.UK Frontend in the following pull requests:
+
+- [#4416: Review and fix HTML attribute trailing spaces etc](https://github.com/alphagov/govuk-frontend/pull/4416)
+- [#4444: Fix UMD component exports with duplicate names](https://github.com/alphagov/govuk-frontend/pull/4444)
+- [#4450: Update descriptions for Nunjucks macro options + fixes](https://github.com/alphagov/govuk-frontend/pull/4450)
+
 ## 5.0.0-beta.1 (Pre-release)
 
 ### Fixes


### PR DESCRIPTION
Adds CHANGELOG entries for the fixes we merged that affect the `govuk-frontend` package itself. 

There's been [other PRs merged since `5.0.0-beta.1`](https://github.com/alphagov/govuk-frontend/pulls?q=is%3Apr+sort%3Aupdated-desc+is%3Aclosed+-author%3Aapp%2Fdependabot+merged%3A%3E%3D2023-11-03+), but they're either affecting the review app or the documentation, so I thought they'd just muddy the content of the CHANGELOG.