### PR TITLE
Fix missed `actions/setup-node` update

### DIFF
--- a/.github/workflows/actions/setup-node/action.yml
+++ b/.github/workflows/actions/setup-node/action.yml
@@ -11,7 +11,7 @@ runs:
 
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v3.8.1
+      uses: actions/setup-node@v4.0.0
       id: setup-node
 
       with:


### PR DESCRIPTION
Quick PR to update an action missed by Dependabot:

https://github.com/alphagov/govuk-frontend/blob/6b93b3667b67a0932c9959ca054ae6fc77d63d9f/.github/workflows/actions/setup-node/action.yml#L13-L14

Possibly because we ignored it in the past?

* https://github.com/alphagov/govuk-frontend/pull/3936