### PR TITLE
Fix header product name wrapping onto new line

### DIFF
--- a/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
+++ b/packages/govuk-frontend-review/src/views/full-page-examples/service-manual-topic/index.njk
@@ -16,6 +16,12 @@ notes: The links within each section are not functional.
 {% set pageTitle = "Technology - Service Manual" %}
 {% block pageTitle %}{{ pageTitle }} - GOV.UK{% endblock %}
 
+{% block header %}
+  {{ govukHeader({
+    productName: "Service Manual"
+  }) }}
+{% endblock %}
+
 {% block beforeContent %}
   {{ govukBreadcrumbs({
     items: [

--- a/packages/govuk-frontend/src/govuk/components/header/_index.scss
+++ b/packages/govuk-frontend/src/govuk/components/header/_index.scss
@@ -168,6 +168,13 @@
       padding-right: $govuk-gutter-half;
       float: left;
       vertical-align: top;
+
+      // Reset float when logo is the last child, without a navigation
+      &:last-child {
+        width: auto;
+        padding-right: 0;
+        float: none;
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes https://github.com/alphagov/govuk-frontend/issues/1502

See the "Service Manual" topic page for an updated example:
https://govuk-frontend-pr-4498.herokuapp.com/full-page-examples/service-manual-topic

## Before

We float the logo and apply `width: 33.33%`

<img width="952" alt="Before" src="https://github.com/alphagov/govuk-frontend/assets/415517/415a8103-65a7-4f05-a4db-b450b7ead071">

## After

When the logo matches `:last-child` (no navigation or service name) we can reset the float

<img width="952" alt="After" src="https://github.com/alphagov/govuk-frontend/assets/415517/ce0a58cf-410a-4b5a-ae5f-0a1fa26291dc">
